### PR TITLE
Bug 1144804 - Vagrant: Update base image from Ubuntu 12.04 to 14.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,8 +10,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "precise32"
-  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+  config.vm.box = "ubuntu/trusty32"
 
   config.vm.hostname = "local.treeherder.mozilla.org"
   config.vm.network "private_network", ip: "192.168.33.10"

--- a/puppet/files/apache/treeherder.conf
+++ b/puppet/files/apache/treeherder.conf
@@ -4,10 +4,14 @@
 
 <VirtualHost *:8080>
   ServerName <%= @APP_URL %>
+
+  <Directory "/home/<%= @APP_USER %>/treeherder/<%= @APP_UI %>/">
+    Require all granted
+  </Directory>
+
   ProxyRequests Off
   <Proxy *>
-    Order deny,allow
-    Allow from all
+    Require all granted
   </Proxy>
 
   ###########

--- a/puppet/manifests/classes/apache.pp
+++ b/puppet/manifests/classes/apache.pp
@@ -34,12 +34,12 @@ class apache {
   file { "${apache_vhost_path}/treeherder.conf":
     content => template("${PROJ_DIR}/puppet/files/apache/treeherder.conf"),
     owner => "root", group => "root", mode => 0644,
-    require => [Package[$apache_devel]],
+    require => Package[$apache_service],
     notify => Service[$apache_service],
   }
 
   exec { "sed -i '/[: ]80$/ s/80/8080/' ${apache_port_definition_file}":
-    require => [Package[$apache_devel]],
+    require => Package[$apache_service],
     before => [
       Service[$apache_service]
     ]
@@ -58,16 +58,16 @@ class apache {
     exec {
       'a2enmod rewrite':
         onlyif => 'test ! -e /etc/apache2/mods-enabled/rewrite.load',
+        require => Package[$apache_service],
         before => Service[$apache_service];
       'a2enmod proxy':
         onlyif => 'test ! -e /etc/apache2/mods-enabled/proxy.load',
+        require => Package[$apache_service],
         before => Service[$apache_service];
       'a2enmod proxy_http':
         onlyif => 'test ! -e /etc/apache2/mods-enabled/proxy_http.load',
+        require => Package[$apache_service],
         before => Service[$apache_service];
     }
-
-
-
   }
 }

--- a/puppet/manifests/classes/init.pp
+++ b/puppet/manifests/classes/init.pp
@@ -9,25 +9,13 @@ class init {
     }
 
     if $operatingsystem == 'Ubuntu'{
-      exec { "update_apt":
-          command => "sudo apt-get update"
-      }
-
-      # Required for add-apt-repository
-      package { python-software-properties:
-          ensure => installed,
-          require => Exec["update_apt"],
-      }
-
-      # Ubuntu 12.04's newest Python is v2.7.3, so we have to use a third party PPA:
+      # Ubuntu 14.04's newest Python is v2.7.6, so we have to use a third party PPA:
       # https://launchpad.net/~fkrull/+archive/ubuntu/deadsnakes-python2.7
       exec { "add_python27_ppa":
           command => "sudo add-apt-repository ppa:fkrull/deadsnakes-python2.7",
-          require => Package['python-software-properties'],
       }
 
-      # Need to update again to pick up the new Python 2.7.9 packages from the PPA
-      exec { "update_apt_for_ppa":
+      exec { "update_apt":
           command => "sudo apt-get update",
           require => Exec["add_python27_ppa"],
       }

--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -26,7 +26,6 @@ class python {
   package{["python2.7",
            $python_devel,
            "gcc",
-           "curl",
            "git",
            $libxml2]:
     ensure => "latest",
@@ -38,7 +37,6 @@ class python {
     command => "curl https://bootstrap.pypa.io/get-pip.py | sudo python -",
     creates => "/usr/local/bin/pip",
     require => [
-      Package[curl],
       Package[$python_devel],
     ],
   }

--- a/puppet/manifests/classes/treeherder.pp
+++ b/puppet/manifests/classes/treeherder.pp
@@ -4,10 +4,6 @@
 
 #any additional stuff goes here
 class treeherder {
-    package{"make":
-        ensure => "installed"
-    }
-
     package{"memcached":
         ensure => "installed"
     }

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -28,11 +28,8 @@ $RABBITMQ_USER = 'guest'
 $RABBITMQ_PASSWORD = 'guest'
 $RABBITMQ_VHOST = '/'
 
-# We need to force output on_failure, since we're using Puppet 2.x which
-# does not have the fix for https://projects.puppetlabs.com/issues/10907
 Exec {
     path => "/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin",
-    logoutput => on_failure,
 }
 
 line {"etc-hosts":


### PR DESCRIPTION
* Fix race conditions with apache setup steps
* Update base image from Ubuntu 12.04 to 14.04 
* Make treeherder apache config compatible with apache 2.4 (which is now the default in 14.04)
* Clean up unnecessary installation of packages that ship with Ubuntu 14.04 by default.
* Remove workaround for older versions of puppet (since 14.04 comes with puppet 3.4.3)

(See individual commit messages for more detail)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/584)
<!-- Reviewable:end -->
