### PR TITLE
Bug 1169758 - reload repo after author filter + get next N

### DIFF
--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -30,11 +30,13 @@ treeherderApp.controller('JobsCtrl', [
 
                     // since we fetched more resultsets, we need to persist the
                     // resultset state in the URL.
-                    $rootScope.skipNextPageReload = true;
                     var rsArray = ThResultSetStore.getResultSetsArray($scope.repoName);
-                    $location.search('fromchange', _.last(rsArray).revision);
+                    var updatedLastRevision = _.last(rsArray).revision;
+                    if ($location.search().fromchange !== updatedLastRevision) {
+                        $rootScope.skipNextPageReload = true;
+                        $location.search('fromchange', updatedLastRevision);
+                    }
                 });
-
         };
 
         // set to the default repo if one not specified


### PR DESCRIPTION
This just needed a check if any revisions were actually loaded, which would change the ``fromchange`` value.  If that value wasn't going to change, we don't set the ``skipNextPageReload`` bit.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/603)
<!-- Reviewable:end -->
