### PR TITLE
Bug 1087578 - Add a ref test analyzer link in logviewer

### DIFF
--- a/ui/css/logviewer.css
+++ b/ui/css/logviewer.css
@@ -81,6 +81,7 @@ body {
 }
 .run-data .steps-data {
     max-height: 210px;
+    min-width: 400px;
     overflow: auto;
     border-color: #dddddd;
     border-width: 1px;
@@ -112,27 +113,31 @@ body {
     border-color: #d58512;
 }
 
-.logviewer-stepbar {
+.logviewer-actionbar {
+    min-width: 410px;
+}
+
+.logviewer-actionbtn {
     display: inline-block;
     margin: 8px 8px 8px 0px;
     padding: 6px 8px;
     border: 1px solid #dddddd;
 }
 
-.logviewer-stepbar span {
+.logviewer-actionbtn span {
     color: #9fa3a5;
 }
 
-.logviewer-stepbar a:hover,
-.logviewer-stepbar a:focus {
+.logviewer-actionbtn a:hover,
+.logviewer-actionbtn a:focus {
     text-decoration: none;
 }
 
-.logviewer-stepbar .raw-log {
+.logviewer-actionbtn .actionbtn-icon {
     padding-right: 5px;
 }
 
-.logviewer-stepbar input[type="checkbox"] {
+.logviewer-actionbtn input[type="checkbox"] {
     margin: 0;
 }
 

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -7,11 +7,11 @@
 logViewerApp.controller('LogviewerCtrl', [
     '$anchorScroll', '$http', '$location', '$q', '$rootScope', '$scope',
     '$timeout', 'ThJobArtifactModel', 'ThLog', 'ThLogSliceModel', 'ThJobModel',
-    'dateFilter', 'thJobSearchStr', 'ThResultSetModel', 'thDateFormat',
+    'dateFilter', 'thJobSearchStr', 'ThResultSetModel', 'thDateFormat', 'thReftestStatus',
     function Logviewer(
         $anchorScroll, $http, $location, $q, $rootScope, $scope,
         $timeout, ThJobArtifactModel, ThLog, ThLogSliceModel, ThJobModel,
-        dateFilter, thJobSearchStr, ThResultSetModel, thDateFormat) {
+        dateFilter, thJobSearchStr, ThResultSetModel, thDateFormat, thReftestStatus) {
 
         var $log = new ThLog('LogviewerCtrl');
 
@@ -189,6 +189,13 @@ logViewerApp.controller('LogviewerCtrl', [
                     {label: "Start", value: dateFilter(job.start_timestamp*1000, thDateFormat)},
                     {label: "End", value: dateFilter(job.end_timestamp*1000, thDateFormat)}
                 ];
+
+                // Test to expose the reftest button in the logviewer actionbar
+                $scope.isReftest = function() {
+                    if (job.job_group_name) {
+                        return thReftestStatus(job);
+                    }
+                };
 
                 // get the revision and linkify it
                 ThResultSetModel.getResultSet($scope.repoName, job.result_set_id).then(function(data){

--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -262,3 +262,13 @@ treeherder.provider('thAggregateIds', function() {
             };
     };
 });
+
+treeherder.provider('thReftestStatus', function() {
+    this.$get = function() {
+        return function(job) {
+            if (job.job_group_name) {
+                return (job.job_group_name.toLowerCase().indexOf('reftest') !== -1);
+            }
+        };
+    };
+});

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -5,6 +5,7 @@
         <title ng-bind="::logViewerTitle">Log viewer</title>
         <!-- build:css css/logviewer.min.css -->
         <link href="vendor/css/bootstrap.css" rel="stylesheet" media="screen">
+        <link href="vendor/css/font-awesome.css" rel="stylesheet" media="screen">
         <link href="css/treeherder.css" rel="stylesheet" type="text/css">
         <link href="css/logviewer.css" rel="stylesheet" type="text/css">
         <!-- endbuild -->

--- a/ui/partials/logviewer/lvLogSteps.html
+++ b/ui/partials/logviewer/lvLogSteps.html
@@ -35,18 +35,32 @@
     </div>
 </div>
 
-<div class="logviewer-stepbar">
-    <a href="{{::artifact.logurl}}">
-        <span class="glyphicon glyphicon-align-left raw-log"></span>
-        <span>open raw log</span>
-    </a>
-</div>
+<div class="logviewer-actionbar">
+    <!-- Raw log button -->
+    <div class="logviewer-actionbtn">
+        <a href="{{::artifact.logurl}}">
+            <span class="glyphicon glyphicon-align-left actionbtn-icon"></span>
+            <span>open raw log</span>
+        </a>
+    </div>
 
-<div ng-if="artifact && hasFailedSteps()"
-     class="logviewer-stepbar">
-    <input type="checkbox"
-           ng-model="showSuccessful"
-           ng-change="toggleSuccessfulSteps()" />
+    <!-- Ref test button -->
+    <div ng-if="isReftest()"
+         class="logviewer-actionbtn">
+        <a title="Launch the Reftest Analyser in a new window"
+           target="_blank"
+           href="http://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl={{::artifact.logurl}}&only_show_unexpected=1">
+            <span class="fa fa-bar-chart-o actionbtn-icon"></span>
+            <span>open analyser</span>
+        </a>
+    </div>
 
-    <span>show successful steps</span>
+    <!-- Show successful steps button -->
+    <div ng-if="artifact && hasFailedSteps()"
+         class="logviewer-actionbtn">
+        <input type="checkbox"
+               ng-model="showSuccessful"
+               ng-change="toggleSuccessfulSteps()" />
+        <span>show successful steps</span>
+    </div>
 </div>

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -10,14 +10,14 @@ treeherder.controller('PluginCtrl', [
     'numberFilter', 'ThBugJobMapModel', 'thResultStatus', 'thJobFilters',
     'ThResultSetModel', 'ThLog', '$q', 'thPinboard', 'ThJobArtifactModel',
     'thBuildApi', 'thNotify', 'ThJobLogUrlModel', 'ThModelErrors', 'thTabs',
-    '$timeout', 'thJobSearchStr',
+    '$timeout', 'thJobSearchStr', 'thReftestStatus',
     function PluginCtrl(
         $scope, $rootScope, $location, thUrl, ThJobClassificationModel,
         thClassificationTypes, ThJobModel, thEvents, dateFilter, thDateFormat,
         numberFilter, ThBugJobMapModel, thResultStatus, thJobFilters,
         ThResultSetModel, ThLog, $q, thPinboard, ThJobArtifactModel,
         thBuildApi, thNotify, ThJobLogUrlModel, ThModelErrors, thTabs,
-        $timeout, thJobSearchStr) {
+        $timeout, thJobSearchStr, thReftestStatus) {
 
         var $log = new ThLog("PluginCtrl");
 
@@ -329,14 +329,10 @@ treeherder.controller('PluginCtrl', [
             thBuildApi.cancelAllJobs($scope.repoName, rs.revision);
         };
 
-        /**
-         * Test whether or not the selected job is a reftest
-         */
+        // Test to expose the reftest button in the job details navbar
         $scope.isReftest = function() {
             if ($scope.selectedJob) {
-                return ($scope.selectedJob.job_group_name.indexOf("Reftest") !== -1);
-            } else {
-                return false;
+                return thReftestStatus($scope.selectedJob);
             }
         };
 

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -100,8 +100,8 @@
               <span class="fa fa-repeat"></span>
             </a>
           </li>
-          <li ng-show="isReftest()" ng-repeat="job_log_url in job_log_urls">
-            <a title="Launch the Reftest Analyser in a new page"
+          <li ng-if="isReftest()" ng-repeat="job_log_url in job_log_urls">
+            <a title="Launch the Reftest Analyser in a new window"
                target="_blank"
                href="http://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl={{::job_log_url.url}}&only_show_unexpected=1">
               <span class="fa fa-bar-chart-o"></span>


### PR DESCRIPTION
This work fixes Bugzilla bug [1087578](https://bugzilla.mozilla.org/show_bug.cgi?id=1087578).

This adds a Reftest analyzer link to the logviewer if the loaded job belongs to a R() or R-e10s() reftest group. Here's the basic workflow and appearance:

Select any Reftest job and click on the log icon:
![reftest1](https://cloud.githubusercontent.com/assets/3660661/8260294/88a455f4-1690-11e5-90a1-1b5ca14ebd15.jpg)

And in Logviewer we see our new Reftest link *'open reftest'* the same as in treeherder:
![reftest2](https://cloud.githubusercontent.com/assets/3660661/8260488/0aeaa800-1692-11e5-926d-fe5f57029d3a.jpg)

Click on the link and we get (what I understand to be) the desired results:

![reftest3](https://cloud.githubusercontent.com/assets/3660661/8260583/acd2ef38-1692-11e5-9ffb-743b997c1f9a.jpg)

![reftest4](https://cloud.githubusercontent.com/assets/3660661/8260585/b2e30138-1692-11e5-9c6b-467c5d7a26ee.jpg)

While I was there I added a new `actionbar` div and set a min-width so that action buttons don't wrap like they do in production below:
![tiling](https://cloud.githubusercontent.com/assets/3660661/8260650/0f6dd7ac-1693-11e5-9d70-b1fd9f34deba.jpg)

That became more frequent with the new link addition. If we need to add more action icons I imagine we might want to look at a navbar of some kind.

I didn't touch the parent `col-md-6` div, so the child div lies outside its parent boundary now. It seems harmless.

![parentdiv](https://cloud.githubusercontent.com/assets/3660661/8261131/2452dc28-1696-11e5-9c94-f054d969a5ed.jpg)

I think that bootstrap div also allows the parent container to flow at narrow browser widths, which continues to work fine.

I sort of mimicked the `isReftest()` in plugins/controller, but we test against the logviewer job properties. I made the $scope comments consistent in both places. I adhered to the 4 space html indent in the current file, for now.

Tested on OSX 10.10.3:
FF Nightly **41.0a1 (2015-06-17)**
Chrome Latest Release **43.0.2357.124**

Adding @camd  for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/664)
<!-- Reviewable:end -->
