### PR TITLE
fix sql error when getting bug suggestions [Fixes #61326400]

### DIFF
--- a/tests/log_parser/test_tasks.py
+++ b/tests/log_parser/test_tasks.py
@@ -23,7 +23,7 @@ def jobs_with_local_log(jm, initial_data):
     return [job]
 
 
-def test_parse_log(jm, initial_data, jobs_with_local_log, sample_resultset, monkeypatch):
+def test_parse_log(jm, initial_data, jobs_with_local_log, sample_resultset):
     """
     check that at least 2 job_artifacts get inserted when running
     a parse_log task

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -21,6 +21,7 @@ def parse_log(project, job_id, check_errors=True):
     """
     jm = JobsModel(project=project)
     rdm = RefDataManager()
+
     try:
         log_references = jm.get_log_references(job_id)
 
@@ -43,8 +44,10 @@ def parse_log(project, job_id, check_errors=True):
 
                 all_errors = artifact_bc.artifacts['Structured Log']['step_data']['all_errors']
                 error_lines = [err['line'] for err in all_errors]
-                open_bugs_suggestions = rdm.get_suggested_bugs(error_lines)
-                closed_bugs_suggestions = rdm.get_suggested_bugs(error_lines, open_bugs=False)
+                open_bugs_suggestions = closed_bugs_suggestions = []
+                for line in error_lines:
+                    open_bugs_suggestions += rdm.get_suggested_bugs(line)
+                    closed_bugs_suggestions += rdm.get_suggested_bugs(line, open_bugs=False)
 
                 for item in open_bugs_suggestions:
                     artifact_list.append((job_id, 'open_bugs', 'json', json.dumps(item)))

--- a/treeherder/model/derived/refdata.py
+++ b/treeherder/model/derived/refdata.py
@@ -1184,6 +1184,10 @@ class RefDataManager(object):
             debug_show=self.DEBUG)
 
     def get_suggested_bugs(self, search_term, open_bugs=True):
+        """
+        retrieves bug suggestions from bugscache using search_term
+        in a full_text search.
+        """
         if not search_term:
             return []
 


### PR DESCRIPTION
The error was caused by a wrong usage of RefdataManager.get_bugs_suggestion. I wrote it to expect a string, while I was passing potentially a list of strings in the parse_log task.
