### PR TITLE
Bug 1182299 - Support custom logname param in logslice

### DIFF
--- a/docs/submitting_data.rst
+++ b/docs/submitting_data.rst
@@ -118,10 +118,12 @@ characters at most. A job collection has the following data structure.
                 # be saved as Tier 2.
                 'tier': 2,
 
+                # the ``name`` of the log can be the default of "buildbot_text"
+                # however, you can use a custom name.  See below.
                 'log_references': [
                     {
                         'url': 'http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/...',
-                        'name': 'builds-4h'
+                        'name': 'buildbot_text'
                         }
                     ],
 
@@ -137,6 +139,9 @@ characters at most. A job collection has the following data structure.
             },
             ...
     ]
+
+see :ref:`custom-log-name` for more info.
+
 
 Artifact Collections
 --------------------
@@ -262,7 +267,7 @@ structures to send, do something like this:
 
         tj.add_option_collection( data['option_collection'] )
 
-        tj.add_log_reference( 'builds-4h', data['log_reference'] )
+        tj.add_log_reference( 'buildbot_text', data['log_reference'] )
 
         # data['artifact'] is a list of artifacts
         for artifact_data in data['artifact']:
@@ -495,3 +500,55 @@ Via the ``/artifact`` endpoint:
 2. Submit ``text_log_summary`` and ``Bug suggestions`` artifacts
     * Will generate nothing
     * This is *Treeherder's* current internal log parser workflow
+
+
+.. _custom-log-name:
+
+Specifying Custom Log Names
+---------------------------
+
+By default, the Log Viewer expects logs to have the name of ``buildbot_text``
+at this time.  However, if you are supplying the ``text_log_summary`` artifact
+yourself (rather than having it generated for you) you can specify a custom
+log name.  You must specify the name in two places for this to work.
+
+1. When you add the log reference to the job:
+
+.. code-block:: python
+
+    tj.add_log_reference( 'my_custom_log', data['log_reference'] )
+
+
+2. In the ``text_log_summary`` artifact blob, specify the ``logname`` param.
+   This artifact is what the Log Viewer uses to find the associated log lines
+   for viewing.
+
+.. code-block:: python
+
+    {
+        "blob":{
+            "step_data": {
+                "all_errors": [ ],
+                "steps": [
+                    {
+                        "errors": [ ],
+                        "name": "step",
+                        "started_linenumber": 1,
+                        "finished_linenumber": 1,
+                        "finished": "2015-07-08 06:13:46",
+                        "result": "success",
+                        "duration": 2671,
+                        "order": 0,
+                        "error_count": 0
+                    }
+                ],
+                "errors_truncated": false
+            },
+            "logurl": "https://example.com/mylog.log",
+            "logname": "my_custom_log"
+        },
+        "type": "json",
+        "id": 10577808,
+        "name": "text_log_summary",
+        "job_id": 1774360
+    }

--- a/treeherder/webapp/api/logslice.py
+++ b/treeherder/webapp/api/logslice.py
@@ -62,11 +62,19 @@ class LogSliceView(viewsets.ViewSet):
         # get only the log that matches the ``log_name``
         logs = jm.get_log_references(job_id)
 
+        # @todo: remove after no more logs named 'builds-4h' exist in the db.  Should be after Aug 30, 2015.
+        exp_log_names = [log_name, 'builds-4h']
+
         try:
-            # @todo: remove after no more logs named 'builds-4h' exist in the db.  Should be after Aug 30, 2015.
-            log = next(log for log in logs if log["name"] in [log_name, 'builds-4h'])
+            log = next(log for log in logs if log["name"] in exp_log_names)
         except StopIteration:
-            raise ResourceNotFoundException("job_artifact {0} not found".format(job_id))
+            act_log_names = [x["name"] for x in logs]
+            raise ResourceNotFoundException(
+                "Expected log names of {} not found in {} for job_id {}".format(
+                    exp_log_names,
+                    act_log_names,
+                    job_id,
+                    ))
 
         try:
             url = log.get("url")

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -90,12 +90,15 @@ logViewerApp.controller('LogviewerCtrl', [
                 }
 
                 $scope.loading = true;
-
-                LogSlice.get_line_range({
+                var lineRangeParams = {
                     job_id: $scope.job_id,
                     start_line: range.start,
                     end_line: range.end
-                }, {
+                };
+                if ($scope.artifact.logname) {
+                    lineRangeParams.name = $scope.artifact.logname;
+                }
+                LogSlice.get_line_range(lineRangeParams, {
                     buffer_size: LINE_BUFFER_SIZE
                 }).then(function(data) {
                     var slicedData, length;


### PR DESCRIPTION
This allows a user to submit log references with custom names.  They then must specify that name in their custom ``text_log_summary`` for the log viewer to find the log to slice and show lines.

The docs in this PR explain how this will work.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/738)
<!-- Reviewable:end -->
