### PR TITLE
Bug 1035222 - Use correct Thunderbird repo name to fix ingestion

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -420,10 +420,10 @@
     "model": "model.repository",
     "fields": {
         "dvcs_type": "hg",
-        "name": "thunderbird-trunk",
+        "name": "comm-central",
         "url": "https://hg.mozilla.org/comm-central",
         "active_status": "active",
-        "codebase": "?",
+        "codebase": "comm",
         "repository_group": 1,
         "description": ""
     }
@@ -433,10 +433,10 @@
     "model": "model.repository",
     "fields": {
         "dvcs_type": "hg",
-        "name": "thunderbird-try",
+        "name": "try-comm-central",
         "url": "https://hg.mozilla.org/try-comm-central",
         "active_status": "active",
-        "codebase": "?",
+        "codebase": "comm",
         "repository_group": 3,
         "description": ""
     }
@@ -446,10 +446,10 @@
     "model": "model.repository",
     "fields": {
         "dvcs_type": "hg",
-        "name": "thunderbird-aurora",
+        "name": "comm-aurora",
         "url": "https://hg.mozilla.org/releases/comm-aurora",
         "active_status": "active",
-        "codebase": "?",
+        "codebase": "comm",
         "repository_group": 2,
         "description": ""
     }
@@ -459,10 +459,10 @@
     "model": "model.repository",
     "fields": {
         "dvcs_type": "hg",
-        "name": "thunderbird-beta",
+        "name": "comm-beta",
         "url": "https://hg.mozilla.org/releases/comm-beta",
         "active_status": "active",
-        "codebase": "?",
+        "codebase": "comm",
         "repository_group": 2,
         "description": ""
     }
@@ -472,10 +472,10 @@
     "model": "model.repository",
     "fields": {
         "dvcs_type": "hg",
-        "name": "thunderbird-esr24",
+        "name": "comm-esr24",
         "url": "https://hg.mozilla.org/releases/comm-esr24",
         "active_status": "active",
-        "codebase": "?",
+        "codebase": "comm",
         "repository_group": 2,
         "description": ""
     }


### PR DESCRIPTION
The repository name must match that used by buildbot in builds-4hr,
builds-running, builds-pending, clobberer & self-serve otherwise
data ingestion and many links in the UI will break.
The only service that requires a different repo name is treestatus,
which will require a treeherder-ui change after this lands.
