### PR TITLE
Bug 1182201 - performance_series blobs are not compressed (part 2)

### DIFF
--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -87,11 +87,7 @@ class ArtifactsModel(TreeherderModelBase):
             debug_show=self.DEBUG,
         )
         for artifact in data:
-            # new blobs are gzip'ed to save space, old ones may not be
-            try:
-                artifact["blob"] = zlib.decompress(artifact["blob"])
-            except zlib.error:
-                pass
+            artifact["blob"] = utils.decompress_if_needed(artifact["blob"])
 
             if artifact["type"] == "json":
                 artifact["blob"] = json.loads(artifact["blob"])
@@ -124,11 +120,7 @@ class ArtifactsModel(TreeherderModelBase):
         )
 
         for artifact in data:
-            # new blobs are gzip'ed to save space, old ones may not be
-            try:
-                artifact["blob"] = zlib.decompress(artifact["blob"])
-            except zlib.error:
-                pass
+            artifact["blob"] = utils.decompress_if_needed(artifact["blob"])
 
             # performance artifacts are always json encoded
             artifact["blob"] = json.loads(artifact["blob"])

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -415,7 +415,7 @@ class JobsModel(TreeherderModelBase):
 
         series_summary = cache.get(cache_key, None)
         if series_summary:
-            series_summary = json.loads(zlib.decompress(series_summary))
+            series_summary = json.loads(utils.decompress_if_needed(series_summary))
         else:
             data = self.get_jobs_dhub().execute(
                 proc="jobs.selects.get_perf_series_properties",
@@ -2095,11 +2095,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 debug_show=self.DEBUG,
                 placeholders=[t_range, signature])
 
-            # new blobs are gzip'ed to save space, old ones may not be
-            try:
-                db_series_json = zlib.decompress(performance_series[0]['blob'])
-            except zlib.error:
-                db_series_json = performance_series[0]['blob']
+            db_series_json = utils.decompress_if_needed(performance_series[0]['blob'])
 
             # If they're equal this was the first time the t_range
             # and signature combination was stored, so there's nothing to

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1944,7 +1944,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             replace=repl)
 
         data = [{"series_signature": x["series_signature"],
-                 "blob": json.loads(x["blob"])} for x in data]
+                 "blob": json.loads(utils.decompress_if_needed(x["blob"]))} for x in data]
 
         return data
 

--- a/treeherder/model/management/commands/rewrite_perf_data.py
+++ b/treeherder/model/management/commands/rewrite_perf_data.py
@@ -7,6 +7,7 @@ import copy
 from django.core.management.base import BaseCommand
 from optparse import make_option
 from treeherder.client import PerformanceTimeInterval
+from treeherder.model import utils
 from treeherder.model.derived.jobs import JobsModel
 from treeherder.model.models import Datasource
 from treeherder.etl.perf_data_adapters import TalosDataAdapter
@@ -70,7 +71,7 @@ class Command(BaseCommand):
             series_list = jm.get_performance_series_from_signatures(
                 [signature_hash], time_interval)
 
-            series = series_list[0]['blob']
+            series = utils.decompress_if_needed(series_list[0]['blob'])
             jm.store_performance_series(time_interval, 'talos_data',
                                         str(new_hash), series)
 

--- a/treeherder/model/utils.py
+++ b/treeherder/model/utils.py
@@ -5,6 +5,8 @@
 import time
 import simplejson as json
 import random
+import zlib
+
 from _mysql_exceptions import OperationalError
 
 
@@ -15,6 +17,17 @@ def get_now_timestamp():
     This is useful because it can be mocked out in unit tests.
     """
     return int(time.time())
+
+
+def decompress_if_needed(blob):
+    """
+    New blobs are gzip'ed to save space, but old ones may not be,
+    in which case we need to handle them gracefully.
+    """
+    try:
+        return zlib.decompress(blob)
+    except zlib.error:
+        return blob
 
 
 def where_wolf(project, flat_exclusions):


### PR DESCRIPTION
* Create a utils.py helper for zlib.decompress try-except …
We have several places where we need to decompress blobs, but have to gracefully handle old data that is not compressed. Let's use a helper function to save repeating the same pattern everywhere.
* Decompress performance_series blobs in a few more places …
Fix a few places where we weren't decompressing the blob retrieved from the performance_series table.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/737)
<!-- Reviewable:end -->
