### PR TITLE
Bug 1083725 - Add a clear button to the filter search box

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -218,9 +218,29 @@ th-watched-repo {
     transition: width 0.2s;
 }
 
+#platform-job-text-search-field-parent {
+    position: relative;
+}
+
 #platform-job-text-search-field:focus,
 #platform-job-text-search-field:valid {
     width: 300px !important;
+    padding-right: 20px;
+}
+
+#platform-job-text-search-field:valid + #filter-clear-button {
+    display: inherit;
+}
+
+#filter-clear-button {
+    color: #bababa;
+    font-size: 13px;
+    cursor: pointer;
+    position: absolute;
+    display: none;
+    top: 7px;
+    right: 5px;
+    height: 16px;
 }
 
 .th-content {

--- a/ui/help.html
+++ b/ui/help.html
@@ -140,6 +140,12 @@
                         </span><span class="kbd">u</span></td>
                       <td>Clear the pinboard</td>
                     </tr>
+                    <td>Save pinboard classification and related bugs</td></tr>
+                    <tr>
+                      <td><span class="kbd">ctrl</span><span class="kbd">shift
+                        </span><span class="kbd">f</span></td>
+                      <td>Clear the filter for platforms and jobs</td>
+                    </tr>
                     <tr><td class="kbd">i</td>
                     <td>Toggle in-progress (running/pending) jobs</td></tr>
                     <tr><td class="kbd">u</td>

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -205,6 +205,14 @@ treeherderApp.controller('MainCtrl', [
                 $('#platform-job-text-search-field').focus();
             });
 
+            // Shortcut: clear the custom filter field
+            Mousetrap.bind('ctrl+shift+f', function(ev) {
+                // Prevent shortcut key overflow during focus
+                ev.preventDefault();
+
+                $scope.$evalAsync($scope.clearFilterBox());
+            });
+
             // Shortcut: escape closes any open panels and clears selected job
             Mousetrap.bind('escape', function() {
                 $scope.$evalAsync($scope.setFilterPanelShowing(false));
@@ -348,6 +356,10 @@ treeherderApp.controller('MainCtrl', [
             $location.search({"repo": repo_name});
         };
 
+        $scope.clearFilterBox = function() {
+            thJobFilters.removeSearchStrFilter();
+            $('#platform-job-text-search-field').focus();
+        }
 
         $scope.isFilterPanelShowing = false;
         $scope.setFilterPanelShowing = function(tf) {

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -357,7 +357,8 @@ treeherderApp.controller('MainCtrl', [
         };
 
         $scope.clearFilterBox = function() {
-            thJobFilters.removeSearchStrFilter();
+            thJobFilters.removeFilter("searchStr");
+            $("#platform-job-text-search-field").val("");
             $('#platform-job-text-search-field').focus();
         };
 

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -359,7 +359,7 @@ treeherderApp.controller('MainCtrl', [
         $scope.clearFilterBox = function() {
             thJobFilters.removeSearchStrFilter();
             $('#platform-job-text-search-field').focus();
-        }
+        };
 
         $scope.isFilterPanelShowing = false;
         $scope.setFilterPanelShowing = function(tf) {

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -300,6 +300,12 @@ treeherder.factory('thJobFilters', [
         $location.search(locationSearch);
     };
 
+    var removeSearchStrFilter = function() {
+        var locationSearch = $location.search();
+        _stripSearchStrFilters(locationSearch);
+        $location.search(locationSearch);
+    }
+
     /**
      * reset the non-field (checkbox in the ui) filters to the default state
      * so the user sees everything.  Doesn't affect the field filters.  This
@@ -447,6 +453,20 @@ treeherder.factory('thJobFilters', [
         return locationSearch;
     };
 
+    /**
+     * Same as _stripFieldFilters, but only removes the filter-searchStr
+     * filter from the passed-in locationSearch without
+     * actually setting it in the location bar
+     */
+    var _stripSearchStrFilters = function(locationSearch) {
+        _.forEach(locationSearch, function (val, field) {
+            if (field == "filter-searchStr") {
+                delete locationSearch[field];
+            }
+        });
+        return locationSearch;
+    };
+
     var _isFieldFilter = function(field) {
         return _startsWith(field, PREFIX) &&
                !_.contains(['resultStatus', 'classifiedState'], _withoutPrefix(field));
@@ -552,6 +572,7 @@ treeherder.factory('thJobFilters', [
         removeFilter: removeFilter,
         replaceFilter: replaceFilter,
         removeAllFieldFilters: removeAllFieldFilters,
+        removeSearchStrFilter: removeSearchStrFilter,
         resetNonFieldFilters: resetNonFieldFilters,
         toggleFilters: toggleFilters,
         toggleInProgress: toggleInProgress,

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -274,17 +274,19 @@ treeherder.factory('thJobFilters', [
     };
 
     var removeFilter = function(field, value) {
-        var oldQsVal = _getFiltersOrDefaults(field);
         // default to just removing the param completely
         var newQsVal = null;
 
-        if (oldQsVal && oldQsVal.length) {
-            newQsVal = _.without(oldQsVal, value);
+        if (value) {
+            var oldQsVal = _getFiltersOrDefaults(field);
+            if (oldQsVal && oldQsVal.length) {
+                newQsVal = _.without(oldQsVal, value);
+            }
+            if (!newQsVal || !newQsVal.length || _matchesDefaults(field, newQsVal)) {
+                newQsVal = null;
+            }
+            $log.debug("remove set " + _withPrefix(field) + " from " + oldQsVal + " to " + newQsVal);
         }
-        if (!newQsVal || !newQsVal.length || _matchesDefaults(field, newQsVal)) {
-            newQsVal = null;
-        }
-        $log.debug("remove set " + _withPrefix(field) + " from " + oldQsVal + " to " + newQsVal);
         $location.search(_withPrefix(field), newQsVal);
     };
 
@@ -297,12 +299,6 @@ treeherder.factory('thJobFilters', [
     var removeAllFieldFilters = function() {
         var locationSearch = $location.search();
         _stripFieldFilters(locationSearch);
-        $location.search(locationSearch);
-    };
-
-    var removeSearchStrFilter = function() {
-        var locationSearch = $location.search();
-        _stripSearchStrFilters(locationSearch);
         $location.search(locationSearch);
     };
 
@@ -453,20 +449,6 @@ treeherder.factory('thJobFilters', [
         return locationSearch;
     };
 
-    /**
-     * Same as _stripFieldFilters, but only removes the filter-searchStr
-     * filter from the passed-in locationSearch without
-     * actually setting it in the location bar
-     */
-    var _stripSearchStrFilters = function(locationSearch) {
-        _.forEach(locationSearch, function (val, field) {
-            if (field === _withPrefix("searchStr")) {
-                delete locationSearch[field];
-            }
-        });
-        return locationSearch;
-    };
-
     var _isFieldFilter = function(field) {
         return _startsWith(field, PREFIX) &&
                !_.contains(['resultStatus', 'classifiedState'], _withoutPrefix(field));
@@ -572,7 +554,6 @@ treeherder.factory('thJobFilters', [
         removeFilter: removeFilter,
         replaceFilter: replaceFilter,
         removeAllFieldFilters: removeAllFieldFilters,
-        removeSearchStrFilter: removeSearchStrFilter,
         resetNonFieldFilters: resetNonFieldFilters,
         toggleFilters: toggleFilters,
         toggleInProgress: toggleInProgress,

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -304,7 +304,7 @@ treeherder.factory('thJobFilters', [
         var locationSearch = $location.search();
         _stripSearchStrFilters(locationSearch);
         $location.search(locationSearch);
-    }
+    };
 
     /**
      * reset the non-field (checkbox in the ui) filters to the default state
@@ -460,7 +460,7 @@ treeherder.factory('thJobFilters', [
      */
     var _stripSearchStrFilters = function(locationSearch) {
         _.forEach(locationSearch, function (val, field) {
-            if (field == "filter-searchStr") {
+            if (field === _withPrefix("searchStr")) {
                 delete locationSearch[field];
             }
         });

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -39,12 +39,14 @@
                 </span>
 
                 <!--Search Field-->
-                <span ng-controller="SearchCtrl" class="form-group form-inline">
+                <span ng-controller="SearchCtrl" class="form-group form-inline" id="platform-job-text-search-field-parent">
                     <input id="platform-job-text-search-field"
                            ng-model="searchQueryStr" ng-keydown="search($event)" type="text"
                            class="form-control input-sm" required
                            placeholder="Filter platforms & jobs"
                            blur-this>
+                    <span id="filter-clear-button" class="fa fa-times-circle" 
+                          ng-click="clearFilterBox()" title="Clear this filter"></span>
                 </span>
             </form>
         </span>


### PR DESCRIPTION
This adds a button to the filter search box that when clicked clears the value of the filter box.
I'm trying to get it to apply the change automatically (so that all of the currently filtered jobs become visible when the value changes to blank) but am having trouble calling or simulating the correct event to apply it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/617)
<!-- Reviewable:end -->
