### PR TITLE
Bug 1085455 - Update the docs Title to be consistent with treeherder-ui

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to treeherder's documentation!
-======================================
+Welcome to Treeherder's Service documentation!
+==============================================
 
 Contents:
 


### PR DESCRIPTION
Trivial change here, but this fixes Bugzilla bug [1085455](https://bugzilla.mozilla.org/show_bug.cgi?id=1085455).

This matches the Title of the Service docs, to be consistent with the UI docs.

This is UI and Service, currently:

![updateservicedocstitle](https://cloud.githubusercontent.com/assets/3660661/4706665/ba4cae4e-5886-11e4-82ab-9dc7df55c922.jpg)

This is the fix for Service, using a local build and the rtd theme:

![updateservicedocstitleproposed](https://cloud.githubusercontent.com/assets/3660661/4706602/2d3de3a6-5886-11e4-9eeb-16e20d57cf7a.jpg)

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @maurodoglio for review.
