### PR TITLE
Bug 1063411 - Remove ui route

### DIFF
--- a/puppet/files/apache/treeherder-service.conf
+++ b/puppet/files/apache/treeherder-service.conf
@@ -6,19 +6,56 @@
     Allow from all
   </Proxy>
 
-
-  Alias /static <%= @PROJ_DIR %>/treeherder/webapp/static
-  ProxyPass        /static !
-
-  Alias /media <%= @PROJ_DIR %>/treeherder/webapp/media
-  ProxyPass        /media !
-
+  ###########
+  # This is for backwords compatibility with old style treeherder urls
+  ###########
   Alias /ui /home/<%= @APP_USER %>/treeherder-ui/<%= @APP_UI %>
   ProxyPass        /ui !
 
+  ###########
+  # Shared locations between production and dev environment
+  ###########
+  Alias /help.html /home/<%= @APP_USER %>/treeherder-ui/<%= @APP_UI %>/help.html
+  ProxyPass        /help.html !
+
+  Alias /logviewer.html /home/<%= @APP_USER %>/treeherder-ui/<%= @APP_UI %>/logviewer.html
+  ProxyPass        /logviewer.html !
+
+  Alias /js /home/<%= @APP_USER %>/treeherder-ui/<%= @APP_UI %>/js
+  ProxyPass        /js !
+
+  Alias /css /home/<%= @APP_USER %>/treeherder-ui/<%= @APP_UI %>/css
+  ProxyPass        /css !
+
+  Alias /img /home/<%= @APP_USER %>/treeherder-ui/<%= @APP_UI %>/img
+  ProxyPass        /img !
+
+  Alias /fonts /home/<%= @APP_USER %>/treeherder-ui/<%= @APP_UI %>/fonts
+  ProxyPass        /fonts !
+
+  ###########
+  # These locations are to support loading files directly from treeherder-ui
+  # to support local development
+  ###########
+  Alias /vendor /home/<%= @APP_USER %>/treeherder-ui/<%= @APP_UI %>/vendor
+  ProxyPass        /vendor !
+
+  Alias /plugins /home/<%= @APP_USER %>/treeherder-ui/<%= @APP_UI %>/plugins
+  ProxyPass        /plugins !
+
+  Alias /partials /home/<%= @APP_USER %>/treeherder-ui/<%= @APP_UI %>/partials
+  ProxyPass        /partials !
+
+  Alias /icons /home/<%= @APP_USER %>/treeherder-ui/<%= @APP_UI %>/icons
+  ProxyPass        /icons !
+  ############
+
+  Alias / /home/<%= @APP_USER %>/treeherder-ui/<%= @APP_UI %>/index.html
+  ProxyPass        / !
+
   ProxyPass        / http://localhost:8000/
   ProxyPassReverse / http://localhost:8000/
-  ProxyPreserveHost On 
+  ProxyPreserveHost On
 
   ErrorLog /var/log/<%= @apache_service %>/treeherder-service_err.log
   LogLevel warn


### PR DESCRIPTION
Removed the requirement for an explicit /ui url location but kept a ProxyPass for it for backwards compatibility for the old style treeherder urls. This PR requires running "vagrant provision" to run locally. We will need to coordinate with IT to update the puppet provisioning to push to production.
