### PR TITLE
Bug 1176482 - Update to WhiteNoise v2.0.2 and add custom index file & cache max-age support

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,8 +7,8 @@
 # sha256: pRec3pItK04EXuWxHocyPud9NjrkApT8glLyXWoOrwY
 gunicorn==19.3.0
 
-# sha256: Pk2AGZlglZuCiVGqJMv6o2zr7RSdzXKMEehVeYsV-HA
-whitenoise==1.0.6
+# sha256: VYVza7U0XcnLcEwSkq997IUSZmqw-RbG8mduDwYCMeg
+whitenoise==2.0.2
 
 # sha256: 7sV9MhlQHsbmhWRoJvLrjndoepP-N0p-aZRJBSDbCT4
 Django==1.7.7

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -63,7 +63,7 @@ USE_L10N = True
 USE_TZ = False
 
 SERVE_MINIFIED_UI = os.environ.get("SERVE_MINIFIED_UI") == "True"
-UI_ROOT = path("..", "dist" if SERVE_MINIFIED_UI else "ui")
+WHITENOISE_ROOT = path("..", "dist" if SERVE_MINIFIED_UI else "ui")
 
 STATIC_ROOT = path("webapp", "static")
 STATIC_URL = "/static/"

--- a/treeherder/webapp/urls.py
+++ b/treeherder/webapp/urls.py
@@ -3,7 +3,6 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.conf.urls import patterns, include, url
-from django.views.generic import RedirectView
 from django.contrib import admin
 
 from .api import urls as api_urls
@@ -18,7 +17,4 @@ urlpatterns = patterns('',
                        url(r'^admin/', include(browserid_admin.urls)),
                        url(r'^docs/', include('rest_framework_swagger.urls')),
                        url(r'', include('django_browserid.urls')),
-                       # Redirect all requests on / to /index.html, where they
-                       # will be served by WhiteNoise.
-                       url(r'^$', RedirectView.as_view(url='index.html'))
                        )

--- a/treeherder/webapp/urls.py
+++ b/treeherder/webapp/urls.py
@@ -2,11 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf import settings
 from django.conf.urls import patterns, include, url
 from django.views.generic import RedirectView
 from django.contrib import admin
-from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 from .api import urls as api_urls
 from treeherder.embed import urls as embed_urls
@@ -27,8 +25,3 @@ urlpatterns += patterns('',
                         # will be served by WhiteNoise.
                         url(r'^$', RedirectView.as_view(url='index.html'))
                         )
-
-if settings.DEBUG:
-    # Add the patterns needed so static files can be viewed without running
-    # collectstatic, even when using gunicorn instead of runserver.
-    urlpatterns += staticfiles_urlpatterns()

--- a/treeherder/webapp/urls.py
+++ b/treeherder/webapp/urls.py
@@ -15,13 +15,10 @@ browserid_admin.copy_registry(admin.site)
 urlpatterns = patterns('',
                        url(r'^api/', include(api_urls)),
                        url(r'^embed/', include(embed_urls)),
+                       url(r'^admin/', include(browserid_admin.urls)),
+                       url(r'^docs/', include('rest_framework_swagger.urls')),
+                       url(r'', include('django_browserid.urls')),
+                       # Redirect all requests on / to /index.html, where they
+                       # will be served by WhiteNoise.
+                       url(r'^$', RedirectView.as_view(url='index.html'))
                        )
-
-urlpatterns += patterns('',
-                        url(r'^admin/', include(browserid_admin.urls)),
-                        url(r'^docs/', include('rest_framework_swagger.urls')),
-                        url(r'', include('django_browserid.urls')),
-                        # Redirect all requests on / to /index.html, where they
-                        # will be served by WhiteNoise.
-                        url(r'^$', RedirectView.as_view(url='index.html'))
-                        )

--- a/treeherder/webapp/whitenoise_custom.py
+++ b/treeherder/webapp/whitenoise_custom.py
@@ -2,11 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+import re
 from whitenoise.django import DjangoWhiteNoise
 
 
 class CustomWhiteNoise(DjangoWhiteNoise):
 
+    IMMUTABLE_FILE_RE = r'\.min-[a-f0-9]{6,}\.(js|css)$'
     INDEX_NAME = 'index.html'
 
     def add_files(self, *args, **kwargs):
@@ -27,3 +29,10 @@ class CustomWhiteNoise(DjangoWhiteNoise):
         if url[-1] == '/':
             url += self.INDEX_NAME
         return super(CustomWhiteNoise, self).find_file(url)
+
+    def is_immutable_file(self, path, url):
+        # The default method only works with Django static files that use the
+        # CachedStaticFilesStorage naming scheme, whereas grunt-cache-busting
+        # uses a different scheme (eg index.min-feae259e2c205af67b0e91306f9363fa.js).
+        match = re.search(self.IMMUTABLE_FILE_RE, url)
+        return True if match else False

--- a/treeherder/webapp/whitenoise_custom.py
+++ b/treeherder/webapp/whitenoise_custom.py
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+from whitenoise.django import DjangoWhiteNoise
+
+
+class CustomWhiteNoise(DjangoWhiteNoise):
+
+    INDEX_NAME = 'index.html'
+
+    def add_files(self, *args, **kwargs):
+        super(CustomWhiteNoise, self).add_files(*args, **kwargs)
+        index_page_suffix = "/" + self.INDEX_NAME
+        index_name_length = len(self.INDEX_NAME)
+        index_files = {}
+        for url, static_file in self.files.items():
+            # Add an additional fake filename to serve index pages for '/'.
+            if url.endswith(index_page_suffix):
+                index_files[url[:-index_name_length]] = static_file
+        self.files.update(index_files)
+
+    def find_file(self, url):
+        # In debug mode, find_file() is used to serve files directly from the filesystem
+        # instead of using the list in `self.files`, so we append the index filename so
+        # that will be served if present.
+        if url[-1] == '/':
+            url += self.INDEX_NAME
+        return super(CustomWhiteNoise, self).find_file(url)

--- a/treeherder/webapp/wsgi.py
+++ b/treeherder/webapp/wsgi.py
@@ -26,7 +26,7 @@ import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "treeherder.settings")
 
 from django.core.wsgi import get_wsgi_application
-from whitenoise.django import DjangoWhiteNoise
+from treeherder.webapp.whitenoise_custom import CustomWhiteNoise
 
 try:
     import newrelic.agent
@@ -45,7 +45,7 @@ application = get_wsgi_application()
 # in production, avoiding the need for Apache/nginx on Heroku. WhiteNoise will
 # serve the Django static files at /static/ and also those in the directory
 # referenced by WHITENOISE_ROOT at the site root.
-application = DjangoWhiteNoise(application)
+application = CustomWhiteNoise(application)
 
 if newrelic:
     application = newrelic.agent.wsgi_application()(application)

--- a/treeherder/webapp/wsgi.py
+++ b/treeherder/webapp/wsgi.py
@@ -25,7 +25,6 @@ import os
 # os.environ["DJANGO_SETTINGS_MODULE"] = "webapp.settings"
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "treeherder.settings")
 
-from django.conf import settings
 from django.core.wsgi import get_wsgi_application
 from whitenoise.django import DjangoWhiteNoise
 
@@ -43,9 +42,10 @@ if newrelic:
 application = get_wsgi_application()
 
 # Wrap the Django WSGI app with WhiteNoise so the UI can be served by gunicorn
-# in production, avoiding the need for Apache/nginx on Heroku.
+# in production, avoiding the need for Apache/nginx on Heroku. WhiteNoise will
+# serve the Django static files at /static/ and also those in the directory
+# referenced by WHITENOISE_ROOT at the site root.
 application = DjangoWhiteNoise(application)
-application.add_files(settings.UI_ROOT)
 
 if newrelic:
     application = newrelic.agent.wsgi_application()(application)
@@ -53,7 +53,3 @@ if newrelic:
 # Fix django closing connection to MemCachier after every request (#11331)
 from django.core.cache.backends.memcached import BaseMemcachedCache
 BaseMemcachedCache.close = lambda self, **kwargs: None
-
-# Apply WSGI middleware here.
-# from helloworld.wsgi import HelloWorldApplication
-# application = HelloWorldApplication(application)


### PR DESCRIPTION
* Use WHITENOISE_ROOT instead of add_files() …
Instead of manually adding the UI directory using add_files(), we can use WhiteNoise's `WHITENOISE_ROOT` variable, per: http://whitenoise.evans.io/en/latest/django.html?#WHITENOISE_ROOT

* Update to v2.0.2 …
https://github.com/evansd/whitenoise/blob/master/CHANGELOG.rst
https://github.com/evansd/whitenoise/compare/v1.0.6...v2.0.2

* Remove superfluous `staticfiles_urlpatterns()` …
WhiteNoise 2.0 now uses staticfiles "finders" in development as of evansd/whitenoise@25f5757 so we don't need to handle urlpatterns for static asserts in urls.py.

* Combine definitions of `urlpatterns`

* Serve index.html for bare '/' URIs too …
Customise the DjangoWhiteNoise class, so that we add additional dummy '/' entries to the file mapping, for each index.html static file found. We also append the index filename to the URL in find_file(), since in debug mode files are served directly from the filesystem instead of
using the list in `self.files`. This means we can remove the site root redirect, allowing the Treeherder homepage to be served from:
https://treeherder-heroku.herokuapp.com/
...rather than:
https://treeherder-heroku.herokuapp.com/index.html
The original `add_files()` method:
https://github.com/evansd/whitenoise/blob/7de97f915479c46834ba7dcaadbd58e3cdc24b40/whitenoise/base.py#L165-L178
The original `find_file()` method:
https://github.com/evansd/whitenoise/blob/7de97f915479c46834ba7dcaadbd58e3cdc24b40/whitenoise/django.py#L85-L90

* Use infinite cache max-age for dist JS/CSS …
The JS/CSS files in the dist directory are given filenames containing the file SHA by grunt build. As such, these files can be given infinite cache max-age headers to save the browser experiencing a HTTP 304 round-trip each time - since when they do change, it will be picked up by the change of filename in the HTML. The default DjangoWhiteNoise `is_immutable_file()` method only works with Django static files that use the `CachedStaticFilesStorage` naming scheme:
https://github.com/evansd/whitenoise/blob/7de97f915479c46834ba7dcaadbd58e3cdc24b40/whitenoise/django.py#L92-L110
...whereas grunt-cache-busting uses a scheme like:
`index.min-feae259e2c205af67b0e91306f9363fa.js`
`logviewer.min-7d3b95c2e9323dfe5f825ebb45c7875d.css`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/713)
<!-- Reviewable:end -->
