### PR TITLE
(Bug 1035129) Fix missing job signatures

### DIFF
--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -26,6 +26,7 @@ def test_job_list(webapp, eleven_jobs_processed, jm):
         "job_guid",
         "state",
         "result",
+        "device_name",
         "build_platform_id",
         "job_coalesced_to_guid",
         "end_timestamp",

--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -145,9 +145,10 @@ class Builds4hTransformerMixin(object):
             platform_info = buildbot.extract_platform_info(prop['buildername'])
             job_name_info = buildbot.extract_name_info(prop['buildername'])
 
-            device_name = 'unknown'
-            if platform_info['vm'] == True:
-                device_name = 'vm'
+            device_name = buildbot.get_device_or_unknown(
+                job_name_info.get('name', ''),
+                platform_info['vm']
+            )
 
             if 'log_url' in prop:
                 log_reference = [{
@@ -299,7 +300,13 @@ class PendingTransformerMixin(object):
                     }
 
                     platform_info = buildbot.extract_platform_info(pending_job['buildername'])
+
                     job_name_info = buildbot.extract_name_info(pending_job['buildername'])
+
+                    device_name = buildbot.get_device_or_unknown(
+                        job_name_info.get('name', ''),
+                        platform_info['vm']
+                    )
 
                     new_job = {
                         'job_guid': common.generate_job_guid(pending_job['id'], pending_job['submitted_at']),
@@ -323,6 +330,7 @@ class PendingTransformerMixin(object):
                             'architecture': platform_info['arch'],
                             'vm': platform_info['vm']
                         },
+                        'device_name': device_name,
                         'who': 'unknown',
 
                         'option_collection': {
@@ -352,9 +360,9 @@ class PendingTransformerMixin(object):
                     treeherder_data['job'] = new_job
 
                     if project not in th_collections:
-                        th_collections[ project ] = TreeherderJobCollection(
+                        th_collections[project] = TreeherderJobCollection(
                             job_type='update'
-                            )
+                        )
 
                     # get treeherder job instance and add the job instance
                     # to the collection instance
@@ -404,6 +412,10 @@ class RunningTransformerMixin(object):
 
                     platform_info = buildbot.extract_platform_info(running_job['buildername'])
                     job_name_info = buildbot.extract_name_info(running_job['buildername'])
+                    device_name = buildbot.get_device_or_unknown(
+                        job_name_info.get('name', ''),
+                        platform_info['vm']
+                    )
 
                     new_job = {
                         'job_guid': common.generate_job_guid(
@@ -430,6 +442,7 @@ class RunningTransformerMixin(object):
                             'architecture': platform_info['arch'],
                             'vm': platform_info['vm']
                         },
+                        'device_name': device_name,
                         'who': 'unknown',
 
                         'option_collection': {

--- a/treeherder/etl/buildbot.py
+++ b/treeherder/etl/buildbot.py
@@ -795,3 +795,16 @@ def get_symbol(name, bn):
     if nummatch:
         n = nummatch.group(1)
     return "{0}{1}".format(s, n)
+
+
+def get_device_or_unknown(job_name, vm):
+    """
+    retrieve the device name or unknown if no device is detected
+    """
+    position = job_name.find("Device")
+    if position > 0:
+        return job_name[0: position-1]
+    elif vm is True:
+        return "vm"
+    else:
+        return "unknown"

--- a/treeherder/model/derived/refdata.py
+++ b/treeherder/model/derived/refdata.py
@@ -224,7 +224,8 @@ class RefDataManager(object):
 
             placeholders = [name, signature]
             placeholders.extend(reference_data)
-            placeholders.extend([int(time.time()), name, build_system_type, repository])
+            placeholders.extend([int(time.time()), name, signature,
+                                 build_system_type, repository])
             self.build_signature_placeholders.append(placeholders)
 
             self.reference_data_signature_lookup[signature] = reference_data

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -548,6 +548,7 @@
                     j.job_coalesced_to_guid,
                     j.failure_classification_id,
                     m.`name` as machine_name,
+                    d.`name` as device_name,
                     mp.`platform` as platform,
                     jt.`name` as job_type_name,
                     jt.`symbol` as job_type_symbol,
@@ -570,6 +571,8 @@
                     ON jt.`job_group_id` = jg.id
                   LEFT JOIN result_set rs
                     ON rs.id = j.result_set_id
+                  LEFT JOIN `REP0`.`device` as d
+                    ON j.device_id = d.id
                   WHERE 1
                   REP1
                   ORDER BY
@@ -588,6 +591,7 @@
                     j.`option_collection_hash`,
                     j.failure_classification_id,
                     m.`name` as machine_name,
+                    d.`name` as device_name,
                     mp.`platform` as platform,
                     mp.`os_name` as machine_platform_os,
                     mp.`architecture` as machine_platform_architecture,
@@ -621,6 +625,8 @@
                     ON j.`job_type_id` = jt.id
 				  LEFT JOIN `REP0`.`job_group` as jg
                     ON jt.`job_group_id` = jg.id
+                  LEFT JOIN `REP0`.`device` as d
+                    ON j.device_id = d.id
                   WHERE 1
                   REP1",
 

--- a/treeherder/model/sql/reference.json
+++ b/treeherder/model/sql/reference.json
@@ -10,9 +10,9 @@
                     SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
                     FROM DUAL
                     WHERE NOT EXISTS (
-                    SELECT `name`, `build_system_type`, `repository`
+                    SELECT `name`, `signature`, `build_system_type`, `repository`
                     FROM `reference_data_signatures`
-                    WHERE `name` = ? AND `build_system_type` = ? AND `repository` = ?
+                    WHERE `name` = ? AND `signature` = ? AND `build_system_type` = ? AND `repository` = ?
                     )",
             "host":"master_host"
         },

--- a/treeherder/model/sql/template_schema/treeherder_reference_1.sql.tmpl
+++ b/treeherder/model/sql/template_schema/treeherder_reference_1.sql.tmpl
@@ -81,7 +81,7 @@ CREATE TABLE `reference_data_signatures` (
   `first_submission_timestamp` int(10) unsigned NOT NULL,
   `review_timestamp` int(10) unsigned DEFAULT NULL,
   `review_status` enum('reviewed', 'not_reviewed', 'on_hold') COLLATE utf8_bin DEFAULT 'not_reviewed',
-  UNIQUE KEY `uni_name_build_type_repository` (`name`, `build_system_type`, `repository`),
+  UNIQUE KEY `uni_name_signature_build_type_repository` (`name`, `signature`, `build_system_type`, `repository`),
   KEY `idx_id` (`id`),
   KEY `idx_signature` (`signature`),
   KEY `idx_build_os_name` (`build_os_name`),


### PR DESCRIPTION
I changed the unique key on the reference data signatures table to
 (signature, name, build_system_type, repository). I also added the
device_name information to the payload submitted by
fetch_buildapi_pending and fetch_buildapi_running. That was the main
cause for the repeated signatures in the reference data signatures
table.
