### PR TITLE
sort the list of result sets descending by push_timestamp

### DIFF
--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -173,12 +173,13 @@
                       `rev`.`repository_id`,
                       `rev`.`comments`
                    FROM result_set as rs
-                   LEFT JOIN revision_map as rm
+                   INNER JOIN revision_map as rm
                        ON rs.id = rm.result_set_id
-                   LEFT JOIN revision as rev
+                   INNER JOIN revision as rev
                        ON rm.revision_id = rev.id
                    WHERE 1
                    REP0
+                   ORDER BY `rs`.`push_timestamp` DESC
                    LIMIT ?,?
                    ",
             "host": "read_host"
@@ -195,7 +196,7 @@
                    FROM result_set as rs
                    LEFT JOIN revision_map as rm
                        ON rs.id = rm.result_set_id
-                   LEFT JOIN revision as rev
+                   LEFT JOIN revision as rev`
                        ON rm.revision_id = rev.id
                    WHERE `rs`.`id` = ?",
             "host": "read_host"
@@ -227,7 +228,7 @@
                     ON j.`job_type_id` = jt.id
 				  LEFT JOIN `treeherder`.`job_group` as jg
                     ON jt.`job_group_id` = jg.id
-                  WHERE `result_set_id` = ?
+                  WHERE j.`result_set_id` = ?
                   REP0
                   ",
             "host": "read_host"

--- a/treeherder/webapp/api/views.py
+++ b/treeherder/webapp/api/views.py
@@ -153,9 +153,9 @@ class ResultSetViewSet(viewsets.ViewSet):
 
             objs = jm.get_result_set_list(
                 page,
-                1000,
+                10,
                 **dict((k, v) for k, v in request.QUERY_PARAMS.iteritems() if k in filters)
-                )
+            )
             return Response(objs)
         except DatasetNotFoundError as e:
             return Response({"message": unicode(e)}, status=404)


### PR DESCRIPTION
this sorts them and limits the number or `resultsets` to 10 per request, paginated.  (though the UI doesn't use the pagination yet)
