### PR TITLE
Bug 1066727 - update exclusion profile on save

### DIFF
--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -596,6 +596,8 @@ class ExclusionProfile(models.Model):
     def save(self, *args, **kwargs):
         super(ExclusionProfile, self).save(*args, **kwargs)
 
+        self.update_flat_exclusions()
+
         # update the old default profile
         if self.is_default:
             ExclusionProfile.objects.filter(is_default=True).exclude(

--- a/treeherder/webapp/api/refdata.py
+++ b/treeherder/webapp/api/refdata.py
@@ -182,6 +182,3 @@ class ExclusionProfileViewSet(viewsets.ModelViewSet):
         if "author" not in request.DATA:
             request.DATA["author"] = request.user.id
         return super(ExclusionProfileViewSet, self).create(request, *args, **kwargs)
-
-    def post_save(self, obj, created=False):
-        obj.update_flat_exclusions()


### PR DESCRIPTION
Simple fix to update the ``flat_exclusions`` on save of a ``job_exclusion``.  In fact, the save of the ``job_exclusion`` was already re-saving the ``exclusion profile``, but that save wasn't explicitly updating its ``flat_exclusions``.  The ``flat_exclusions`` are the important part of which jobs to exclude for a profile.  Now any save on the exclusion profile updates its ``flat_exclusion``.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/479)
<!-- Reviewable:end -->
