### PR TITLE
Bug 1155868 - Update RTD that single ingestion is limited to builds4hr

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -121,7 +121,9 @@ Ingestion tasks populate the database with version control push logs, queued/run
   The "-B" option tells the celery worker to startup a beat service, so that periodic tasks can be executed.
   You only need one worker with the beat service enabled. Multiple beat services will result in periodic tasks being executed multiple times.
 
-* Alternatively, instead of running a full ingestion task, you can process just the jobs associated with a single push in a synchronous manner. This is ideal for testing.
+* Alternatively, instead of running a full ingestion task, you can process just the jobs associated with any single push generated in the last 4 hours (builds-4h_), in a synchronous manner. This is ideal for testing.
+
+  .. _builds-4h: http://builddata.pub.build.mozilla.org/buildjson/
 
   .. code-block:: bash
 


### PR DESCRIPTION
This fixes Bugzilla bug [1155868](https://bugzilla.mozilla.org/show_bug.cgi?id=1155868).

I ran this change through http://rst.ninjs.org/ and it appears to be fine. I thought it might be reasonable to provide a little extra context on what builds-4hr is, by linking to the build dir so people can see it. I was unable to find other MDN / RelEng docs which describe builds-4hr in any great detail.

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/478)
<!-- Reviewable:end -->
