### PR TITLE
Bug 1182201 - Compress blobs in the performance_series table

### DIFF
--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -7,6 +7,7 @@ import json
 import pytest
 import copy
 import threading
+import zlib
 
 from django.conf import settings
 from django.core.management import call_command
@@ -474,7 +475,7 @@ def test_store_performance_series(jm, test_project):
     stored_series = jm.get_jobs_dhub().execute(
         proc="jobs.selects.get_performance_series",
         placeholders=[FakePerfData.TIME_INTERVAL, FakePerfData.SIGNATURE])
-    blob = json.loads(stored_series[0]['blob'])
+    blob = json.loads(zlib.decompress(stored_series[0]['blob']))
     assert len(blob) == 1
     assert blob[0] == FakePerfData.SERIES[0]
 
@@ -509,7 +510,7 @@ def test_store_performance_series_timeout_recover(jm, test_project):
         proc="jobs.selects.get_performance_series",
         placeholders=[FakePerfData.TIME_INTERVAL, FakePerfData.SIGNATURE])
 
-    blob = json.loads(stored_series[0]['blob'])
+    blob = json.loads(zlib.decompress(stored_series[0]['blob']))
     assert len(blob) == 1
     assert blob[0] == FakePerfData.SERIES[0]
 


### PR DESCRIPTION
Since they can be up to 800+ KB in size and whilst there are not many rows in the table, if they are not compressed it bloats the binlogs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/736)
<!-- Reviewable:end -->
