### PR TITLE
Bug 1069493 - Stop mirroring classification comments to TBPL's DB

### DIFF
--- a/treeherder/etl/tasks/tbpl_tasks.py
+++ b/treeherder/etl/tasks/tbpl_tasks.py
@@ -5,8 +5,8 @@
 """
 This module contains
 """
-from celery import task, group
-from treeherder.etl.tbpl import OrangeFactorBugRequest, TbplBugRequest, BugzillaBugRequest
+from celery import task
+from treeherder.etl.tbpl import OrangeFactorBugRequest, BugzillaBugRequest
 
 
 @task(name="submit-star-comment", max_retries=10, time_limit=30)
@@ -21,23 +21,6 @@ def submit_star_comment(project, job_id, bug_id, submit_timestamp, who):
         req.send_request()
     except Exception, e:
         submit_star_comment.retry(exc=e)
-        # this exception will be raised once the number of retries
-        # exceeds max_retries
-        raise
-
-
-@task(name="submit-build-star", max_retries=10, time_limit=30)
-def submit_build_star(project, job_id, who, bug_id=None, classification_id=None, note=None):
-    """
-    Send a post request to tbpl's submitBuildStar.php to mirror sheriff's activity
-    from treeherder to tbpl. It can be used for both bug association and classification
-    """
-    try:
-        req = TbplBugRequest(project, job_id, who, bug_id=bug_id, classification_id=classification_id, note=note)
-        req.generate_request_body()
-        req.send_request()
-    except Exception, e:
-        submit_build_star.retry(exc=e)
         # this exception will be raised once the number of retries
         # exceeds max_retries
         raise

--- a/treeherder/etl/tbpl.py
+++ b/treeherder/etl/tbpl.py
@@ -7,8 +7,6 @@ import logging
 
 import requests
 from treeherder.model.derived import JobsModel
-from treeherder.model.models import FailureClassification
-from treeherder.model.derived.base import ObjectNotFoundException
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -69,69 +67,6 @@ class OrangeFactorBugRequest(object):
         """
         tbpl_host = settings.TBPL_HOST
         tbpl_script = "/php/starcomment.php"
-        tbpl_url = "".join([tbpl_host, tbpl_script])
-        logger.info("Sending data to %s: %s", tbpl_url, self.body)
-        r = requests.post(tbpl_url, data=self.body)
-        r.raise_for_status()
-
-
-class TbplBugRequest(object):
-
-    def __init__(self, project, job_id, who, bug_id=None, classification_id=None, note=None):
-        self.project = project
-        self.job_id = job_id
-        self.bug_id = bug_id
-        self.note = note
-        self.classification_id = classification_id
-        self.who = who
-        self.body = {}
-
-    def generate_request_body(self):
-        """
-        Create the data structure required by tbpl's submitBuildStar.php script
-        It's used by both the bug_job_map endpoint and the job note endpoint.
-        """
-        jm = JobsModel(self.project)
-        try:
-            buildapi_artifact = jm.get_job_artifact_list(0, 1, {
-                'job_id': set([("=", self.job_id)]),
-                'name': set([("=", "buildapi_complete")])
-            })[0]
-            job_data = jm.get_job(self.job_id)[0]
-        except IndexError:
-            logger.exception(("Unable to find buildapi_complete artifact for "
-                              "job_id: {0}").format(self.job_id))
-            raise
-        finally:
-            jm.disconnect()
-
-        note = ""
-        if self.bug_id:
-            note = "Bug {0}".format(self.bug_id)
-        if self.classification_id:
-            if note:
-                note += " - "
-            note += FailureClassification.objects.get(
-                id=self.classification_id).name
-            if self.note:
-                if note:
-                    note += " - "
-                note += self.note
-
-        self.body = {
-            "id": buildapi_artifact["blob"]["id"],
-            "machinename": job_data["machine_name"],
-            "starttime": int(job_data["start_timestamp"]),
-            "note": note,
-            "who": self.who
-        }
-
-    def send_request(self):
-        """
-        send request to tbpl host
-        """
-        tbpl_host = settings.TBPL_HOST
-        tbpl_script = "/php/submitBuildStar.php"
         tbpl_url = "".join([tbpl_host, tbpl_script])
         logger.info("Sending data to %s: %s", tbpl_url, self.body)
         r = requests.post(tbpl_url, data=self.body)

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -549,25 +549,6 @@ class JobsModel(TreeherderModelBase):
         )
         self.update_last_job_classification(job_id)
 
-        if settings.TBPL_BUGS_TRANSFER_ENABLED:
-            job = self.get_job(job_id)[0]
-            if job["state"] == "completed":
-                if self.get_build_system_type() == 'buildbot':
-                    # importing here to avoid an import loop
-                    from treeherder.etl.tasks import submit_build_star
-                    submit_build_star.apply_async(
-                        args=[
-                            self.project,
-                            int(job_id),
-                            who
-                        ],
-                        kwargs={
-                            'classification_id': int(failure_classification_id),
-                            'note': note
-                        },
-                        routing_key='high_priority'
-                    )
-
     def delete_job_note(self, note_id, job_id):
         """
         Delete a job note and updates the failure classification for that job
@@ -608,7 +589,6 @@ class JobsModel(TreeherderModelBase):
                 if self.get_build_system_type() == 'buildbot':
                     # importing here to avoid an import loop
                     from treeherder.etl.tasks import (submit_star_comment,
-                                                      submit_build_star,
                                                       submit_bug_comment)
                     # submit bug association to tbpl
                     # using an async task
@@ -620,18 +600,6 @@ class JobsModel(TreeherderModelBase):
                             submit_timestamp,
                             who
                         ],
-                        routing_key='high_priority'
-                    )
-
-                    submit_build_star.apply_async(
-                        args=[
-                            self.project,
-                            int(job_id),
-                            who
-                        ],
-                        kwargs={
-                            'bug_id': bug_id
-                        },
                         routing_key='high_priority'
                     )
 


### PR DESCRIPTION
TBPL is going to be EOLed soon, and few people are still using it. As
such we can stop mirroring failure classification comments to
submitBuildStar.php.
