### PR TITLE
Bug 1056049 - Add NFS transport protocol troubleshooting to RTD

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -37,6 +37,15 @@ Setting up Vagrant
 
     apt-get install nfs-kernel-server
 
+  **Troubleshooting**: If you encounter an error saying *"mount.nfs: requested NFS version or transport protocol is not supported"*, you should restart the kernel server service using this sequence of commands:
+
+  .. code-block:: bash
+
+    systemctl stop nfs-kernel-server.service
+    systemctl disable nfs-kernel-server.service
+    systemctl enable nfs-kernel-server.service
+    systemctl start nfs-kernel-server.service
+
   **Troubleshooting**: If you encounter an error saying *"The guest machine entered an invalid state while waiting for it to boot. Valid states are 'starting, running'. The machine is in the 'poweroff' state. Please verify everything is configured properly and try again."* you should should check your host machine's virtualization technology (vt-x) is enabled in the BIOS (see this guide_), then continue with ``vagrant up``.
 
   .. _guide: http://www.sysprobs.com/disable-enable-virtualization-technology-bios


### PR DESCRIPTION
This change fixes Bugzilla bug [1056049](https://bugzilla.mozilla.org/show_bug.cgi?id=1164166).

This guides the user to restart `nfs-kernel-server.service` in the event of the specified vagrant up failure case. I tested the markdown with http://rst.ninjs.org, it seems to look as I intend/expect.

I didn't have a failure condition to locally test and confirm the fix/workaround.

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/530)
<!-- Reviewable:end -->
