### PR TITLE
Bug 1169340 - Supplemental linting to use correct js indentation

### DIFF
--- a/ui/js/compareperf.js
+++ b/ui/js/compareperf.js
@@ -22,18 +22,20 @@ perf.controller('CompareChooserCtrl', [
         });
 
         ThResultSetModel.getResultSetsFromRevision($scope.newProject.name, $scope.newRevision).then(
-              function(resultSets) {
-               $scope.newRevisionError = undefined;
-               if($scope.originalRevisionError == undefined && $scope.newRevisionError == undefined) {
+            function (resultSets) {
+                $scope.newRevisionError = undefined;
+                if ($scope.originalRevisionError === undefined && $scope.newRevisionError === undefined) {
                 $state.go('compare', {
-                originalProject: $scope.originalProject.name,
-                originalRevision: $scope.originalRevision,
-                newProject: $scope.newProject.name,
-                newRevision: $scope.newRevision });
+                        originalProject: $scope.originalProject.name,
+                        originalRevision: $scope.originalRevision,
+                        newProject: $scope.newProject.name,
+                        newRevision: $scope.newRevision
+                    });
                 }
-        }, function(error) {
-                $scope.newRevisionError = error;
-        });
+            }, function (error) {
+                    $scope.newRevisionError = error;
+            }
+        );
       };
     });
   }]);

--- a/ui/partials/perf/comparechooserctrl.html
+++ b/ui/partials/perf/comparechooserctrl.html
@@ -11,7 +11,7 @@
           <select id="original-project-selector" class="form-control" ng-model="originalProject" ng-options="project.name for project in projects"/>
           <label for="original-revision-input">Revision</label>
           <div class="form-group has-error">
-            <input id="original-revision-input" maxlength="12" class="form-control" ng-model="originalRevision">
+            <input id="original-revision-input" maxlength="12" class="form-control" ng-model="originalRevision"/>
             <br/>
           </div>
            <label class="control-label" style="color:#A94442" ng-show="originalRevisionError">{{originalRevisionError}}"</label>
@@ -24,8 +24,8 @@
           <select id="new-project-selector" class="form-control" ng-model="newProject" ng-options="project.name for project in projects"/>
           <label for="new-revision-input">Revision</label>
             <div class="form-group has-error">
-            <input id="new-revision-input" maxlength="12" class="form-control" ng-model="newRevision">
-            <br/>
+              <input id="new-revision-input" maxlength="12" class="form-control" ng-model="newRevision"/>
+              <br/>
             </div>
             <label class="control-label" style="color:#A94442" ng-show="newRevisionError">{{newRevisionError}}"</label>
         </div>


### PR DESCRIPTION
I fix some code style problem for bug-1169340 which has been merged. Follow French's advice, I use JSLint to find my style issue. But I found it's a little different from original code style of this file(like }); looks like code style mistake in JSLint). So, please tell me if you found some places I should improve, thank you:)
@tojonmz

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/614)
<!-- Reviewable:end -->
