### PR TITLE
Bug 1162526 - Protect against null properties during ingestion

### DIFF
--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -192,7 +192,7 @@ class Builds4hTransformerMixin(object):
             if 'blobber_files' in prop:
                 blobber_files = json.loads(prop['blobber_files'])
                 for bf, url in blobber_files.items():
-                    if bf.endswith('_raw.log'):
+                    if bf and url and bf.endswith('_raw.log'):
                         log_reference.append({
                             'url': url,
                             'name': 'mozlog_json'

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1479,13 +1479,13 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
         job_guid = job['job_guid']
         job_guid = job_guid[0:50]
 
-        who = job.get('who', 'unknown')
+        who = job.get('who') or 'unknown'
         who = who[0:50]
 
-        reason = job.get('reason', 'unknown')
+        reason = job.get('reason') or 'unknown'
         reason = reason[0:125]
 
-        state = job.get('state', 'unknown')
+        state = job.get('state') or 'unknown'
         state = state[0:25]
 
         if job.get('result', 'unknown') == 'retry':
@@ -1535,11 +1535,10 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
         log_refs = job.get('log_references', [])
         if log_refs:
             for log in log_refs:
-
-                name = log.get('name', 'unknown')
+                name = log.get('name') or 'unknown'
                 name = name[0:50]
 
-                url = log.get('url', 'unknown')
+                url = log.get('url') or 'unknown'
                 url = url[0:255]
 
                 # the parsing status of this log.  'pending' or 'parsed'


### PR DESCRIPTION
* builds-4hr ingestion: Only add mozlog_json URLs to log_references if not null.
The url for items in blobber_properties can sometimes be null, so skip adding a mozlog_json entry for them to log_references if so.
* Objectstore processing: Protect against null properties during ingestion.
Sometimes a property is present, but its value is null in the json_blob in the objectstore. We must set the default value in this case too, and not just when the property does not exist at all, to prevent exceptions when we later perform string operations on it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/521)
<!-- Reviewable:end -->
