### PR TITLE
Bug 1181529 - Update peep to v2.4.1

### DIFF
--- a/bin/peep.py
+++ b/bin/peep.py
@@ -105,7 +105,7 @@ except ImportError:
     DownloadProgressBar = DownloadProgressSpinner = NullProgressBar
 
 
-__version__ = 2, 4, 0
+__version__ = 2, 4, 1
 
 
 ITS_FINE_ITS_FINE = 0
@@ -354,7 +354,6 @@ class DownloadedReq(object):
         self._req = req
         self._argv = argv
         self._finder = finder
-
 
         # We use a separate temp dir for each requirement so requirements
         # (from different indices) that happen to have the same archive names
@@ -890,7 +889,7 @@ def exception_handler(exc_type, exc_value, exc_tb):
     print('---')
     print('peep:', repr(__version__))
     print('python:', repr(sys.version))
-    print('pip:', repr(pip.__version__))
+    print('pip:', repr(getattr(pip, '__version__', 'no __version__ attr')))
     print('Command line: ', repr(sys.argv))
     print(
         ''.join(traceback.format_exception(exc_type, exc_value, exc_tb)))

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 [pep8]
-exclude = .git,__pycache__,.vagrant,bin/peep.py,node_modules
+exclude = .git,__pycache__,.vagrant,node_modules
 # E121,E123,E126,E226,E24,E704: Ignored in default pep8 config:
 # https://github.com/jcrocholl/pep8/blob/8ca030e2d8f6d377631bae69a18307fb2d051049/pep8.py#L68
 # Our additions...
@@ -15,7 +15,7 @@ max-line-length = 140
 # flake8 is a combination of pyflakes & pep8.
 # Unfortunately we have to mostly duplicate the above, since some tools use
 # pep8's config (eg autopep8) so we can't just define everything under [flake8].
-exclude = .git,__pycache__,.vagrant,bin/peep.py,node_modules
+exclude = .git,__pycache__,.vagrant,node_modules
 # The ignore list for pep8 above, plus our own PyFlakes addition:
 # F403: 'from module import *' used; unable to detect undefined names
 ignore = E121,E123,E126,E226,E24,E704,E501,F403


### PR DESCRIPTION
* Tolerates `pip.__version__` being missing, which can happen in arcane
  situations during error handling, obscuring informative tracebacks.
* flake8 warnings are fixed again, so peep.py can be removed from the
  exclude list.

https://github.com/erikrose/peep/releases/tag/2.4.1
https://github.com/erikrose/peep/compare/2.4...2.4.1

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/719)
<!-- Reviewable:end -->
