### PR TITLE
Bug 1160615 - Add graph links and graphing to Perf Compare - do not merge

### DIFF
--- a/ui/js/compareperf.js
+++ b/ui/js/compareperf.js
@@ -91,8 +91,8 @@ perf.controller('CompareResultsCtrl', [
     function displayResults(rawResultsMap, newRawResultsMap) {
       $scope.compareResults = {};
       $scope.titles = {};
-      window.document.title = ("Comparison between " + $scope.originalRevision + 
-                              " (" + $scope.originalProject.name + ") " + 
+      window.document.title = ("Comparison between " + $scope.originalRevision +
+                              " (" + $scope.originalProject.name + ") " +
                               "and " + $scope.newRevision + " (" + $scope.newProject.name + ")");
 
       $scope.testList.forEach(function(testName) {
@@ -109,6 +109,7 @@ perf.controller('CompareResultsCtrl', [
             return;
           }
 
+          // Construct the details link to the subtest for each row
           var detailsLink = 'perf.html#/comparesubtest?';
           detailsLink += _.map(_.pairs({
             originalProject: $scope.originalProject.name,
@@ -119,6 +120,29 @@ perf.controller('CompareResultsCtrl', [
             newSignature: newSig
           }), function(kv) { return kv[0]+"="+kv[1] }).join("&");
 
+
+          // Construct the graph link for each row
+          var originalSeries = encodeURIComponent(JSON.stringify(
+                        { project: $scope.originalProject.name,
+                          signature: oldSig,
+                          visible: true}));
+
+          var newSeries = encodeURIComponent(JSON.stringify(
+                        { project: $scope.newProject.name,
+                          signature: newSig,
+                          visible: true}));
+
+          var timeRange = PhCompare.getInterval($scope.originalTimestamp, $scope.newTimestamp);
+          var graphLink = 'perf.html#/graphs?timerange=' + timeRange +
+                          '&series=' + newSeries;
+
+          if (oldSig != newSig) {
+              graphLink += '&series=' + originalSeries;
+          }
+          graphLink += '&highlightedRevisions=' + $scope.originalRevision;
+          graphLink += '&highlightedRevisions=' + $scope.newRevision;
+
+          cmap.graphLink = graphLink;
           cmap.detailsLink = detailsLink;
           cmap.name = platform;
           cmap.hideMinorChanges = $scope.hideMinorChanges;
@@ -271,16 +295,16 @@ perf.controller('CompareSubtestResultsCtrl', [
                           signature: newSig,
                           visible: true}));
 
-          var detailsLink = 'perf.html#/graphs?timerange=' +
+          var graphLink = 'perf.html#/graphs?timerange=' +
               timeRange + '&series=' + newSeries;
 
           if (oldSig != newSig) {
-            detailsLink += '&series=' + originalSeries;
+            graphLink += '&series=' + originalSeries;
           }
-          detailsLink += '&highlightedRevisions=' + $scope.originalRevision;
-          detailsLink += '&highlightedRevisions=' + $scope.newRevision;
+          graphLink += '&highlightedRevisions=' + $scope.originalRevision;
+          graphLink += '&highlightedRevisions=' + $scope.newRevision;
 
-          cmap.detailsLink = detailsLink;
+          cmap.graphLink = graphLink;
           cmap.name = page;
           cmap.hideMinorChanges = $scope.hideMinorChanges;
           $scope.compareResults[testName].push(cmap);

--- a/ui/partials/perf/comparectrl.html
+++ b/ui/partials/perf/comparectrl.html
@@ -23,7 +23,7 @@
             <td>{{titles[testName]}}</td><td>Old Geomean</td><td>Old StdDev</td><td>New Geomean</td><td>New StdDev</td><td>Delta</td><td>Delta %</td><td></td><td>Confidence</td>
           </tr>
           <tr ng-class="getCompareClasses(compareResult, 'row')" ng-repeat="compareResult in compareResults[testName]">
-            <td>{{compareResult.name}} (<a ng-href="{{compareResult.detailsLink}}">Details</a>)</td>
+            <td>{{compareResult.name}} (<a ng-href="{{compareResult.detailsLink}}">details</a>) (<a ng-href="{{compareResult.graphLink}}">graph</a>)</td>
             <td ng-attr-title="runs: {{compareResult.originalRuns}}">{{compareResult.originalGeoMean|displayPrecision}}</td>
             <td ng-if="compareResult.originalStddev">+/-{{compareResult.originalStddev|displayPrecision}} ({{compareResult.originalStddevPct|displayPrecision}}%)</td>
             <td ng-if="!compareResult.originalStddev">N/A</td>

--- a/ui/partials/perf/comparesubtestctrl.html
+++ b/ui/partials/perf/comparesubtestctrl.html
@@ -17,7 +17,7 @@
           <td>{{platformList[0]}} : {{titles[testName]}}</td><td>Old Geomean</td><td>Old StdDev</td><td>New Geomean</td><td>New StdDev</td><td>Delta</td><td>Delta %</td><td></td><td>Confidence</td>
         </tr>
         <tr ng-class="getCompareClasses(compareResult, 'row')" ng-repeat="compareResult in compareResults[testName]">
-          <td>{{compareResult.name}} (<a ng-href="{{compareResult.detailsLink}}">graph</a>)</td>
+          <td>{{compareResult.name}} (<a ng-href="{{compareResult.graphLink}}">graph</a>)</td>
           <td ng-attr-title="runs: {{compareResult.originalRuns}}">{{compareResult.originalGeoMean|displayPrecision}}</td>
           <td ng-if="compareResult.originalStddev">+/-{{compareResult.originalStddev|displayPrecision}}
             ({{compareResult.originalStddevPct|displayPrecision}}%)</td>


### PR DESCRIPTION
This (hopefully) fixes Bugzilla bug [1160615](https://bugzilla.mozilla.org/show_bug.cgi?id=1160615).

This adds graph links to the main Perfherder compare page. Based on the way the controllers get assigned in Perherder's html, it seemed I needed to add similar js to `CompareResultsCtrl` that is present in `CompareSubtestResultsCtrl` so the graphs can be accessed.

Current appearance:

![comparegraphcurrent](https://cloud.githubusercontent.com/assets/3660661/7758123/3197c07e-ffd5-11e4-8ce8-48b440ae5f59.jpg)

Proposed:

![comparegraphproposed](https://cloud.githubusercontent.com/assets/3660661/7758121/2c9e1938-ffd5-11e4-854c-76e4d483bb40.jpg)

And the result when clicking on 'graph':

![graphlinkresult](https://cloud.githubusercontent.com/assets/3660661/7758149/674f9836-ffd5-11e4-8de6-57b7b85e2dd0.jpg)

Maybe there is a better way to do it, but I assumed we wanted to preserve the 1:1 relationship between the current Perf partials and the controllers per https://github.com/mozilla/treeherder/blob/master/ui/js/perfapp.js#L10-L26. Assuming we use this approach I'd still like to re-check what I added to make sure there isn't anything unnecessary, so marking do-not-merge for now.

Tested on OSX 10.10.3:
FF Release **38.0.1**
Chrome Latest Release **42.0.2311.152** (64-bit)

Adding @wlach for initial review and @jmaher for visibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/549)
<!-- Reviewable:end -->
