### PR TITLE
update puppet modules for amazon linux compatibility

### DIFF
--- a/puppet/files/apache/treeherder-service.conf
+++ b/puppet/files/apache/treeherder-service.conf
@@ -1,5 +1,5 @@
 <VirtualHost *:80>
-  ServerName 192.168.33.10
+  ServerName <%= @APP_URL %>
   ProxyRequests Off
   <Proxy *>
     Order deny,allow
@@ -7,17 +7,17 @@
   </Proxy>
 
 
-  Alias /static/ /home/vagrant/treeherder-service/treeherder/webapp/static/
+  Alias /static/ <%= @PROJ_DIR %>/treeherder/webapp/static/
   ProxyPass        /static/ !
 
-  Alias /media/ /home/vagrant/treeherder-service/treeherder/webapp/media/
+  Alias /media/ <%= @PROJ_DIR %>/treeherder/webapp/media/
   ProxyPass        /media/ !
 
   ProxyPass        / http://localhost:8000/
   ProxyPassReverse / http://localhost:8000/
   ProxyPreserveHost On 
 
-  ErrorLog /var/log/apache2/treeherder-service_err.log
+  ErrorLog /var/log/<%= @apache_service %>/treeherder-service_err.log
   LogLevel warn
-  CustomLog /var/log/apache2/treeherder-service_access.log combined
+  CustomLog /var/log/<%= @apache_service %>/treeherder-service_access.log combined
 </VirtualHost>

--- a/puppet/files/mysql/my.cnf
+++ b/puppet/files/mysql/my.cnf
@@ -124,4 +124,5 @@ key_buffer      = 16M
 # * IMPORTANT: Additional settings that can override those from this file!
 #   The files must end with '.cnf', otherwise they'll be ignored.
 #
+
 !includedir /etc/mysql/conf.d/

--- a/puppet/manifests/classes/apache.pp
+++ b/puppet/manifests/classes/apache.pp
@@ -1,44 +1,54 @@
+$apache_devel = $operatingsystem ? {
+  ubuntu => "apache2-dev",
+  default => "httpd-devel",
+}
+
+$apache_vhost_path = $operatingsystem ? {
+  ubuntu => "/etc/apache2/sites-enabled",
+  default => "/etc/httpd/conf.d",
+}
+
+$apache_service = $operatingsystem ? {
+  ubuntu => "apache2",
+  default => "httpd",
+}
+
 class apache {
-            package { "apache2":
-                ensure => present,
-                before => File['/etc/apache2/sites-enabled/treeherder-service.conf'];
-            }
+  package { $apache_devel:
+    ensure => present
+  }
 
-            package { "apache2-dev":
-                ensure => present,
-                before => [
-                    Exec['a2enmod rewrite'],
-                    Exec['a2enmod proxy'],
-                    Exec['a2enmod proxy_http'],   
-                ];
-            }
+  package { $apache_service:
+    ensure => present
+  }
 
-            file { "/etc/apache2/sites-enabled/treeherder-service.conf":
-                source => "$PROJ_DIR/puppet/files/apache/treeherder-service.conf",
-                owner => "root", group => "root", mode => 0644,
-                notify => Service["apache2"],
-                require => [
-                    Package['apache2']
-                ];
-            }
+  file { "${apache_vhost_path}/treeherder-service.conf":
+    content => template("${PROJ_DIR}/puppet/files/apache/treeherder-service.conf"),
+    owner => "root", group => "root", mode => 0644,
+    require => [Package[$apache_devel]],
+    notify => Service[$apache_service],
+  }
 
-            exec {
-                'a2enmod rewrite':
-                    onlyif => 'test ! -e /etc/apache2/mods-enabled/rewrite.load';
-                'a2enmod proxy':
-                    onlyif => 'test ! -e /etc/apache2/mods-enabled/proxy.load';
-                'a2enmod proxy_http':
-                    onlyif => 'test ! -e /etc/apache2/mods-enabled/proxy_http.load';
+  service { $apache_service:
+    ensure => running,
+    enable => true,
+    require => [
+      File["${apache_vhost_path}/treeherder-service.conf"]
+    ],
+  }
 
-            }
-
-            service { "apache2":
-                ensure => running,
-                enable => true,
-                require => [
-                    Package['apache2'],
-                    File['/etc/apache2/sites-enabled/treeherder-service.conf']
-                ];
-            }
-
-        }
+  if $operatingsystem == 'ubuntu'{
+    /*by default ubuntu doesn't have these modules enabled*/
+    exec {
+      'a2enmod rewrite':
+        onlyif => 'test ! -e /etc/apache2/mods-enabled/rewrite.load',
+        before => Service[$apache_service];
+      'a2enmod proxy':
+        onlyif => 'test ! -e /etc/apache2/mods-enabled/proxy.load',
+        before => Service[$apache_service];
+      'a2enmod proxy_http':
+        onlyif => 'test ! -e /etc/apache2/mods-enabled/proxy_http.load',
+        before => Service[$apache_service];
+    }
+  }
+}

--- a/puppet/manifests/classes/init.pp
+++ b/puppet/manifests/classes/init.pp
@@ -4,7 +4,9 @@ class init {
         ensure => "present",
     }
 
-    exec { "update_apt":
-        command => "sudo apt-get update",
+    if $operatingsystem == 'Ubuntu'{
+      exec { "update_apt":
+          command => "sudo apt-get update"
+      }
     }
 }

--- a/puppet/manifests/classes/mysql.pp
+++ b/puppet/manifests/classes/mysql.pp
@@ -1,41 +1,57 @@
-# Get mysql up and running
+# mysqldev and mysql service need to be parametrized
+# based on the OS
+$mysqldev = $operatingsystem ? {
+    ubuntu => libmysqld-dev,
+    default => mysql-devel
+}
+
+$mysqlservice = $operatingsystem ? {
+    Amazon => mysqld,
+    default => mysql
+
+}
+
 class mysql {
-    package { "mysql-server":
-        ensure => installed;
-    }
-        
-    package { "libmysqld-dev":
-        ensure => installed;
-    }
+  package { mysql-server:
+    ensure => installed
+  }
 
+  package { $mysqldev:
+    ensure => installed
+  }
+
+  service { $mysqlservice:
+    ensure => running,
+    enable => true,
+    require => Package['mysql-server'],
+  }
+
+  if $operatingsystem == 'ubuntu'{
     file{"/etc/mysql/my.cnf":
-        source => "$PROJ_DIR/puppet/files/mysql/my.cnf",
-        owner => "root", group => "root", mode => 0644,
-        notify => Service["mysql"],
-        require => [
-            Package['mysql-server']
-        ],
+      source => "${PROJ_DIR}/puppet/files/mysql/my.cnf",
+      owner => "root", group => "root", mode => 0644,
+      notify => Service[$mysqlservice],
+      require => [
+          Package['mysql-server']
+      ]
     }
+  }
 
-    service { "mysql":
-        ensure => running,
-        enable => true,
-        require => Package['mysql-server'];
-    }
 
-    exec { "create-${DB_NAME}-db":
-        unless => "mysql -uroot ${DB_NAME}",
-        command => "mysql -uroot -e \"create database ${DB_NAME};\"",
-        require => Service["mysql"],
-    }
+  exec { "create-${DB_NAME}-db":
+    unless => "mysql -uroot ${DB_NAME}",
+    command => "mysql -uroot -e \"create database ${DB_NAME};\"",
+    require => Service[$mysqlservice],
+  }
 
-    exec { "grant-${DB_USER}-db":
-        unless => "mysql -u${DB_USER} -p${DB_PASS}",
-        command =>  "mysql -uroot -e \"
-         CREATE USER '${DB_USER}'@'%' IDENTIFIED BY '${DB_PASS}';
-         CREATE USER '${DB_USER}'@'localhost' IDENTIFIED BY '${DB_PASS}';
-         GRANT ALL PRIVILEGES ON *.* to '${DB_USER}'@'%';
-         GRANT ALL PRIVILEGES ON *.* to '${DB_USER}'@'localhost';\"",
-        require => [Service["mysql"], Exec["create-${DB_NAME}-db"]]
-    }
+  exec { "grant-${DB_USER}-db":
+    unless => "mysql -u${DB_USER} -p${DB_PASS}",
+    command =>  "mysql -uroot -e \"
+     CREATE USER '${DB_USER}'@'%' IDENTIFIED BY '${DB_PASS}';
+     CREATE USER '${DB_USER}'@'localhost' IDENTIFIED BY '${DB_PASS}';
+     GRANT ALL PRIVILEGES ON *.* to '${DB_USER}'@'%';
+     GRANT ALL PRIVILEGES ON *.* to '${DB_USER}'@'localhost';\"",
+    require => [Service[$mysqlservice], Exec["create-${DB_NAME}-db"]]
+  }
+
 }

--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -1,53 +1,78 @@
 # Install python and compiled modules for project
+
+$python_devel = $operatingsystem ? {
+    ubuntu => "python-dev",
+    default => "python-devel",
+}
+
+$libxml2 = $operatingsystem ? {
+    ubuntu => "libxml2-dev",
+    default => "libxml2-devel",
+}
+
+$site_packages = $operatingsystem ? {
+    ubuntu => "lib/python2.7/site-packages",
+    default => "lib64/python2.6/site-packages",
+}
+
 class python {
-    package {
-        ["python2.7-dev", "python2.7", "python-pip", "python-virtualenv", "git"]:
-            ensure => installed;
-    }
 
-    exec { "create-virtualenv":
-        command => "virtualenv /home/vagrant/venv/",
-        creates => "/home/vagrant/venv/",
-        require => [
-            Package['python-virtualenv'],
-        ],
-        user => "vagrant"
-    }
+  package{[$python_devel,
+           "gcc",
+           "python-setuptools",
+           "python-pip",
+           "python-virtualenv",
+           $libxml2]:
+    ensure => installed;
+  }
 
-    exec { "update-distribute":
-        command => "/home/vagrant/venv/bin/pip install --upgrade distribute",
+  exec {
+    "create-virtualenv":
+    cwd => "/home/${APP_USER}",
+    user => "${APP_USER}",
+    command => "virtualenv --no-site-packages ${VENV_DIR}",
+    creates => "${VENV_DIR}",
+    require => Package["python-virtualenv"],
+  }
+
+  exec {"activate-venv-on-login":
+    unless => "cat /home/${APP_USER}/.bashrc | grep 'source venv/bin/activate'",
+    command => "echo 'source venv/bin/activate' >> /home/${APP_USER}/.bashrc",
+    require => Exec["create-virtualenv"],
+    user => "${APP_USER}",
+  }
+
+  exec{"pip-install-compiled":
+    require => [
+      Exec['create-virtualenv'],
+      File[ "/home/${APP_USER}/pip_cache"],
+      Exec['update-distribute']
+    ],
+    user => "${APP_USER}",
+    cwd => '/tmp',
+    command => "${VENV_DIR}/bin/pip install --download-cache=/home/${APP_USER}/pip_cache -r ${PROJ_DIR}/requirements/compiled.txt",
+    timeout => 1800,
+  }
+
+  file {"/home/${APP_USER}/pip_cache":
+    ensure => directory,
+    owner  => "${APP_USER}",
+    group  => "${APP_GROUP}",
+  }
+
+  file { "vendor.pth":
+    path => "${VENV_DIR}/${site_packages}/vendor.pth",
+    ensure => present,
+    content => "$PROJ_DIR/vendor/",
+    require => Exec["create-virtualenv"],
+  }
+
+  exec { "update-distribute":
+        command => "${VENV_DIR}/bin/pip install --upgrade distribute",
         require => [
             Package['python-pip'],
-            Exec['create-virtualenv'],
+            Exec['create-virtualenv']
         ]
     }
 
-    file { "vendor.pth":
-        path => "/home/vagrant/venv/lib/python2.7/site-packages/vendor.pth",
-        ensure => present,
-        content => "$PROJ_DIR/vendor/",
-        require => Exec["create-virtualenv"],
-    }
-
-    exec { "pip-install-requirements":
-        command => "/home/vagrant/venv/bin/pip install \
-        -r $PROJ_DIR/requirements/compiled.txt -r $PROJ_DIR/requirements/dev.txt \
-        -r $PROJ_DIR/requirements/pure.txt",
-        require => [
-            Package['python-pip'],
-            Package['git'],
-            Package['python2.7-dev'],
-            Exec['update-distribute'],
-            Exec['create-virtualenv'],
-        ],
-        user => "vagrant",
-        logoutput => "on_failure",
-    }
-
-    exec {"activate-venv-on-login":
-        unless => "cat /home/vagrant/.bashrc | grep 'source venv/bin/activate'",
-        command => "echo 'source venv/bin/activate' >> /home/vagrant/.bashrc",
-        require => Exec["create-virtualenv"],
-        user => vagrant
-    }
 }

--- a/puppet/manifests/classes/rabbitmq.pp
+++ b/puppet/manifests/classes/rabbitmq.pp
@@ -1,32 +1,32 @@
 class rabbitmq {
-    package { "rabbitmq-server":
-        ensure => installed;
-    }
+  package { "rabbitmq-server":
+    ensure => installed;
+  }
 
-    service { "rabbitmq-server":
-        ensure => running,
-        enable => true,
-        require => Package['rabbitmq-server'];
-    }
+  service { "rabbitmq-server":
+    ensure => running,
+    enable => true,
+    require => Package['rabbitmq-server'],
+  }
 
-    exec{ "create-rabbitmq-user":
-        command => "rabbitmqctl add_user ${RABBITMQ_USER} ${RABBITMQ_PASSWORD}",
-        unless => "rabbitmqctl list_users | grep ${RABBITMQ_USER}",
-        require => Service['rabbitmq-server']
-    }
+  exec{ "create-rabbitmq-user":
+    command => "rabbitmqctl add_user ${RABBITMQ_USER} ${RABBITMQ_PASSWORD}",
+    unless => "rabbitmqctl list_users | grep ${RABBITMQ_USER}",
+    require => Service['rabbitmq-server'],
+  }
 
-    exec{ "create-rabbitmq-vhost":
-        command => "rabbitmqctl add_vhost ${RABBITMQ_VHOST}",
-        unless => "rabbitmqctl list_vhosts | grep ${RABBITMQ_VHOST}",
-        require => Service['rabbitmq-server']
-    }
+  exec{ "create-rabbitmq-vhost":
+    command => "rabbitmqctl add_vhost ${RABBITMQ_VHOST}",
+    unless => "rabbitmqctl list_vhosts | grep ${RABBITMQ_VHOST}",
+    require => Service['rabbitmq-server'],
+  }
 
-    exec{ "grant-rabbitmq-permissions":
-        command => "rabbitmqctl set_permissions -p ${RABBITMQ_VHOST} ${RABBITMQ_USER} \".*\" \".*\" \".*\"",
-        unless => "rabbitmqctl list_user_permissions ${RABBITMQ_USER} | grep -P \"${RABBITMQ_VHOST}\t.*\t.*\t.*\"",
-        require => [
-            Exec["create-rabbitmq-user"],
-            Exec["create-rabbitmq-vhost"]
-        ]
-    }
+  exec{ "grant-rabbitmq-permissions":
+    command => "rabbitmqctl set_permissions -p ${RABBITMQ_VHOST} ${RABBITMQ_USER} \".*\" \".*\" \".*\"",
+    unless => "rabbitmqctl list_user_permissions ${RABBITMQ_USER} | grep -P \"${RABBITMQ_VHOST}\t.*\t.*\t.*\"",
+    require => [
+      Exec["create-rabbitmq-user"],
+      Exec["create-rabbitmq-vhost"]
+    ],
+  }
 }

--- a/puppet/manifests/classes/treeherder.pp
+++ b/puppet/manifests/classes/treeherder.pp
@@ -11,6 +11,6 @@ class treeherder {
     service{"memcached":
         ensure => running,
         enable => true,
-        require => Package['memcached'];
+        require => Package['memcached'],
     }
 }

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -3,8 +3,11 @@
 #
 import "classes/*.pp"
 
-$PROJ_DIR = "/home/vagrant/treeherder-service"
-
+$APP_URL="local.treeherder.mozilla.org"
+$APP_USER="vagrant"
+$APP_GROUP="vagrant"
+$PROJ_DIR = "/home/${APP_USER}/treeherder-service"
+$VENV_DIR = "/home/${APP_USER}/venv"
 # You can make these less generic if you like, but these are box-specific
 # so it's not required.
 $DB_NAME = "treeherder"
@@ -43,11 +46,11 @@ export TREEHERDER_RABBITMQ_PORT='${RABBITMQ_PORT}'
 
 class dev {
     class {
-        init: before => Class[mysql];
-        mysql: before  => Class[python];
-        python: before => Class[apache];
-        apache: before => Class[treeherder];
-        treeherder: before => Class[rabbitmq];
+        init: before => Class["mysql"];
+        mysql: before  => Class["python"];
+        python: before => Class["apache"];
+        apache: before => Class["treeherder"];
+        treeherder: before => Class["rabbitmq"];
         rabbitmq:;
     }
 }


### PR DESCRIPTION
This patch makes the provisioning more generic, removing hardcoded ip addresses, users, etc from the puppet code.
To provision a new system you got to produce a puppet file similar to vagrant.pp. This file will contain some settings specific to your target machine.
