### PR TITLE
Bug 1169178 - Consolidate peep invocations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ services:
   - memcached
 install:
   - npm install
-  - ./bin/peep.py install -r requirements/common.txt
-  - ./bin/peep.py install -r requirements/dev.txt
+  - ./bin/peep.py install -r requirements/common.txt -r requirements/dev.txt
 before_script:
   - flake8 --show-source
   # Required for Karma tests (http://docs.travis-ci.com/user/gui-and-headless-browsers/)

--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -49,8 +49,7 @@ def update(ctx):
         execfile(activate_script, dict(__file__=activate_script))
         # Install requirements using peep, so hashes are verified.
         with ctx.lcd(th_service_src):
-            ctx.local('python2.7 bin/peep.py install -r requirements/common.txt')
-            ctx.local('python2.7 bin/peep.py install -r requirements/prod.txt')
+            ctx.local('python2.7 bin/peep.py install -r requirements/common.txt -r requirements/prod.txt')
         # Make the virtualenv relocatable since paths are hard-coded by default.
         ctx.local('virtualenv --relocatable venv')
         # Fix lib64 symlink to be relative instead of absolute.


### PR DESCRIPTION
There's no need to make multiple calls to peep - we can just combine them into one. Not changing the puppet instances for Vagrant, since the calls are made in two separate puppet modules and so would require a bit of re-factoring, which is going to occur in bug 1074151 and friends.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/573)
<!-- Reviewable:end -->
