### PR TITLE
Bug 1179214 - Stop storing the list of files changed in a revision

### DIFF
--- a/tests/client/data/resultset_data.json
+++ b/tests/client/data/resultset_data.json
@@ -4,11 +4,6 @@
     "push_timestamp": 1384353511,
     "revisions": [
       {
-        "files": [
-          "dom/bluetooth/BluetoothA2dpManager.cpp",
-          "dom/bluetooth/BluetoothHidManager.cpp",
-          "dom/bluetooth/linux/BluetoothDBusService.cpp"
-        ],
         "comment": "Bug 936711 - Fix crash which happened at disabling Bluetooth during reconnection. r=gyeh, a=koi+",
         "repository": "test_treeherder",
         "author": "Some Person <sperson@someplace.com>",
@@ -22,9 +17,6 @@
     "push_timestamp": 1384347643,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 1 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/b946d5776d33\nDesc: Merge pull request #13593 from wanderview/contacts-group-overflow\n\nBug 937291:  Limit overflow of each group list.  r=jmcf",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",
@@ -38,9 +30,6 @@
     "push_timestamp": 1384363842,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 1 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/b5b1d9aa0cc4\nDesc: Bug 934402 - Write an atom to send SMS using 'MozSMS' API",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",
@@ -54,9 +43,6 @@
     "push_timestamp": 1384358742,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 2 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/39145004f7c6\nDesc: Merge pull request #13659 from AndreiH/bug925851_v1.2\n\nBug 925851 - Re-enable test_capture_multiple_shots\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/b8010ab0e121\nDesc: Bug 925851 - Re-enable test_capture_multiple_shots",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",
@@ -70,9 +56,6 @@
     "push_timestamp": 1384365342,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 8 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/3b19a90a8cec\ndelvalle@gmail.com>\nDesc: Merge pull request #13628 from gtorodelvalle/contacts-bug-936283-search-bar-plus-Gmail-or-Outlook\n\nBug 936283 - [B2G][Contacts] Search bar stops functioning when searching contacts in Gmail or Outlook more than once(cherry picked from commit 351f9ad4b8f5e427cd90ae6bdfbafb9a4c9639c7)\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/aa52963f4c22\nDesc: Merge pull request #13604 from snowmantw/issue937023\n\nBug 937023 - [v1.2] Remove transparent to blue transition of lock screen handle and animation after unlock, r=timdream(cherry picked from commit 002578cc3cd0ca31e1333aafd8d019d9dd83e408)\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/05617615ced6\nDesc: Merge pull request #13570 from timdream/keyboard-settings-back\n\nBug 914093 - Back button for Gaia Keyboard settings page, r=rudyl(cherry picked from commit 9abc79e45a7283a557f177a3f9b54bec2668a2b8)\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/13af00ed5c50\nDesc: Merge pull request #13540 from asutherland/makefile-fix\n\nBug 931550 - Clock and Mail app only have rocket icon on homescreen, can't launch/broken. r=:yurenju(cherry picked from commit 513bafaceb391b5fb102ae3ac5a2a753f91ce164)\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/d0df3d96ac80\nDesc: Merge pull request #13516 from fcampo/sim-import-FTE-933381\n\nBug 933381 - [FTE] No message when importing from empty SIM (r=jmcf)(cherry picked from commit c560ddbda27b4c3cc129acad2fa8a6ec0d148308)\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/3521ebd132ea\nDesc: Merge pull request #13531 from fcampo/retry-import-Contacts-935301\n\nBug 935301 - [Contacts] Clicking retry on error while importing from SD doesn't retry(cherry picked from commit 164bed00446439e2aabb6e58587c379ff8850800)\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/303169692648\nDesc: Merge pull request #13568 from comoyo/hu_gone\n\nBug 936579 - Bring back Hungarian autocorrect. r=RudyL(cherry picked from commit fecd21241feb20df0e9bbed2f279c42112cd283c)\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/70d7967a35e7\nDesc: Bug 936418 - [keyboard] 'Layout selection' in keyboard style switcher dialog isn't localized\n(cherry picked from commit ff35da1e70028276510c39f7ebaa421a7acb3ade)",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",
@@ -86,9 +69,6 @@
     "push_timestamp": 1384364465,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 1 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/c7e53e332dcb\nDesc: Revert \"Merge pull request #13504 from jaoo/927486\"\n\nThis reverts commit c624b65c1333d2f951533ff5f5d3094681cb1916.",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",
@@ -102,9 +82,6 @@
     "push_timestamp": 1384365942,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 2 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/33a44ec49b53\nDesc: Merge pull request #13662 from AndreiH/bug934446_v1.2\n\nBug 934446 - Test Messages contact input validation\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/c6fdfdccfb2e\nDesc: Bug 934446 - Test Messages contact input validation",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",
@@ -118,9 +95,6 @@
     "push_timestamp": 1384366574,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 2 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/2ba51c7eadb0\nDesc: Merge pull request #13624 from teodosia/aurora-contact-photo-wait\n\nBug 937068 - Unxfail and enhance wait in test_contact_add_photo\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/d195214d4708\nDesc: Bug 937068 - Unxfail and enhance wait in test_contact_add_photo",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",
@@ -134,9 +108,6 @@
     "push_timestamp": 1384367498,
     "revisions": [
       {
-        "files": [
-          "parser/html/nsHtml5TreeOperation.cpp"
-        ],
         "comment": "Bug 930281 - Use nsINode instead of nsIContent. r=smaug, a=lsblakk.",
         "repository": "test_treeherder",
         "author": "Some Person <sperson@someplace.com>",
@@ -144,9 +115,6 @@
         "revision": "14ed3e7e606e"
       },
       {
-        "files": [
-          "js/src/jit/IonCaches.cpp"
-        ],
         "comment": "Bug 929261 - Fix for GetElementIC. r=shu, a=abillings",
         "repository": "test_treeherder",
         "author": "Some Person <sperson@someplace.com>",
@@ -154,11 +122,6 @@
         "revision": "80d76b93040f"
       },
       {
-        "files": [
-          "js/src/ctypes/CTypes.cpp",
-          "js/src/ctypes/CTypes.h",
-          "js/src/jsapi.h"
-        ],
         "comment": "Bug 919021 - Convert ctypes over to use JS::AutoValueVector instead of its own array class. r=terrence, a=lsblakk",
         "repository": "test_treeherder",
         "author": "Some Person <sperson@someplace.com>",
@@ -166,10 +129,6 @@
         "revision": "949dbbda2cfc"
       },
       {
-        "files": [
-          "configure.in",
-          "js/src/configure.in"
-        ],
         "comment": "Bug 927073 - Binary compatibility broken for maintenance releases due to strict version-script - regression fix. r=glandium, a=lsblakk",
         "repository": "test_treeherder",
         "author": "Some Person <sperson@someplace.com>",
@@ -177,9 +136,6 @@
         "revision": "344b9cd8dc62"
       },
       {
-        "files": [
-          "content/base/test/csp/test_policyuri_regression_from_multipolicy.html"
-        ],
         "comment": "Bug 934062 - Add waitForExplicitFinish to stop intermittent CSP test errors. r=sstamm, a=test-only",
         "repository": "test_treeherder",
         "author": "Some Person <sperson@someplace.com>",
@@ -187,14 +143,6 @@
         "revision": "1ba2f441a418"
       },
       {
-        "files": [
-          "toolkit/components/places/nsNavHistoryResult.cpp",
-          "toolkit/components/places/nsNavHistoryResult.h",
-          "toolkit/components/places/tests/queries/head_queries.js",
-          "toolkit/components/places/tests/queries/test_history_queries_tags_liveUpdate.js",
-          "toolkit/components/places/tests/queries/test_history_queries_titles_liveUpdate.js",
-          "toolkit/components/places/tests/unit/test_nsINavHistoryViewer.js"
-        ],
         "comment": "Bug 913160 - Back out Bug 894331 to solve browser hangs when deleting history. a=lsblakk",
         "repository": "test_treeherder",
         "author": "Some Person <sperson@someplace.com>",
@@ -202,15 +150,6 @@
         "revision": "1008d7007411"
       },
       {
-        "files": [
-          "config/config.mk",
-          "config/makefiles/precompile/Makefile.in",
-          "config/makefiles/xpidl/Makefile.in",
-          "js/src/config/config.mk",
-          "moz.build",
-          "python/mozbuild/mozbuild/action/xpidl-process.py",
-          "toolkit/toolkit.mozbuild"
-        ],
         "comment": "Bug 921816 - Handle idls in --with-libxul-sdk builds. r=gps, a=lsblakk",
         "repository": "test_treeherder",
         "author": "Some Person <sperson@someplace.com>",
@@ -218,9 +157,6 @@
         "revision": "77e95b4af9f0"
       },
       {
-        "files": [
-          "mobile/android/chrome/content/downloads.js"
-        ],
         "comment": "Bug 921776 - Notification completed not showing when download was started from a private tab. r=wesj, a=lsblakk",
         "repository": "test_treeherder",
         "author": "Some Person <sperson@someplace.com>",
@@ -228,9 +164,6 @@
         "revision": "a39f4c0f075d"
       },
       {
-        "files": [
-          "mobile/android/base/BrowserToolbar.java"
-        ],
         "comment": "Bug 934900 - Ensure back/forward are not re-enabled while in editing mode. r=sriram, a=lsblakk",
         "repository": "test_treeherder",
         "author": "Some Person <sperson@someplace.com>",
@@ -238,9 +171,6 @@
         "revision": "9ba6a44a6dfa"
       },
       {
-        "files": [
-          "configure.in"
-        ],
         "comment": "Merge m-b to b2g26. a=merge",
         "repository": "test_treeherder",
         "author": "Some Person <sperson@someplace.com>",
@@ -254,9 +184,6 @@
     "push_timestamp": 1384377343,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 2 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/9cde9c357524\nDesc: Merge pull request #13618 from viorelaioia/bug_937344_v1.2\n\n[v1.2] Bug 937344 - Replace get_all_video files in test_camera_capture_video with video_files property\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/d7f28b459e97\nDesc: [v1.2] Bug 937344 - Replace get_all_video files in test_camera_capture_video with video_files property",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",

--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -148,7 +148,6 @@ class TreeherderResultsetTest(DataSetup, unittest.TestCase):
                 tr.add_revision(revision['revision'])
                 tr.add_author(revision['author'])
                 tr.add_comment(revision['comment'])
-                tr.add_files(revision['files'])
                 tr.add_repository(revision['repository'])
 
                 trs.add_revision(tr)

--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -302,9 +302,6 @@ def _do_missing_resultset_test(jm, etl_process):
             "changesets": [
                 {
                     "node": new_revision + "b344655ed7be9a408d2970a736c4",
-                    "files": [
-                        "browser/base/content/browser.js"
-                    ],
                     "tags": [],
                     "author": "John Doe <jdoe@mozilla.com>",
                     "branch": "default",

--- a/tests/model/derived/conftest.py
+++ b/tests/model/derived/conftest.py
@@ -13,8 +13,4 @@ def revision_params():
         "comments": u"Bug 854583 - Use _pointer_ instead of...",
         "repository": u"mozilla-aurora",
         "revision": u"c91ee0e8a980",
-        "files": [
-            "file1",
-            "file2"
-        ]
     }

--- a/tests/sample_data/hg_pushlog.json
+++ b/tests/sample_data/hg_pushlog.json
@@ -4,11 +4,6 @@
   "changesets": [
    {
     "node": "1a046ece14db3801ab5ebaa3bb85b196ed3bbae3", 
-    "files": [
-     "content/base/src/nsDOMFile.cpp", 
-     "content/html/content/src/HTMLInputElement.cpp", 
-     "content/html/content/src/nsFormSubmission.cpp"
-    ], 
     "tags": [], 
     "author": "John Doe <jdoe@mozilla.com>", 
     "branch": "default", 
@@ -22,9 +17,6 @@
   "changesets": [
    {
     "node": "5371262398a0c4d194832052ca932c1e44279758", 
-    "files": [
-     "js/src/jit-test/tests/basic/testOOMInAutoEnterCompartment.js"
-    ], 
     "tags": [], 
     "author": "John Doe <jdoe@mozilla.com>", 
     "branch": "default", 
@@ -38,9 +30,6 @@
   "changesets": [
    {
     "node": "47b8ffe6ecc4b344655ed7be9a408d2970a736c4", 
-    "files": [
-     "browser/base/content/browser.js"
-    ], 
     "tags": [], 
     "author": "John Doe <jdoe@mozilla.com>", 
     "branch": "default", 
@@ -54,11 +43,6 @@
   "changesets": [
    {
     "node": "e1976a0ce384ed6601cfbf2903dfc6f5aa638547", 
-    "files": [
-     "testing/marionette/client/marionette/marionette.py", 
-     "testing/marionette/client/marionette/tests/unit/test_screenshot.py", 
-     "testing/marionette/marionette-listener.js"
-    ], 
     "tags": [], 
     "author": "John Doe <jdoe@mozilla.com>", 
     "branch": "default", 
@@ -72,10 +56,6 @@
   "changesets": [
    {
     "node": "f12a3d9e4cd6426ad9579b572281aa6327d99527", 
-    "files": [
-     "image/src/VectorImage.cpp", 
-     "image/src/VectorImage.h"
-    ], 
     "tags": [], 
     "author": "John Doe <jdoe@mozilla.com>", 
     "branch": "default", 
@@ -83,9 +63,6 @@
    }, 
    {
     "node": "8d8c2ce395a10f9dc7927332c2ba8bfc502044c6", 
-    "files": [
-     "layout/base/nsDisplayList.cpp"
-    ], 
     "tags": [], 
     "author": "John Doe <jdoe@mozilla.com>", 
     "branch": "default", 
@@ -93,11 +70,6 @@
    }, 
    {
     "node": "1c690d9998f7dfd50cce7129432d9f6ee9f267a5", 
-    "files": [
-     "image/test/mochitest/Makefile.in", 
-     "image/test/mochitest/lime-anim-100x100-2.svg", 
-     "image/test/mochitest/test_animSVGImage2.html"
-    ], 
     "tags": [], 
     "author": "John Doe <jdoe@mozilla.com>", 
     "branch": "default", 
@@ -111,10 +83,6 @@
   "changesets": [
    {
     "node": "bb1d06db46ebc7a1f9e114c11f99172ffb4a5fe8", 
-    "files": [
-     "js/src/TraceLogging.cpp", 
-     "js/src/TraceLogging.h"
-    ], 
     "tags": [], 
     "author": "John Doe <jdoe@mozilla.com>", 
     "branch": "default", 
@@ -128,10 +96,6 @@
   "changesets": [
    {
     "node": "f5743e7da43667013c15cb3796cffebd5c723fe0", 
-    "files": [
-     "js/xpconnect/src/Sandbox.cpp", 
-     "js/xpconnect/src/XPCWrappedNativeScope.cpp"
-    ], 
     "tags": [], 
     "author": "John Doe <jdoe@mozilla.com>", 
     "branch": "default", 
@@ -139,15 +103,6 @@
    }, 
    {
     "node": "365f2aca45cf51fc85184c09ed844744ee68ab46", 
-    "files": [
-     "dom/tests/mochitest/chrome/test_sandbox_eventhandler.xul", 
-     "js/xpconnect/src/Sandbox.cpp", 
-     "js/xpconnect/src/xpcprivate.h", 
-     "js/xpconnect/tests/unit/test_allowedDomainsXHR.js", 
-     "js/xpconnect/tests/unit/test_bug868675.js", 
-     "js/xpconnect/tests/unit/test_bug872772.js", 
-     "js/xpconnect/tests/unit/test_exportFunction.js"
-    ], 
     "tags": [], 
     "author": "John Doe <jdoe@mozilla.com>", 
     "branch": "default", 
@@ -155,12 +110,6 @@
    }, 
    {
     "node": "f186c97c90117a68f1dc91793e5a9e6e8f07b1a4", 
-    "files": [
-     "js/xpconnect/src/Sandbox.cpp", 
-     "js/xpconnect/src/xpcprivate.h", 
-     "js/xpconnect/tests/unit/test_textDecoder.js", 
-     "js/xpconnect/tests/unit/xpcshell.ini"
-    ], 
     "tags": [], 
     "author": "John Doe <jdoe@mozilla.com>", 
     "branch": "default", 
@@ -174,10 +123,6 @@
   "changesets": [
    {
     "node": "43566dc5dfbbdc3d31653623ac131d9461854c97", 
-    "files": [
-     "content/media/MediaDecoder.cpp", 
-     "content/media/MediaDecoder.h"
-    ], 
     "tags": [], 
     "author": "John Doe <jdoe@mozilla.com>", 
     "branch": "default", 
@@ -185,13 +130,6 @@
    }, 
    {
     "node": "b48f9c8d7aff27f9b072a59a1fd3694cfde29f06", 
-    "files": [
-     "layout/reftests/image-element/invalidate-1-ref.html", 
-     "layout/reftests/image-element/invalidate-1.html", 
-     "layout/reftests/image-element/reftest.list", 
-     "layout/reftests/image-element/repeatable-diagonal-gradient.png", 
-     "layout/style/ImageLoader.cpp"
-    ], 
     "tags": [], 
     "author": "John Doe <jdoe@mozilla.com>", 
     "branch": "default", 
@@ -205,9 +143,6 @@
   "changesets": [
    {
     "node": "1250c160eaec3d19764d0dc7ab32d81dc320c106", 
-    "files": [
-     "gfx/thebes/gfxFont.cpp"
-    ], 
     "tags": [], 
     "author": "John Doe <jdoe@mozilla.com>", 
     "branch": "default", 
@@ -221,9 +156,6 @@
   "changesets": [
    {
     "node": "2c25d2bbbcd6ddbd45962606911fd429e366b8e1", 
-    "files": [
-     "js/src/TraceLogging.h"
-    ], 
     "tags": [
      "tip"
     ], 

--- a/tests/sample_data/resultset_data.json
+++ b/tests/sample_data/resultset_data.json
@@ -4,11 +4,6 @@
     "push_timestamp": 1384353511,
     "revisions": [
       {
-        "files": [
-          "dom/bluetooth/BluetoothA2dpManager.cpp",
-          "dom/bluetooth/BluetoothHidManager.cpp",
-          "dom/bluetooth/linux/BluetoothDBusService.cpp"
-        ],
         "comment": "Bug 936711 - Fix crash which happened at disabling Bluetooth during reconnection. r=gyeh, a=koi+",
         "repository": "test_treeherder",
         "author": "Eric Chou <echou@mozilla.com>",
@@ -22,9 +17,6 @@
     "push_timestamp": 1384347643,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 1 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/b946d5776d33\nAuthor: Ben Kelly <bkelly@mozilla.com>\nDesc: Merge pull request #13593 from wanderview/contacts-group-overflow\n\nBug 937291:  Limit overflow of each group list.  r=jmcf",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",
@@ -38,9 +30,6 @@
     "push_timestamp": 1384363842,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 1 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/b5b1d9aa0cc4\nAuthor: Sergey Tupchiy <tupchii.sergii@gmail.com>\nDesc: Bug 934402 - Write an atom to send SMS using 'MozSMS' API",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",
@@ -54,9 +43,6 @@
     "push_timestamp": 1384358742,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 2 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/39145004f7c6\nAuthor: Teodosia Pop <teodosia.pop@gmail.com>\nDesc: Merge pull request #13659 from AndreiH/bug925851_v1.2\n\nBug 925851 - Re-enable test_capture_multiple_shots\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/b8010ab0e121\nAuthor: Andrei Hutusoru <andreihutusoru@P5069.(none)>\nDesc: Bug 925851 - Re-enable test_capture_multiple_shots",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",
@@ -70,9 +56,6 @@
     "push_timestamp": 1384365342,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 8 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/3b19a90a8cec\nAuthor: Germán Toro del Valle <gtorodelvalle@gmail.com>\nDesc: Merge pull request #13628 from gtorodelvalle/contacts-bug-936283-search-bar-plus-Gmail-or-Outlook\n\nBug 936283 - [B2G][Contacts] Search bar stops functioning when searching contacts in Gmail or Outlook more than once(cherry picked from commit 351f9ad4b8f5e427cd90ae6bdfbafb9a4c9639c7)\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/aa52963f4c22\nAuthor: Timothy Guan-tin Chien <timdream@gmail.com>\nDesc: Merge pull request #13604 from snowmantw/issue937023\n\nBug 937023 - [v1.2] Remove transparent to blue transition of lock screen handle and animation after unlock, r=timdream(cherry picked from commit 002578cc3cd0ca31e1333aafd8d019d9dd83e408)\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/05617615ced6\nAuthor: Timothy Guan-tin Chien <timdream@gmail.com>\nDesc: Merge pull request #13570 from timdream/keyboard-settings-back\n\nBug 914093 - Back button for Gaia Keyboard settings page, r=rudyl(cherry picked from commit 9abc79e45a7283a557f177a3f9b54bec2668a2b8)\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/13af00ed5c50\nAuthor: Andrew Sutherland <asutherland@asutherland.org>\nDesc: Merge pull request #13540 from asutherland/makefile-fix\n\nBug 931550 - Clock and Mail app only have rocket icon on homescreen, can't launch/broken. r=:yurenju(cherry picked from commit 513bafaceb391b5fb102ae3ac5a2a753f91ce164)\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/d0df3d96ac80\nAuthor: Fernando Campo <fernando.campo@o2.com>\nDesc: Merge pull request #13516 from fcampo/sim-import-FTE-933381\n\nBug 933381 - [FTE] No message when importing from empty SIM (r=jmcf)(cherry picked from commit c560ddbda27b4c3cc129acad2fa8a6ec0d148308)\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/3521ebd132ea\nAuthor: Jose M. Cantera <jmcanterafonseca@gmail.com>\nDesc: Merge pull request #13531 from fcampo/retry-import-Contacts-935301\n\nBug 935301 - [Contacts] Clicking retry on error while importing from SD doesn't retry(cherry picked from commit 164bed00446439e2aabb6e58587c379ff8850800)\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/303169692648\nAuthor: Jan Jongboom <janjongboom@gmail.com>\nDesc: Merge pull request #13568 from comoyo/hu_gone\n\nBug 936579 - Bring back Hungarian autocorrect. r=RudyL(cherry picked from commit fecd21241feb20df0e9bbed2f279c42112cd283c)\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/70d7967a35e7\nAuthor: mpizza <mmm198219@gmail.com>\nDesc: Bug 936418 - [keyboard] 'Layout selection' in keyboard style switcher dialog isn't localized\n(cherry picked from commit ff35da1e70028276510c39f7ebaa421a7acb3ade)",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",
@@ -86,9 +69,6 @@
     "push_timestamp": 1384364465,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 1 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/c7e53e332dcb\nAuthor: Julien Wajsberg <felash@gmail.com>\nDesc: Revert \"Merge pull request #13504 from jaoo/927486\"\n\nThis reverts commit c624b65c1333d2f951533ff5f5d3094681cb1916.",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",
@@ -102,9 +82,6 @@
     "push_timestamp": 1384365942,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 2 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/33a44ec49b53\nAuthor: Bob Silverberg <bob.silverberg@gmail.com>\nDesc: Merge pull request #13662 from AndreiH/bug934446_v1.2\n\nBug 934446 - Test Messages contact input validation\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/c6fdfdccfb2e\nAuthor: Andrei Hutusoru <andreihutusoru@P5069.(none)>\nDesc: Bug 934446 - Test Messages contact input validation",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",
@@ -118,9 +95,6 @@
     "push_timestamp": 1384366574,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 2 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/2ba51c7eadb0\nAuthor: Bob Silverberg <bob.silverberg@gmail.com>\nDesc: Merge pull request #13624 from teodosia/aurora-contact-photo-wait\n\nBug 937068 - Unxfail and enhance wait in test_contact_add_photo\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/d195214d4708\nAuthor: Teodosia Pop <teodosia.pop@gmail.com>\nDesc: Bug 937068 - Unxfail and enhance wait in test_contact_add_photo",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",
@@ -134,9 +108,6 @@
     "push_timestamp": 1384367498,
     "revisions": [
       {
-        "files": [
-          "parser/html/nsHtml5TreeOperation.cpp"
-        ],
         "comment": "Bug 930281 - Use nsINode instead of nsIContent. r=smaug, a=lsblakk.",
         "repository": "test_treeherder",
         "author": "Henri Sivonen <hsivonen@hsivonen.fi>",
@@ -144,9 +115,6 @@
         "revision": "14ed3e7e606e"
       },
       {
-        "files": [
-          "js/src/jit/IonCaches.cpp"
-        ],
         "comment": "Bug 929261 - Fix for GetElementIC. r=shu, a=abillings",
         "repository": "test_treeherder",
         "author": "Eric Faust <efaustbmo@gmail.com>",
@@ -154,11 +122,6 @@
         "revision": "80d76b93040f"
       },
       {
-        "files": [
-          "js/src/ctypes/CTypes.cpp",
-          "js/src/ctypes/CTypes.h",
-          "js/src/jsapi.h"
-        ],
         "comment": "Bug 919021 - Convert ctypes over to use JS::AutoValueVector instead of its own array class. r=terrence, a=lsblakk",
         "repository": "test_treeherder",
         "author": "Jeff Walden <jwalden@mit.edu>",
@@ -166,10 +129,6 @@
         "revision": "949dbbda2cfc"
       },
       {
-        "files": [
-          "configure.in",
-          "js/src/configure.in"
-        ],
         "comment": "Bug 927073 - Binary compatibility broken for maintenance releases due to strict version-script - regression fix. r=glandium, a=lsblakk",
         "repository": "test_treeherder",
         "author": "Philipp Kewisch <mozilla@kewis.ch>",
@@ -177,9 +136,6 @@
         "revision": "344b9cd8dc62"
       },
       {
-        "files": [
-          "content/base/test/csp/test_policyuri_regression_from_multipolicy.html"
-        ],
         "comment": "Bug 934062 - Add waitForExplicitFinish to stop intermittent CSP test errors. r=sstamm, a=test-only",
         "repository": "test_treeherder",
         "author": "Garrett Robinson <grobinson@mozilla.com>",
@@ -187,14 +143,6 @@
         "revision": "1ba2f441a418"
       },
       {
-        "files": [
-          "toolkit/components/places/nsNavHistoryResult.cpp",
-          "toolkit/components/places/nsNavHistoryResult.h",
-          "toolkit/components/places/tests/queries/head_queries.js",
-          "toolkit/components/places/tests/queries/test_history_queries_tags_liveUpdate.js",
-          "toolkit/components/places/tests/queries/test_history_queries_titles_liveUpdate.js",
-          "toolkit/components/places/tests/unit/test_nsINavHistoryViewer.js"
-        ],
         "comment": "Bug 913160 - Back out Bug 894331 to solve browser hangs when deleting history. a=lsblakk",
         "repository": "test_treeherder",
         "author": "Marco Bonardo <mbonardo@mozilla.com>",
@@ -202,15 +150,6 @@
         "revision": "1008d7007411"
       },
       {
-        "files": [
-          "config/config.mk",
-          "config/makefiles/precompile/Makefile.in",
-          "config/makefiles/xpidl/Makefile.in",
-          "js/src/config/config.mk",
-          "moz.build",
-          "python/mozbuild/mozbuild/action/xpidl-process.py",
-          "toolkit/toolkit.mozbuild"
-        ],
         "comment": "Bug 921816 - Handle idls in --with-libxul-sdk builds. r=gps, a=lsblakk",
         "repository": "test_treeherder",
         "author": "Mike Hommey <mh+mozilla@glandium.org>",
@@ -218,9 +157,6 @@
         "revision": "77e95b4af9f0"
       },
       {
-        "files": [
-          "mobile/android/chrome/content/downloads.js"
-        ],
         "comment": "Bug 921776 - Notification completed not showing when download was started from a private tab. r=wesj, a=lsblakk",
         "repository": "test_treeherder",
         "author": "Federico Paolinelli <fedepaol@gmail.com>",
@@ -228,9 +164,6 @@
         "revision": "a39f4c0f075d"
       },
       {
-        "files": [
-          "mobile/android/base/BrowserToolbar.java"
-        ],
         "comment": "Bug 934900 - Ensure back/forward are not re-enabled while in editing mode. r=sriram, a=lsblakk",
         "repository": "test_treeherder",
         "author": "Lucas Rocha <lucasr@lucasr.org>",
@@ -238,9 +171,6 @@
         "revision": "9ba6a44a6dfa"
       },
       {
-        "files": [
-          "configure.in"
-        ],
         "comment": "Merge m-b to b2g26. a=merge",
         "repository": "test_treeherder",
         "author": "Ryan VanderMeulen <ryanvm@gmail.com>",
@@ -254,9 +184,6 @@
     "push_timestamp": 1384377343,
     "revisions": [
       {
-        "files": [
-          "b2g/config/gaia.json"
-        ],
         "comment": "Bumping gaia.json for 2 gaia-1_2 revision(s) a=gaia-bump\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/9cde9c357524\nAuthor: Bob Silverberg <bob.silverberg@gmail.com>\nDesc: Merge pull request #13618 from viorelaioia/bug_937344_v1.2\n\n[v1.2] Bug 937344 - Replace get_all_video files in test_camera_capture_video with video_files property\n\n========\n\nhttps://hg.mozilla.org/integration/gaia-1_2/rev/d7f28b459e97\nAuthor: Viorela Ioia <viorelaioia@gmail.com>\nDesc: [v1.2] Bug 937344 - Replace get_all_video files in test_camera_capture_video with video_files property",
         "repository": "test_treeherder",
         "author": "Gaia Pushbot <release+gaiajson@mozilla.com>",

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -362,7 +362,6 @@ class TreeherderRevision(TreeherderData, ValidatorMixin):
         self.required_properties = {
             'revision': {'len': 50, 'cb': self.validate_existence},
             'repository': {'cb': self.validate_existence},
-            'files': {'type': list, 'cb': self.validate_existence},
             }
 
     def init_data(self):
@@ -372,8 +371,6 @@ class TreeherderRevision(TreeherderData, ValidatorMixin):
             'author': '',
             # Stored in project_jobs_1.revision.comments
             'comment': '',
-            # Stored in project_jobs_1.revision.files
-            'files': [],
             # Stored in treeherder_reference_1.repository.name
             'repository': '',
             # Stored in project_jobs_1.revision.revision
@@ -385,14 +382,6 @@ class TreeherderRevision(TreeherderData, ValidatorMixin):
 
     def add_comment(self, comment):
         self.data['comment'] = comment
-
-    def add_files(self, files):
-        if files:
-            self.data['files'] = files
-
-    def add_file(self, src_file):
-        if src_file:
-            self.data['files'].append(src_file)
 
     def add_repository(self, repository):
         self.data['repository'] = repository

--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -211,7 +211,6 @@ def get_not_found_onhold_push(url, revision):
             "changesets": [
                 {
                     "node": revision,
-                    "files": [],
                     "tags": [],
                     "author": "Unknown",
                     "branch": "default",

--- a/treeherder/etl/mixins.py
+++ b/treeherder/etl/mixins.py
@@ -90,11 +90,6 @@ class ResultSetsLoaderMixin(JsonLoaderMixin):
                 "revisions": [
                     {
                         "id": "d62d628d5308f2b9ee81be755140d77f566bb400",
-                        "files": [
-                            "file1",
-                            "file2",
-                            "file3"
-                        ],
                         "author": "Mauro Doglio <mdoglio@mozilla.com>",
                         "branch": "default",
                         "comment":" Lorem ipsum dolor sit amet, consectetur adipiscing elit.",

--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -46,7 +46,6 @@ class HgPushlogTransformerMixin(object):
                 # because buildapi doesn't provide the long one
                 # and we need to match it
                 revision['revision'] = change['node'][0:12]
-                revision['files'] = change['files']
                 revision['author'] = change['author']
                 revision['branch'] = change['branch']
                 revision['comment'] = change['desc']

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -2279,7 +2279,6 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
              "author": "some-sheriff@mozilla.com",
              "revisions": [
                 {
-                    "files": ["js/src/TraceLogging.h"],
                     "comment": "Bug 911954 - Add forward declaration of JSScript to TraceLogging.h, r=h4writer",
                     "repository": "test_treeherder",
                     "author": "John Doe <jdoe@mozilla.com>",
@@ -2349,18 +2348,11 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                     'comment', None
                 )
 
-                # Convert the file list to a comma delimited string
-                file_list = rev_datum.get(
-                    'files', []
-                )
-                file_str = ','.join(file_list)
-
                 repository_id = repository_id_lookup[rev_datum['repository']]
                 revision_placeholders.append(
                     [rev_datum['revision'],
                      rev_datum['author'],
                      comment,
-                     file_str,
                      commit_timestamp,
                      repository_id,
                      rev_datum['revision'],

--- a/treeherder/model/sample_data/pushlog.json.sample
+++ b/treeherder/model/sample_data/pushlog.json.sample
@@ -14,8 +14,6 @@
             'author': 'John Doe <jdoe@mozilla.com>',
             'branch': 'default',
             'comment': 'Bug 892203 - Minor cleanups in sandbox.cpp. r=bholley',
-            'files': ['js/xpconnect/src/Sandbox.cpp',
-                'js/xpconnect/src/XPCWrappedNativeScope.cpp'],
             'repository': 'test_treeherder',
             'revision': 'f5743e7da436'
         },
@@ -23,13 +21,6 @@
             'author': 'John Doe <jdoe@mozilla.com>',
             'branch': 'default',
             'comment': 'Bug 892203 - DOMConstructors for SandboxOptions. r=bholley',
-            'files': ['dom/tests/mochitest/chrome/test_sandbox_eventhandler.xul',
-                'js/xpconnect/src/Sandbox.cpp',
-                'js/xpconnect/src/xpcprivate.h',
-                'js/xpconnect/tests/unit/test_allowedDomainsXHR.js',
-                'js/xpconnect/tests/unit/test_bug868675.js',
-                'js/xpconnect/tests/unit/test_bug872772.js',
-                'js/xpconnect/tests/unit/test_exportFunction.js'],
             'repository': 'test_treeherder',
             'revision': '365f2aca45cf'
         },
@@ -37,10 +28,6 @@
             'author': 'John Doe <jdoe@mozilla.com>',
             'branch': 'default',
             'comment': 'Bug 892203 - TextEncoder and TextDecoder for sandbox. r=bholley',
-            'files': ['js/xpconnect/src/Sandbox.cpp',
-                'js/xpconnect/src/xpcprivate.h',
-                'js/xpconnect/tests/unit/test_textDecoder.js',
-                'js/xpconnect/tests/unit/xpcshell.ini'],
             'repository': 'test_treeherder',
             'revision': 'f186c97c9011'
         }

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -156,11 +156,10 @@
                     `revision`,
                     `author`,
                     `comments`,
-                    `files`,
                     `commit_timestamp`,
                     `repository_id`
                     )
-                SELECT ?,?,?,?,?,?
+                SELECT ?,?,?,?,?
                 FROM DUAL
                 WHERE NOT EXISTS (
                     SELECT `revision`

--- a/treeherder/model/sql/template_schema/project_jobs.sql.tmpl
+++ b/treeherder/model/sql/template_schema/project_jobs.sql.tmpl
@@ -504,7 +504,6 @@ CREATE TABLE `revision` (
   `author` varchar(150) COLLATE utf8_bin NOT NULL,
   `comments` text DEFAULT NULL,
   `commit_timestamp` int(11) unsigned default NULL,
-  `files` mediumtext COLLATE utf8_bin,
   `repository_id` int(11) unsigned NOT NULL,
   `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
   PRIMARY KEY (`id`),


### PR DESCRIPTION
Since we're not currently using it, and the schema we need will likely be different if we were to start using it in the future.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/714)
<!-- Reviewable:end -->
