### PR TITLE
Bug 1170172 - RTD Grunt Build updates - supplemental

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -3,7 +3,7 @@ Deployment
 
 Serving the UI build from the dist directory
 --------------------------------------------
-This step required prior to deployment concatenates and minifies the js and css and moves all required assets to a directory in the project root called ``dist``. To do this, if you haven't already done so:
+This step required prior to deployment concatenates and minifies the js and css and moves all required assets to a directory in the project root called ``dist``. To do this:
 
 * Install the Grunt wrapper globally by running as root ``npm install -g grunt-cli``
 * Install local dependencies by running as root ``npm install`` from the project root

--- a/docs/ui/installation.rst
+++ b/docs/ui/installation.rst
@@ -41,7 +41,7 @@ If you wish to run the full treeherder Vagrant project (service + UI), remember 
 Running the unit tests
 ======================
 
-The unit tests for the UI are run with Karma_. To do this, if you haven't already done so:
+The unit tests for the UI are run with Karma_. To do this:
 
 * Install the Karma wrapper globally by running as root ``npm install -g karma-cli``
 * Install local dependencies by running as root ``npm install`` from the project root


### PR DESCRIPTION
A small tweak to the previously landed https://github.com/mozilla/treeherder/pull/593.

I think the "if you haven't already done so" was kind of implied and not really needed. Simpler and less to read, is better.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/607)
<!-- Reviewable:end -->
