### PR TITLE
Bug 1158177 - Vagrant: Update from Python 2.7.3 to 2.7.9

### DIFF
--- a/puppet/manifests/classes/init.pp
+++ b/puppet/manifests/classes/init.pp
@@ -12,5 +12,24 @@ class init {
       exec { "update_apt":
           command => "sudo apt-get update"
       }
+
+      # Required for add-apt-repository
+      package { python-software-properties:
+          ensure => installed,
+          require => Exec["update_apt"],
+      }
+
+      # Ubuntu 12.04's newest Python is v2.7.3, so we have to use a third party PPA:
+      # https://launchpad.net/~fkrull/+archive/ubuntu/deadsnakes-python2.7
+      exec { "add_python27_ppa":
+          command => "sudo add-apt-repository ppa:fkrull/deadsnakes-python2.7",
+          require => Package['python-software-properties'],
+      }
+
+      # Need to update again to pick up the new Python 2.7.9 packages from the PPA
+      exec { "update_apt_for_ppa":
+          command => "sudo apt-get update",
+          require => Exec["add_python27_ppa"],
+      }
     }
 }

--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -21,12 +21,15 @@ $site_packages = $operatingsystem ? {
 
 class python {
 
-  package{[$python_devel,
+  # Python2.7 is already installed, but we need to update it to the
+  # latest version from the third party PPA.
+  package{["python2.7",
+           $python_devel,
            "gcc",
            "curl",
            "git",
            $libxml2]:
-    ensure => installed;
+    ensure => "latest",
   }
 
   exec { "install-pip":


### PR DESCRIPTION
Now we're using an Ubuntu 12.04 image for Vagrant, and the latest Python available officially is 2.7.3, so we have to use a third party PPA:
https://launchpad.net/~fkrull/+archive/ubuntu/deadsnakes-python2.7
https://launchpad.net/+help-soyuz/ppa-sources-list.html

The easiest way to add this PPA is using |add-apt-repository|, but Ubuntu 12.04 doesn't ship with it by default, so we also have to install the python-software-properties package, sigh:
http://ubuntuforums.org/showthread.php?t=1320536

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/482)
<!-- Reviewable:end -->
