### PR TITLE
Bug 1158380 - Update requests to v2.6.2

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -79,8 +79,8 @@ treeherder-client==1.1
 Unipath==1.0
 
 # Required by django-browserid, WebTest & responses
-# sha256: uePBDlCStES7TBsLM39X5sPXaArXxRkvWX6E3ZMftZg
-requests==2.4.1
+# sha256: jw9WgT-C0MJ9lXgiEmismvSPB2xx7mlpMwXOymyjVb0
+requests==2.6.2
 
 # Required by django-browserid
 # sha256: akF58qKszaKyc7_Ybeb3AkzuIDBDzJp8BA_nswa74SA


### PR DESCRIPTION
Fixes security bugs, includes perf improvements & also means we can use the 'json' param for uploads instead of having to json.dumps() them.

https://github.com/kennethreitz/requests/blob/master/HISTORY.rst
https://github.com/kennethreitz/requests/compare/v2.4.1...v2.6.2

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/487)
<!-- Reviewable:end -->
