### PR TITLE
Bug 1136918 - Get rid of the link to hg.m.o in the revision list and move it to a separate button

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -397,11 +397,14 @@ th-watched-repo {
     overflow: auto;
 }
 
-.revision > a:first-child {
-    float: left;
+.revision-holder > a {
     padding-top: 2px;
-    padding-right: 11px;
     font: 11px "Lucida Console",Monaco,monospace;
+}
+
+.revision-holder {
+    padding-left:20px;
+    padding-right: 11px;
 }
 
 .revision-comment {

--- a/ui/index.html
+++ b/ui/index.html
@@ -119,10 +119,11 @@
             <div class="clearfix"></div>
             <li>
                 <span class="revision">
-                    <a href="{{currentRepo.getRevisionHref(revision)}}"
-                       title="Open revision {{revision}} on {{currentRepo.url}}"
-                       ignore-job-clear-on-click
-                       >{{revision}}</a>
+                    <span class="revision-holder">
+                        <a href="{{currentRepo.getRevisionHref(revision)}}"
+                           title="Open revision {{revision}} on {{currentRepo.url}}"
+                           ignore-job-clear-on-click>{{revision}}</a>
+                    </span>
                     <span title="{{name}}: {{email}}">{{name|initials}}</span>
                     <span title="{{escaped_comment}}">
                         <span class="revision-comment">


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/678)
<!-- Reviewable:end -->
