### PR TITLE
Temporarily consume buildapi and pushlog queues from default

### DIFF
--- a/bin/run_celery_worker
+++ b/bin/run_celery_worker
@@ -21,4 +21,4 @@ if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec $NEWRELIC_ADMIN $PYTHON manage.py celeryd -c 3 -Q default -E --maxtasksperchild=500 --logfile=$LOGFILE -l INFO
+exec $NEWRELIC_ADMIN $PYTHON manage.py celeryd -c 3 -Q default,buildapi,pushlog -E --maxtasksperchild=500 --logfile=$LOGFILE -l INFO


### PR DESCRIPTION
This is to support the use of separate queues for etl tasks until we
have dedicated machines on production
