### PR TITLE
add persona authentication service

### DIFF
--- a/requirements/pure.txt
+++ b/requirements/pure.txt
@@ -4,5 +4,6 @@ python-memcached==1.48
 mozillapulse==0.61
 djangorestframework==2.3.5
 django-cors-headers==0.11
+django-browserid==0.8
 
 git+git://github.com/jeads/datasource@143ac08d11

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -60,6 +60,11 @@ TEMPLATE_DIRS = [
     path("webapp", "templates")
 ]
 
+TEMPLATE_CONTEXT_PROCESSORS = (
+   'django.contrib.auth.context_processors.auth',
+   'django_browserid.context_processors.browserid'
+)
+
 MIDDLEWARE_CLASSES = [
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -70,6 +75,25 @@ MIDDLEWARE_CLASSES = [
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+AUTHENTICATION_BACKENDS = (
+   'django_browserid.auth.BrowserIDBackend',
+   'django.contrib.auth.backends.ModelBackend'
+)
+
+# this tells browserid to not create users.
+# a user must be created first in the admin
+# and then can be recognized with persona login
+BROWSERID_CREATE_USER = False
+
+# Path to redirect to on successful login.
+LOGIN_REDIRECT_URL = '/'
+
+# Path to redirect to on unsuccessful login attempt.
+LOGIN_REDIRECT_URL_FAILURE = '/'
+
+# Path to redirect to on logout.
+LOGOUT_REDIRECT_URL = '/'
 
 INSTALLED_APPS = [
     'django.contrib.auth',
@@ -85,6 +109,7 @@ INSTALLED_APPS = [
     'south',
     'rest_framework',
     'corsheaders',
+    'django_browserid',
     # treeherder apps
     'treeherder.model',
     'treeherder.webapp',
@@ -148,7 +173,7 @@ REST_FRAMEWORK = {
     )
 }
 
-API_HOSTNAME = "http://localhost"
+SITE_URL = "http://local.treeherder.mozilla.org"
 
 # this setting allows requests from any host
 CORS_ORIGIN_ALLOW_ALL = True
@@ -193,3 +218,6 @@ BROKER_URL = 'amqp://{0}:{1}@{2}:{3}/{4}'.format(
     RABBITMQ_PORT,
     RABBITMQ_VHOST
 )
+
+API_HOSTNAME = SITE_URL
+ALLOWED_HOSTS = [SITE_URL]

--- a/treeherder/settings/local.sample.py
+++ b/treeherder/settings/local.sample.py
@@ -21,3 +21,8 @@ SECRET_KEY = os.environ.get("TREEHERDER_DJANGO_SECRET_KEY", "")
 # Make this unique so that if you execute the tests against a shared database,
 # you don't conflict with other people running the tests simultaneously.
 TEST_DB_PREFIX = ""
+
+SITE_URL = "http://dev.treeherder.mozilla.org"
+
+TREEHERDER_RO_DATABASE_USER     = os.environ.get("TREEHERDER_RO_DATABASE_USER", "TREEHERDER_DATABASE_USER")
+TREEHERDER_RO_DATABASE_PASSWORD = os.environ.get("TREEHERDER_RO_DATABASE_PASSWORD", "TREEHERDER_DATABASE_PASSWORD")

--- a/treeherder/webapp/templates/admin/login.html
+++ b/treeherder/webapp/templates/admin/login.html
@@ -1,0 +1,64 @@
+{% extends "admin/base_site.html" %}
+{% load browserid %}
+{% load i18n admin_static %}
+{% load url from future %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/login.css" %}" />{% endblock %}
+
+{% block extrahead %}{{ block.super }}{% browserid_info %}{% endblock %}
+
+{% block bodyclass %}login{% endblock %}
+
+{% block nav-global %}{% endblock %}
+
+{% block content_title %}{% endblock %}
+
+{% block breadcrumbs %}{% endblock %}
+
+{% block content %}
+{% if form.errors and not form.non_field_errors and not form.this_is_the_login_form.errors %}
+<p class="errornote">
+{% blocktrans count counter=form.errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktrans %}
+</p>
+{% endif %}
+
+{% if form.non_field_errors or form.this_is_the_login_form.errors %}
+{% for error in form.non_field_errors|add:form.this_is_the_login_form.errors %}
+<p class="errornote">
+    {{ error }}
+</p>
+{% endfor %}
+{% endif %}
+
+<div id="content-main">
+<form action="{{ app_path }}" method="post" id="login-form">{% csrf_token %}
+  <div class="form-row">
+    {% if not form.this_is_the_login_form.errors %}{{ form.username.errors }}{% endif %}
+    <label for="id_username" class="required">{% trans 'Username:' %}</label> {{ form.username }}
+  </div>
+  <div class="form-row">
+    {% if not form.this_is_the_login_form.errors %}{{ form.password.errors }}{% endif %}
+    <label for="id_password" class="required">{% trans 'Password:' %}</label> {{ form.password }}
+    <input type="hidden" name="this_is_the_login_form" value="1" />
+    <input type="hidden" name="next" value="{{ next }}" />
+  </div>
+  {% url 'admin_password_reset' as password_reset_url %}
+  {% if password_reset_url %}
+  <div class="password-reset-link">
+    <a href="{{ password_reset_url }}">{% trans 'Forgotten your password or username?' %}</a>
+  </div>
+  {% endif %}
+  <div class="submit-row">
+    <label>&nbsp;</label><input type="submit" value="{% trans 'Log in' %}" />
+  </div>
+  <p style="text-align: center;">or</p>
+  <p style="text-align: center;">{% browserid_login text='login with Persona' %}</p>
+</form>
+
+<script type="text/javascript">
+document.getElementById('id_username').focus()
+</script>
+<script src="http://code.jquery.com/jquery-1.9.1.min.js"></script>
+    {% browserid_js %}
+</div>
+{% endblock %}

--- a/treeherder/webapp/urls.py
+++ b/treeherder/webapp/urls.py
@@ -1,10 +1,15 @@
 from django.conf.urls import patterns, include, url
+from django.views.generic import TemplateView, RedirectView
 from django.contrib import admin
+
 from .api import urls as api_urls
 
 admin.autodiscover()
 
 urlpatterns = patterns('',
     url(r'^api/', include(api_urls)),
+    url(r'^browserid/', include('django_browserid.urls')),
     url(r'^admin/', include(admin.site.urls)),
+    # by default redirect all request on / to /admin/
+    url(r'^$', RedirectView.as_view(url='/admin/'))
 )


### PR DESCRIPTION
I added support for persona authentication on the project. In order to authenticate in the django admin a user must be created first (by another administrator for example) and then he can decide to authenticate with persona or with username and password. This should be enough to provide authentication in the ui as well.
I also added a redirection to /admin/ from / (index). That makes sense if the ui is not plugged. If the ui is plugged, we can set a redirection (or a simple alias) to /ui/ in the apache vhost.
