### PR TITLE
Bug 1172052 - handle text_log_summary artifact blobs that are both di…

### DIFF
--- a/tests/webapp/api/test_artifact_api.py
+++ b/tests/webapp/api/test_artifact_api.py
@@ -127,8 +127,6 @@ def test_artifact_create_text_log_summary_and_bug_suggestions(
     submitted.
     """
 
-    credentials = OAuthCredentials.get_credentials(test_project)
-
     with JobsModel(test_project) as jobs_model:
         job = jobs_model.get_job_list(0, 1)[0]
     tls = sample_data.text_log_summary
@@ -144,7 +142,7 @@ def test_artifact_create_text_log_summary_and_bug_suggestions(
     tac.add(client.TreeherderArtifact({
         'type': 'json',
         'name': 'Bug suggestions',
-        'blob': json.dumps(bs_blob),
+        'blob': bs_blob,
         'job_guid': job['job_guid']
     }))
 

--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -344,14 +344,25 @@ class ArtifactsModel(TreeherderModelBase):
         return job_data
 
     @staticmethod
+    def serialize_artifact_json_blobs(artifacts):
+        """
+        Ensure that JSON artifact blobs passed as dicts are converted to JSON
+        """
+        for artifact in artifacts:
+            blob = artifact['blob']
+            if (artifact['type'].lower() == 'json' and
+                    not isinstance(blob, str) and
+                    not isinstance(blob, unicode)):
+                artifact['blob'] = json.dumps(blob)
+
+        return artifacts
+
+    @staticmethod
     def populate_placeholders(artifacts, artifact_placeholders, job_guid):
         for artifact in artifacts:
             name = artifact.get('name')
             artifact_type = artifact.get('type')
-
             blob = artifact.get('blob')
-            if (artifact_type == 'json') and (not isinstance(blob, str)):
-                blob = json.dumps(blob)
 
             if name and artifact_type and blob:
                 artifact_placeholders.append(

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1591,6 +1591,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
 
         text_log_summary = False
         if artifacts:
+            artifacts = ArtifactsModel.serialize_artifact_json_blobs(artifacts)
             # the artifacts in this list could be ones that should have
             # bug suggestions generated for them.  If so, queue them to be
             # scheduled for asynchronous generation.

--- a/treeherder/webapp/api/artifact.py
+++ b/treeherder/webapp/api/artifact.py
@@ -56,7 +56,7 @@ class ArtifactViewSet(viewsets.ViewSet):
 
     @oauth_required
     def create(self, request, project):
-        artifacts = request.DATA
+        artifacts = ArtifactsModel.serialize_artifact_json_blobs(request.DATA)
 
         job_guids = [x['job_guid'] for x in artifacts]
         with JobsModel(project) as jobs_model, ArtifactsModel(project) as artifacts_model:


### PR DESCRIPTION
It is possible (and easy) in the client  to submit an artifact blob as either JSON  or a ``dict`` value.  We could modify the ``add_artifact`` function to handle it, but it's also possible, in the client, to create a ``TreeherderJob`` with a big dict, part of which can be a blob within an artifact.  

It seems easiest (and most resilient) to handle this in the service.  If the artifact is type "json" then we just ensure it's dumped to a JSON string before writing to the DB.  

This PR lets us handle inspection of that artifact in the service BEFORE it's written to the DB, when it could still be either JSON or a ``dict``.  That inspection happens at the time when we decide whether or not to trigger generating a "Bug suggestions" artifact.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/611)
<!-- Reviewable:end -->
