### PR TITLE
added same filtering as jobs to resultsets

### DIFF
--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -332,7 +332,6 @@
                    WHERE rs.active_status = 'active'
                    REP0
                    ORDER BY rs.push_timestamp DESC
-                   LIMIT ?,?
                    ",
             "host": "read_host"
         },

--- a/treeherder/webapp/api/views.py
+++ b/treeherder/webapp/api/views.py
@@ -272,19 +272,17 @@ class ResultSetViewSet(viewsets.ViewSet):
         """
         GET method for list of ``resultset`` records with revisions
 
-        resultsetlist - specific resultset ids to retrieve
         """
 
-        filters = ["author", "revision", "resultsetlist"]
+        filters = UrlQueryFilter(request.QUERY_PARAMS).parse()
 
-        offset = int(request.QUERY_PARAMS.get('offset', 0))
-        count = int(request.QUERY_PARAMS.get('count', 10))
+        limit_condition = filters.pop("limit", set([("=", "0,10")])).pop()
+        offset, limit = limit_condition[1].split(",")
 
         objs = jm.get_result_set_list(
             offset,
-            count,
-            **dict((k, v) for k, v in request.QUERY_PARAMS.iteritems()
-                   if k in filters)
+            limit,
+            filters
         )
         return Response(self.get_resultsets_with_jobs(jm, objs, {}))
 


### PR DESCRIPTION
had to add `id` to jobs field list.  Only have `id` for resultsets at this time.  we will need support for some `revision` fields in there at some point to support `author` and such at a later time.
