### PR TITLE
Bug 1182455 - Remove support for different DB hosts per datasource

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,8 +166,6 @@ def jobs_ds():
     return Datasource.objects.create(
         project=settings.DATABASES["default"]["TEST_NAME"],
         contenttype="jobs",
-        host=settings.TREEHERDER_DATABASE_HOST,
-        read_only_host=settings.TREEHERDER_RO_DATABASE_HOST,
     )
 
 
@@ -178,8 +176,6 @@ def objectstore_ds():
     return Datasource.objects.create(
         project=settings.DATABASES["default"]["TEST_NAME"],
         contenttype="objectstore",
-        host=settings.TREEHERDER_DATABASE_HOST,
-        read_only_host=settings.TREEHERDER_RO_DATABASE_HOST,
     )
 
 

--- a/tests/model/sql/test_models.py
+++ b/tests/model/sql/test_models.py
@@ -2,22 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import datetime
 from contextlib import contextmanager
 
 
 def create_datasource(model, **kwargs):
     """Utility function to easily create a test DataSource."""
 
-    from django.conf import settings
-
     defaults = {
         "project": "foo",
         "contenttype": "jobs",
-        "host": settings.TREEHERDER_DATABASE_HOST,
-        "read_only_host": settings.TREEHERDER_RO_DATABASE_HOST,
-        "type": "MySQL-InnoDB",
-        "creation_date": datetime.datetime.now(),
     }
 
     defaults.update(kwargs)

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -142,23 +142,16 @@ class JobsModel(TreeherderModelBase):
     ]
 
     @classmethod
-    def create(cls, project, host=None, read_only_host=None):
+    def create(cls, project):
         """
         Create all the datasource tables for this project.
 
         """
 
-        if not host:
-            host = settings.DATABASES['default']['HOST']
-        if not read_only_host:
-            read_only_host = settings.DATABASES['read_only']['HOST']
-
         for ct in [cls.CT_JOBS, cls.CT_OBJECTSTORE]:
             source = Datasource(
                 project=project,
                 contenttype=ct,
-                host=host,
-                read_only_host=read_only_host,
             )
             source.save()
 

--- a/treeherder/model/management/commands/init_datasources.py
+++ b/treeherder/model/management/commands/init_datasources.py
@@ -5,8 +5,6 @@
 from optparse import make_option
 from django.utils.six.moves import input
 
-from django.conf import settings
-
 from django.core.management.base import BaseCommand
 from treeherder.model.models import Datasource, Repository
 
@@ -16,16 +14,6 @@ class Command(BaseCommand):
             "create the connected databases")
 
     option_list = BaseCommand.option_list + (
-        make_option('--host',
-                    action='store',
-                    dest='host',
-                    default=settings.TREEHERDER_DATABASE_HOST,
-                    help='Host to associate the datasource to'),
-        make_option('--readonly-host',
-                    action='store',
-                    dest='readonly_host',
-                    default=settings.TREEHERDER_RO_DATABASE_HOST,
-                    help='Readonly host to associate the datasource to'),
         make_option('--reset',
                     action='store_true',
                     dest='reset',
@@ -50,7 +38,5 @@ Type 'yes' to continue, or 'no' to cancel: """)
                 Datasource.objects.get_or_create(
                     contenttype=contenttype,
                     project=project,
-                    host=options['host'],
-                    read_only_host=options['readonly_host']
                 )
         Datasource.reset_cache()

--- a/treeherder/model/management/commands/run_sql.py
+++ b/treeherder/model/management/commands/run_sql.py
@@ -80,10 +80,10 @@ class Command(BaseCommand):
             self.stdout.write("--------------------------")
             db_options = settings.DATABASES['default'].get('OPTIONS', {})
             conn = MySQLdb.connect(
-                host=datasource.host,
+                host=settings.DATABASES['default']['HOST'],
                 db=datasource.name,
-                user=settings.TREEHERDER_DATABASE_USER,
-                passwd=settings.TREEHERDER_DATABASE_PASSWORD,
+                user=settings.DATABASES['default']['USER'],
+                passwd=settings.DATABASES['default']['PASSWORD'],
                 **db_options
             )
             try:

--- a/treeherder/model/migrations/0001_initial.py
+++ b/treeherder/model/migrations/0001_initial.py
@@ -54,13 +54,9 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, primary_key=True)),
                 ('project', models.CharField(max_length=50L)),
                 ('contenttype', models.CharField(max_length=25L)),
-                ('host', models.CharField(max_length=128L)),
-                ('read_only_host', models.CharField(max_length=128L, blank=True)),
-                ('name', models.CharField(max_length=128L)),
-                ('type', models.CharField(max_length=25L)),
+                ('name', models.CharField(unique=True, max_length=128L)),
                 ('oauth_consumer_key', models.CharField(max_length=45L, null=True, blank=True)),
                 ('oauth_consumer_secret', models.CharField(max_length=45L, null=True, blank=True)),
-                ('creation_date', models.DateTimeField(auto_now_add=True)),
             ],
             options={
                 'db_table': 'datasource',
@@ -292,6 +288,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='datasource',
-            unique_together=set([('host', 'name'), ('project', 'contenttype')]),
+            unique_together=set([('project', 'contenttype')]),
         ),
     ]

--- a/treeherder/model/sql/template_schema/treeherder.sql.tmpl
+++ b/treeherder/model/sql/template_schema/treeherder.sql.tmpl
@@ -48,38 +48,22 @@ DROP TABLE IF EXISTS `datasource`;
  *              jobs in project_jobs.sql.tmpl, reference in treeherder_reference_1.sql.tmpl
  *              A project can have any number of contenttypes associated with it.
  *
- *  host - Name of the database host.
- *
- *  read_only_host - A read only host associated with the database.
- *
  *  name - Name of the database. Can be anything but typically project_contenttype. So,
  *         try_jobs or mozillaaurora_jobs.
- *
- *  type - Type of storage engine associated with the database. This is automatically added
- *         to the template schema when a user runs a manage command that creates a database
- *         schema. There is currently support for MariaDB and MySQL storage engines.
  *
  *  oauth_consumer_key - The OAuth consumer key. This is automatically added when a new datasource
                          is added.
  *
  *  oauth_consumer_secret - The OAuth consumer secret. This is automatically added when a new datasource
                             is added.
- *
- *  creation_date - Date the database was created.
- *
- *  cron_batch - The cron interval to use when running cron jobs on this database.
  **************************/
 CREATE TABLE `datasource` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `project` varchar(50) COLLATE utf8_bin NOT NULL,
   `contenttype` varchar(25) COLLATE utf8_bin NOT NULL,
-  `host` varchar(128) COLLATE utf8_bin NOT NULL,
-  `read_only_host` varchar(128) COLLATE utf8_bin DEFAULT NULL,
-  `name` varchar(128) COLLATE utf8_bin NOT NULL,
-  `type` varchar(25) COLLATE utf8_bin NOT NULL,
+  `name` varchar(128) COLLATE utf8_bin NOT NULL UNIQUE,
   `oauth_consumer_key` varchar(45) COLLATE utf8_bin DEFAULT NULL,
   `oauth_consumer_secret` varchar(45) COLLATE utf8_bin DEFAULT NULL,
-  `creation_date` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `project` (`project`,`contenttype`)
 ) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;


### PR DESCRIPTION
Having the ability to use different DB hosts for each project sounded like a good idea, but in reality, we have no need for it.

This switches us to using the global read-write and read-only database host names rather than the fields on the datasource table. As such, the 'host', 'read_only_host' and 'type' (eg 'mysql') fields can be removed. The Django model had a unique_together on host+name, so we now need to make 'name' (ie database name) a unique key on it's own.

In addition, this removes the 'creation_date' field, since we don't use it anywhere, and we can just look at the commit history to see when a repo was created. (I imagine it may have had more use if we actually had started partitioning the databases uses the old 'dataset' count field).

In a future bug, I'll remove the redundant substitution of 'engine' for 'InnoDB' in the template schema, given that engine is now always InnoDB in create_db().

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/739)
<!-- Reviewable:end -->
