### PR TITLE
Bug 1159505 - generate bug suggestions for artifacts submitted with a job

### DIFF
--- a/tests/e2e/test_client_job_ingestion.py
+++ b/tests/e2e/test_client_job_ingestion.py
@@ -5,7 +5,7 @@
 import thclient
 
 from treeherder.etl.oauth_utils import OAuthCredentials
-from treeherder.model.derived import JobsModel
+from treeherder.model.derived import JobsModel, ArtifactsModel
 
 
 def test_post_job_with_parsed_log(test_project, result_set_stored,
@@ -55,3 +55,72 @@ def test_post_job_with_parsed_log(test_project, result_set_stored,
 
         assert len(job_log_list) == 1
         assert job_log_list[0]['parse_status'] == 'parsed'
+
+
+def test_post_job_with_text_log_summary_artifact(test_project,
+                                                 result_set_stored,
+                                                 mock_send_request):
+    """
+    test submitting a job with a pre-parsed log gets the right job_log_url
+    parse_status value.
+    """
+
+    credentials = OAuthCredentials.get_credentials(test_project)
+
+    job_guid = 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
+    tjc = thclient.TreeherderJobCollection()
+    tj = thclient.TreeherderJob({
+        'project': test_project,
+        'revision_hash': result_set_stored[0]['revision_hash'],
+        'job': {
+            'job_guid': job_guid,
+            'state': 'completed',
+            'artifacts': [{
+                "blob": """
+                    {
+                    "header": {},
+                    "step_data": {
+                           "all_errors": [
+                               {
+                               "line": "\u001b7\u001b8\u001b[1G\u001b[J\u001b[34m 6:49.97\u001b(B\u001b[m /home/worker/workspace/gecko/toolkit/xre/nsAppRunner.cpp:108:40: fatal error: mozilla/a11y/Compatibility.h: No such file or directory",
+                               "linenumber": 955
+                               }
+                            ],
+                           "steps": [
+                               {"name": "Clone gecko tc-vcs "},
+                               {"name": "Build ./build-b2g-desktop.sh /home/worker/workspace"}
+                            ],
+                           "errors_truncated": false},
+                       "logurl": "https://queue.taskcluster.net/v1/task/nhxC4hC3RE6LSVWTZT4rag/runs/0/artifacts/public/logs/live_backing.log"}
+                       """,
+                "type": "json",
+                "name": "text_log_summary",
+                "job_guid": job_guid
+            }]
+        }
+    })
+
+    tjc.add(tj)
+
+    req = thclient.TreeherderRequest(
+        protocol='http',
+        host='localhost',
+        project=test_project,
+        oauth_key=credentials['consumer_key'],
+        oauth_secret=credentials['consumer_secret']
+        )
+
+    # Post the request to treeherder
+    resp = req.post(tjc)
+    assert resp.status_int == 200
+    assert resp.body == '{"message": "well-formed JSON stored"}'
+
+    with JobsModel(test_project) as jobs_model, \
+            ArtifactsModel(test_project) as artifacts_model:
+
+        jobs_model.process_objects(10)
+
+        job_ids = [x['id'] for x in jobs_model.get_job_list(0, 20)]
+        artifacts = artifacts_model.get_job_artifact_references(job_ids[0])
+        artifact_names = {x['name'] for x in artifacts}
+        assert {'Bug suggestions', 'text_log_summary'} == artifact_names

--- a/treeherder/model/bug_suggestions.py
+++ b/treeherder/model/bug_suggestions.py
@@ -25,7 +25,8 @@ def get_bug_suggestions_artifacts(artifact_list):
     for artifact in artifact_list:
         # this is the only artifact name eligible to trigger generation of bug
         # suggestions.
-        assert artifact['name'] == 'text_log_summary'
+        if artifact['name'] != 'text_log_summary':
+            continue
 
         all_errors = get_all_errors(artifact)
         if all_errors:

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -23,6 +23,7 @@ from treeherder.model.models import (Datasource,
                                      ExclusionProfile)
 
 from treeherder.model import utils
+from treeherder.model.bug_suggestions import get_bug_suggestions_artifacts
 from treeherder.model.tasks import (publish_resultset,
                                     publish_job_action)
 
@@ -1609,6 +1610,12 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 log_placeholders.append([job_guid, name, url, parse_status])
 
         artifacts = job.get('artifacts', [])
+
+        # the artifacts in this list could be ones that should have
+        # bug suggestions generated for them.  If so, add them in.
+        bug_suggestion_artifacts = get_bug_suggestions_artifacts(artifacts)
+        artifacts.extend(bug_suggestion_artifacts)
+
         if artifacts:
             ArtifactsModel.populate_placeholders(artifacts,
                                                  artifact_placeholders,


### PR DESCRIPTION
This adds support for submitting jobs with the ``artifacts`` field populated.  This won't happen from buildbot, but could easily come from ``treeherder-client`` users, or the REST API, like Task Cluster.  If they submit a ``test_log_summary`` artifact this way, this code will know to generate bug suggestions for it.

This also fixes an error in ``get_bug_suggestions_artifacts`` where it would assert if it came across an artifact that was NOT a ``text_log_summary``.  This change makes it more resilient to that and just skips it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/503)
<!-- Reviewable:end -->
