### PR TITLE
Bug 1164868 - Split the buildapi tasks into {pending,running,4hr} queues

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -5,8 +5,9 @@
 web: newrelic-admin run-program gunicorn treeherder.webapp.wsgi:application --log-file - --timeout 29 --max-requests 2000
 worker_beat: newrelic-admin run-program celery -A treeherder beat
 worker_pushlog: newrelic-admin run-program celery -A treeherder worker -Q pushlog,fetch_missing_push_logs --maxtasksperchild=500 --concurrency=5
-worker_buildapi: newrelic-admin run-program celery -A treeherder worker -Q buildapi --maxtasksperchild=20 --concurrency=5
+worker_buildapi_pending: newrelic-admin run-program celery -A treeherder worker -Q buildapi_pending --maxtasksperchild=20 --concurrency=5
+worker_buildapi_running: newrelic-admin run-program celery -A treeherder worker -Q buildapi_running --maxtasksperchild=20 --concurrency=5
+worker_buildapi_4hr: newrelic-admin run-program celery -A treeherder worker -Q buildapi_4hr --maxtasksperchild=20 --concurrency=5
 worker_default: newrelic-admin run-program celery -A treeherder worker -Q default,process_objects,cycle_data,calculate_eta,populate_performance_series,fetch_bugs --maxtasksperchild=50 --concurrency=3
 worker_hp: newrelic-admin run-program celery -A treeherder worker -Q classification_mirroring,publish_to_pulse --maxtasksperchild=50 --concurrency=1
 worker_log_parser: newrelic-admin run-program celery -A treeherder worker -Q log_parser_fail,log_parser,log_parser_hp,log_parser_json --maxtasksperchild=50 --concurrency=5
-

--- a/bin/run_celery_worker_buildapi
+++ b/bin/run_celery_worker_buildapi
@@ -22,7 +22,7 @@ if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec $NEWRELIC_ADMIN celery -A treeherder worker -Q buildapi \
+exec $NEWRELIC_ADMIN celery -A treeherder worker -Q buildapi_pending,buildapi_running,buildapi_4hr \
     --concurrency=5 --logfile=$LOGFILE -l INFO \
     --maxtasksperchild=20 -n buildapi.%h
 

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -195,8 +195,9 @@ CELERY_QUEUES = (
     Queue('publish_to_pulse', Exchange('default'), routing_key='publish_to_pulse'),
     Queue('pushlog', Exchange('default'), routing_key='pushlog'),
     Queue('fetch_missing_push_logs', Exchange('default'), routing_key='fetch_missing_push_logs'),
-    Queue('buildapi', Exchange('default'), routing_key='buildapi'),
-
+    Queue('buildapi_pending', Exchange('default'), routing_key='buildapi_pending'),
+    Queue('buildapi_running', Exchange('default'), routing_key='buildapi_running'),
+    Queue('buildapi_4hr', Exchange('default'), routing_key='buildapi_4hr'),
     Queue('process_objects', Exchange('default'), routing_key='process_objects'),
     Queue('cycle_data', Exchange('default'), routing_key='cycle_data'),
     Queue('calculate_eta', Exchange('default'), routing_key='calculate_eta'),
@@ -227,7 +228,7 @@ CELERYBEAT_SCHEDULE = {
         'schedule': timedelta(minutes=1),
         'relative': True,
         'options': {
-            "queue": "buildapi"
+            "queue": "buildapi_pending"
         }
     },
     'fetch-buildapi-running-every-minute': {
@@ -235,7 +236,7 @@ CELERYBEAT_SCHEDULE = {
         'schedule': timedelta(minutes=1),
         'relative': True,
         'options': {
-            "queue": "buildapi"
+            "queue": "buildapi_running"
         }
     },
     'fetch-buildapi-build4h-every-3-minute': {
@@ -243,7 +244,7 @@ CELERYBEAT_SCHEDULE = {
         'schedule': timedelta(minutes=3),
         'relative': True,
         'options': {
-            "queue": "buildapi"
+            "queue": "buildapi_4hr"
         }
     },
     'fetch-process-objects-every-minute': {


### PR DESCRIPTION
Previously all three of the buildapi ETL ingestion tasks (pending, running, 4hr) were run under one queue. In order to be able to tell issues (such as backlogs or leaks) apart, these have now been split onto their own queues.

On Heroku, these queues now also have a dyno each - which should mean we can easily tell which is leaking and possibly also downgrade from the expensive performance dyno even before the leak is fixed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/548)
<!-- Reviewable:end -->
