### PR TITLE
Bug 1161520 - Handle jobs that are missing the buildername

### DIFF
--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -104,6 +104,10 @@ class Builds4hTransformerMixin(object):
         for build in data['builds']:
             prop = build['properties']
 
+            if 'buildername' not in prop:
+                logger.warning("skipping builds-4hr job since no buildername found")
+                continue
+
             if 'branch' not in prop:
                 logger.warning("skipping builds-4hr job since no branch found: %s", prop['buildername'])
                 continue


### PR DESCRIPTION
Since we now use the buildername as part of the error messages, we get a KeyError if it's not present. We were already skipping over these jobs previously, since they are also missing the branch.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/517)
<!-- Reviewable:end -->
