### PR TITLE
Bug 1132662 - Prevent classification comment shift on Firefox

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -986,6 +986,7 @@ ul.failure-summary-list li .btn-xs {
 
 .classification-comment-container {
     margin-top: 5px;
+    height: 20px;
 }
 
 .classification-comment-preload-txt {


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1132662](https://bugzilla.mozilla.org/show_bug.cgi?id=1132662).

This prevents the pinboard from shifting vertically on Firefox when the user enters a comment like so:

![classificationentry](https://cloud.githubusercontent.com/assets/3660661/8465352/79662622-2017-11e5-88d3-957d28b3821a.jpg)

It seems ok to just set the height of this container to the same computed height as its child input. Since the adjacent pinboard and related bugs containers are what drive the height of the pinboard, and the comment is always only one line.

Chrome was fine anyway, but I checked the change on both browsers.

Tested on OSX 10.10.3:
FF Nightly **41.0a1 (2015-07-01)**
Chrome Latest Release **43.0.2357.130**

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/703)
<!-- Reviewable:end -->
