### PR TITLE
clear the pushlog cache when init_datasources gets called

### DIFF
--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -5,6 +5,7 @@ from thclient import TreeherderRequest, TreeherderResultSetCollection
 from .mixins import JsonExtractorMixin, OAuthLoaderMixin
 from treeherder.etl.common import generate_revision_hash
 
+PUSHLOG_CACHE_KEY = "{0}:last_push"
 
 class HgPushlogTransformerMixin(object):
 
@@ -61,7 +62,7 @@ class HgPushlogTransformerMixin(object):
 
         # cache the last push seen
         if last_push:
-            cache.set("{0}:last_push".format(repository), last_push)
+            cache.set(PUSHLOG_CACHE_KEY.format(repository), last_push)
 
         return th_collections
 
@@ -74,7 +75,7 @@ class HgPushlogProcess(JsonExtractorMixin,
 
         # get the last object seen from cache. this will
         # reduce the number of pushes processed every time
-        last_object = cache.get("{0}:last_push".format(repository))
+        last_object = cache.get(PUSHLOG_CACHE_KEY.format(repository))
         if last_object:
             source_url += "&startID=" + last_object
 

--- a/treeherder/model/management/commands/init_datasources.py
+++ b/treeherder/model/management/commands/init_datasources.py
@@ -4,7 +4,9 @@ from django.utils.six.moves import input
 from django.conf import settings
 
 from django.core.management.base import BaseCommand, CommandError
+from django.core.cache import cache
 from treeherder.model.models import Datasource, Repository
+from treeherder.etl.pushlog import PUSHLOG_CACHE_KEY
 
 
 class Command(BaseCommand):
@@ -50,4 +52,6 @@ Type 'yes' to continue, or 'no' to cancel: """)
                     host=options['host'],
                     read_only_host=options['readonly_host']
                 )
+            # clear the pushlog cache
+            cache.delete(PUSHLOG_CACHE_KEY.format(project))
         Datasource.reset_cache()


### PR DESCRIPTION
A very quick fix for something pretty annoying for contributors. There is no bug open for this, ping me if you want me to open one.
