### PR TITLE
Bug 1156448 - Switch to the new OrangeFactor-only ES cluster

### DIFF
--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -330,7 +330,7 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Set this to True to submit bug associations to Bugzilla & Elasticsearch.
 MIRROR_CLASSIFICATIONS = True
-ES_HOST = "http://elasticsearch-zlb.webapp.scl3.mozilla.com:9200"
+ES_HOST = "http://of-elasticsearch-zlb.webapp.scl3.mozilla.com:9200"
 
 # TBPLBOT is the Bugzilla account used to make the bug comments on
 # intermittent failure bugs when failures are classified.


### PR DESCRIPTION
OrangeFactor is moving to a new ES cluster, so we need to submit the intermittent bug associations to the new endpoint instead.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/473)
<!-- Reviewable:end -->
