### PR TITLE
Bug 1164881 - Add MPL2.0 headers to recent treeherder repo files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 FROM python:2.7
 MAINTAINER Mozilla
 RUN virtualenv /venv

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 web: newrelic-admin run-program gunicorn treeherder.webapp.wsgi:application --log-file - --timeout 29 --max-requests 2000
 worker_beat: newrelic-admin run-program celery -A treeherder beat
 worker_pushlog: newrelic-admin run-program celery -A treeherder worker -Q pushlog,fetch_missing_push_logs --maxtasksperchild=500 --concurrency=5

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,2 +1,7 @@
 #! /bin/bash -e
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 python setup.py build_ext --inplace

--- a/docker/etc/profile.d/treeherder.sh
+++ b/docker/etc/profile.d/treeherder.sh
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Mapping is taken from docker link assumptions
 export TREEHERDER_DEBUG='1'
 export TREEHERDER_DJANGO_SECRET_KEY='5up3r53cr3t'

--- a/docker/generate_test_credentials.py
+++ b/docker/generate_test_credentials.py
@@ -1,5 +1,9 @@
 #! /usr/bin/env python
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # In many cases you want to hit treeherder services but it is difficult
 # particularly in tests if you don't know the oauth credentials. This file
 # rewrites the credentials for all projects so both user/pass are the same (the

--- a/docker/gunicorn.sh
+++ b/docker/gunicorn.sh
@@ -1,4 +1,9 @@
 #! /bin/bash -ex
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 source /etc/profile.d/treeherder.sh
 ./docker/generate_test_credentials.py
 

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,5 +1,9 @@
 #! /bin/bash -ex
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Initialize the basics needed to run treeherder-service.
 
 source /etc/profile.d/treeherder.sh

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -67,7 +67,7 @@ As you can see it's very similar to the file used to startup the vagrant environ
 You can run this file with the following command
 
 .. code-block:: bash
-  
+ 
   (venv)vagrant@precise32:~/treeherder$ sudo puppet apply puppet/your_manifest_file.pp
 
 Once puppet has finished, the only thing left to do is to start all the treeherder services (gunicorn, celery, etc).

--- a/docs/submitting_data.rst
+++ b/docs/submitting_data.rst
@@ -132,7 +132,7 @@ characters at most. A job collection has the following data structure.
                         }
                     ],
 
-                # The artifact can contain any kind of structured data associated with a test. 
+                # The artifact can contain any kind of structured data associated with a test.
                 'artifacts': [{
                     'type': 'json',
                     'name': '',

--- a/docs/ui_integration.rst
+++ b/docs/ui_integration.rst
@@ -10,7 +10,7 @@ If you want to develop both the ui and the service side by side it may be conven
 * If you have an existing Vagrant environment set up, you will need to reload it using:
 
   .. code-block:: bash
-     
+
      >vagrant reload
 
 You should now be able to access the ui on http://local.treeherder.mozilla.org/ui/

--- a/fig.yml
+++ b/fig.yml
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 memcached:
   image: memcached:1.4
 

--- a/puppet/files/apache/treeherder.conf
+++ b/puppet/files/apache/treeherder.conf
@@ -11,7 +11,7 @@
   </Proxy>
 
   ###########
-  # This is for backwords compatibility with old style treeherder urls
+  # This is for backwards compatibility with old style treeherder urls
   ###########
   Alias /ui /home/<%= @APP_USER %>/treeherder-ui/<%= @APP_UI %>
   ProxyPass        /ui !

--- a/puppet/files/treeherder/local.production.py
+++ b/puppet/files/treeherder/local.production.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import logging
 
 LOGGING = {

--- a/puppet/files/treeherder/local.vagrant.py
+++ b/puppet/files/treeherder/local.vagrant.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': True,

--- a/puppet/files/varnish/default.vcl
+++ b/puppet/files/varnish/default.vcl
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 backend apache {
     .host = "127.0.0.1";
     .port = "8080";

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # HEROKU REQUIREMENTS
 
 -r requirements/common.txt

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Packages that are shared between deployment and dev environments.
 
 # sha256: yMvuXERhj0nnt8b5RabHSI5ah2V8oZp6a7Lm_ea6Dmg

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Dependencies needed only for development/testing.
 
 # for the test suite and coverage metrics

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Dependencies for building the documentation, intended to be used standalone
 # since Read the Docs does not need all of the requirements in common.txt
+
 Sphinx==1.3
 sphinxcontrib-httpdomain==1.3.0
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,2 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 # sha256: _d1HqNBI4MX0Lu5RGoqvNYkcmW1slZVTx77Is6x0s8s
 newrelic==2.50.0.39

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 python-2.7.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 [pep8]
 exclude = .git,__pycache__,.vagrant,bin/peep.py,build
 # E121,E123,E126,E226,E24,E704: Ignored in default pep8 config:

--- a/tests/log_parser/test_performance_log_parser.py
+++ b/tests/log_parser/test_performance_log_parser.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import pytest
 from treeherder.log_parser.parsers import TalosParser
 

--- a/tests/log_parser/test_step_parser.py
+++ b/tests/log_parser/test_step_parser.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from treeherder.log_parser.parsers import StepParser
 from datetime import datetime
 

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from __future__ import unicode_literals
 
 import requests

--- a/treeherder/embed/urls.py
+++ b/treeherder/embed/urls.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.conf.urls import patterns, url
 from .views import ResultsetStatusView
 

--- a/treeherder/embed/views.py
+++ b/treeherder/embed/views.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from django.views.generic.base import TemplateView
 from django.http import Http404
 from treeherder.model.derived import JobsModel

--- a/treeherder/etl/th_publisher.py
+++ b/treeherder/etl/th_publisher.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import logging
 
 from django.utils.encoding import python_2_unicode_compatible

--- a/treeherder/model/error_summary.py
+++ b/treeherder/model/error_summary.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import logging
 import re
 import urllib

--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from optparse import make_option
 import datetime
 from django.core.management.base import BaseCommand

--- a/treeherder/model/sql/template_schema/project_jobs_1.sql.tmpl
+++ b/treeherder/model/sql/template_schema/project_jobs_1.sql.tmpl
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* This file contains {engine} markers that must be replaced
    before it is sent to MySQL.
 */

--- a/treeherder/model/sql/template_schema/project_objectstore_1.sql.tmpl
+++ b/treeherder/model/sql/template_schema/project_objectstore_1.sql.tmpl
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* This file contains {engine} markers that must be replaced
    before it is sent to MySQL.
 */

--- a/treeherder/model/sql/template_schema/treeherder.sql.tmpl
+++ b/treeherder/model/sql/template_schema/treeherder.sql.tmpl
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* This file contains {engine} markers that must be replaced
    before it is sent to MySQL.
 */
@@ -32,7 +36,7 @@ DROP TABLE IF EXISTS `datasource`;
  *  Holds the complete list of projects and their associated RDBS hosts
  *  managed by treeherder.
  *
- * Population Method: manual by admin 
+ * Population Method: manual by admin
  *
  * Example Data:
  *
@@ -40,10 +44,10 @@ DROP TABLE IF EXISTS `datasource`;
  *              try, alder, holly, mozilla-aurora, treeherder in treeherder_reference_1.sql.tmpl
  *            This string becomes the location field in the url for related web service methods.
  *
- *  contenttype - A string describing the content type associated with the database. 
+ *  contenttype - A string describing the content type associated with the database.
  *              jobs in project_jobs_1.sql.tmpl, reference in treeherder_reference_1.sql.tmpl
  *              A project can have any number of contenttypes associated with it.
- *    
+ *
  *  dataset -  An integer that can be enumerated. This allows more than one database to exist
  *             for the same project/contenttype pair.
  *
@@ -58,7 +62,7 @@ DROP TABLE IF EXISTS `datasource`;
  *         to the template schema when a user runs a manage command that creates a database
  *         schema. There is currently support for MariaDB and MySQL storage engines.
  *
- *  oauth_consumer_key - The OAuth consumer key. This is automatically added when a new datasource 
+ *  oauth_consumer_key - The OAuth consumer key. This is automatically added when a new datasource
                          is added.
  *
  *  oauth_consumer_secret - The OAuth consumer secret. This is automatically added when a new datasource
@@ -66,7 +70,7 @@ DROP TABLE IF EXISTS `datasource`;
  *
  *  creation_date - Date the database was created.
  *
- *  cron_batch - The cron interval to use when running cron jobs on this database. 
+ *  cron_batch - The cron interval to use when running cron jobs on this database.
  **************************/
 CREATE TABLE `datasource` (
   `id` int(11) NOT NULL AUTO_INCREMENT,

--- a/treeherder/model/sql/template_schema/treeherder_reference_1.sql.tmpl
+++ b/treeherder/model/sql/template_schema/treeherder_reference_1.sql.tmpl
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* This file contains {engine} markers that must be replaced
    before it is sent to MySQL.
 */
@@ -161,7 +165,7 @@ DROP TABLE IF EXISTS `build_platform`;
  *
  * A list of build platforms associated with project test data.
  *
- * Population Method: dynamic from incoming data. 
+ * Population Method: dynamic from incoming data.
  *
  * Example Data:
  *
@@ -200,7 +204,7 @@ DROP TABLE IF EXISTS `failure_classification`;
  *
  * Example Data:
  *
- *  name - broken | clobber-needed | infrastructure | intermittent | needs-filing | other | ... 
+ *  name - broken | clobber-needed | infrastructure | intermittent | needs-filing | other | ...
  **************************/
 CREATE TABLE `failure_classification` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -366,7 +370,7 @@ DROP TABLE IF EXISTS `machine_note`;
 /**************************
  * Table: machine_note
  *
- * A list of notes associated with particular machines. Notes can be set by a sheriff to record 
+ * A list of notes associated with particular machines. Notes can be set by a sheriff to record
  * a repeated pattern of failures.
  *
  * Population Method: manual by admin
@@ -406,7 +410,7 @@ DROP TABLE IF EXISTS `machine_platform`;
  *
  * A list of machine platforms associated with project test data.
  *
- * Population Method: dynamic from incoming data. 
+ * Population Method: dynamic from incoming data.
  *
  * Example Data:
  *
@@ -604,7 +608,7 @@ DROP TABLE IF EXISTS `repository_group`;
  * List of repository group names.
  *
  * Population Method: manual by admin
- * 
+ *
  * Example Data:
  *
  *  name - train | development | ...

--- a/treeherder/model/tasks.py
+++ b/treeherder/model/tasks.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 from celery import task
 from django.core.management import call_command

--- a/treeherder/webapp/api/resultset.py
+++ b/treeherder/webapp/api/resultset.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.decorators import link, action

--- a/treeherder/webapp/api/throttling.py
+++ b/treeherder/webapp/api/throttling.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 from rest_framework import throttling
 
 


### PR DESCRIPTION
This fixes Bugzilla bug [1164881](https://bugzilla.mozilla.org/show_bug.cgi?id=1164881).

This adds missing MPL2.0 headers where applicable, and chmod's `bin/post_compile` to be executable. I also made some trailing white space corrections and in affected files. :)

Of particular note to check are the first two, Procfile and Dockerfile, just to ensure I have the comment style correct. Based on what I see checking their docs, it appears to follow the `#` format.

Since in some cases these are deployment files, this change has not been tested locally.

Adding @edmorley for review and @maurodoglio for visibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/535)
<!-- Reviewable:end -->
