### PR TITLE
Bug 1168211 - Continued Annotations panel improvements

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -950,10 +950,6 @@ ul.failure-summary-list li .btn-xs {
     background-color: #FFFFFF;
 }
 
-#pinboard-related-bugs a {
-    text-decoration: none;
-}
-
 .add-related-bugs-icon {
     margin-right: 2px;
     font-size: 17px;
@@ -999,15 +995,9 @@ ul.failure-summary-list li .btn-xs {
     margin-bottom: -1px;
 }
 
-.pinboard-related-bugs-btn > .pinboard-related-bugs-link,
-.pinboard-related-bugs-btn:hover > .pinboard-related-bugs-link:hover {
-    border-top-right-radius: 3px !important;
-    border-bottom-right-radius: 3px !important;
-}
-
-.pinboard-related-bugs-btn:hover > .pinboard-related-bugs-link {
-    border-top-right-radius: 0 !important;
-    border-bottom-right-radius: 0 !important;
+.pinboard-related-bugs-btn:hover > .related-bugs-link {
+    color: #2a6496;
+    text-decoration: underline;
 }
 
 /* Spin button suppression on chrome */
@@ -1081,18 +1071,48 @@ ul.failure-summary-list li .btn-xs {
     margin-right: 0;
 }
 
-.classifications-panel {
+.classifications-pane {
     border-right: solid 1px lightgray;
 }
 
-.bug-list {
+/* Annotation tab classification headers */
+.classifications-pane table tr th {
+    padding-right: 16px;
+    padding-bottom: 4px;
+}
+
+/* Annotation tab classification fields */
+.classifications-pane table tr td {
+    padding-right: 16px;
+}
+
+/* Annotations tab classification trash can */
+.classifications-pane table tr td:last-child {
+    padding-left: 16px;
+}
+
+/* Override bootstrap row highlighting */
+.classifications-pane table tr:hover td {
+    background: #fff;
+}
+
+.annotations-bug-list {
     list-style: none inside none;
     padding-left: 0;
 }
 
-.bug-header {
-    margin-top: 8px;
-    margin-bottom: 8px;
+.annotations-bug-header {
+    margin-top: 4px;
+    margin-bottom: 2px;
+    font-size: 0.9em;
+}
+
+.annotations-bug {
+    padding-top: 2px;
+    padding-bottom: 0;
+    padding-left: 0;
+    border: none;
+    font-size: 0.9em;
 }
 
 /**

--- a/ui/partials/main/thRelatedBugQueued.html
+++ b/ui/partials/main/thRelatedBugQueued.html
@@ -1,9 +1,9 @@
 <span class="btn-group pinboard-related-bugs-btn">
-    <a class="btn btn-default btn-xs pinboard-related-bugs-link"
+    <a class="btn btn-xs related-bugs-link"
        title="{{::bug.summary}}"
        href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.id}}"
        target="_blank"
-       >{{::bug.id}}</a>
+       ><em>{{::bug.id}}</em></a>
     <span class="btn btn-ltgray btn-xs pinned-job-close-btn"
           ng-click="removeBug(bug.id)"
           title="remove this bug"><i class="fa fa-times"></i></span>

--- a/ui/partials/main/thRelatedBugSaved.html
+++ b/ui/partials/main/thRelatedBugSaved.html
@@ -1,9 +1,9 @@
 <span class="btn-group pinboard-related-bugs-btn">
-    <a class="btn btn-default btn-xs pinboard-related-bugs-link"
+    <a class="btn btn-xs annotations-bug related-bugs-link"
        href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.bug_id}}"
        target="_blank"
-       >{{::bug.bug_id}}</a>
-    <span class="btn btn-ltgray btn-xs pinned-job-close-btn"
+       ><em>{{::bug.bug_id}}</em></a>
+    <span class="btn btn-ltgray btn-xs pinned-job-close-btn annotations-bug"
           ng-click="deleteBug(bug)"
-          title="delete relation to bug {{::bug.bug_id}}"><i class="fa fa-trash-o"></i></span>
+          title="Delete relation to bug {{::bug.bug_id}}"><i class="fa fa-trash-o"></i></span>
 </span>

--- a/ui/plugins/annotations/main.html
+++ b/ui/plugins/annotations/main.html
@@ -1,13 +1,13 @@
 <div ng-controller="AnnotationsPluginCtrl" class="annotations-panel">
-    <div class="col-xs-10 classifications-panel job-tabs-content">
-        <table class="table-condensed table-hover">
+    <div class="col-xs-10 classifications-pane job-tabs-content">
+        <table class="table-super-condensed table-hover">
             <thead ng-hide="classifications.length < 1">
-                <tr><th>Datetime</th><th>Author</th><th>Failure type</th><th>Note</th></tr>
+                <tr><th>Classified</th><th>Author</th><th>Classification</th><th>Comment</th></tr>
             </thead>
             <tbody>
                 <tr ng-repeat="classification in classifications">
                     <td>
-                        {{ ::classification.note_timestamp*1000|date:'medium' }}
+                        {{ ::classification.note_timestamp*1000|date:'EEE MMM d, H:mm:ss' }}
                     </td>
                     <td>
                         {{::classification.who}}
@@ -20,8 +20,8 @@
                     </td>
                     <td>
                         <span ng-click="deleteClassification(classification)"
-                              class="click-able-icon"
-                              title="delete this classification">
+                              class="btn-ltgray click-able-icon"
+                              title="Delete this classification">
                             <i class="fa fa-trash-o"></i>
                         </span>
                     </td>
@@ -30,9 +30,9 @@
         </table>
         <div ng-show="classifications.length < 1">This job has not been classified</div>
     </div>
-    <div class="col-xs-2 bug-list-panel">
-        <h6 class="bug-header" ng-hide="classifications.length < 1"><strong>Bugs</strong></h6>
-        <ul class="bug-list">
+    <div class="col-xs-2 bug-list-pane">
+        <div class="annotations-bug-header" ng-hide="classifications.length < 1"><strong>Bugs</strong></div>
+        <ul class="annotations-bug-list">
             <li ng-repeat="bug in bugs">
                 <th-related-bug-saved></th-related-bug-saved>
             </li>


### PR DESCRIPTION
This work fixes Bugzilla bug [1168211](https://bugzilla.mozilla.org/show_bug.cgi?id=1168211).

This makes some more layout and consistency improvements to the Annotations tab, specifically:

* Switching to the same blue italic link style for annotation bugs
* Decluttering and removing bug button borders
* Using the same `table-super-condensed` table class as Similar jobs
* Using the same `0.9em` font size used elsewhere in the job panel
* Aligning classification rows to their adjacent bug rows when multiples exist
* Renaming "Datetime" to "Classified"; "Note" to "Comment", and "Failure type" to "Classification"
* Using the same date format used in the rest of Treeherder

Here's the before:

![currentannotations](https://cloud.githubusercontent.com/assets/3660661/7845892/f667eba2-0487-11e5-8b07-1c7765790e96.jpg)

Here's after:

![proposedannotations](https://cloud.githubusercontent.com/assets/3660661/7845895/fe532d40-0487-11e5-8ac3-d0a4656f952b.jpg)
In the above scenario when no *Comment* exists, I had thought about having a mid-grey "(none)" in that field. Maybe it's less ambiguous than no data.

We now use the same grey-to-black hover style change, for the trash cans:
![deleteclassificationproposed](https://cloud.githubusercontent.com/assets/3660661/7845905/1d77c906-0488-11e5-9d08-d1be3c36d0bb.jpg)

I also decluttered 'queued' pinboard bugs with the same styling. I will probably look at improvements there later, in terms of alignment between queued bugs and the [+] icon.
![pinboardsamestyle](https://cloud.githubusercontent.com/assets/3660661/7845923/39ea7e44-0488-11e5-8c0d-cab25956b99d.jpg)

Everything seems fine in both browsers.

Tested on OSX 10.10.3:
FF Nightly **41.0a1**
Chrome Latest Release **43.0.2357.81 (64-bit)**

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/570)
<!-- Reviewable:end -->
