### PR TITLE
Bug 1076886 - Deploy: Don't specify the wrong revision to New Relic

### DIFF
--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -135,7 +135,6 @@ def ping_newrelic(ctx):
         print 'Post deployment to New Relic'
         data = urllib.urlencode({
             'deployment[user]': 'Chief',
-            'deployment[revision]': settings.UPDATE_REF,
             'deployment[application_id]': settings.NEW_RELIC_APP_ID
         })
         headers = {'x-api-key': settings.NEW_RELIC_API_KEY}


### PR DESCRIPTION
We're passing settings.UPDATE_REF, which is the default ref value, not the actual value that was passed via the Chief web UI. As such, New Relic was always displaying the revision deployed as "master", even if it was a non-master branch deploy. Ideally we'd use the value of 'ref' from pre_update(), but that's not available during the deploy() task (the script is run in three independent stages & Chief unhelpfully only passes 'ref' to the first stage), so we'll have to read it back from the media/revision file - which will require more mangling in bug 1076886.

For now, seeing as the 'revision' property is optional, lets just omit it, rather than setting it to a sometimes-wrong value.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/477)
<!-- Reviewable:end -->
