### PR TITLE
add init_datasources command

### DIFF
--- a/tests/model/commands/test_init_datasource.py
+++ b/tests/model/commands/test_init_datasource.py
@@ -1,0 +1,35 @@
+from django.core.management import call_command
+import pytest
+
+from treeherder.model.models import Repository, RepositoryGroup, Datasource
+
+
+@pytest.fixture
+def repository_group():
+    return RepositoryGroup.objects.create(name="mygroup")
+
+
+@pytest.fixture
+def repository(repository_group):
+    return Repository.objects.create(
+        repository_group=repository_group,
+        name="my_test_repo",
+        dvcs_type = "hg",
+        url="my_repo_url"
+    )
+
+
+def test_init_datasources(repository):
+    """check that a new datasource is created if a repo is available"""
+    count_before = Datasource.objects.all().count()
+    call_command("init_datasources")
+    count_after = Datasource.objects.all().count()
+    assert count_after == count_before+2
+
+
+def test_init_datasources_no_repo():
+    """check that no datasources are created if there are no repo"""
+    count_before = Datasource.objects.all().count()
+    call_command("init_datasources")
+    count_after = Datasource.objects.all().count()
+    assert count_after == count_before

--- a/treeherder/model/management/commands/init_datasources.py
+++ b/treeherder/model/management/commands/init_datasources.py
@@ -1,0 +1,17 @@
+from django.core.management.base import BaseCommand
+from treeherder.model.models import Datasource, Repository
+
+
+class Command(BaseCommand):
+    help = ("Populate the datasource table and"
+            "create the connected databases")
+
+    def handle(self, *args, **options):
+        projects = Repository.objects.all().values_list('name',flat=True)
+        for project in projects:
+        	for contenttype in ("jobs","objectstore"):
+	        	Datasource.objects.get_or_create(
+                    contenttype=contenttype,
+                    dataset=1,
+                    project=project
+                )

--- a/treeherder/model/management/commands/load_initial_data.py
+++ b/treeherder/model/management/commands/load_initial_data.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
-
+from treeherder.model.models import Datasource, Repository
 
 class Command(BaseCommand):
     help = "Load initial data into the master db"

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -256,7 +256,7 @@ class Datasource(models.Model):
         if inserting or kwargs.get('force_insert', False):
             if not self.name:
                 self.name = "{0}_{1}_{2}".format(
-                    self.project,
+                    self.project.replace("-","_"),
                     self.contenttype,
                     self.dataset
                 )


### PR DESCRIPTION
This command populate the datasource table with one entry per repository. As a side effect, a new db is created for each datasource. Given the initial fixtures for the repository table, we are now able to populate the datasource table with real data!
