### PR TITLE
Bug 1159288 - Add clarity to RTD for vagrant ssh access

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,7 +35,7 @@ Setting up Vagrant
 
 * Once to this point in the installation, it will typically take 5 to 30 minutes for the vagrant up to complete, depending on your network performance.
 
-* Once the virtual machine is set up, you can log into it with
+* Once the virtual machine is set up, in any shell, cd into your project root and log into it with
 
   .. code-block:: bash
 


### PR DESCRIPTION
This tweak hopefully fixes Bugzilla bug [1159288](https://bugzilla.mozilla.org/show_bug.cgi?id=1159288) and the contributor problem encountered in this [bug comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1144417#c18).

From what I can tell from the bug thread, he was later successful and perhaps hadn't been in his `/treeherder` directory when issuing a vagrant command.

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/493)
<!-- Reviewable:end -->
