### PR TITLE
Gevent celery worker

### DIFF
--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -864,10 +864,10 @@ class JobsModel(TreeherderModelBase):
                     routing_key = 'parse_log.failures'
                 else:
                     routing_key = 'parse_log.success'
+                parse_log.apply_async(args=[self.project, task['id']],
+                                      kwargs={'check_errors': task['check_errors']},
+                                      routing_key=routing_key)
 
-                    parse_log.apply_async(args=[self.project, task['id']],
-                                          kwargs=dict(check_errors=task['check_errors']),
-                                          routing_key=routing_key)
 
     def store_job_artifact(self, artifact_placeholders):
         """

--- a/treeherder/model/derived/refdata.py
+++ b/treeherder/model/derived/refdata.py
@@ -1167,7 +1167,6 @@ class RefDataManager(object):
             debug_show=self.DEBUG)
 
     def get_suggested_bugs(self, search_term, open_bugs=True):
-
         if not search_term:
             return []
 
@@ -1178,9 +1177,3 @@ class RefDataManager(object):
             placeholders=[search_term] * 2,
             debug_show=self.DEBUG,
             replace=[replacement])
-
-
-
-
-
-

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -175,9 +175,9 @@ from kombu import Exchange, Queue
 CELERY_QUEUES = (
     Queue('default', Exchange('default'), routing_key='default'),
     # queue for failed jobs/logs
-    Queue('log_parser_fail', routing_key='parse_log.failures'),
+    Queue('log_parser_fail', Exchange('default'), routing_key='parse_log.failures'),
     # queue for successful jobs/logs
-    Queue('log_parser', routing_key='parse_log.success'),
+    Queue('log_parser', Exchange('default'), routing_key='parse_log.success'),
 )
 
 # default value when no task routing info is specified


### PR DESCRIPTION
This patch runs a worker on gevent, so that the log parser can be run on it. To achieve that, a couple of queues were added to host the parse_log tasks. The gevent-based celery worker will only listen to those queues.
