### PR TITLE
Bug 1180266 - Add a quick filter input tooltip

### DIFF
--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -41,11 +41,12 @@
                 <!--Search Field-->
                 <span ng-controller="SearchCtrl" class="form-group form-inline" id="platform-job-text-search-field-parent">
                     <input id="platform-job-text-search-field"
+                           title="Click to enter filter values"
                            ng-model="searchQueryStr" ng-keydown="search($event)" type="text"
                            class="form-control input-sm" required
                            placeholder="Filter platforms & jobs"
                            blur-this>
-                    <span id="filter-clear-button" class="fa fa-times-circle" 
+                    <span id="filter-clear-button" class="fa fa-times-circle"
                           ng-click="clearFilterBox()" title="Clear this filter"></span>
                 </span>
             </form>


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1180266](https://bugzilla.mozilla.org/show_bug.cgi?id=1180266).

This adds a tooltip for the Filter Platforms & Jobs input, so we don't just inherit the Firefox default of "Please fill out this field." which seems imperative/misleading, and the Chrome default of (nothing).

![quickfiltertooltip](https://cloud.githubusercontent.com/assets/3660661/8502813/9f1a421e-2183-11e5-9533-d2789e2a6f9d.jpg)

Everything seems fine, plus some trailing whitespace removal.

Tested on OSX 10.10.3:
FF Nightly **41.0a1 (2015-07-03)**
Chrome Latest Release **43.0.2357.130**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/708)
<!-- Reviewable:end -->
