### PR TITLE
 	Bug 1171707 - Fix locking when concurrently updating performance series

### DIFF
--- a/treeherder/model/sql/generic.json
+++ b/treeherder/model/sql/generic.json
@@ -35,7 +35,13 @@
     "locks": {
         "get_lock": {
 
-            "sql":"SELECT GET_LOCK(?, ?) AS 'lock'",
+            "sql":"SELECT GET_LOCK(?, 60) AS 'lock'",
+
+            "host_type":"master_host"
+        },
+        "is_free_lock": {
+
+            "sql":"SELECT IS_FREE_LOCK(?) AS 'lock'",
 
             "host_type":"master_host"
         },

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -355,6 +355,9 @@ BZ_MAX_COMMENT_LENGTH = 40000
 # like ftp.mozilla.org or hg.mozilla.org
 TREEHERDER_REQUESTS_TIMEOUT = 30
 
+# timeout for acquiring lock to update performance series
+PERFHERDER_UPDATE_SERIES_LOCK_TIMEOUT = 60
+
 # Build the default pulse uri this is passed to kombu
 PULSE_URI = 'amqps://{}:{}@pulse.mozilla.org/'.format(
     os.environ.get('PULSE_USERNAME', 'guest'),


### PR DESCRIPTION
Before if two celery jobs were updating the same series, one would overwrite
the other because the locking code did not actually work (it just always
unconditonally got a new lock without checking if anything was using it).
This fixes that.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/663)
<!-- Reviewable:end -->
