### PR TITLE
Bug 1118023 - Update to django-browserid v0.10

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -56,8 +56,8 @@ drf-extensions==0.2.5
 # sha256: K4vVpzVtJqYxx0mHxxkr4PmTT-zym6or5e6e8kfCtU0
 django-cors-headers==0.11
 
-# sha256: v4ie7vvNAolM8xczjwX69_YhxRxJpPfbL5xvS1VEmgw
-https://github.com/mozilla/django-browserid/archive/e8d1d57145401cf3f42993fe84edc32e29e5903f.zip#egg=django-browserid
+# sha256: DVwMS2xs2dJb59eoJqXAxEzwQKEn2Sb4pX6mvnTrypg
+django-browserid==0.10
 
 # sha256: gqOPZ02h-klsD8TfcUy7BYVAvtcqMMUKLjRLDZhMTSE
 oauth2==1.5.211

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -86,7 +86,6 @@ TEMPLATE_DIRS = [
 
 TEMPLATE_CONTEXT_PROCESSORS = (
     'django.contrib.auth.context_processors.auth',
-    'django_browserid.context_processors.browserid',
     'django.contrib.messages.context_processors.messages'
 )
 


### PR DESCRIPTION
Changes:
https://github.com/mozilla/django-browserid/compare/e8d1d57145401cf3f42993fe84edc32e29e5903f...v0.10

Using a specific version release of django-browserid (vs the Git zip archive for a specific revision) means peep doesn't have to re-download the package each time.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/492)
<!-- Reviewable:end -->
