### PR TITLE
Bug 1159375 - Disable Angular's debug data to improve perf

### DIFF
--- a/ui/js/logviewer.js
+++ b/ui/js/logviewer.js
@@ -5,3 +5,8 @@
 'use strict';
 
 var logViewerApp = angular.module('logviewer', ['treeherder']);
+
+logViewerApp.config(function($compileProvider) {
+  // Disable debug data, as recommended by https://docs.angularjs.org/guide/production
+  $compileProvider.debugInfoEnabled(false);
+});

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -4,7 +4,10 @@
 
 "use strict";
 
-perf.config(function($stateProvider, $urlRouterProvider) {
+perf.config(function($compileProvider, $stateProvider, $urlRouterProvider) {
+  // Disable debug data, as recommended by https://docs.angularjs.org/guide/production
+  $compileProvider.debugInfoEnabled(false);
+
   $urlRouterProvider.deferIntercept(); // so we don't reload on url change
 
   $stateProvider.state('graphs', {

--- a/ui/js/treeherder_app.js
+++ b/ui/js/treeherder_app.js
@@ -8,7 +8,9 @@ var treeherderApp = angular.module('treeherder.app',
                                    ['treeherder', 'ui.bootstrap', 'ngRoute',
                                     'mc.resizer']);
 
-treeherderApp.config(function($routeProvider, $httpProvider, $logProvider) {
+treeherderApp.config(function($compileProvider, $routeProvider, $httpProvider, $logProvider) {
+    // Disable debug data, as recommended by https://docs.angularjs.org/guide/production
+    $compileProvider.debugInfoEnabled(false);
 
     // enable or disable debug messages using $log.
     // comment out the next line to enable them


### PR DESCRIPTION
As recommended by:
https://docs.angularjs.org/guide/production
http://blog.thoughtram.io/angularjs/2014/12/22/exploring-angular-1.3-disabling-debug-info.html

The debug data can be repopulated on the fly using:
angular.reloadWithDebugInfo();
...from the console.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/590)
<!-- Reviewable:end -->
