### PR TITLE
Bug 1090689 - Add MPL2.0 headers to the repo

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 uses:
     - django
     - celery

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 language: python
 python:
   - "2.6"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 

--- a/bin/download_logs.py
+++ b/bin/download_logs.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import sys
 import urllib2
 

--- a/bin/generate-vendor-lib.py
+++ b/bin/generate-vendor-lib.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 """
 (Re)-generate the vendor library in ``vendor/`` from the requirements listed
 in ``requirements/pure.txt``.

--- a/bin/run_celery_worker
+++ b/bin/run_celery_worker
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 curr_dir=$( dirname "${BASH_SOURCE[0]}" )
 cd $( dirname $curr_dir)
 

--- a/bin/run_celery_worker_buildapi
+++ b/bin/run_celery_worker_buildapi
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 curr_dir=$( dirname "${BASH_SOURCE[0]}" )
 cd $( dirname $curr_dir)
 source /etc/profile.d/treeherder.sh

--- a/bin/run_celery_worker_gevent
+++ b/bin/run_celery_worker_gevent
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 curr_dir=$( dirname "${BASH_SOURCE[0]}" )
 cd $( dirname $curr_dir)
 source /etc/profile.d/treeherder.sh

--- a/bin/run_celery_worker_hp
+++ b/bin/run_celery_worker_hp
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 curr_dir=$( dirname "${BASH_SOURCE[0]}" )
 cd $( dirname $curr_dir)
 

--- a/bin/run_celery_worker_pushlog
+++ b/bin/run_celery_worker_pushlog
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 curr_dir=$( dirname "${BASH_SOURCE[0]}" )
 cd $( dirname $curr_dir)
 

--- a/bin/run_celerybeat
+++ b/bin/run_celerybeat
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 curr_dir=$( dirname "${BASH_SOURCE[0]}" )
 cd $( dirname $curr_dir)
 

--- a/bin/run_gunicorn
+++ b/bin/run_gunicorn
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 set -e
 
 curr_dir=$( dirname "${BASH_SOURCE[0]}" )

--- a/bin/run_pulse_adapter
+++ b/bin/run_pulse_adapter
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 LOGDIR=/var/log/pulse_consumer/
 
 if [ ! -d $LOGDIR ]; then

--- a/deployment/supervisord/admin_node.conf
+++ b/deployment/supervisord/admin_node.conf
@@ -1,3 +1,7 @@
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 [supervisord]
 http_port=/var/tmp/supervisor.sock ; (default is to run a UNIX domain socket server)
 loglevel=info               ; (logging level;default info; others: debug,warn)

--- a/deployment/supervisord/etl_node.conf
+++ b/deployment/supervisord/etl_node.conf
@@ -1,3 +1,7 @@
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 [supervisord]
 http_port=/var/tmp/supervisor.sock ; (default is to run a UNIX domain socket server)
 loglevel=info               ; (logging level;default info; others: debug,warn)

--- a/deployment/supervisord/worker_node.conf
+++ b/deployment/supervisord/worker_node.conf
@@ -1,3 +1,7 @@
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 [supervisord]
 http_port=/var/tmp/supervisor.sock ; (default is to run a UNIX domain socket server)
 loglevel=info               ; (logging level;default info; others: debug,warn)

--- a/deployment/update/commander_settings.py-example
+++ b/deployment/update/commander_settings.py-example
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Example Commander configuration file for Chief deployment.
 # Copy to commander_settings.py & adjust as required.
 SRC_DIR = '/data/treeherder/src/treeherder.mozilla.org/'

--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 """
 Deploy this project in dev/stage/production.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # -*- coding: utf-8 -*-
 #
 # treeherder documentation build configuration file, created by

--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 import sys
 

--- a/puppet/files/apache/treeherder-service.conf
+++ b/puppet/files/apache/treeherder-service.conf
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 <VirtualHost *:8080>
   ServerName <%= @APP_URL %>
   ProxyRequests Off

--- a/puppet/manifests/classes/apache.pp
+++ b/puppet/manifests/classes/apache.pp
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 $apache_devel = $operatingsystem ? {
   ubuntu => "apache2-dev",
   default => "httpd-devel",

--- a/puppet/manifests/classes/dev.pp
+++ b/puppet/manifests/classes/dev.pp
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 class dev{
   exec{"pip-install-dev":
     user => "${APP_USER}",

--- a/puppet/manifests/classes/init.pp
+++ b/puppet/manifests/classes/init.pp
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Commands to run before all others in puppet.
 class init {
     group { "puppet":

--- a/puppet/manifests/classes/mysql.pp
+++ b/puppet/manifests/classes/mysql.pp
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # mysqldev and mysql service need to be parametrized
 # based on the OS
 $mysqldev = $operatingsystem ? {

--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Install python and compiled modules for project
 
 $python_devel = $operatingsystem ? {

--- a/puppet/manifests/classes/rabbitmq.pp
+++ b/puppet/manifests/classes/rabbitmq.pp
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 class rabbitmq {
   package { "rabbitmq-server":
     ensure => installed;

--- a/puppet/manifests/classes/treeherder.pp
+++ b/puppet/manifests/classes/treeherder.pp
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 #any additional stuff goes here
 class treeherder {
     package{"make":

--- a/puppet/manifests/classes/utils.pp
+++ b/puppet/manifests/classes/utils.pp
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 define line($file, $line, $ensure = 'present') {
     case $ensure {
         default : { err ( "unknown ensure value ${ensure}" ) }

--- a/puppet/manifests/classes/varnish.pp
+++ b/puppet/manifests/classes/varnish.pp
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 $varnish_port_file = $operatingsystem ? {
   ubuntu => "/etc/default/varnish",
   default => "/etc/sysconfig/varnish",

--- a/puppet/manifests/production.pp
+++ b/puppet/manifests/production.pp
@@ -1,6 +1,8 @@
-#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Playdoh puppet magic for dev boxes
-#
 import "classes/*.pp"
 
 $APP_URL="local.treeherder.mozilla.org"

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -1,6 +1,8 @@
-#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Playdoh puppet magic for dev boxes
-#
 import "classes/*.pp"
 
 $APP_URL="local.treeherder.mozilla.org"

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,2 +1,7 @@
 #!/bin/sh
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 py.test tests/$* --cov-report html --cov treeherder

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from distutils.core import setup
 from Cython.Build import cythonize
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 from os.path import dirname
 import sys

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 
 import pytest

--- a/tests/e2e/test_jobs_loaded.py
+++ b/tests/e2e/test_jobs_loaded.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.core.urlresolvers import reverse
 from webtest import TestApp
 from treeherder.webapp.wsgi import application

--- a/tests/etl/conftest.py
+++ b/tests/etl/conftest.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import pytest
 import json
 from webtest.app import TestApp

--- a/tests/etl/test_bugzilla.py
+++ b/tests/etl/test_bugzilla.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import pytest
 import os
 import json

--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 import pytest
 import responses

--- a/tests/etl/test_buildbot.py
+++ b/tests/etl/test_buildbot.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from treeherder.etl import buildbot
 import pytest
 import datetime

--- a/tests/etl/test_common.py
+++ b/tests/etl/test_common.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 
 from django.conf import settings
 

--- a/tests/etl/test_perf_data_adapters.py
+++ b/tests/etl/test_perf_data_adapters.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 
 from tests.sampledata import SampleData

--- a/tests/etl/test_pushlog.py
+++ b/tests/etl/test_pushlog.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 import json
 import responses

--- a/tests/etl/test_tbpl.py
+++ b/tests/etl/test_tbpl.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from datetime import datetime
 from treeherder.etl.tbpl import OrangeFactorBugRequest, BugzillaBugRequest
 import json

--- a/tests/log_parser/conftest.py
+++ b/tests/log_parser/conftest.py
@@ -1,0 +1,4 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+

--- a/tests/log_parser/test_artifact_builder_collection.py
+++ b/tests/log_parser/test_artifact_builder_collection.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from treeherder.log_parser.artifactbuildercollection import ArtifactBuilderCollection
 from treeherder.log_parser.artifactbuilders import BuildbotLogViewArtifactBuilder
 from ..sampledata import SampleData

--- a/tests/log_parser/test_job_artifact_builder.py
+++ b/tests/log_parser/test_job_artifact_builder.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 from datadiff import diff
 

--- a/tests/log_parser/test_log_view_artifact_builder.py
+++ b/tests/log_parser/test_log_view_artifact_builder.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 import pytest
 from datadiff import diff

--- a/tests/log_parser/test_performance_artifact_builder.py
+++ b/tests/log_parser/test_performance_artifact_builder.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 from datadiff import diff
 from jsonschema import validate

--- a/tests/log_parser/test_tasks.py
+++ b/tests/log_parser/test_tasks.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import pytest
 import simplejson as json
 

--- a/tests/log_parser/test_tinderbox_print_parser.py
+++ b/tests/log_parser/test_tinderbox_print_parser.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import pytest
 from treeherder.log_parser.parsers import TinderboxPrintParser
 

--- a/tests/log_parser/test_utils.py
+++ b/tests/log_parser/test_utils.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import pytest
 from treeherder.log_parser.utils import (get_error_search_term,
                                          get_crash_signature)

--- a/tests/model/commands/test_init_datasource.py
+++ b/tests/model/commands/test_init_datasource.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.core.management import call_command
 import pytest
 

--- a/tests/model/derived/conftest.py
+++ b/tests/model/derived/conftest.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import pytest
 
 

--- a/tests/model/derived/sample_data_generator.py
+++ b/tests/model/derived/sample_data_generator.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 """
 Functions for flexible generation of sample input job JSON.
 

--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import time
 import json
 import pytest

--- a/tests/model/derived/test_objectstore_model.py
+++ b/tests/model/derived/test_objectstore_model.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 import pytest
 

--- a/tests/model/derived/test_refdata.py
+++ b/tests/model/derived/test_refdata.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 import time
 import urllib2

--- a/tests/model/sql/test_models.py
+++ b/tests/model/sql/test_models.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import datetime
 from contextlib import contextmanager
 

--- a/tests/sample_data_generator.py
+++ b/tests/sample_data_generator.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 """
 Functions for flexible generation of sample input job JSON.
 

--- a/tests/sampledata.py
+++ b/tests/sampledata.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 import os
 from django.conf import settings

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import pytest
 from django.conf import settings
 from treeherder.model.models import Datasource

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 import itertools
 from webtest.app import TestApp, AppError

--- a/tests/webapp/api/test_artifact_api.py
+++ b/tests/webapp/api/test_artifact_api.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 import pytest
 from django.core.urlresolvers import reverse

--- a/tests/webapp/api/test_bug_job_map_api.py
+++ b/tests/webapp/api/test_bug_job_map_api.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.core.urlresolvers import reverse
 from rest_framework.test import APIClient
 from django.contrib.auth.models import User

--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 
 from django.core.urlresolvers import reverse

--- a/tests/webapp/api/test_note_api.py
+++ b/tests/webapp/api/test_note_api.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 from django.core.urlresolvers import reverse
 from rest_framework.test import APIClient

--- a/tests/webapp/api/test_objectstore_api.py
+++ b/tests/webapp/api/test_objectstore_api.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.core.urlresolvers import reverse
 
 from thclient import TreeherderJobCollection

--- a/tests/webapp/api/test_project_api.py
+++ b/tests/webapp/api/test_project_api.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 def test_project_endpoint(webapp, eleven_jobs_processed, jm):
     """
     tests the project endpoint

--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import pytest
 from django.core.urlresolvers import reverse
 

--- a/tests/webapp/api/test_utils.py
+++ b/tests/webapp/api/test_utils.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from treeherder.webapp.api.utils import UrlQueryFilter
 
 

--- a/tests/webapp/conftest.py
+++ b/tests/webapp/conftest.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 import os
 from treeherder.webapp import wsgi

--- a/treeherder/cache.py
+++ b/treeherder/cache.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.core.cache.backends import memcached
 
 

--- a/treeherder/celery.py
+++ b/treeherder/celery.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from __future__ import absolute_import
 
 import os

--- a/treeherder/etl/bugzilla.py
+++ b/treeherder/etl/bugzilla.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from urllib import urlencode
 
 from django.conf import settings

--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import logging
 import time
 import datetime

--- a/treeherder/etl/buildbot.py
+++ b/treeherder/etl/buildbot.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import re
 
 RESULT_DICT = {

--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from collections import defaultdict
 import hashlib
 import urllib2

--- a/treeherder/etl/daemon.py
+++ b/treeherder/etl/daemon.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import sys, os, time, atexit
 from signal import SIGTERM 
 

--- a/treeherder/etl/management/commands/export_project_credentials.py
+++ b/treeherder/etl/management/commands/export_project_credentials.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 import json
 

--- a/treeherder/etl/management/commands/import_project_credentials.py
+++ b/treeherder/etl/management/commands/import_project_credentials.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 import json
 

--- a/treeherder/etl/management/commands/start_pulse_consumer.py
+++ b/treeherder/etl/management/commands/start_pulse_consumer.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 
 from optparse import make_option

--- a/treeherder/etl/management/commands/test_builds4h.py
+++ b/treeherder/etl/management/commands/test_builds4h.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.core.management.base import BaseCommand
 from treeherder.etl import buildapi
 

--- a/treeherder/etl/mixins.py
+++ b/treeherder/etl/mixins.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from StringIO import StringIO
 import gzip
 import urllib2

--- a/treeherder/etl/oauth_utils.py
+++ b/treeherder/etl/oauth_utils.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 from treeherder import path
 import copy

--- a/treeherder/etl/perf_data_adapters.py
+++ b/treeherder/etl/perf_data_adapters.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 from json import encoder
 

--- a/treeherder/etl/pulse.py
+++ b/treeherder/etl/pulse.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 import time
 import datetime

--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.core.cache import cache
 from django.conf import settings
 import time

--- a/treeherder/etl/tasks/buildapi_tasks.py
+++ b/treeherder/etl/tasks/buildapi_tasks.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 """
 This module contains
 """

--- a/treeherder/etl/tasks/cleanup_tasks.py
+++ b/treeherder/etl/tasks/cleanup_tasks.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import urllib
 import logging
 

--- a/treeherder/etl/tasks/tasks.py
+++ b/treeherder/etl/tasks/tasks.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 """
 This module contains
 """

--- a/treeherder/etl/tasks/tbpl_tasks.py
+++ b/treeherder/etl/tasks/tbpl_tasks.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 """
 This module contains
 """

--- a/treeherder/etl/tbpl.py
+++ b/treeherder/etl/tbpl.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from datetime import datetime
 import logging
 

--- a/treeherder/events/consumer.py
+++ b/treeherder/events/consumer.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from kombu.mixins import ConsumerMixin
 from kombu import Connection, Exchange, Consumer, Queue
 import logging

--- a/treeherder/events/publisher.py
+++ b/treeherder/events/publisher.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import logging
 from kombu import Connection, Exchange, Producer
 

--- a/treeherder/events/run_socketio.py
+++ b/treeherder/events/run_socketio.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 #!/usr/bin/env python
 import sys
 import argparse

--- a/treeherder/events/sockets.py
+++ b/treeherder/events/sockets.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import logging
 from collections import defaultdict
 from socketio.namespace import BaseNamespace

--- a/treeherder/log_parser/artifactbuildercollection.pyx
+++ b/treeherder/log_parser/artifactbuildercollection.pyx
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import urllib2
 import gzip
 import io

--- a/treeherder/log_parser/artifactbuilders.pyx
+++ b/treeherder/log_parser/artifactbuilders.pyx
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from .parsers import (ErrorParser, TinderboxPrintParser,
                       HeaderParser, StepParser, TalosParser)
 

--- a/treeherder/log_parser/parsers.pyx
+++ b/treeherder/log_parser/parsers.pyx
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import re
 import datetime
 import json

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 
 import time
 from celery import task

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import re
 import urllib
 

--- a/treeherder/model/derived/base.py
+++ b/treeherder/model/derived/base.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 """
 ``TreeHerderModelBase`` (and subclasses) are the public interface for all data
 access.

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 import MySQLdb
 import time

--- a/treeherder/model/derived/refdata.py
+++ b/treeherder/model/derived/refdata.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 import logging
 from hashlib import sha1

--- a/treeherder/model/exchanges.py
+++ b/treeherder/model/exchanges.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from treeherder.model.pulse_publisher import PulsePublisher, Exchange, Key
 
 class TreeherderPublisher(PulsePublisher):

--- a/treeherder/model/management/commands/calculate_eta.py
+++ b/treeherder/model/management/commands/calculate_eta.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from optparse import make_option
 from django.core.management.base import BaseCommand
 from treeherder.model.models import Repository

--- a/treeherder/model/management/commands/clear_cache.py
+++ b/treeherder/model/management/commands/clear_cache.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.core.management.base import BaseCommand
 from django.core.cache import cache
 

--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from optparse import make_option
 from django.core.management.base import BaseCommand
 from treeherder.model.models import Repository

--- a/treeherder/model/management/commands/init_datasources.py
+++ b/treeherder/model/management/commands/init_datasources.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from optparse import make_option
 from django.utils.six.moves import input
 

--- a/treeherder/model/management/commands/init_master_db.py
+++ b/treeherder/model/management/commands/init_master_db.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 from optparse import make_option
 

--- a/treeherder/model/management/commands/load_initial_data.py
+++ b/treeherder/model/management/commands/load_initial_data.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
 from treeherder.model.models import Datasource, Repository

--- a/treeherder/model/management/commands/populate_performance_series.py
+++ b/treeherder/model/management/commands/populate_performance_series.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 import sys
 

--- a/treeherder/model/management/commands/process_objects.py
+++ b/treeherder/model/management/commands/process_objects.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from optparse import make_option
 from django.core.management.base import BaseCommand
 from treeherder.model.tasks import process_objects

--- a/treeherder/model/management/commands/publish_result_set_to_pulse.py
+++ b/treeherder/model/management/commands/publish_result_set_to_pulse.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from optparse import make_option
 from django.core.management.base import BaseCommand
 from treeherder.model.models import Repository

--- a/treeherder/model/management/commands/run_sql.py
+++ b/treeherder/model/management/commands/run_sql.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import MySQLdb
 from optparse import make_option
 

--- a/treeherder/model/management/commands/update_repository_version.py
+++ b/treeherder/model/management/commands/update_repository_version.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from optparse import make_option
 from django.core.management.base import BaseCommand
 from treeherder.model.derived import RefDataManager

--- a/treeherder/model/migrations/0001_initial.py
+++ b/treeherder/model/migrations/0001_initial.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # -*- coding: utf-8 -*-
 import datetime
 from south.db import db

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from __future__ import unicode_literals
 
 import uuid

--- a/treeherder/model/pulse_publisher.py
+++ b/treeherder/model/pulse_publisher.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import kombu, re, json, os, jsonschema, logging
 logger = logging.getLogger(__name__)
 

--- a/treeherder/model/tasks.py
+++ b/treeherder/model/tasks.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from celery import task
 from django.conf import settings
 

--- a/treeherder/model/utils.py
+++ b/treeherder/model/utils.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import time
 import json
 import random

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Django settings for webapp project.
 import os
 import sys

--- a/treeherder/settings/local.sample.py
+++ b/treeherder/settings/local.sample.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 
 TREEHERDER_DATABASE_NAME     = os.environ.get("TREEHERDER_DATABASE_NAME", "")

--- a/treeherder/webapp/admin.py
+++ b/treeherder/webapp/admin.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.contrib import admin
 from treeherder.model.models import *
 from django_browserid.admin import site as browserid_admin

--- a/treeherder/webapp/api/artifact.py
+++ b/treeherder/webapp/api/artifact.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from rest_framework import viewsets
 from rest_framework.response import Response
 from treeherder.etl.perf_data_adapters import PerformanceDataAdapter

--- a/treeherder/webapp/api/bug.py
+++ b/treeherder/webapp/api/bug.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from time import time
 from treeherder.model.derived.jobs import JobDataIntegrityError
 from rest_framework import viewsets

--- a/treeherder/webapp/api/exceptions.py
+++ b/treeherder/webapp/api/exceptions.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from rest_framework import exceptions
 from rest_framework.response import Response
 from rest_framework.views import exception_handler as drf_exc_handler

--- a/treeherder/webapp/api/job_log_url.py
+++ b/treeherder/webapp/api/job_log_url.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import logging
 from rest_framework import viewsets
 from rest_framework.response import Response

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.decorators import action, link

--- a/treeherder/webapp/api/logslice.py
+++ b/treeherder/webapp/api/logslice.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from rest_framework import viewsets
 from rest_framework.response import Response
 from django.core import cache

--- a/treeherder/webapp/api/note.py
+++ b/treeherder/webapp/api/note.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.conf import settings
 from rest_framework import viewsets
 from rest_framework.response import Response

--- a/treeherder/webapp/api/objectstore.py
+++ b/treeherder/webapp/api/objectstore.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 
 from rest_framework import viewsets

--- a/treeherder/webapp/api/performance_artifact.py
+++ b/treeherder/webapp/api/performance_artifact.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from rest_framework import viewsets
 from rest_framework.response import Response
 from treeherder.etl.perf_data_adapters import PerformanceDataAdapter

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 
 from rest_framework import viewsets

--- a/treeherder/webapp/api/permissions.py
+++ b/treeherder/webapp/api/permissions.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from rest_framework import permissions
 
 

--- a/treeherder/webapp/api/projects.py
+++ b/treeherder/webapp/api/projects.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.http import HttpResponse, HttpResponseNotFound
 from treeherder.model.derived import DatasetNotFoundError
 import json

--- a/treeherder/webapp/api/refdata.py
+++ b/treeherder/webapp/api/refdata.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.authentication import SessionAuthentication

--- a/treeherder/webapp/api/resultset.py
+++ b/treeherder/webapp/api/resultset.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import itertools
 import re
 

--- a/treeherder/webapp/api/revision.py
+++ b/treeherder/webapp/api/revision.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.contrib.auth.models import User
 from rest_framework import serializers
 

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.conf.urls import patterns, include, url
 from treeherder.webapp.api import (refdata, objectstore, jobs, resultset,
                                    artifact, note, revision, bug, logslice,

--- a/treeherder/webapp/api/utils.py
+++ b/treeherder/webapp/api/utils.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from collections import defaultdict
 import time
 import datetime

--- a/treeherder/webapp/urls.py
+++ b/treeherder/webapp/urls.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.conf import settings
 from django.conf.urls import patterns, include, url
 from django.views.generic import RedirectView

--- a/treeherder/webapp/wsgi.py
+++ b/treeherder/webapp/wsgi.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 """
 WSGI config for webapp project.
 

--- a/treeherder/workers/management/commands/shutdown_workers.py
+++ b/treeherder/workers/management/commands/shutdown_workers.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.core.management.base import BaseCommand
 from celery.task.control import broadcast
 

--- a/treeherder/workers/models.py
+++ b/treeherder/workers/models.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.db import models
 
 # Create your models here.

--- a/treeherder/workers/tests.py
+++ b/treeherder/workers/tests.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 """
 This file demonstrates writing tests using the unittest module. These will pass
 when you run "manage.py test".

--- a/treeherder/workers/views.py
+++ b/treeherder/workers/views.py
@@ -1,1 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Create your views here.


### PR DESCRIPTION
This work fixes part2 of Bugzilla bug [1090689](https://bugzilla.mozilla.org/show_bug.cgi?id=1090689).

This adds MPL2.0 headers to all the relevant files in the treeherder-service repo. The main file types receiving headers are:
- .py
- .pp
- .conf
- .sh
- .yml

Puppet config files can apparently use either `\* blockquote *\` or `# blockquote`, I chose the latter since there were existing single line `#` comments in some of those files.

All files were added via a list agreed on in the bug with @edmorley, and the .py injected en masse. Other files like .yml and the Vagrant file were manually added. Executables were reordered with their command interpreter invocation above the MPL block.

All init, .json, .rst docs and .txt files have been ignored. I had a look at a few of them to check. The odd file like `tests/log_parser/conftest.py` have been injected, even though they are empty at this time.

I don't have access to vagrant at the moment, so probably a good idea for someone to try this branch locally and make sure there are no errors on start up, before merge.

Sorry there are a lot of files :)

Adding @maurodoglio for review and @edmorley for visibility.
