### PR TITLE
Bug 1126943 - Delete jobs from the objectstore table once ingested

### DIFF
--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -348,11 +348,13 @@ def get_objectstore_last_error(jm):
     row_id = jm._get_last_insert_id("objectstore")
 
     row_data = jm.get_dhub(jm.CT_OBJECTSTORE).execute(
-        proc="objectstore_test.selects.row", placeholders=[row_id])[0]
+        proc="objectstore_test.selects.row", placeholders=[row_id])
 
     jm.disconnect()
 
-    return row_data['error_msg']
+    # If the job wasn't found, it was removed from the objectstore after
+    # successful ingestion.
+    return row_data[0]['error_msg'] if row_data else None
 
 
 def test_store_result_set_data(jm, initial_data, sample_resultset):

--- a/tests/objectstore_test.json
+++ b/tests/objectstore_test.json
@@ -7,10 +7,9 @@
                    ",
             "host_type": "master_host"
         },
-        "complete": {
-            "sql": "SELECT COUNT(`id`) AS complete_count
+        "all": {
+            "sql": "SELECT COUNT(`id`) AS all_count
                     FROM   `objectstore`
-                    WHERE  processed_state = 'complete'
                    ",
             "host_type": "master_host"
         }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -192,14 +192,11 @@ def do_job_ingestion(jm, refdata, job_data, sample_resultset, verify_data=True):
         verify_artifacts(jm, artifacts_ref)
         verify_coalesced(jm, coalesced_job_guids, coalesced_replacements)
 
-    # Default verification confirms we loaded all of the objects
-    complete_count = jm.get_os_dhub().execute(
-        proc="objectstore_test.counts.complete")[0]["complete_count"]
-    loading_count = jm.get_os_dhub().execute(
-        proc="objectstore_test.counts.loading")[0]["loading_count"]
+    objectstore_count = jm.get_os_dhub().execute(
+        proc="objectstore_test.counts.all")[0]["all_count"]
 
-    assert complete_count == len(job_data)
-    assert loading_count == 0
+    # If all objects were successfully loaded, none should remain in the objectstore.
+    assert objectstore_count == 0
 
 
 def grouper(iterable, n, fillvalue=None):

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1271,9 +1271,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 )
 
                 if 'id' in datum:
-                    object_placeholders.append(
-                        [revision_hash, datum['id']]
-                    )
+                    object_placeholders.append([datum['id']])
 
                 for coalesced_guid in coalesced:
                     coalesced_job_guid_placeholders.append(
@@ -1368,9 +1366,6 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 placeholders=job_update_placeholders,
                 executemany=True)
 
-        # Mark job status
-        self.mark_objects_complete(object_placeholders)
-
         # set the job_coalesced_to_guid column for any coalesced
         # job found
         if coalesced_job_guid_placeholders:
@@ -1379,6 +1374,9 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 debug_show=self.DEBUG,
                 placeholders=coalesced_job_guid_placeholders,
                 executemany=True)
+
+        # Remove the completed tasks from the objectstore.
+        self.delete_completed_objects(object_placeholders)
 
     def _remove_existing_jobs(self, data):
         """
@@ -2162,8 +2160,8 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
 
         return json_blobs
 
-    def mark_objects_complete(self, object_placeholders):
-        """ Call to database to mark the task completed
+    def delete_completed_objects(self, object_placeholders):
+        """ Call to database to delete the tasks now they are completed.
 
             object_placeholders = [
                 [ revision_hash, object_id ],
@@ -2173,7 +2171,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
         """
         if object_placeholders:
             self.os_execute(
-                proc="objectstore.updates.mark_complete",
+                proc="objectstore.deletes.delete_completed",
                 placeholders=object_placeholders,
                 executemany=True,
                 debug_show=self.DEBUG

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1380,16 +1380,6 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 placeholders=coalesced_job_guid_placeholders,
                 executemany=True)
 
-        # send socket.io events for the newly loaded jobs
-        # get all the job_guids for the insertions and updates
-        # the 0th element of both lists is the job_guid.
-        loaded_job_guids = {}
-        for loaded_job in job_placeholders:
-            loaded_job_guids[loaded_job[self.JOB_PH_JOB_GUID]] = {
-                "result_set_id": loaded_job[self.JOB_PH_RESULT_SET_ID],
-                "result_set_push_timestamp": push_timestamps[loaded_job[self.JOB_PH_RESULT_SET_ID]]
-            }
-
     def _remove_existing_jobs(self, data):
         """
         Remove jobs from data where we already have them in the same state.

--- a/treeherder/model/sql/objectstore.json
+++ b/treeherder/model/sql/objectstore.json
@@ -1,5 +1,10 @@
 {
     "deletes":{
+        "delete_completed":{
+            "sql":"DELETE FROM objectstore WHERE `id` = ?",
+            "host_type":"master_host"
+        },
+
         "cycle_objectstore":{
 
             "sql":"DELETE FROM objectstore WHERE job_guid IN (REP0)",
@@ -154,20 +159,6 @@
                    AND    `error` = 'N'
                    ORDER BY `id`
                    LIMIT ?
-                  ",
-
-            "host_type":"master_host"
-
-        },
-
-        "mark_complete":{
-
-            "sql":"UPDATE   `objectstore`
-                   SET      `processed_state` = 'complete',
-                            `revision_hash` = ?
-                   WHERE    `processed_state` = 'loading'
-                   AND      `id` = ?
-                   AND      `worker_id` = CONNECTION_ID()
                   ",
 
             "host_type":"master_host"

--- a/treeherder/model/sql/objectstore.json
+++ b/treeherder/model/sql/objectstore.json
@@ -188,18 +188,6 @@
 
             "host_type":"master_host"
 
-        },
-
-        "update_json":{
-
-            "sql":"UPDATE  `objectstore`
-                  SET `loaded_timestamp` = ?,
-                      `json_blob` = ?,
-                      `error` = ?,
-                      `error_msg` = ?
-                  WHERE `job_guid` = ?",
-            "host_type":"master_host"
         }
     }
 }
-

--- a/treeherder/model/sql/template_schema/project_objectstore_1.sql.tmpl
+++ b/treeherder/model/sql/template_schema/project_objectstore_1.sql.tmpl
@@ -41,10 +41,9 @@ DROP TABLE IF EXISTS `objectstore`;
  *  job_guid - Referenced project_jobs_1.job.guid
  *  revision_hash - Hash of any number of revisions associated with the result set.
  *  loaded_timestamp - Timestamp when the structure was first loaded.
- *  processed_state - ready | loading | complete
+ *  processed_state - ready | loading
  *                  ready - Object ready for processing
  *                  loading - Object in the process of loading
- *                  complete - Object processing is complete.
  *  error - N | Y, if yes there may be a error_msg
  *  error_msg - Any error messages associated with processing the JSON into
  *              the reference and project job schemas.
@@ -56,7 +55,7 @@ CREATE TABLE `objectstore` (
   `job_guid` varchar(50) COLLATE utf8_bin NOT NULL,
   `revision_hash` varchar(50) COLLATE utf8_bin DEFAULT NULL,
   `loaded_timestamp` int(11) unsigned NOT NULL,
-  `processed_state` enum('ready','loading','complete') COLLATE utf8_bin DEFAULT 'ready',
+  `processed_state` enum('ready','loading') COLLATE utf8_bin DEFAULT 'ready',
   `error` enum('N','Y') COLLATE utf8_bin DEFAULT 'N',
   `error_msg` mediumtext COLLATE utf8_bin,
   `json_blob` mediumblob,


### PR DESCRIPTION
Rather than retaining a job in the objectstore and giving it a 'processed_state' of 'completed', we now delete the job from the objectstore. This reduces data usage, as well as improves the performance of the table, since it will now only contain at most a thousand or so rows, rather than millions (there are currently 2.9 million rows in the inbound objectstore).

Many tests had to be updated, since they assumed that a job would persist in the objectstore after being successfully ingested. Rather than counting the number of rows with a 'processed_state' of 'completed' we can now just check there are no rows left at all in the objectstore, which covers both the 'pending' and error cases.

Plus some clean-up:
* Remove unused objectstore 'update_json' stored proc. Its caller was removed in: b1c5603
* Remove socket.io publishing dead code in load_job_data(). Unused since: 27b0b19

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/513)
<!-- Reviewable:end -->
