### PR TITLE
Bug 1065786 - Disable swagger by default

### DIFF
--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -136,7 +136,6 @@ INSTALLED_APPS = [
     'south',
     'rest_framework',
     'rest_framework_extensions',
-    'rest_framework_swagger',
     'corsheaders',
     'django_browserid',
     # treeherder apps

--- a/treeherder/settings/local.sample.py
+++ b/treeherder/settings/local.sample.py
@@ -11,7 +11,7 @@ TREEHERDER_MEMCACHED_KEY_PREFIX = os.environ.get("TREEHERDER_MEMCACHED_KEY_PREFI
 
 # Applications useful for development, e.g. debug_toolbar, django_extensions.
 # Always empty in production
-LOCAL_APPS = []
+LOCAL_APPS = ["rest_framework_swagger"]
 
 DEBUG = os.environ.get("TREEHERDER_DEBUG") is not None
 

--- a/treeherder/webapp/urls.py
+++ b/treeherder/webapp/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.conf.urls import patterns, include, url
 from django.views.generic import RedirectView
 from django.contrib import admin
@@ -11,9 +12,16 @@ browserid_admin.copy_registry(admin.site)
 
 urlpatterns = patterns('',
     url(r'^api/', include(api_urls)),
+)
 
+# make swagger available only if it's installed in INSTALLED_APPS
+if 'rest_framework_swagger' in settings.INSTALLED_APPS:
+    urlpatterns += patterns('',
+        url(r'^docs/', include('rest_framework_swagger.urls')),
+    )
+
+urlpatterns += patterns('',
     url(r'^admin/', include(browserid_admin.urls)),
-    url(r'^docs/', include('rest_framework_swagger.urls')),
     url(r'', include('django_browserid.urls')),
     # by default redirect all request on / to /ui/
     url(r'^$', RedirectView.as_view(url='/ui/'))


### PR DESCRIPTION
This allows to enable it on dev and stage only.
The sample local.py settings file has swagger enabled, so new
contributors will get it locally by default
