### PR TITLE
Bug 1181572 - Stop calculating/storing pending_eta

### DIFF
--- a/tests/ui/mock/job_list/job_1.json
+++ b/tests/ui/mock/job_list/job_1.json
@@ -23,7 +23,6 @@
     "platform",
     "state",
     "running_eta",
-    "pending_eta",
     "build_os",
     "option_collection_hash",
     "who",

--- a/tests/ui/mock/job_list/job_2.json
+++ b/tests/ui/mock/job_list/job_2.json
@@ -23,7 +23,6 @@
     "platform",
     "state",
     "running_eta",
-    "pending_eta",
     "build_os",
     "option_collection_hash",
     "who",

--- a/tests/ui/mock/job_list/pagination/page_1.json
+++ b/tests/ui/mock/job_list/pagination/page_1.json
@@ -23,7 +23,6 @@
     "platform",
     "state",
     "running_eta",
-    "pending_eta",
     "build_os",
     "option_collection_hash",
     "who",

--- a/tests/ui/mock/job_list/pagination/page_2.json
+++ b/tests/ui/mock/job_list/pagination/page_2.json
@@ -23,7 +23,6 @@
     "platform",
     "state",
     "running_eta",
-    "pending_eta",
     "build_os",
     "option_collection_hash",
     "who",

--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -56,7 +56,6 @@ def test_job_list(webapp, eleven_jobs_processed, jm):
         "build_os",
         "machine_platform_architecture",
         "failure_classification_id",
-        "pending_eta",
         "running_eta",
         "tier",
         "last_modified",

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -83,10 +83,9 @@
                 `submit_timestamp`,
                 `start_timestamp`,
                 `end_timestamp`,
-                `pending_eta`,
                 `running_eta`,
                 `tier`)
-                SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?
+                SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?
                 FROM DUAL WHERE NOT EXISTS (
                     SELECT `job_guid`
                     FROM `job`
@@ -418,27 +417,16 @@
             "host_type":"read_host"
 
         },
-        "get_max_job_submit_timestamp":{
+        "get_max_job_start_timestamp":{
 
-            "sql": "SELECT MAX(`submit_timestamp`) AS 'submit_timestamp' FROM `job`",
+            "sql": "SELECT MAX(`start_timestamp`) AS 'start_timestamp' FROM `job`",
 
             "host_type":"master_host"
 
         },
-        "get_eta_groups":{
+        "get_running_eta_stats":{
 
             "sql":"SELECT signature,
-                          CAST(
-                            ROUND( AVG(start_timestamp - submit_timestamp) )
-                            AS UNSIGNED) AS 'pending_avg_sec',
-
-                          MIN(start_timestamp - submit_timestamp) AS 'pending_min_sec',
-                          MAX(start_timestamp - submit_timestamp) AS 'pending_max_sec',
-
-                          CAST(
-                            ROUND( STD(start_timestamp - submit_timestamp))
-                            AS UNSIGNED) AS 'pending_std',
-
                           CAST(
                             ROUND( AVG(end_timestamp - start_timestamp) )
                             AS UNSIGNED) AS 'running_avg_sec',
@@ -450,14 +438,10 @@
                             ROUND( STD(end_timestamp - start_timestamp) )
                             AS SIGNED) AS 'running_std',
 
-                          GROUP_CONCAT(start_timestamp - submit_timestamp SEPARATOR ',')
-                            AS 'pending_samples',
-
                           GROUP_CONCAT(end_timestamp - start_timestamp SEPARATOR ',')
                             AS 'running_samples'
                    FROM job
-                   WHERE submit_timestamp >= ? AND
-                         start_timestamp >= submit_timestamp AND
+                   WHERE start_timestamp >= ? AND
                          end_timestamp >= start_timestamp AND
                          start_timestamp > 0 AND end_timestamp > 0
                    GROUP BY signature",
@@ -552,7 +536,6 @@
                     j.`start_timestamp`,
                     j.`end_timestamp`,
                     j.`submit_timestamp`,
-                    j.`pending_eta`,
                     j.`running_eta`,
                     j.`last_modified`,
                     j.`tier`,
@@ -609,7 +592,6 @@
                     j.`start_timestamp`,
                     j.`end_timestamp`,
                     j.`submit_timestamp`,
-                    j.`pending_eta`,
                     j.`running_eta`,
                     j.`last_modified`,
                     j.`tier`,

--- a/treeherder/model/sql/template_schema/project_jobs.sql.tmpl
+++ b/treeherder/model/sql/template_schema/project_jobs.sql.tmpl
@@ -103,7 +103,6 @@ DROP TABLE IF EXISTS `job`;
  *  start_timestamp - Time the job was started.
  *  end_timestamp - Time the job completed.
  *  last_modified - The last time the job was modified
- *  pending_eta - ETA to a running state. A rolling average over a 6 hr window of start_timestamp - submit_timestamp, recomputed every 30 min.
  *  running_eta - ETA to a completed state. A rolling average over a 6 hr window of end_timestamp - start_timestamp, recomputed every 30 min.
  **************************/
 CREATE TABLE `job` (
@@ -128,7 +127,6 @@ CREATE TABLE `job` (
   `start_timestamp` int(10) unsigned DEFAULT NULL,
   `end_timestamp` int(10) unsigned DEFAULT NULL,
   `last_modified` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  `pending_eta` int(10) unsigned DEFAULT NULL,
   `running_eta` int(10) unsigned DEFAULT NULL,
   `tier` int(10) unsigned DEFAULT 1,
   `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
@@ -153,7 +151,6 @@ CREATE TABLE `job` (
   KEY `idx_start_timestamp` (`start_timestamp`),
   KEY `idx_end_timestamp` (`end_timestamp`),
   KEY `idx_last_modified` (`last_modified`),
-  KEY `idx_pending_eta` (`pending_eta`),
   KEY `idx_running` (`running_eta`),
   KEY `idx_tier` (`tier`),
   KEY `idx_active_status` (`active_status`),


### PR DESCRIPTION
Since bug 1096605, the UI no longer uses pending_eta, since it's too hard to predict, and thus unreliable. As such, we can remove it from the API response & stop calculating/storing it during ingestion.

Once this is deployed, we can delete all rows in the job_eta tables that have a 'state' of 'pending'. After that, we can remove the 'state' field and perform some further simplification of ETA handling (but that cannot be done now, or we'll inadvertently include pending rows in the running ETA stats).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/721)
<!-- Reviewable:end -->
