### PR TITLE
Bug 1065568 - Make the pushlog ingestion more frequent

### DIFF
--- a/treeherder/model/fixtures/tasks.json
+++ b/treeherder/model/fixtures/tasks.json
@@ -68,7 +68,7 @@
             "enabled": true,
             "routing_key": null,
             "crontab": null,
-            "interval": 1,
+            "interval": 2,
             "queue": null,
             "total_run_count": 0,
             "expires": null,


### PR DESCRIPTION
This addresses Bugzilla bug [1065568](https://bugzilla.mozilla.org/show_bug.cgi?id=1065568).

This change increases the frequency of pushlog ingestion from every 3 minutes to every 1 minute.

Adding @camd and @jeads  for review.
