### PR TITLE
Bug 1175870 - Stop adding a "header" property to the text_log_summary

### DIFF
--- a/tests/client/data/artifact_data.json
+++ b/tests/client/data/artifact_data.json
@@ -10,15 +10,6 @@
     },
     {
         "blob": {
-            "header": {
-                "slave": "t-xp32-ix-106",
-                "buildid": "20140307053537",
-                "builder": "try_xp-ix_test-jsreftest",
-                "results": "success (0)",
-                "starttime": "1394205123.64",
-                "builduid": "e1e66d12f0b44c19b1a356131d10469a",
-                "revision": "ecedbb0a251b"
-            },
             "step_data": {
                 "all_errors": [],
                 "steps": [
@@ -195,15 +186,6 @@
     },
     {
         "blob": {
-            "header": {
-                "slave": "talos-linux32-ix-008",
-                "buildid": "20140307064810",
-                "builder": "try_ubuntu32_hw_test-other",
-                "results": "success (0)",
-                "starttime": "1394205502.73",
-                "builduid": "8dccc4db044e4ca0988724d3109dd6cf",
-                "revision": "3125296c850d"
-            },
             "step_data": {
                 "all_errors": [],
                 "steps": [
@@ -380,15 +362,6 @@
     },
     {
         "blob": {
-            "header": {
-                "slave": "tst-linux64-spot-675",
-                "buildid": "20140307064756",
-                "builder": "try_ubuntu64_vm_test-mochitest-2",
-                "results": "success (0)",
-                "starttime": "1394205281.79",
-                "builduid": "8dccc4db044e4ca0988724d3109dd6cf",
-                "revision": "3125296c850d"
-            },
             "step_data": {
                 "all_errors": [],
                 "steps": [
@@ -565,15 +538,6 @@
     },
     {
         "blob": {
-            "header": {
-                "slave": "tst-linux64-spot-835",
-                "buildid": "20140307064756",
-                "builder": "try_ubuntu64_vm_test-crashtest",
-                "results": "success (0)",
-                "starttime": "1394205274.3",
-                "builduid": "8dccc4db044e4ca0988724d3109dd6cf",
-                "revision": "3125296c850d"
-            },
             "step_data": {
                 "all_errors": [],
                 "steps": [
@@ -750,15 +714,6 @@
     },
     {
         "blob": {
-            "header": {
-                "slave": "tst-linux64-spot-008",
-                "buildid": "20140307064756",
-                "builder": "try_ubuntu64_vm_test-mochitest-3",
-                "results": "success (0)",
-                "starttime": "1394205270.41",
-                "builduid": "8dccc4db044e4ca0988724d3109dd6cf",
-                "revision": "3125296c850d"
-            },
             "step_data": {
                 "all_errors": [],
                 "steps": [

--- a/tests/e2e/test_client_job_ingestion.py
+++ b/tests/e2e/test_client_job_ingestion.py
@@ -17,7 +17,6 @@ from treeherder.model import error_summary
 @pytest.fixture
 def text_log_summary_dict():
     return {
-        "header": {},
         "step_data": {
             "all_errors": [
                 {"line": "12:34:13     INFO -  Assertion failure: addr % CellSize == 0, at ../../../js/src/gc/Heap.h:1041", "linenumber": 61918},

--- a/tests/log_parser/test_artifact_builder_collection.py
+++ b/tests/log_parser/test_artifact_builder_collection.py
@@ -44,7 +44,7 @@ def test_check_errors_false():
         check_errors=False
     )
 
-    assert abc.builders[0].parsers[1].check_errors is False
+    assert abc.builders[0].parsers[0].check_errors is False
 
 
 def test_all_builders_complete():
@@ -62,7 +62,6 @@ def test_all_builders_complete():
     lpc.parse()
     exp = {
         "text_log_summary": {
-            "header": {},
             "step_data": {
                 "all_errors": [],
                 "steps": [],

--- a/tests/sample_data/artifacts/structured_log_artifact.json
+++ b/tests/sample_data/artifacts/structured_log_artifact.json
@@ -1,13 +1,4 @@
 {
-  "header": {
-    "slave": "talos-mtnlion-r5-049",
-    "buildid": "20130815111917",
-    "builder": "mozilla-inbound_mountainlion-debug_test-jsreftest",
-    "results": "warnings (1)",
-    "starttime": "1376594840.25",
-    "builduid": "943ad43ba8054f7e84e6c1bbade8ca48",
-    "revision": "eba687b0842e"
-  },
   "step_data": {
     "all_errors": [
       {

--- a/tests/sample_data/artifacts/text_log_summary.json
+++ b/tests/sample_data/artifacts/text_log_summary.json
@@ -1,14 +1,5 @@
 {
     "blob": {
-        "header": {
-            "slave": "t-snow-r4-0001",
-            "buildid": "20150415030206",
-            "builder": "mozilla-central_snowleopard_test-mochitest-2",
-            "results": "warnings (1)",
-            "starttime": "1429100703.17",
-            "builduid": "8ad46455f18545abbdff94ba9dce402e",
-            "revision": "a6f7a33731bc3fe22073129bba83fc7480e387e2"
-        },
         "step_data": {
             "all_errors": [
                 {

--- a/tests/sample_data/logs/crash-1.logview.json
+++ b/tests/sample_data/logs/crash-1.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/crash-2.logview.json
+++ b/tests/sample_data/logs/crash-2.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/crash-mac-1.logview.json
+++ b/tests/sample_data/logs/crash-mac-1.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/crashtest-timeout.logview.json
+++ b/tests/sample_data/logs/crashtest-timeout.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/jsreftest-fail.logview.json
+++ b/tests/sample_data/logs/jsreftest-fail.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/jsreftest-timeout-crash.logview.json
+++ b/tests/sample_data/logs/jsreftest-timeout-crash.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/large-number-of-error-lines.logview.json
+++ b/tests/sample_data/logs/large-number-of-error-lines.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "tst-linux64-spot-1233", 
-        "buildid": "20150122095609", 
-        "builder": "mozilla-inbound_ubuntu64_vm_test-mochitest-e10s-browser-chrome-3", 
-        "results": "failure (2)", 
-        "starttime": "1421951393.3", 
-        "builduid": "77ff0fdd74594b17a144ec98f57aba09", 
-        "revision": "b46d45067c8479f3f91e9c8144128fa8a1be5f72"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/leaks-1.logview.json
+++ b/tests/sample_data/logs/leaks-1.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/mochitest-test-end.logview.json
+++ b/tests/sample_data/logs/mochitest-test-end.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/mozilla-central-win32-pgo-bm85-build1-build111.logview.json
+++ b/tests/sample_data/logs/mozilla-central-win32-pgo-bm85-build1-build111.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "b-2008-ix-0084", 
-        "buildid": "20140629223002", 
-        "builder": "mozilla-central-win32-pgo", 
-        "results": "success (0)", 
-        "starttime": "1404106216.35", 
-        "builduid": "6acfcd5939d0431a9b25983811dc7959", 
-        "revision": "b6408c32a170"
-    }, 
     "step_data": {
         "all_errors": [], 
         "steps": [

--- a/tests/sample_data/logs/mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50.logview.json
+++ b/tests/sample_data/logs/mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-fed-088", 
-        "buildid": "20130605115738", 
-        "builder": "mozilla-central_fedora-b2g_test-crashtest-1", 
-        "results": "success (0)", 
-        "starttime": "1370461197.84", 
-        "builduid": "0356dff218744cf4b6ca832f12ec183f", 
-        "revision": "1658dc513572"
-    }, 
     "step_data": {
         "all_errors": [], 
         "steps": [

--- a/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141.logview.json
+++ b/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-mtnlion-r5-080", 
-        "buildid": "20130605115738", 
-        "builder": "mozilla-central_mountainlion_test-mochitest-2", 
-        "results": "success (0)", 
-        "starttime": "1370462102.79", 
-        "builduid": "48d01a5d6b0c43d593f8d9e9f60857be", 
-        "revision": "1658dc513572"
-    }, 
     "step_data": {
         "all_errors": [], 
         "steps": [

--- a/tests/sample_data/logs/mozilla-central_ubuntu64_hw_test-androidx86-set-4-bm103-tests1-linux-build369.logview.json
+++ b/tests/sample_data/logs/mozilla-central_ubuntu64_hw_test-androidx86-set-4-bm103-tests1-linux-build369.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-linux64-ix-096", 
-        "buildid": "20140717073317", 
-        "builder": "mozilla-central_ubuntu64_hw_test-androidx86-set-4", 
-        "results": "warnings (1)", 
-        "starttime": "1405611918.8", 
-        "builduid": "bc9003254bc748bbb6890c140cca6eba", 
-        "revision": "75db55f6fd2c"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.logview.json
+++ b/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085", 
-        "buildid": "20130605090546", 
-        "builder": "mozilla-esr17_xp_test_pgo-mochitest-browser-chrome", 
-        "results": "warnings (1)", 
-        "starttime": "1370461908.77", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f", 
-        "revision": "e2eecb449eeb"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122.logview.json
+++ b/tests/sample_data/logs/mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "tst-linux64-ec2-428", 
-        "buildid": "20130605113136", 
-        "builder": "mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other", 
-        "results": "warnings (1)", 
-        "starttime": "1370461498.84", 
-        "builduid": "3d82a57013fe406b9740463bad56394e", 
-        "revision": "4d2d0bc38fec"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/multiple-timeouts.logview.json
+++ b/tests/sample_data/logs/multiple-timeouts.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/opt-objc-exception.logview.json
+++ b/tests/sample_data/logs/opt-objc-exception.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/reftest-fail-crash.logview.json
+++ b/tests/sample_data/logs/reftest-fail-crash.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/reftest-jserror.logview.json
+++ b/tests/sample_data/logs/reftest-jserror.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/reftest-opt-fail.logview.json
+++ b/tests/sample_data/logs/reftest-opt-fail.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/reftest-timeout.logview.json
+++ b/tests/sample_data/logs/reftest-timeout.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/tinderbox-exception.logview.json
+++ b/tests/sample_data/logs/tinderbox-exception.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.logview.json
+++ b/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "tst-linux32-ec2-094", 
-        "buildid": "20130605124039", 
-        "builder": "ux_ubuntu32_vm_test-jetpack", 
-        "results": "warnings (1)", 
-        "starttime": "1370462504.72", 
-        "builduid": "929df1a898e14a06a7ad65987f35d4a8", 
-        "revision": "546ccc10a18f"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/xpcshell-crash.logview.json
+++ b/tests/sample_data/logs/xpcshell-crash.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/xpcshell-multiple.logview.json
+++ b/tests/sample_data/logs/xpcshell-multiple.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/tests/sample_data/logs/xpcshell-timeout.logview.json
+++ b/tests/sample_data/logs/xpcshell-timeout.logview.json
@@ -1,13 +1,4 @@
 {
-    "header": {
-        "slave": "talos-r3-xp-085\r", 
-        "buildid": "20130605090546\r", 
-        "builder": "dummy-error-log\r", 
-        "results": "warnings (1)\r", 
-        "starttime": "1370461908.77\r", 
-        "builduid": "11d37c0c73ec4f4aa16b29cbe6481a9f\r", 
-        "revision": "e2eecb449eeb\r"
-    }, 
     "step_data": {
         "all_errors": [
             {

--- a/treeherder/log_parser/artifactbuilders.pyx
+++ b/treeherder/log_parser/artifactbuilders.pyx
@@ -11,8 +11,7 @@ from django.conf import settings
 
 from mozlog.structured import reader
 
-from .parsers import (TinderboxPrintParser,
-                      HeaderParser, StepParser, TalosParser)
+from .parsers import TinderboxPrintParser, StepParser, TalosParser
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +91,6 @@ class BuildbotLogViewArtifactBuilder(ArtifactBuilderBase):
         """Construct artifact builder for the log viewer"""
         super(BuildbotLogViewArtifactBuilder, self).__init__(url)
         self.parsers = [
-            HeaderParser(),
             StepParser(check_errors=check_errors)
         ]
         self.name = "text_log_summary"

--- a/treeherder/log_parser/parsers.pyx
+++ b/treeherder/log_parser/parsers.pyx
@@ -34,42 +34,6 @@ class ParserBase(object):
         return self.artifact
 
 
-RE_HEADER_VALUE = re.compile(r'^(?P<key>[a-z]+): (?P<value>.*)$')
-RE_HEADER_START = re.compile(r"={9} Started (.*)$")
-
-
-class HeaderParser(ParserBase):
-
-    def __init__(self):
-        """Setup the artifact to hold the header lines."""
-        super(HeaderParser, self).__init__("header")
-        # for this parser, we actually want the artifact to be a dict instead
-        # of a list.
-        self.artifact = {}
-
-    def parse_line(self, line, lineno):
-        """
-        Parse out a value in the header
-
-        The header values in the log look like this:
-            builder: mozilla-central_ubuntu32_vm_test-crashtest-ipc
-            slave: tst-linux32-ec2-137
-            starttime: 1368466076.01
-            results: success (0)
-            buildid: 20130513091541
-            builduid: acddb5f7043c4d5b9f66619f9433cab0
-            revision: c80dc6ffe865
-
-        """
-        if RE_HEADER_START.match(line):
-            self.complete = True
-        else:
-            match = RE_HEADER_VALUE.match(line)
-            if match:
-                key, value = match.groups()
-                self.artifact[key] = value
-
-
 PATTERN = r' (?P<name>.*?) \(results: (?P<result>\d+), elapsed: .*?\) \(at (?P<timestamp>.*?)\)'
 RE_STEP_START = re.compile(r'={9} Started' + PATTERN)
 RE_STEP_FINISH = re.compile(r'={9} Finished' + PATTERN)


### PR DESCRIPTION
The header property is no longer used, since bug 1057341 made the log viewer display job details from /jobs/ endpoint instead.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/653)
<!-- Reviewable:end -->
