### PR TITLE
Bug 1180740 - Improve the wait/spinner cursors

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -57,6 +57,14 @@ input:focus::-moz-placeholder {
     padding: 0px;
 }
 
+.th-spinner {
+    color: rgba(145, 164, 221, 0.7);
+}
+
+.th-spinner-lg {
+    color: rgba(145, 164, 221, 0.3);
+}
+
 .th-navbar {
     background-color: #273038;
     margin-bottom: 0px;

--- a/ui/index.html
+++ b/ui/index.html
@@ -152,7 +152,7 @@
                     <ul class="list-unstyled"></ul>
                 </span>
                 <span class="job-list col-xs-7 job-list-pad">
-                    <span class="fa fa-refresh fa-spin"></span>
+                    <span class="fa fa-spinner fa-pulse th-spinner"></span>
                     <table id="{{ aggregateId }}" class="table-hover"></table>
                 </span>
             </div>

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -59,7 +59,7 @@
       <a href="{{currentRepo.getPushLogHref(revision)}}"
          target="_blank"
          title="open revision {{revision}} on {{currentRepo.url}}">(view pushlog)</a>
-    <span class="fa fa-refresh fa-spin"></span>
+    <span class="fa fa-spinner fa-pulse th-spinner"></span>
     <div>If the push exists, it will appear in a few minutes once it has been processed.
     </div>
   </span>

--- a/ui/plugins/failure_summary/main.html
+++ b/ui/plugins/failure_summary/main.html
@@ -94,7 +94,7 @@
     </ul>
     <div ng-if="tabs.failureSummary.is_loading" class="overlay">
         <div>
-            <span class="fa fa-refresh fa-spin"></span>
+            <span class="fa fa-spinner fa-pulse th-spinner-lg"></span>
         </div>
     </div>
 </div>

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -210,7 +210,7 @@
 
       <div ng-if="job_detail_loading" class="overlay">
         <div>
-          <span class="fa fa-refresh fa-spin"></span>
+          <span class="fa fa-spinner fa-pulse th-spinner-lg"></span>
         </div>
       </div>
     </div>

--- a/ui/plugins/similar_jobs/main.html
+++ b/ui/plugins/similar_jobs/main.html
@@ -122,7 +122,7 @@
             </div>
     <div ng-if="tabs.similar_jobs.is_loading" class="overlay">
         <div>
-            <span class="fa fa-refresh fa-spin"></span>
+            <span class="fa fa-spinner fa-pulse th-spinner-lg"></span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1180740](https://bugzilla.mozilla.org/show_bug.cgi?id=1180740).

This improves our wait/spinner cursors from the all black "smooth rotation" (which wasn't really) icon, to an 8-step pulse which seems to give a bit more polished look.

There are two new opacities; one for our 'large' spinners in the job details tabs, and a more opaque one for our 'small' spinners in the resultset container.

The animation is pretty attention getting, so I think we can use this more subtle color (`hex: #91a4dd`). It's sort of a blend of pinboard blue and search provider purple :) If anyone has another color preference let me know we can try it.

Job details current:
![currentspinner](https://cloud.githubusercontent.com/assets/3660661/8526396/8836c984-23d4-11e5-812b-779f536ab76e.jpg)

Job details proposed:
![proposedspinner](https://cloud.githubusercontent.com/assets/3660661/8526403/8fb02ae8-23d4-11e5-86c8-331850ca3033.jpg)

Main page:

![pushwaitcursorproposed](https://cloud.githubusercontent.com/assets/3660661/8526608/c426f620-23d5-11e5-82f4-7f863baa0874.jpg)

Everything seems fine on both browsers.

nb. I tried to make the `-lg` spinner a bit larger at 40px, but unfortunately there is some weird popping that occurs as the angular condition is met and the cursor is shut off. The cursor fleetingly redraws at its smaller default (30px) size and opacity. So I left that change out for now.

Tested on OSX 10.10.3:
FF Nightly **41.0a1 (2015-07-05)**
Chrome Latest Release **43.0.2357.130**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/710)
<!-- Reviewable:end -->
