### PR TITLE
Bug 1151806 - Implement chunking for job ingestion

### DIFF
--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -248,6 +248,40 @@ class TreeherderArtifactCollectionTest(DataSetup, unittest.TestCase):
 
         self.assertTrue(len(self.artifact_data) == len(tac.data))
 
+    def test_collection_chunking(self):
+        tac = TreeherderArtifactCollection()
+
+        for artifact in self.artifact_data:
+            ta = TreeherderArtifact(artifact)
+            tac.add(ta)
+
+        # reconstruct the chunks and make sure we have the same data
+        rebuilt_data = []
+        chunk_num = 0
+        for chunk in tac.get_chunks(3):
+            chunk_data = chunk.get_collection_data()
+            rebuilt_data.extend(chunk_data)
+
+            chunk_num += 1
+            # the last one should be the "remainder" in an uneven size
+            if chunk_num == 4:
+                assert len(chunk_data) == 1
+            else:
+                assert len(chunk_data) == 3
+
+        assert rebuilt_data == tac.get_collection_data()
+
+    def test_chunk_endpoint_base(self):
+        """Confirm the endpoint_base of the chunks is the same as the original"""
+        tac = TreeherderArtifactCollection()
+
+        for artifact in self.artifact_data:
+            ta = TreeherderArtifact(artifact)
+            tac.add(ta)
+
+        for chunk in tac.get_chunks(3):
+            assert tac.endpoint_base == chunk.endpoint_base
+
 
 class TreeherderJobCollectionTest(DataSetup, unittest.TestCase):
 

--- a/tests/sample_data/builds-running.json
+++ b/tests/sample_data/builds-running.json
@@ -3,17 +3,17 @@
         "test_treeherder": {
             "4b40022e5c4c": [
                 {
-                    "submitted_at": 1369231311,
-                    "buildername": "WINNT 5.2 profiling build",
+                    "submitted_at": 1376416924,
+                    "buildername": "win64_vm try opt test mochitest-other",
                     "start_time": 1369231311,
                     "number": 3,
                     "claimed_by_name": "buildbot-master66.srv.releng.usw2.mozilla.com:/builds/buildbot/build1/master",
                     "request_ids": [
-                        24526180
+                        27949897
                     ],
                     "last_heartbeat": 1369231939,
                     "id": 24767134,
-                    "revision": "77aa19fd5c2eaa71f463867b15d956a972ae7574"
+                    "revision": "45f8637cb9f7"
                 }
             ]
         }

--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -445,7 +445,8 @@ class Builds4hJobsProcess(JsonExtractorMixin,
                 self.transform(extracted_content,
                                filter_to_revision=filter_to_revision,
                                filter_to_project=filter_to_project,
-                               filter_to_job_group=filter_to_job_group)
+                               filter_to_job_group=filter_to_job_group),
+                chunk_size=settings.BUILDAPI_BUILDS4H_CHUNK_SIZE
             )
 
 
@@ -462,7 +463,8 @@ class PendingJobsProcess(JsonExtractorMixin,
                                'pending',
                                filter_to_revision=filter_to_revision,
                                filter_to_project=filter_to_project,
-                               filter_to_job_group=filter_to_job_group)
+                               filter_to_job_group=filter_to_job_group),
+                chunk_size=settings.BUILDAPI_PENDING_CHUNK_SIZE
             )
 
 
@@ -479,5 +481,6 @@ class RunningJobsProcess(JsonExtractorMixin,
                                'running',
                                filter_to_revision=filter_to_revision,
                                filter_to_project=filter_to_project,
-                               filter_to_job_group=filter_to_job_group)
+                               filter_to_job_group=filter_to_job_group),
+                chunk_size=settings.BUILDAPI_RUNNING_CHUNK_SIZE
             )

--- a/treeherder/etl/mixins.py
+++ b/treeherder/etl/mixins.py
@@ -121,5 +121,5 @@ class ResultSetsLoaderMixin(JsonLoaderMixin):
 
 class OAuthLoaderMixin(object):
 
-    def load(self, th_collections):
-        th_publisher.post_treeherder_collections(th_collections)
+    def load(self, th_collections, chunk_size=1):
+        th_publisher.post_treeherder_collections(th_collections, chunk_size)

--- a/treeherder/etl/th_publisher.py
+++ b/treeherder/etl/th_publisher.py
@@ -3,6 +3,7 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import logging
+import traceback
 
 from django.utils.encoding import python_2_unicode_compatible
 from django.conf import settings
@@ -14,31 +15,36 @@ from treeherder.etl.oauth_utils import OAuthCredentials
 logger = logging.getLogger(__name__)
 
 
-def post_treeherder_collections(th_collections):
+def post_treeherder_collections(th_collections, chunk_size=1):
+
     errors = []
+    cli = TreeherderClient(
+        protocol=settings.TREEHERDER_REQUEST_PROTOCOL,
+        host=settings.TREEHERDER_REQUEST_HOST,
+    )
+
     for project in th_collections:
 
         credentials = OAuthCredentials.get_credentials(project)
-
-        cli = TreeherderClient(
-            protocol=settings.TREEHERDER_REQUEST_PROTOCOL,
-            host=settings.TREEHERDER_REQUEST_HOST,
-        )
 
         logger.info(
             "collection loading request for project {0}: {1}".format(
                 project,
                 th_collections[project].endpoint_base))
-        try:
-            cli.post_collection(project, credentials.get('consumer_key'),
-                                credentials.get('consumer_secret'),
-                                th_collections[project])
-        except Exception, e:
-            errors.append({
-                "project": project,
-                "url": th_collections[project].endpoint_base,
-                "message": str(e)
-            })
+
+        collection_chunks = th_collections[project].get_chunks(chunk_size)
+
+        for collection in collection_chunks:
+            try:
+                cli.post_collection(project, credentials.get('consumer_key'),
+                                    credentials.get('consumer_secret'),
+                                    collection)
+            except Exception:
+                errors.append({
+                    "project": project,
+                    "url": th_collections[project].endpoint_base,
+                    "message": traceback.format_exc()
+                })
 
     if errors:
         raise CollectionNotLoadedException(errors)

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -306,6 +306,14 @@ BUILDAPI_PENDING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson
 BUILDAPI_RUNNING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-running.js"
 BUILDAPI_BUILDS4H_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-4hr.js.gz"
 
+# the max size of a posted request to treeherder client during Buildbot
+# data job ingestion.
+# If TreeherderCollections are larger, they will be chunked
+# to this size.
+BUILDAPI_PENDING_CHUNK_SIZE = 500
+BUILDAPI_RUNNING_CHUNK_SIZE = 500
+BUILDAPI_BUILDS4H_CHUNK_SIZE = 500
+
 PARSER_MAX_STEP_ERROR_LINES = 100
 PARSER_MAX_SUMMARY_LINES = 200
 


### PR DESCRIPTION
This is a re-submission of an earlier commit for chunking.  The code is largely the same, but there was a bug where ``pending`` and ``running`` jobs got submitted to the objectstore.  This meant that when a job transitioned from pending to running or running to complete, we would skip it, because we would find a duplicate ``job_guid`` in the objectstore (already stored as pending/running).

**THE BUG**
The problem was that when I created the chunked ``TreeherderCollections`` I copied the data, but not the ``endpoint_base``.  In the case of ``TreeherderJobsCollection`` that value is determined in the constructor based on a ``job_type`` param.  I missed that originally and re-created the object without the param, which defaults to the objectstore.

**THE FIX**
So the fix is to copy the ``endpoint_base`` from the main collection to the new chunk each time we create it.

**TESTS**
I added a few more tests and a re-wrote the fixture to mock only the POST within the client.  We were mocking too early before, which is part of how this got past the tests.  The new fixture improves several other tests that were using it by hitting more of the code-path.  But new tests were also needed to check the specific case we hit.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/554)
<!-- Reviewable:end -->
