### PR TITLE
Bug 1178719 - Use --noinput when running migrate from scripts

### DIFF
--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -63,7 +63,7 @@ def update(ctx):
         # Rebuild the Cython code (eg the log parser)
         ctx.local("python2.7 setup.py build_ext --inplace")
         # Update the database schema, if necessary.
-        ctx.local("python2.7 manage.py migrate")
+        ctx.local("python2.7 manage.py migrate --noinput")
         # Update reference data & tasks config from the in-repo fixtures.
         ctx.local("python2.7 manage.py load_initial_data")
         # Populate the datasource table and create the connected databases.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,7 @@ def pytest_runtest_teardown(item):
     for ds in ds_list:
         ds.delete()
 
-    call_command("migrate", 'model', '0001_initial')
+    call_command("migrate", 'model', '0001_initial', interactive=False)
 
 
 def increment_cache_key_prefix():

--- a/treeherder/model/management/commands/init_master_db.py
+++ b/treeherder/model/management/commands/init_master_db.py
@@ -71,7 +71,7 @@ Type 'yes' to continue, or 'no' to cancel: """ % connection.settings_dict['NAME'
                 print "Sql files executed successfully."
 
             # safely apply all migrations
-            call_command("migrate")
+            call_command("migrate", interactive=interactive)
             # load initial fixtures for reference data
             # the order of this list of fixtures is important
             # to avoid integrity errors


### PR DESCRIPTION
Since otherwise we may end up with interactive prompts.

Note: When using call_command() we instead have to use 'interactive' instead of 'noinput' due to https://code.djangoproject.com/ticket/22985, which is only fixed in Django 1.8+.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/696)
<!-- Reviewable:end -->
