### PR TITLE
Bug 1174557 - Parse taskcluster error messages

### DIFF
--- a/treeherder/log_parser/parsers.pyx
+++ b/treeherder/log_parser/parsers.pyx
@@ -315,6 +315,7 @@ RE_ERR_MATCH = re.compile((
     r"|^Output exceeded \d+ bytes"
     r"|^The web-page 'stop build' button was pressed"
     r"|.*\.js: line \d+, col \d+, Error -"
+    r"|^\[taskcluster\] Error:"
 ))
 
 RE_ERR_SEARCH = re.compile((


### PR DESCRIPTION
Goal here is to be able to see taskcluster specific error messages on the Failure Summary tab in TH so sheriffs have better information to go off of.

This should match error lines like:
"[taskcluster] Error: Task timeout after 3600 seconds. Force killing container."

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/627)
<!-- Reviewable:end -->
