### PR TITLE
Bug 1139941 - Remove leftover references to with_jobs URL parameter

### DIFF
--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -156,8 +156,7 @@ def test_resultset_list_without_jobs(webapp, initial_data,
     jm.store_result_set_data(sample_resultset)
 
     resp = webapp.get(
-        reverse("resultset-list", kwargs={"project": jm.project}),
-        {"with_jobs": "false"}
+        reverse("resultset-list", kwargs={"project": jm.project})
     )
     assert resp.status_int == 200
 
@@ -169,9 +168,7 @@ def test_resultset_list_without_jobs(webapp, initial_data,
 
     assert meta == {
         u'count': len(results),
-        u'filter_params': {
-            u"with_jobs": u"false",
-        },
+        u'filter_params': {},
         u'repository': u'test_treeherder'
     }
 


### PR DESCRIPTION
Since it was removed in bug 1097090.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/497)
<!-- Reviewable:end -->
