### PR TITLE
Bug 1168770 - web-server.js: Serve index.html by default, if present

### DIFF
--- a/docs/ui/installation.rst
+++ b/docs/ui/installation.rst
@@ -2,7 +2,7 @@ Installation
 ============
 
 You can work on the UI without needing a VM, by using web-server.js.
-There are a few limitations, since URL rewriting is not supported (and so some links will be broken), but it works well enough for quick testing. For instructions on how to serve the UI with working URL rewriting, see the Vagrant instructions.
+There are a few limitations, such as Persona login not working (bug 1168797), but it works well enough for quick testing. For instructions on how to serve the UI with working URL rewriting, see the Vagrant instructions.
 
 Cloning the Repo
 ----------------
@@ -28,7 +28,7 @@ Viewing the UI
 --------------
 
 Once the server is running, you can navigate to:
-`<http://localhost:8000/index.html>`_
+`<http://localhost:8000>`_
 
 Configuration
 =============

--- a/web-server.js
+++ b/web-server.js
@@ -9,6 +9,7 @@ var util = require('util'),
 
 var DEFAULT_PORT = 8000;
 var APP_ROOT = path.join(__dirname, "ui");
+var INDEX_FILE = 'index.html';
 
 function main(argv) {
   new HttpServer({
@@ -115,7 +116,14 @@ StaticServlet.prototype.handleDirectoryRequest_ = function(req, res, path) {
     var redirectUrl = url.format(url.parse(url.format(req.url)));
     return self.sendRedirect_(req, res, redirectUrl);
   }
-  return self.sendDirectory_(req, res, path);
+  // Check if there is an index file (eg index.html) we can serve.
+  var indexpath = path + INDEX_FILE;
+  fs.stat(indexpath, function(err, stat) {
+    if (stat && stat.isFile())
+      return self.sendFile_(req, res, indexpath);
+    // Otherwise just display the directory listing.
+    return self.sendDirectory_(req, res, path);
+  });
 };
 
 StaticServlet.prototype.sendError_ = function(req, res, error) {

--- a/web-server.js
+++ b/web-server.js
@@ -103,10 +103,20 @@ StaticServlet.prototype.handleRequest = function(req, res) {
     if (err)
       return self.sendMissing_(req, res, path);
     if (stat.isDirectory())
-      return self.sendDirectory_(req, res, path);
+      return self.handleDirectoryRequest_(req, res, path);
     return self.sendFile_(req, res, path);
   });
-}
+};
+
+StaticServlet.prototype.handleDirectoryRequest_ = function(req, res, path) {
+  var self = this;
+  if (path.match(/[^\/]$/)) {
+    req.url.pathname += '/';
+    var redirectUrl = url.format(url.parse(url.format(req.url)));
+    return self.sendRedirect_(req, res, redirectUrl);
+  }
+  return self.sendDirectory_(req, res, path);
+};
 
 StaticServlet.prototype.sendError_ = function(req, res, error) {
   res.writeHead(500, {
@@ -192,11 +202,6 @@ StaticServlet.prototype.sendFile_ = function(req, res, path) {
 
 StaticServlet.prototype.sendDirectory_ = function(req, res, path) {
   var self = this;
-  if (path.match(/[^\/]$/)) {
-    req.url.pathname += '/';
-    var redirectUrl = url.format(url.parse(url.format(req.url)));
-    return self.sendRedirect_(req, res, redirectUrl);
-  }
   fs.readdir(path, function(err, files) {
     if (err)
       return self.sendError_(req, res, error);


### PR DESCRIPTION
Instead of always displaying the directory file listing, if index.html is present we serve that instead. This not only fixes the remaining broken URLs when using web-server.js, but also means people can click the "Starting web server at <URL>" link in the console and immediately see Treeherder, without having to then manually navigate to index.html themselves.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/567)
<!-- Reviewable:end -->
