### PR TITLE
Make --host/--readonly-host params to init_datasources required

### DIFF
--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -34,7 +34,11 @@ To add a new repository, the following steps are needed:
 
   .. code-block:: bash
 
-     > python manage.py init_datasources
+     > python manage.py init_datasources --host localhost --readonly-host localhost
+
+  .. note::
+    If you are running treeherder in a non-development environment make sure to set ``--host`` and
+    ``--readonly-host`` to the correct database fqdns
 
 * Restart memcached to clean any previously cached datasource
 

--- a/treeherder/model/management/commands/init_datasources.py
+++ b/treeherder/model/management/commands/init_datasources.py
@@ -12,16 +12,18 @@ class Command(BaseCommand):
         make_option('--host',
             action='store',
             dest='host',
-            default='localhost',
             help='Host to associate the datasource to'),
         make_option('--readonly-host',
             action='store',
             dest='readonly_host',
-            default='localhost',
             help='Readonly host to associate the datasource to'),
     )
 
     def handle(self, *args, **options):
+        if not options['host']:
+            raise CommandError("The --host option is required")
+        if not options['readonly_host']:
+            raise CommandError("The --readonly-host option is required")
         projects = Repository.objects.all().values_list('name', flat=True)
         for project in projects:
             for contenttype in ("jobs","objectstore"):


### PR DESCRIPTION
We encounter issues where the defaults were incorrect when deploying in
production. We decided that having the user explicitly set where they
expect their databases to be was a good thing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-service/157)
<!-- Reviewable:end -->
