### PR TITLE
Bug 1059306 - Return a dict not None if no valid search terms found; r=mdoglio

### DIFF
--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -74,7 +74,7 @@ def parse_log(project, job_log_url, job_guid, check_errors=False):
                     clean_line = get_mozharness_substring(err['line'])
                     # get a meaningful search term out of the error line
                     search_term = get_error_search_term(clean_line)
-                    bugs = None
+                    bugs = dict(open_recent=[], all_others=[])
 
                     # collect open recent and all other bugs suggestions
                     if search_term:


### PR DESCRIPTION
The UI expects bugs to be a dict, rather than None. This change also
makes the return value consistent with that when a search term is
identified, but the get_bugs_for_search_term() found zero bugs.
