### PR TITLE
Bug 1137370 - add param to jobs endpoint to return only hidden

### DIFF
--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -216,7 +216,8 @@ class JobsModel(TreeherderModelBase):
         return None
 
     def get_job_list(self, offset, limit,
-                     conditions=None, exclusion_profile=None):
+                     conditions=None, exclusion_profile=None,
+                     visibility="included"):
         """
         Retrieve a list of jobs. It's mainly used by the restful api to list
         the jobs. The conditions parameter is a dict containing a set of
@@ -242,7 +243,11 @@ class JobsModel(TreeherderModelBase):
                         name=exclusion_profile
                     )
                 signatures = profile.flat_exclusion[self.project]
-                replace_str += " AND j.signature NOT IN ({0})".format(
+                # NOT here means "not part of the exclusion profile"
+                inclusion = "NOT" if visibility == "included" else ""
+
+                replace_str += " AND j.signature {0} IN ({1})".format(
+                    inclusion,
                     ",".join(["%s"] * len(signatures))
                 )
                 placeholders += signatures

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -69,10 +69,12 @@ class JobsViewSet(viewsets.ViewSet):
         count = min(int(filter.pop("count", 10)), 2000)
         return_type = filter.pop("return_type", "dict").lower()
         exclusion_profile = filter.pop("exclusion_profile", "default")
+        visibility = filter.pop("visibility", "included")
         if exclusion_profile in ('false', 'null'):
             exclusion_profile = None
         results = jm.get_job_list(offset, count, conditions=filter.conditions,
-                                  exclusion_profile=exclusion_profile)
+                                  exclusion_profile=exclusion_profile,
+                                  visibility=visibility)
 
         if results:
             option_collections = jm.refdata_model.get_all_option_collections()


### PR DESCRIPTION
This adds a new param of ``visibility`` on the jobs endpoint

``visibility=included`` (the default) will return only jobs NOT excluded by the ``exclusion_profile``
``visibility=excluded`` returns ONLY jobs excluded by the ``exclusion_profile``

Has no effect if the param ``exclusion_profile=false`` is present.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/645)
<!-- Reviewable:end -->
