### PR TITLE
Bug 1167212 - Update to Celery v3.1.18, Kombu v3.0.26, billiard v3.3.0.20

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -10,11 +10,11 @@ gunicorn==19.3.0
 # sha256: 7sV9MhlQHsbmhWRoJvLrjndoepP-N0p-aZRJBSDbCT4
 Django==1.7.7
 
-# sha256: 6ESYN2-wUkFQQGlrefsPGF48cycpZwEJtPHiMDvmyfU
-celery==3.1.16
+# sha256: 2_WWGNWp7_Fy0lAh82YUvlrwUB5FJ5dcpQS5WGPxT-0
+celery==3.1.18
 
-# sha256: sZX6jrUgwymU2LvRY3AA3j0JZTKy5FGDgy28tlwhHo4
-kombu==3.0.23
+# sha256: _qhlOuS4en6wmWWUCfCeaANqe4PwoVoLxq7629mKUdw
+kombu==3.0.26
 
 # sha256: KjGJ950ce4ohSaDng8C0IX-tmzCm59YEUPJVPcLA5X4
 simplejson==3.6.5
@@ -27,8 +27,8 @@ Cython==0.22
 MySQL-python==1.2.5
 
 # Required by celery
-# sha256: bmuOxuRbiTiQUXN8fmIV2OVag4lutiEvpybKdugMehk
-billiard==3.3.0.19
+# sha256: aI-UZrHDrhQQY4Hm29MoEV51xSYMVC60jmxGkx9pKMw
+billiard==3.3.0.20
 # sha256: VDjXSekjyRR0H-KkELUoq-JwUwAPv4eLxDdCjQiuCrE
 pytz==2014.10
 


### PR DESCRIPTION
Celery 3.1.18 now requires at least Kombu 3.0.25 and billiard 3.3.0.20, so we have to update them at the same time.

http://docs.celeryproject.org/en/latest/changelog.html
https://github.com/celery/celery/compare/v3.1.16...v3.1.18

http://kombu.readthedocs.org/en/latest/changelog.html
https://github.com/celery/kombu/compare/v3.0.23...v3.0.26

https://github.com/celery/billiard/blob/v3.3.0.20/CHANGES.txt
https://github.com/celery/billiard/compare/v3.3.0.19...v3.3.0.20

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/648)
<!-- Reviewable:end -->
