### PR TITLE
Bug 1045606 - make filters more discoverable

### DIFF
--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -162,6 +162,60 @@ th-watched-repo {
    font-size: 14px;
 }
 
+.btn-nav-filter {
+    padding: 7px 2px;
+}
+
+.btn.btn-view-nav.btn-orange-filter-chicklet,
+.btn.btn-view-nav.btn-orange-filter-chicklet:hover {
+    color: #dd6602;
+}
+
+.btn.btn-view-nav.btn-red-filter-chicklet,
+.btn.btn-view-nav.btn-red-filter-chicklet:hover {
+    color: #c03a44;
+}
+
+.btn.btn-view-nav.btn-purple-filter-chicklet,
+.btn.btn-view-nav.btn-purple-filter-chicklet:hover {
+    color: #77438d;
+}
+
+.btn.btn-view-nav.btn-green-filter-chicklet,
+.btn.btn-view-nav.btn-green:hover {
+    color: rgba(2, 130, 51, 0.75);
+}
+
+.btn.btn-view-nav.btn-dkblue-filter-chicklet,
+.btn.btn-view-nav.btn-dkblue-filter-chicklet:hover {
+    color: #3656ff;
+}
+
+.btn.btn-view-nav.btn-pink-filter-chicklet,
+.btn.btn-view-nav.btn-pink-filter-chicklet:hover {
+    color: rgba(250, 115, 172, 0.82);
+}
+
+.btn.btn-view-nav.btn-ltblue-filter-chicklet,
+.btn.btn-view-nav.btn-ltblue-filter-chicklet:hover {
+    color: #81b8ed;
+}
+
+.btn.btn-view-nav.btn-ltgray-filter-chicklet,
+.btn.btn-view-nav.btn-ltgray-filter-chicklet:hover {
+    color: #e0e0e0;
+}
+
+.btn.btn-view-nav.btn-dkgray-filter-chicklet,
+.btn.btn-view-nav.btn-dkgray-filter-chicklet:hover {
+    color: #7c7a7d;
+}
+
+.btn.btn-view-nav.btn-black-filter-chicklet,
+.btn.btn-view-nav.btn-black-filter-chicklet:hover {
+    color: black;
+}
+
 /*
  * Quick Filter
  */

--- a/ui/js/controllers/filters.js
+++ b/ui/js/controllers/filters.js
@@ -24,14 +24,19 @@ treeherderApp.controller('FilterPanelCtrl', [
                 name: "non-failures",
                 resultStatuses: ["success", "retry", "usercancel", "coalesced"]
             },
-            inProgress: {
-                value: "inProgress",
+            "in progress": {
+                value: "in progress",
                 name: "in progress",
                 resultStatuses: ["pending", "running"]
             }
         };
 
         $scope.resultStatusFilters = {};
+        $scope.filterChicklets = _.flatten([
+            "failures",
+            $scope.filterGroups.nonfailures.resultStatuses,
+            "in progress"
+        ]);
 
         // field filters
         $scope.newFieldFilter = null;
@@ -66,6 +71,33 @@ treeherderApp.controller('FilterPanelCtrl', [
             } else {
                 thJobFilters.addFilter(thJobFilters.resultStatus, filter);
             }
+        };
+
+        $scope.isFilterOn = function(filter) {
+            if (_.contains(_.keys($scope.filterGroups), filter)) {
+                // this is a filter grouping, so toggle all on/off
+                return _.some(
+                    _.at($scope.resultStatusFilters,
+                    $scope.filterGroups[filter].resultStatuses)
+                );
+            } else {
+                return $scope.resultStatusFilters[filter];
+            }
+        };
+
+        /**
+         * Handle toggling one of the individual result status filter chicklets
+         * on the nav bar
+         */
+        $scope.toggleResultStatusFilterChicklet = function(filter) {
+            var filterValues;
+            if (_.contains(_.keys($scope.filterGroups), filter)) {
+                // this is a filter grouping, so toggle all on/off
+                filterValues = $scope.filterGroups[filter].resultStatuses;
+            } else {
+                filterValues = [filter];
+            }
+            thJobFilters.toggleResultStatuses(filterValues);
         };
 
         /**

--- a/ui/js/directives/treeherder/top_nav_bar.js
+++ b/ui/js/directives/treeherder/top_nav_bar.js
@@ -182,3 +182,16 @@ treeherder.directive('thExclusionState', function () {
         }
     };
 });
+
+treeherder.directive('thResultStatusChicklet', [
+    'thResultStatusInfo', function (thResultStatusInfo) {
+        return {
+            restrict: "E",
+            link: function(scope, element, attrs) {
+                scope.chickletClass = thResultStatusInfo(scope.filterName).btnClass +
+                    "-filter-chicklet";
+            },
+            templateUrl: 'partials/main/thResultStatusChicklet.html'
+        };
+    }
+]);

--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -63,77 +63,66 @@ treeherder.provider('thResultStatusInfo', function() {
         return function(resultState, failure_classification_id) {
             // default if there is no match, used for pending
             var resultStatusInfo = {
-                severity: 100,
                 btnClass: "btn-default"
             };
 
             switch (resultState) {
                 case "busted":
                     resultStatusInfo = {
-                        severity: 1,
                         btnClass: "btn-red",
                         countText: "busted"
                     };
                     break;
                 case "exception":
                     resultStatusInfo = {
-                        severity: 2,
                         btnClass: "btn-purple",
                         countText: "exception"
                     };
                     break;
                 case "testfailed":
                     resultStatusInfo = {
-                        severity: 3,
                         btnClass: "btn-orange",
                         countText: "failed"
                     };
                     break;
                 case "unknown":
                     resultStatusInfo = {
-                        severity: 4,
                         btnClass: "btn-yellow",
                         countText: "unknown"
                     };
                     break;
                 case "usercancel":
                     resultStatusInfo = {
-                        severity: 5,
                         btnClass: "btn-pink",
                         countText: "cancel"
                     };
                     break;
                 case "retry":
                     resultStatusInfo = {
-                        severity: 6,
                         btnClass: "btn-dkblue",
                         countText: "retry"
                     };
                     break;
                 case "success":
                     resultStatusInfo = {
-                        severity: 7,
                         btnClass: "btn-green",
                         countText: "success"
                     };
                     break;
                 case "running":
                     resultStatusInfo = {
-                        severity: 8,
                         btnClass: "btn-dkgray",
                         countText: "running"
                     };
                     break;
                 case "pending":
                     resultStatusInfo = {
-                        severity: 100,
                         btnClass: "btn-ltgray",
                         countText: "pending"
                     };
                     break;
                 case "coalesced":
                     resultStatusInfo = {
-                        severity: 101,
                         btnClass: "btn-ltblue",
                         countText: "coalesced"
                     };

--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -68,6 +68,7 @@ treeherder.provider('thResultStatusInfo', function() {
 
             switch (resultState) {
                 case "busted":
+                case "failures":
                     resultStatusInfo = {
                         btnClass: "btn-red",
                         countText: "busted"
@@ -110,6 +111,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     };
                     break;
                 case "running":
+                case "in progress":
                     resultStatusInfo = {
                         btnClass: "btn-dkgray",
                         countText: "running"

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -172,8 +172,8 @@ treeherder.factory('thJobFilters', [
             var filters = _.clone($location.search()[_withPrefix(field)]);
             if (filters) {
                 return _toArray(filters);
-            } else if (DEFAULTS.hasOwnProperty(field)) {
-                return DEFAULTS[field].values.slice();
+            } else if (DEFAULTS.hasOwnProperty(_withoutPrefix(field))) {
+                return DEFAULTS[_withoutPrefix(field)].values.slice();
             }
             return [];
         };
@@ -330,12 +330,15 @@ treeherder.factory('thJobFilters', [
         };
 
         var toggleInProgress = function() {
-            var rsValues = _toArray($location.search()[QS_RESULT_STATUS]);
-            var pendRun = ['pending', 'running'];
-            if (_.difference(pendRun, rsValues).length === 0) {
-                rsValues = _.without(rsValues, 'pending', 'running');
+            toggleResultStatuses(['pending', 'running']);
+        };
+
+        var toggleResultStatuses = function(resultStatuses) {
+            var rsValues = _getFiltersOrDefaults(RESULT_STATUS);
+            if (_.difference(resultStatuses, rsValues).length === 0) {
+                rsValues = _.difference(rsValues, resultStatuses);
             } else {
-                rsValues = _.uniq(_.flatten(rsValues, pendRun));
+                rsValues = _.uniq(rsValues.concat(resultStatuses));
             }
             $location.search(QS_RESULT_STATUS, rsValues);
         };
@@ -555,6 +558,7 @@ treeherder.factory('thJobFilters', [
             removeAllFieldFilters: removeAllFieldFilters,
             resetNonFieldFilters: resetNonFieldFilters,
             toggleFilters: toggleFilters,
+            toggleResultStatuses: toggleResultStatuses,
             toggleInProgress: toggleInProgress,
             toggleUnclassifiedFailures: toggleUnclassifiedFailures,
             toggleTier1Only: toggleTier1Only,

--- a/ui/partials/main/thFilterChicklets.html
+++ b/ui/partials/main/thFilterChicklets.html
@@ -1,0 +1,6 @@
+<span id="filterChicklets" ng-controller="FilterPanelCtrl">
+    <!-- result status filters -->
+    <span ng-repeat="filterName in filterChicklets">
+        <th-result-status-chicklet></th-result-status-chicklet>
+    </span>
+</span>

--- a/ui/partials/main/thResultStatusChicklet.html
+++ b/ui/partials/main/thResultStatusChicklet.html
@@ -1,0 +1,5 @@
+<span class="btn btn-view-nav btn-sm btn-nav-filter {{chickletClass}} fa"
+      ng-class="{'fa-dot-circle-o': (isFilterOn(filterName)), 'fa-circle-thin': (!isFilterOn(filterName))}"
+      ng-click="toggleResultStatusFilterChicklet(filterName)"
+      title="{{filterName}}">
+</span>

--- a/ui/partials/main/thShortcutTable.html
+++ b/ui/partials/main/thShortcutTable.html
@@ -54,6 +54,8 @@
         <td>Delete job classification and related bugs</td></tr>
       <tr><td class="kbd">u</td>
         <td>Show only unclassified failures</td></tr>
+      <tr><td class="kbd">i</td>
+        <td>Toggle pending and running jobs</td></tr>
       <tr ng-if="!onscreenShortcutsShowing"><td class="kbd">?</td>
         <td>Display onscreen keyboard shortcuts</td></tr>
     </table>

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -54,6 +54,11 @@
           )</span>
         </span>
 
+        <!--Result Status Filter Chicklets-->
+        <span class="resultStatusChicklets">
+            <ng-include src="'partials/main/thFilterChicklets.html'"></ng-include>
+        </span>
+
         <!--Quick Filter Field-->
         <span ng-controller="SearchCtrl"
               id="quick-filter-parent"


### PR DESCRIPTION
We mentioned this briefly at the work week, so I decided to take a few minutes and dust this branch off and rebase it. 

I removed the "compact mode" on/off stuff and just made it compact.  We can add that in later, if we like.  Seems like that would be good in a separate PR where we compactify/verbosinate lots of things.

This aggregates ``busted``, ``testfailed``, and ``exception`` to one chicklet called "failures".  Also
``pending`` and ``running`` are one chicklet called "in progress".

So here's what it currently looks like:
![screenshot 2015-11-16 09 24 29](https://cloud.githubusercontent.com/assets/419924/11189267/1bd659d4-8c44-11e5-98b0-c8d296bddba6.png)


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/633)
<!-- Reviewable:end -->
