### PR TITLE
Bug 1175948 - Remove duplicate line in Help keyboard table

### DIFF
--- a/ui/help.html
+++ b/ui/help.html
@@ -140,7 +140,6 @@
                         </span><span class="kbd">u</span></td>
                       <td>Clear the pinboard</td>
                     </tr>
-                    <td>Save pinboard classification and related bugs</td></tr>
                     <tr>
                       <td><span class="kbd">ctrl</span><span class="kbd">shift
                         </span><span class="kbd">f</span></td>


### PR DESCRIPTION
This fixes Bugzilla bug [1175948](https://bugzilla.mozilla.org/show_bug.cgi?id=1175948).

Nothing exciting, an extra line got added in PR https://github.com/mozilla/treeherder/pull/617, so I'm just removing it.

Before:
![before](https://cloud.githubusercontent.com/assets/3660661/8235408/d3f94ab4-15af-11e5-9fd9-60a0692860d4.jpg)

After:
![after](https://cloud.githubusercontent.com/assets/3660661/8235413/dd63cb9c-15af-11e5-9e9d-fbd6cfddbaea.jpg)

Tested on OSX 10.10.3:
FF Nightly **41.0a1 (2015-06-17)**
Chrome Latest Release **43.0.2357.124**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/656)
<!-- Reviewable:end -->
