### PR TITLE
Bug 1060322 - Move hardcoded Bugzilla & slave health URLs in the UI to thUrl

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -202,7 +202,7 @@
                     <tr>
                         <th class="small">Machine name</th>
                         <td class="small">
-                            <a target="_blank" href="https://secure.pub.build.mozilla.org/builddata/reports/slave_health/slave.html?name={{ job.machine_name }}">{{ job.machine_name }}</a>
+                            <a target="_blank" href="{{ getSlaveHealthUrl(job.machine_name) }}">{{ job.machine_name }}</a>
                         </td>
                     </tr>
                     <tr ng-repeat="(label, value) in visibleFields"><th>{{label}}</th><td>{{ value }}</td></tr>

--- a/ui/js/filters.js
+++ b/ui/js/filters.js
@@ -47,7 +47,7 @@ treeherder.filter('linkifyBugs', function() {
 
         // Settings
         var bug_title = 'bugzilla.mozilla.org';
-        var bug_url = '<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=$1" ' +
+        var bug_url = '<a href="{{ getBugUrl($1) }}" ' +
             'data-bugid=$1 ' + 'title=' + bug_title + '>$1</a>';
         var pr_title = 'github.com';
         var pr_url = '<a href="https://github.com/mozilla-b2g/gaia/pull/$1" ' +

--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -21,6 +21,12 @@ treeherder.factory('thUrl', [
             },
             getLogViewerUrl: function(job_id) {
                 return "logviewer.html#?job_id=" + job_id + "&repo=" + $rootScope.repoName;
+            },
+            getBugUrl: function(bug_id) {
+                return "https://bugzilla.mozilla.org/show_bug.cgi?id=" + bug_id;
+            },
+            getSlaveHealthUrl: function(machine_name) {
+                return "https://secure.pub.build.mozilla.org/builddata/reports/slave_health/slave.html?name=" + machine_name;
             }
         };
         return thUrl;

--- a/ui/partials/main/thRelatedBugQueued.html
+++ b/ui/partials/main/thRelatedBugQueued.html
@@ -1,7 +1,7 @@
 <span class="btn-group pinboard-related-bugs-btn">
     <a class="btn btn-xs related-bugs-link"
        title="{{::bug.summary}}"
-       href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.id}}"
+       href="{{ getBugUrl(bug.id) }}"
        target="_blank"
        ><em>{{::bug.id}}</em></a>
     <span class="btn btn-ltgray btn-xs pinned-job-close-btn"

--- a/ui/partials/main/thRelatedBugSaved.html
+++ b/ui/partials/main/thRelatedBugSaved.html
@@ -1,6 +1,6 @@
 <span class="btn-group pinboard-related-bugs-btn">
     <a class="btn btn-xs annotations-bug related-bugs-link"
-       href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.bug_id}}"
+       href="{{ getBugUrl(bug.bug_id) }}"
        target="_blank"
        title="View bug {{::bug.bug_id}}"
        ><em>{{::bug.bug_id}}</em></a>

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -439,5 +439,9 @@ treeherder.controller('PluginCtrl', [
 
         // expose the tab service properties on the scope
         $scope.tabService = thTabs;
+
+        //fetch URLs
+        $scope.getBugUrl = thUrl.getBugUrl;
+        $scope.getSlaveHealthUrl = thUrl.getSlaveHealthUrl;
     }
 ]);

--- a/ui/plugins/failure_summary/main.html
+++ b/ui/plugins/failure_summary/main.html
@@ -15,7 +15,7 @@
                        title="add to list of bugs to associate with all pinned jobs">
                       <i class="glyphicon glyphicon-pushpin"></i>
                     </a>
-                    <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.id}}"
+                    <a href="{{ getBugUrl(bug.id) }}"
                        target="_blank">{{::bug.id}}
                         <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search"
                               title="{{::bug.summary}}">{{::bug.summary}}
@@ -40,14 +40,14 @@
                       <i class="glyphicon glyphicon-pushpin"></i>
                     </a>
                     <a ng-if="bug.resolution === ''"
-                       href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.id}}"
+                       href="{{ getBugUrl(bug.id) }}"
                        target="_blank">{{::bug.id}}
                         <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search"
                               title="{{::bug.summary}}">{{::bug.summary}}
                         </span>
                     </a>
                     <a ng-if="bug.resolution !== ''"
-                       href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.id}}"
+                       href="{{ getBugUrl(bug.id) }}"
                        target="_blank"
                        class="deleted">{{::bug.id}}
                         <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search"

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -115,9 +115,8 @@
           class="list-unstyled content-spacer">
         <li ng-if="classifications.length > 0">
           <span th-failure-classification failure-id="classifications[0].failure_classification_id"></span>
-
           <a target="_blank" ng-repeat="bug in bugs"
-             href="https://bugzilla.mozilla.org/show_bug.cgi?id={{bug.bug_id}}"
+             href="{{ getBugUrl(bug.bug_id) }}"
              title="View bug {{bug.bug_id}}"><em> {{bug.bug_id}}</em></a>
         </li>
         <li ng-if="classifications[0].note.length > 0"><em>{{classifications[0].note}}</em></li>
@@ -168,7 +167,7 @@
           <span ng-switch on="job.machine_name">
             <span ng-switch-when='unknown'>{{job.machine_name}}</span>
             <a title="Open buildbot slave health report" target="_blank"
-               href="https://secure.pub.build.mozilla.org/builddata/reports/slave_health/slave.html?name={{job.machine_name}}"
+               href="{{ getSlaveHealthUrl(job.machine_name) }}"
                ng-switch-default>
                {{job.machine_name}}
             </a>

--- a/ui/plugins/similar_jobs/main.html
+++ b/ui/plugins/similar_jobs/main.html
@@ -67,7 +67,7 @@
                         <tr>
                             <th>Machine name</th>
                             <td>
-                                <a target="_blank" href="https://secure.pub.build.mozilla.org/builddata/reports/slave_health/slave.html?name={{ similar_job_selected.machine_name }}">
+                                <a target="_blank" href="{{ getSlaveHealthUrl(similar_job_selected.machine_name) }}">
                                     {{ similar_job_selected.machine_name }}
                                 </a>
                             </td>


### PR DESCRIPTION
Bug 1060322 - Move hardcoded treeherder-ui URLs to a config file
---------------------------------------------------------------------------------------------------------------------------------
Respected all,
                    I have moved only those URLs which have been repeated more than once in a angularJS app..There are a lot of changes( 8 i think) besides two file inclusions.I have tried my best to keep the basic code structure and philosophy intact.However i am a beginner so there can be mistakes..I have tested it locally(but partially) so i suggest the reviewer to kindly check it once.   
                   In case of any suggestions/changes feel free to contact me at <tapesh.mandal@gmail.com>.My IRC nick tapesh and i hang out in #treeherder channel in irc.mozilla.org.

Regards
Tapesh Mandal

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/598)
<!-- Reviewable:end -->
