### PR TITLE
Bug 1181685 - Reconcile main UI element names/ids

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -31,6 +31,13 @@ input:focus::-moz-placeholder {
     height: 100%;
 }
 
+#global-navbar-container {
+    background-color: #273038;
+    margin-bottom: 0px;
+    flex: none;
+    -webkit-flex: none;
+}
+
 .pagination, .carousel, .panel-title a {
     cursor: pointer;
 }
@@ -65,13 +72,6 @@ input:focus::-moz-placeholder {
     color: rgba(145, 164, 221, 0.3);
 }
 
-.th-navbar {
-    background-color: #273038;
-    margin-bottom: 0px;
-    flex: none;
-    -webkit-flex: none;
-}
-
 .navbar {
     min-height: 36px;
     margin-bottom: 0px;
@@ -85,7 +85,7 @@ input:focus::-moz-placeholder {
     padding-bottom: 8px;
 }
 
-.th-global-navbar {
+#th-global-navbar-top {
     padding-left: 0;
     border-bottom: 1px solid black;
 }
@@ -251,7 +251,7 @@ th-watched-repo {
     height: 16px;
 }
 
-.th-content {
+.th-global-content {
     flex: 1; /* Not using auto because it causes unnecessary reflows, see https://bugzilla.mozilla.org/show_bug.cgi?id=1162725 */
     -webkit-flex: auto;
     position: relative;/* need this to position inner content */
@@ -470,7 +470,7 @@ th-watched-repo {
     padding-right: 10px;
 }
 
-.result-set-title {
+.result-set-bar {
     border-top: 1px solid black;
     padding: 2px 0px 0px 14px;
     white-space: nowrap;
@@ -607,23 +607,10 @@ th-watched-repo {
 }
 
 /*
- * resizer
- */
-div#bottom-panel-resizer {
-    display: flex;
-    flex: none;
-    -webkit-flex: none;
-    background-color: #919dad;
-    cursor: ns-resize;
-    height: 2px;
-}
-
-
-/*
- * bottom panel
+ * Info panel
  */
 
-div#bottom-panel {
+div#info-panel {
     background-color: #AAAAAA;
     font-size: 12px;
 
@@ -638,7 +625,7 @@ div#bottom-panel {
     flex-flow: column;
 }
 
-div#bottom-panel .navbar{
+div#info-panel .navbar {
     border-radius: 0px;
     border-style: solid;
     border-color: #42484F;
@@ -652,27 +639,36 @@ div#bottom-panel .navbar{
     z-index: 100;
 }
 
-div#bottom-panel .navbar-nav > ul{
-    height:32px;
+div#info-panel-resizer {
+    display: flex;
+    flex: none;
+    -webkit-flex: none;
+    background-color: #919dad;
+    cursor: ns-resize;
+    height: 2px;
 }
 
-div#bottom-panel .navbar-nav > li > a{
+div#info-panel .navbar-nav > ul {
+    height: 32px;
+}
+
+div#info-panel .navbar-nav > li > a {
     padding: 6px 15px;
     line-height: 19px;
 }
 
-div#bottom-panel .navbar-nav > li > a.disabled {
+div#info-panel .navbar-nav > li > a.disabled {
     cursor: not-allowed;
     text-decoration: none;
 }
 
-div#bottom-panel .navbar-nav > li.active a,
-div#bottom-panel .navbar-nav > li.active a:hover,
-div#bottom-panel .navbar-nav > li.active a:focus {
+div#info-panel .navbar-nav > li.active a,
+div#info-panel .navbar-nav > li.active a:hover,
+div#info-panel .navbar-nav > li.active a:focus {
     outline: 0;
 }
 
-div#bottom-panel .navbar > ul.tab-headers > li{
+div#info-panel .navbar > ul.tab-headers > li {
     border-right: 1px solid #42484F;
 }
 
@@ -691,14 +687,14 @@ div#bottom-panel .navbar > ul.tab-headers > li{
     color: #D3D8DA;
 }
 
-div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a,
-div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:hover,
-div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
+div#info-panel .navbar.navbar-dark .navbar-nav > li.active a,
+div#info-panel .navbar.navbar-dark .navbar-nav > li.active a:hover,
+div#info-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
     background-color: #1A4666;
     color: #EEF0F2;
 }
 
-#bottom-panel-content {
+#info-panel-content {
    position: relative; /* So we can absolutely position the loading overlay */
    height: 60%;
 
@@ -711,7 +707,7 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
            flex-flow: row;
 }
 
-#bottom-left-panel, #bottom-center-panel {
+#job-details-panel, #job-tabs-panel {
     background-color: #fff;
     display: -webkit-flex;
     display:         flex;
@@ -719,7 +715,7 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
     flex-flow: column;
 }
 
-#bottom-left-top, #bottom-center-top {
+#job-details-actionbar, #job-tabs-navbar {
     min-height: 33px;
     overflow-y: auto;
 }
@@ -728,54 +724,56 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
     margin-left: 5px;
 }
 
-#bottom-left-panel {
-    width:260px;
+#job-details-panel {
+    width: 260px;
 }
 
-#bottom-left-bottom > ul {
+#job-details-pane > ul {
     margin: 0px;
     padding: 0px;
     line-height:12px;
 }
 
-#bottom-left-panel .content-spacer {
+#job-details-panel .content-spacer {
     padding-top: 2px;
     padding-bottom: 4px;
 }
 
-#bottom-left-panel ul li {
+#job-details-panel ul li {
     padding: 0px 0px 0px 5px;
     line-height: 15px;
     word-wrap: break-word;
 }
 
-#bottom-left-panel ul li label{
+#job-details-panel ul li label {
     padding: 0;
     margin: 2px 0px;
 }
 
-#bottom-left-panel .star {
+#job-details-panel .star {
     color: #f0ad4e;
 }
 
-#bottom-left-panel em.testfail{ color:red;}
+#job-details-panel em.testfail {
+    color: red;
+}
 
-#bottom-left-bottom {
+#job-details-pane {
     overflow: auto;
 }
 
-#bottom-center-panel {
+#job-tabs-panel {
     -webkit-flex: 1 6;
     flex: 1 6;
     padding:0px;
     min-width: 500px;
 }
 
-#bottom-panel nav.navbar.navbar-sub{
+#info-panel nav.navbar.navbar-sub {
     border-top: none;
 }
 
-#bottom-center-bottom {
+#job-tabs-pane {
     max-height: calc(100% - 33px);
     -webkit-flex: 1;
     flex: 1;
@@ -784,28 +782,28 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
     overflow: auto;
 }
 
-#bottom-center-bottom > * {
+#job-tabs-pane > * {
     -webkit-flex: 1;
     flex: 1;
     display: -webkit-flex;
     display: flex;
 }
 
-#bottom-center-bottom > * > * {
+#job-tabs-pane > * > * {
     -webkit-flex: 1;
     flex: 1;
     display: -webkit-flex;
     display: flex;
 }
 
-#bottom-center-bottom > * > * > * {
+#job-tabs-pane > * > * > * {
     -webkit-flex: 1;
     flex: 1;
     display: -webkit-flex;
     display: flex;
 }
 
-#bottom-center-panel ul.failure-summary-list{
+#job-tabs-panel ul.failure-summary-list {
     width: 100%;
     margin-bottom: 0;
 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -18,17 +18,17 @@
     </head>
     <body ng-controller="MainCtrl" ng-keydown="processKeyboardInput($event)">
         <div id="global-container">
-            <div class="th-navbar">
+            <div id="global-navbar-container">
                 <ng-include id="th-global-top-nav-panel" src="'partials/main/thGlobalTopNavPanel.html'"></ng-include>
             </div>
-            <div class="th-content"
+            <div id="th-global-content" class="th-global-content"
                  ng-click="clearJobOnClick($event)">
                 <span class="th-view-content" ng-cloak>
                     <ng-view ></ng-view>
                 </span>
             </div>
             <div ng-controller="PluginCtrl"
-                 id="bottom-panel"
+                 id="info-panel"
                  ng-show="selectedJob"
                  ng-class="{'with-pinboard':isPinboardVisible}"
                  ng-include src="'plugins/pluginpanel.html'">

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -590,7 +590,7 @@ treeherder.directive('thCloneJobs', [
     var scrollToElement = function(el){
 
         if(el.position() !== undefined){
-          $('.th-content').scrollTo(el, 100, {offset: -40});
+          $('.th-global-content').scrollTo(el, 100, {offset: -40});
         }
 
     };

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -8,7 +8,7 @@
      class="result-set"
      data-id="{{::resultset.id}}">
 
-    <div class="result-set-title">
+    <div class="result-set-bar">
       <span class="result-set-left">
         <span class="result-set-title-left">
           <span class="btn btn-default btn-sm glyphicon glyphicon-download" ng-show="isLoadingJobs"></span>

--- a/ui/partials/main/thGlobalTopNavPanel.html
+++ b/ui/partials/main/thGlobalTopNavPanel.html
@@ -1,5 +1,5 @@
-<nav class="navbar navbar-inverse">
-    <div class="navbar-collapse collapse th-global-navbar">
+<nav id="th-global-navbar" class="navbar navbar-inverse">
+    <div id="th-global-navbar-top" class="navbar-collapse collapse">
         <!-- Logo Menu -->
         <span class="dropdown">
             <button id="th-logo" title="Treeherder services" role="button"

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -1,4 +1,4 @@
-<div class="th-context-navbar watched-repo-navbar clearfix" >
+<div id="watched-repo-navbar" class="th-context-navbar watched-repo-navbar clearfix">
     <th-watched-repo ng-repeat="(name, repoData) in repoModel.watchedRepos"></th-watched-repo>
     <div class="navbar-right">
         <span>

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -1,16 +1,16 @@
-<div id="bottom-panel-resizer"
+<div id="info-panel-resizer"
      resizer="horizontal"
      resizer-height="6"
-     resizer-bottom="#bottom-panel">
+     resizer-bottom="#info-panel">
 </div>
 <div ng-controller="PinboardCtrl"
      id="pinboard-panel"
      ng-show="isPinboardVisible"
      ng-include src="'partials/main/thPinboardPanel.html'">
 </div>
-<div id="bottom-panel-content">
-  <div id="bottom-left-panel">
-    <div id="bottom-left-top">
+<div id="info-panel-content">
+  <div id="job-details-panel">
+    <div id="job-details-actionbar">
       <nav class="navbar navbar-dark">
         <ul class="nav navbar-nav">
 
@@ -110,7 +110,7 @@
         </ul>
       </nav>
     </div>
-    <div id="bottom-left-bottom">
+    <div id="job-details-pane">
       <ul ng-if="classifications.length > 0 || bugs.length > 0"
           class="list-unstyled content-spacer">
         <li ng-if="classifications.length > 0">
@@ -215,8 +215,8 @@
       </div>
     </div>
   </div>
-  <div id="bottom-center-panel">
-    <div id="bottom-center-top">
+  <div id="job-tabs-panel">
+    <div id="job-tabs-navbar">
       <nav class="navbar navbar-dark">
         <ul class="nav navbar-nav tab-headers">
           <li ng-class="{'active': tabService.selectedTab == 'jobDetails'}">
@@ -279,7 +279,7 @@
         </ul>
       </nav>
     </div>
-    <div id="bottom-center-bottom">
+    <div id="job-tabs-pane">
       <div ng-repeat="(tabId, tab) in tabService.tabs"
            ng-show="tabId == tabService.selectedTab"
            class="job-tabs-divider">


### PR DESCRIPTION
This work fixes Bugzilla bug [1181685](https://bugzilla.mozilla.org/show_bug.cgi?id=1181685).

This reconciles the name of the main Treeherder elements for future selenium testing, and a shared understanding/terminology for the various parts of the UI for new and current users.

I opted to use '*info-panel*' instead of the originally proposed '*details-panel*', for our main lower panel, as it's a bit more generalized and doesn't overload the word 'details' which we are also using here for job details.

I also did a pass on the main navbar, resultset elements, and minor css rearrangement where it made sense.
 
Everything seems fine in local testing.

Tested on OSX 10.10.3:
FF Nightly **42.0a1 (2015-07-09)**
Chrome Latest Release **43.0.2357.132 (64-bit)**

Adding @wlach for review and @rbillings for visibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/740)
<!-- Reviewable:end -->
