### PR TITLE
Bug 1170172 - RTD Grunt build updates

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -1,15 +1,20 @@
 Deployment
 ==========
 
-Serving the UI build from the distribution directory
-----------------------------------------------------
-To serve the UI from the ``dist`` directory, run:
+Serving the UI build from the dist directory
+--------------------------------------------
+This step required prior to deployment concatenates and minifies the js and css and moves all required assets to a directory in the project root called ``dist``. To do this, if you haven't already done so:
+
+* Install the Grunt wrapper globally by running as root ``npm install -g grunt-cli``
+* Install local dependencies by running as root ``npm install`` from the project root
+* Then run the following command:
 
 .. code-block:: bash
 
-  (venv)vagrant@precise32:~/treeherder$ grunt build
+    grunt build
 
-This will build the UI by concatenating and minifying the js and css and move all required assets to a directory called ``dist`` in the repository root. Then in ``Vagrantfile`` change ``serve_minified_ui`` to true:
+
+Then in ``Vagrantfile`` change ``serve_minified_ui`` to true:
 
 .. code-block:: ruby
 

--- a/docs/ui/installation.rst
+++ b/docs/ui/installation.rst
@@ -1,3 +1,8 @@
+Requirements
+============
+
+* Node.js_
+
 Installation
 ============
 
@@ -8,11 +13,6 @@ Cloning the Repo
 ----------------
 
 * Clone the `treeherder repo`_ from Github.
-
-Requirements
-------------
-
-* Node.js_
 
 Running the web-server
 ----------------------
@@ -41,33 +41,16 @@ If you wish to run the full treeherder Vagrant project (service + UI), remember 
 Running the unit tests
 ======================
 
-The unit tests run with Karma: http://karma-runner.github.io/0.8/config/configuration-file.html
+The unit tests for the UI are run with Karma_. To do this, if you haven't already done so:
 
-Requirements
-------------
+* Install the Karma wrapper globally by running as root ``npm install -g karma-cli``
+* Install local dependencies by running as root ``npm install`` from the project root
+* Then run the following command to execute the tests:
 
-* Node.js_
-
-Execution::
-
-First run ``npm install`` at the root to install local dependencies
-(if you haven't already done so). To avoid a bunch of path mangling,
-you also want to install karma-cli globally (``sudo npm install -g karma-cli``).
-
-Once that's done, you can just run this shell script to execute the tests:
+.. code-block:: bash
 
     ./tests/ui/scripts/test.sh
 
-Build
-=====
-* Install grunt ``sudo npm install grunt-cli -g``
-* Install the ``devDependencies`` in ``package.json`` by running ``npm install`` from the project root
-* Run the following command in the repo root:
-
-Build::
-    grunt build
-
-This will create a ``dist`` directory in the repo root, where concatenated and minified js, css, and application assets can be served from.
-
+.. _Karma: http://karma-runner.github.io/0.8/config/configuration-file.html
 .. _treeherder repo: https://github.com/mozilla/treeherder
 .. _Node.js: http://nodejs.org/download/


### PR DESCRIPTION
This work fixes Bugzilla bug [1170172](https://bugzilla.mozilla.org/show_bug.cgi?id=1170172).

In it we do a bunch of updates for Grunt, specifically:

* centralize the documentation in the 'Development' page (should we move it to Common Tasks?)
* link to it in our main Installation page for vagrant users
* remove the (sort of duplicated) grunt docs for UI-only/web-server.js users (should we link there too?)
* remove the use of `sudo` and just say "As root" for all platforms
* try to use "project root" everywhere, and other wordsmithing

I may still need to tweak a couple of things per Ed's comments in bug [1139998](https://bugzilla.mozilla.org/show_bug.cgi?id=1139998#c0) and build the docs to test the new `development` link locally. After that I'll add a review flag.

Adding @edmorley and @camd for visibility though in advance of that, for feedback.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/593)
<!-- Reviewable:end -->
