### PR TITLE
Bug 1157863 - Add a local.conf setup step to merged-repo RTD

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -84,6 +84,15 @@ Setting up a local Treeherder instance
 
      192.168.33.10    local.treeherder.mozilla.org
 
+* If not already present, copy the example service configuration file to one read by default by Treeherder
+
+  .. code-block:: bash
+
+     (venv)vagrant@precise32:~/treeherder$ cp app/js/config/sample.local.conf.js app/js/config/local.conf.js
+
+  and edit local.conf.js and set ``window.thServiceDomain = vagrant;`` to pull data from your local backend service.
+
+
 Viewing the local server
 ------------------------
 


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1157863](https://bugzilla.mozilla.org/show_bug.cgi?id=1157863).

In it we provide the step for the local server to find the backend vagrant service. Since I think(?) we may still support `web-server.js` running without vagrant, I phrased it in such a way that local.config.js may already exist.

Though I wonder with the new repo, if we could potentially add `local.conf.js` itself, so we could omit the copy-step, for vagrant or web-server workflows.

Adding @edmorley for review and his high-level understanding of the repo unification :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/480)
<!-- Reviewable:end -->
