### PR TITLE
Bug 1170269 - Docs: Remove unnecessary initial-setup Cython compile step

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,14 +62,6 @@ Setting up Vagrant
 
      (venv)vagrant@precise32:~$ cd treeherder
 
-* Build the log parser Cython files, since they are required for both running the tests and a local Treeherder instance
-
-  .. code-block:: bash
-
-     (venv)vagrant@local:~/treeherder$ ./setup.py build_ext --inplace
-
-  NB: If you change something in the treeherder/log_parser folder, remember to repeat this step, otherwise the changes will not take effect.
-
 * If you just wish to :ref:`run the tests <running-tests>`, you can stop now without performing the remaining steps below.
 
 Setting up a local Treeherder instance


### PR DESCRIPTION
Puppet runs it on provision, so it's not necessary to do so manually.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/596)
<!-- Reviewable:end -->
