### PR TITLE
Bug 1158893 - Delete any existing Cython build output as part of deploy

### DIFF
--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -33,14 +33,13 @@ def pre_update(ctx, ref=settings.UPDATE_REF):
     with ctx.lcd(th_service_src):
         ctx.local('git fetch --quiet origin %s' % ref)
         ctx.local('git reset --hard FETCH_HEAD')
-        ctx.local("find . -type f -name '*.pyc' -delete")
+        ctx.local('find . -type f \( -name "*.pyc" -o -name "*.c" -o -name "*.so" \) -delete')
         ctx.local('git status -s')
         ctx.local('git rev-parse HEAD > treeherder/webapp/media/revision')
 
     with ctx.lcd(th_ui_src):
         ctx.local('git fetch --quiet origin %s' % ref)
         ctx.local('git reset --hard FETCH_HEAD')
-        ctx.local("find . -type f -name '*.pyc' -delete")
         ctx.local('git status -s')
         ctx.local('git rev-parse HEAD >> ../treeherder-service/treeherder/webapp/media/revision')
 


### PR DESCRIPTION
The Cython build process creates .c and .so files in the log_parser directory, which only get re-created if the original source changes. We recently updated the version of Cython, however this doesn't trigger
re-building them. To avoid surprises, we should purge them like we do for the .pyc files.

In addition, there is no need to delete .pyc files from the UI source directory, since that does not contain any Python files.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/490)
<!-- Reviewable:end -->
