### PR TITLE
Bug 1156098 - Clarify the link text for Bugherder in the per-push dropdown menu

### DIFF
--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -8,7 +8,8 @@
         </a>
         <ul class="dropdown-menu pull-right">
             <li><a target="_blank" ignore-job-clear-on-click
-                   href="https://mcmerge.paas.allizom.org/?cset={{::resultset.revision}}&tree={{::repoName}}">Bugherder</a></li>
+                   href="https://mcmerge.paas.allizom.org/?cset={{::resultset.revision}}&amp;tree={{::repoName}}"
+                   title="Use Bugherder to mark the bugs in this push">Mark with Bugherder</a></li>
             <li><a target="_blank" ignore-job-clear-on-click
                    href="https://secure.pub.build.mozilla.org/buildapi/self-serve/{{::repoName}}/rev/{{::resultset.revision}}">BuildAPI</a></li>
             <li><a target="_blank" ignore-job-clear-on-click


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/679)
<!-- Reviewable:end -->
