### PR TITLE
Bug 1118023 - Update to django-browserid v0.11.1

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -56,8 +56,8 @@ drf-extensions==0.2.5
 # sha256: K4vVpzVtJqYxx0mHxxkr4PmTT-zym6or5e6e8kfCtU0
 django-cors-headers==0.11
 
-# sha256: v4ie7vvNAolM8xczjwX69_YhxRxJpPfbL5xvS1VEmgw
-https://github.com/mozilla/django-browserid/archive/e8d1d57145401cf3f42993fe84edc32e29e5903f.zip#egg=django-browserid
+# sha256: EXGi39Bz0MuXOkgtic_AweW52n1VHcCgAkEoZ-z1KT4
+django-browserid==0.11.1
 
 # sha256: gqOPZ02h-klsD8TfcUy7BYVAvtcqMMUKLjRLDZhMTSE
 oauth2==1.5.211


### PR DESCRIPTION
Changes:
https://github.com/mozilla/django-browserid/compare/e8d1d57145401cf3f42993fe84edc32e29e5903f...v0.11.1

This will fix the spurious "Setting BROWSERID_VERIFY_CLASS not found" errors in logs, as well as possibly help with people getting logged out intermittently. It also brings us up to the latest django-browserid release, which means updating later to a (yet to be released) Django 1.8 compatible version of django-browserid should be much easier.

Using a specific version release of django-browserid (vs the Git zip archive for a specific revision) also means peep doesn't have to re-download the package each time.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/483)
<!-- Reviewable:end -->
