### PR TITLE
Bug 1171625 - Update Troubleshooting RTD

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,34 +1,55 @@
 Troubleshooting
 ===============
 
-Using supervisord for development
----------------------------------
+My log parsing isn't working
+----------------------------
 
-On an ubuntu machine you can install supervisord with
-
-.. code-block:: bash
-
-   >sudo apt-get install supervisor
-
-To start supervisord with an arbitrary configuration, you can type:
+If you encounter job log parsing not working in general, or when selecting a job, you should ``ctrl-c`` to do a warm shutdown of your celery process then:
 
 .. code-block:: bash
 
-   >supervisord -c my_config_file.conf
+    (venv)vagrant@local:~/treeherder$ rm celerybeat-schedule
 
-You can find a supervisord config file inside the deployment/supervisord folder.
-That config file contains a section for each service that you may want to run.
-Feel free to comment one or more of those sections if you don't need that specific service.
-If you just want to access the restful api or the admin for example, comment all those sections but the one
-related to gunicorn.
-You can stop supervisord (and all processes he's taking care of) with ctrl+c.
-Please note that for some reason you may need to manually kill the celery worker when it's under heavy load.
+And then restart your celery worker as normal via:
+
+.. code-block:: bash
+
+    (venv)vagrant@local:~/treeherder$ celery -A treeherder worker -B
+
+Can I use supervisord instead for my services?
+----------------------------------------------
+
+Yes, you can install supervisord in your environment with:
+
+.. code-block:: bash
+
+   (venv)vagrant@local:~/treeherder$ pip install supervisor
+
+And then start the treeherder services in individual shells:
+
+.. code-block:: bash
+
+   (venv)vagrant@local:~/treeherder$ sudo /home/vagrant/venv/bin/supervisord -c deployment/supervisord/admin_node.conf
+
+   (venv)vagrant@local:~/treeherder$ sudo /home/vagrant/venv/bin/supervisord -c deployment/supervisord/etl_node.conf
+
+   (venv)vagrant@local:~/treeherder$ sudo /home/vagrant/venv/bin/supervisord -c deployment/supervisord/worker_node.conf
+
+Each config file contains a section for each service that you may want to run. Feel free to comment one or more of those sections if you don't need that specific service. If you just want to access the restful api or the admin for example, comment all those sections but the one related to gunicorn. You can stop supervisord and all processes it takes care of with ``ctrl+c``. Please note you may need to manually kill the celery worker when it's under heavy load.
 
 Where are my log files?
 -----------------------
 
-You can find the various services log files under
-  * /var/log/celery
-  * /var/log/gunicorn
+You can find the various service log files under:
 
-You may also want to inspect the main treeherder log file ~/treeherder/treeherder.log
+.. code-block:: bash
+
+  (venv)vagrant@local:/var/log/celery/
+
+  (venv)vagrant@local:/var/log/gunicorn/
+
+You may also want to inspect the main treeherder log file in:
+
+.. code-block:: bash
+
+  (venv)vagrant@local:~/treeherder/treeherder/


### PR DESCRIPTION
This fixes Bugzilla bug [1171625](https://bugzilla.mozilla.org/show_bug.cgi?id=1171625).

This adds a new troubleshooting entry for stuck log parsers, and (hopefully) improves the existing content with relevant command path examples, and some minor wordsmithing.

I used @camd's suggested pip install supervisor, which I used successfully, rather than apt-get. I can switch it back if needed. I can't confirm the last `treeherder.log` exists in the listed location. I haven't seen it in my own instance. Everything else matches and is correct when running locally.

Perhaps easiest for review to just *View* the file in Github below :)

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/608)
<!-- Reviewable:end -->
