### PR TITLE
Bug 1145712 - upgrade django-rest-framework from 2.4.5 to 3.1.3

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -48,8 +48,8 @@ python-memcached==1.48
 # sha256: WvNmhsJxCX8l7AI1RsOXy5m8Z6XbODblLms3vbRcoh4
 jsonschema==2.4.0
 
-# sha256: IvfBJQ8MAom2HaZlS1HhRzM7q3ed4ZMng3a9_WpSe0Y
-djangorestframework==2.4.5
+# sha256: J_-iz0sFAeyfxBDyUmKmh3dtO2Qy0lEX8vt69Bia1Kw
+djangorestframework==3.1.3
 
 # sha256: 1PH7p2aNspPnPQd7QBnvUkor3A7Z4Xh3WI9ZUDFpks4
 django-rest-swagger==0.3.2

--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -330,4 +330,4 @@ def test_resultset_status(webapp, eleven_jobs_processed, jm):
     )
     assert resp.status_int == 200
     assert isinstance(resp.json, dict)
-    assert resp.json == {'success': '1'}
+    assert resp.json == {'success': 1}

--- a/treeherder/webapp/api/exceptions.py
+++ b/treeherder/webapp/api/exceptions.py
@@ -19,7 +19,7 @@ class ResourceNotFoundException(exceptions.APIException):
     default_detail = "Resource not found"
 
 
-def exception_handler(exc):
+def exception_handler(exc, context):
     """
 Add treeherder-specific exception handling to the rest framework
 Mostly a conversion of treeherders ORM exceptions to drf APIExceptions
@@ -38,7 +38,7 @@ Mostly a conversion of treeherders ORM exceptions to drf APIExceptions
             "{0} object not found using: {1}".format(
                 exc.table, unicode(exc.extra_info)))
 
-    response = drf_exc_handler(exc)
+    response = drf_exc_handler(exc, context)
     if response is None:
         msg = {"detail": unicode(exc)}
         if settings.DEBUG:

--- a/treeherder/webapp/api/job_log_url.py
+++ b/treeherder/webapp/api/job_log_url.py
@@ -6,7 +6,7 @@ import logging
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
-from rest_framework.decorators import action
+from rest_framework.decorators import detail_route
 
 from treeherder.webapp.api.utils import with_jobs, oauth_required
 
@@ -47,7 +47,7 @@ class JobLogUrlViewSet(viewsets.ViewSet):
 
         return Response(job_log_url_list)
 
-    @action()
+    @detail_route(methods=['post'])
     @with_jobs
     @oauth_required
     def update_parse_status(self, request, project, jm, pk=None):
@@ -62,7 +62,7 @@ class JobLogUrlViewSet(viewsets.ViewSet):
         except KeyError:
             raise ParseError(detail=("The parse_status parameter is mandatory for this endpoint"))
 
-    @action()
+    @detail_route(methods=['post'])
     @with_jobs
     def parse(self, request, project, jm, pk=None):
         """Trigger an async task to parse this log."""

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -4,7 +4,7 @@
 
 from rest_framework import viewsets
 from rest_framework.response import Response
-from rest_framework.decorators import action
+from rest_framework.decorators import detail_route
 from rest_framework.reverse import reverse
 from rest_framework.permissions import IsAuthenticated
 
@@ -91,7 +91,7 @@ class JobsViewSet(viewsets.ViewSet):
 
         return Response(response_body)
 
-    @action(permission_classes=[IsAuthenticated])
+    @detail_route(methods=['post'], permission_classes=[IsAuthenticated])
     @with_jobs
     def update_state(self, request, project, jm, pk=None):
         """
@@ -120,7 +120,7 @@ class JobsViewSet(viewsets.ViewSet):
         else:
             return Response("No job with id: {0}".format(pk), 404)
 
-    @action(permission_classes=[IsAuthenticated])
+    @detail_route(methods=['post'], permission_classes=[IsAuthenticated])
     @with_jobs
     def cancel(self, request, project, jm, pk=None):
         """
@@ -133,7 +133,7 @@ class JobsViewSet(viewsets.ViewSet):
         else:
             return Response("No job with id: {0}".format(pk), 404)
 
-    @action(permission_classes=[IsAuthenticated])
+    @detail_route(methods=['post'], permission_classes=[IsAuthenticated])
     @with_jobs
     def retrigger(self, request, project, jm, pk=None):
         """

--- a/treeherder/webapp/api/refdata.py
+++ b/treeherder/webapp/api/refdata.py
@@ -23,27 +23,30 @@ from treeherder.webapp.api.permissions import (IsStaffOrReadOnly,
 class ProductViewSet(viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata Product model"""
-    model = models.Product
+    queryset = models.Product.objects.all()
+    serializer_class = th_serializers.ProductSerializer
 
 
 class BuildPlatformViewSet(viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata BuildPlatform model"""
-    model = models.BuildPlatform
+    queryset = models.BuildPlatform.objects.all()
+    serializer_class = th_serializers.BuildPlatformSerializer
 
 
 class JobGroupViewSet(viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata JobGroup model"""
-    model = models.JobGroup
+    queryset = models.JobGroup.objects.all()
+    serializer_class = th_serializers.JobGroupSerializer
 
 
 class RepositoryViewSet(CacheResponseAndETAGMixin,
                         viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata Repository model"""
-    serializer_class = th_serializers.RepositorySerializer
     queryset = models.Repository.objects.filter(active_status='active')
+    serializer_class = th_serializers.RepositorySerializer
 
     def list_cache_key_func(self, **kwargs):
         return models.REPOSITORY_LIST_CACHE_KEY
@@ -52,13 +55,15 @@ class RepositoryViewSet(CacheResponseAndETAGMixin,
 class MachinePlatformViewSet(viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata MachinePlatform model"""
-    model = models.MachinePlatform
+    queryset = models.MachinePlatform.objects.all()
+    serializer_class = th_serializers.MachinePlatformSerializer
 
 
 class BugscacheViewSet(viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata Bugscache model"""
-    model = models.Bugscache
+    queryset = models.Bugscache.objects.all()
+    serializer_class = th_serializers.BugscacheSerializer
 
     def list(self, request):
         """
@@ -76,7 +81,8 @@ class BugscacheViewSet(viewsets.ReadOnlyModelViewSet):
 class MachineViewSet(viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata Machine model"""
-    model = models.Machine
+    queryset = models.Machine.objects.all()
+    serializer_class = th_serializers.MachineSerializer
 
 
 class OptionCollectionHashViewSet(viewsets.ViewSet):
@@ -98,14 +104,16 @@ class OptionCollectionHashViewSet(viewsets.ViewSet):
 class JobTypeViewSet(viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata JobType model"""
-    model = models.JobType
+    queryset = models.JobType.objects.all()
+    serializer_class = th_serializers.JobTypeSerializer
 
 
 class FailureClassificationViewSet(CacheResponseAndETAGMixin,
                                    viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata FailureClassification model"""
-    model = models.FailureClassification
+    queryset = models.FailureClassification.objects.all()
+    serializer_class = th_serializers.FailureClassificationSerializer
 
     def list_cache_key_func(self, **kwargs):
         return models.FAILURE_CLASSIFICAION_LIST_CACHE_KEY
@@ -121,7 +129,6 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
     Info about a logged-in user.
     Used by Treeherder's UI to inspect user properties like the exclusion profile
     """
-    model = User
     serializer_class = th_serializers.UserSerializer
     authentication_classes = (SessionAuthentication,)
 
@@ -130,14 +137,14 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class UserExclusionProfileViewSet(viewsets.ModelViewSet):
-    model = models.UserExclusionProfile
+    queryset = models.UserExclusionProfile.objects.all()
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsOwnerOrReadOnly,)
     serializer_class = th_serializers.UserExclusionProfileSerializer
 
 
 class JobExclusionViewSet(viewsets.ModelViewSet):
-    model = models.JobExclusion
+    queryset = models.JobExclusion.objects.all()
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsStaffOrReadOnly,)
     serializer_class = th_serializers.JobExclusionSerializer
@@ -157,7 +164,7 @@ class ExclusionProfileViewSet(viewsets.ModelViewSet):
     """
 
     """
-    model = models.ExclusionProfile
+    queryset = models.ExclusionProfile.objects.all()
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsStaffOrReadOnly,)
     serializer_class = th_serializers.ExclusionProfileSerializer

--- a/treeherder/webapp/api/resultset.py
+++ b/treeherder/webapp/api/resultset.py
@@ -4,7 +4,7 @@
 
 from rest_framework import viewsets
 from rest_framework.response import Response
-from rest_framework.decorators import link, action
+from rest_framework.decorators import detail_route
 from rest_framework.reverse import reverse
 from rest_framework.permissions import IsAuthenticated
 from treeherder.model.derived import DatasetNotFoundError
@@ -107,7 +107,7 @@ class ResultSetViewSet(viewsets.ViewSet):
         else:
             return Response("No resultset with id: {0}".format(pk), 404)
 
-    @link()
+    @detail_route()
     @with_jobs
     def revisions(self, request, project, jm, pk=None):
         """
@@ -116,7 +116,7 @@ class ResultSetViewSet(viewsets.ViewSet):
         objs = jm.get_resultset_revisions_list(pk)
         return Response(objs)
 
-    @action(permission_classes=[IsAuthenticated])
+    @detail_route(methods=['post'], permission_classes=[IsAuthenticated])
     @with_jobs
     def cancel_all(self, request, project, jm, pk=None):
         """
@@ -152,7 +152,7 @@ class ResultSetViewSet(viewsets.ViewSet):
 
         return Response({"message": "well-formed JSON stored"})
 
-    @link()
+    @detail_route()
     @with_jobs
     def status(self, request, project, jm, pk=None):
         """

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -1,15 +1,28 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from django.contrib.auth.models import User
-from rest_framework import serializers
 
 from treeherder.model import models
 
+from rest_framework import serializers
+
+
+class NoOpSerializer(serializers.Serializer):
+    """
+    This serializer is necessary because we are using JSONField.
+    The json renderers/parsers already take care of the serialization/deserialization of the objects
+    to/from json, so we need a field serializer for those fields that just return the input.
+    """
+
+    def to_internal_value(self, data):
+        return data
+
+    def to_representation(self, value):
+        return value
+
 
 class UserExclusionProfileSerializer(serializers.ModelSerializer):
-    exclusion_profile = serializers.PrimaryKeyRelatedField()
 
     class Meta:
         model = models.UserExclusionProfile
@@ -17,7 +30,6 @@ class UserExclusionProfileSerializer(serializers.ModelSerializer):
 
 
 class UserSerializer(serializers.ModelSerializer):
-    exclusion_profiles = UserExclusionProfileSerializer()
 
     class Meta:
         model = User
@@ -25,20 +37,27 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class JobExclusionSerializer(serializers.ModelSerializer):
-    info = serializers.WritableField()
+    info = NoOpSerializer()
 
     class Meta:
         model = models.JobExclusion
 
+    # We need to override create because ModelSerializer raises an error
+    # if it finds nested resources. A JSONField instance is either a dict or a list
+    # which makes it look like a nested relationship.
+    def create(self, validated_data):
+        info = validated_data.pop('info')
+        instance = models.JobExclusion.objects.create(**validated_data)
+        instance.info = info
+        instance.save()
+        return instance
+
 
 class ExclusionProfileSerializer(serializers.ModelSerializer):
-
-    flat_exclusion = serializers.WritableField(required=False)
-    exclusions = serializers.PrimaryKeyRelatedField(many=True)
+    flat_exclusion = NoOpSerializer(read_only=True)
 
     class Meta:
         model = models.ExclusionProfile
-        exclude = ['users']
 
 
 class RepositoryGroupSerializer(serializers.ModelSerializer):
@@ -53,3 +72,51 @@ class RepositorySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Repository
+
+
+class ProductSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = models.Product
+
+
+class BuildPlatformSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = models.BuildPlatform
+
+
+class MachinePlatformSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = models.MachinePlatform
+
+
+class JobGroupSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = models.JobGroup
+
+
+class JobTypeSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = models.JobType
+
+
+class MachineSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = models.Machine
+
+
+class FailureClassificationSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = models.FailureClassification
+
+
+class BugscacheSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = models.Bugscache

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -95,7 +95,7 @@ default_router.register(r'optioncollectionhash', refdata.OptionCollectionHashVie
                         base_name='optioncollectionhash')
 default_router.register(r'bugscache', refdata.BugscacheViewSet)
 default_router.register(r'failureclassification', refdata.FailureClassificationViewSet)
-default_router.register(r'user', refdata.UserViewSet)
+default_router.register(r'user', refdata.UserViewSet, base_name='user')
 default_router.register(r'exclusion-profile', refdata.ExclusionProfileViewSet)
 default_router.register(r'job-exclusion', refdata.JobExclusionViewSet)
 


### PR DESCRIPTION
This patch upgrades the version stored in the requirements file and fixes some issues introduced by breaking changes in the new version of the library:
 - Writable nested fields are not available anymore, you need an explicit create method on the serializer to write a nested field.
 - ModelViewSet now requires serializer_class and queryset attributes.
 - @action and @link decorators are now replaced by either @detail_route or @list_route.
 - any attempt to create a ModelSerializer instance with an attribute which type is either dict or list will raise an exception.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/745)
<!-- Reviewable:end -->
