### PR TITLE
Update the readme to make it more comprehensive (1046639)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,32 @@ treeherder-service
 [![Code Health](https://landscape.io/github/mozilla/treeherder-service/master/landscape.png)](https://landscape.io/github/mozilla/treeherder-service/master)
 
 
-For installation instructions, see:
-https://treeherder-service.readthedocs.org/en/latest/installation.html
+#### Description
+<strong><a href="https://treeherder.mozilla.org" target=_newtab>Treeherder</a></strong> is a reporting dashboard for Mozilla checkins. It allows users to see the results of automatic builds and their respective tests. **Treeherder-service** manages the etl layer for data ingestion, web services, and the data model behind Treeherder.
+
+Treeherder is comprised of this repo for providing those back end services, and several other component repos:
+
+A <a href="https://github.com/mozilla/treeherder-ui" target=_newtab>treeherder-ui</a> repo for the front end UI.
+
+A <a href="https://github.com/mozilla/treeherder-client" target=_newtab>treeherder-client</a> for data submission.
+
+A <a href="https://github.com/lightsofapollo/treeherder-node" target=_newtab>treeherder-node</a> NodeJS interface.
+
+
+#### Instances
+Treeherder exists on three instances, <a href="http://treeherder-dev.allizom.org" target=_newtab>dev</a> for treeherder development, <a href="https://treeherder.allizom.org" target=_newtab>stage</a> for pre-deployment validation, and <a href="https://treeherder.mozilla.org" target=_newtab>production</a> for actual use.
+
+
+#### Installation
+The steps to install the treeherder-service are provided <a href="https://treeherder-service.readthedocs.org/en/latest/installation.html" target=_newtab>here</a>.
+
+
+#### Links
+
+Visit our project tracking Wiki at:  
+https://wiki.mozilla.org/Auto-tools/Projects/Treeherder
+
+Visit our **readthedocs** page for other setup and configuration at:  
+https://treeherder-service.readthedocs.org/en/latest/index.html
+
+File any bugs you may encounter [here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&component=Treeherder).


### PR DESCRIPTION
This work fixes item 2 of Bugzilla bug [1046639](https://bugzilla.mozilla.org/show_bug.cgi?id=1046639).

This updates the readme with all the requested content. I iterated with jeads on it in-channel this morning, and he is happy with it. The only question in my mind is should .md content have forced line breaks, or should the content line wrap? I am assuming the latter.

We have consciously chosen to use links with _newtab redirects to preserve the user's readme page.

Viewed on Windows in Github:
FF Release **31.0**
Chrome Latest Release **36.0.1985.125 m**

Adding @camd and @maurodoglio for visibility.
