### PR TITLE
Set re.IGNORECASE correctly for the build_type regex (bug 1062228)

### DIFF
--- a/tests/etl/test_buildbot.py
+++ b/tests/etl/test_buildbot.py
@@ -595,7 +595,7 @@ buildernames = [
                    'os_platform': 'osx-10-8',
                    'vm': False}}),
     ('Ubuntu ASAN VM 12.04 x64 mozilla-inbound opt test crashtest',
-    {'build_type': 'opt',
+    {'build_type': 'asan',
       'job_type': 'unittest',
       'name': {'group_name': 'Reftest',
                'group_symbol': 'R',

--- a/treeherder/etl/buildbot.py
+++ b/treeherder/etl/buildbot.py
@@ -264,11 +264,11 @@ VM_STATUS = [
 BUILD_TYPE_BUILDERNAME = [
     {
         'type': 'pgo',
-        'regex': re.compile('.+ pgo(?:[ ]|-).+'),
+        'regex': re.compile('.+ pgo[ -].+', re.IGNORECASE),
     },
     {
         'type': 'asan',
-        'regex': re.compile('.+ asan .+'),
+        'regex': re.compile('.+ asan .+', re.IGNORECASE),
     },
     {
         'type': 'debug',
@@ -752,7 +752,7 @@ def extract_vm_status(source_string):
 def extract_build_type(source_string):
     output = 'opt'
     for build_type in BUILD_TYPE_BUILDERNAME:
-        if build_type["regex"].search(source_string, re.IGNORECASE):
+        if build_type["regex"].search(source_string):
             output = build_type["type"]
             return output
     return output


### PR DESCRIPTION
Only the re module function .search() accepts the flags argument - for the regexobject search() method it actually gets interpreted as the 'pos' parameter, since |re.IGNORECASE == 2|.

With this change we now correctly identify tests run on ASAN builds as buildtype 'asan'.
Updates the test that was testing we were wrong, doh.
