### PR TITLE
Bug 1126943 - Expire data from the objectstore independently of the others

### DIFF
--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -623,12 +623,11 @@ class JobsModel(TreeherderModelBase):
         """Delete data older than cycle_interval, splitting the target data
 into chunks of chunk_size size. Returns the number of result sets deleted"""
 
-        max_date = datetime.now() - cycle_interval
-        max_timestamp = int(time.mktime(max_date.timetuple()))
+        jobs_max_timestamp = self._get_max_timestamp(cycle_interval)
         # Retrieve list of result sets to delete
         result_set_data = self.jobs_execute(
             proc='jobs.selects.get_result_sets_to_cycle',
-            placeholders=[max_timestamp],
+            placeholders=[jobs_max_timestamp],
             debug_show=self.DEBUG
         )
         if not result_set_data:
@@ -711,6 +710,10 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             self._execute_table_deletes(jobs_targets, 'jobs', sleep_time)
 
         return len(result_set_data)
+
+    def _get_max_timestamp(self, cycle_interval):
+        max_date = datetime.now() - cycle_interval
+        return int(time.mktime(max_date.timetuple()))
 
     def _execute_table_deletes(self, sql_to_execute, data_type, sleep_time):
 

--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -86,13 +86,13 @@ class Command(BaseCommand):
         for project in projects:
             self.debug("Cycling Database: {0}".format(project))
             with JobsModel(project) as jm:
-                num_deleted = jm.cycle_data(os_cycle_interval,
-                                            cycle_interval,
-                                            options['os_chunk_size'],
-                                            options['chunk_size'],
-                                            options['sleep_time'])
-                self.debug("Deleted {0} resultsets from {1}".format(
-                           num_deleted, project))
+                os_deleted, rs_deleted = jm.cycle_data(os_cycle_interval,
+                                                       cycle_interval,
+                                                       options['os_chunk_size'],
+                                                       options['chunk_size'],
+                                                       options['sleep_time'])
+                self.debug("Deleted {} objectstore rows and {} resultsets from {}".format(
+                           os_deleted, rs_deleted, project))
 
     def debug(self, msg):
         if self.is_debug:

--- a/treeherder/model/sql/objectstore.json
+++ b/treeherder/model/sql/objectstore.json
@@ -1,12 +1,16 @@
 {
     "deletes":{
         "cycle_objectstore":{
-
-            "sql":"DELETE FROM objectstore WHERE job_guid IN (REP0)",
-
+            "sql":"DELETE
+                   FROM objectstore
+                   WHERE `processed_state` = 'complete'
+                   AND `loaded_timestamp` < ?
+                   ORDER BY `id`
+                   LIMIT ?",
             "host_type": "master_host"
         }
     },
+
     "inserts":{
         "store_json":{
 


### PR DESCRIPTION
Items in the objectstore are currently expired by finding the list of result sets matching the date range, then looking up the jobs for those result sets, and finally searching for matching job guids in the datastore table. This is not only bad for performance of objectstore deletes (since we end up with lists of thousands of guids), but also means we cannot set a different cycle interval for the objectstore.

The new approach is much simpler: we only query the objectstore, and use loaded_timestamp to determine which rows to cycle. The objectstore does not have any foreign keys, so this isn't a problem. The only constraint is that we must keep the complete jobs long enough for the job to stop appearing in builds-4hr, to prevent us from continually re-adding it to the objectstore. For now, we also only cycle jobs with a processed_state of 'complete', so entries with errors (or that are stuck in the 'loading' state due to bug 1125476) are not lost (this matches the prior behaviour, since the list of job_guids would only include successfully ingested jobs).

For now the objectstore cycle interval has been set to the same default interval as the jobs tables, but this will be reduced once manual cycle data runs are run on stage/prod.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/516)
<!-- Reviewable:end -->
