### PR TITLE
Bug 1090484 - Add support for getting maximum job id for a project

### DIFF
--- a/tests/webapp/api/test_project_api.py
+++ b/tests/webapp/api/test_project_api.py
@@ -1,0 +1,15 @@
+def test_project_endpoint(webapp, eleven_jobs_processed, jm):
+    """
+    tests the project endpoint
+    """
+    url = '/api/project/%s' % jm.project
+    resp = webapp.get(url)
+    assert resp.json['max_job_id'] == 11
+
+def test_project_endpoint_does_not_exist(webapp, eleven_jobs_processed, jm):
+    """
+    tests the project endpoint where project does not exist
+    """
+    url = '/api/project/%s1234' % jm.project
+    resp = webapp.get(url, status=404)
+    assert resp.status_int == 404

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -411,6 +411,14 @@ class JobsModel(TreeherderModelBase):
 
         return data
 
+    def get_max_job_id(self):
+        """Get the maximum job id."""
+        data = self.get_jobs_dhub().execute(
+            proc="jobs.selects.get_max_job_id",
+            debug_show=self.DEBUG,
+        )
+        return int(data[0]['max_id'])
+
     def get_job_note(self, id):
         """Return the job note by id."""
         data = self.get_jobs_dhub().execute(

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -668,6 +668,10 @@
                    WHERE `job_id` = ?",
             "host": "read_host"
         },
+        "get_max_job_id":{
+            "sql":"SELECT max(`id`) as max_id from `job`",
+            "host": "read_host"
+        },
         "get_job_note":{
             "sql":"SELECT * from `job_note`
                    WHERE `id` = ?",

--- a/treeherder/webapp/api/projects.py
+++ b/treeherder/webapp/api/projects.py
@@ -1,0 +1,13 @@
+from django.http import HttpResponse, HttpResponseNotFound
+from treeherder.model.derived import DatasetNotFoundError
+import json
+
+from treeherder.model.derived import JobsModel
+
+def project_info(request, project):
+    try:
+        jm = JobsModel(project)
+        return HttpResponse(json.dumps({'max_job_id': jm.get_max_job_id()}),
+                            mimetype='application/json')
+    except DatasetNotFoundError:
+        return HttpResponseNotFound('Project does not exist')

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import patterns, include, url
 from treeherder.webapp.api import (refdata, objectstore, jobs, resultset,
                                    artifact, note, revision, bug, logslice,
                                    performance_data, job_log_url,
-                                   performance_artifact)
+                                   performance_artifact, projects)
 
 from rest_framework import routers
 
@@ -102,6 +102,8 @@ urlpatterns = patterns(
     '',
     url(r'^project/(?P<project>[\w-]{0,50})/',
         include(project_bound_router.urls)),
+    url(r'^project/(?P<project>[\w-]{0,50})/?',
+        projects.project_info, name='project_info'),
     url(r'^',
         include(default_router.urls)),
 )


### PR DESCRIPTION
This pull request adds an api method /project/<projectname> which lets you query for project-wide-information of interest (currently limited to max_job_id, but we could easily add other stuff). I implemented it somewhat differently from the other methods, but this way seemed to make the most sense.
