### PR TITLE
Bug 1158878 - support job submission with pre-parsed logs

### DIFF
--- a/tests/e2e/test_client_job_ingestion.py
+++ b/tests/e2e/test_client_job_ingestion.py
@@ -1,0 +1,57 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+import thclient
+
+from treeherder.etl.oauth_utils import OAuthCredentials
+from treeherder.model.derived import JobsModel
+
+
+def test_post_job_with_parsed_log(test_project, result_set_stored,
+                                  mock_send_request):
+    """
+    test submitting a job with a pre-parsed log gets the right job_log_url
+    parse_status value.
+    """
+
+    credentials = OAuthCredentials.get_credentials(test_project)
+
+    tjc = thclient.TreeherderJobCollection()
+    tj = thclient.TreeherderJob({
+        'project': test_project,
+        'revision_hash': result_set_stored[0]['revision_hash'],
+        'job': {
+            'job_guid': 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33',
+            'state': 'completed',
+            'log_references': [{
+                'url': 'http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/...',
+                'name': 'builbot_text',
+                'parse_status': 'parsed'
+            }]
+        }
+    })
+
+    tjc.add(tj)
+
+    req = thclient.TreeherderRequest(
+        protocol='http',
+        host='localhost',
+        project=test_project,
+        oauth_key=credentials['consumer_key'],
+        oauth_secret=credentials['consumer_secret']
+        )
+
+    # Post the request to treeherder
+    resp = req.post(tjc)
+    assert resp.status_int == 200
+    assert resp.body == '{"message": "well-formed JSON stored"}'
+
+    with JobsModel(test_project) as jm:
+        jm.process_objects(10)
+
+        job_ids = [x['id'] for x in jm.get_job_list(0, 20)]
+        job_log_list = jm.get_job_log_url_list(job_ids)
+
+        assert len(job_log_list) == 1
+        assert job_log_list[0]['parse_status'] == 'parsed'

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -184,9 +184,10 @@
                 `job_id`,
                 `name`,
                 `url`,
+                `parse_status`,
                 `parse_timestamp`
                 )
-            VALUES (?,?,?,?)",
+            VALUES (?,?,?,?,?)",
 
             "host_type":"master_host"
         },


### PR DESCRIPTION
This supports ingesting job ``log_references`` that have a
``parse_status`` value.  This is so that external tools can submit jobs
that don’t require our internal log parsing.  They will then submit
their own log summary artifact.

I will add a ``parse_status`` field to the ``add_log_references()`` function in ``treeherder-client`` as well.  But they user can still submit like this if they create the job object with a dict, like the test does here.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/491)
<!-- Reviewable:end -->
