### PR TITLE
Bug 1057341 - The log viewer overview should display properties from the job

### DIFF
--- a/ui/css/logviewer.css
+++ b/ui/css/logviewer.css
@@ -152,7 +152,7 @@ body {
 .lv-log-msg-step {
     padding: 2px 5px;
     background: #fff;
-    border: solid #f0ad4e;
+    border-style: solid;
     border-width: 4px 2px 2px;
     border-radius: 2px;
 }

--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -1132,14 +1132,38 @@ ul.failure-summary-list li .btn-xs {
     width: 11.25em;
 }
 
-.result-status-shading-success {background-color: rgba(2, 131, 44, 0.24);}
-.result-status-shading-testfailed {background-color: rgba(221, 102, 2, 0.25);}
-.result-status-shading-busted {background-color: rgba(144, 0, 0, 0.25);}
-.result-status-shading-exception {background-color: rgba(61, 2, 85, 0.25);}
-.result-status-shading-retry {background-color: rgba(38, 63, 195, 0.25);}
-.result-status-shading-usercancel {background-color: rgba(250, 115, 172, 0.25);}
-.result-status-shading-pending {background-color: rgba(160, 160, 160, 0.2);}
-.result-status-shading-running {background-color: rgba(70, 70, 70, 0.25);}
+.result-status-shading-success {
+    background-color: rgba(2, 131, 44, 0.24);
+    border-color: rgba(2, 131, 44, 0.24);
+}
+.result-status-shading-testfailed {
+    background-color: rgba(221, 102, 2, 0.25);
+    border-color: rgba(221, 102, 2, 0.25);
+ }
+.result-status-shading-busted {
+    background-color: rgba(144, 0, 0, 0.25);
+    border-color: rgba(144, 0, 0, 0.25);
+ }
+.result-status-shading-exception {
+    background-color: rgba(61, 2, 85, 0.25);
+    border-color: rgba(61, 2, 85, 0.25);
+ }
+.result-status-shading-retry {
+    background-color: rgba(38, 63, 195, 0.25);
+    border-color: rgba(38, 63, 195, 0.25);
+}
+.result-status-shading-usercancel {
+    background-color: rgba(250, 115, 172, 0.25);
+    border-color: rgba(250, 115, 172, 0.25);
+}
+.result-status-shading-pending {
+    background-color: rgba(160, 160, 160, 0.2);
+    border-color: rgba(160, 160, 160, 0.2);
+}
+.result-status-shading-running {
+    background-color: rgba(70, 70, 70, 0.25);
+    border-color: rgba(70, 70, 70, 0.25);
+}
 .result-status-shading-coalesced {background-color: white;}
 
 .click-able-icon, .nav-tabs li {

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -36,7 +36,9 @@ logViewerApp.controller('LogviewerCtrl', [
         $scope.showSuccessful = true;
 
         $scope.$watch('artifact', function () {
-            if (!$scope.artifact) return;
+            if (!$scope.artifact) {
+                return;
+            }
             $scope.showSuccessful = !$scope.hasFailedSteps();
         });
 
@@ -75,7 +77,9 @@ logViewerApp.controller('LogviewerCtrl', [
                 }
 
                 // dont do the call if we already have all the lines
-                if ( range.start === range.end ) return deferred.promise;
+                if (range.start === range.end) {
+                    return deferred.promise;
+                }
 
                 $scope.loading = true;
 
@@ -93,21 +97,27 @@ logViewerApp.controller('LogviewerCtrl', [
                     if (bounds.top) {
                         for (var i = data.length - 1; i >= 0; i--) {
                             // make sure we are inserting at the right place
-                            if ($scope.displayedLogLines[0].index != data[i].index + 1) continue;
+                            if ($scope.displayedLogLines[0].index !== data[i].index + 1) {
+                                continue;
+                            }
                             $scope.displayedLogLines.unshift(data[i]);
                         }
 
                         $timeout(function () {
-                            if (above) removeChunkBelow();
+                            if (above) {
+                                removeChunkBelow();
+                            }
                         }, 100);
                     } else if (bounds.bottom) {
                         var sh = element.scrollHeight;
                         var lines = $scope.displayedLogLines;
 
-                        for (var i = 0; i < data.length; i++) {
+                        for (var j = 0; j < data.length; j++) {
                             // make sure we are inserting at the right place
-                            if (lines[ lines.length - 1 ].index != data[i].index - 1) continue;
-                            $scope.displayedLogLines.push(data[i]);
+                            if (lines[lines.length - 1].index !== data[j].index - 1) {
+                                continue;
+                            }
+                            $scope.displayedLogLines.push(data[j]);
                         }
 
                         $timeout(function () {
@@ -215,7 +225,9 @@ logViewerApp.controller('LogviewerCtrl', [
         }
 
         function drawErrorLines (data) {
-            if (data.length === 0) return;
+            if (data.length === 0) {
+                return;
+            }
 
             var min = data[0].index;
             var max = data[ data.length - 1 ].index;
@@ -224,7 +236,9 @@ logViewerApp.controller('LogviewerCtrl', [
                 step.errors.forEach(function(err) {
                     var line = err.linenumber;
 
-                    if (line < min || line > max) return;
+                    if (line < min || line > max) {
+                        return;
+                    }
 
                     var index = line - min;
                     data[index].hasError = true;

--- a/ui/js/directives/log_viewer_steps.js
+++ b/ui/js/directives/log_viewer_steps.js
@@ -46,7 +46,9 @@ treeherder.directive('lvLogSteps', ['$timeout', '$q', function ($timeout, $q) {
                     return step.result && step.result !== "success";
                 })[0];
 
-                if (!firstError) return;
+                if (!firstError) {
+                    return;
+                }
 
                 // scroll to the first error
                 $timeout(function () {

--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -20,13 +20,13 @@ treeherder.factory('ThJobModel', [
         return Math.round( ( timestampSeconds - (
                 parseInt(this.submit_timestamp) + parseInt(this.pending_eta) +
                 parseInt(this.running_eta) ) )/60 );
-    }
+    };
 
     ThJobModel.prototype.get_typical_eta = function(){
         return Math.round(
             (parseInt(this.pending_eta) + parseInt(this.running_eta) )/60
         );
-    }
+    };
 
     ThJobModel.get_uri = function(repoName){return thUrl.getProjectUrl("/jobs/", repoName);};
 
@@ -44,7 +44,7 @@ treeherder.factory('ThJobModel', [
                 var item_list;
                 var next_pages_jobs = [];
                 // if the number of elements returned equals the page size, fetch the next pages
-                if(fetch_all && (response.data.results.length == response.data.meta.count)){
+                if(fetch_all && (response.data.results.length === response.data.meta.count)) {
                     var current_offset = parseInt(response.data.meta.offset);
                     var page_size = parseInt(response.data.meta.count);
                     var new_options = angular.copy(options);
@@ -68,7 +68,7 @@ treeherder.factory('ThJobModel', [
                 // either a promise or a value
                 return $q.when(next_pages_jobs).then(function(maybe_job_list){
                     return  item_list.concat(maybe_job_list);
-                })
+                });
         });
     };
 

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -114,6 +114,11 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location', '$q'
                 {params: params}
             );
         },
+        getResultSet: function(repoName, pk) {
+            return $http.get(
+                thUrl.getProjectUrl("/resultset/"+pk+"/", repoName)
+            );
+        },
         get: function(uri) {
             return $http.get(thServiceDomain + uri);
         },

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -2,7 +2,7 @@
 <html ng-controller="LogviewerCtrl" ng-init="init()" ng-app="logviewer">
     <head>
         <meta charset="utf-8">
-        <title ng-bind="getLogviewerTitle()">Log viewer</title>
+        <title ng-bind="::logViewerTitle">Log viewer</title>
         <!-- build:css css/logviewer.min.css -->
         <link href="vendor/css/bootstrap.css" rel="stylesheet" media="screen">
         <link href="css/treeherder.css" rel="stylesheet" type="text/css">
@@ -15,15 +15,19 @@
             <div class="col-md-6" >
                 <div class="job-header">
                     <table class="table table-condensed" >
-                        <tr ng-repeat="property in logProperties | orderBy:'label'">
+                        <tr class="{{::resultStatusShading}}">
+                            <th>{{result.label}}</th>
+                            <td class="break-word">{{result.value}}</td>
+                        </tr>
+                        <tr ng-repeat="property in logProperties">
                             <th ng-cloak>{{property.label}}</th>
-                            <td ng-if="property.label == 'revision'" class="break-word">
-                                <a href="{{logRevisionFilterUrl}}"
+                            <td ng-if="property.label == 'Revision'" class="break-word">
+                                <a href="{{::logRevisionFilterUrl}}"
                                    title="Open resultset"
                                    class="repo-link"
                                    ng-cloak>{{property.value}}</a>
                             </td>
-                            <td ng-if="property.label != 'revision'"
+                            <td ng-if="property.label != 'Revision'"
                                 ng-cloak class="break-word">{{property.value}}</td>
                         </tr>
                     </table>
@@ -54,6 +58,7 @@
         <script src="js/treeherder.js"></script>
         <script src="js/logviewer.js"></script>
         <script src="js/providers.js"></script>
+        <script src="js/values.js"></script>
 
         <!-- Directives -->
         <script src="js/directives/log_viewer_infinite_scroll.js"></script>
@@ -66,6 +71,8 @@
 
         <!-- Model services -->
         <script src="js/models/job_artifact.js"></script>
+        <script src="js/models/job.js"></script>
+        <script src="js/models/resultset.js"></script>
         <script src="js/models/log_slice.js"></script>
 
         <!-- Controllers -->

--- a/ui/partials/logviewer/lvLogLines.html
+++ b/ui/partials/logviewer/lvLogLines.html
@@ -1,6 +1,6 @@
 <div class="lv-log-msg"
      ng-if="!loading && !logError && displayedLogLines.length == 0">
-     Click a <span class="lv-log-msg-step">log step</span> above to view
+     Click a <span class="{{::resultStatusShading}} lv-log-msg-step">log step</span> above to view
 </div>
 
 <div class="lv-log-msg lv-log-overlay"

--- a/ui/partials/logviewer/lvLogSteps.html
+++ b/ui/partials/logviewer/lvLogSteps.html
@@ -1,11 +1,9 @@
 <div class="steps-data">
     <div ng-repeat="step in artifact.step_data.steps"
          ng-click="displayLog(step)"
-         ng-class="{'selected': (displayedStep.order === step.order),
-                    'btn-success': (step.result === 'success'),
-                    'btn-warning': (step.result !== 'success')}"
+         ng-class="{'selected': (displayedStep.order === step.order)}"
          ng-if="showSuccessful === true || step.result !== 'success'"
-         class="btn btn-block logviewer-step clearfix"
+         class="btn btn-block logviewer-step clearfix {{::getShadingClass(step.result)}}"
          order="{{step.order}}">
         <span class="pull-left clearfix text-left">
             {{::step.order+1}}. {{::step.name}}

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -157,7 +157,7 @@
             {{jobSearchStr}}</a>
         </li>
         <li class="small">
-          <label>Machine name:</label>
+          <label>Machine:</label>
           <span ng-switch on="job.machine_name">
             <span ng-switch-when='unknown'>{{job.machine_name}}</span>
             <a title="Open buildbot slave health report" target="_blank"


### PR DESCRIPTION
Now getting the header field values directly from the ``jobs`` endpoint, rather than the ``header`` field in the ``text_log_summary`` artifact.  So these are more consistent and accurate.  Also, Task Cluster won't have to fake them anymore.

Also adjusted the coloring to match the job result and the color scheme used for the main Treeherder UI.

Before:
![screenshot 2015-06-12 10 39 55](https://cloud.githubusercontent.com/assets/419924/8135926/7bb51136-10ef-11e5-9682-62a6505e7db5.png)

After:
![screenshot 2015-06-12 12 25 03](https://cloud.githubusercontent.com/assets/419924/8138261/15b3f76c-10fe-11e5-8a01-8f7f7de32fbf.png)


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/624)
<!-- Reviewable:end -->
