### PR TITLE
Bug 1168797 - Fix Persona login when using web-server.js

### DIFF
--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -448,7 +448,9 @@ CELERY_IGNORE_RESULT = True
 
 API_HOSTNAME = SITE_URL
 
-BROWSERID_AUDIENCES = [SITE_URL]
+# The localhost entry is necessary so that people using web-server.js can
+# log in when the local UI is pointed at the stage/production service.
+BROWSERID_AUDIENCES = [SITE_URL, "http://localhost:8000"]
 
 SWAGGER_SETTINGS = {"enabled_methods": ['get', ]}
 

--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -124,8 +124,9 @@ treeherder.factory('BrowserId', [
             return browserid.info.then(function(response){
                 browserid.logoutDeferred = $q.defer();
                 navigator.id.logout();
+                var logoutUrl = thServiceDomain + response.data.logoutUrl;
                 return browserid.logoutDeferred.promise.then(function(){
-                    return $http.post(response.data.logoutUrl);
+                    return $http.post(logoutUrl);
                 })
             });
         },
@@ -148,8 +149,9 @@ treeherder.factory('BrowserId', [
         */
         verifyAssertion: function(assertion){
             return browserid.info.then(function(response){
+                var loginUrl = thServiceDomain + response.data.loginUrl;
                 return $http.post(
-                    response.data.loginUrl, {assertion: assertion},{
+                    loginUrl, {assertion: assertion},{
                         headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'},
                         transformRequest: browserid.transform_data
                     });


### PR DESCRIPTION
There were two issues:
* The login/logout URLs were retrieved from <thServiceDomain>/browserid/info - but then the values returned were not prefixed with thServiceDomain before being used later on.
* Persona limits the domain/port/protocol combinations to those listed in BROWSERID_AUDIENCES. Since localhost wasn't listed, it results in a 403 forbidden when trying to log in from web-server.js. It's important not to list malicious sites in BROWSERID_AUDIENCES, since the assertions generated from any of the sites listed can be used against the others. However adding localhost seems safe enough, since if the users' own machine is compromised, then they have bigger things to worry about.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/568)
<!-- Reviewable:end -->
