### PR TITLE
modified result set paging to work off of a result set id offset

### DIFF
--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -375,7 +375,8 @@ class JobsModel(TreeherderModelBase):
 
         return result_set_id_lookup
 
-    def get_result_set_list(self, offset, limit, full=True, conditions=None):
+    def get_result_set_list(
+        self, offset_id, limit, full=True, conditions=None):
         """
         Retrieve a list of ``result_sets`` (also known as ``pushes``)
         If ``full`` is set to ``True`` then return revisions, too.
@@ -383,7 +384,6 @@ class JobsModel(TreeherderModelBase):
 
         Mainly used by the restful api to list the pushes in the UI
         """
-
         replace_str, placeholders = self._process_conditions(
             conditions, self.INDEXED_COLUMNS['result_set']
         )
@@ -398,7 +398,7 @@ class JobsModel(TreeherderModelBase):
             proc=proc,
             replace=[replace_str],
             placeholders=placeholders,
-            limit="{0},{1}".format(offset, limit),
+            limit=limit,
             debug_show=self.DEBUG,
         )
 

--- a/treeherder/webapp/api/views.py
+++ b/treeherder/webapp/api/views.py
@@ -390,12 +390,12 @@ class ResultSetViewSet(viewsets.ViewSet):
 
         filter = UrlQueryFilter(request.QUERY_PARAMS)
 
-        offset = filter.pop("offset", 0)
+        offset_id = filter.pop("id__lt", 0)
         count = filter.pop("count", 10)
         full = filter.pop('full', 'true').lower() == 'true'
 
         objs = jm.get_result_set_list(
-            offset,
+            offset_id,
             count,
             full,
             filter.conditions


### PR DESCRIPTION
This branch requires the treeherder-ui branch `rsMap-undefined-fix` for the UI to make use of the paging changes.
