### PR TITLE
Bug 1158766 - Pin datasource dependency using a tagged version not SHA

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -68,8 +68,8 @@ jsonfield==0.9.20
 # sha256: HYBs6IKx3VBrKM04OI_9AhHx2ASI7eeJLEwmMF1e7GA
 mozlog==2.10
 
-# sha256: ImrtF9QIcMI8Ivl_3KZPtrDs557NAbzNptFgD5uEFkA
-https://github.com/jeads/datasource/archive/2f09c9cc8700be71c1e63bc4f34c6cc05ffc5a66.zip#egg=datasource
+# sha256: EdbpC9WxbfhNw4c3kDfij8HZ-pkkUnv5Oe07q0cSH4w
+https://github.com/jeads/datasource/archive/v0.6.tar.gz#egg=datasource
 
 # sha256: G9t_FDD0NgPDFK2yU-V94CECNCVgoWA9nfhlMGfhppk
 treeherder-client==1.1


### PR DESCRIPTION
This is a no-op, the v0.6 release tag corresponds to the same revision, it just avoids peeps SHA special-casing which causes continual re-installation of the package & subsequent Travis cache invalidation.

https://github.com/jeads/datasource/releases/tag/v0.6

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/489)
<!-- Reviewable:end -->
