### PR TITLE
Bug 1059788 - Limit search term lengths to 100 characters.

### DIFF
--- a/tests/log_parser/test_utils.py
+++ b/tests/log_parser/test_utils.py
@@ -26,6 +26,34 @@ def test_get_error_search_term(line, exp_search_term):
 
     assert actual_search_term == exp_search_term
 
+LONG_LINE_TEST_CASES = (
+    (
+        (
+            'command timed out: 2400 seconds without output running '
+            '[\'/tools/buildbot/bin/python\', '
+            '\'scripts/scripts/android_emulator_unittest.py\', \'--cfg\', '
+            '\'android/androidx86.py\', \'--test-suite\', \'robocop-1\', '
+            '\'--test-suite\', \'robocop-2\', \'--test-suite\', \'robocop-3\', '
+            '\'--test-suite\', \'xpcshell\', \'--blob-upload-branch\', '
+            '\'b2g-inbound\', \'--download-symbols\', \'ondemand\'], '
+            'attempting to kill'
+        ),
+        (
+            'command timed out: 2400 seconds without output running '
+            '[\'/tools/buildbot/bin/python\', \'scripts/scrip'
+        )
+    ),
+)
+
+#command timed out: 2400 seconds without output running ['/tools/buildbot/bin/python', 'scripts/scripts/android_emulator_unittest.py', '--cfg', 'android/androidx86.py', '--test-suite', 'robocop-1', '--test-suite', 'robocop-2', '--test-suite', 'robocop-3', '--test-suite', 'xpcshell', '--blob-upload-branch', 'b2g-inbound', '--download-symbols', 'ondemand'], attempting to kill
+
+@pytest.mark.parametrize(("line", "exp_search_term"), LONG_LINE_TEST_CASES)
+def test_get_long_search_term(line, exp_search_term):
+    """tests that long search terms are capped at 100 characters"""
+
+    actual_search_term = get_error_search_term(line)
+
+    assert actual_search_term == exp_search_term
 
 CRASH_LINE_TEST_CASES = (
     (

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -74,6 +74,16 @@ def get_error_search_term(error_line):
     if not (search_term and is_helpful_search_term(search_term)):
        search_term = error_line if is_helpful_search_term(error_line) else None
 
+    # Searching for extremely long search terms is undesirable, since:
+    # a) Bugzilla's max summary length is 256 characters, and once "Intermittent "
+    # and platform/suite information is prefixed, there are even fewer characters
+    # left for us to use for the failure string against which we need to match.
+    # b) For long search terms, the additional length does little to prevent against
+    # false positives, but means we're more susceptible to false negatives due to
+    # run-to-run variances in the error messages (eg paths, process IDs).
+    if search_term:
+       search_term = search_term[:100]
+
     return search_term
 
 


### PR DESCRIPTION
I have no confidence in this patch, but I think this might possibly work.
