### PR TITLE
Bug 1154470 - refactor artifact handling into its own model

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,6 +205,12 @@ def sample_resultset(sample_data):
 
 
 @pytest.fixture
+def test_project():
+    from django.conf import settings
+    return settings.DATABASES["default"]["TEST_NAME"]
+
+
+@pytest.fixture
 def test_repository():
     from django.conf import settings
     from treeherder.model.models import Repository, RepositoryGroup

--- a/tests/log_parser/test_tasks.py
+++ b/tests/log_parser/test_tasks.py
@@ -13,6 +13,8 @@ from django.utils.six import BytesIO
 
 from ..sampledata import SampleData
 
+from treeherder.model.derived import ArtifactsModel
+
 
 @pytest.fixture
 def jobs_with_local_log(initial_data):
@@ -156,8 +158,8 @@ def test_parse_mozlog_log(jm, initial_data, jobs_with_local_mozlog_log,
     assert len(fails) == 3
 
 
-def test_parse_talos_log(jm, initial_data, jobs_with_local_talos_log, sample_resultset,
-                         mock_send_request, mock_get_remote_content):
+def test_parse_talos_log(jm, test_project, initial_data, jobs_with_local_talos_log,
+                         sample_resultset, mock_send_request, mock_get_remote_content):
     """
     check that performance job_artifacts get inserted when running
     a parse_log task for a talos job
@@ -169,7 +171,8 @@ def test_parse_talos_log(jm, initial_data, jobs_with_local_talos_log, sample_res
     jm.store_job_data(jobs)
     jm.process_objects(1, raise_errors=True)
 
-    artifact_list = jm.get_performance_artifact_list(0, 10)
+    with ArtifactsModel(test_project) as artifacts_model:
+        artifact_list = artifacts_model.get_performance_artifact_list(0, 10)
     assert len(artifact_list) >= 1  # should parse out at least one perf artifact
 
 

--- a/tests/webapp/api/test_artifact_api.py
+++ b/tests/webapp/api/test_artifact_api.py
@@ -4,19 +4,21 @@
 
 import pytest
 from django.core.urlresolvers import reverse
+from treeherder.model.derived import ArtifactsModel
 
 xfail = pytest.mark.xfail
 
 
 # we don't have/need an artifact list endpoint.
 
-def test_artifact_detail(webapp, eleven_jobs_processed, sample_artifacts, jm):
+def test_artifact_detail(webapp, test_project, eleven_jobs_processed, sample_artifacts, jm):
     """
     test retrieving a single job from the jobs-detail
     endpoint.
     """
     job = jm.get_job_list(0, 1)[0]
-    artifact = jm.get_job_artifact_references(job["id"])[0]
+    with ArtifactsModel(test_project) as artifacts_model:
+        artifact = artifacts_model.get_job_artifact_references(job["id"])[0]
 
     resp = webapp.get(
         reverse("artifact-detail",

--- a/tests/webapp/conftest.py
+++ b/tests/webapp/conftest.py
@@ -4,6 +4,7 @@
 
 import json
 from treeherder.webapp import wsgi
+from treeherder.model.derived import ArtifactsModel
 from tests.sample_data_generator import job_data
 import pytest
 from webtest.app import TestApp
@@ -43,7 +44,8 @@ def sample_artifacts(jm, sample_data):
             "data_1"
         ])
 
-    jm.store_job_artifact(artifact_placeholders)
+    with ArtifactsModel(jm.project) as artifacts_model:
+        artifacts_model.store_job_artifact(artifact_placeholders)
 
 
 @pytest.fixture

--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -1,0 +1,363 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import simplejson as json
+import logging
+import zlib
+
+from treeherder.model import utils
+
+from .base import TreeherderModelBase
+
+from treeherder.etl.perf_data_adapters import (PerformanceDataAdapter,
+                                               TalosDataAdapter)
+
+logger = logging.getLogger(__name__)
+
+
+class ArtifactsModel(TreeherderModelBase):
+
+    """
+    Represent the artifacts for a job repository
+
+    content-types:
+        jobs
+    """
+
+    # content types that every project will have
+    CT_JOBS = "jobs"
+    CONTENT_TYPES = [CT_JOBS]
+
+    INDEXED_COLUMNS = {
+        "job_artifact": {
+            "id": "id",
+            "job_id": "job_id",
+            "name": "name",
+            "type": "type"
+        },
+        "performance_artifact": {
+            "id": "id",
+            "job_id": "job_id",
+            "series_signature": "series_signature",
+            "name": "name",
+            "type": "type"
+        }
+    }
+
+    def jobs_execute(self, **kwargs):
+        return utils.retry_execute(self.get_dhub(self.CT_JOBS), logger, **kwargs)
+
+    def get_job_artifact_references(self, job_id):
+        """
+        Return the job artifact references for the given ``job_id``.
+
+        This is everything about the artifact, but not the artifact blob
+        itself.
+        """
+        data = self.jobs_execute(
+            proc="jobs.selects.get_job_artifact_references",
+            placeholders=[job_id],
+            debug_show=self.DEBUG,
+        )
+        return data
+
+    def get_job_artifact_list(self, offset, limit, conditions=None):
+        """
+        Retrieve a list of job artifacts. The conditions parameter is a
+        dict containing a set of conditions for each key. e.g.:
+        {
+            'job_id': set([('IN', (1, 2))])
+        }
+        """
+
+        replace_str, placeholders = self._process_conditions(
+            conditions, self.INDEXED_COLUMNS['job_artifact']
+        )
+
+        repl = [replace_str]
+
+        proc = "jobs.selects.get_job_artifact"
+
+        data = self.jobs_execute(
+            proc=proc,
+            replace=repl,
+            placeholders=placeholders,
+            limit="{0},{1}".format(offset, limit),
+            debug_show=self.DEBUG,
+        )
+        for artifact in data:
+            # new blobs are gzip'ed to save space, old ones may not be
+            try:
+                artifact["blob"] = zlib.decompress(artifact["blob"])
+            except zlib.error:
+                pass
+
+            if artifact["type"] == "json":
+                artifact["blob"] = json.loads(artifact["blob"])
+
+        return data
+
+    def get_performance_artifact_list(self, offset, limit, conditions=None):
+        """
+        Retrieve a list of performance artifacts. The conditions parameter is a
+        dict containing a set of conditions for each key. e.g.:
+        {
+            'job_id': set([('IN', (1, 2))])
+        }
+        """
+
+        replace_str, placeholders = self._process_conditions(
+            conditions, self.INDEXED_COLUMNS['performance_artifact']
+        )
+
+        repl = [replace_str]
+
+        proc = "jobs.selects.get_performance_artifact_list"
+
+        data = self.jobs_execute(
+            proc=proc,
+            replace=repl,
+            placeholders=placeholders,
+            limit="{0},{1}".format(offset, limit),
+            debug_show=self.DEBUG,
+        )
+
+        for artifact in data:
+            # new blobs are gzip'ed to save space, old ones may not be
+            try:
+                artifact["blob"] = zlib.decompress(artifact["blob"])
+            except zlib.error:
+                pass
+
+            # performance artifacts are always json encoded
+            artifact["blob"] = json.loads(artifact["blob"])
+
+        return data
+
+    def get_max_performance_artifact_id(self):
+        """Get the maximum performance artifact id."""
+        data = self.jobs_execute(
+            proc="jobs.selects.get_max_performance_artifact_id",
+            debug_show=self.DEBUG,
+        )
+        return int(data[0]['max_id'] or 0)
+
+    def store_job_artifact(self, artifact_placeholders):
+        """
+        Store a list of job_artifacts given a list of placeholders
+        """
+
+        self.jobs_execute(
+            proc='jobs.inserts.set_job_artifact',
+            debug_show=self.DEBUG,
+            placeholders=artifact_placeholders,
+            executemany=True)
+
+    def store_performance_artifact(
+            self, job_ids, performance_artifact_placeholders):
+        """
+        Store the performance data
+        """
+
+        # Retrieve list of job signatures associated with the jobs
+        job_data = self.get_job_signatures_from_ids(job_ids)
+
+        job_ref_data_signatures = set()
+        map(
+            lambda job_guid: job_ref_data_signatures.add(
+                job_data[job_guid]['signature']
+            ),
+            job_data.keys()
+        )
+
+        # Retrieve associated data in reference_data_signatures
+        reference_data = self.refdata_model.get_reference_data(
+            list(job_ref_data_signatures))
+
+        tda = TalosDataAdapter()
+
+        for perf_data in performance_artifact_placeholders:
+            job_guid = perf_data["job_guid"]
+            ref_data_signature = job_data[job_guid]['signature']
+            ref_data = reference_data[ref_data_signature]
+
+            if 'signature' in ref_data:
+                del ref_data['signature']
+
+            # adapt and load data into placeholder structures
+            tda.adapt_and_load(ref_data, job_data, perf_data)
+
+        self.jobs_execute(
+            proc="jobs.inserts.set_performance_artifact",
+            debug_show=self.DEBUG,
+            placeholders=tda.performance_artifact_placeholders,
+            executemany=True)
+
+        self.jobs_execute(
+            proc='jobs.inserts.set_series_signature',
+            debug_show=self.DEBUG,
+            placeholders=tda.signature_property_placeholders,
+            executemany=True)
+
+        tda.submit_tasks(self.project)
+
+    def load_job_artifacts(self, artifact_data, job_id_lookup):
+        """
+        Determine what type of artifacts are contained in artifact_data and
+        store a list of job artifacts substituting job_guid with job_id. All
+        of the datums in artifact_data need to be one of the three
+        different tasty "flavors" described below.
+
+        artifact_placeholders:
+
+            Comes in through the web service as the "artifacts" property
+            in a job in a job collection
+            (https://github.com/mozilla/treeherder-client#job-collection)
+
+            A list of lists
+            [
+                [job_guid, name, artifact_type, blob, job_guid, name]
+            ]
+
+        job_artifact_collection:
+
+            Comes in  through the web service as an artifact collection.
+            (https://github.com/mozilla/treeherder-client#artifact-collection)
+
+            A list of job artifacts:
+            [
+                {
+                    'type': 'json',
+                    'name': 'my-artifact-name',
+                    # blob can be any kind of structured data
+                    'blob': { 'stuff': [1, 2, 3, 4, 5] },
+                    'job_guid': 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
+                }
+            ]
+
+        performance_artifact:
+
+            Same structure as a job_artifact_collection but the blob contains
+            a specialized data structure designed for performance data.
+        """
+        artifact_placeholders_list = []
+        job_artifact_list = []
+
+        performance_artifact_list = []
+        performance_artifact_job_id_list = []
+
+        for index, artifact in enumerate(artifact_data):
+
+            # Determine what type of artifact we have received
+            if artifact:
+
+                job_id = None
+                job_guid = None
+
+                if isinstance(artifact, list):
+
+                    job_guid = artifact[0]
+                    job_id = job_id_lookup.get(job_guid, {}).get('id', None)
+
+                    self._adapt_job_artifact_placeholders(
+                        artifact, artifact_placeholders_list, job_id)
+
+                else:
+                    artifact_name = artifact['name']
+                    job_guid = artifact.get('job_guid', None)
+                    job_id = job_id_lookup.get(
+                        artifact['job_guid'], {}
+                    ).get('id', None)
+
+                    if artifact_name in PerformanceDataAdapter.performance_types:
+                        self._adapt_performance_artifact_collection(
+                            artifact, performance_artifact_list,
+                            performance_artifact_job_id_list, job_id)
+                    else:
+                        self._adapt_job_artifact_collection(
+                            artifact, job_artifact_list, job_id)
+
+                if not job_id:
+                    logger.error(
+                        ('load_job_artifacts: No job_id for '
+                         '{0} job_guid {1}'.format(self.project, job_guid)))
+
+            else:
+                logger.error(
+                    ('load_job_artifacts: artifact not '
+                     'defined for {0}'.format(self.project)))
+
+        # Store the various artifact types if we collected them
+        if artifact_placeholders_list:
+            self.store_job_artifact(artifact_placeholders_list)
+
+        if job_artifact_list:
+            self.store_job_artifact(job_artifact_list)
+
+        if performance_artifact_list and performance_artifact_job_id_list:
+            self.store_performance_artifact(
+                performance_artifact_job_id_list, performance_artifact_list)
+
+    def _adapt_job_artifact_placeholders(
+            self, artifact, artifact_placeholders_list, job_id):
+
+        if job_id:
+            # Replace job_guid with id in artifact data
+            artifact[0] = job_id
+            artifact[4] = job_id
+
+            artifact_placeholders_list.append(artifact)
+
+    def _adapt_job_artifact_collection(
+            self, artifact, artifact_data, job_id):
+
+        if job_id:
+            artifact_data.append((
+                job_id,
+                artifact['name'],
+                artifact['type'],
+                zlib.compress(artifact['blob']),
+                job_id,
+                artifact['name'],
+            ))
+
+    def _adapt_performance_artifact_collection(
+            self, artifact, artifact_data, job_id_list, job_id):
+
+        if job_id:
+            job_id_list.append(job_id)
+            artifact_data.append(artifact)
+
+    def get_job_signatures_from_ids(self, job_ids):
+
+        job_data = {}
+
+        if job_ids:
+
+            jobs_signatures_where_in_clause = [','.join(['%s'] * len(job_ids))]
+
+            job_data = self.jobs_execute(
+                proc='jobs.selects.get_signature_list_from_job_ids',
+                debug_show=self.DEBUG,
+                replace=jobs_signatures_where_in_clause,
+                key_column='job_guid',
+                return_type='dict',
+                placeholders=job_ids)
+
+        return job_data
+
+    @staticmethod
+    def populate_placeholders(artifacts, artifact_placeholders, job_guid):
+        for artifact in artifacts:
+            name = artifact.get('name')
+            artifact_type = artifact.get('type')
+
+            blob = artifact.get('blob')
+            if (artifact_type == 'json') and (not isinstance(blob, str)):
+                blob = json.dumps(blob)
+
+            if name and artifact_type and blob:
+                artifact_placeholders.append(
+                    [job_guid, name, artifact_type, blob, job_guid, name]
+                )

--- a/treeherder/webapp/api/artifact.py
+++ b/treeherder/webapp/api/artifact.py
@@ -4,8 +4,8 @@
 
 from rest_framework import viewsets
 from rest_framework.response import Response
-from treeherder.webapp.api.utils import (UrlQueryFilter, with_jobs,
-                                         oauth_required)
+from treeherder.webapp.api.utils import UrlQueryFilter, oauth_required
+from treeherder.model.derived import JobsModel, ArtifactsModel
 
 
 class ArtifactViewSet(viewsets.ViewSet):
@@ -13,21 +13,20 @@ class ArtifactViewSet(viewsets.ViewSet):
     """
     This viewset is responsible for the artifact endpoint.
     """
-    @with_jobs
-    def retrieve(self, request, project, jm, pk=None):
+    def retrieve(self, request, project, pk=None):
         """
         retrieve a single instance of job_artifact
         """
         filter = UrlQueryFilter({"id": pk})
 
-        objs = jm.get_job_artifact_list(0, 1, filter.conditions)
-        if objs:
-            return Response(objs[0])
-        else:
-            return Response("job_artifact {0} not found".format(pk), 404)
+        with ArtifactsModel(project) as artifactModel:
+            objs = artifactModel.get_job_artifact_list(0, 1, filter.conditions)
+            if objs:
+                return Response(objs[0])
+            else:
+                return Response("job_artifact {0} not found".format(pk), 404)
 
-    @with_jobs
-    def list(self, request, project, jm):
+    def list(self, request, project):
         """
         return a list of job artifacts
         """
@@ -45,16 +44,21 @@ class ArtifactViewSet(viewsets.ViewSet):
         offset = filter.pop("offset", 0)
         count = min(int(filter.pop("count", 10)), 1000)
 
-        objs = jm.get_job_artifact_list(offset, count, filter.conditions)
-        return Response(objs)
+        with ArtifactsModel(project) as artifacts_model:
+            objs = artifacts_model.get_job_artifact_list(
+                offset,
+                count,
+                filter.conditions
+            )
+            return Response(objs)
 
-    @with_jobs
     @oauth_required
-    def create(self, request, project, jm):
+    def create(self, request, project):
 
         job_guids = [x['job_guid'] for x in request.DATA]
-        job_id_lookup = jm.get_job_ids_by_guid(job_guids)
+        with JobsModel(project) as jobsModel, ArtifactsModel(project) as artifacts_model:
 
-        jm.load_job_artifacts(request.DATA, job_id_lookup)
+            job_id_lookup = jobsModel.get_job_ids_by_guid(job_guids)
+            artifacts_model.load_job_artifacts(request.DATA, job_id_lookup)
 
-        return Response({'message': 'Artifacts stored successfully'})
+            return Response({'message': 'Artifacts stored successfully'})

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -10,6 +10,7 @@ from rest_framework.permissions import IsAuthenticated
 
 from treeherder.webapp.api.utils import (UrlQueryFilter, with_jobs,
                                          oauth_required, get_option)
+from treeherder.model.derived import ArtifactsModel
 
 
 class JobsViewSet(viewsets.ViewSet):
@@ -36,7 +37,9 @@ class JobsViewSet(viewsets.ViewSet):
             job["logs"] = jm.get_log_references(pk)
 
             # make artifact ids into uris
-            artifact_refs = jm.get_job_artifact_references(pk)
+
+            with ArtifactsModel(project) as artifacts_model:
+                artifact_refs = artifacts_model.get_job_artifact_references(pk)
             job["artifacts"] = []
             for art in artifact_refs:
                 ref = reverse("artifact-detail",

--- a/treeherder/webapp/api/projects.py
+++ b/treeherder/webapp/api/projects.py
@@ -6,17 +6,19 @@ from django.http import HttpResponse, HttpResponseNotFound
 from treeherder.model.derived import DatasetNotFoundError
 import simplejson as json
 
-from treeherder.model.derived import JobsModel
+from treeherder.model.derived import JobsModel, ArtifactsModel
 
 
 def project_info(request, project):
     try:
-        jm = JobsModel(project)
-        return HttpResponse(content=json.dumps({'max_job_id': jm.get_max_job_id(),
-                                                'max_performance_artifact_id':
-                                                jm.get_max_performance_artifact_id()}
-                                               ),
-                            content_type='application/json'
-                            )
+        with JobsModel(project) as jobs_model, ArtifactsModel(project) as artifacts_model:
+            return HttpResponse(
+                content=json.dumps(
+                    {'max_job_id': jobs_model.get_max_job_id(),
+                     'max_performance_artifact_id':
+                     artifacts_model.get_max_performance_artifact_id()}
+                ),
+                content_type='application/json'
+            )
     except DatasetNotFoundError:
         return HttpResponseNotFound('Project does not exist')


### PR DESCRIPTION
There comes a time when a class should not grow any larger.  ``model/derived/jobs.py`` is nearing 3000 lines!  I can't, in good conscience, add MORE code that throws it over that size.  While working on auto-generation of ``bug_suggestions`` for non-buildbot submissions for artifacts, I hit on this.

This PR creates a new ``ArtifactsModel`` which refactors ``artifact`` handling out of ``JobsModel``.  The ``JobsModel`` still calls ``ArtifactsModel`` during job ingestion.

Let's discuss this proposal and see if it makes sense to all of us.  Thanks!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-service/462)
<!-- Reviewable:end -->
