### PR TITLE
Bug 1158202 - Update to treeherder-client v1.1

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -71,8 +71,8 @@ mozlog==2.10
 # sha256: ImrtF9QIcMI8Ivl_3KZPtrDs557NAbzNptFgD5uEFkA
 https://github.com/jeads/datasource/archive/2f09c9cc8700be71c1e63bc4f34c6cc05ffc5a66.zip#egg=datasource
 
-# sha256: W3vd4fNt2t-31K2-CEk-jTDF0BsjaZfWOQmwLlpC_nw
-https://github.com/mozilla/treeherder-client/archive/f236a3487eb042638836d4d9c9f79d51cab2a362.zip#egg=treeherder-client
+# sha256: G9t_FDD0NgPDFK2yU-V94CECNCVgoWA9nfhlMGfhppk
+treeherder-client==1.1
 
 # Required by django-rest-swagger
 # sha256: 7wE5rDCRO0Po04ij53blNKIvgZdZZpaNKDaewDOKabc


### PR DESCRIPTION
Changes:
https://github.com/mozilla/treeherder-client/compare/f236a3487eb042638836d4d9c9f79d51cab2a362...1.1

Using a specific version release of treeherder-client (vs the Git zip archive for a specific revision) also means peep doesn't have to re-download the package each time.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/484)
<!-- Reviewable:end -->
