### PR TITLE
Bug 1181636 - Improve the resultset bar tooltips

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -120,7 +120,7 @@
             <li>
                 <span class="revision">
                     <a href="{{currentRepo.getRevisionHref(revision)}}"
-                       title="open revision {{revision}} on {{currentRepo.url}}"
+                       title="Open revision {{revision}} on {{currentRepo.url}}"
                        ignore-job-clear-on-click
                        >{{revision}}</a>
                     <span title="{{name}}: {{email}}">{{name|initials}}</span>

--- a/ui/js/directives/treeherder/resultsets.js
+++ b/ui/js/directives/treeherder/resultsets.js
@@ -86,7 +86,7 @@ treeherder.directive('thAuthor', function () {
             scope.authorName = userTokens[0].trim();
             scope.authorEmail = email;
         },
-        template: '<span title="open resultsets for {{authorName}}: {{authorEmail}}">' +
+        template: '<span title="View resultsets for {{authorName}}: {{authorEmail}}">' +
                       '<a href="{{authorResultsetFilterUrl}}"' +
                          'ignore-job-clear-on-click>{{authorName}}</a></span>'
     };

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -26,7 +26,7 @@
 
         <span class="btn btn-sm btn-resultset"
               tabindex="0" role="button"
-              title="cancel all jobs in this resultset"
+              title="Cancel all jobs in this resultset"
               ng-show="currentRepo.repository_group.name == 'try' || user.is_staff"
               ignore-job-clear-on-click
               ng-click="cancelAllJobs(resultset.revision)">
@@ -36,7 +36,7 @@
 
         <span class="btn btn-sm btn-resultset"
               tabindex="0" role="button"
-              title="pin all visible jobs in this resultset"
+              title="Pin all visible jobs in this resultset"
               ignore-job-clear-on-click
               ng-click="pinAllShownJobs()">
           <span class="glyphicon glyphicon-pushpin"


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1181636](https://bugzilla.mozilla.org/show_bug.cgi?id=1181636).

This makes the Author title use the same term ('View') as the Date title, and capitalizes other titles in the bar for consistency.

![resultsettitletweaks](https://cloud.githubusercontent.com/assets/3660661/8576465/535dc54e-2570-11e5-81b0-422f825c6851.jpg)

Tested on OSX 10.10.3:
FF Nightly 41.0a1 (2015-07-05)
Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/724)
<!-- Reviewable:end -->
