### PR TITLE
Bug 1074851 - Implement server side job filtering

### DIFF
--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -849,6 +849,7 @@
                     ON jt.`job_group_id` = jg.id
                   WHERE j.`result_set_id` IN (REP1)
                   REP2
+                  REP3
                   ",
             "host": "read_host"
         },
@@ -897,6 +898,7 @@
                     ON jt.`job_group_id` = jg.id
                   WHERE j.`result_set_id` IN (REP1)
                   REP2
+                  REP3
                   ",
             "host": "read_host"
         },


### PR DESCRIPTION
This is the service companion to this ui PR: https://github.com/mozilla/treeherder-ui/pull/280

This moves the filtering of **excluded** jobs (via the `exclusion profiles`) to the server, rather than the client.  This improves performance in several ways:
1. reduced payload for every fetch of jobs
2. don't have to download the exclusion profiles to the client, unless editing the profiles themselves
3. don't need special handling on the client to compensate for hidden/non-hidden jobs in counts, and elsewhere
4. don't need to filter for exclusions on every job.  (this is perhaps the biggest one)

The format of the `flat_exclusions` has changed, so when we push to dev/stage/production, you have to go into the Sheriff panel and re-save the `exclusion profiles` (not each `job exclusion`)

*\* not in this PR **
I opted not to expand the list of excluded job `signatures` into a m2m table with the exclusion profile.  I created bug 1105515 to explore if we want to do that
