### PR TITLE
Bug 1172039 -  Make the classification deletion icons more prominent

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -501,7 +501,7 @@ th-watched-repo {
     color: #0de00d !important;
 }
 
-.icon-red:hover {
+.hover-warning:hover {
     color: #fa4444 !important;
 }
 
@@ -1086,9 +1086,14 @@ ul.failure-summary-list li .btn-xs {
     padding-right: 16px;
 }
 
-/* Annotations tab classification trash can */
+/* Annotations tab classification deletion container */
 .classifications-pane table tr td:last-child {
-    padding-left: 16px;
+    padding-left: 10px;
+}
+
+.classification-delete-icon {
+  font-size: 11px;
+  color: #bababa;
 }
 
 /* Override bootstrap row highlighting */

--- a/ui/partials/main/thRelatedBugSaved.html
+++ b/ui/partials/main/thRelatedBugSaved.html
@@ -2,8 +2,11 @@
     <a class="btn btn-xs annotations-bug related-bugs-link"
        href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.bug_id}}"
        target="_blank"
+       title="View bug {{::bug.bug_id}}"
        ><em>{{::bug.bug_id}}</em></a>
-    <span class="btn btn-ltgray btn-xs pinned-job-close-btn annotations-bug"
+    <span class="btn classification-delete-icon hover-warning btn-xs
+                 pinned-job-close-btn annotations-bug"
           ng-click="deleteBug(bug)"
-          title="Delete relation to bug {{::bug.bug_id}}"><i class="fa fa-trash-o"></i></span>
+          title="Delete relation to bug {{::bug.bug_id}}">
+      <i class="fa fa-times-circle"></i></span>
 </span>

--- a/ui/plugins/annotations/main.html
+++ b/ui/plugins/annotations/main.html
@@ -20,9 +20,9 @@
                     </td>
                     <td>
                         <span ng-click="deleteClassification(classification)"
-                              class="btn-ltgray click-able-icon"
+                              class="classification-delete-icon hover-warning click-able-icon"
                               title="Delete this classification">
-                            <i class="fa fa-trash-o"></i>
+                            <i class="fa fa-times-circle"></i>
                         </span>
                     </td>
                 </tr>

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -80,7 +80,7 @@
           </li>
           <li ng-show="canCancel()">
             <a title="Cancel this job"
-               class="icon-red"
+               class="hover-warning"
                href="" prevent-default-on-left-click
                target="_blank"
                ng-click="cancelJob()">
@@ -114,7 +114,7 @@
 
           <a target="_blank" ng-repeat="bug in bugs"
              href="https://bugzilla.mozilla.org/show_bug.cgi?id={{bug.bug_id}}"
-             title="Bug {{bug.bug_id}}"><em> {{bug.bug_id}}</em></a>
+             title="View bug {{bug.bug_id}}"><em> {{bug.bug_id}}</em></a>
         </li>
         <li ng-if="classifications[0].note.length > 0"><em>{{classifications[0].note}}</em></li>
         <li class="revision-comment">


### PR DESCRIPTION
This fixes Bugzilla bug [1172039](https://bugzilla.mozilla.org/show_bug.cgi?id=1172039).

This makes the Annotation tab deletion icons more prominent, specifically:

* moving the classification deletion icon a bit closer to its adjacent column
* converting to fa-times-circle, analogue to a pinboard queued bug which uses fa-times
* darker grey for visibility, and red hover, like other 'destructive' actions like cancel job

Here's the before:
![current](https://cloud.githubusercontent.com/assets/3660661/8011948/6322efe4-0b8b-11e5-8ea0-73db01b4b45b.jpg)

Here's after:
![deletetimescircle](https://cloud.githubusercontent.com/assets/3660661/8011950/6e30f138-0b8b-11e5-8cd0-e62854c434e8.jpg)

And on hover (sans tooltip in this screen grab):
![deletetimescirclehover](https://cloud.githubusercontent.com/assets/3660661/8011965/8f651cb2-0b8b-11e5-9e81-6608c99cd2dd.jpg)

I added a bug link tooltip while I was there, and tweaked its equivalent in the job details panel for consistency.

Tested on OSX 10.10.3:
FF Nightly **41.0a1 (2015-06-04)**
Chrome Latest Release **43.0.2357.81 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/612)
<!-- Reviewable:end -->
