### PR TITLE
Bug suggestions take 3

### DIFF
--- a/bin/run_celery_worker_log_parser
+++ b/bin/run_celery_worker_log_parser
@@ -23,6 +23,6 @@ if [ ! -f $LOGFILE ]; then
 fi
 
 exec $NEWRELIC_ADMIN celery -A treeherder worker \
-    -Q log_parser_fail,log_parser,log_parser_hp,log_parser_json \
+    -Q log_parser_fail,log_parser,log_parser_hp,log_parser_json,error_summary \
     --concurrency=5 --logfile=$LOGFILE -l INFO \
     --maxtasksperchild=500 -n log_parser.%h

--- a/docs/submitting_data.rst
+++ b/docs/submitting_data.rst
@@ -466,3 +466,39 @@ will be rendered. Here are the possible values:
 * **Raw Html** - The last resource for when you need to show some formatted
   content.
 
+
+
+Some Specific Collection POSTing Rules
+--------------------------------------
+
+Treeherder will detect what data is submitted in the ``TreeherderCollection``
+and generate the necessary artifacts accordingly.  The outline below describes
+what artifacts *Treeherder* will generate depending on what has been submitted.
+
+
+JobCollections
+^^^^^^^^^^^^^^
+Via the ``/jobs`` endpoint:
+
+1. Submit a Log URL with no ``parse_status`` or ``parse_status`` set to "pending"
+    * This will generate ``text_log_summary`` and ``Bug suggestions`` artifacts
+    * Current *Buildbot* workflow
+
+2. Submit a Log URL with ``parse_status`` set to "parsed" and a ``text_log_summary`` artifact
+    * Will generate a ``Bug suggestions`` artifact only
+    * Desired future state of *Task Cluster*
+
+3. Submit a Log URL with ``parse_status`` of "parsed", with ``text_log_summary`` and ``Bug suggestions`` artifacts
+    * Will generate nothing
+
+
+ArtifactCollections
+^^^^^^^^^^^^^^^^^^^
+Via the ``/artifact`` endpoint:
+
+1. Submit a ``text_log_summary`` artifact
+    * Will generate a ``Bug suggestions`` artifact if it does not already exist for that job.
+
+2. Submit ``text_log_summary`` and ``Bug suggestions`` artifacts
+    * Will generate nothing
+    * This is *Treeherder's* current internal log parser workflow

--- a/tests/e2e/test_client_job_ingestion.py
+++ b/tests/e2e/test_client_job_ingestion.py
@@ -2,27 +2,101 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from treeherder import client
+import pytest
+from mock import MagicMock
+import json
+
+from treeherder.client.thclient import client
 
 from treeherder.etl.oauth_utils import OAuthCredentials
-from treeherder.model.derived import JobsModel
+from treeherder.log_parser.parsers import StepParser
+from treeherder.model.derived import JobsModel, ArtifactsModel
+from treeherder.model import error_summary
+
+
+@pytest.fixture
+def text_log_summary_blob():
+    return {
+        "header": {},
+        "step_data": {
+            "all_errors": [
+                {"line": "12:34:13     INFO -  Assertion failure: addr % CellSize == 0, at ../../../js/src/gc/Heap.h:1041", "linenumber": 61918},
+                {"line": "12:34:24  WARNING -  TEST-UNEXPECTED-FAIL | file:///builds/slave/talos-slave/test/build/tests/jsreftest/tests/jsreftest.html?test=ecma_5/JSON/parse-array-gc.js | Exited with code 1 during test run", "linenumber": 61919}, {"line": "12:34:37  WARNING -  PROCESS-CRASH | file:///builds/slave/talos-slave/test/build/tests/jsreftest/tests/jsreftest.html?test=ecma_5/JSON/parse-array-gc.js | application crashed [@ js::gc::Cell::tenuredZone() const]", "linenumber": 61922},
+                {"line": "12:34:38    ERROR - Return code: 256", "linenumber": 64435}
+            ],
+            "steps": [
+                {"name": "Clone gecko tc-vcs "},
+                {"name": "Build ./build-b2g-desktop.sh /home/worker/workspace"}
+            ],
+            "errors_truncated": False
+        },
+        "logurl": "https://queue.taskcluster.net/v1/task/nhxC4hC3RE6LSVWTZT4rag/runs/0/artifacts/public/logs/live_backing.log"
+    }
+
+
+def do_post_collection(project, collection):
+    # assume if there were no exceptions we're ok
+    cli = client.TreeherderClient(protocol='http', host='localhost')
+    credentials = OAuthCredentials.get_credentials(project)
+    cli.post_collection(project, credentials['consumer_key'],
+                        credentials['consumer_secret'], collection)
+
+
+def check_artifacts(test_project,
+                    job_guid,
+                    parse_status,
+                    num_artifacts,
+                    exp_artifact_names=None,
+                    exp_error_summary=None):
+
+    with JobsModel(test_project) as jobs_model:
+        jobs_model.process_objects(10)
+        job_id = [x['id'] for x in jobs_model.get_job_list(0, 20)
+                  if x['job_guid'] == job_guid][0]
+        job_log_list = jobs_model.get_job_log_url_list([job_id])
+
+        print job_log_list
+        assert len(job_log_list) == 1
+        assert job_log_list[0]['parse_status'] == parse_status
+
+    with ArtifactsModel(test_project) as artifacts_model:
+        artifacts = artifacts_model.get_job_artifact_list(0, 10, conditions={
+            'job_id': {('=', job_id)}
+        })
+
+        assert len(artifacts) == num_artifacts
+
+        if exp_artifact_names:
+            artifact_names = {x['name'] for x in artifacts}
+            assert set(artifact_names) == exp_artifact_names
+
+        if exp_error_summary:
+            act_bs_obj = [x['blob'] for x in artifacts if x['name'] == 'Bug suggestions'][0]
+            assert exp_error_summary == act_bs_obj
 
 
 def test_post_job_with_parsed_log(test_project, result_set_stored,
-                                  mock_post_collection):
+                                  mock_post_collection,
+                                  monkeypatch,
+                                  ):
     """
-    test submitting a job with a pre-parsed log gets the right job_log_url
-    parse_status value.
+    test submitting a job with a pre-parsed log gets job_log_url
+    parse_status of "parsed" and does not parse, even though no text_log_summary
+    exists.
+
+    This is for the case where they may want to submit it at a later time.
     """
 
-    credentials = OAuthCredentials.get_credentials(test_project)
+    mock_parse = MagicMock(name="parse_line")
+    monkeypatch.setattr(StepParser, 'parse_line', mock_parse)
 
     tjc = client.TreeherderJobCollection()
+    job_guid = 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
     tj = client.TreeherderJob({
         'project': test_project,
         'revision_hash': result_set_stored[0]['revision_hash'],
         'job': {
-            'job_guid': 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33',
+            'job_guid': job_guid,
             'state': 'completed',
             'log_references': [{
                 'url': 'http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/...',
@@ -31,22 +105,174 @@ def test_post_job_with_parsed_log(test_project, result_set_stored,
             }]
         }
     })
+    tjc.add(tj)
+
+    do_post_collection(test_project, tjc)
+
+    check_artifacts(test_project, job_guid, 'parsed', 0)
+
+    # ensure the parsing didn't happen
+    assert mock_parse.called is False
+
+
+def test_post_job_with_text_log_summary_artifact_parsed(
+        test_project,
+        monkeypatch,
+        result_set_stored,
+        mock_post_collection,
+        mock_error_summary,
+        text_log_summary_blob,
+        ):
+    """
+    test submitting a job with a pre-parsed log gets parse_status of
+    "parsed" and doesn't parse the log, but still generates
+    the bug suggestions.
+    """
+
+    mock_parse = MagicMock(name="parse_line")
+    monkeypatch.setattr(StepParser, 'parse_line', mock_parse)
+
+    job_guid = 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
+    tjc = client.TreeherderJobCollection()
+    tj = client.TreeherderJob({
+        'project': test_project,
+        'revision_hash': result_set_stored[0]['revision_hash'],
+        'job': {
+            'job_guid': job_guid,
+            'state': 'completed',
+            'log_references': [{
+                'url': 'http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/...',
+                'name': 'builbot_text',
+                'parse_status': 'parsed'
+            }],
+            'artifacts': [{
+                "blob": json.dumps(text_log_summary_blob),
+                "type": "json",
+                "name": "text_log_summary",
+                "job_guid": job_guid
+            }]
+        }
+    })
+    tjc.add(tj)
+
+    do_post_collection(test_project, tjc)
+
+    check_artifacts(test_project, job_guid, 'parsed', 2,
+                    {'Bug suggestions', 'text_log_summary'}, mock_error_summary)
+
+    # ensure the parsing didn't happen
+    assert mock_parse.called is False
+
+
+def test_post_job_with_text_log_summary_artifact_pending(
+        test_project,
+        monkeypatch,
+        result_set_stored,
+        mock_post_collection,
+        mock_error_summary,
+        mock_update_parse_status,
+        text_log_summary_blob,
+        ):
+    """
+    test submitting a job with a log set to pending, but with a text_log_summary.
+
+    This should detect the artifact, not parse, and just mark the log as parsed,
+    then generate bug suggestions.
+    """
+
+    mock_parse = MagicMock(name="parse_line")
+    monkeypatch.setattr(StepParser, 'parse_line', mock_parse)
+
+    job_guid = 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
+    tjc = client.TreeherderJobCollection()
+    tj = client.TreeherderJob({
+        'project': test_project,
+        'revision_hash': result_set_stored[0]['revision_hash'],
+        'job': {
+            'job_guid': job_guid,
+            'state': 'completed',
+            'log_references': [{
+                'url': 'http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/...',
+                'name': 'builbot_text',
+                'parse_status': 'pending'
+            }],
+            'artifacts': [{
+                "blob": json.dumps(text_log_summary_blob),
+                "type": "json",
+                "name": "text_log_summary",
+                "job_guid": job_guid
+            }]
+        }
+    })
 
     tjc.add(tj)
 
-    cli = client.TreeherderClient(protocol='http', host='localhost')
+    do_post_collection(test_project, tjc)
 
-    # Post the request to treeherder
-    cli.post_collection(test_project, credentials['consumer_key'],
-                        credentials['consumer_secret'], tjc)
+    check_artifacts(test_project, job_guid, 'parsed', 2,
+                    {'Bug suggestions', 'text_log_summary'}, mock_error_summary)
 
-    # assume if there were no exceptions we're ok
+    # ensure the parsing didn't happen
+    assert mock_parse.called is False
 
-    with JobsModel(test_project) as jm:
-        jm.process_objects(10)
 
-        job_ids = [x['id'] for x in jm.get_job_list(0, 20)]
-        job_log_list = jm.get_job_log_url_list(job_ids)
+def test_post_job_with_text_log_summary_and_bug_suggestions_artifact(
+        test_project,
+        monkeypatch,
+        result_set_stored,
+        mock_post_collection,
+        mock_error_summary,
+        text_log_summary_blob,
+        ):
+    """
+    test submitting a job with a pre-parsed log and both artifacts
+    does not generate parse the log or generate any artifacts, just uses
+    the supplied ones.
+    """
 
-        assert len(job_log_list) == 1
-        assert job_log_list[0]['parse_status'] == 'parsed'
+    mock_parse = MagicMock(name="parse_line")
+    monkeypatch.setattr(StepParser, 'parse_line', mock_parse)
+    mock_get_error_summary = MagicMock(name="get_error_summary_artifacts")
+    monkeypatch.setattr(error_summary, 'get_error_summary_artifacts', mock_get_error_summary)
+
+    error_summary_blob = ["fee", "fie", "foe", "fum"]
+
+    job_guid = 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
+    tjc = client.TreeherderJobCollection()
+    tj = client.TreeherderJob({
+        'project': test_project,
+        'revision_hash': result_set_stored[0]['revision_hash'],
+        'job': {
+            'job_guid': job_guid,
+            'state': 'completed',
+            'log_references': [{
+                'url': 'http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/...',
+                'name': 'builbot_text',
+                'parse_status': 'parsed'
+            }],
+            'artifacts': [
+                {
+                    "blob": json.dumps(text_log_summary_blob),
+                    "type": "json",
+                    "name": "text_log_summary",
+                    "job_guid": job_guid
+                },
+                {
+                    "blob": json.dumps(error_summary_blob),
+                    "type": "json",
+                    "name": "Bug suggestions",
+                    "job_guid": job_guid
+                },
+            ]
+        }
+    })
+
+    tjc.add(tj)
+
+    do_post_collection(test_project, tjc)
+
+    check_artifacts(test_project, job_guid, 'parsed', 2,
+                    {'Bug suggestions', 'text_log_summary'}, error_summary_blob)
+
+    assert mock_parse.called is False
+    assert mock_get_error_summary.called is False

--- a/tests/model/derived/test_artifacts_model.py
+++ b/tests/model/derived/test_artifacts_model.py
@@ -1,0 +1,95 @@
+import json
+import pytest
+
+from treeherder.model.derived import ArtifactsModel, JobsModel
+
+
+xfail = pytest.mark.xfail
+
+
+def test_load_single_artifact(
+        test_project, eleven_jobs_processed,
+        mock_post_collection, mock_error_summary,
+        sample_data):
+    """
+    test loading a single artifact
+
+    """
+
+    with JobsModel(test_project) as jobs_model:
+        job = jobs_model.get_job_list(0, 1)[0]
+    bs_blob = ["flim", "flam"]
+
+    bs_artifact = {
+        'type': 'json',
+        'name': 'Bug suggestions',
+        'blob': json.dumps(bs_blob),
+        'job_guid': job['job_guid']
+    }
+
+    with ArtifactsModel(test_project) as artifacts_model:
+        artifacts_model.load_job_artifacts(
+            [bs_artifact],
+            {bs_artifact['job_guid']: job}
+        )
+
+        artifacts = artifacts_model.get_job_artifact_list(0, 10, conditions={
+            'job_id': {('=', job["id"])}
+        })
+
+    assert len(artifacts) == 1
+    artifact_names = {x['name'] for x in artifacts}
+    act_bs_obj = [x['blob'] for x in artifacts if x['name'] == 'Bug suggestions'][0]
+
+    assert set(artifact_names) == {'Bug suggestions'}
+    assert bs_blob == act_bs_obj
+
+
+def test_load_artifact_second_time_fails(
+        test_project, eleven_jobs_processed,
+        mock_post_collection, mock_error_summary,
+        sample_data):
+    """
+    test loading two of the same named artifact only gets the first one
+
+    """
+
+    with JobsModel(test_project) as jobs_model:
+        job = jobs_model.get_job_list(0, 1)[0]
+    bs_blob = ["flim", "flam"]
+
+    bs_artifact1 = {
+        'type': 'json',
+        'name': 'Bug suggestions',
+        'blob': json.dumps(bs_blob),
+        'job_guid': job['job_guid']
+    }
+    bs_artifact2 = {
+        'type': 'json',
+        'name': 'Bug suggestions',
+        'blob': json.dumps(["me", "you"]),
+        'job_guid': job['job_guid']
+    }
+
+    with ArtifactsModel(test_project) as artifacts_model:
+        artifacts_model.load_job_artifacts(
+            [bs_artifact1],
+            {bs_artifact1['job_guid']: job}
+        )
+
+        artifacts_model.load_job_artifacts(
+            [bs_artifact2],
+            {bs_artifact2['job_guid']: job}
+        )
+
+        artifacts = artifacts_model.get_job_artifact_list(0, 10, conditions={
+            'job_id': {('=', job["id"])}
+        })
+
+    assert len(artifacts) == 1
+    artifact_names = {x['name'] for x in artifacts}
+    act_bs_obj = [x['blob'] for x in artifacts
+                  if x['name'] == 'Bug suggestions'][0]
+
+    assert set(artifact_names) == {'Bug suggestions'}
+    assert bs_blob == act_bs_obj

--- a/tests/sample_data/artifacts/text_log_summary.json
+++ b/tests/sample_data/artifacts/text_log_summary.json
@@ -1,0 +1,262 @@
+{
+    "blob": {
+        "header": {
+            "slave": "t-snow-r4-0001",
+            "buildid": "20150415030206",
+            "builder": "mozilla-central_snowleopard_test-mochitest-2",
+            "results": "warnings (1)",
+            "starttime": "1429100703.17",
+            "builduid": "8ad46455f18545abbdff94ba9dce402e",
+            "revision": "a6f7a33731bc3fe22073129bba83fc7480e387e2"
+        },
+        "step_data": {
+            "all_errors": [
+                {
+                    "line": "05:35:49     INFO -  2018 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Should be able to get objectStore - expected PASS",
+                    "linenumber": 8151
+                },
+                {
+                    "line": "05:35:49     INFO -  2019 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Should be able to get index - expected PASS",
+                    "linenumber": 8152
+                },
+                {
+                    "line": "05:35:49     INFO -  2023 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Ordering is correct. - expected PASS",
+                    "linenumber": 8156
+                },
+                {
+                    "line": "05:35:49     INFO -  2024 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Worker: uncaught exception [http://mochi.test:8888/tests/dom/indexedDB/test/unit/test_transaction_lifetimes.js:45]: ': InvalidStateError: An attempt was made to use an object that is not, or is no longer, usable' - expected PASS",
+                    "linenumber": 8157
+                }
+            ],
+            "steps": [
+                {
+                    "errors": [ ],
+                    "name": "set props: master",
+                    "started": "2015-04-15 05:25:03.168328",
+                    "started_linenumber": 8,
+                    "finished_linenumber": 10,
+                    "finished": "2015-04-15 05:25:03.168795",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 0,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "set props: basedir",
+                    "started": "2015-04-15 05:25:03.169099",
+                    "started_linenumber": 12,
+                    "finished_linenumber": 40,
+                    "finished": "2015-04-15 05:25:03.597219",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 1,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "downloading to buildprops.json",
+                    "started": "2015-04-15 05:25:03.597542",
+                    "started_linenumber": 42,
+                    "finished_linenumber": 43,
+                    "finished": "2015-04-15 05:25:03.726142",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 2,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "'rm -rf ...'",
+                    "started": "2015-04-15 05:25:03.726523",
+                    "started_linenumber": 45,
+                    "finished_linenumber": 71,
+                    "finished": "2015-04-15 05:25:03.777120",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 3,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "set props: script_repo_url",
+                    "started": "2015-04-15 05:25:03.777445",
+                    "started_linenumber": 73,
+                    "finished_linenumber": 75,
+                    "finished": "2015-04-15 05:25:03.777817",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 4,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "'bash -c ...'",
+                    "started": "2015-04-15 05:25:03.778747",
+                    "started_linenumber": 77,
+                    "finished_linenumber": 114,
+                    "finished": "2015-04-15 05:25:03.945448",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 5,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "set props: script_repo_revision script_repo_url",
+                    "started": "2015-04-15 05:25:03.945809",
+                    "started_linenumber": 116,
+                    "finished_linenumber": 146,
+                    "finished": "2015-04-15 05:25:04.682022",
+                    "error_count": 0,
+                    "duration": 1,
+                    "order": 6,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "'rm -rf ...'",
+                    "started": "2015-04-15 05:25:04.682572",
+                    "started_linenumber": 148,
+                    "finished_linenumber": 174,
+                    "finished": "2015-04-15 05:25:05.278125",
+                    "error_count": 0,
+                    "duration": 1,
+                    "order": 7,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "'hg clone ...'",
+                    "started": "2015-04-15 05:25:05.278437",
+                    "started_linenumber": 176,
+                    "finished_linenumber": 210,
+                    "finished": "2015-04-15 05:25:11.964370",
+                    "error_count": 0,
+                    "duration": 7,
+                    "order": 8,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "'hg update ...'",
+                    "started": "2015-04-15 05:25:11.964712",
+                    "started_linenumber": 212,
+                    "finished_linenumber": 239,
+                    "finished": "2015-04-15 05:25:12.506740",
+                    "error_count": 0,
+                    "duration": 1,
+                    "order": 9,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "set props: script_repo_revision",
+                    "started": "2015-04-15 05:25:12.507514",
+                    "started_linenumber": 241,
+                    "finished_linenumber": 269,
+                    "finished": "2015-04-15 05:25:12.700263",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 10,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "downloading to oauth.txt",
+                    "started": "2015-04-15 05:25:12.700568",
+                    "started_linenumber": 271,
+                    "finished_linenumber": 272,
+                    "finished": "2015-04-15 05:25:12.730239",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 11,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "tinderboxprint_script_revlink",
+                    "started": "2015-04-15 05:25:12.730485",
+                    "started_linenumber": 274,
+                    "finished_linenumber": 276,
+                    "finished": "2015-04-15 05:25:12.730832",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 12,
+                    "result": "success"
+                },
+                {
+                    "errors": [
+                        {
+                            "line": "05:35:49     INFO -  2018 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Should be able to get objectStore - expected PASS",
+                            "linenumber": 8151
+                        },
+                        {
+                            "line": "05:35:49     INFO -  2019 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Should be able to get index - expected PASS",
+                            "linenumber": 8152
+                        },
+                        {
+                            "line": "05:35:49     INFO -  2023 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Ordering is correct. - expected PASS",
+                            "linenumber": 8156
+                        },
+                        {
+                            "line": "05:35:49     INFO -  2024 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Worker: uncaught exception [http://mochi.test:8888/tests/dom/indexedDB/test/unit/test_transaction_lifetimes.js:45]: ': InvalidStateError: An attempt was made to use an object that is not, or is no longer, usable' - expected PASS",
+                            "linenumber": 8157
+                        }
+                    ],
+                    "name": "'/tools/buildbot/bin/python scripts/scripts/desktop_unittest.py ...' warnings",
+                    "started": "2015-04-15 05:25:12.731202",
+                    "started_linenumber": 278,
+                    "finished_linenumber": 9248,
+                    "finished": "2015-04-15 05:36:51.808779",
+                    "error_count": 4,
+                    "duration": 699,
+                    "order": 13,
+                    "result": "testfailed"
+                },
+                {
+                    "errors": [ ],
+                    "name": "set props: build_url blobber_files",
+                    "started": "2015-04-15 05:36:51.812718",
+                    "started_linenumber": 9250,
+                    "finished_linenumber": 9280,
+                    "finished": "2015-04-15 05:36:51.871786",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 14,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "'rm -f ...'",
+                    "started": "2015-04-15 05:36:51.872124",
+                    "started_linenumber": 9282,
+                    "finished_linenumber": 9308,
+                    "finished": "2015-04-15 05:36:51.927004",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 15,
+                    "result": "success"
+                },
+                {
+                    "errors": [ ],
+                    "name": "reboot skipped",
+                    "started": "2015-04-15 05:36:51.927332",
+                    "started_linenumber": 9310,
+                    "finished_linenumber": 9311,
+                    "finished": "2015-04-15 05:36:51.927750",
+                    "error_count": 0,
+                    "duration": 0,
+                    "order": 16,
+                    "result": "skipped"
+                }
+            ],
+            "errors_truncated": false
+        },
+        "logurl": "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/2015/04/2015-04-15-03-02-06-mozilla-central/mozilla-central_snowleopard_test-mochitest-2-bm107-tests1-macosx-build128.txt.gz"
+    },
+    "type": "json",
+    "id": 8217463,
+    "name": "text_log_summary",
+    "job_id": 1330578
+}

--- a/tests/sampledata.py
+++ b/tests/sampledata.py
@@ -57,6 +57,10 @@ class SampleData(object):
                   os.path.dirname(__file__))) as f:
             self.job_artifact = f.readlines()
 
+        with open("{0}/sample_data/artifacts/text_log_summary.json".format(
+                  os.path.dirname(__file__))) as f:
+            self.text_log_summary = json.load(f)
+
         self.job_data = []
         self.resultset_data = []
 

--- a/tests/webapp/api/test_artifact_api.py
+++ b/tests/webapp/api/test_artifact_api.py
@@ -2,10 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+import json
 import pytest
+
 from django.core.urlresolvers import reverse
 
-from treeherder.model.derived import ArtifactsModel
+from treeherder.client.thclient import client
+
+from treeherder.etl.oauth_utils import OAuthCredentials
+from treeherder.model.derived import ArtifactsModel, JobsModel
+
 
 xfail = pytest.mark.xfail
 
@@ -14,7 +20,7 @@ xfail = pytest.mark.xfail
 
 def test_artifact_detail(webapp, test_project, eleven_jobs_processed, sample_artifacts, jm):
     """
-    test retrieving a single job from the jobs-detail
+    test retrieving a single artifact from the artifact-detail
     endpoint.
     """
     job = jm.get_job_list(0, 1)[0]
@@ -69,3 +75,92 @@ def test_artifact_detail_bad_project(webapp, jm):
     assert resp.json == {"detail": "No project with name foo"}
 
     jm.disconnect()
+
+
+def test_artifact_create_text_log_summary(webapp, test_project, eleven_jobs_processed,
+                                          mock_post_collection, mock_error_summary,
+                                          sample_data):
+    """
+    test submitting a text_log_summary artifact which auto-generates bug suggestions
+    """
+
+    credentials = OAuthCredentials.get_credentials(test_project)
+
+    with JobsModel(test_project) as jobs_model:
+        job = jobs_model.get_job_list(0, 1)[0]
+    tls = sample_data.text_log_summary
+
+    tac = client.TreeherderArtifactCollection()
+    ta = client.TreeherderArtifact({
+        'type': 'json',
+        'name': 'text_log_summary',
+        'blob': json.dumps(tls['blob']),
+        'job_guid': job['job_guid']
+    })
+    tac.add(ta)
+
+    cli = client.TreeherderClient(protocol='http', host='localhost')
+    credentials = OAuthCredentials.get_credentials(test_project)
+    cli.post_collection(test_project, credentials['consumer_key'],
+                        credentials['consumer_secret'], tac)
+
+    with ArtifactsModel(test_project) as artifacts_model:
+        artifacts = artifacts_model.get_job_artifact_list(0, 10, conditions={
+            'job_id': {('=', job["id"])}
+        })
+
+    artifact_names = {x['name'] for x in artifacts}
+    act_bs_obj = [x['blob'] for x in artifacts if x['name'] == 'Bug suggestions'][0]
+
+    assert set(artifact_names) == {'Bug suggestions', 'text_log_summary'}
+    assert mock_error_summary == act_bs_obj
+
+
+def test_artifact_create_text_log_summary_and_bug_suggestions(
+        webapp, test_project, eleven_jobs_processed,
+        mock_post_collection, mock_error_summary,
+        sample_data):
+    """
+    test submitting text_log_summary and Bug suggestions artifacts
+
+    This should NOT generate a Bug suggestions artifact, just post the one
+    submitted.
+    """
+
+    credentials = OAuthCredentials.get_credentials(test_project)
+
+    with JobsModel(test_project) as jobs_model:
+        job = jobs_model.get_job_list(0, 1)[0]
+    tls = sample_data.text_log_summary
+    bs_blob = ["flim", "flam"]
+
+    tac = client.TreeherderArtifactCollection()
+    tac.add(client.TreeherderArtifact({
+        'type': 'json',
+        'name': 'text_log_summary',
+        'blob': json.dumps(tls['blob']),
+        'job_guid': job['job_guid']
+    }))
+    tac.add(client.TreeherderArtifact({
+        'type': 'json',
+        'name': 'Bug suggestions',
+        'blob': json.dumps(bs_blob),
+        'job_guid': job['job_guid']
+    }))
+
+    cli = client.TreeherderClient(protocol='http', host='localhost')
+    credentials = OAuthCredentials.get_credentials(test_project)
+    cli.post_collection(test_project, credentials['consumer_key'],
+                        credentials['consumer_secret'], tac)
+
+    with ArtifactsModel(test_project) as artifacts_model:
+        artifacts = artifacts_model.get_job_artifact_list(0, 10, conditions={
+            'job_id': {('=', job["id"])}
+        })
+
+    assert len(artifacts) == 2
+    artifact_names = {x['name'] for x in artifacts}
+    act_bs_obj = [x['blob'] for x in artifacts if x['name'] == 'Bug suggestions'][0]
+
+    assert set(artifact_names) == {'Bug suggestions', 'text_log_summary'}
+    assert bs_blob == act_bs_obj

--- a/tests/webapp/api/test_note_api.py
+++ b/tests/webapp/api/test_note_api.py
@@ -22,7 +22,7 @@ def test_note_list(webapp, sample_notes, jm):
     assert isinstance(resp.json, list)
     note_list = resp.json
 
-    assert set(note_list[0].keys()) == set([
+    assert set(note_list[0].keys()) == {
         'note_timestamp',
         'job_id',
         'who',
@@ -30,7 +30,7 @@ def test_note_list(webapp, sample_notes, jm):
         'note',
         'active_status',
         'id'
-    ])
+    }
 
     # remove fields we don't want to compare
     for note in note_list:

--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -147,7 +147,6 @@ class ArtifactsModel(TreeherderModelBase):
         """
         Store a list of job_artifacts given a list of placeholders
         """
-
         self.jobs_execute(
             proc='jobs.inserts.set_job_artifact',
             debug_show=self.DEBUG,
@@ -254,7 +253,6 @@ class ArtifactsModel(TreeherderModelBase):
                 job_guid = None
 
                 if isinstance(artifact, list):
-
                     job_guid = artifact[0]
                     job_id = job_id_lookup.get(job_guid, {}).get('id', None)
 

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -23,9 +23,10 @@ from django.core.exceptions import ObjectDoesNotExist
 from treeherder.model.models import (Datasource,
                                      ExclusionProfile)
 
-from treeherder.model import utils
+from treeherder.model import utils, error_summary
 from treeherder.model.tasks import (publish_resultset,
-                                    publish_job_action)
+                                    publish_job_action,
+                                    populate_error_summary)
 
 from treeherder.events.publisher import JobStatusPublisher
 
@@ -1180,6 +1181,8 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
 
         retry_job_guids = []
 
+        async_error_summary_list = []
+
         # get the tier-2 data signatures for this project.
         # if there are none, then just return an empty list
         tier_2_signatures = []
@@ -1245,7 +1248,8 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                     log_placeholders,
                     artifact_placeholders,
                     retry_job_guids,
-                    tier_2_signatures
+                    tier_2_signatures,
+                    async_error_summary_list
                 )
 
                 if 'id' in datum:
@@ -1339,6 +1343,14 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
 
         with ArtifactsModel(self.project) as artifacts_model:
             artifacts_model.load_job_artifacts(artifact_placeholders, job_id_lookup)
+
+        # schedule the generation of ``Bug suggestions`` artifacts
+        # asynchronously now that the jobs have been created
+        if async_error_summary_list:
+            populate_error_summary.apply_async(
+                args=[self.project, async_error_summary_list, job_id_lookup],
+                routing_key='error_summary'
+            )
 
         # If there is already a job_id stored with pending/running status
         # we need to update the information for the complete job
@@ -1445,7 +1457,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
         self, job, revision_hash, revision_hash_lookup,
         unique_revision_hashes, rh_where_in, job_placeholders,
         log_placeholders, artifact_placeholders, retry_job_guids,
-        tier_2_signatures
+        tier_2_signatures, async_artifact_list
     ):
         """
         Take the raw job object after etl and convert it to job_placeholders.
@@ -1570,6 +1582,23 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             get_guid_root(job_guid)  # will be the same except for ``retry`` jobs
         ])
 
+        artifacts = job.get('artifacts', [])
+
+        text_log_summary = False
+        if artifacts:
+            # the artifacts in this list could be ones that should have
+            # bug suggestions generated for them.  If so, queue them to be
+            # scheduled for asynchronous generation.
+            tls_list = error_summary.get_artifacts_that_need_bug_suggestions(
+                artifacts)
+            text_log_summary = next((x for x in artifacts
+                                     if x['name'] == 'text_log_summary'), None)
+            async_artifact_list.extend(tls_list)
+
+            ArtifactsModel.populate_placeholders(artifacts,
+                                                 artifact_placeholders,
+                                                 job_guid)
+
         log_refs = job.get('log_references', [])
         if log_refs:
             for log in log_refs:
@@ -1579,16 +1608,17 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 url = log.get('url') or 'unknown'
                 url = url[0:255]
 
-                # the parsing status of this log.  'pending' or 'parsed'
-                parse_status = log.get('parse_status', 'pending')
+                # this indicates that a summary artifact was submitted with
+                # this job that corresponds to the buildbot_text log url.
+                # Therefore, the log does not need parsing.  So we should
+                # ensure that it's marked as already parsed.
+                if text_log_summary and name == 'builbot_text':
+                    parse_status = 'parsed'
+                else:
+                    # the parsing status of this log.  'pending' or 'parsed'
+                    parse_status = log.get('parse_status', 'pending')
 
                 log_placeholders.append([job_guid, name, url, parse_status])
-
-        artifacts = job.get('artifacts', [])
-        if artifacts:
-            ArtifactsModel.populate_placeholders(artifacts,
-                                                 artifact_placeholders,
-                                                 job_guid)
 
         return job_guid
 

--- a/treeherder/model/tasks.py
+++ b/treeherder/model/tasks.py
@@ -10,6 +10,8 @@ from django.conf import settings
 from treeherder.model.models import Datasource, Repository
 from treeherder.model.exchanges import TreeherderPublisher
 from treeherder.model.pulse_publisher import load_schemas
+from treeherder.model.error_summary import load_error_summary
+
 
 # Load schemas for validation of messages published on pulse
 SOURCE_FOLDER = os.path.dirname(os.path.realpath(__file__))
@@ -173,3 +175,16 @@ def publish_resultset(project, ids):
             # messages will still get published... Well, assuming nothing goes
             # wrong, because we're not using confirm channels for publishing...
             publisher.connection.release()
+
+
+@task(name='populate-error-summary')
+def populate_error_summary(project, artifacts, job_id_lookup):
+    """
+    Create bug suggestions artifact(s) for any text_log_summary artifacts.
+
+    ``artifacts`` here is a list of one or more ``text_log_summary`` artifacts.
+    If any of them have ``error_lines``, then we generate the
+    ``bug suggestions`` artifact from them.
+    """
+
+    load_error_summary(project, artifacts, job_id_lookup)

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -191,6 +191,7 @@ CELERY_QUEUES = (
     Queue('log_parser_json', Exchange('default'), routing_key='parse_log.json'),
     # Queue for mirroring the failure classification activity to Bugzilla/Elasticsearch
     Queue('classification_mirroring', Exchange('default'), routing_key='classification_mirroring'),
+    Queue('error_summary', Exchange('default'), routing_key='error_summary'),
     Queue('publish_to_pulse', Exchange('default'), routing_key='publish_to_pulse'),
     Queue('pushlog', Exchange('default'), routing_key='pushlog'),
     Queue('fetch_missing_push_logs', Exchange('default'), routing_key='fetch_missing_push_logs'),

--- a/ui/js/models/job_log_url.js
+++ b/ui/js/models/job_log_url.js
@@ -19,9 +19,9 @@ treeherder.factory('ThJobLogUrlModel', [
         if(!this.hasOwnProperty("id")){
             throw "The id property is required in order to parse a log";
         }
-        var uri = ThJobLogUrlModel.get_uri()+this.id+"/parse/"
+        var uri = ThJobLogUrlModel.get_uri()+this.id+"/parse/";
         return $http.post(uri);
-    }
+    };
 
     ThJobLogUrlModel.get_uri = function(){
         var url = thUrl.getProjectUrl("/job-log-url/");
@@ -42,7 +42,7 @@ treeherder.factory('ThJobLogUrlModel', [
             var item_list = [];
             angular.forEach(response.data, function(elem){
                 var buildData = elem.url.split("/");
-                var buildUrl = elem.url.slice(0, elem.url.lastIndexOf("/")) + "/"
+                var buildUrl = elem.url.slice(0, elem.url.lastIndexOf("/")) + "/";
                 elem.buildUrl = buildUrl;
                 item_list.push(new ThJobLogUrlModel(elem));
             });

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -171,9 +171,6 @@ treeherder.controller('PluginCtrl', [
                                 function(parseLogResponse){return parseLogResponse.status === 200;}
                             )){
                                 selectJobRetryPromise = $timeout(function(){
-                                    // the failure summary tab update must also be triggered here,
-                                    // otherwise it will never update.
-                                    thTabs.tabs.failureSummary.update();
                                     // refetch the job data details
                                     selectJobAndRender(job_id);
                                 }, 5000);

--- a/ui/plugins/failure_summary/controller.js
+++ b/ui/plugins/failure_summary/controller.js
@@ -5,9 +5,9 @@
 "use strict";
 
 treeherder.controller('BugsPluginCtrl', [
-    '$scope', 'ThLog', 'ThJobArtifactModel','$q', 'thTabs',
+    '$scope', 'ThLog', 'ThJobArtifactModel','$q', 'thTabs', '$timeout',
     function BugsPluginCtrl(
-        $scope, ThLog, ThJobArtifactModel, $q, thTabs) {
+        $scope, ThLog, ThJobArtifactModel, $q, thTabs, $timeout) {
 
         var $log = new ThLog(this.constructor.name);
 
@@ -61,6 +61,12 @@ treeherder.controller('BugsPluginCtrl', [
                             suggestions.push(suggestion);
                         });
                         $scope.suggestions = suggestions;
+                        $scope.bugSuggestionsLoaded = true;
+                    } else {
+                        $scope.bugSuggestionsLoaded = false;
+
+                        // set a timer to re-run update() after 5 seconds
+                        $timeout(thTabs.tabs.failureSummary.update, 5000);
                     }
                 })
                 .finally(function () {

--- a/ui/plugins/failure_summary/controller.js
+++ b/ui/plugins/failure_summary/controller.js
@@ -18,10 +18,10 @@ treeherder.controller('BugsPluginCtrl', [
         $scope.tabs = thTabs.tabs;
 
         // update function triggered by the plugins controller
-        thTabs.tabs.failureSummary.update = function(){
+        thTabs.tabs.failureSummary.update = function() {
             var newValue = thTabs.tabs.failureSummary.contentId;
             $scope.suggestions = [];
-            if(angular.isDefined(newValue)){
+            if(angular.isDefined(newValue)) {
                 thTabs.tabs.failureSummary.is_loading = true;
                 // if there's a ongoing request, abort it
                 if (timeout_promise !== null) {

--- a/ui/plugins/failure_summary/main.html
+++ b/ui/plugins/failure_summary/main.html
@@ -63,9 +63,16 @@
 
         </li>
 
-        <li ng-if="!tabs.failureSummary.is_loading && jobLogsAllParsed && job_log_urls.length && suggestions.length == 0">
+        <li ng-if="!tabs.failureSummary.is_loading && jobLogsAllParsed && bugSuggestionsLoaded && job_log_urls.length && suggestions.length == 0">
             <div class="failure-summary-line-empty">
                 <span>Failure summary is empty</span>
+            </div>
+        </li>
+
+        <li ng-if="!tabs.failureSummary.is_loading && jobLogsAllParsed && !bugSuggestionsLoaded && job_log_urls.length">
+            <div class="failure-summary-line-empty">
+                <span>Log parsing complete.  Generating bug suggestions</span>
+                <span>The content of this panel will refresh in 5 seconds.</span>
             </div>
         </li>
 


### PR DESCRIPTION
Fixes [Bug 1080760](https://bugzilla.mozilla.org/show_bug.cgi?id=1080760)
Follow-on to [PR 525](https://github.com/mozilla/treeherder/pull/525)

This generates bug suggestions for ``text_log_summary`` artifacts submitted to the ``artifact``  REST endpoint.  It schedules those asynchronously with ``celery``.

If a job is submitted to through the ``job`` REST endpoint and it contains a ``text_log_summary`` artifact with it, then the ``Bug suggestions`` artifact is created immediately (not asynchronously).  I created [Bug 1163253](https://bugzilla.mozilla.org/show_bug.cgi?id=1163253) to address possibly making that ``jobs`` endpoint asynchronous as well.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/518)
<!-- Reviewable:end -->
