### PR TITLE
Bug 1080760 - Bug suggestions artifact auto generation

### DIFF
--- a/tests/log_parser/test_utils.py
+++ b/tests/log_parser/test_utils.py
@@ -3,8 +3,8 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from treeherder.log_parser.utils import (get_error_search_term,
-                                         get_crash_signature)
+from treeherder.model.bug_suggestions import (get_error_search_term,
+                                              get_crash_signature)
 
 
 PIPE_DELIMITED_LINE_TEST_CASES = (

--- a/tests/sample_data/artifacts/text_log_summary.json
+++ b/tests/sample_data/artifacts/text_log_summary.json
@@ -1,0 +1,262 @@
+{
+    "blob": {
+        "header": {
+            "slave": "t-snow-r4-0001",
+            "buildid": "20150415030206",
+            "builder": "mozilla-central_snowleopard_test-mochitest-2",
+            "results": "warnings (1)",
+            "starttime": "1429100703.17",
+            "builduid": "8ad46455f18545abbdff94ba9dce402e",
+            "revision": "a6f7a33731bc3fe22073129bba83fc7480e387e2"
+        },
+        "step_data": {
+            "all_errors": [
+                {
+                    "line": "05:35:49     INFO -  2018 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Should be able to get objectStore - expected PASS",
+                    "linenumber": 8151
+                },
+                {
+                    "line": "05:35:49     INFO -  2019 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Should be able to get index - expected PASS",
+                    "linenumber": 8152
+                },
+                {
+                    "line": "05:35:49     INFO -  2023 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Ordering is correct. - expected PASS",
+                    "linenumber": 8156
+                },
+                {
+                    "line": "05:35:49     INFO -  2024 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Worker: uncaught exception [http://mochi.test:8888/tests/dom/indexedDB/test/unit/test_transaction_lifetimes.js:45]: ': InvalidStateError: An attempt was made to use an object that is not, or is no longer, usable' - expected PASS",
+                    "linenumber": 8157
+                }
+            ],
+            "steps": [
+                {
+                    "errors": [ ],
+                    "name": "set props: master",
+                    "started": "2015-04-15 05:25:03.168328",
+                    "started_linenumber": 8,
+                    "finished_linenumber": 10,
+                    "finished": "2015-04-15 05:25:03.168795",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 0,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "set props: basedir",
+                    "started": "2015-04-15 05:25:03.169099",
+                    "started_linenumber": 12,
+                    "finished_linenumber": 40,
+                    "finished": "2015-04-15 05:25:03.597219",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 1,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "downloading to buildprops.json",
+                    "started": "2015-04-15 05:25:03.597542",
+                    "started_linenumber": 42,
+                    "finished_linenumber": 43,
+                    "finished": "2015-04-15 05:25:03.726142",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 2,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "'rm -rf ...'",
+                    "started": "2015-04-15 05:25:03.726523",
+                    "started_linenumber": 45,
+                    "finished_linenumber": 71,
+                    "finished": "2015-04-15 05:25:03.777120",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 3,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "set props: script_repo_url",
+                    "started": "2015-04-15 05:25:03.777445",
+                    "started_linenumber": 73,
+                    "finished_linenumber": 75,
+                    "finished": "2015-04-15 05:25:03.777817",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 4,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "'bash -c ...'",
+                    "started": "2015-04-15 05:25:03.778747",
+                    "started_linenumber": 77,
+                    "finished_linenumber": 114,
+                    "finished": "2015-04-15 05:25:03.945448",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 5,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "set props: script_repo_revision script_repo_url",
+                    "started": "2015-04-15 05:25:03.945809",
+                    "started_linenumber": 116,
+                    "finished_linenumber": 146,
+                    "finished": "2015-04-15 05:25:04.682022",
+                    "error_count": 0,
+                    "duration": 1,
+                    "order": 6,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "'rm -rf ...'",
+                    "started": "2015-04-15 05:25:04.682572",
+                    "started_linenumber": 148,
+                    "finished_linenumber": 174,
+                    "finished": "2015-04-15 05:25:05.278125",
+                    "error_count": 0,
+                    "duration": 1,
+                    "order": 7,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "'hg clone ...'",
+                    "started": "2015-04-15 05:25:05.278437",
+                    "started_linenumber": 176,
+                    "finished_linenumber": 210,
+                    "finished": "2015-04-15 05:25:11.964370",
+                    "error_count": 0,
+                    "duration": 7,
+                    "order": 8,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "'hg update ...'",
+                    "started": "2015-04-15 05:25:11.964712",
+                    "started_linenumber": 212,
+                    "finished_linenumber": 239,
+                    "finished": "2015-04-15 05:25:12.506740",
+                    "error_count": 0,
+                    "duration": 1,
+                    "order": 9,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "set props: script_repo_revision",
+                    "started": "2015-04-15 05:25:12.507514",
+                    "started_linenumber": 241,
+                    "finished_linenumber": 269,
+                    "finished": "2015-04-15 05:25:12.700263",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 10,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "downloading to oauth.txt",
+                    "started": "2015-04-15 05:25:12.700568",
+                    "started_linenumber": 271,
+                    "finished_linenumber": 272,
+                    "finished": "2015-04-15 05:25:12.730239",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 11,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "tinderboxprint_script_revlink",
+                    "started": "2015-04-15 05:25:12.730485",
+                    "started_linenumber": 274,
+                    "finished_linenumber": 276,
+                    "finished": "2015-04-15 05:25:12.730832",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 12,
+                    "result": "success"
+                },
+                {
+                    "errors": [
+                        {
+                            "line": "05:35:49     INFO -  2018 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Should be able to get objectStore - expected PASS",
+                            "linenumber": 8151
+                        },
+                        {
+                            "line": "05:35:49     INFO -  2019 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Should be able to get index - expected PASS",
+                            "linenumber": 8152
+                        },
+                        {
+                            "line": "05:35:49     INFO -  2023 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Ordering is correct. - expected PASS",
+                            "linenumber": 8156
+                        },
+                        {
+                            "line": "05:35:49     INFO -  2024 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Worker: uncaught exception [http://mochi.test:8888/tests/dom/indexedDB/test/unit/test_transaction_lifetimes.js:45]: ': InvalidStateError: An attempt was made to use an object that is not, or is no longer, usable' - expected PASS",
+                            "linenumber": 8157
+                        }
+                    ],
+                    "name": "'/tools/buildbot/bin/python scripts/scripts/desktop_unittest.py ...' warnings",
+                    "started": "2015-04-15 05:25:12.731202",
+                    "started_linenumber": 278,
+                    "finished_linenumber": 9248,
+                    "finished": "2015-04-15 05:36:51.808779",
+                    "error_count": 4,
+                    "duration": 699,
+                    "order": 13,
+                    "result": "testfailed"
+                },
+                {
+                    "errors": [ ],
+                    "name": "set props: build_url blobber_files",
+                    "started": "2015-04-15 05:36:51.812718",
+                    "started_linenumber": 9250,
+                    "finished_linenumber": 9280,
+                    "finished": "2015-04-15 05:36:51.871786",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 14,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "'rm -f ...'",
+                    "started": "2015-04-15 05:36:51.872124",
+                    "started_linenumber": 9282,
+                    "finished_linenumber": 9308,
+                    "finished": "2015-04-15 05:36:51.927004",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 15,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "reboot skipped",
+                    "started": "2015-04-15 05:36:51.927332",
+                    "started_linenumber": 9310,
+                    "finished_linenumber": 9311,
+                    "finished": "2015-04-15 05:36:51.927750",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 16,
+                    "result": "skipped"
+                }
+            ],
+            "errors_truncated": false
+        },
+        "logurl": "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/2015/04/2015-04-15-03-02-06-mozilla-central/mozilla-central_snowleopard_test-mochitest-2-bm107-tests1-macosx-build128.txt.gz"
+    },
+    "type": "json",
+    "id": 8217463,
+    "name": "text_log_summary",
+    "job_id": 1330578
+}

--- a/tests/sampledata.py
+++ b/tests/sampledata.py
@@ -57,6 +57,10 @@ class SampleData(object):
                   os.path.dirname(__file__))) as f:
             self.job_artifact = f.readlines()
 
+        with open("{0}/sample_data/artifacts/text_log_summary.json".format(
+                  os.path.dirname(__file__))) as f:
+            self.text_log_summary = json.load(f)
+
         self.job_data = []
         self.resultset_data = []
 

--- a/tests/webapp/api/test_artifact_api.py
+++ b/tests/webapp/api/test_artifact_api.py
@@ -2,9 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+import json
 import pytest
+
 from django.core.urlresolvers import reverse
+
+import thclient
+
+from treeherder.etl.oauth_utils import OAuthCredentials
 from treeherder.model.derived import ArtifactsModel
+
 
 xfail = pytest.mark.xfail
 
@@ -13,7 +20,7 @@ xfail = pytest.mark.xfail
 
 def test_artifact_detail(webapp, test_project, eleven_jobs_processed, sample_artifacts, jm):
     """
-    test retrieving a single job from the jobs-detail
+    test retrieving a single artifact from the artifact-detail
     endpoint.
     """
     job = jm.get_job_list(0, 1)[0]
@@ -66,5 +73,61 @@ def test_artifact_detail_bad_project(webapp, jm):
     )
     assert resp.status_int == 404
     assert resp.json == {"detail": "No project with name foo"}
+
+    jm.disconnect()
+
+
+def test_artifact_create_text_log_summary(webapp, eleven_jobs_processed,
+                                          mock_send_request, monkeypatch,
+                                          sample_data, jm):
+    """
+    test creating a text_log_summary artifact which auto-generates bug suggestions
+    """
+    bs_obj = ["foo", "bar"]
+
+    from treeherder.model import bug_suggestions
+
+    def _get_bug_suggestions(params):
+        return bs_obj
+
+    monkeypatch.setattr(bug_suggestions, "get_bug_suggestions", _get_bug_suggestions)
+
+    credentials = OAuthCredentials.get_credentials(jm.project)
+
+    job = jm.get_job_list(0, 1)[0]
+    tls = sample_data.text_log_summary
+
+    tac = thclient.TreeherderArtifactCollection()
+    ta = thclient.TreeherderArtifact({
+        'type': 'json',
+        'name': 'text_log_summary',
+        'blob': json.dumps(tls['blob']),
+        'job_guid': job['job_guid']
+    })
+    tac.add(ta)
+
+    req = thclient.TreeherderRequest(
+        protocol='http',
+        host='localhost',
+        project=jm.project,
+        oauth_key=credentials['consumer_key'],
+        oauth_secret=credentials['consumer_secret']
+        )
+
+    # Post the request to treeherder
+    resp = req.post(tac)
+    assert resp.status_int == 200
+    assert resp.body == '{"message": "Artifacts stored successfully"}'
+
+    with ArtifactsModel(jm.project) as artifacts_model:
+        artifacts = artifacts_model.get_job_artifact_list(0, 10, conditions={
+            'job_id': {('=', job["id"])}
+        })
+
+    artifact_names = {x['name'] for x in artifacts}
+    act_bs_obj = [x['blob'] for x in artifacts if x['name'] == 'Bug suggestions'][0]
+
+    assert set(artifact_names) == {'Bug suggestions', 'text_log_summary'}
+    assert bs_obj == act_bs_obj
 
     jm.disconnect()

--- a/treeherder/etl/mixins.py
+++ b/treeherder/etl/mixins.py
@@ -10,12 +10,10 @@ from collections import defaultdict
 
 import simplejson as json
 
-from thclient import TreeherderRequest
-
 from django.core.urlresolvers import reverse
 from django.conf import settings
-from django.utils.encoding import python_2_unicode_compatible
-from treeherder.etl.oauth_utils import OAuthCredentials
+
+from treeherder.etl import th_publisher
 
 
 logger = logging.getLogger(__name__)
@@ -121,50 +119,7 @@ class ResultSetsLoaderMixin(JsonLoaderMixin):
                 logger.error("ResultSet loading failed: {0}".format(message['message']))
 
 
-@python_2_unicode_compatible
-class CollectionNotLoadedException(Exception):
-
-    def __init__(self, error_list, *args, **kwargs):
-        """
-        error_list contains dictionaries, each containing
-        project, url and message
-        """
-        super(CollectionNotLoadedException, self).__init__(args, kwargs)
-        self.error_list = error_list
-
-    def __str__(self):
-        return "\n".join(
-            ["[{project}] Error posting data to {url}: {message}".format(
-                **error) for error in self.error_list]
-        )
-
-
 class OAuthLoaderMixin(object):
 
     def load(self, th_collections):
-        errors = []
-        for project in th_collections:
-
-            credentials = OAuthCredentials.get_credentials(project)
-
-            th_request = TreeherderRequest(
-                protocol=settings.TREEHERDER_REQUEST_PROTOCOL,
-                host=settings.TREEHERDER_REQUEST_HOST,
-                project=project,
-                oauth_key=credentials.get('consumer_key', None),
-                oauth_secret=credentials.get('consumer_secret', None)
-            )
-
-            logger.info(
-                "collection loading request: {0}".format(
-                    th_request.get_uri(th_collections[project].endpoint_base)))
-            response = th_request.post(th_collections[project])
-
-            if not response or response.status != 200:
-                errors.append({
-                    "project": project,
-                    "url": th_collections[project].endpoint_base,
-                    "message": response.read()
-                })
-        if errors:
-            raise CollectionNotLoadedException(errors)
+        th_publisher.post_treeherder_collections(th_collections)

--- a/treeherder/etl/th_publisher.py
+++ b/treeherder/etl/th_publisher.py
@@ -1,0 +1,58 @@
+import logging
+
+from django.utils.encoding import python_2_unicode_compatible
+from django.conf import settings
+
+from thclient import TreeherderRequest
+
+from treeherder.etl.oauth_utils import OAuthCredentials
+
+
+logger = logging.getLogger(__name__)
+
+
+def post_treeherder_collections(th_collections):
+    errors = []
+    for project in th_collections:
+
+        credentials = OAuthCredentials.get_credentials(project)
+
+        th_request = TreeherderRequest(
+            protocol=settings.TREEHERDER_REQUEST_PROTOCOL,
+            host=settings.TREEHERDER_REQUEST_HOST,
+            project=project,
+            oauth_key=credentials.get('consumer_key', None),
+            oauth_secret=credentials.get('consumer_secret', None)
+        )
+
+        logger.info(
+            "collection loading request: {0}".format(
+                th_request.get_uri(th_collections[project].endpoint_base)))
+        response = th_request.post(th_collections[project])
+
+        if not response or response.status == 200:
+            errors.append({
+                "project": project,
+                "url": th_collections[project].endpoint_base,
+                "message": response.read()
+            })
+    if errors:
+        raise CollectionNotLoadedException(errors)
+
+
+@python_2_unicode_compatible
+class CollectionNotLoadedException(Exception):
+
+    def __init__(self, error_list, *args, **kwargs):
+        """
+        error_list contains dictionaries, each containing
+        project, url and message
+        """
+        super(CollectionNotLoadedException, self).__init__(args, kwargs)
+        self.error_list = error_list
+
+    def __str__(self):
+        return "\n".join(
+            ["[{project}] Error posting data to {url}: {message}".format(
+                **error) for error in self.error_list]
+        )

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -2,15 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import re
-import urllib
 import urllib2
 import logging
 import time
 
 import simplejson as json
 from django.conf import settings
-from django.core.urlresolvers import reverse
 
 from treeherder.log_parser.artifactbuildercollection import \
     ArtifactBuilderCollection
@@ -22,130 +19,6 @@ from treeherder.etl.oauth_utils import OAuthCredentials
 logger = logging.getLogger(__name__)
 
 
-def is_helpful_search_term(search_term):
-    # Search terms that will match too many bug summaries
-    # and so not result in useful suggestions.
-    search_term = search_term.strip()
-
-    blacklist = [
-        'automation.py',
-        'remoteautomation.py',
-        'Shutdown',
-        'undefined',
-        'Main app process exited normally',
-        'Traceback (most recent call last):',
-        'Return code: 0',
-        'Return code: 1',
-        'Return code: 2',
-        'Return code: 9',
-        'Return code: 10',
-        'Exiting 1',
-        'Exiting 9',
-        'CrashingThread(void *)',
-        'libSystem.B.dylib + 0xd7a',
-        'linux-gate.so + 0x424',
-        'TypeError: content is null',
-        'leakcheck'
-    ]
-
-    return len(search_term) > 4 and not (search_term in blacklist)
-
-
-LEAK_RE = re.compile(r'\d+ bytes leaked \((.+)\)$')
-CRASH_RE = re.compile(r'.+ application crashed \[@ (.+)\]$')
-
-
-def get_error_search_term(error_line):
-    """
-    retrieves bug suggestions from bugscache using search_term
-    in a full_text search.
-    """
-    if not error_line:
-        return None
-
-    # This is strongly inspired by
-    # https://hg.mozilla.org/webtools/tbpl/file/tip/php/inc/AnnotatedSummaryGenerator.php#l73
-
-    tokens = error_line.split(" | ")
-    search_term = None
-
-    if len(tokens) >= 3:
-        # it's in the "FAILURE-TYPE | testNameOrFilePath | message" type format.
-        test_name_or_path = tokens[1]
-        message = tokens[2]
-
-        # Leak failure messages are of the form:
-        # leakcheck | .*\d+ bytes leaked (Object-1, Object-2, Object-3, ...)
-        match = LEAK_RE.search(message)
-        if match:
-            search_term = match.group(1)
-        else:
-            for splitter in ("/", "\\"):
-                # if this is a path, we are interested in the last part
-                test_name_or_path = test_name_or_path.split(splitter)[-1]
-            search_term = test_name_or_path
-
-    # If the failure line was not in the pipe symbol delimited format or the search term
-    # will likely return too many (or irrelevant) results (eg: too short or matches terms
-    # on the blacklist), then we fall back to searching for the entire failure line if
-    # it is suitable.
-    if not (search_term and is_helpful_search_term(search_term)):
-        if is_helpful_search_term(error_line):
-            search_term = error_line
-        else:
-            search_term = None
-
-    # Searching for extremely long search terms is undesirable, since:
-    # a) Bugzilla's max summary length is 256 characters, and once "Intermittent "
-    # and platform/suite information is prefixed, there are even fewer characters
-    # left for us to use for the failure string against which we need to match.
-    # b) For long search terms, the additional length does little to prevent against
-    # false positives, but means we're more susceptible to false negatives due to
-    # run-to-run variances in the error messages (eg paths, process IDs).
-    if search_term:
-        search_term = search_term[:100]
-
-    return search_term
-
-
-def get_crash_signature(error_line):
-    """
-    Detect if the error_line contains a crash signature
-    and return it if it's a helpful search term
-    """
-    search_term = None
-    match = CRASH_RE.match(error_line)
-    if match and is_helpful_search_term(match.group(1)):
-        search_term = match.group(1)
-    return search_term
-
-
-def get_bugs_for_search_term(search, base_uri):
-    """
-    Fetch the base_uri endpoint filtering on search and status.
-    Status must be either 'open' or 'closed'
-    """
-    from treeherder.etl.common import get_remote_content
-
-    params = {
-        'search': search
-    }
-    query_string = urllib.urlencode(params)
-    url = '{0}?{1}'.format(
-        base_uri,
-        query_string
-    )
-    return get_remote_content(url)
-
-mozharness_pattern = re.compile(
-    r'^\d+:\d+:\d+[ ]+(?:DEBUG|INFO|WARNING|ERROR|CRITICAL|FATAL) - [ ]?'
-)
-
-
-def get_mozharness_substring(line):
-    return mozharness_pattern.sub('', line).strip()
-
-
 def is_parsed(job_log_url):
     # if parse_status is not available, consider it pending
     parse_status = job_log_url.get("parse_status", "pending")
@@ -154,12 +27,6 @@ def is_parsed(job_log_url):
 
 def extract_text_log_artifacts(log_url, job_guid, check_errors):
     """Generate a summary artifact for the raw text log."""
-    bug_suggestions = []
-    bugscache_uri = '{0}{1}'.format(
-        settings.API_HOSTNAME,
-        reverse("bugscache-list")
-    )
-    terms_requested = {}
 
     # parse a log given its url
     artifact_bc = ArtifactBuilderCollection(log_url,
@@ -170,65 +37,6 @@ def extract_text_log_artifacts(log_url, job_guid, check_errors):
     for name, artifact in artifact_bc.artifacts.items():
         artifact_list.append((job_guid, name, 'json',
                               json.dumps(artifact)))
-    if check_errors:
-        all_errors = artifact_bc.artifacts\
-            .get('text_log_summary', {})\
-            .get('step_data', {})\
-            .get('all_errors', [])
-
-        for err in all_errors:
-            # remove the mozharness prefix
-            clean_line = get_mozharness_substring(err['line'])
-            search_terms = []
-            # get a meaningful search term out of the error line
-            search_term = get_error_search_term(clean_line)
-            bugs = dict(open_recent=[], all_others=[])
-
-            # collect open recent and all other bugs suggestions
-            if search_term:
-                search_terms.append(search_term)
-                if search_term not in terms_requested:
-                    # retrieve the list of suggestions from the api
-                    bugs = get_bugs_for_search_term(
-                        search_term,
-                        bugscache_uri
-                    )
-                    terms_requested[search_term] = bugs
-                else:
-                    bugs = terms_requested[search_term]
-
-            if not bugs or not (bugs['open_recent'] or
-                                bugs['all_others']):
-                # no suggestions, try to use
-                # the crash signature as search term
-                crash_signature = get_crash_signature(clean_line)
-                if crash_signature:
-                    search_terms.append(crash_signature)
-                    if crash_signature not in terms_requested:
-                        bugs = get_bugs_for_search_term(
-                            crash_signature,
-                            bugscache_uri
-                        )
-                        terms_requested[crash_signature] = bugs
-                    else:
-                        bugs = terms_requested[crash_signature]
-
-            # TODO: Rename 'search' to 'error_text' or similar, since that's
-            # closer to what it actually represents (bug 1091060).
-            bug_suggestions.append({
-                "search": clean_line,
-                "search_terms": search_terms,
-                "bugs": bugs
-            })
-
-    artifact_list.append(
-        (
-            job_guid,
-            'Bug suggestions',
-            'json',
-            json.dumps(bug_suggestions)
-        )
-    )
 
     return artifact_list
 

--- a/treeherder/model/bug_suggestions.py
+++ b/treeherder/model/bug_suggestions.py
@@ -1,0 +1,227 @@
+import logging
+import re
+import urllib
+import json
+
+from django.core.urlresolvers import reverse
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_bug_suggestions_artifacts(artifact_list):
+    """
+    Create bug suggestions artifact(s) for any text_log_summary artifacts.
+
+    ``artifact_list`` here is a list of artifacts that may contain one or more
+        ``text_log_artifact`` objects.  If it does, we extract the error lines
+        from it.  If there ARE error lines, then we generate the
+        ``bug suggestions`` artifacts and return them.
+    """
+
+    bug_suggestion_artifacts = []
+
+    for artifact in artifact_list:
+        # this is the only artifact name eligible to trigger generation of bug
+        # suggestions.
+        assert artifact['name'] == 'text_log_summary'
+
+        all_errors = get_all_errors(artifact)
+        if all_errors:
+            bug_suggestion_artifacts.append({
+                "job_guid": artifact['job_guid'],
+                "name": 'Bug suggestions',
+                "type": 'json',
+                "blob": json.dumps(get_bug_suggestions(all_errors))
+            })
+
+    return bug_suggestion_artifacts
+
+
+def get_all_errors(artifact):
+    """Extract the error lines from an artifact's blob field"""
+
+    artifact_blob = json.loads(artifact['blob'])
+    if isinstance(artifact_blob, dict):
+        return artifact_blob.get('step_data', {}).get('all_errors', [])
+
+
+def get_bug_suggestions(all_errors):
+    bug_suggestions = []
+    bugscache_uri = '{0}{1}'.format(
+        settings.API_HOSTNAME,
+        reverse("bugscache-list")
+    )
+    terms_requested = {}
+
+    for err in all_errors:
+        # remove the mozharness prefix
+        clean_line = get_mozharness_substring(err['line'])
+        search_terms = []
+        # get a meaningful search term out of the error line
+        search_term = get_error_search_term(clean_line)
+        bugs = dict(open_recent=[], all_others=[])
+
+        # collect open recent and all other bugs suggestions
+        if search_term:
+            search_terms.append(search_term)
+            if search_term not in terms_requested:
+                # retrieve the list of suggestions from the api
+                bugs = get_bugs_for_search_term(
+                    search_term,
+                    bugscache_uri
+                )
+                terms_requested[search_term] = bugs
+            else:
+                bugs = terms_requested[search_term]
+
+        if not bugs or not (bugs['open_recent'] or
+                            bugs['all_others']):
+            # no suggestions, try to use
+            # the crash signature as search term
+            crash_signature = get_crash_signature(clean_line)
+            if crash_signature:
+                search_terms.append(crash_signature)
+                if crash_signature not in terms_requested:
+                    bugs = get_bugs_for_search_term(
+                        crash_signature,
+                        bugscache_uri
+                    )
+                    terms_requested[crash_signature] = bugs
+                else:
+                    bugs = terms_requested[crash_signature]
+
+        # TODO: Rename 'search' to 'error_text' or similar, since that's
+        # closer to what it actually represents (bug 1091060).
+        bug_suggestions.append({
+            "search": clean_line,
+            "search_terms": search_terms,
+            "bugs": bugs
+        })
+
+    return bug_suggestions
+
+
+def get_bugs_for_search_term(search, base_uri):
+    """
+    Fetch the base_uri endpoint filtering on search and status.
+    Status must be either 'open' or 'closed'
+    """
+    from treeherder.etl.common import get_remote_content
+
+    params = {
+        'search': search
+    }
+    query_string = urllib.urlencode(params)
+    url = '{0}?{1}'.format(
+        base_uri,
+        query_string
+    )
+    return get_remote_content(url)
+
+LEAK_RE = re.compile(r'\d+ bytes leaked \((.+)\)$')
+CRASH_RE = re.compile(r'.+ application crashed \[@ (.+)\]$')
+
+
+def get_error_search_term(error_line):
+    """
+    retrieves bug suggestions from bugscache using search_term
+    in a full_text search.
+    """
+    if not error_line:
+        return None
+
+    # This is strongly inspired by
+    # https://hg.mozilla.org/webtools/tbpl/file/tip/php/inc/AnnotatedSummaryGenerator.php#l73
+
+    tokens = error_line.split(" | ")
+    search_term = None
+
+    if len(tokens) >= 3:
+        # it's in the "FAILURE-TYPE | testNameOrFilePath | message" type format.
+        test_name_or_path = tokens[1]
+        message = tokens[2]
+
+        # Leak failure messages are of the form:
+        # leakcheck | .*\d+ bytes leaked (Object-1, Object-2, Object-3, ...)
+        match = LEAK_RE.search(message)
+        if match:
+            search_term = match.group(1)
+        else:
+            for splitter in ("/", "\\"):
+                # if this is a path, we are interested in the last part
+                test_name_or_path = test_name_or_path.split(splitter)[-1]
+            search_term = test_name_or_path
+
+    # If the failure line was not in the pipe symbol delimited format or the search term
+    # will likely return too many (or irrelevant) results (eg: too short or matches terms
+    # on the blacklist), then we fall back to searching for the entire failure line if
+    # it is suitable.
+    if not (search_term and is_helpful_search_term(search_term)):
+        if is_helpful_search_term(error_line):
+            search_term = error_line
+        else:
+            search_term = None
+
+    # Searching for extremely long search terms is undesirable, since:
+    # a) Bugzilla's max summary length is 256 characters, and once "Intermittent "
+    # and platform/suite information is prefixed, there are even fewer characters
+    # left for us to use for the failure string against which we need to match.
+    # b) For long search terms, the additional length does little to prevent against
+    # false positives, but means we're more susceptible to false negatives due to
+    # run-to-run variances in the error messages (eg paths, process IDs).
+    if search_term:
+        search_term = search_term[:100]
+
+    return search_term
+
+
+def get_crash_signature(error_line):
+    """
+    Detect if the error_line contains a crash signature
+    and return it if it's a helpful search term
+    """
+    search_term = None
+    match = CRASH_RE.match(error_line)
+    if match and is_helpful_search_term(match.group(1)):
+        search_term = match.group(1)
+    return search_term
+
+
+mozharness_pattern = re.compile(
+    r'^\d+:\d+:\d+[ ]+(?:DEBUG|INFO|WARNING|ERROR|CRITICAL|FATAL) - [ ]?'
+)
+
+
+def get_mozharness_substring(line):
+    return mozharness_pattern.sub('', line).strip()
+
+
+def is_helpful_search_term(search_term):
+    # Search terms that will match too many bug summaries
+    # and so not result in useful suggestions.
+    search_term = search_term.strip()
+
+    blacklist = [
+        'automation.py',
+        'remoteautomation.py',
+        'Shutdown',
+        'undefined',
+        'Main app process exited normally',
+        'Traceback (most recent call last):',
+        'Return code: 0',
+        'Return code: 1',
+        'Return code: 2',
+        'Return code: 9',
+        'Return code: 10',
+        'Exiting 1',
+        'Exiting 9',
+        'CrashingThread(void *)',
+        'libSystem.B.dylib + 0xd7a',
+        'linux-gate.so + 0x424',
+        'TypeError: content is null',
+        'leakcheck'
+    ]
+
+    return len(search_term) > 4 and not (search_term in blacklist)


### PR DESCRIPTION
This PR addresses [Bug 1080760](https://bugzilla.mozilla.org/show_bug.cgi?id=1080760)

The big change is that the ``artifacts`` creation endpoint now checks the incoming artifact.  If it is named "text_log_summary" and has a blob that contains ``error_lines``, then a ``Bug suggestions`` artifact is generated for it.

Also:
* extracts the generation of ``Bug suggestions`` artifacts from the ``log_parser`` into a ``model/bug_suggestions`` file.  
* added a test for this functionality.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/466)
<!-- Reviewable:end -->
