### PR TITLE
Bug 1174277 - Add a shortcut to open the Logviewer

### DIFF
--- a/ui/help.html
+++ b/ui/help.html
@@ -149,6 +149,8 @@
                     <td>Toggle in-progress (running/pending) jobs</td></tr>
                     <tr><td class="kbd">u</td>
                     <td>Show only unclassified failures</td></tr>
+                    <tr><td class="kbd">l</td>
+                    <td>Open the logviewer for the selected job</td></tr>
                 </table>
             </div>
             <div class="panel-heading"><h3>Copy values on hover</h3></div>

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -6,13 +6,13 @@
 
 treeherderApp.controller('MainCtrl', [
     '$scope', '$rootScope', '$routeParams', '$location', 'ThLog',
-    'ThRepositoryModel', 'thPinboard',
+    'ThRepositoryModel', 'thPinboard', 'thNotify',
     'thClassificationTypes', 'thEvents', '$interval', '$window',
     'ThExclusionProfileModel', 'thJobFilters', 'ThResultSetStore',
     'thDefaultRepo', 'thJobNavSelectors',
     function MainController(
         $scope, $rootScope, $routeParams, $location, ThLog,
-        ThRepositoryModel, thPinboard,
+        ThRepositoryModel, thPinboard, thNotify,
         thClassificationTypes, thEvents, $interval, $window,
         ThExclusionProfileModel, thJobFilters, ThResultSetStore,
         thDefaultRepo, thJobNavSelectors) {
@@ -51,6 +51,8 @@ treeherderApp.controller('MainCtrl', [
         // Single key shortcuts to allow in ui events (usually inputs)
         var mousetrapExclusions = [
             'i',     // Toggle display in-progress jobs (pending/running)
+            'right', // Select next job
+            'left',  // Select previous job
             'j',     // Select next unclassified failure
             'n',     // Select next unclassified failure
             'k',     // Select previous unclassified failure
@@ -61,8 +63,7 @@ treeherderApp.controller('MainCtrl', [
             'b',     // Pin selected job and add related bug
             'c',     // Pin selected job and add classification
             'f',     // Enter a custom job or platform filter
-            'left',  // Select previous job
-            'right'  // Select next job
+            'l'      // Open the logviewer for the selected job
         ];
 
         // Make the single key exclusions available
@@ -229,6 +230,13 @@ treeherderApp.controller('MainCtrl', [
             // Shortcut: save pinboard classification and related bugs
             Mousetrap.bind('ctrl+enter', function() {
                 $scope.$evalAsync($rootScope.$emit(thEvents.saveClassification));
+            });
+
+            // Shortcut: open the logviewer for the selected job
+            Mousetrap.bind('l', function() {
+                if ($scope.selectedJob) {
+                    $scope.$evalAsync($rootScope.$emit(thEvents.openLogviewer));
+                }
             });
 
         };

--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -229,7 +229,9 @@ treeherder.provider('thEvents', function() {
 
             applyNewJobs: "apply-new-jobs-EVT",
 
-            initSheriffPanel: "init-sheriff-panel-EVT"
+            initSheriffPanel: "init-sheriff-panel-EVT",
+
+            openLogviewer: "open-logviewer-EVT"
         };
     };
 });

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -16,6 +16,7 @@
 
           <li ng-repeat="job_log_url in job_log_urls">
             <a ng-if="job_log_url.parse_status == 'parsed'"
+               id="logviewer-btn"
                title="Open the log viewer in a new window"
                target="_blank"
                href="{{::lvUrl}}"
@@ -25,12 +26,14 @@
                    class="logviewer-icon"><img>
             </a>
             <a ng-if="job_log_url.parse_status == 'failed'"
+               id="logviewer-btn"
                title="Log parsing has failed"
                class="disabled" >
               <img src="./img/logviewerIcon.svg"
                    class="logviewer-icon"><img>
             </a>
             <a ng-if="job_log_url.parse_status == 'pending'"
+               id="logviewer-btn"
                class="disabled"
                title="Log parsing in progress">
               <img src="./img/logviewerIcon.svg"
@@ -39,6 +42,7 @@
           </li>
           <li>
             <a ng-if="!job_log_urls.length"
+               id="logviewer-btn"
                class="disabled"
                title="No logs available for this job">
               <img src="./img/logviewerIcon.svg"


### PR DESCRIPTION
This work fixes Bugzilla bug [1174277](https://bugzilla.mozilla.org/show_bug.cgi?id=1174277).

This adds a shortcut `l` to open the Logviewer on the selected job. A series of screen grabs for the workflow:

Starting with a selected job:
![scstep1](https://cloud.githubusercontent.com/assets/3660661/8185244/1961395e-1411-11e5-8be5-a5c804ea45ac.jpg)

Depress the `l` key and we launch the Logviewer the same as if the user had clicked on the icon:
![scstep2](https://cloud.githubusercontent.com/assets/3660661/8184991/8560362a-140f-11e5-93f9-b73df88ad544.jpg)

I added some notifications in for users who may not notice the Job info panel or icon tooltip when job logs are either unavailable, pending, or failed and they still depress the `l` key.

![notifunavail](https://cloud.githubusercontent.com/assets/3660661/8185042/d1b95b14-140f-11e5-9e93-4a69bebb2deb.jpg)
![notifpending](https://cloud.githubusercontent.com/assets/3660661/8185054/df2135c4-140f-11e5-9449-b05a7da19c44.jpg)
![notiffailed](https://cloud.githubusercontent.com/assets/3660661/8185061/e52dda9e-140f-11e5-9717-c8fc683e6a81.jpg)

Everything seems to be fine on Chrome, Opera, Safari.

Firefox - is the only browser which for better or worse treats a shortcut `.click()` as requiring the user to allow the popup. But once allowed, it's fine. There doesn't seem to be any way of getting around that. `window.open` does the same thing on Firefox.

![firefoxblocker](https://cloud.githubusercontent.com/assets/3660661/8185144/8e997750-1410-11e5-8af0-95a4d22d7db9.jpg)

Tested on OSX 10.10.3:
FF Nightly **41.0a1 (2015-06-15)**
Chrome Latest Release **43.0.2357.124**
Safari **8.0.5 (10600.5.17)**
Opera **30.0.1835.59**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/630)
<!-- Reviewable:end -->
