### PR TITLE
returning excluded count of failures

### DIFF
--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -262,7 +262,7 @@
         },
 
         "get_unclassified_failure_count_excluded":{
-            "sql":"SELECT count(j.id) as count FROM job as j
+            "sql":"SELECT count(j.id) as count_excluded FROM job as j
                    LEFT JOIN REP0.machine_platform as mp
                      ON j.machine_platform_id = mp.id
                    LEFT JOIN REP0.job_type as jt
@@ -274,10 +274,10 @@
                    LEFT JOIN result_set as rs
                      ON rs.id = j.result_set_id
 
-                   WHERE failure_classification_id=1
-                   AND result in (REP1)
-                   AND rs.push_timestamp > REP2
-                   REP3",
+                   WHERE j.failure_classification_id=1
+                   AND j.result in (REP1)
+                   AND rs.push_timestamp > ?
+                   REP2",
             "host":"read_host"
         },
 

--- a/treeherder/model/utils.py
+++ b/treeherder/model/utils.py
@@ -44,22 +44,16 @@ def where_wolf(project, flat_exclusions):
 
     """
 
-    condition_list = []
+    values_list = []
 
     for exclusion in flat_exclusions:
         repos = json.loads(exclusion["flat_exclusion"])
-        for repo, platforms in repos.items():
-            if repo == project:
-                for platform, jobs in platforms.items():
-                    for job, opts in jobs.items():
-                        for opt, v in opts.items():
-                            condition_list.append(
-                                (" (mp.platform = '{0}' AND "
-                                "jt.name = '{1}' AND "
-                                "opt.name = '{2}')").format(platform, job, opt)
-                            )
+        platforms = repos[project]
+        for platform, jobs in platforms.items():
+            for job, opts in jobs.items():
+                for opt, v in opts.items():
+                    values_list.extend([platform, job, opt])
 
-    if condition_list:
-        return "AND ({0})".format(" OR ".join(condition_list))
-    else:
-        return None
+    condition = " (mp.platform = %s AND jt.name = %s AND opt.name = %s)"
+    condition_list = " OR ".join([condition] * (len(values_list)/3))
+    return " AND ({0})".format(condition_list), values_list

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -19,7 +19,7 @@ class JobsViewSet(viewsets.ViewSet):
         GET method for revisions of a resultset
         """
         all = jm.get_unclassified_failure_count()["count"]
-        excluded = jm.get_unclassified_failure_count_excluded()["count"]
+        excluded = jm.get_unclassified_failure_count_excluded()["count_excluded"]
 
         return Response({
             "repository": project,


### PR DESCRIPTION
This update adds a count of unclassified failures that are within the repo's default exclusion profile.

The `unclassified_failure_count` endpoint now returns something like this:

```
{
    "count": 99,
    "count_excluded": 28,
    "repository": "mozilla-inbound"
}
```

Where `count` is the total count of unclassified failures in the last week.  and `count_excluded` is the count of unclassified failures in this repo that are excluded by the default exclusion profile for the same time period.
