### PR TITLE
Make the filter textbox grow when focused or has content

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -213,8 +213,14 @@ th-watched-repo {
 
 #platform-job-text-search-field {
     height:28px;
-    width: inherit;
+    width: 150px;
     display: inherit;
+    transition: width 0.2s;
+}
+
+#platform-job-text-search-field:focus,
+#platform-job-text-search-field:valid {
+    width: 300px !important;
 }
 
 .th-content {

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -42,7 +42,7 @@
                 <span ng-controller="SearchCtrl" class="form-group form-inline">
                     <input id="platform-job-text-search-field"
                            ng-model="searchQueryStr" ng-keydown="search($event)" type="text"
-                           class="form-control input-sm"
+                           class="form-control input-sm" required
                            placeholder="Filter platforms & jobs"
                            blur-this>
                 </span>


### PR DESCRIPTION
The filter box is too small to see any filters of somewhat-significant length. This patch keeps it small most of the time, but grows to a larger size when it has focus and/or when there's something typed into the filter box.

It (ab)uses the 'required' property to make the :valid CSS selector work when the filter box has something typed in it, since apparently CSS has no selector for this use case.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/551)
<!-- Reviewable:end -->
