### PR TITLE
Bug 1176253 - Heroku: Remove licence boilerplate from runtime.txt

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,5 +1,1 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 python-2.7.9


### PR DESCRIPTION
Since it breaks the Heroku Python buildpack build script.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/666)
<!-- Reviewable:end -->
