### PR TITLE
Bug 1083305 - fix resultsets with missing revisions

### DIFF
--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -2625,13 +2625,13 @@ class JobsModel(TreeherderModelBase):
                     result_set_id_lookup[revision_hash]['id']
                     )
 
-            # Insert new revisions
-            dhub.execute(
-                proc='jobs.inserts.set_revision',
-                placeholders=revision_placeholders,
-                executemany=True,
-                debug_show=self.DEBUG
-                )
+        # Insert new revisions
+        dhub.execute(
+            proc='jobs.inserts.set_revision',
+            placeholders=revision_placeholders,
+            executemany=True,
+            debug_show=self.DEBUG
+            )
 
         # Retrieve new revision ids
         rev_where_in_clause = ','.join(rev_where_in_list)


### PR DESCRIPTION
this tries to ingest the revisions for a resultset, even if the resultset itself already exists.  If we already have the revisions, it will just skip them anyway.

@jeads had looked over and approved this change yesterday.
