### PR TITLE
Bug 1078209 - Get next N fixes

### DIFF
--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -213,7 +213,7 @@ treeherderApp.controller('ResultSetCtrl', [
                     ThModelErrors.format(e, "Failed to cancel all jobs"),
                     'danger', true
                 );
-            })
+            });
         };
 
         $scope.revisionResultsetFilterUrl = $scope.urlBasePath + "?repo=" +

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -322,6 +322,12 @@ treeherderApp.controller('MainCtrl', [
 
         // reload the page if certain params were changed in the URL.  For
         // others, such as filtering, just re-filter without reload.
+
+        // the param ``skipNextPageReload`` will cause a single run through
+        // this code to skip the page reloading even on a param that would
+        // otherwise trigger a page reload.  This is useful for a param that
+        // is being changed by code in a specific situation as opposed to when
+        // the user manually edits the URL location bar.
         $rootScope.$on('$locationChangeSuccess', function() {
 
             // used to test for display of watched-repo-navbar
@@ -337,12 +343,15 @@ treeherderApp.controller('MainCtrl', [
                              !$scope.cachedReloadTriggerParams.repo;
 
             if (!defaulting && $scope.cachedReloadTriggerParams &&
-                !_.isEqual(newReloadTriggerParams, $scope.cachedReloadTriggerParams)) {
+                !_.isEqual(newReloadTriggerParams, $scope.cachedReloadTriggerParams) &&
+                !$rootScope.skipNextPageReload) {
 
                 $window.location.reload();
             } else {
                 $scope.cachedReloadTriggerParams = newReloadTriggerParams;
             }
+            $rootScope.skipNextPageReload = false;
+
         });
 
         $scope.changeRepo = function(repo_name) {

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -314,6 +314,10 @@ treeherderApp.controller('MainCtrl', [
             );
         };
 
+        $scope.setLocationSearchParam = function(param, value) {
+            $location.search(param, value);
+        };
+
         $scope.cachedReloadTriggerParams = getNewReloadTriggerParams();
 
         // reload the page if certain params were changed in the URL.  For

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -12,6 +12,8 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location', '$q'
 
     var $log = new ThLog("ThResultSetModel");
 
+    var MAX_RESULTSET_FETCH_SIZE = 100;
+
     var convertDates = function(locationParams) {
         // support date ranges.  we must convert the strings to a timezone
         // appropriate timestamp
@@ -31,6 +33,11 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location', '$q'
         return locationParams;
     };
 
+    // return whether an OLDEST resultset range is set.
+    var hasLowerRange = function (locationParams) {
+        return locationParams.fromchange || locationParams.startdate;
+    };
+
     // get the resultsets for this repo
     return {
         // used for polling new resultsets after initial load
@@ -48,7 +55,6 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location', '$q'
 
         getResultSets: function(repoName, rsOffsetTimestamp, count, resultsetlist, full, keep_filters) {
             rsOffsetTimestamp = typeof rsOffsetTimestamp === 'undefined'?  0: rsOffsetTimestamp;
-            count = typeof count === 'undefined'?  10: count;
             full = _.isUndefined(full) ? true: full;
             keep_filters = _.isUndefined(keep_filters) ? true : keep_filters;
 
@@ -56,18 +62,15 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location', '$q'
                 full: full
             };
 
-            if (count > 0) {
-                params.count = count;
-            }
+            // count defaults to 10, but can be no larger than the max.
+            params.count = !count ? 10 : Math.min(count, MAX_RESULTSET_FETCH_SIZE);
 
             if(rsOffsetTimestamp){
                 params.push_timestamp__lte = rsOffsetTimestamp;
                 // we will likely re-fetch the oldest we already have, but
                 // that's not guaranteed.  There COULD be two resultsets
                 // with the same timestamp, theoretically.
-                if (params.count) {
-                    params.count++;
-                }
+                params.count++;
             }
 
             if (keep_filters) {
@@ -77,6 +80,21 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location', '$q'
                 // service at this time, but it could be confusing.
                 var locationParams = _.clone($location.search());
                 delete locationParams.repo;
+
+                // if they submit an offset timestamp, then they have resultsets
+                // and are fetching more.  So don't honor the fromchange/tochange
+                // or else we won't be able to fetch more resultsets.
+
+                // we DID already check for rsOffsetTimestamp above, but that was
+                // not within the ``keep_filters`` check.  If we don't
+                // keep filters, we don't need to clone the $location.search().
+                if (rsOffsetTimestamp) {
+                    delete locationParams.tochange;
+                    delete locationParams.fromchange;
+                } else if (hasLowerRange(locationParams)) {
+                    // fetch the maximum number of resultsets if a lower range is specified
+                    params.count = MAX_RESULTSET_FETCH_SIZE;
+                }
 
                 locationParams = convertDates(locationParams);
 

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -60,7 +60,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location', '$q'
                 params.count = count;
             }
 
-            if(rsOffsetTimestamp > 0){
+            if(rsOffsetTimestamp){
                 params.push_timestamp__lte = rsOffsetTimestamp;
                 // we will likely re-fetch the oldest we already have, but
                 // that's not guaranteed.  There COULD be two resultsets
@@ -70,7 +70,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location', '$q'
                 }
             }
 
-            if(keep_filters){
+            if (keep_filters) {
                 // if there are any search params on the url line, they should
                 // pass directly to the set of resultsets.
                 // with the exception of ``repo``.  That has no effect on the

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -806,7 +806,7 @@ treeherder.factory('ThResultSetStore', [
                 resultsets = data.data;
             });
 
-        $q.all([loadRepositories, loadResultsets]).
+        return $q.all([loadRepositories, loadResultsets]).
             then(
                 function() {
                     appendResultSets(repoName, resultsets);

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -211,7 +211,6 @@ treeherder.factory('ThResultSetStore', [
                 rsMap:{},
                 jobMap:{},
                 unclassifiedFailureMap: {},
-                jobMapOldestId:null,
                 //used as the offset in paging
                 rsMapOldestTimestamp:null,
                 resultSets:[],
@@ -294,13 +293,6 @@ treeherder.factory('ThResultSetStore', [
             };
             repositories[repoName].rsMap[rs_obj.id] = rsMapElement;
 
-            // keep track of the oldest push_timestamp, so we don't auto-fetch resultsets
-            // that are out of the range we care about.
-            if ( !repositories[repoName].rsMapOldestTimestamp ||
-                 (repositories[repoName].rsMapOldestTimestamp > rs_obj.push_timestamp)) {
-                repositories[repoName].rsMapOldestTimestamp = rs_obj.push_timestamp;
-            }
-
             // platforms
             if(rs_obj.platforms !== undefined){
                 mapPlatforms(repoName, rs_obj);
@@ -310,7 +302,8 @@ treeherder.factory('ThResultSetStore', [
         $log.debug("sorting", repoName, repositories[repoName]);
         repositories[repoName].resultSets.sort(rsCompare);
 
-        $log.debug("oldest job: ", repositories[repoName].jobMapOldestId);
+        repositories[repoName].rsMapOldestTimestamp = _.last(repositories[repoName].resultSets).push_timestamp;
+
         $log.debug("oldest result set: ", repositories[repoName].rsMapOldestTimestamp);
         $log.debug("done mapping:", repositories[repoName].rsMap);
     };
@@ -351,12 +344,6 @@ treeherder.factory('ThResultSetStore', [
                     grMapElement.jobs[key] = jobMapElement;
                     repositories[repoName].jobMap[key] = jobMapElement;
                     updateUnclassifiedFailureMap(repoName, job_obj);
-
-                    // track oldest job id
-                    if (!repositories[repoName].jobMapOldestId ||
-                        (repositories[repoName].jobMapOldestId > job_obj.id)) {
-                        repositories[repoName].jobMapOldestId = job_obj.id;
-                    }
                 }
             }
         }

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -97,11 +97,11 @@
 </div>
 
 <!-- Get next resultsets footer -->
-<div class="well" ng-if="result_sets.length > 1">
+<div class="well">
      get next:
     <div class="btn-group">
         <div class="btn btn-default btn-sm"
-             ng-click="fetchResultSets(count, true)"
+             ng-click="getNextResultSets(count, true)"
              ng-repeat="count in [10, 20, 50]">{{::count}}</div>
         </div>
     </div>

--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -16,9 +16,9 @@
                    ng-click="openRevisionListWindow()">Revision URL List</a></li>
             <li><a target="_blank" ignore-job-clear-on-click
                    href="" prevent-default-on-left-click
-                   ng-click="setLocationSearchParam('tochange', resultset.revision)">Set as tochange</a></li>
+                   ng-click="setLocationSearchParam('tochange', resultset.revision)">Set as top of range</a></li>
             <li><a target="_blank" ignore-job-clear-on-click
                    href="" prevent-default-on-left-click
-                   ng-click="setLocationSearchParam('fromchange', resultset.revision)">Set as fromchange</a></li>
+                   ng-click="setLocationSearchParam('fromchange', resultset.revision)">Set as bottom of range</a></li>
         </ul>
     </span>

--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -14,5 +14,11 @@
             <li><a target="_blank" ignore-job-clear-on-click
                    href="" prevent-default-on-left-click
                    ng-click="openRevisionListWindow()">Revision URL List</a></li>
+            <li><a target="_blank" ignore-job-clear-on-click
+                   href="" prevent-default-on-left-click
+                   ng-click="setLocationSearchParam('tochange', resultset.revision)">Set as tochange</a></li>
+            <li><a target="_blank" ignore-job-clear-on-click
+                   href="" prevent-default-on-left-click
+                   ng-click="setLocationSearchParam('fromchange', resultset.revision)">Set as fromchange</a></li>
         </ul>
     </span>


### PR DESCRIPTION
This addresses [Bug 1078209](https://bugzilla.mozilla.org/show_bug.cgi?id=1078209)

Here are the workflows this change facilitates:

1. If you have the ``revision`` value set (so you're viewing a single revision) hitting "Next N" will change the param from ``revision`` to ``tochange`` and set the ``fromchange`` to the latest loaded (earliest) resultset.

2. after loading default of latest 10, click next 10 will load them and set only the ``fromchange`` value to the latest revision loaded.  Hit next N again and it will update the ``fromchange`` to the latest again.  
Note: ``tochange`` is not updated in this scenario, so that new resultsets will continue to be loaded by default

3. The "action" menu (at the right end of each resultset) has two new menu items:

    1. "Set as tochange" will set the ``tochange`` param to that revision and will therefore stop loading any new resultsets.

    2. "Set as fromchange`` will set the ``fromchange`` param to that revision.  Hitting "Next N" will update that value as you go.

Found, but not addressed in this PR:
[Bug 1168896](https://bugzilla.mozilla.org/show_bug.cgi?id=1168896)


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/560)
<!-- Reviewable:end -->
