### PR TITLE
Bug 1159236 - Add a timeout troubleshooting section to RTD

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,6 +23,14 @@ Setting up Vagrant
 
      >vagrant up
 
+  **Troubleshooting**: The Vagrant provisioning process during ``vagrant up`` assumes the presence of a stable internet connection. In the event of a connection interruption during provision, you may see errors similar to *"Temporary failure resolving.."* or *"E: Unable to fetch some archives.."* after the process has completed. In that situation, you can attempt to re-provision using the command:
+
+  .. code-block:: bash
+
+     >vagrant provision
+
+  If that is still unsuccessful, you should attempt a ``vagrant destroy`` followed by another ``vagrant up``.
+
   **Troubleshooting**: If you encounter an error saying *"It appears your machine doesn't support NFS, or there is not an adapter to enable NFS on this machine for Vagrant."*, then you need to install ``nfs-kernel-server`` using the command:
 
   .. code-block:: bash
@@ -33,7 +41,11 @@ Setting up Vagrant
 
   .. _guide: http://www.sysprobs.com/disable-enable-virtualization-technology-bios
 
-* Once to this point in the installation, it will typically take 5 to 30 minutes for the vagrant up to complete, depending on your network performance.
+  For the full list of available Vagrant commands, please see their command line documentation_.
+
+  .. _documentation: http://docs.vagrantup.com/v2/cli/
+
+* It will typically take 5 to 30 minutes for the vagrant up to complete, depending on your network performance.
 
 * Once the virtual machine is set up, in any shell, cd into your project root and log into it with
 


### PR DESCRIPTION
This change fixes Bugzilla bug [1159236](https://bugzilla.mozilla.org/show_bug.cgi?id=1159236).

This guides the user to use `vagrant provision` in the event of a network interruption during their vagrant creation.

I also included a reference to the Vagrant CLI while I was there in an appropriate spot, and removed the *"Once to this point in installation.."* clause, since installation may have already completed.

I tested the markdown with http://rst.ninjs.org, it seems to look as I intend/expect.

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/496)
<!-- Reviewable:end -->
