### PR TITLE
Docs: Further streamlining of initial setup docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -69,10 +69,11 @@ Setting up a local Treeherder instance
 
      (venv)vagrant@local:~/treeherder$ ./manage.py export_project_credentials
 
-* And an entry to your **host** machine's /etc/hosts so that you can point your browser to local.treeherder.mozilla.org to reach it
+* And this line to your **host** machine's /etc/hosts so that you can point your browser to local.treeherder.mozilla.org to reach the VM
 
   .. code-block:: bash
 
+     # Copy this line verbatim (do not adjust the IP)
      192.168.33.10    local.treeherder.mozilla.org
 
 Viewing the local server

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -90,13 +90,11 @@ Setting up a local Treeherder instance
 Viewing the local server
 ------------------------
 
-* Start a gunicorn instance listening on port 8000
+* Start a gunicorn instance, to serve API requests:
 
   .. code-block:: bash
 
      (venv)vagrant@local:~/treeherder$ ./bin/run_gunicorn
-
-  all the request sent to local.treeherder.mozilla.org will be proxied to it by varnish/apache.
 
 * Or for development you can use the django runserver instead of gunicorn:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -63,18 +63,6 @@ Setting up Vagrant
 Setting up a local Treeherder instance
 --------------------------------------
 
-* Initialize the master database
-
-  .. code-block:: bash
-
-     (venv)vagrant@local:~/treeherder$ ./manage.py init_master_db
-
-* Populate the database with repository data sources
-
-  .. code-block:: bash
-
-     (venv)vagrant@local:~/treeherder$ ./manage.py init_datasources
-
 * Export oauth credentials for all data source projects
 
   .. code-block:: bash

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -100,7 +100,7 @@ Ingestion tasks populate the database with version control push logs, queued/run
 
   .. code-block:: bash
 
-     (venv)vagrant@local:~/treeherder$ celery -A treeherder worker -B
+     (venv)vagrant@local:~/treeherder$ celery -A treeherder worker -B --concurrency 5
 
   The "-B" option tells the celery worker to startup a beat service, so that periodic tasks can be executed.
   You only need one worker with the beat service enabled. Multiple beat services will result in periodic tasks being executed multiple times.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -63,12 +63,6 @@ Setting up Vagrant
 Setting up a local Treeherder instance
 --------------------------------------
 
-* Export oauth credentials for all data source projects
-
-  .. code-block:: bash
-
-     (venv)vagrant@local:~/treeherder$ ./manage.py export_project_credentials
-
 * And this line to your **host** machine's /etc/hosts so that you can point your browser to local.treeherder.mozilla.org to reach the VM
 
   .. code-block:: bash

--- a/puppet/manifests/classes/dev.pp
+++ b/puppet/manifests/classes/dev.pp
@@ -22,4 +22,11 @@ class dev{
     require => Exec["init_master_db"],
     user => "${APP_USER}",
   }
+
+  exec{"export_project_credentials":
+    cwd => "${PROJ_DIR}",
+    command => "bash -c 'source /etc/profile.d/treeherder.sh; ${VENV_DIR}/bin/python manage.py export_project_credentials'",
+    require => Exec["init_datasources"],
+    user => "${APP_USER}",
+  }
 }


### PR DESCRIPTION
* Bug 1172020 - Docs: Remove port 8000 mention on installation docs
* Bug 1172021 - Docs: Remove unnecessary steps from setup instructions
* Bug 1168741 - Docs: Emphasise that the hosts entry must be copied as-is 
* Bug 1172036 - Vagrant: Run export_project_credentials during provision
* Bug 1170827 - Docs: Add |--concurrency| to the example celery command
(See individual commit messages for more details)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/610)
<!-- Reviewable:end -->
