### PR TITLE
 Bug 1158572 - Create and use a fake buildername for taskcluster jobs 

### DIFF
--- a/tests/etl/test_classification_mirroring.py
+++ b/tests/etl/test_classification_mirroring.py
@@ -85,6 +85,7 @@ def test_bugzilla_comment_request_body(test_project, eleven_jobs_processed):
                     u'start_time: 2013-11-13T06:39:13\n'
                     u'who: user[at]mozilla[dot]com\n'
                     u'machine: bld-linux64-ec2-132\n'
+                    u'buildname: non-buildbot b2g-emu-jb test B2G Emulator Image Build\n'
                     u'revision: cdfe03e77e66\n\n'
                     u'First error line\n'
                     u'Second error line')

--- a/treeherder/etl/classification_mirroring.py
+++ b/treeherder/etl/classification_mirroring.py
@@ -137,6 +137,9 @@ class BugzillaCommentRequest(object):
 
         if buildapi_info:
             job_description['buildname'] = buildapi_info[0]["blob"]["buildername"]
+        else:
+            # make up a buildername for taskcluster jobs
+            job_description['buildname'] = 'non-buildbot %s test %s' % (job["platform"], job["job_type_name"])
 
         body_comment = '\n'.join(
             ["{0}: {1}".format(k, v) for k, v in job_description.items()])


### PR DESCRIPTION
I'm sure there's more to this like changing a test, but wanted to get this posted while I was still looking at it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/675)
<!-- Reviewable:end -->
