### PR TITLE
Bug 1093743 retrigger fix

### DIFF
--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -452,7 +452,7 @@ class RunningTransformerMixin(object):
 
                     new_job = {
                         'job_guid': common.generate_job_guid(
-                            ",".join(map(str, running_job['request_ids'])),
+                            running_job['request_ids'][0],
                             running_job['submitted_at']
                         ),
                         'name': job_name_info.get('name', ''),


### PR DESCRIPTION
I confirmed this fix with these two resultsets:
http://local.treeherder.mozilla.org/ui/#/jobs?repo=mozilla-inbound&tochange=a2551ec63d3c&searchQuery=os%20x%2010.8%20debug&fromchange=49d26513f6be

On the old code, when I retriggered the red build from change a2551ec63d3c, the retrigger showed in change 49d26513f6be.  With the new code, it showed in the first change a2551ec63d3c.
