### PR TITLE
Bug 1156457 - Set the New Relic deploy user to "Chief"

### DIFF
--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -115,6 +115,7 @@ def ping_newrelic(ctx):
 
         print 'Post deployment to New Relic'
         data = urllib.urlencode({
+            'deployment[user]': 'Chief',
             'deployment[revision]': settings.UPDATE_REF,
             'deployment[application_id]': settings.NEW_RELIC_APP_ID
         })


### PR DESCRIPTION
So we don't use the default.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/474)
<!-- Reviewable:end -->
