### PR TITLE
Bug 1078239 - Fix bug suggestions for recently modified, resolved bugs

### DIFF
--- a/tests/etl/test_bugzilla.py
+++ b/tests/etl/test_bugzilla.py
@@ -43,8 +43,8 @@ def test_bz_api_process(mock_extract, refdata):
     refdata.disconnect()
 
     # the number of rows inserted should equal to the number of bugs
-    assert len(row_data) == 14
+    assert len(row_data) == 15
 
     # test that a second ingestion of the same bugs doesn't insert new rows
     process.run()
-    assert len(row_data) == 14
+    assert len(row_data) == 15

--- a/tests/model/derived/test_refdata.py
+++ b/tests/model/derived/test_refdata.py
@@ -521,6 +521,25 @@ def test_get_all_other_bugs(refdata, sample_bugs, search_term, exp_bugs):
     assert all_others_bugs == exp_bugs
 
 
+def test_get_recent_resolved_bugs(refdata, sample_bugs):
+    """Test that we retrieve recent, but fixed bugs for a search term."""
+    search_term = "Recently modified resolved bugs should be returned in all_others"
+    exp_bugs = [100001]
+
+    bug_list = sample_bugs['bugs']
+    fifty_days_ago = datetime.now() - timedelta(days=50)
+    # Update the last_change date so that all bugs will be placed in
+    # the open_recent bucket, and none in all_others.
+    for bug in bug_list:
+        bug['last_change_time'] = fifty_days_ago
+    refdata.update_bugscache(bug_list)
+
+    suggestions = refdata.get_bug_suggestions(search_term)
+    assert len(suggestions['open_recent']) == 0
+    all_others_bugs = [b['id'] for b in suggestions['all_others']]
+    assert all_others_bugs == exp_bugs
+
+
 def test_delete_bugscache(refdata, sample_bugs):
     bug_list = sample_bugs['bugs']
     refdata.update_bugscache(bug_list)

--- a/tests/sample_data/bug_list.json
+++ b/tests/sample_data/bug_list.json
@@ -1,6 +1,19 @@
 {
     "bugs":  [
         {
+            "status": "FIXED",
+            "id": 100001,
+            "summary": "Recently modified resolved bugs should be returned in all_others",
+            "cf_crash_signature": "",
+            "keywords": [
+                "intermittent-failure"
+            ],
+            "resolution": "RESOLVED",
+            "op_sys": "All",
+            "last_change_time": "2014-01-01 00:00:00"
+
+        },
+        {
             "status": "NEW",
             "id": 453969,
             "summary": "Intermittent test_bug382113.html | Child got load event - got false, expected true",

--- a/treeherder/model/sql/reference.json
+++ b/treeherder/model/sql/reference.json
@@ -334,7 +334,7 @@
                     FROM bugscache
                     WHERE 1
                         AND `summary` LIKE CONCAT ('%%', ?, '%%') ESCAPE '='
-                        AND modified < ?
+                        AND (modified < ? OR resolution <> '')
                     ORDER BY relevance DESC
                     LIMIT 0,?",
             "host": "read_host"


### PR DESCRIPTION
We divide bug suggestions for a search term into 'open_recent' and
'all_others'. The former is supposed to be group 1 below, and the
latter groups 2-4, with the two groups combined corresponding to every
bug whose summary matches the search term.

1) Open + recently modified
2) Open + not recently modified
3) Resolved + recently modified
4) Resolved + not recently modified

However prior to this patch group 3 was not being returned at all, when
it should have been included in all_others.
