### PR TITLE
Bug 1164545 - Select next prev unclassified failure

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -9,13 +9,13 @@ treeherderApp.controller('MainCtrl', [
     'ThRepositoryModel', 'thPinboard',
     'thClassificationTypes', 'thEvents', '$interval', '$window',
     'ThExclusionProfileModel', 'thJobFilters', 'ThResultSetStore',
-    'thDefaultRepo',
+    'thDefaultRepo', 'thJobNavSelectors',
     function MainController(
         $scope, $rootScope, $routeParams, $location, ThLog,
         ThRepositoryModel, thPinboard,
         thClassificationTypes, thEvents, $interval, $window,
         ThExclusionProfileModel, thJobFilters, ThResultSetStore,
-        thDefaultRepo) {
+        thDefaultRepo, thJobNavSelectors) {
 
         var $log = new ThLog("MainCtrl");
 
@@ -102,22 +102,30 @@ treeherderApp.controller('MainCtrl', [
 
             // Shortcut: select previous job
             Mousetrap.bind('left', function() {
-                $rootScope.$emit(thEvents.changeSelection,'previous');
+                $rootScope.$emit(thEvents.changeSelection,
+                                 'previous',
+                                 thJobNavSelectors.ALL_JOBS);
             });
 
             // Shortcut: select next job
             Mousetrap.bind('right', function() {
-                $rootScope.$emit(thEvents.changeSelection,'next');
+                $rootScope.$emit(thEvents.changeSelection,
+                                 'next',
+                                 thJobNavSelectors.ALL_JOBS);
             });
 
             // Shortcut: select next unclassified failure
             Mousetrap.bind(['j', 'n'], function() {
-                $rootScope.$emit(thEvents.selectNextUnclassifiedFailure);
+                $rootScope.$emit(thEvents.changeSelection,
+                                 'next',
+                                 thJobNavSelectors.UNCLASSIFIED_FAILURES);
             });
 
             // Shortcut: select previous unclassified failure
             Mousetrap.bind(['k', 'p'], function() {
-                $rootScope.$emit(thEvents.selectPreviousUnclassifiedFailure);
+                $rootScope.$emit(thEvents.changeSelection,
+                                 'previous',
+                                 thJobNavSelectors.UNCLASSIFIED_FAILURES);
             });
 
             // Shortcut: retrigger selected job

--- a/ui/js/directives/clonejobs.js
+++ b/ui/js/directives/clonejobs.js
@@ -66,24 +66,7 @@ treeherder.directive('thCloneJobs', [
 
     //Global event listeners
     $rootScope.$on(
-        thEvents.selectNextUnclassifiedFailure, function(ev){
-
-            var jobMap = ThResultSetStore.getJobMap($rootScope.repoName);
-            var lastJobSelected = ThResultSetStore.getSelectedJob($rootScope.repoName);
-
-            var targetEl, jobKey;
-            if(!_.isEmpty(lastJobSelected.el)){
-                jobKey = getJobMapKey(lastJobSelected.job);
-                getNextUnclassifiedFailure(jobMap[jobKey].job_obj);
-
-            }else{
-                //Select the first unclassified failure
-                getNextUnclassifiedFailure({});
-            }
-    });
-
-    $rootScope.$on(
-        thEvents.changeSelection, function(ev, direction){
+        thEvents.changeSelection, function(ev, direction, selector){
 
         var jobMap = ThResultSetStore.getJobMap($rootScope.repoName);
         var el, key, job, jobs, getIndex;
@@ -98,7 +81,7 @@ treeherder.directive('thCloneJobs', [
             };
         }
 
-        jobs = $(".th-view-content .job-btn");
+        jobs = $(selector);
         var idx = jobs.index(jobs.filter(".selected-job"));
         idx = getIndex(idx, jobs);
 
@@ -109,27 +92,9 @@ treeherder.directive('thCloneJobs', [
         }
 
         key = el.attr(jobKeyAttr);
-        job = jobMap[key].job_obj;
-        selectJob(job);
-
-    });
-
-    $rootScope.$on(
-        thEvents.selectPreviousUnclassifiedFailure, function(ev){
-
-            var jobMap = ThResultSetStore.getJobMap($rootScope.repoName);
-
-            var lastJobSelected = ThResultSetStore.getSelectedJob($rootScope.repoName);
-
-            var targetEl, jobKey;
-            if(!_.isEmpty(lastJobSelected.el)){
-                jobKey = getJobMapKey(lastJobSelected.job);
-                getPreviousUnclassifiedFailure(jobMap[jobKey].job_obj);
-
-            }else{
-                //Select the first unclassified failure
-                getPreviousUnclassifiedFailure({});
-            }
+        if (jobMap && jobMap[key]) {
+            selectJob(jobMap[key].job_obj);
+        }
 
     });
 
@@ -626,129 +591,6 @@ treeherder.directive('thCloneJobs', [
                     );
             }
         }, this);
-    };
-
-    var getNextUnclassifiedFailure = function(currentJob){
-
-        var resultsets = ThResultSetStore.getResultSetsArray($rootScope.repoName);
-
-        var firstJob = null;
-        var foundJob = false;
-        var startWatch = false;
-        if(_.isEmpty(currentJob)){
-            startWatch = true;
-        }
-
-        var platforms, groups, jobs, r;
-
-        for(r = 0; r < resultsets.length; r++){
-
-            platforms = resultsets[r].platforms;
-            if(platforms === undefined){
-                continue;
-            }
-
-            var p;
-            for(p = 0; p < platforms.length; p++){
-
-                groups = platforms[p].groups;
-                var g;
-                for(g = 0; g < groups.length; g++){
-
-                    jobs = groups[g].jobs;
-                    var j;
-                    for(j = 0; j < jobs.length; j++){
-
-                        if(currentJob.id === jobs[j].id){
-
-                            //This is the current selection, get the next
-                            startWatch = true;
-                            continue;
-                        }
-
-                        if(startWatch || !firstJob){
-                            if( (jobs[j].visible === true) &&
-                                (classificationRequired[jobs[j].result] === 1) &&
-                                ( (parseInt(jobs[j].failure_classification_id, 10) === 1) ||
-                                  (jobs[j].failure_classification_id === null)  )){
-                                if (startWatch) {
-                                    foundJob = true;
-                                    selectJob(jobs[j]);
-                                    return;
-                                } else {
-                                    firstJob = jobs[j];
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        if (!foundJob && firstJob) {
-          // we were at the last job, start again from the beginning
-          selectJob(firstJob);
-        }
-    };
-
-    var getPreviousUnclassifiedFailure = function(currentJob){
-
-        var resultsets = ThResultSetStore.getResultSetsArray($rootScope.repoName);
-
-        var foundJob = false;
-        var lastJob = null;
-        var startWatch = false;
-        if(_.isEmpty(currentJob)){
-            startWatch = true;
-        }
-
-        var platforms, groups, jobs, r;
-
-        for(r = resultsets.length - 1; r >= 0; r--){
-
-            platforms = resultsets[r].platforms;
-            if(platforms === undefined){
-                continue;
-            }
-
-            var p;
-            for(p = platforms.length - 1; p >= 0; p--){
-
-                groups = platforms[p].groups;
-                var g;
-                for(g = groups.length - 1; g >= 0; g--){
-
-                    jobs = groups[g].jobs;
-                    var j;
-                    for(j = jobs.length - 1; j >= 0; j--){
-                        if(currentJob.id === jobs[j].id){
-
-                            //This is the current selection, get the next
-                            startWatch = true;
-                            continue;
-                        }
-                        if(startWatch || !lastJob){
-                            if( (jobs[j].visible === true) &&
-                                (classificationRequired[jobs[j].result] === 1) &&
-                                ( (parseInt(jobs[j].failure_classification_id, 10) === 1) ||
-                                  (jobs[j].failure_classification_id === null)  )){
-
-                                if (startWatch) {
-                                    selectJob(jobs[j]);
-                                    return;
-                                } else {
-                                    lastJob = jobs[j];
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        if (!foundJob && lastJob) {
-            // we were at the first job, go to the very end
-            selectJob(lastJob);
-        }
     };
 
     var scrollToElement = function(el){

--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -217,10 +217,6 @@ treeherder.provider('thEvents', function() {
 
             toggleUnclassifiedFailures: "toggle-unclassified-failures-EVT",
 
-            selectNextUnclassifiedFailure: "next-unclassified-failure-EVT",
-
-            selectPreviousUnclassifiedFailure: "previous-unclassified-failure-EVT",
-
             changeSelection: "next-previous-job-EVT",
 
             addRelatedBug: "add-related-bug-EVT",

--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -135,3 +135,13 @@ treeherder.value("phTimeRanges", [
       { "value":2592000, "text": "Last 30 days" },
       { "value":5184000, "text": "Last 60 days" },
       { "value":7776000, "text": "Last 90 days" } ]);
+
+treeherder.value("thJobNavSelectors",
+    {
+        ALL_JOBS: ".th-view-content .job-btn",
+        UNCLASSIFIED_FAILURES: ".selected-job, " +
+                               ".th-view-content .job-btn.btn-red, " +
+                               ".th-view-content .job-btn.btn-orange, " +
+                               ".th-view-content .job-btn.btn-purple"
+    }
+);


### PR DESCRIPTION
This addresses the Treeherder portion of [Bug 1164545](https://bugzilla.mozilla.org/show_bug.cgi?id=1164545)

A contributor added a feature to move to the next/previous job with the arrows.  This change modifies it slightly so it also works with unclassified failures.  That way we can remove a TON of complex code that was used for that purpose.

This way we are not relying on the ``jobMap``, we are only relying on the CSS.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/577)
<!-- Reviewable:end -->
