### PR TITLE
Bug 1056052 - Add new user addition to RTD

### DIFF
--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -120,6 +120,25 @@ To add a new repository, the following steps are needed:
      > sudo /etc/init.d/supervisord restart
 
 
+Add a new full access user
+--------------------------
+
+To add a new user with full staff access to Treeherder's interface, open a python shell in vagrant
+
+  .. code-block:: bash
+
+      (venv)vagrant@local:~/treeherder$ python manage.py shell
+
+Then type:
+
+  .. code-block:: python
+
+      >>> from django.contrib.auth.models import User
+      >>> u = User.objects.get(email="your@email.com")
+      >>> u.is_staff = True
+      >>> u.save()
+
+
 Restarting varnish
 ------------------
 

--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -123,7 +123,19 @@ To add a new repository, the following steps are needed:
 Add a new full access user
 --------------------------
 
-To add a new user with full staff access to Treeherder's interface, open a python shell in vagrant
+To add a new user with full staff access to Treeherder's interface, in vagrant type
+
+  .. code-block:: bash
+
+      (venv)vagrant@local:~/treeherder$ python manage.py createsuperuser
+
+and follow the prompts.
+
+
+Promote an existing user to full access
+---------------------------------------
+
+To promote an existing user to full staff access to Treeherder's interface, open a python shell in vagrant
 
   .. code-block:: bash
 


### PR DESCRIPTION
This fixes Bugzilla bug [1056052](https://bugzilla.mozilla.org/show_bug.cgi?id=1056052).

This adds a section to Common Tasks, describing how to add a new full access user to Treeherder. I used @maurodoglio's steps from IRC this morning.

Adding @maurodoglio and @edmorley for visibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/631)
<!-- Reviewable:end -->
