### PR TITLE
Rename repositories to show branch names for the Bugzilla and BMO projec...

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -745,7 +745,7 @@
     "model": "model.repository",
     "fields": {
         "dvcs_type": "git",
-        "name": "bugzilla",
+        "name": "bugzilla-master",
         "url": "https://github.com/bugzilla/bugzilla",
         "active_status": "active",
         "codebase": "bugzilla",
@@ -758,7 +758,7 @@
     "model": "model.repository",
     "fields": {
         "dvcs_type": "git",
-        "name": "bmo",
+        "name": "bmo-master",
         "url": "https://github.com/mozilla/webtools-bmo-bugzilla",
         "active_status": "active",
         "codebase": "bugzilla",
@@ -790,6 +790,58 @@
         "codebase": "comm",
         "repository_group": 2,
         "description": ""
+    }
+},
+{
+    "pk": 65,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "bugzilla-5_0",
+        "url": "https://github.com/bugzilla/bugzilla",
+        "active_status": "active",
+        "codebase": "bugzilla",
+        "repository_group": 4,
+        "description": "A suite of tests to check the quality of the Bugzilla 5.0 codebase."
+    }
+},
+{
+    "pk": 66,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "bugzilla-4_4",
+        "url": "https://github.com/bugzilla/bugzilla",
+        "active_status": "active",
+        "codebase": "bugzilla",
+        "repository_group": 4,
+        "description": "A suite of tests to check the quality of the Bugzilla 4.4 codebase."
+    }
+},
+{
+    "pk": 67,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "bugzilla-4_2",
+        "url": "https://github.com/bugzilla/bugzilla",
+        "active_status": "active",
+        "codebase": "bugzilla",
+        "repository_group": 4,
+        "description": "A suite of tests to check the quality of the Bugzilla 4.2 codebase."
+    }
+},
+{
+    "pk": 68,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "bmo-development",
+        "url": "https://github.com/mozilla/webtools-bmo-bugzilla",
+        "active_status": "active",
+        "codebase": "bugzilla",
+        "repository_group": 4,
+        "description": "A suite of tests to check the quality of the BMO codebase."
     }
 }
 ]


### PR DESCRIPTION
In order to distinguish between different branches in the upstream Bugzilla code (and BMO) I would like to rename the repositories to show the branch in the names.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/504)
<!-- Reviewable:end -->
