### PR TITLE
Bug 1170613 - gzip artifact blobs submitted via the jobs endpoint too

### DIFF
--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -371,7 +371,7 @@ class ArtifactsModel(TreeherderModelBase):
                 job_guid,
                 name,
                 artifact_type,
-                blob,
+                zlib.compress(blob),
                 job_guid,
                 name
             ])

--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -364,7 +364,14 @@ class ArtifactsModel(TreeherderModelBase):
             artifact_type = artifact.get('type')
             blob = artifact.get('blob')
 
-            if name and artifact_type and blob:
-                artifact_placeholders.append(
-                    [job_guid, name, artifact_type, blob, job_guid, name]
-                )
+            if not (name and artifact_type and blob):
+                continue
+
+            artifact_placeholders.append([
+                job_guid,
+                name,
+                artifact_type,
+                blob,
+                job_guid,
+                name
+            ])


### PR DESCRIPTION
Currently we only gzip artifacts submitted via the artifacts endpoint and not those submitted at the same time as the job (ie using the jobs endpoint).

I'll land a test as a follow-up bug, I just don't want to block landing the fix any longer (and testing requires doing manual queries, since the API does a try-except to handle old non-compressed data; so isn't just a simple copy-paste of some of the existing tests - and I haven't had a chance to come back to it).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/674)
<!-- Reviewable:end -->
