### PR TITLE
Bug 1170330 - Update treeherder package.json post repo-merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "treeherder-ui",
-  "description": "The UI portion of Mozilla Treeherder",
+  "name": "treeherder",
+  "description": "Mozilla Treeherder reporting dashboard",
   "repository": {
     "type": "git",
     "url": "https://github.com/mozilla/treeherder.git"


### PR DESCRIPTION
This fixes Bugzilla bug [1170330](https://bugzilla.mozilla.org/show_bug.cgi?id=1170330).

This updates the package descriptors for Treeherder, post repo-merge. I am assuming this is cosmetic only. In the interim I will do some testing with this change.

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/597)
<!-- Reviewable:end -->
