### PR TITLE
Bug 1169915 - Make flake8 check .pyx files too

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 [pep8]
+filename = *.py,*.pyx
 exclude = .git,__pycache__,.vagrant,bin/peep.py,build,node_modules
 # E121,E123,E126,E226,E24,E704: Ignored in default pep8 config:
 # https://github.com/jcrocholl/pep8/blob/8ca030e2d8f6d377631bae69a18307fb2d051049/pep8.py#L68
@@ -15,6 +16,7 @@ max-line-length = 140
 # flake8 is a combination of pyflakes & pep8.
 # Unfortunately we have to mostly duplicate the above, since some tools use
 # pep8's config (eg autopep8) so we can't just define everything under [flake8].
+filename = *.py,*.pyx
 exclude = .git,__pycache__,.vagrant,bin/peep.py,build,node_modules
 # The ignore list for pep8 above, plus our own PyFlakes addition:
 # F403: 'from module import *' used; unable to detect undefined names

--- a/treeherder/log_parser/artifactbuildercollection.pyx
+++ b/treeherder/log_parser/artifactbuildercollection.pyx
@@ -122,7 +122,7 @@ BuildbotPerformanceDataArtifactBuilder
             # interesting write-up here:
             # http://www.enricozini.org/2011/cazzeggio/python-gzip/
 
-            GZIP_WINDOW_SIZE = 16 + zlib.MAX_WBITS # zlib window size for gzip
+            GZIP_WINDOW_SIZE = 16 + zlib.MAX_WBITS  # zlib window size for gzip
             zipobj = zlib.decompressobj(GZIP_WINDOW_SIZE)
             with closing(io.BytesIO()) as f:
                 readpos = 0

--- a/treeherder/log_parser/artifactbuilders.pyx
+++ b/treeherder/log_parser/artifactbuilders.pyx
@@ -16,6 +16,7 @@ from .parsers import (TinderboxPrintParser,
 
 logger = logging.getLogger(__name__)
 
+
 class ArtifactBuilderBase(object):
     """
     Base class for all Buildbot log parsers.
@@ -96,6 +97,7 @@ class BuildbotLogViewArtifactBuilder(ArtifactBuilderBase):
         ]
         self.name = "text_log_summary"
 
+
 class BuildbotPerformanceDataArtifactBuilder(ArtifactBuilderBase):
     """Makes the artifact for performance data."""
 
@@ -106,6 +108,7 @@ class BuildbotPerformanceDataArtifactBuilder(ArtifactBuilderBase):
             TalosParser()
         ]
         self.name = "talos_data"
+
 
 class MozlogArtifactBuilder(ArtifactBuilderBase):
     """Extracts a summary artifact from a Mozlog log"""
@@ -123,13 +126,12 @@ class MozlogArtifactBuilder(ArtifactBuilderBase):
         def is_fault(self, message):
             try:
                 return any(["level" in message and
-                    message["level"] in ("ERROR", "WARNING", "CRITICAL"),
-                    "expected" in message,
-                    message["action"] == "crash"])
+                            message["level"] in ("ERROR", "WARNING", "CRITICAL"),
+                            "expected" in message,
+                            message["action"] == "crash"])
             except:
                 logger.warning("SummaryHandler line exception {0}".format(message))
                 return False
-
 
         def __call__(self, data):
             self.serial += 1
@@ -149,7 +151,6 @@ class MozlogArtifactBuilder(ArtifactBuilderBase):
                url,
                timeout=settings.TREEHERDER_REQUESTS_TIMEOUT
         ).content))
-
 
     def parse_log(self):
         """

--- a/treeherder/log_parser/parsers.pyx
+++ b/treeherder/log_parser/parsers.pyx
@@ -170,7 +170,7 @@ class StepParser(ParserBase):
         """Convert a string date into a datetime."""
         # DATE_FORMAT expects a decimal on the seconds.  If it's not
         # present, we must add it so the date parsing does not fail.
-        if not "." in match:
+        if "." not in match:
             match = "{0}.0".format(match)
         return datetime.datetime.strptime(match, self.DATE_FORMAT)
 


### PR DESCRIPTION
flake8/pep8 default to just checking *.py, but we have Cython .pyx files in treeherder/log_parser/.

Fixes some flake8 warnings in the pyx files so Travis is green when this lands.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/585)
<!-- Reviewable:end -->
