### PR TITLE
Bug 1175334 - improve thresetall alias in vagrant

### DIFF
--- a/puppet/files/treeherder/.bash_aliases
+++ b/puppet/files/treeherder/.bash_aliases
@@ -67,8 +67,21 @@ function thqueuespurge {
 }
 
 function thresetall {
-    thqueuespurge
+    echo "Deleting logs"
     thlogsdelete
+
+    echo "Deleting celerybeat-schedule"
+    if [ -f ~/treeherder/celerybeat-schedule ]
+    then
+        rm ~/treeherder/celerybeat-schedule
+    fi
+
+    echo "Restarting memcache"
     sudo service memcached restart
-    rm ~/treeherder/celerybeat-schedule
+
+    echo "Restarting rabbitmq"
+    sudo service rabbitmq-server restart
+
+    echo "Purging queues"
+    thqueuespurge
 }


### PR DESCRIPTION
delete ``celerybeat-schedule``, restart rabbitmq, and echo what it’s
doing as it goes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/638)
<!-- Reviewable:end -->
