### PR TITLE
Bug 1131244 - Use newrelic-admin run-program when running celery beat

### DIFF
--- a/bin/run_celerybeat
+++ b/bin/run_celerybeat
@@ -10,12 +10,16 @@ cd $SRC_DIR
 PROJECT_ROOT=$(readlink -f ../)
 PATH=$PROJECT_ROOT/venv/bin:$PATH
 
+source /etc/profile.d/treeherder.sh
+
+if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then
+    NEWRELIC_ADMIN="newrelic-admin run-program"
+fi
+
 LOGFILE=/var/log/celery/celerybeat.log
 
 if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-source /etc/profile.d/treeherder.sh
-
-exec celery -A treeherder beat -f $LOGFILE
+exec $NEWRELIC_ADMIN celery -A treeherder beat -f $LOGFILE


### PR DESCRIPTION
Copies the same pattern used in the other celery wrapper scripts.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/654)
<!-- Reviewable:end -->
