### PR TITLE
Bug 1180052 - Include the job_id in the submission to ElasticSearch

### DIFF
--- a/tests/etl/test_classification_mirroring.py
+++ b/tests/etl/test_classification_mirroring.py
@@ -28,10 +28,10 @@ def test_elasticsearch_doc_request_body(test_project, eleven_jobs_processed):
     with ArtifactsModel(test_project) as artifacts_model:
         artifacts_model.store_job_artifact(placeholders)
 
-    submit_timestamp = int(time())
+    classification_timestamp = int(time())
     who = "user@mozilla.com"
 
-    req = ElasticsearchDocRequest(test_project, job_id, bug_id, submit_timestamp, who)
+    req = ElasticsearchDocRequest(test_project, job_id, bug_id, classification_timestamp, who)
     req.generate_request_body()
 
     expected = {
@@ -49,7 +49,7 @@ def test_elasticsearch_doc_request_body(test_project, eleven_jobs_processed):
         "rev": "cdfe03e77e66",
         "bug": str(bug_id),
         "who": who,
-        "timestamp": str(submit_timestamp)
+        "timestamp": str(classification_timestamp),
     }
     assert req.body == expected, diff(expected, req.body)
 

--- a/tests/etl/test_classification_mirroring.py
+++ b/tests/etl/test_classification_mirroring.py
@@ -44,12 +44,12 @@ def test_elasticsearch_doc_request_body(test_project, eleven_jobs_processed):
         "type": "B2G Emulator Image Build",
         "buildtype": "debug",
         "starttime": "1384353553",
-        "logfile": "00000000",
         "tree": "test_treeherder",
         "rev": "cdfe03e77e66",
         "bug": str(bug_id),
         "who": who,
         "timestamp": str(classification_timestamp),
+        "treeherder_job_id": job_id,
     }
     assert req.body == expected, diff(expected, req.body)
 

--- a/treeherder/etl/classification_mirroring.py
+++ b/treeherder/etl/classification_mirroring.py
@@ -62,7 +62,7 @@ class ElasticsearchDocRequest(object):
             "bug": str(self.bug_id),
             "who": self.who,
             "timestamp": str(self.classification_timestamp),
-            "logfile": "00000000"
+            "treeherder_job_id": self.job_id,
         }
 
     def send_request(self):

--- a/treeherder/etl/classification_mirroring.py
+++ b/treeherder/etl/classification_mirroring.py
@@ -15,11 +15,11 @@ logger = logging.getLogger(__name__)
 
 class ElasticsearchDocRequest(object):
 
-    def __init__(self, project, job_id, bug_id, submit_timestamp, who):
+    def __init__(self, project, job_id, bug_id, classification_timestamp, who):
         self.project = project
         self.job_id = job_id
         self.bug_id = bug_id
-        self.submit_timestamp = submit_timestamp
+        self.classification_timestamp = classification_timestamp
         self.who = who
         self.body = {}
 
@@ -61,7 +61,7 @@ class ElasticsearchDocRequest(object):
             "rev": revision_list[0]["revision"],
             "bug": str(self.bug_id),
             "who": self.who,
-            "timestamp": str(self.submit_timestamp),
+            "timestamp": str(self.classification_timestamp),
             "logfile": "00000000"
         }
 

--- a/treeherder/etl/tasks/classification_mirroring_tasks.py
+++ b/treeherder/etl/tasks/classification_mirroring_tasks.py
@@ -7,13 +7,13 @@ from treeherder.etl.classification_mirroring import ElasticsearchDocRequest, Bug
 
 
 @task(name="submit-elasticsearch-doc", max_retries=10, time_limit=30)
-def submit_elasticsearch_doc(project, job_id, bug_id, submit_timestamp, who):
+def submit_elasticsearch_doc(project, job_id, bug_id, classification_timestamp, who):
     """
     Mirror the classification to Elasticsearch using a post request, until
     OrangeFactor is rewritten to use Treeherder's API directly.
     """
     try:
-        req = ElasticsearchDocRequest(project, job_id, bug_id, submit_timestamp, who)
+        req = ElasticsearchDocRequest(project, job_id, bug_id, classification_timestamp, who)
         req.generate_request_body()
         req.send_request()
     except Exception as e:


### PR DESCRIPTION
* Rename submit_timestamp to classification_timestamp when referring to the datetime that a classification was made.
This avoids confusion in ElasticsearchDocRequest, since previously we had
two similarly named variables: 'job_data["submit_timestamp"]' and 'self.submit_timestamp', the former referring to the time the job was scheduled, the latter to the time the classification was submitted. 
* Include the job_id in the submission to ElasticSearch. 
So that OrangeFactor can use it to link to the log viewer (and more). Also stop sending the dummy 'logfile' key, since it's not used by OrangeFactor.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/706)
<!-- Reviewable:end -->
