### PR TITLE
Bug 1178832 - Cleanup leftovers from using Cython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,7 @@
 *.py[cod]
 
-# C extensions
-*.so
-
 #vi files
 *.swp
-
-# Packages
-*.egg
-*.egg-info
-build
-eggs
-parts
-var
-sdist
-develop-eggs
-.installed.cfg
-lib
-lib64
 
 # Installer logs
 pip-log.txt
@@ -70,8 +54,6 @@ docs/_build/
 #supervisor
 .nfs*
 *.pid
-
-*.c
 
 treeherder/webapp/log_cache
 celerybeat-schedule

--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -32,7 +32,7 @@ def pre_update(ctx, ref=settings.UPDATE_REF):
     with ctx.lcd(th_service_src):
         ctx.local('git fetch --quiet origin %s' % ref)
         ctx.local('git reset --hard FETCH_HEAD')
-        ctx.local('find . -type f \( -name "*.pyc" -o -name "*.c" -o -name "*.so" \) -delete')
+        ctx.local('find . -type f -name "*.pyc" -delete')
         ctx.local('git status -s')
         ctx.local('git rev-parse HEAD > treeherder/webapp/media/revision')
 


### PR DESCRIPTION
Also remove some .gitignore entries from when we had a vendor directory.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/700)
<!-- Reviewable:end -->
