### PR TITLE
Bug 1056877 - Update links & puppet/Vagrant config for new repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 treeherder-service
 ==================
-[![Build Status](https://travis-ci.org/mozilla/treeherder-service.png?branch=master)](https://travis-ci.org/mozilla/treeherder-service)
-[![Code Health](https://landscape.io/github/mozilla/treeherder-service/master/landscape.png)](https://landscape.io/github/mozilla/treeherder-service/master)
+[![Build Status](https://travis-ci.org/mozilla/treeherder.png?branch=master)](https://travis-ci.org/mozilla/treeherder)
+[![Code Health](https://landscape.io/github/mozilla/treeherder/master/landscape.png)](https://landscape.io/github/mozilla/treeherder/master)
 
 
 #### Description

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = "local.treeherder.mozilla.org"
   config.vm.network "private_network", ip: "192.168.33.10"
 
-  config.vm.synced_folder ".", "/home/vagrant/treeherder-service", type: "nfs"
+  config.vm.synced_folder ".", "/home/vagrant/treeherder", type: "nfs"
   config.vm.synced_folder "../treeherder-ui", "/home/vagrant/treeherder-ui", type: "nfs"
 
   config.vm.provider "virtualbox" do |vb|

--- a/deployment/supervisord/admin_node.conf
+++ b/deployment/supervisord/admin_node.conf
@@ -11,14 +11,14 @@ nodaemon=true              ; (start in foreground if true;default false)
 serverurl=unix:///var/tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [program:gunicorn]
-command=/home/vagrant/treeherder-service/bin/run_gunicorn
+command=/home/vagrant/treeherder/bin/run_gunicorn
 user=vagrant
 autostart=true
 autorestart=true
 redirect_stderr=true
 
 [program:celerybeat]
-command=/home/vagrant/treeherder-service/bin/run_celerybeat
+command=/home/vagrant/treeherder/bin/run_celerybeat
 user=vagrant
 autostart=true
 autorestart=true
@@ -26,7 +26,7 @@ startsecs=10
 priority=999
 
 [program:celery]
-command=/home/vagrant/treeherder-service/bin/run_celery_worker
+command=/home/vagrant/treeherder/bin/run_celery_worker
 user=vagrant
 numprocs=1
 autostart=true
@@ -38,7 +38,7 @@ stdout_logfile=/var/log/celery/worker.log
 stderr_logfile=/var/log/celery/worker_err.log
 
 [program:celery_hp]
-command=/home/vagrant/treeherder-service/bin/run_celery_worker_hp
+command=/home/vagrant/treeherder/bin/run_celery_worker_hp
 user=vagrant
 numprocs=1
 autostart=true
@@ -50,7 +50,7 @@ stdout_logfile=/var/log/celery/worker_hp.log
 stderr_logfile=/var/log/celery/worker_hp_err.log
 
 [program:celery_pushlog]
-command=/home/vagrant/treeherder-service/bin/run_celery_worker_pushlog
+command=/home/vagrant/treeherder/bin/run_celery_worker_pushlog
 user=vagrant
 numprocs=1
 autostart=true

--- a/deployment/supervisord/etl_node.conf
+++ b/deployment/supervisord/etl_node.conf
@@ -11,7 +11,7 @@ nodaemon=true              ; (start in foreground if true;default false)
 serverurl=unix:///var/tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [program:celery_pushlog]
-command=/home/vagrant/treeherder-service/bin/run_celery_worker_pushlog
+command=/home/vagrant/treeherder/bin/run_celery_worker_pushlog
 user=vagrant
 autostart=true
 autorestart=true
@@ -22,7 +22,7 @@ stdout_logfile=/var/log/celery/worker_pushlog.log
 stderr_logfile=/var/log/celery/worker_pushlog_err.log
 
 [program:celery_buildapi]
-command=/home/vagrant/treeherder-service/bin/run_celery_worker_buildapi
+command=/home/vagrant/treeherder/bin/run_celery_worker_buildapi
 user=vagrant
 autostart=true
 autorestart=true

--- a/deployment/supervisord/worker_node.conf
+++ b/deployment/supervisord/worker_node.conf
@@ -11,7 +11,7 @@ nodaemon=true              ; (start in foreground if true;default false)
 serverurl=unix:///var/tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [program:celery_log_parser]
-command=/home/vagrant/treeherder-service/bin/run_celery_worker_log_parser
+command=/home/vagrant/treeherder/bin/run_celery_worker_log_parser
 user=vagrant
 autostart=true
 autorestart=true

--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -27,21 +27,21 @@ Running the tests
 
   .. code-block:: bash
 
-     (venv)vagrant@precise32:~/treeherder-service$ ./runtests.sh
+     (venv)vagrant@precise32:~/treeherder$ ./runtests.sh
 
 * Or for more control, run py.test directly
 
   .. code-block:: bash
 
-     (venv)vagrant@precise32:~/treeherder-service$ py.test tests/
-     (venv)vagrant@precise32:~/treeherder-service$ py.test tests/log_parser/test_utils.py
-     (venv)vagrant@precise32:~/treeherder-service$ py.test tests/etl/test_buildapi.py -k test_ingest_builds4h_jobs
+     (venv)vagrant@precise32:~/treeherder$ py.test tests/
+     (venv)vagrant@precise32:~/treeherder$ py.test tests/log_parser/test_utils.py
+     (venv)vagrant@precise32:~/treeherder$ py.test tests/etl/test_buildapi.py -k test_ingest_builds4h_jobs
 
 * To run all tests, including slow tests that are normally skipped, use
 
   .. code-block:: bash
 
-     (venv)vagrant@precise32:~/treeherder-service$ py.test --runslow tests/
+     (venv)vagrant@precise32:~/treeherder$ py.test --runslow tests/
 
 * For more options, see ``py.test --help`` or http://pytest.org/latest/usage.html
 
@@ -49,7 +49,7 @@ Running the tests
 
   .. code-block:: bash
 
-     (venv)vagrant@precise32:~/treeherder-service$ flake8
+     (venv)vagrant@precise32:~/treeherder$ flake8
 
 Add a new repository
 --------------------

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -12,7 +12,7 @@ manifest like this inside the puppet directory:
     $APP_URL="your.webapp.url"
     $APP_USER="your_app_user"
     $APP_GROUP="your_app_group"
-    $PROJ_DIR = "/home/${APP_USER}/treeherder-service"
+    $PROJ_DIR = "/home/${APP_USER}/treeherder"
     $VENV_DIR = "/home/${APP_USER}/venv"
     # You can make these less generic if you like, but these are box-specific
     # so it's not required.
@@ -68,7 +68,7 @@ You can run this file with the following command
 
 .. code-block:: bash
   
-  (venv)vagrant@precise32:~/treeherder-service$ sudo puppet apply puppet/your_manifest_file.pp
+  (venv)vagrant@precise32:~/treeherder$ sudo puppet apply puppet/your_manifest_file.pp
 
 Once puppet has finished, the only thing left to do is to start all the treeherder services (gunicorn, celery, etc).
 The easiest way to do it is via supervisord.
@@ -99,7 +99,7 @@ To serve the UI from the ``treeherder-ui/dist`` directory, in the ``treeherder-u
 
   (venv)vagrant@precise32:~/treeherder-ui$ grunt build
 
-This will build the UI by concatenating and minifying the js and css and move all required assets to a directory called ``dist`` in the repository root of ``treeherder-ui``. In ``treeherder-service/Vagrantfile`` uncomment this line:
+This will build the UI by concatenating and minifying the js and css and move all required assets to a directory called ``dist`` in the repository root of ``treeherder-ui``. In ``treeherder/Vagrantfile`` uncomment this line:
 
 .. code-block:: ruby
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 Cloning the Repo
 ----------------
 
-* Clone the `treeherder-service repo`_ from Github.
+* Clone the `treeherder repo`_ from Github.
 
 Setting up Vagrant
 ------------------
@@ -42,13 +42,13 @@ Setting up Vagrant
 
   .. code-block:: bash
 
-     (venv)vagrant@precise32:~$ cd treeherder-service
+     (venv)vagrant@precise32:~$ cd treeherder
 
 * Build the log parser Cython files, since they are required for both running the tests and a local Treeherder instance
 
   .. code-block:: bash
 
-     (venv)vagrant@precise32:~/treeherder-service$ ./setup.py build_ext --inplace
+     (venv)vagrant@precise32:~/treeherder$ ./setup.py build_ext --inplace
 
   NB: If you change something in the treeherder/log_parser folder, remember to repeat this step, otherwise the changes will not take effect.
 
@@ -61,19 +61,19 @@ Setting up a local Treeherder instance
 
   .. code-block:: bash
 
-     (venv)vagrant@precise32:~/treeherder-service$ ./manage.py init_master_db
+     (venv)vagrant@precise32:~/treeherder$ ./manage.py init_master_db
 
 * Populate the database with repository data sources
 
   .. code-block:: bash
 
-     (venv)vagrant@precise32:~/treeherder-service$ ./manage.py init_datasources
+     (venv)vagrant@precise32:~/treeherder$ ./manage.py init_datasources
 
 * Export oauth credentials for all data source projects
 
   .. code-block:: bash
 
-     (venv)vagrant@precise32:~/treeherder-service$ ./manage.py export_project_credentials
+     (venv)vagrant@precise32:~/treeherder$ ./manage.py export_project_credentials
 
 * And an entry to your **host** machine's /etc/hosts so that you can point your browser to local.treeherder.mozilla.org to reach it
 
@@ -88,7 +88,7 @@ Viewing the local server
 
   .. code-block:: bash
 
-     (venv)vagrant@precise32:~/treeherder-service$ ./bin/run_gunicorn
+     (venv)vagrant@precise32:~/treeherder$ ./bin/run_gunicorn
 
   all the request sent to local.treeherder.mozilla.org will be proxied to it by varnish/apache.
 
@@ -96,7 +96,7 @@ Viewing the local server
 
   .. code-block:: bash
 
-     (venv)vagrant@precise32:~/treeherder-service$ ./manage.py runserver
+     (venv)vagrant@precise32:~/treeherder$ ./manage.py runserver
 
   this is more convenient because it automatically refreshes every time there's a change in the code. However it can consume too much memory when under load (eg due to data ingestion), causing the OS to kill it.
 
@@ -113,7 +113,7 @@ Ingestion tasks populate the database with version control push logs, queued/run
 
   .. code-block:: bash
 
-     (venv)vagrant@precise32:~/treeherder-service$ celery -A treeherder worker -B
+     (venv)vagrant@precise32:~/treeherder$ celery -A treeherder worker -B
 
   The "-B" option tells the celery worker to startup a beat service, so that periodic tasks can be executed.
   You only need one worker with the beat service enabled. Multiple beat services will result in periodic tasks being executed multiple times.
@@ -122,9 +122,9 @@ Ingestion tasks populate the database with version control push logs, queued/run
 
   .. code-block:: bash
 
-     (venv)vagrant@precise32:~/treeherder-service$ ./manage.py ingest_push mozilla-central 63f8a47cfdf5
+     (venv)vagrant@precise32:~/treeherder$ ./manage.py ingest_push mozilla-central 63f8a47cfdf5
 
 
-.. _treeherder-service repo: https://github.com/mozilla/treeherder-service
+.. _treeherder repo: https://github.com/mozilla/treeherder
 .. _Vagrant: https://www.vagrantup.com
 .. _Virtualbox: https://www.virtualbox.org

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -31,4 +31,4 @@ You can find the various services log files under
   * /var/log/celery
   * /var/log/gunicorn
 
-You may also want to inspect the main treeherder log file ~/treeherder-service/treeherder.log
+You may also want to inspect the main treeherder log file ~/treeherder/treeherder.log

--- a/docs/ui_integration.rst
+++ b/docs/ui_integration.rst
@@ -3,7 +3,7 @@ Integrating the ui
 
 If you want to develop both the ui and the service side by side it may be convenient to load the ui from the vagrant environment.
 
-* Make sure the `treeherder-ui repo`_ is cloned in the same parent folder as treeherder-service (and with the directory name 'treeherder-ui').
+* Make sure the `treeherder-ui repo`_ is cloned in the same parent folder as treeherder (and with the directory name 'treeherder-ui').
 
 * If you previously commented out the treeherder-ui line in the Vagrantfile as part of the :doc:`installation` instructions, undo that now.
 

--- a/puppet/files/apache/treeherder.conf
+++ b/puppet/files/apache/treeherder.conf
@@ -59,9 +59,9 @@
   ###############
   # Serve static and media files
   ###############
-  Alias /static /home/<%= @APP_USER %>/treeherder-service/treeherder/webapp/static
+  Alias /static /home/<%= @APP_USER %>/treeherder/treeherder/webapp/static
   ProxyPass        /static !
-  Alias /media /home/<%= @APP_USER %>/treeherder-service/treeherder/webapp/media
+  Alias /media /home/<%= @APP_USER %>/treeherder/treeherder/webapp/media
   ProxyPass        /media !
 
   Alias / /home/<%= @APP_USER %>/treeherder-ui/<%= @APP_UI %>/index.html
@@ -71,8 +71,8 @@
   ProxyPassReverse / http://localhost:8000/
   ProxyPreserveHost On
 
-  ErrorLog /var/log/<%= @apache_service %>/treeherder-service_err.log
+  ErrorLog /var/log/<%= @apache_service %>/treeherder_err.log
   LogLevel warn
-  CustomLog /var/log/<%= @apache_service %>/treeherder-service_access.log combined
+  CustomLog /var/log/<%= @apache_service %>/treeherder_access.log combined
 
 </VirtualHost>

--- a/puppet/manifests/classes/apache.pp
+++ b/puppet/manifests/classes/apache.pp
@@ -31,8 +31,8 @@ class apache {
     ensure => present
   }
 
-  file { "${apache_vhost_path}/treeherder-service.conf":
-    content => template("${PROJ_DIR}/puppet/files/apache/treeherder-service.conf"),
+  file { "${apache_vhost_path}/treeherder.conf":
+    content => template("${PROJ_DIR}/puppet/files/apache/treeherder.conf"),
     owner => "root", group => "root", mode => 0644,
     require => [Package[$apache_devel]],
     notify => Service[$apache_service],
@@ -49,7 +49,7 @@ class apache {
     ensure => running,
     enable => true,
     require => [
-      File["${apache_vhost_path}/treeherder-service.conf"]
+      File["${apache_vhost_path}/treeherder.conf"]
     ],
   }
 

--- a/puppet/manifests/production.pp
+++ b/puppet/manifests/production.pp
@@ -8,7 +8,7 @@ import "classes/*.pp"
 $APP_URL="local.treeherder.mozilla.org"
 $APP_USER="vagrant"
 $APP_GROUP="vagrant"
-$PROJ_DIR = "/home/${APP_USER}/treeherder-service"
+$PROJ_DIR = "/home/${APP_USER}/treeherder"
 $VENV_DIR = "/home/${APP_USER}/venv"
 # Serve ui from distribution directory, the contents of dist
 # should be built with "grunt build", run in treeherder-ui

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -8,7 +8,7 @@ import "classes/*.pp"
 $APP_URL="local.treeherder.mozilla.org"
 $APP_USER="vagrant"
 $APP_GROUP="vagrant"
-$PROJ_DIR = "/home/${APP_USER}/treeherder-service"
+$PROJ_DIR = "/home/${APP_USER}/treeherder"
 $VENV_DIR = "/home/${APP_USER}/venv"
 # Serve ui from app directory
 $APP_UI="webapp/app"

--- a/tests/sample_data/logs/crash-1.logview.json
+++ b/tests/sample_data/logs/crash-1.logview.json
@@ -108,5 +108,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/crash-1.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/crash-1.txt.gz"
 }

--- a/tests/sample_data/logs/crash-2.logview.json
+++ b/tests/sample_data/logs/crash-2.logview.json
@@ -132,5 +132,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/crash-2.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/crash-2.txt.gz"
 }

--- a/tests/sample_data/logs/crash-mac-1.logview.json
+++ b/tests/sample_data/logs/crash-mac-1.logview.json
@@ -116,5 +116,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/crash-mac-1.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/crash-mac-1.txt.gz"
 }

--- a/tests/sample_data/logs/crashtest-timeout.logview.json
+++ b/tests/sample_data/logs/crashtest-timeout.logview.json
@@ -84,5 +84,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/crashtest-timeout.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/crashtest-timeout.txt.gz"
 }

--- a/tests/sample_data/logs/jsreftest-fail.logview.json
+++ b/tests/sample_data/logs/jsreftest-fail.logview.json
@@ -484,5 +484,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/jsreftest-fail.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/jsreftest-fail.txt.gz"
 }

--- a/tests/sample_data/logs/jsreftest-timeout-crash.logview.json
+++ b/tests/sample_data/logs/jsreftest-timeout-crash.logview.json
@@ -100,5 +100,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/jsreftest-timeout-crash.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/jsreftest-timeout-crash.txt.gz"
 }

--- a/tests/sample_data/logs/large-number-of-error-lines.logview.json
+++ b/tests/sample_data/logs/large-number-of-error-lines.logview.json
@@ -996,5 +996,5 @@
         ], 
         "errors_truncated": true
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/large-number-of-error-lines.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/large-number-of-error-lines.txt.gz"
 }

--- a/tests/sample_data/logs/leaks-1.logview.json
+++ b/tests/sample_data/logs/leaks-1.logview.json
@@ -124,5 +124,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/leaks-1.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/leaks-1.txt.gz"
 }

--- a/tests/sample_data/logs/mochitest-test-end.logview.json
+++ b/tests/sample_data/logs/mochitest-test-end.logview.json
@@ -92,5 +92,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mochitest-test-end.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mochitest-test-end.txt.gz"
 }

--- a/tests/sample_data/logs/mozilla-central-macosx64-debug-bm65-build1-build15.jobartifact.json
+++ b/tests/sample_data/logs/mozilla-central-macosx64-debug-bm65-build1-build15.jobartifact.json
@@ -1,4 +1,4 @@
 {
     "job_details": [],
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mozilla-central-macosx64-debug-bm65-build1-build15.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-central-macosx64-debug-bm65-build1-build15.txt.gz"
 }

--- a/tests/sample_data/logs/mozilla-central-win32-pgo-bm85-build1-build111.logview.json
+++ b/tests/sample_data/logs/mozilla-central-win32-pgo-bm85-build1-build111.logview.json
@@ -674,5 +674,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mozilla-central-win32-pgo-bm85-build1-build111.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-central-win32-pgo-bm85-build1-build111.txt.gz"
 }

--- a/tests/sample_data/logs/mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50.jobartifact.json
+++ b/tests/sample_data/logs/mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50.jobartifact.json
@@ -12,5 +12,5 @@
             "title": "crashtest"
         }
     ],
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50.txt.gz"
 }

--- a/tests/sample_data/logs/mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50.logview.json
+++ b/tests/sample_data/logs/mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50.logview.json
@@ -158,5 +158,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50.txt.gz"
 }

--- a/tests/sample_data/logs/mozilla-central_mountainlion-debug_test-mochitest-2-bm80-tests1-macosx-build93.jobartifact.json
+++ b/tests/sample_data/logs/mozilla-central_mountainlion-debug_test-mochitest-2-bm80-tests1-macosx-build93.jobartifact.json
@@ -3,5 +3,5 @@
         {"url": "http://hg.mozilla.org/build/mozharness/rev/c43ba6cb3db3", "content_type": "link", "value": "http://hg.mozilla.org/build/mozharness/rev/c43ba6cb3db3", "title": "mozharness_revlink"},
         {"content_type": "raw_html", "value": "206414/0/18501", "title": "mochitest-plain2"}
     ],
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mozilla-central_mountainlion-debug_test-mochitest-2-bm80-tests1-macosx-build93.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-central_mountainlion-debug_test-mochitest-2-bm80-tests1-macosx-build93.txt.gz"
 }

--- a/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141.jobartifact.json
+++ b/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141.jobartifact.json
@@ -3,5 +3,5 @@
         {"url": "http://hg.mozilla.org/build/mozharness/rev/c43ba6cb3db3", "content_type": "link", "value": "http://hg.mozilla.org/build/mozharness/rev/c43ba6cb3db3", "title": "mozharness_revlink"},
         {"content_type": "raw_html", "value": "206415/0/18500", "title": "mochitest-plain2"}
     ],
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141.txt.gz"
 }

--- a/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141.logview.json
+++ b/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141.logview.json
@@ -158,5 +158,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141.txt.gz"
 }

--- a/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm80-tests1-macosx-build138.jobartifact.json
+++ b/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm80-tests1-macosx-build138.jobartifact.json
@@ -3,5 +3,5 @@
         {"url": "http://hg.mozilla.org/build/mozharness/rev/97228ea173cb", "content_type": "link", "value": "http://hg.mozilla.org/build/mozharness/rev/97228ea173cb", "title": "mozharness_revlink"},
         {"content_type": "raw_html", "value": "<em class=\"testfail\">T-FAIL</em>", "title": "mochitest-plain2"}
     ],
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm80-tests1-macosx-build138.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm80-tests1-macosx-build138.txt.gz"
 }

--- a/tests/sample_data/logs/mozilla-central_ubuntu64_hw_test-androidx86-set-4-bm103-tests1-linux-build369.logview.json
+++ b/tests/sample_data/logs/mozilla-central_ubuntu64_hw_test-androidx86-set-4-bm103-tests1-linux-build369.logview.json
@@ -200,5 +200,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mozilla-central_ubuntu64_hw_test-androidx86-set-4-bm103-tests1-linux-build369.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-central_ubuntu64_hw_test-androidx86-set-4-bm103-tests1-linux-build369.txt.gz"
 }

--- a/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.jobartifact.json
+++ b/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.jobartifact.json
@@ -3,5 +3,5 @@
         {"content_type": "raw_html", "value": "<a href=http://hg.mozilla.org/releases/mozilla-esr17/rev/e2eecb449eeb title=\"Built from revision e2eecb449eeb\">rev:e2eecb449eeb</a>\r"},
         {"content_type": "raw_html", "value": "31776/<em class=\"testfail\">2</em>/40", "title": "mochitest-browser-chrome"}
     ],
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.txt.gz"
 }

--- a/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.logview.json
+++ b/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.logview.json
@@ -308,5 +308,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.txt.gz"
 }

--- a/tests/sample_data/logs/mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122.jobartifact.json
+++ b/tests/sample_data/logs/mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122.jobartifact.json
@@ -5,5 +5,5 @@
         {"content_type": "raw_html", "value": "<em class=\"testfail\">T-FAIL</em>&nbsp;<em class=\"testfail\">CRASH</em>", "title": "mochitest-a11y"},
         {"content_type": "raw_html", "value": "<em class=\"testfail\">T-FAIL</em>&nbsp;<em class=\"testfail\">CRASH</em>", "title": "mochitest-plugins"}
     ],
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122.txt.gz"
 }

--- a/tests/sample_data/logs/mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122.logview.json
+++ b/tests/sample_data/logs/mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122.logview.json
@@ -256,5 +256,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122.txt.gz"
 }

--- a/tests/sample_data/logs/multiple-timeouts.logview.json
+++ b/tests/sample_data/logs/multiple-timeouts.logview.json
@@ -164,5 +164,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/multiple-timeouts.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/multiple-timeouts.txt.gz"
 }

--- a/tests/sample_data/logs/opt-objc-exception.logview.json
+++ b/tests/sample_data/logs/opt-objc-exception.logview.json
@@ -92,5 +92,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/opt-objc-exception.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/opt-objc-exception.txt.gz"
 }

--- a/tests/sample_data/logs/reftest-fail-crash.logview.json
+++ b/tests/sample_data/logs/reftest-fail-crash.logview.json
@@ -116,5 +116,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/reftest-fail-crash.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/reftest-fail-crash.txt.gz"
 }

--- a/tests/sample_data/logs/reftest-jserror.logview.json
+++ b/tests/sample_data/logs/reftest-jserror.logview.json
@@ -84,5 +84,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/reftest-jserror.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/reftest-jserror.txt.gz"
 }

--- a/tests/sample_data/logs/reftest-opt-fail.logview.json
+++ b/tests/sample_data/logs/reftest-opt-fail.logview.json
@@ -84,5 +84,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/reftest-opt-fail.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/reftest-opt-fail.txt.gz"
 }

--- a/tests/sample_data/logs/reftest-timeout.logview.json
+++ b/tests/sample_data/logs/reftest-timeout.logview.json
@@ -100,5 +100,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/reftest-timeout.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/reftest-timeout.txt.gz"
 }

--- a/tests/sample_data/logs/tinderbox-exception.logview.json
+++ b/tests/sample_data/logs/tinderbox-exception.logview.json
@@ -100,5 +100,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/tinderbox-exception.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/tinderbox-exception.txt.gz"
 }

--- a/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.jobartifact.json
+++ b/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.jobartifact.json
@@ -3,5 +3,5 @@
         {"content_type": "raw_html", "value": "<a href=http://hg.mozilla.org/projects/ux/rev/546ccc10a18f title=\"Built from revision 546ccc10a18f\">rev:546ccc10a18f</a>"},
         {"content_type": "raw_html", "value": "7270/6", "title": "jetpack"}
     ],
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.txt.gz"
 }

--- a/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.logview.json
+++ b/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.logview.json
@@ -328,5 +328,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.txt.gz"
 }

--- a/tests/sample_data/logs/xpcshell-crash.logview.json
+++ b/tests/sample_data/logs/xpcshell-crash.logview.json
@@ -92,5 +92,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/xpcshell-crash.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/xpcshell-crash.txt.gz"
 }

--- a/tests/sample_data/logs/xpcshell-multiple.logview.json
+++ b/tests/sample_data/logs/xpcshell-multiple.logview.json
@@ -92,5 +92,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/xpcshell-multiple.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/xpcshell-multiple.txt.gz"
 }

--- a/tests/sample_data/logs/xpcshell-timeout.logview.json
+++ b/tests/sample_data/logs/xpcshell-timeout.logview.json
@@ -92,5 +92,5 @@
         ], 
         "errors_truncated": false
     }, 
-    "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/xpcshell-timeout.txt.gz"
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/xpcshell-timeout.txt.gz"
 }


### PR DESCRIPTION
The 'treeherder-service' repo has been renamed to 'treeherder', ready for when the treeherder-ui repo is imported into it. This means the Github URL, Travis URL and directory name when cloned changes. The Read The Docs URL cannot be changed, so for now we will leave as-is, and in the future (once service and UI docs combined) we will create a new project on RTD with name "treeherder".

This updates doc links and puppet/Vagrant configs, but leaves the stage/prod deploy script alone, since renaming the directories on our infra is non-trivial. The dev instance will need some TLC since unlike stage/prod, it does use the puppet scripts in the repo.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/472)
<!-- Reviewable:end -->
