### PR TITLE
Bug 1063473 - Make grunt build clean up the .tmp directory

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,10 @@ module.exports = function(grunt) {
 
         pkg: grunt.file.readJSON('package.json'),
 
-        clean: ['dist/'],
+        clean: {
+            dist: ['dist/'],
+            tmp: ['.tmp/']
+        },
 
         htmlangular: {
             options: {
@@ -232,7 +235,7 @@ module.exports = function(grunt) {
 
     // Default tasks
     grunt.registerTask('build', [
-        'clean',
+        'clean:dist',
         'copy:main',
         'copy:img',
         'copy:fonts',
@@ -242,6 +245,7 @@ module.exports = function(grunt) {
         'uglify',
         'usemin',
         'ngtemplates',
-        'cache-busting'
+        'cache-busting',
+        'clean:tmp'
         ]);
 };


### PR DESCRIPTION
grunt-usemin uses ``.tmp/`` as a staging area, however doesn't clean up after itself. As such, let's run an additional grunt-clean step at the end of the build, which removes this temporary staging directory.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/589)
<!-- Reviewable:end -->
