### PR TITLE
Bug 1146184 - Deploying should peep install into a virtualenv and rsync to all nodes

### DIFF
--- a/bin/run_celery_worker
+++ b/bin/run_celery_worker
@@ -4,8 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-curr_dir=$( dirname "${BASH_SOURCE[0]}" )
-cd $( dirname $curr_dir)
+SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
+cd $SRC_DIR
 
 source /etc/profile.d/treeherder.sh
 

--- a/bin/run_celery_worker
+++ b/bin/run_celery_worker
@@ -7,17 +7,13 @@
 SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
 cd $SRC_DIR
 
+PROJECT_ROOT=$(readlink -f ../)
+PATH=$PROJECT_ROOT/venv/bin:$PATH
+
 source /etc/profile.d/treeherder.sh
 
 if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then
     NEWRELIC_ADMIN="newrelic-admin run-program"
-fi
-
-if [ -f ../venv/bin/celery ]; then
-    source ../venv/bin/activate
-    CELERY=../venv/bin/celery
-else
-    CELERY=celery
 fi
 
 LOGFILE=/var/log/celery/celery_worker.log
@@ -26,7 +22,7 @@ if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec $NEWRELIC_ADMIN $CELERY -A treeherder worker -c 3 \
+exec $NEWRELIC_ADMIN celery -A treeherder worker -c 3 \
      -Q default,process_objects,cycle_data,calculate_eta,populate_performance_series,fetch_bugs \
      -E --maxtasksperchild=500 \
      --logfile=$LOGFILE -l INFO -n default.%h

--- a/bin/run_celery_worker_buildapi
+++ b/bin/run_celery_worker_buildapi
@@ -4,8 +4,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-curr_dir=$( dirname "${BASH_SOURCE[0]}" )
-cd $( dirname $curr_dir)
+SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
+cd $SRC_DIR
+
 source /etc/profile.d/treeherder.sh
 
 if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then

--- a/bin/run_celery_worker_buildapi
+++ b/bin/run_celery_worker_buildapi
@@ -7,17 +7,13 @@
 SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
 cd $SRC_DIR
 
+PROJECT_ROOT=$(readlink -f ../)
+PATH=$PROJECT_ROOT/venv/bin:$PATH
+
 source /etc/profile.d/treeherder.sh
 
 if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then
     NEWRELIC_ADMIN="newrelic-admin run-program"
-fi
-
-if [ -f ../venv/bin/celery ]; then
-    source ../venv/bin/activate
-    CELERY=../venv/bin/celery
-else
-    CELERY=celery
 fi
 
 LOGFILE=/var/log/celery/celery_worker_buildapi.log
@@ -26,7 +22,7 @@ if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec $NEWRELIC_ADMIN $CELERY -A treeherder worker -Q buildapi \
+exec $NEWRELIC_ADMIN celery -A treeherder worker -Q buildapi \
     --concurrency=5 --logfile=$LOGFILE -l INFO \
     --maxtasksperchild=20 -n buildapi.%h
 

--- a/bin/run_celery_worker_hp
+++ b/bin/run_celery_worker_hp
@@ -4,8 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-curr_dir=$( dirname "${BASH_SOURCE[0]}" )
-cd $( dirname $curr_dir)
+SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
+cd $SRC_DIR
 
 source /etc/profile.d/treeherder.sh
 

--- a/bin/run_celery_worker_hp
+++ b/bin/run_celery_worker_hp
@@ -7,17 +7,13 @@
 SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
 cd $SRC_DIR
 
+PROJECT_ROOT=$(readlink -f ../)
+PATH=$PROJECT_ROOT/venv/bin:$PATH
+
 source /etc/profile.d/treeherder.sh
 
 if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then
     NEWRELIC_ADMIN="newrelic-admin run-program"
-fi
-
-if [ -f ../venv/bin/celery ]; then
-    source ../venv/bin/activate
-    CELERY=../venv/bin/celery
-else
-    CELERY=celery
 fi
 
 LOGFILE=/var/log/celery/celery_worker_hp.log
@@ -26,6 +22,6 @@ if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec $NEWRELIC_ADMIN $CELERY -A treeherder worker -c 1 \
+exec $NEWRELIC_ADMIN celery -A treeherder worker -c 1 \
      -Q classification_mirroring,publish_to_pulse -E --maxtasksperchild=500 \
      --logfile=$LOGFILE -l INFO -n hp.%h

--- a/bin/run_celery_worker_log_parser
+++ b/bin/run_celery_worker_log_parser
@@ -7,17 +7,13 @@
 SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
 cd $SRC_DIR
 
+PROJECT_ROOT=$(readlink -f ../)
+PATH=$PROJECT_ROOT/venv/bin:$PATH
+
 source /etc/profile.d/treeherder.sh
 
 if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then
     NEWRELIC_ADMIN="newrelic-admin run-program"
-fi
-
-if [ -f ../venv/bin/celery ]; then
-    source ../venv/bin/activate
-    CELERY=../venv/bin/celery
-else
-    CELERY=celery
 fi
 
 LOGFILE=/var/log/celery/celery_worker_log_parser.log
@@ -26,7 +22,7 @@ if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec $NEWRELIC_ADMIN $CELERY -A treeherder worker \
+exec $NEWRELIC_ADMIN celery -A treeherder worker \
     -Q log_parser_fail,log_parser,log_parser_hp,log_parser_json \
     --logfile=$LOGFILE -l INFO \
     --maxtasksperchild=500 -n log_parser.%h

--- a/bin/run_celery_worker_log_parser
+++ b/bin/run_celery_worker_log_parser
@@ -4,8 +4,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-curr_dir=$( dirname "${BASH_SOURCE[0]}" )
-cd $( dirname $curr_dir)
+SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
+cd $SRC_DIR
+
 source /etc/profile.d/treeherder.sh
 
 if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then

--- a/bin/run_celery_worker_pushlog
+++ b/bin/run_celery_worker_pushlog
@@ -4,8 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-curr_dir=$( dirname "${BASH_SOURCE[0]}" )
-cd $( dirname $curr_dir)
+SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
+cd $SRC_DIR
 
 source /etc/profile.d/treeherder.sh
 

--- a/bin/run_celery_worker_pushlog
+++ b/bin/run_celery_worker_pushlog
@@ -7,17 +7,13 @@
 SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
 cd $SRC_DIR
 
+PROJECT_ROOT=$(readlink -f ../)
+PATH=$PROJECT_ROOT/venv/bin:$PATH
+
 source /etc/profile.d/treeherder.sh
 
 if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then
     NEWRELIC_ADMIN="newrelic-admin run-program"
-fi
-
-if [ -f ../venv/bin/celery ]; then
-    source ../venv/bin/activate
-    CELERY=../venv/bin/celery
-else
-    CELERY=celery
 fi
 
 LOGFILE=/var/log/celery/celery_worker_pushlog.log
@@ -26,7 +22,7 @@ if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec $NEWRELIC_ADMIN $CELERY -A treeherder worker \
+exec $NEWRELIC_ADMIN celery -A treeherder worker \
     -Q pushlog,fetch_missing_push_logs \
     --concurrency=5 --logfile=$LOGFILE -l INFO \
     --maxtasksperchild=500 -n pushlog.%h

--- a/bin/run_celerybeat
+++ b/bin/run_celerybeat
@@ -4,8 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-curr_dir=$( dirname "${BASH_SOURCE[0]}" )
-cd $( dirname $curr_dir)
+SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
+cd $SRC_DIR
 
 LOGFILE=/var/log/celery/celerybeat.log
 

--- a/bin/run_celerybeat
+++ b/bin/run_celerybeat
@@ -7,6 +7,9 @@
 SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
 cd $SRC_DIR
 
+PROJECT_ROOT=$(readlink -f ../)
+PATH=$PROJECT_ROOT/venv/bin:$PATH
+
 LOGFILE=/var/log/celery/celerybeat.log
 
 if [ ! -f $LOGFILE ]; then
@@ -15,11 +18,4 @@ fi
 
 source /etc/profile.d/treeherder.sh
 
-if [ -f ../venv/bin/celery ]; then
-    source ../venv/bin/activate
-    CELERY=../venv/bin/celery
-else
-    CELERY=celery
-fi
-
-exec $CELERY -A treeherder beat -f $LOGFILE
+exec celery -A treeherder beat -f $LOGFILE

--- a/bin/run_gunicorn
+++ b/bin/run_gunicorn
@@ -6,8 +6,8 @@
 
 set -e
 
-curr_dir=$( dirname "${BASH_SOURCE[0]}" )
-cd $( dirname $curr_dir)
+SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
+cd $SRC_DIR
 
 LOGDIR=/var/log/gunicorn
 ACCESS_LOGFILE=$LOGDIR/treeherder_access.log

--- a/bin/run_gunicorn
+++ b/bin/run_gunicorn
@@ -9,6 +9,9 @@ set -e
 SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
 cd $SRC_DIR
 
+PROJECT_ROOT=$(readlink -f ../)
+PATH=$PROJECT_ROOT/venv/bin:$PATH
+
 LOGDIR=/var/log/gunicorn
 ACCESS_LOGFILE=$LOGDIR/treeherder_access.log
 ERROR_LOGFILE=$LOGDIR/treeherder_error.log
@@ -25,14 +28,7 @@ NUM_WORKERS=5
 
 source /etc/profile.d/treeherder.sh
 
-if [ -f ../venv/bin/gunicorn ]; then
-    source ../venv/bin/activate
-    GUNICORN=../venv/bin/gunicorn
-else
-    GUNICORN=/usr/bin/gunicorn
-fi
-
-exec $GUNICORN -w $NUM_WORKERS \
+exec gunicorn -w $NUM_WORKERS \
     --max-requests=150 \
     --access-logfile=$ACCESS_LOGFILE \
     --error-logfile=$ERROR_LOGFILE treeherder.webapp.wsgi:application \


### PR DESCRIPTION
I've tested this on stage and it appear to work well. eg:

First deploy:
http://treeherderadm.private.scl3.mozilla.com/chief/treeherder.stage/logs/virtualenv-deploy.1429119652

Later deploy (with no-op package install step, since the venv is already populated):
http://treeherderadm.private.scl3.mozilla.com/chief/treeherder.stage/logs/virtualenv-deploy.1429123134

I've also verified that we're using the binaries from the virtualenv bin:
```bash
[root@treeherder1.stage.webapp.scl3 ~]# ps aux | grep [g]unicorn
<snip>
495      20228  5.6  1.1 551368 71500 ?        Sl   18:01   0:04 python2.7 /data/www/treeherder.allizom.org/venv/bin/gunicorn <snip>
[root@treeherder1.stage.webapp.scl3 ~]# ls -l /proc/20228/exe
lrwxrwxrwx 1 treeherder treeherder 0 Apr 15 18:02 /proc/20228/exe -> /data/www/treeherder.allizom.org/venv/bin/python2.7
```

For explanation of the changes, see the individual commit messages.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-service/464)
<!-- Reviewable:end -->
