### PR TITLE
Bug 1175191 - Add a cloak to our new logviewer header label

### DIFF
--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -16,8 +16,8 @@
                 <div class="job-header">
                     <table class="table table-condensed" >
                         <tr class="{{::resultStatusShading}}">
-                            <th>{{result.label}}</th>
-                            <td class="break-word">{{result.value}}</td>
+                            <th ng-cloak>{{result.label}}</th>
+                            <td ng-cloak class="break-word">{{result.value}}</td>
                         </tr>
                         <tr ng-repeat="property in logProperties">
                             <th ng-cloak>{{property.label}}</th>


### PR DESCRIPTION
This fixes Bugzilla bug [1175191](https://bugzilla.mozilla.org/show_bug.cgi?id=1175191).

This prevents the header template from appearing during page load, particularly if the page wasn't previously loaded or cached.

Log viewer mid-load:
![noncloakedload](https://cloud.githubusercontent.com/assets/3660661/8189444/56a6293c-142a-11e5-9332-d37c3b571610.jpg)

Everything seems fine with the change on Nightly and Chrome, and we don't see the above during page load.

We do see a few other bits but those are unrelated to the recent header work.

Tested on OSX 10.10.3:
FF Nightly **41.0a1 (2015-06-15)**
Chrome Latest Release **43.0.2357.124**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/632)
<!-- Reviewable:end -->
