### PR TITLE
Bug 1163996 - run_sql: Print the query response to stdout

### DIFF
--- a/treeherder/model/management/commands/run_sql.py
+++ b/treeherder/model/management/commands/run_sql.py
@@ -86,7 +86,9 @@ class Command(BaseCommand):
             try:
                 cursor = db.cursor()
                 cursor.execute(sql_code)
-                self.stdout.write("Sql code executed on {0}".format(datasource))
+                self.stdout.write("Sql code executed on {}:".format(datasource))
+                for row in cursor:
+                    self.stdout.write("  {}".format(row))
             except Exception as e:
                 error_string = "!!! Sql code execution failed on {0} !!!"
                 self.stderr.write(error_string.format(datasource))


### PR DESCRIPTION
This gives output like:
```
(venv)vagrant@local:~/treeherder$ ./manage.py run_sql --data-type objectstore -s "OPTIMIZE TABLE objectstore"
SQL command: OPTIMIZE TABLE objectstore
46 datasource found
--------------------------
Sql code executed on mozilla-central - objectstore - 1:
  ('mozilla_central_objectstore_1.objectstore', 'optimize', 'note', 'Table does not support optimize, doing recreate + analyze instead')
  ('mozilla_central_objectstore_1.objectstore', 'optimize', 'status', 'OK')
--------------------------
Sql code executed on mozilla-inbound - objectstore - 1:
  ('mozilla_inbound_objectstore_1.objectstore', 'optimize', 'note', 'Table does not support optimize, doing recreate + analyze instead')
  ('mozilla_inbound_objectstore_1.objectstore', 'optimize', 'status', 'OK')
````

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/528)
<!-- Reviewable:end -->
