### PR TITLE
improve socketio channel subscription

### DIFF
--- a/treeherder/events/run_socketio.py
+++ b/treeherder/events/run_socketio.py
@@ -50,14 +50,14 @@ def broadcast_subscribers(body, msg):
     for session_id, socket in server.sockets.iteritems():
         # loop over all the open connections
         # and send a message when needed
-        if "event" not in socket.session or "branch" not in socket.session:
+        if "subscriptions" not in socket.session:
             continue
-        branch_condition = "*" in socket.session["branch"] \
-                           or body["branch"] in socket.session["branch"]
-        event_condition = "*" in socket.session["event"] \
-                           or body["event"] in socket.session["event"]
-        if branch_condition and event_condition:
-            socket.send_packet(pkt)
+
+        for branch, events in socket.session['subscriptions'].items():
+            if branch == body["branch"] or branch == "*":
+                if body["event"] in events or "*" in events:
+                    socket.send_packet(pkt)
+                    break
     msg.ack()
 
 


### PR DESCRIPTION
This patch allows more flexible subscription system, like the ability of subscribing for different events on different repositories. It also adds the ability to unsubscribe from a specific routing key, falling back to a complete cleaning if no key is specified
