### PR TITLE
Bug 1093743 - Attempt to generate job_guids more consistently

### DIFF
--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -122,12 +122,12 @@ def generate_revision_hash(revisions):
     return sh.hexdigest()
 
 
-def generate_job_guid(request_id, request_time, endtime=None):
-    """Converts a request_id and request_time into a guid"""
+def generate_job_guid(request_id, buildername, endtime=None):
+    """Converts a request_id and buildername into a guid"""
     sh = hashlib.sha1()
 
     sh.update(str(request_id))
-    sh.update(str(request_time))
+    sh.update(str(buildername))
     job_guid = sh.hexdigest()
 
     # for some jobs (I'm looking at you, ``retry``) we need the endtime to be


### PR DESCRIPTION
In order that Treeherder can track a buildbot ingested job as it moves from pending to running to completed, a unique job_guid must be generated, since buildbot doesn't directly give us one. To make things worse, each of the three data sources (builds-{pending,running,4hr}) make slightly different properties available to us, and the data in them is not always correct. Until now we've been calculating the guid in such a way that as some jobs (particularly those that are coalesced) change state, the guid generated changes, causing us to think it's a brand new job, thereby leaving behind an orphaned pending/running job.

The new method of generating a guid uses only the single request_id corresponding to the job that ran, rather than all of the request_ids. This is because when in the pending state, there is only ever one request id, so if we use the full list later on, there is no way it will match, if the job had others coalesced into it.

In addition, the request_times properties are known to be unreliable (see bug 1141603), so we've stopped using them. This isn't a problem, since they didn't help us with the buildbot retry case anyway (where the request id is recycled), and we already handle that by using endtime.

We instead now use the buildername to add uniqueness rather than request_times.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/514)
<!-- Reviewable:end -->
