### PR TITLE
Bug 1165356 - switch to ``requests`` for etl processes

### DIFF
--- a/tests/etl/conftest.py
+++ b/tests/etl/conftest.py
@@ -6,10 +6,12 @@ import pytest
 import json
 from webtest.app import TestApp
 from urllib2 import HTTPError
+import urllib
 
 from treeherder.webapp.wsgi import application
 
 from treeherder import client
+from treeherder import etl
 
 
 @pytest.fixture
@@ -37,3 +39,14 @@ def mock_post_json_data(monkeypatch, set_oauth_credentials):
                             jsondata)
 
     monkeypatch.setattr(client.TreeherderClient, "_post_json", _mock_post_json)
+
+
+@pytest.fixture
+def mock_extract(monkeypatch):
+
+    def _mock_extract(thisone, url):
+        opener = urllib.FancyURLopener({})
+        f = opener.open(url)
+        return json.loads(f.read())
+
+    monkeypatch.setattr(etl.mixins.JsonExtractorMixin, "extract", _mock_extract)

--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -102,6 +102,7 @@ def mock_buildapi_builds4h_missing_branch_url(monkeypatch):
 
 
 def test_ingest_pending_jobs(jm, initial_data,
+                             mock_extract,
                              mock_buildapi_pending_url,
                              mock_post_json_data,
                              mock_log_parser,
@@ -123,6 +124,7 @@ def test_ingest_pending_jobs(jm, initial_data,
 
 
 def test_ingest_running_jobs(jm, initial_data,
+                             mock_extract,
                              mock_buildapi_running_url,
                              mock_post_json_data,
                              mock_log_parser,
@@ -144,6 +146,7 @@ def test_ingest_running_jobs(jm, initial_data,
 
 
 def test_ingest_builds4h_jobs(jm, initial_data,
+                              mock_extract,
                               mock_buildapi_builds4h_url,
                               mock_post_json_data,
                               mock_log_parser,
@@ -166,6 +169,7 @@ def test_ingest_builds4h_jobs(jm, initial_data,
 
 
 def test_ingest_running_to_complete_job(jm, initial_data,
+                                        mock_extract,
                                         mock_buildapi_running_url,
                                         mock_buildapi_builds4h_url,
                                         mock_post_json_data,
@@ -214,6 +218,7 @@ def test_ingest_running_to_complete_job(jm, initial_data,
 
 
 def test_ingest_running_job_fields(jm, initial_data,
+                                   mock_extract,
                                    mock_buildapi_running_url,
                                    mock_post_json_data,
                                    mock_log_parser,
@@ -239,7 +244,7 @@ def test_ingest_running_job_fields(jm, initial_data,
 #####################
 
 
-def test_ingest_pending_jobs_1_missing_resultset(jm, initial_data,
+def test_ingest_pending_jobs_1_missing_resultset(jm, initial_data, mock_extract,
                                                  sample_resultset, test_repository, mock_buildapi_pending_missing1_url,
                                                  mock_post_json_data, mock_get_resultset, mock_get_remote_content,
                                                  activate_responses):
@@ -251,7 +256,7 @@ def test_ingest_pending_jobs_1_missing_resultset(jm, initial_data,
     _do_missing_resultset_test(jm, etl_process)
 
 
-def test_ingest_running_jobs_1_missing_resultset(jm, initial_data,
+def test_ingest_running_jobs_1_missing_resultset(jm, initial_data, mock_extract,
                                                  sample_resultset, test_repository, mock_buildapi_running_missing1_url,
                                                  mock_post_json_data, mock_get_resultset, mock_get_remote_content,
                                                  activate_responses):
@@ -263,7 +268,7 @@ def test_ingest_running_jobs_1_missing_resultset(jm, initial_data,
     _do_missing_resultset_test(jm, etl_process)
 
 
-def test_ingest_builds4h_jobs_1_missing_resultset(jm, initial_data,
+def test_ingest_builds4h_jobs_1_missing_resultset(jm, initial_data, mock_extract,
                                                   sample_resultset, test_repository, mock_buildapi_builds4h_missing1_url,
                                                   mock_post_json_data, mock_log_parser, mock_get_resultset,
                                                   mock_get_remote_content):
@@ -275,7 +280,7 @@ def test_ingest_builds4h_jobs_1_missing_resultset(jm, initial_data,
     _do_missing_resultset_test(jm, etl_process)
 
 
-def test_ingest_builds4h_jobs_missing_branch(jm, initial_data,
+def test_ingest_builds4h_jobs_missing_branch(jm, initial_data, mock_extract,
                                              sample_resultset, test_repository, mock_buildapi_builds4h_missing_branch_url,
                                              mock_post_json_data, mock_log_parser, mock_get_resultset,
                                              mock_get_remote_content):

--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -3,7 +3,7 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import hashlib
-import urllib2
+import requests
 import simplejson as json
 import time
 
@@ -57,34 +57,20 @@ class JobData(dict):
         return value
 
 
-def retrieve_api_content(url):
-    req = urllib2.Request(url)
-    req.add_header('Content-Type', 'application/json')
-    conn = urllib2.urlopen(
-        req,
+def get_remote_content(url):
+    """A thin layer of abstraction over requests. """
+    resp = requests.get(
+        url,
+        headers={'Accept': 'application/json', 'Content-Type': 'application/json'},
         timeout=settings.TREEHERDER_REQUESTS_TIMEOUT
     )
-    if conn.getcode() == 404:
-        return None
 
-
-def get_remote_content(url):
-    """A thin layer of abstraction over urllib. """
-    req = urllib2.Request(url)
-    req.add_header('Accept', 'application/json')
-    req.add_header('Content-Type', 'application/json')
-    conn = urllib2.urlopen(
-        req,
-        timeout=settings.TREEHERDER_REQUESTS_TIMEOUT)
-
-    if not conn.getcode() == 200:
+    if not resp.status_code == 200:
         return None
     try:
-        content = json.loads(conn.read())
+        content = resp.json()
     except:
         content = None
-    finally:
-        conn.close()
 
     return content
 


### PR DESCRIPTION
This covers [Bug 1165356](http://bugzil.la/1165356)
Switch to from ``urllib2`` to ``requests`` just for job ingestion.  This does not cover the log parser.  

This also removes a dead function called ``retrieve_api_content`` which was not used anywhere.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/637)
<!-- Reviewable:end -->
