### PR TITLE
Bug 1175991 - Supplemental tweak for monospaced revisions

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -391,7 +391,7 @@ th-watched-repo {
 
 .revision > a:first-child {
     float: left;
-    padding-top: 1px;
+    padding-top: 2px;
     padding-right: 11px;
     font: 11px "Lucida Console",Monaco,monospace;
 }


### PR DESCRIPTION
This tweak fixes the baseline text alignment in the new monospaced revisions. It was slightly high relative to the adjacent push message summaries.

Tested on OSX 10.10.3:
FF Nightly **41.0a1 (2015-06-26)**
Chrome Latest Release 43.0.2357.130

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/686)
<!-- Reviewable:end -->
