### PR TITLE
Bug 1085579 - Docs: Use the Read the Docs theme for local builds too

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,7 +109,14 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+
+if not os.environ.get('READTHEDOCS'):
+    # Only import and set the theme if we're building docs locally:
+    # https://docs.readthedocs.org/en/latest/theme.html#how-do-i-use-this-locally-and-on-read-the-docs
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# otherwise, readthedocs.org uses their theme by default, so no need to specify it
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,4 +11,5 @@
 # would not help those who wish to build the docs locally.
 
 Sphinx
+sphinx-rtd-theme
 sphinxcontrib-httpdomain


### PR DESCRIPTION
Using the instructions from:
https://docs.readthedocs.org/en/latest/theme.html#how-do-i-use-this-locally-and-on-read-the-docs

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/564)
<!-- Reviewable:end -->
