### PR TITLE
Bug 1133519: Improve the interaction with the result-set endpoint

### DIFF
--- a/ui/js/graphs.js
+++ b/ui/js/graphs.js
@@ -23,6 +23,7 @@ perf.controller('GraphsCtrl', [
 
     $scope.ttHideTimer = null;
     $scope.selectedDataPoint = null;
+    $scope.showToolTipTimeout = null;
 
     function getSeriesDataPoint(flotItem) {
       // gets universal elements of a series given a flot item
@@ -50,6 +51,11 @@ perf.controller('GraphsCtrl', [
     }
 
     function showTooltip(dataPoint) {
+      if ($scope.showToolTipTimeout){
+         window.clearTimeout($scope.showToolTipTimeout)
+      }
+
+      $scope.showToolTipTimeout = window.setTimeout(function() {
       if ($scope.ttHideTimer) {
         clearTimeout($scope.ttHideTimer);
         $scope.ttHideTimer = null;
@@ -150,6 +156,7 @@ perf.controller('GraphsCtrl', [
           tip.css({ opacity: 1, left: tipPosition.left, top: tipPosition.top });
         }
       });
+     },400);
     }
 
     function hideTooltip(now) {

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -134,9 +134,10 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location', '$q'
             return jobsPromiseList;
         },
 
+
         getRevisions: function(projectName, resultSetId) {
             return $http.get(thUrl.getProjectUrl(
-                "/resultset/" + resultSetId, projectName), {cache: true}).then(
+                "/resultset/" + resultSetId + "/", projectName), {cache: true}).then(
                     function(response) {
                         if (response.data.revisions.length > 0) {
                             return _.map(response.data.revisions, function(r) {


### PR DESCRIPTION
Mentor:  William Lachance (:wlach)  

The fix sets timeout to 400 ms for showToolTip function and cancels timeout if the user moves to another point before the timeout elapses. Further updated getRevisions in resultset.js to include the trailing "/".

I verified the changes by manually testing and using charles proxy. Please let me know if you need me to run automated tests. I was running into problem when I ran. ./tests/ui/scripts/test.sh.  I thought I will research the error further after bringing this to your notice. 

Automated Test Error ():  
Firefox 38.0.0 (Mac OS X 10.10) ERROR
	Error: JSONFixture could not be loaded: base/test/mock/repositories.json (status: error, message: undefined)
	at /Users/akhileshpillai/Documents/gitrepo/treeherder/ui/vendor/jasmine-jquery.js:292

Thanks,
Akhilesh

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/561)
<!-- Reviewable:end -->
