### PR TITLE
Bug 1067481 - Adjust build type & VM regex to fix jetpack asan jobs

### DIFF
--- a/tests/etl/test_buildbot.py
+++ b/tests/etl/test_buildbot.py
@@ -848,6 +848,17 @@ buildernames = [
                    'os': 'b2g',
                    'os_platform': 'b2g-device-image',
                    'vm': False}}),
+    ('jetpack-fx-team-ubuntu64-asan_vm-opt',
+     {'build_type': 'asan',
+      'job_type': 'unittest',
+      'name': {'group_name': 'unknown',
+               'group_symbol': '?',
+               'name': 'Jetpack SDK Test',
+               'job_symbol': 'JP'},
+      'platform': {'arch': 'x86_64',
+                   'os': 'linux',
+                   'os_platform': 'linux64',
+                   'vm': True}}),
 ]
 
 

--- a/treeherder/etl/buildbot.py
+++ b/treeherder/etl/buildbot.py
@@ -21,6 +21,10 @@ RESULT_DICT = {
 #         pulse stream these structures can be removed.
 ####
 
+# Buildernames use a mixture of spaces, underscores and hyphens as separators.
+# Since \b doesn't match against underscores, we need to supplement it.
+WORD_BOUNDARY_RE = r'(?:_|\b)'
+
 # source for these is in ``Data.js.getMachine`` function.
 PLATFORMS_BUILDERNAME = [
 
@@ -257,22 +261,21 @@ PLATFORMS_BUILDERNAME = [
 ]
 
 VM_STATUS = [
-    re.compile(' VM '),
-    re.compile('.*_vm ')
+    re.compile(WORD_BOUNDARY_RE + r'vm' + WORD_BOUNDARY_RE, re.IGNORECASE)
 ]
 
 BUILD_TYPE_BUILDERNAME = [
     {
         'type': 'pgo',
-        'regex': re.compile('.+ pgo[ -].+', re.IGNORECASE),
+        'regex': re.compile(WORD_BOUNDARY_RE + r'pgo', re.IGNORECASE),
     },
     {
         'type': 'asan',
-        'regex': re.compile('.+ asan .+', re.IGNORECASE),
+        'regex': re.compile(WORD_BOUNDARY_RE + r'asan', re.IGNORECASE),
     },
     {
         'type': 'debug',
-        'regex': re.compile('(?:debug|leak)', re.IGNORECASE),
+        'regex': re.compile(WORD_BOUNDARY_RE + r'(?:debug|leak test)', re.IGNORECASE),
     }
     # defaults to "opt" if not found
 ]


### PR DESCRIPTION
Jetpack (addon-sdk) asan jobs have the buildername:
"jetpack-fx-team-ubuntu64-asan_vm-opt"

Both the build type of asan and the VM status of the job were not
caught by the previous regex, due to the word separators differing
from those seen on other repositories.
