### PR TITLE
Bug 1159934 - Don't generate log parser exceptions if the log URL 403s

### DIFF
--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -274,8 +274,8 @@ def post_log_artifacts(project,
                                              job_guid, check_errors)
     except Exception as e:
         update_parse_status(req, job_log_url, 'failed')
-        if isinstance(e, urllib2.HTTPError) and e.code == 404:
-            logger.debug("Log not found for %s", log_description)
+        if isinstance(e, urllib2.HTTPError) and e.code in (403, 404):
+            logger.debug("Unable to retrieve log for %s: %s", log_description, e)
             return
         logger.error("Failed to download/parse log for %s: %s", log_description, e)
         _retry(e)


### PR DESCRIPTION
Similar to the 404 case, 403s are not something within our control, and are not unusual due to the current taskcluster implementation. As such, let's suppress these from New Relic (and retries) too.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/505)
<!-- Reviewable:end -->
