### PR TITLE
Bug 1182372 - Pass the database SSL options to MySQLdb.connect()

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -11,10 +11,12 @@ from celery import current_app
 
 @pytest.fixture
 def db_conn():
+    db_options = settings.DATABASES['default'].get('OPTIONS', {})
     return MySQLdb.connect(
         host=settings.TREEHERDER_DATABASE_HOST,
         user=settings.TREEHERDER_DATABASE_USER,
         passwd=settings.TREEHERDER_DATABASE_PASSWORD,
+        **db_options
     )
 
 

--- a/treeherder/model/management/commands/run_sql.py
+++ b/treeherder/model/management/commands/run_sql.py
@@ -78,11 +78,14 @@ class Command(BaseCommand):
 
         for datasource in datasources:
             self.stdout.write("--------------------------")
+            db_options = settings.DATABASES['default'].get('OPTIONS', {})
             conn = MySQLdb.connect(
                 host=datasource.host,
                 db=datasource.name,
                 user=settings.TREEHERDER_DATABASE_USER,
-                passwd=settings.TREEHERDER_DATABASE_PASSWORD)
+                passwd=settings.TREEHERDER_DATABASE_PASSWORD,
+                **db_options
+            )
             try:
                 cursor = conn.cursor()
                 cursor.execute(sql_code)


### PR DESCRIPTION
Since otherwise we get access denied errors using run_sql on Heroku.

All other calls use datasource, so have already been set up to pass the SSL options.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/743)
<!-- Reviewable:end -->
