### PR TITLE
Bug 1162682 - Catch exceptions whilst processing objectstore jobs

### DIFF
--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1200,15 +1200,12 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 # object is responsible for what error. If we validate here
                 # we can capture the error and associate it with the object
                 # and also skip it before generating any database errors.
-
             except JobDataError as e:
-
                 if 'id' in datum:
                     self.mark_object_error(datum['id'], str(e))
-
                 if raise_errors:
                     raise e
-
+                continue
             except Exception as e:
                 if 'id' in datum:
                     self.mark_object_error(
@@ -1218,8 +1215,9 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                     )
                 if raise_errors:
                     raise e
-            else:
+                continue
 
+            try:
                 # json object can be successfully deserialized
                 # load reference data
                 job_guid = self._load_ref_and_job_data_structs(
@@ -1245,6 +1243,15 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                         # coalesced to guid, coalesced guid
                         [job_guid, coalesced_guid]
                     )
+            except Exception as e:
+                if 'id' in datum:
+                    self.mark_object_error(
+                        datum['id'],
+                        u"Unknown error: {}: {}".format(
+                            e.__class__.__name__, unicode(e))
+                    )
+                if raise_errors:
+                    raise e
 
         # Store all reference data and retrieve associated ids
         id_lookups = self.refdata_model.set_all_reference_data()


### PR DESCRIPTION
Now if an exception occurs during _load_ref_and_job_data_structs(), we mark that job in the objectstore as errored and continue inserting the other jobs. Previously the exception would have meant all of the other jobs were not inserted, causing up to 100 rows in the objectstore to be stuck in the 'loading' processed_state indefinitely.

The exception string passed to mark_object_error() isn't ideal, but it's the same as the handling above, so will do for now until we remove the objectstore.

In addition, this change means that we lose visibility in New Relic for these exceptions - and someone has to manually check the objectstore for jobs with error = "Y". However short term this seems preferable to dropping 100 jobs every time we get an exception, particularly since this is already the case for de-serialisation exceptions. In a follow-up bug we could always try using the New Relic Python agent's record_exception() to maintain reporting without having to re-raise the exception ourselves.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/522)
<!-- Reviewable:end -->
