### PR TITLE
Bug 1175991 - Use monospaced revisions for column readability

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -391,10 +391,9 @@ th-watched-repo {
 
 .revision > a:first-child {
     float: left;
-    width: 7.5em;
-    padding-top: 2px;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    padding-top: 1px;
+    padding-right: 11px;
+    font: 11px "Lucida Console",Monaco,monospace;
 }
 
 .revision-comment {
@@ -530,11 +529,9 @@ th-watched-repo {
 }
 
 .revision-text {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    width: 7.2em;
     display: inline-block;
     vertical-align: middle;
+    font: 12px "Lucida Console",Monaco,monospace;
 }
 
 .revision-button {


### PR DESCRIPTION
This hopefully fixes our side of Bugzilla bug [1175991](https://bugzilla.mozilla.org/show_bug.cgi?id=1175991).

In it, a regression in Nightly (1173826) was [causing a variety of oversized fonts and resulting ellipses](https://bug1175991.bugzilla.mozilla.org/attachment.cgi?id=8624339) for the resultset author, sha, and revisions, on Ubuntu.

That's outside of our control, but to avoid ragged presentation of the revision column, this PR makes the revisions and main header revision monospaced, and removes the fixed width so user font size changes will push the revision comments to the right instead of ellipsizing the revisions.

I matched the spacing for the revision columns exactly so there is no change other than the font family.

Current:
![revisionsbefore](https://cloud.githubusercontent.com/assets/3660661/8241325/b6e329f0-15d6-11e5-859c-e4ed212a09b7.jpg)

Proposed:
![revisionmonospace](https://cloud.githubusercontent.com/assets/3660661/8241384/104fa036-15d7-11e5-8a58-a036196b6b1e.jpg)

Everything seems fine in both browsers.

Tested on OSX 10.10.3:
FF Nightly **41.0a1 (2015-06-17)**
Chrome Latest Release **43.0.2357.124**

Adding @camd for review and @dholbert for visibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/662)
<!-- Reviewable:end -->
