### PR TITLE
fixing ``platform_opt`` to ``platform_option``

### DIFF
--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -39,7 +39,7 @@ def test_job_list(webapp, eleven_jobs_processed, jm):
         "job_type_symbol",
         "platform",
         "job_group_description",
-        "platform_opt",
+        "platform_option",
         "machine_platform_os",
         "build_os",
         "machine_platform_architecture",

--- a/treeherder/webapp/api/views.py
+++ b/treeherder/webapp/api/views.py
@@ -349,7 +349,7 @@ class JobsViewSet(viewsets.ViewSet):
                 job["artifacts"].append(art)
 
             option_collections = jm.refdata_model.get_all_option_collections()
-            job["platform_opt"] = get_option(job, option_collections)
+            job["platform_option"] = get_option(job, option_collections)
 
             return Response(job)
         else:
@@ -372,7 +372,7 @@ class JobsViewSet(viewsets.ViewSet):
         if objs:
             option_collections = jm.refdata_model.get_all_option_collections()
             for job in objs:
-                job["platform_opt"] = get_option(job, option_collections)
+                job["platform_option"] = get_option(job, option_collections)
 
         return Response(objs)
 
@@ -551,7 +551,6 @@ class ResultSetViewSet(viewsets.ViewSet):
                     for job in by_job_type:
                         job["id"] = job["job_id"]
                         del(job["job_id"])
-                        del(job["result_set_id"])
                         del(job["option_collection_hash"])
 
                         job["platform_option"] = platform_option


### PR DESCRIPTION
we broke starring a bit ago because we stopped doing a `_.extend` on job detail to the stored job in resultset model.  This extend was hiding the fact that the `resultset` endpoint was returning this field as `platform_option` but the `jobs` endpoint was returning it as `platform_opt`.  It also returns `result_set_id` with the resultset endpoint as another part of the bug.

So this is the service portion that standardizes on `platform_option`.  

The companion ui pr is: https://github.com/mozilla/treeherder-ui/pull/57
