### PR TITLE
Bug 1169943 - Prevent setup.py ImportError on Read the Docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+import os
 from distutils.core import setup
-from Cython.Build import cythonize
+
+# Prevents an ImportError on Read the Docs, since they don't use
+# (or need) the packages in common.txt, which includes Cython.
+if os.environ.get('READTHEDOCS'):
+    ext_modules = []
+else:
+    from Cython.Build import cythonize
+    ext_modules = cythonize("treeherder/log_parser/*.pyx")
 
 setup(
-    ext_modules=cythonize("treeherder/log_parser/*.pyx")
+    name="treeherder",
+    ext_modules=ext_modules
 )


### PR DESCRIPTION
Read the Docs has no need to install the full list of packages in requirements/common.txt, so currently gets an ImportError when trying to import from Cython. This doesn't break the build, but is misleading when it comes to debugging unrelated Read the Docs build issues.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/587)
<!-- Reviewable:end -->
