### PR TITLE
Bug 1167353 - Perfherder API's have a superfluous /0/ in them

### DIFF
--- a/treeherder/client/thclient/perfherder.py
+++ b/treeherder/client/thclient/perfherder.py
@@ -107,9 +107,9 @@ class PerformanceSeries(list):
 
 class PerfherderClient(TreeherderClient):
 
-    PERFORMANCE_SERIES_SUMMARY_ENDPOINT = 'performance-data/0/get_performance_series_summary'
-    SIGNATURE_PROPERTIES_ENDPOINT = 'performance-data/0/get_signature_properties'
-    PERFORMANCE_DATA_ENDPOINT = 'performance-data/0/get_performance_data'
+    PERFORMANCE_SERIES_SUMMARY_ENDPOINT = 'performance-data/get_performance_series_summary'
+    SIGNATURE_PROPERTIES_ENDPOINT = 'performance-data/get_signature_properties'
+    PERFORMANCE_DATA_ENDPOINT = 'performance-data/get_performance_data'
 
     def get_performance_signatures(self, project,
                                    time_interval=PerformanceTimeInterval.WEEK,

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -5,7 +5,7 @@
 from django.core.cache import cache
 from rest_framework import viewsets
 from rest_framework.response import Response
-from rest_framework.decorators import link
+from rest_framework.decorators import list_route
 from rest_framework_extensions.etag.decorators import etag
 
 
@@ -29,7 +29,7 @@ class PerformanceDataViewSet(viewsets.ViewSet):
 
         return None
 
-    @link()
+    @list_route()
     @etag(etag_func=_calculate_etag)
     @with_jobs
     def get_performance_series_summary(self, request, project, jm, pk=None):
@@ -48,7 +48,7 @@ class PerformanceDataViewSet(viewsets.ViewSet):
 
         return Response(summary)
 
-    @link()
+    @list_route()
     @with_jobs
     def get_signatures_from_properties(self, request, project, jm, pk=None):
         """
@@ -67,7 +67,7 @@ class PerformanceDataViewSet(viewsets.ViewSet):
 
         return Response(signatures)
 
-    @link()
+    @list_route()
     @with_jobs
     def get_signature_properties(self, request, project, jm, pk=None):
         """
@@ -88,7 +88,7 @@ class PerformanceDataViewSet(viewsets.ViewSet):
 
         return Response(data)
 
-    @link()
+    @list_route()
     @with_jobs
     def get_performance_data(self, request, project, jm, pk=None):
         """

--- a/ui/js/graphs.js
+++ b/ui/js/graphs.js
@@ -479,7 +479,7 @@ perf.controller('GraphsCtrl', [
     function getSeriesData(series) {
       return $http.get(thServiceDomain + '/api/project/' +
                        series.projectName +
-                       '/performance-data/0/get_performance_data/' +
+                       '/performance-data/get_performance_data/' +
                        '?interval_seconds=' + $scope.myTimerange.value +
                        '&signatures=' + series.signature).then(
                          function(response) {
@@ -523,7 +523,7 @@ perf.controller('GraphsCtrl', [
       return $q.all(partialSeriesList.map(
         function(partialSeries) {
           return $http.get(thServiceDomain + '/api/project/' +
-                           partialSeries.project + '/performance-data/0/' +
+                           partialSeries.project + '/performance-data/' +
                            'get_signature_properties/?signatures=' +
                            partialSeries.signature).then(function(response) {
                              var data = response.data;

--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -29,7 +29,7 @@ perf.factory('PhSeries', ['$http', 'thServiceDomain', function($http, thServiceD
 
   var _getAllSeries = function(projectName, timeRange, optionMap) {
     var signatureURL = thServiceDomain + '/api/project/' + projectName +
-      '/performance-data/0/get_performance_series_summary/?interval=' +
+      '/performance-data/get_performance_series_summary/?interval=' +
       timeRange;
 
     return $http.get(signatureURL).then(function(response) {
@@ -386,7 +386,7 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
 
     getResultsMap: function(projectName, seriesList, timeRange, resultSetIds) {
       var baseURL = thServiceDomain + '/api/project/' +
-        projectName + '/performance-data/0/' +
+        projectName + '/performance-data/' +
         'get_performance_data/?interval_seconds=' + timeRange;
 
       var resultsMap = {};


### PR DESCRIPTION
Replaced use of link decorator with the list_route decorator in performance_data.py. Also, removed the usage of /0/ in the client file client/thclient/perfherder.py.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/668)
<!-- Reviewable:end -->
