### PR TITLE
Bug 1166308 - Remove bash cmd highlighing from rtd NFS troubleshooting

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,7 +39,7 @@ Setting up Vagrant
 
   **Troubleshooting**: If you encounter an error saying *"mount.nfs: requested NFS version or transport protocol is not supported"*, you should restart the kernel server service using this sequence of commands:
 
-  .. code-block:: bash
+  .. code-block:: none
 
     systemctl stop nfs-kernel-server.service
     systemctl disable nfs-kernel-server.service


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1166308](https://bugzilla.mozilla.org/show_bug.cgi?id=1166308).

We no longer interpret this code block as bash in RTD, so avoid the interpretation of the argument `enable` as a unix command.

Before:
![before](https://cloud.githubusercontent.com/assets/3660661/7706992/9e5dfe6e-fe1b-11e4-8ddb-11d88b7f3905.jpg)

After:
![after](https://cloud.githubusercontent.com/assets/3660661/7706997/a6876ec2-fe1b-11e4-95fa-e2a485f56b70.jpg)

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/539)
<!-- Reviewable:end -->
