### PR TITLE
Publish messages to pulse

### DIFF
--- a/schemas/resultset-message.json
+++ b/schemas/resultset-message.json
@@ -1,0 +1,25 @@
+{
+  "id":           "https://treeherder.mozilla.org/schemas/v1/resultset-message.json#",
+  "$schema":      "http://json-schema.org/draft-04/schema#",
+  "title":        "New ResultSet Message",
+  "description":  "Pulse message sent whenever a new result-set is created.",
+  "type":         "object",
+  "properties": {
+    "version": {
+      "title":                "Message-format version",
+      "enum":                 [1]
+    },
+    "project": {
+      "title":                "Project Name",
+      "description":          "Identifier for treeherder project, like `try` or `mozilla-central`.",
+      "type":                 "string"
+    },
+    "revision_hash": {
+      "title":                "Revision Hash Identifier",
+      "description":          "Identifier for the result-set that was created.",
+      "type":                 "string"
+    }
+  },
+  "additionalProperties":     true,
+  "required": ["version", "revision_hash"]
+}

--- a/treeherder/model/exchanges.py
+++ b/treeherder/model/exchanges.py
@@ -1,0 +1,29 @@
+from pulse_publisher import PulsePublisher, Exchange, Key
+
+class TreeherderPublisher(PulsePublisher):
+    title = "TreeHerder Exchanges"
+    description = """
+        Exchanges for services that wants to know what shows up on TreeHerder.
+    """
+    exchange_prefix = 'v1/'
+
+    new_result_set = Exchange(
+        exchange      = 'new-result-set',
+        title         = "New Result-Set Messages",
+        description   = """
+            Whenever a new result-set is created a message featuring the
+            `revision_hash` is published on this exchange.
+        """,
+        routing_keys  = [
+            Key(
+                name    = 'project',
+                summary = "Project (or branch) that this result-set concerns"
+            ),
+            Key(
+                name    = 'revision_hash',
+                summary = "result-set identifier for the message"
+            )
+        ],
+        schema = "https://treeherder.mozilla.org/schemas/v1/resultset-message.json#"
+    )
+

--- a/treeherder/model/pulse_publisher.py
+++ b/treeherder/model/pulse_publisher.py
@@ -1,0 +1,193 @@
+import kombu, re, json, os, jsonschema
+
+def toCamelCase(input):
+    def replace(match):
+        return match.group(1).upper()
+    return re.sub(r'_(.)', replace, input)
+
+def load_schemas(folder):
+    """ Load JSON schemas from folder """
+    schemas = {}
+
+    # List files in folder
+    for filename in os.listdir(folder):
+        # Skip non-json files
+        if not filename.endswith('.json'):
+            continue
+
+        # Read file and insert into schemas
+        with open(os.path.join(folder, filename)) as f:
+            data = json.load(f)
+            assert data.has_key('id'), "JSON schemas must have an 'id' property"
+            schemas[data['id']] = data
+
+    # Return schemas loaded
+    return schemas
+
+
+class Exchange(object):
+    """
+        Exchange declaration that can be used as property on a subclass of
+        PulsePublisher.
+    """
+    def __init__(self, exchange, title, description, routing_keys, schema):
+        """
+          Create exchange instance
+        """
+        self.exchange     = exchange
+        self.title        = title
+        self.description  = description
+        self.routing_keys = routing_keys
+        self.schema       = schema
+
+    def message(self, message, **keys):
+        """ Construct message """
+        return message
+
+    def routing(self, message, **keys):
+        """ Construct routing key """
+        return '.'.join([key.build(**keys) for key in self.routing_keys])
+
+    def reference(self, name):
+        """ Construct reference entry with given name """
+        return {
+            'type':           'topic-exchange',
+            'exchange':       self.exchange,
+            'name':           toCamelCase(name),
+            'title':          self.title,
+            'description':    self.description,
+            'routingKey':     [key.reference() for key in self.routing_keys],
+            'schema':         self.schema
+        }
+
+class Key(object):
+    """ Routing key entry """
+    def __init__(self, name, summary, required = True, multiple_words = False):
+        self.name           = name
+        self.summary        = summary
+        self.required       = required
+        self.multiple_words = multiple_words
+
+    def build(self, **keys):
+        """ Build routing key entry """
+        key = keys.get(self.name)
+        # Ensure the key is present if required
+        if self.required and key is None:
+            raise ValueError("Key %s is required" % self.name)
+        key = key or '_'
+        # Check if has multiple words
+        if '.' in key and not self.multiple_words:
+            raise ValueError("Key %s cannot contain dots" % self.name)
+        # Return constructed key
+        return key
+
+    def reference(self):
+        """ Construct reference entry for this routing key entry """
+        return {
+            'name':               toCamelCase(self.name),
+            'summary':            self.summary,
+            'multipleWords':      self.multiple_words,
+            'required':           self.required
+        }
+
+
+class PulsePublisher(object):
+    """
+        Base class for pulse publishers.
+
+        All subclasses of this class must define the properties:
+          * title
+          * description
+          * exchange_prefix
+
+        Additional properties of type `Exchange` will be declared as exchanges.
+    """
+    def __init__(self, client_id, access_token, schemas, namespace = None):
+        """
+            Create publisher, requires a connection_string and a mapping from
+            JSON schema uris to JSON schemas.
+        """
+        # Validate properties
+        assert hasattr(self, 'title'), "Title is required"
+        assert hasattr(self, 'description'), "description is required"
+        assert hasattr(self, 'exchange_prefix'), "exchange_prefix is required"
+
+        # Set attributes
+        self.client_id      = client_id
+        self.access_token   = access_token
+        self.schemas        = schemas
+        self.namespace      = namespace or client_id
+        self.exchanges      = []
+        self.connection     = kombu.Connection(
+            userid              = client_id,
+            password            = access_token,
+            hostname            = 'pulse.mozilla.org',
+            virtual_host        = '/',
+            port                = 5671,
+            ssl                 = True,
+            transport           = 'amqp',
+            # This should work, but it doesn't... Basically, docs either lie,
+            # or everything python is broken as usual. At this point the best
+            # work around to call publisher.connection.release() after
+            # publishing something. It doesn't provide the same safety, but it's
+            # better than closing process to early.
+            transport_options   = {
+                'confirm_publish':  True,
+                'block_for_ack':    True
+            }
+        )
+
+        # Find exchanges
+        for name in dir(self):
+            exchange = getattr(self, name)
+            if isinstance(exchange, Exchange):
+                self.exchanges += ((name, exchange),)
+
+        # Wrap exchanges in functions
+        for name, exchange in self.exchanges:
+            # Create producer for the exchange
+            exchange_path = "exchange/%s/%s%s" % (
+                                self.namespace,
+                                self.exchange_prefix,
+                                exchange.exchange
+                            )
+            producer = kombu.Producer(
+                channel       = self.connection,
+                exchange      = kombu.Exchange(
+                                    name            = exchange_path,
+                                    type            = 'topic',
+                                    durable         = True,
+                                    delivery_mode   = 'persistent'
+                                ),
+                auto_declare  = True
+            )
+            publish_message = self.connection.ensure(
+                producer, producer.publish, max_retries = 3
+            )
+            # Create publication method for the exchange
+            def publish(**kwargs):
+                message = exchange.message(**kwargs)
+                jsonschema.validate(message, self.schemas[exchange.schema])
+                publish_message(
+                    body          = json.dumps(message),
+                    routing_key   = exchange.routing(**kwargs),
+                    content_type  = 'application/json'
+                )
+            setattr(self, name, publish)
+
+    def error(self, error, exchange, routing_key, message):
+        print routing_key
+        print err
+
+    def reference(self):
+        """ Construct reference for this publisher"""
+        return {
+            'version':          '0.2.0',
+            'title':            self.title,
+            'description':      self.description,
+            'exchangePrefix':   "exchange/%s/%s" % (
+                                    self.namespace,
+                                    self.exchange_prefix
+                                ),
+            'entries':  [ex.reference(name) for name, ex in self.exchanges]
+        }


### PR DESCRIPTION
So I did some utilities for publishing messages to pulse, adapted JSON schema and generated JSON reference following the JSON schema for exchange references that I have proposed:
http://docs.taskcluster.net/tools/references/index.html

Regardless of whether or not you like to document and publish your exchange reference and JSON schemas. The utilities I've coded to for publishing messages here isn't all crazy :)
For example if using a `treeherder-stage` pulse-user for the staging site, all of its events will be published under `exchange/treeherder-stage/v1/new-result-set`. 
As I barely know what things do, I've left it to you to add a few documentation strings here and there.. and maybe rename the exhanges. **I don't know what I'm doing** :)

My use-case is that I want to pick up pushes (for certain branches) and then create additional tests/tasks/builds and append their results back into treeherder. As far as I understand that should be fairly straight forward. Assuming I get the right events, identifiers and can guess what the identifiers are good for :)

Things needed:
1. get `treeherder` user for pulse (the name treeherder is important as it is used in exchange naming)
2. publication of JSON reference and JSON schema
3. Resolution of `repository_id` to repository/branch name or whatever it's supposed to cover...
4. Proper naming and a bit of docs about what it is I am reporting here (I'm not sure)
    (In particular `revision_hash` vs `revision`).
5. Cleanup of code, if you have a way to organize things
6. See TODOs for config and stuff...

Note, ideally, I think (2) could be done by the pulse publisher utilities, which I propose that we convince mcote to make a part of the official pulse package. (2) isn't critical, ideally, pulse-guardian could have an API end-point that would allow one to upload references and JSON schemas.
