### PR TITLE
Bug 1127774 - Include the URL in the logs for pushlog HTTPErrors

### DIFF
--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -73,7 +73,11 @@ class HgPushlogProcess(HgPushlogTransformerMixin,
 
     def extract(self, url):
         response = requests.get(url, timeout=settings.TREEHERDER_REQUESTS_TIMEOUT)
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError:
+            logger.warning("HTTPError %s fetching: %s", response.status_code, url)
+            raise
         return response.json()
 
     def run(self, source_url, repository, changeset=None):
@@ -160,7 +164,11 @@ class MissingHgPushlogProcess(HgPushlogTransformerMixin,
             # resultsets
             return get_not_found_onhold_push(url, revision)
         else:
-            response.raise_for_status()
+            try:
+                response.raise_for_status()
+            except requests.exceptions.HTTPError:
+                logger.warning("HTTPError %s fetching: %s", response.status_code, url)
+                raise
         return response.json()
 
     def run(self, source_url, repository, revision):


### PR DESCRIPTION
At some point as we move more things to using the requests library, we should probably add some wrappers around requests to common.py and use those instead.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/511)
<!-- Reviewable:end -->
