### PR TITLE
treeherder RDBS schemas

### DIFF
--- a/treeherder-service/model/sample_data/job_data.json.sample
+++ b/treeherder-service/model/sample_data/job_data.json.sample
@@ -1,0 +1,58 @@
+/****
+ * Data structure sample sent to object store
+ ****/
+ { 
+    sources: { 
+        gecko: "revision",
+        gaia: "revision",
+        mozharness: "revision,
+        ...
+        },
+            
+    jobs: [
+        {
+            job_guid:"",
+            name:"build | mochitest_one | ...",
+            product_name:"Firefox | Firefox OS | Thunderbird | ...",
+            state: "pending | running | completed | coalesced |  ...",
+            result: "success | warnings | failure | exception | retry | cancelled",
+            reason: "push | scheduled | self-serve | manual",
+            who: " gaia | scheduler name | username ",
+            submit_timestamp:"",
+            start_timestamp:"",
+            end_timestamp:"",
+            machine:"",    
+            build_platform:"",
+            machine_platform:"",
+    
+            option_collection: {
+                },
+
+            /* Not Indexed */    
+            log_references: [
+                { url:"",
+                  name:"" },
+                  ...
+                  ],
+                  
+            artifact:"{
+                type:" json | img | ...",
+                name:"",
+                log_urls:[
+                    ]
+                blob:""
+                }"
+            },
+        ...
+        ],
+
+    /****
+     * May not be present if there are no job_guid's coalesced. If present
+     * the job_guids present in jobs are where the jobs were coalesced to
+     ****/        
+    coalesced: [
+        "job_guid",
+        ...
+        ]
+}
+

--- a/treeherder-service/model/sql/template_schema/project_jobs_1.sql.tmpl
+++ b/treeherder-service/model/sql/template_schema/project_jobs_1.sql.tmpl
@@ -1,0 +1,230 @@
+/* This file contains {engine} markers that must be replaced
+   before it is sent to MySQL.
+*/
+
+--
+-- Host: localhost    Database: project_jobs_1
+-- ------------------------------------------------------
+-- Server version	5.6.10
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `bug_job_map`
+--
+
+DROP TABLE IF EXISTS `bug_job_map`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `bug_job_map` (
+  `job_id` bigint(20) unsigned NOT NULL,
+  `bug_id` int(10) unsigned NOT NULL,
+  `type` varchar(50) COLLATE utf8_bin NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  UNIQUE KEY `uni_job_id_bug_id` (`job_id`,`bug_id`),
+  KEY `idx_job_id` (`job_id`),
+  KEY `idx_bug_id` (`bug_id`),
+  KEY `idx_type` (`type`),
+  KEY `idx_active_status` (`active_status`),
+  CONSTRAINT `fk_bug_job` FOREIGN KEY (`job_id`) REFERENCES `job` (`id`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `job`
+--
+
+DROP TABLE IF EXISTS `job`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `job` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `job_guid` varchar(50) COLLATE utf8_bin NOT NULL,
+  `job_coalesced_to_guid` varchar(50) COLLATE utf8_bin DEFAULT NULL,
+  `result_set_id` bigint(20) unsigned NOT NULL,
+  `build_platform_id` int(10) unsigned NOT NULL,
+  `machine_platform_id` int(10) unsigned NOT NULL,
+  `machine_id` int(10) unsigned NOT NULL,
+  `option_collection_id` int(10) unsigned DEFAULT NULL,
+  `job_type_id` int(10) unsigned NOT NULL,
+  `product_id` int(10) unsigned NOT NULL,
+  `who` varchar(50) COLLATE utf8_bin NOT NULL,
+  `reason` varchar(25) COLLATE utf8_bin NOT NULL,
+  `result` varchar(25) COLLATE utf8_bin DEFAULT NULL,
+  `state` varchar(25) COLLATE utf8_bin NOT NULL,
+  `submit_timestamp` int(10) unsigned NOT NULL,
+  `start_timestamp` int(10) unsigned DEFAULT NULL,
+  `end_timestamp` int(10) unsigned DEFAULT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_job_guid` (`job_guid`),
+  KEY `idx_job_coalesced_to_guid` (`job_coalesced_to_guid`),
+  KEY `idx_result_set_id` (`result_set_id`),
+  KEY `idx_build_platform_id` (`build_platform_id`),
+  KEY `idx_machine_platform_id` (`machine_platform_id`),
+  KEY `idx_machine_id` (`machine_id`),
+  KEY `idx_option_collection_id` (`option_collection_id`),
+  KEY `idx_job_type_id` (`job_type_id`),
+  KEY `idx_product_id` (`product_id`),
+  KEY `idx_who` (`who`),
+  KEY `idx_reason` (`reason`),
+  KEY `idx_result` (`result`),
+  KEY `idx_state` (`state`),
+  KEY `idx_submit_timestamp` (`submit_timestamp`),
+  KEY `idx_start_timestamp` (`start_timestamp`),
+  KEY `idx_end_timestamp` (`end_timestamp`),
+  KEY `idx_active_status` (`active_status`),
+  CONSTRAINT `fk_result_set` FOREIGN KEY (`result_set_id`) REFERENCES `result_set` (`id`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `job_artifact`
+--
+
+DROP TABLE IF EXISTS `job_artifact`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `job_artifact` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `job_id` bigint(20) unsigned NOT NULL,
+  `name` varchar(50) COLLATE utf8_bin NOT NULL,
+  `type` varchar(50) COLLATE utf8_bin NOT NULL,
+  `blob` mediumblob NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_job_id` (`job_id`),
+  KEY `idx_name` (`name`),
+  KEY `idx_type` (`type`),
+  KEY `idx_active_status` (`active_status`),
+  CONSTRAINT `fk_job_artifact` FOREIGN KEY (`job_id`) REFERENCES `job` (`id`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `job_log_url`
+--
+
+DROP TABLE IF EXISTS `job_log_url`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `job_log_url` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `job_id` bigint(20) unsigned NOT NULL,
+  `name` varchar(50) COLLATE utf8_bin NOT NULL,
+  `url` varchar(255) COLLATE utf8_bin NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_job_id` (`job_id`),
+  KEY `idx_name` (`name`),
+  KEY `idx_active_status` (`active_status`),
+  CONSTRAINT `fk_job_log_url` FOREIGN KEY (`job_id`) REFERENCES `job` (`id`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `job_note`
+--
+
+DROP TABLE IF EXISTS `job_note`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `job_note` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `job_id` bigint(20) unsigned NOT NULL,
+  `failure_classification_id` int(10) unsigned DEFAULT NULL,
+  `who` varchar(50) COLLATE utf8_bin NOT NULL,
+  `note` mediumtext COLLATE utf8_bin,
+  `note_timestamp` int(10) unsigned NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_job_id` (`job_id`),
+  KEY `idx_failure_classification_id` (`failure_classification_id`),
+  KEY `idx_who` (`who`),
+  KEY `idx_note_timestamp` (`note_timestamp`),
+  KEY `idx_active_status` (`active_status`),
+  CONSTRAINT `fk_job_note` FOREIGN KEY (`job_id`) REFERENCES `job` (`id`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `result_set`
+--
+
+DROP TABLE IF EXISTS `result_set`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `result_set` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `revision_hash` varchar(50) COLLATE utf8_bin NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_revision_hash` (`revision_hash`),
+  KEY `idx_active_status` (`active_status`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `revision`
+--
+
+DROP TABLE IF EXISTS `revision`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `revision` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `revision` varchar(50) COLLATE utf8_bin NOT NULL,
+  `author` varchar(50) COLLATE utf8_bin NOT NULL,
+  `push_timestamp` int(11) unsigned NOT NULL,
+  `commit_timestamp` int(11) unsigned NOT NULL,
+  `repository_id` int(11) unsigned NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_revision` (`revision`),
+  KEY `idx_author` (`author`),
+  KEY `idx_push_timestamp` (`push_timestamp`),
+  KEY `idx_commit_timestamp` (`commit_timestamp`),
+  KEY `idx_repository_id` (`repository_id`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `revision_map`
+--
+
+DROP TABLE IF EXISTS `revision_map`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `revision_map` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `revision_id` bigint(20) unsigned NOT NULL,
+  `result_set_id` bigint(20) unsigned NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_revision_id` (`revision_id`),
+  KEY `idx_result_set_id` (`result_set_id`),
+  KEY `idx_active_status` (`active_status`),
+  CONSTRAINT `fk_revision_map` FOREIGN KEY (`revision_id`) REFERENCES `revision` (`id`),
+  CONSTRAINT `fk_revision_map_result_set` FOREIGN KEY (`result_set_id`) REFERENCES `result_set` (`id`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2013-02-27  8:54:01

--- a/treeherder-service/model/sql/template_schema/project_objectstore_1.sql.tmpl
+++ b/treeherder-service/model/sql/template_schema/project_objectstore_1.sql.tmpl
@@ -1,0 +1,54 @@
+/* This file contains {engine} markers that must be replaced
+   before it is sent to MySQL.
+*/
+
+--
+-- Host: localhost    Database: project_objectstore_1
+-- ------------------------------------------------------
+-- Server version	5.6.10
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `objectstore`
+--
+
+DROP TABLE IF EXISTS `objectstore`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `objectstore` (
+  `id` bigint(11) unsigned NOT NULL AUTO_INCREMENT,
+  `job_id` bigint(11) unsigned DEFAULT NULL,
+  `loaded_timestamp` int(11) unsigned NOT NULL,
+  `processed_state` enum('ready','loading','complete') COLLATE utf8_bin DEFAULT 'ready',
+  `error` enum('N','Y') COLLATE utf8_bin DEFAULT 'N',
+  `error_msg` mediumtext COLLATE utf8_bin,
+  `json_blob` mediumblob,
+  `worker_id` int(11) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_job_id` (`job_id`),
+  KEY `idx_processed_state` (`processed_state`),
+  KEY `idx_error` (`error`),
+  KEY `idx_worker_id` (`worker_id`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2013-02-27  8:55:27

--- a/treeherder-service/model/sql/template_schema/treeherder.sql.tmpl
+++ b/treeherder-service/model/sql/template_schema/treeherder.sql.tmpl
@@ -1,0 +1,55 @@
+/* This file contains {engine} markers that must be replaced
+   before it is sent to MySQL.
+*/
+
+--
+-- Host: localhost    Database: treeherder
+-- ------------------------------------------------------
+-- Server version	5.6.10
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `datasource`
+--
+
+DROP TABLE IF EXISTS `datasource`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `datasource` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `project` varchar(25) COLLATE utf8_bin NOT NULL,
+  `contenttype` varchar(25) COLLATE utf8_bin NOT NULL,
+  `dataset` int(11) NOT NULL,
+  `host` varchar(128) COLLATE utf8_bin NOT NULL,
+  `read_only_host` varchar(128) COLLATE utf8_bin DEFAULT NULL,
+  `name` varchar(128) COLLATE utf8_bin NOT NULL,
+  `type` varchar(25) COLLATE utf8_bin NOT NULL,
+  `oauth_consumer_key` varchar(45) COLLATE utf8_bin DEFAULT NULL,
+  `oauth_consumer_secret` varchar(45) COLLATE utf8_bin DEFAULT NULL,
+  `creation_date` datetime NOT NULL,
+  `cron_batch` varchar(45) COLLATE utf8_bin DEFAULT 'small',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `project` (`project`,`dataset`,`contenttype`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2013-02-27  8:55:02

--- a/treeherder-service/model/sql/template_schema/treeherder_reference_1.sql.tmpl
+++ b/treeherder-service/model/sql/template_schema/treeherder_reference_1.sql.tmpl
@@ -1,0 +1,324 @@
+/* This file contains {engine} markers that must be replaced
+   before it is sent to MySQL.
+*/
+
+--
+-- Host: localhost    Database: treeherder_reference_1
+-- ------------------------------------------------------
+-- Server version	5.6.10
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `bugscache`
+--
+
+DROP TABLE IF EXISTS `bugscache`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `bugscache` (
+  `id` int(10) unsigned NOT NULL,
+  `status` varchar(64) COLLATE utf8_bin DEFAULT NULL,
+  `resolution` varchar(64) COLLATE utf8_bin DEFAULT NULL,
+  `summary` varchar(255) COLLATE utf8_bin NOT NULL,
+  `crash_signature` mediumtext COLLATE utf8_bin,
+  `keywords` mediumtext COLLATE utf8_bin,
+  `os` varchar(64) COLLATE utf8_bin DEFAULT NULL,
+  `modified` datetime COLLATE utf8_bin DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_status` (`status`),
+  KEY `idx_resolution` (`resolution`),
+  FULLTEXT KEY `idx_summary` (`summary`),
+  FULLTEXT KEY `idx_crash_signature` (`crash_signature`),
+  FULLTEXT KEY `idx_keywords` (`keywords`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `build_platform`
+--
+
+DROP TABLE IF EXISTS `build_platform`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `build_platform` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `os_name` varchar(25) COLLATE utf8_bin NOT NULL,
+  `platform` varchar(25) COLLATE utf8_bin NOT NULL,
+  `architecture` varchar(25) COLLATE utf8_bin DEFAULT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_os_name` (`os_name`),
+  KEY `idx_platform` (`platform`),
+  KEY `idx_architecture` (`architecture`),
+  KEY `idx_active_status` (`active_status`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `failure_classification`
+--
+
+DROP TABLE IF EXISTS `failure_classification`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `failure_classification` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) COLLATE utf8_bin NOT NULL,
+  `description` text COLLATE utf8_bin NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_name` (`name`),
+  KEY `idx_active_status` (`active_status`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `job_group`
+--
+
+DROP TABLE IF EXISTS `job_group`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `job_group` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `symbol` char(10) COLLATE utf8_bin NOT NULL,
+  `name` varchar(50) COLLATE utf8_bin NOT NULL,
+  `description` text COLLATE utf8_bin NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_symbol` (`symbol`),
+  KEY `idx_name` (`name`),
+  KEY `idx_active_status` (`active_status`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `job_type`
+--
+
+DROP TABLE IF EXISTS `job_type`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `job_type` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `job_group_id` int(10) unsigned DEFAULT NULL,
+  `symbol` char(10) COLLATE utf8_bin NOT NULL,
+  `name` varchar(50) COLLATE utf8_bin NOT NULL,
+  `description` text COLLATE utf8_bin NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_symbol` (`symbol`),
+  KEY `idx_name` (`name`),
+  KEY `idx_active_status` (`active_status`),
+  KEY `fk_job_type_job_group` (`job_group_id`),
+  CONSTRAINT `fk_job_type_job_group` FOREIGN KEY (`job_group_id`) REFERENCES `job_group` (`id`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `machine`
+--
+
+DROP TABLE IF EXISTS `machine`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `machine` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) COLLATE utf8_bin NOT NULL,
+  `first_timestamp` int(10) unsigned NOT NULL,
+  `last_timestamp` int(10) unsigned NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_name` (`name`),
+  KEY `idx_first_timestamp` (`first_timestamp`),
+  KEY `idx_last_timestamp` (`last_timestamp`),
+  KEY `idx_active_status` (`active_status`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `machine_note`
+--
+
+DROP TABLE IF EXISTS `machine_note`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `machine_note` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `machine_id` int(10) unsigned NOT NULL,
+  `author` varchar(50) COLLATE utf8_bin NOT NULL,
+  `machine_timestamp` int(10) unsigned NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  `note` text COLLATE utf8_bin,
+  PRIMARY KEY (`id`),
+  KEY `idx_machine_id` (`machine_id`),
+  KEY `idx_author` (`author`),
+  KEY `idx_machine_timestamp` (`machine_timestamp`),
+  KEY `idx_active_status` (`active_status`),
+  CONSTRAINT `fk_machine_note_machine` FOREIGN KEY (`machine_id`) REFERENCES `machine` (`id`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `machine_platform`
+--
+
+DROP TABLE IF EXISTS `machine_platform`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `machine_platform` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `os_name` varchar(25) COLLATE utf8_bin NOT NULL,
+  `platform` varchar(25) COLLATE utf8_bin NOT NULL,
+  `architecture` varchar(25) COLLATE utf8_bin DEFAULT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_os_name` (`os_name`),
+  KEY `idx_platform` (`platform`),
+  KEY `idx_architecture` (`architecture`),
+  KEY `idx_active_status` (`active_status`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `option`
+--
+
+DROP TABLE IF EXISTS `option`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `option` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) COLLATE utf8_bin NOT NULL,
+  `description` text COLLATE utf8_bin NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_name` (`name`),
+  KEY `idx_active_status` (`active_status`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `option_collection`
+--
+
+DROP TABLE IF EXISTS `option_collection`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `option_collection` (
+  `id` int(10) unsigned NOT NULL,
+  `option_id` int(10) unsigned NOT NULL,
+  UNIQUE KEY `uni_option_collection` (`id`,`option_id`),
+  KEY `fk_option` (`option_id`),
+  CONSTRAINT `fk_option` FOREIGN KEY (`option_id`) REFERENCES `option` (`id`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `product`
+--
+
+DROP TABLE IF EXISTS `product`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `product` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) COLLATE utf8_bin NOT NULL,
+  `description` text COLLATE utf8_bin NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_name` (`name`),
+  KEY `idx_active_status` (`active_status`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `repository`
+--
+
+DROP TABLE IF EXISTS `repository`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `repository` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `repository_group_id` int(10) unsigned NOT NULL,
+  `name` varchar(50) COLLATE utf8_bin NOT NULL,
+  `type` varchar(25) COLLATE utf8_bin NOT NULL,
+  `url` varchar(255) COLLATE utf8_bin NOT NULL,
+  `branch` varchar(50) COLLATE utf8_bin DEFAULT NULL,
+  `project_name` varchar(25) COLLATE utf8_bin DEFAULT NULL,
+  `description` text COLLATE utf8_bin NOT NULL,
+  `purpose` varchar(50) COLLATE utf8_bin NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_repository_group_id` (`repository_group_id`),
+  KEY `idx_name` (`name`),
+  KEY `idx_type` (`type`),
+  KEY `idx_branch` (`branch`),
+  KEY `idx_project_name` (`project_name`),
+  KEY `idx_purpose` (`purpose`),
+  KEY `idx_active_status` (`active_status`),
+  CONSTRAINT `fk_repository_group` FOREIGN KEY (`repository_group_id`) REFERENCES `repository_group` (`id`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `repository_group`
+--
+
+DROP TABLE IF EXISTS `repository_group`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `repository_group` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) COLLATE utf8_bin NOT NULL,
+  `description` text COLLATE utf8_bin NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_name` (`name`),
+  KEY `idx_active_status` (`active_status`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `repository_version`
+--
+
+DROP TABLE IF EXISTS `repository_version`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `repository_version` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `repository_id` int(10) unsigned NOT NULL,
+  `version` varchar(50) COLLATE utf8_bin NOT NULL,
+  `timestamp` int(10) unsigned NOT NULL,
+  `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  KEY `idx_repository_id` (`repository_id`),
+  KEY `idx_version` (`version`),
+  KEY `idx_timestamp_id` (`timestamp`),
+  KEY `idx_active_status` (`active_status`),
+  CONSTRAINT `fk_repository` FOREIGN KEY (`repository_id`) REFERENCES `repository` (`id`)
+) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2013-02-27  8:55:49


### PR DESCRIPTION
This branch adds the directory structure for model, sql, and template schemas.  The template schemas are found in treeherder-service/model/sql/template_schema. Each schema references the database engine to be used as the string "{engine}". This needs to be replaced with "InnoDB | TokuDB | ...", or whatever is appropriate for the run environment before the file is executed in the database. This will be done automatically by a custom django manage.py command that will be included in a subsequent branch.
