### PR TITLE
Bug 1163591 - run_sql: support specifying the SQL statement via the CLI

### DIFF
--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -97,11 +97,12 @@ Executing arbitrary SQL
 As part of a larger change, you may want to execute some arbitrary SQL
 on the server. You can do this with the `run_sql` management command.
 
-Example:
+Examples:
 
   .. code-block:: bash
 
-     > ./manage.py run_sql -f <sqlfile>
+     > ./manage.py run_sql -s <sql-statement>
+     > ./manage.py run_sql -f <path-to-sql-file>
 
 By default, this will run the sql against the `jobs` database for each
 project. If you want to run against the object store or only against a


### PR DESCRIPTION
Previously the run_sql manage.py command only supported reading the SQL command from a specified file. It can now also be provided via the CLI.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/527)
<!-- Reviewable:end -->
