### PR TITLE
Bug 918281 - Service-side additions of tree-specific rules pages

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -7,6 +7,7 @@
         "name": "mozilla-central",
         "url": "https://hg.mozilla.org/mozilla-central",
         "active_status": "active",
+        "rules": "https://wiki.mozilla.org/Tree_Rules#mozilla-central_.28Nightly_channel.29",
         "codebase": "gecko",
         "repository_group": 1,
         "description": ""
@@ -20,6 +21,7 @@
         "name": "mozilla-inbound",
         "url": "https://hg.mozilla.org/integration/mozilla-inbound",
         "active_status": "active",
+        "rules": "https://wiki.mozilla.org/Tree_Rules/Integration",
         "codebase": "gecko",
         "repository_group": 1,
         "description": ""
@@ -33,6 +35,7 @@
         "name": "b2g-inbound",
         "url": "https://hg.mozilla.org/integration/b2g-inbound",
         "active_status": "active",
+        "rules": "https://wiki.mozilla.org/Tree_Rules/Integration",
         "codebase": "gecko",
         "repository_group": 1,
         "description": ""
@@ -59,6 +62,7 @@
         "name": "mozilla-aurora",
         "url": "https://hg.mozilla.org/releases/mozilla-aurora",
         "active_status": "active",
+        "rules": "https://wiki.mozilla.org/TreeStatus#mozilla-aurora",
         "codebase": "gecko",
         "repository_group": 2,
         "description": ""
@@ -72,6 +76,7 @@
         "name": "mozilla-beta",
         "url": "https://hg.mozilla.org/releases/mozilla-beta",
         "active_status": "active",
+        "rules": "https://wiki.mozilla.org/TreeStatus#mozilla-beta",
         "codebase": "gecko",
         "repository_group": 2,
         "description": ""
@@ -85,6 +90,7 @@
         "name": "mozilla-release",
         "url": "https://hg.mozilla.org/releases/mozilla-release",
         "active_status": "active",
+        "rules": "https://wiki.mozilla.org/TreeStatus#mozilla-release",
         "codebase": "gecko",
         "repository_group": 2,
         "description": ""
@@ -98,6 +104,7 @@
         "name": "mozilla-esr17",
         "url": "https://hg.mozilla.org/releases/mozilla-esr17",
         "active_status": "onhold",
+        "rules": "https://wiki.mozilla.org/Release_Management/ESR_Landing_Process",
         "codebase": "gecko",
         "repository_group": 2,
         "description": ""
@@ -111,6 +118,7 @@
         "name": "mozilla-esr24",
         "url": "https://hg.mozilla.org/releases/mozilla-esr24",
         "active_status": "onhold",
+        "rules": "https://wiki.mozilla.org/Release_Management/ESR_Landing_Process",
         "codebase": "gecko",
         "repository_group": 2,
         "description": ""
@@ -124,6 +132,7 @@
         "name": "mozilla-b2g18",
         "url": "https://hg.mozilla.org/releases/mozilla-b2g18",
         "active_status": "onhold",
+        "rules": "https://wiki.mozilla.org/Release_Management/B2G_Landing",
         "codebase": "gecko",
         "repository_group": 2,
         "description": ""
@@ -137,6 +146,7 @@
         "name": "mozilla-b2g18_v1_1_0_hd",
         "url": "https://hg.mozilla.org/releases/mozilla-b2g18_v1_1_0_hd",
         "active_status": "onhold",
+        "rules": "https://wiki.mozilla.org/Release_Management/B2G_Landing",
         "codebase": "gecko",
         "repository_group": 2,
         "description": ""
@@ -176,6 +186,7 @@
         "name": "fx-team",
         "url": "https://hg.mozilla.org/integration/fx-team",
         "active_status": "active",
+        "rules": "https://wiki.mozilla.org/Tree_Rules/Integration",
         "codebase": "gecko",
         "repository_group": 1,
         "description": ""
@@ -423,6 +434,7 @@
         "name": "comm-central",
         "url": "https://hg.mozilla.org/comm-central",
         "active_status": "active",
+        "rules": "https://wiki.mozilla.org/Tree_Rules/comm-central",
         "codebase": "comm",
         "repository_group": 1,
         "description": ""
@@ -449,6 +461,7 @@
         "name": "comm-aurora",
         "url": "https://hg.mozilla.org/releases/comm-aurora",
         "active_status": "active",
+        "rules": "https://wiki.mozilla.org/Tree_Rules/comm-central#comm-aurora",
         "codebase": "comm",
         "repository_group": 2,
         "description": ""
@@ -462,6 +475,7 @@
         "name": "comm-beta",
         "url": "https://hg.mozilla.org/releases/comm-beta",
         "active_status": "active",
+        "rules": "https://wiki.mozilla.org/Tree_Rules/comm-central#comm-beta",
         "codebase": "comm",
         "repository_group": 2,
         "description": ""
@@ -644,6 +658,7 @@
         "name": "mozilla-b2g32_v2_0",
         "url": "https://hg.mozilla.org/releases/mozilla-b2g32_v2_0",
         "active_status": "active",
+        "rules": "https://wiki.mozilla.org/Release_Management/B2G_Landing",
         "codebase": "gecko",
         "repository_group": 2,
         "description": ""
@@ -657,6 +672,7 @@
         "name": "mozilla-b2g28_v1_3t",
         "url": "https://hg.mozilla.org/releases/mozilla-b2g28_v1_3t",
         "active_status": "onhold",
+        "rules": "https://wiki.mozilla.org/Release_Management/B2G_Landing",
         "codebase": "gecko",
         "repository_group": 2,
         "description": ""
@@ -683,6 +699,7 @@
         "name": "mozilla-esr31",
         "url": "https://hg.mozilla.org/releases/mozilla-esr31",
         "active_status": "active",
+        "rules": "https://wiki.mozilla.org/Release_Management/ESR_Landing_Process",
         "codebase": "gecko",
         "repository_group": 2,
         "description": ""
@@ -696,6 +713,7 @@
         "name": "mozilla-b2g34_v2_1",
         "url": "https://hg.mozilla.org/releases/mozilla-b2g34_v2_1",
         "active_status": "active",
+        "rules": "https://wiki.mozilla.org/Release_Management/B2G_Landing",
         "codebase": "gecko",
         "repository_group": 2,
         "description": ""
@@ -709,6 +727,7 @@
         "name": "comm-esr31",
         "url": "https://hg.mozilla.org/releases/comm-esr31",
         "active_status": "active",
+        "rules": "https://wiki.mozilla.org/Release_Management/ESR_Landing_Process",
         "codebase": "comm",
         "repository_group": 2,
         "description": ""


### PR DESCRIPTION
This adds the links to tree-specific tree rules pages to the repository model. This goes along with the ui pull request 412.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-service/418)
<!-- Reviewable:end -->
