### PR TITLE
Bug 1166474 - Add even/odd job-row backgrounds when revisions hidden

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -528,20 +528,19 @@ th-watched-repo {
     white-space: nowrap;
 }
 
-.result-set .job-list-pad-left {
-    padding-left: 8;
+.result-set .job-list-pad {
     padding-right: 0;
 }
 
-.job-list-pad-left table {
+.job-list table {
     width: 100%;
 }
 
-.job-list-pad-left table tr {
+.job-list table tr {
     border-bottom: 1px dotted lightgrey;
 }
 
-.job-list-pad-left table tr:nth-child(even) {
+.job-list table tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -149,7 +149,7 @@
                 <span style="display:block;" class="revision-list col-xs-5">
                     <ul class="list-unstyled"></ul>
                 </span>
-                <span class="job-list col-xs-7 job-list-pad-left">
+                <span class="job-list col-xs-7 job-list-pad">
                     <span class="fa fa-refresh fa-spin"></span>
                     <table id="{{ aggregateId }}" class="table-hover"></table>
                 </span>

--- a/ui/js/directives/clonejobs.js
+++ b/ui/js/directives/clonejobs.js
@@ -35,7 +35,7 @@ treeherder.directive('thCloneJobs', [
     var col7Cls = 'col-xs-7';
     var col12Cls = 'col-xs-12';
     var jobListNoPadCls = 'job-list-nopad';
-    var jobListPadLeftCls = 'job-list-pad-left';
+    var jobListPadCls = 'job-list-pad';
 
     // Custom Attributes
     var jobKeyAttr = 'data-jmkey';
@@ -415,12 +415,12 @@ treeherder.directive('thCloneJobs', [
         el.removeClass(jobListNoPadCls);
         el.removeClass(col12Cls);
         el.addClass(col7Cls);
-        el.addClass(jobListPadLeftCls);
+        el.addClass(jobListPadCls);
     };
     var toggleJobsSpanOnWithoutRevisions = function(el){
         el.css('display', 'block');
         el.removeClass(col7Cls);
-        el.removeClass(jobListPadLeftCls);
+        el.removeClass(jobListPadCls);
         el.addClass(jobListNoPadCls);
         el.addClass(col12Cls);
     };


### PR DESCRIPTION
This fixes Bugzilla bug [1166474](https://bugzilla.mozilla.org/show_bug.cgi?id=1166474).

This adds our alternate job-row backgrounds, when the user invokes Hide revisions, and the job table is full page width. Prior to the fix, at full width the row coloring was missing.

Show/hide (revisions showing, unchanged):
![showrevisionscurrent](https://cloud.githubusercontent.com/assets/3660661/7729372/7627f6c6-fee2-11e4-98a3-63a6f32455bc.jpg)

Show/hide (revision hidden, the fix)
![hiderevisionsproposed](https://cloud.githubusercontent.com/assets/3660661/7729396/8b2d4b8e-fee2-11e4-8129-e3496b9d1bc8.jpg)

We basically hook the styling to `job-list` instead of the dynamic `job-list-pad-left`, which we change to be a generic `job-list-pad`. It now only ensures zero padding on the right hand side of the table when showing revisions.

Everything seems fine on both browsers.

Tested on OSX 10.10.3:
FF Release **38.0.1**
FF Nightly **41.0a1**
Chrome Latest Release **42.0.2311.152** (64-bit)

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/542)
<!-- Reviewable:end -->
