### PR TITLE
Bug 1161449 - Fix validation errors in /embed/resultset-status/ template

### DIFF
--- a/treeherder/embed/templates/embed/resultset_status.html
+++ b/treeherder/embed/templates/embed/resultset_status.html
@@ -1,20 +1,13 @@
-{% load staticfiles %}
 <!DOCTYPE html>
 <html>
     <head>
+        {% load staticfiles %}
         <link rel="stylesheet" href="{% static "embed/css/embed.css" %}" media="screen"/>
         <base target="_blank" />
     </head>
-    {% if update_needed %}
-    <script type="text/javascript">
-        setTimeout(function(){
-            window.location.reload()
-        },60*1000);
-    </script>
-    {% endif %}
 <body>
     <div id="resultset_status">
-        <ul >
+        <ul>
             {% for status, tot in resultset_status_dict.items %}
                 <li class="btn-{{status}}">
                     <a href="https://treeherder.mozilla.org/#/jobs?repo={{repository}}&revision={{revision}}&filter-resultStatus={{status}}">{{status}}</a>: {{ tot }}
@@ -26,5 +19,12 @@
         See it on <a href="https://treeherder.mozilla.org/#/jobs?repo={{repository}}&revision={{revision}}"
                      title="Push {{revision}} on Treeherder" target="_blank">Treeherder</a>
     </div>
+    {% if update_needed %}
+    <script type="text/javascript">
+        setTimeout(function(){
+            window.location.reload()
+        },60*1000);
+    </script>
+    {% endif %}
 </body>
 </html>


### PR DESCRIPTION
The reload javascript block was neither in <head> nor <body>.
I've also moved the {% load staticfiles %} since it was adding a newline at start of file.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/508)
<!-- Reviewable:end -->
