### PR TITLE
Bug 1166426 - Update readthedocs links to point at the new RTD location

### DIFF
--- a/README-UI.md
+++ b/README-UI.md
@@ -19,7 +19,7 @@ cp ui/js/config/sample.local.conf.js ui/js/config/local.conf.js
 
 The UI can then be viewed at [http://localhost:8000/index.html](http://localhost:8000/index.html).
 
-Data will be pulled from the production instance API by default. See the [installation docs](https://treeherder-service.readthedocs.org/en/latest/installation.html) for more options, how to run the tests & using the Vagrant project for a more robust environment that also allows you to run the back-end locally.
+Data will be pulled from the production instance API by default. See the [installation docs](https://treeherder.readthedocs.org/installation.html) for more options, how to run the tests & using the Vagrant project for a more robust environment that also allows you to run the back-end locally.
 
 
 #### Links
@@ -28,6 +28,6 @@ Visit our project tracking Wiki at:
 https://wiki.mozilla.org/Auto-tools/Projects/Treeherder
 
 Visit our **readthedocs** page for more detailed documentation at:  
-https://treeherder-service.readthedocs.org/en/latest/index.html
+https://treeherder.readthedocs.org/
 
 File any bugs you may encounter [here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&component=Treeherder).

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@ treeherder
 ==================
 [![Build Status](https://travis-ci.org/mozilla/treeherder.png?branch=master)](https://travis-ci.org/mozilla/treeherder)
 [![Code Health](https://landscape.io/github/mozilla/treeherder/master/landscape.png)](https://landscape.io/github/mozilla/treeherder/master)
+[![Documentation Status](https://readthedocs.org/projects/treeherder/badge/?version=latest)](https://readthedocs.org/projects/treeherder/?badge=latest)
 
 
 #### Description
-[Treeherder](https://treeherder.mozilla.org) is a reporting dashboard for Mozilla checkins. It allows users to see the results of automatic builds and their respective tests. **Treeherder-service** manages the etl layer for data ingestion, web services, and the data model behind Treeherder.
+[Treeherder](https://treeherder.mozilla.org) is a reporting dashboard for Mozilla checkins. It allows users to see the results of automatic builds and their respective tests. The Treeherder service manages the etl layer for data ingestion, web services, and the data model behind Treeherder.
 
 
 #### Instances
@@ -13,7 +14,7 @@ Treeherder exists on two instances, [stage](https://treeherder.allizom.org) for 
 
 
 #### Installation
-The steps to install treeherder are provided [here](https://treeherder-service.readthedocs.org/en/latest/installation.html).
+The steps to install treeherder are provided [here](https://treeherder.readthedocs.org/installation.html).
 
 
 #### Links
@@ -22,6 +23,6 @@ Visit our project tracking Wiki at:
 https://wiki.mozilla.org/Auto-tools/Projects/Treeherder
 
 Visit our **readthedocs** page for other setup and configuration at:  
-https://treeherder-service.readthedocs.org/en/latest/index.html
+https://treeherder.readthedocs.org/
 
 File any bugs you may encounter [here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&component=Treeherder).

--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -1,7 +1,7 @@
 Common tasks
 ============
 
-This is a list of maintenance tasks you may have to execute on a treeherder-service deployment
+This is a list of maintenance tasks you may have to execute on a treeherder deployment
 
 Apply a change in the code
 --------------------------

--- a/docs/submitting_data.rst
+++ b/docs/submitting_data.rst
@@ -202,7 +202,7 @@ data structures to send, do something like this.
     # Send the collection to treeherder
 
     # The OAuth key and secret for your project should be supplied to you by the
-    # treeherder-service administrator.
+    # treeherder administrator.
     client = TreeherderClient(protocol='https', host='treeherder.mozilla.org')
 
     # Post the result collection to a project

--- a/docs/ui/installation.rst
+++ b/docs/ui/installation.rst
@@ -36,7 +36,7 @@ Configuration
 The sample configuration makes the UI load job/push data from the production service API. If you wish to test the UI against stage/dev's service instead, adjust ``thServiceDomain`` in the config file created as part of installation:
 ``ui/js/config/local.conf.js``
 
-If you wish to run the full treeherder-service Vagrant project (service + UI), remember to remove local.conf.js or else change ``thServiceDomain`` within it to refer to ``vagrant``, so the UI will use the local Vagrant service API.
+If you wish to run the full treeherder Vagrant project (service + UI), remember to remove local.conf.js or else change ``thServiceDomain`` within it to refer to ``vagrant``, so the UI will use the local Vagrant service API.
 
 Running the unit tests
 ======================

--- a/treeherder/client/setup.py
+++ b/treeherder/client/setup.py
@@ -8,7 +8,7 @@ version = '1.2'
 
 setup(name='treeherder-client',
       version=version,
-      description="Python library to submit data to treeherder-service",
+      description="Python library to submit data to the Treeherder API",
       long_description="""\
 """,
       classifiers=[
@@ -23,7 +23,7 @@ setup(name='treeherder-client',
       keywords='',
       author='Mozilla Automation and Testing Team',
       author_email='tools@lists.mozilla.org',
-      url='https://github.com/mozilla/treeherder-client',
+      url='https://github.com/mozilla/treeherder',
       license='MPL',
       packages=['thclient'],
       zip_safe=False,


### PR DESCRIPTION
The docs have been moved from treeherder-service.readthedocs.org to treeherder.readthedocs.org.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/546)
<!-- Reviewable:end -->
