### PR TITLE
Bug 1175579 - Only refresh the log summary pane if the job isn't pending

### DIFF
--- a/ui/js/models/job_artifact.js
+++ b/ui/js/models/job_artifact.js
@@ -22,11 +22,12 @@ treeherder.factory('ThJobArtifactModel', [
             var timeout = config.timeout || null;
 
             // Bail without fetching the log if there's no log to fetch
-            if(state == "pending" || state == "running") {
+            if(state === "pending" || state === "running") {
                 return $q(function(resolve, reject) {
                     resolve([]);
                 });
             }
+
             return $http.get(ThJobArtifactModel.get_uri(),{
                 params: options,
                 timeout: timeout

--- a/ui/js/models/job_artifact.js
+++ b/ui/js/models/job_artifact.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('ThJobArtifactModel', [
-    '$http', 'ThLog', 'thUrl',
-    function($http, ThLog, thUrl) {
+    '$http', 'ThLog', 'thUrl', '$q',
+    function($http, ThLog, thUrl, $q) {
 
         // ThJobArtifactModel is the js counterpart of job_artifact
 
@@ -14,13 +14,19 @@ treeherder.factory('ThJobArtifactModel', [
 
         ThJobArtifactModel.get_uri = function(){return thUrl.getProjectUrl("/artifact/");};
 
-        ThJobArtifactModel.get_list = function(options, config) {
+        ThJobArtifactModel.get_list = function(options, config, state) {
             // a static method to retrieve a list of ThJobArtifactModel
             // the timeout configuration parameter is a promise that can be used to abort
             // the ajax request
             config = config || {};
             var timeout = config.timeout || null;
 
+            // Bail without fetching the log if there's no log to fetch
+            if(state == "pending" || state == "running") {
+                return $q(function(resolve, reject) {
+                    resolve([]);
+                });
+            }
             return $http.get(ThJobArtifactModel.get_uri(),{
                 params: options,
                 timeout: timeout

--- a/ui/plugins/failure_summary/controller.js
+++ b/ui/plugins/failure_summary/controller.js
@@ -18,6 +18,8 @@ treeherder.controller('BugsPluginCtrl', [
         // update function triggered by the plugins controller
         thTabs.tabs.failureSummary.update = function() {
             var newValue = thTabs.tabs.failureSummary.contentId;
+            var jobState = $scope.selectedJob.state;
+
             $scope.suggestions = [];
             if(angular.isDefined(newValue)) {
                 thTabs.tabs.failureSummary.is_loading = true;
@@ -36,7 +38,7 @@ treeherder.controller('BugsPluginCtrl', [
                     name__in: "Bug suggestions,text_log_summary",
                     "type": "json",
                     job_id: newValue
-                }, {timeout: requestPromise})
+                }, {timeout: requestPromise}, jobState)
                 .then(function(artifact_list){
                     // using a temporary array here to not trigger a
                     // dirty check for every element pushed


### PR DESCRIPTION
I think this should work. Haven't tested it yet, though.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/671)
<!-- Reviewable:end -->
