### PR TITLE
Bug 1181693 - Update futures to v3.0.3

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -72,8 +72,8 @@ jsonfield==0.9.20
 # sha256: VWwL-EtIVxnxoh6fOyr3I1Xfknt53vLkVD2QwBA4vfc
 mozlog==2.11
 
-# sha256: ImnQ8PfxhxMzeMZknae86g-jPdJ2kQo5Ii2SQ8AVY1E
-futures==3.0.2
+# sha256: BK-ioGq33MqdgXF7Qgp6FIJgYemyYUpcd90kx1zPl-Q
+futures==3.0.3
 
 # sha256: nnifUs_v5v9XxzD-_XayNXIzZOVCB12Z34M7zdrOV9c
 https://github.com/jeads/datasource/archive/v0.7.tar.gz#egg=datasource


### PR DESCRIPTION
Only one change:
* Fixed AttributeErrors on exit on Python 2.x

https://github.com/agronholm/pythonfutures/blob/master/CHANGES
https://github.com/agronholm/pythonfutures/compare/3.0.2...3.0.3

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/725)
<!-- Reviewable:end -->
