### PR TITLE
Bug 1182465 - Remove substitution of 'engine' in the template schema

### DIFF
--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -293,8 +293,6 @@ class Datasource(models.Model):
         """
         import MySQLdb
 
-        engine = "InnoDB"
-
         if schema_file is None:
             schema_file = path(
                 "model",
@@ -310,7 +308,7 @@ class Datasource(models.Model):
             try:
                 with open(schema_file) as f:
                     # set the engine to use
-                    sql = f.read().format(engine=engine)
+                    sql = f.read()
                     statement_list = sql.split(";")
                     for statement in statement_list:
                         cursor.execute(statement)

--- a/treeherder/model/sql/template_schema/project_jobs.sql.tmpl
+++ b/treeherder/model/sql/template_schema/project_jobs.sql.tmpl
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* This file contains {engine} markers that must be replaced
-   before it is sent to MySQL.
-*/
-
 --
 -- Host: localhost    Database: project_jobs_1
 -- ------------------------------------------------------
@@ -61,7 +57,7 @@ CREATE TABLE `bug_job_map` (
   KEY `idx_submit_timestamp` (`submit_timestamp`),
   KEY `idx_active_status` (`active_status`),
   CONSTRAINT `fk_bug_job` FOREIGN KEY (`job_id`) REFERENCES `job` (`id`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -158,7 +154,7 @@ CREATE TABLE `job` (
   KEY `idx_tier` (`tier`),
   KEY `idx_active_status` (`active_status`),
   CONSTRAINT `fk_result_set` FOREIGN KEY (`result_set_id`) REFERENCES `result_set` (`id`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `job_eta`;
@@ -203,7 +199,7 @@ CREATE TABLE `job_eta` (
   KEY `idx_median_sec` (`median_sec`),
   KEY `idx_sample_count` (`sample_count`),
   KEY `idx_submit_timestamp` (`submit_timestamp`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -242,7 +238,7 @@ CREATE TABLE `job_artifact` (
   KEY `idx_type` (`type`),
   KEY `idx_active_status` (`active_status`),
   CONSTRAINT `fk_job_artifact` FOREIGN KEY (`job_id`) REFERENCES `job` (`id`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `performance_artifact`;
@@ -282,7 +278,7 @@ CREATE TABLE `performance_artifact` (
   KEY `idx_type` (`type`),
   KEY `idx_active_status` (`active_status`),
   CONSTRAINT `fk_performance_artifact` FOREIGN KEY (`job_id`) REFERENCES `job` (`id`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `series_signature`;
@@ -313,7 +309,7 @@ CREATE TABLE `series_signature` (
   KEY `idx_signature` (`signature`),
   KEY `idx_property` (`property`),
   UNIQUE KEY `idx_series` (`signature`, `property`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `performance_series`;
@@ -350,7 +346,7 @@ CREATE TABLE `performance_series` (
   KEY `idx_type` (`type`),
   KEY `idx_active_status` (`active_status`),
   UNIQUE KEY `idx_series` (`interval_seconds`, `series_signature`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -388,7 +384,7 @@ CREATE TABLE `job_log_url` (
   KEY `idx_active_status` (`active_status`),
   KEY `idx_parse_status` (`parse_status`),
   CONSTRAINT `fk_job_log_url` FOREIGN KEY (`job_id`) REFERENCES `job` (`id`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -429,7 +425,7 @@ CREATE TABLE `job_note` (
   KEY `idx_note_timestamp` (`note_timestamp`),
   KEY `idx_active_status` (`active_status`),
   CONSTRAINT `fk_job_note` FOREIGN KEY (`job_id`) REFERENCES `job` (`id`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -471,7 +467,7 @@ CREATE TABLE `result_set` (
   KEY `idx_type` (`type`),
   KEY `idx_push_timestamp` (`push_timestamp`),
   KEY `idx_active_status` (`active_status`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -511,7 +507,7 @@ CREATE TABLE `revision` (
   KEY `idx_author` (`author`),
   KEY `idx_commit_timestamp` (`commit_timestamp`),
   KEY `idx_repository_id` (`repository_id`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -545,7 +541,7 @@ CREATE TABLE `revision_map` (
   KEY `idx_active_status` (`active_status`),
   CONSTRAINT `fk_revision_map` FOREIGN KEY (`revision_id`) REFERENCES `revision` (`id`),
   CONSTRAINT `fk_revision_map_result_set` FOREIGN KEY (`result_set_id`) REFERENCES `result_set` (`id`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/treeherder/model/sql/template_schema/project_objectstore.sql.tmpl
+++ b/treeherder/model/sql/template_schema/project_objectstore.sql.tmpl
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* This file contains {engine} markers that must be replaced
-   before it is sent to MySQL.
-*/
-
 --
 -- Host: localhost    Database: project_objectstore_1
 -- ------------------------------------------------------
@@ -70,7 +66,7 @@ CREATE TABLE `objectstore` (
   KEY `idx_processed_state` (`processed_state`),
   KEY `idx_error` (`error`),
   KEY `idx_worker_id` (`worker_id`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/treeherder/model/sql/template_schema/treeherder.sql.tmpl
+++ b/treeherder/model/sql/template_schema/treeherder.sql.tmpl
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* This file contains {engine} markers that must be replaced
-   before it is sent to MySQL.
-*/
-
 --
 -- Host: localhost    Database: treeherder
 -- ------------------------------------------------------
@@ -66,7 +62,7 @@ CREATE TABLE `datasource` (
   `oauth_consumer_secret` varchar(45) COLLATE utf8_bin DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `project` (`project`,`contenttype`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/treeherder/model/sql/template_schema/treeherder_reference_1.sql.tmpl
+++ b/treeherder/model/sql/template_schema/treeherder_reference_1.sql.tmpl
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* This file contains {engine} markers that must be replaced
-   before it is sent to MySQL.
-*/
-
 --
 -- Host: localhost    Database: treeherder_reference_1
 -- ------------------------------------------------------
@@ -105,7 +101,7 @@ CREATE TABLE `reference_data_signatures` (
   KEY `idx_first_submission_timestamp` (`first_submission_timestamp`),
   KEY `idx_review_timestamp` (`review_timestamp`),
   KEY `idx_review_status` (`review_status`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -184,7 +180,7 @@ CREATE TABLE `build_platform` (
   KEY `idx_platform` (`platform`),
   KEY `idx_architecture` (`architecture`),
   KEY `idx_active_status` (`active_status`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -214,7 +210,7 @@ CREATE TABLE `failure_classification` (
   PRIMARY KEY (`id`),
   KEY `idx_name` (`name`),
   KEY `idx_active_status` (`active_status`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -248,7 +244,7 @@ CREATE TABLE `job_group` (
   KEY `idx_name` (`name`),
   KEY `idx_active_status` (`active_status`),
   UNIQUE KEY `uni_name_symbol` (`name`,`symbol`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -291,7 +287,7 @@ CREATE TABLE `job_type` (
   KEY `fk_job_type_job_group` (`job_group_id`),
   UNIQUE KEY `uni_name_symbol` (`name`,`symbol`),
   CONSTRAINT `fk_job_type_job_group` FOREIGN KEY (`job_group_id`) REFERENCES `job_group` (`id`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -326,7 +322,7 @@ CREATE TABLE `machine` (
   KEY `idx_first_timestamp` (`first_timestamp`),
   KEY `idx_last_timestamp` (`last_timestamp`),
   KEY `idx_active_status` (`active_status`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -361,7 +357,7 @@ CREATE TABLE `machine_platform` (
   KEY `idx_platform` (`platform`),
   KEY `idx_architecture` (`architecture`),
   KEY `idx_active_status` (`active_status`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `device`;
@@ -387,7 +383,7 @@ CREATE TABLE `device` (
   PRIMARY KEY (`id`),
   KEY `idx_name` (`name`),
   KEY `idx_active_status` (`active_status`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 --
 -- Table structure for table `option`
@@ -418,7 +414,7 @@ CREATE TABLE `option` (
   PRIMARY KEY (`id`),
   KEY `idx_name` (`name`),
   KEY `idx_active_status` (`active_status`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -450,7 +446,7 @@ CREATE TABLE `option_collection` (
   KEY `idx_option` (`option_id`),
   KEY `idx_option_collection_hash` (`option_collection_hash`),
   CONSTRAINT `fk_option` FOREIGN KEY (`option_id`) REFERENCES `option` (`id`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -480,7 +476,7 @@ CREATE TABLE `product` (
   PRIMARY KEY (`id`),
   KEY `idx_name` (`name`),
   KEY `idx_active_status` (`active_status`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -523,7 +519,7 @@ CREATE TABLE `repository` (
   KEY `idx_codebase` (`codebase`),
   KEY `idx_active_status` (`active_status`),
   CONSTRAINT `fk_repository_group` FOREIGN KEY (`repository_group_id`) REFERENCES `repository_group` (`id`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -553,7 +549,7 @@ CREATE TABLE `repository_group` (
   PRIMARY KEY (`id`),
   KEY `idx_name` (`name`),
   KEY `idx_active_status` (`active_status`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `job_exclusion`;
@@ -582,7 +578,7 @@ CREATE TABLE `job_exclusion` (
     `author_id` integer NOT NULL,
 
 KEY `idx_name` (`name`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 
@@ -612,7 +608,7 @@ CREATE TABLE `exclusion_profile` (
 KEY `idx_name` (`name`),
 KEY `idx_is_default` (`is_default`),
 KEY `idx_author` (`author_id`)
-)ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 
@@ -643,7 +639,7 @@ CREATE TABLE `user_exclusion_profile` (
   KEY `idx_is_default` (`is_default`),
   KEY `idx_user` (`user_id`),
   CONSTRAINT `fk_exclusion_profile` FOREIGN KEY (`exclusion_profile_id`) REFERENCES `exclusion_profile` (`id`)
-)ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 
@@ -669,7 +665,7 @@ CREATE TABLE `exclusion_profile_exclusions` (
     UNIQUE (`exclusionprofile_id`, `jobexclusion_id`),
   CONSTRAINT `fk_exclusionprofile` FOREIGN KEY (`exclusionprofile_id`) REFERENCES `exclusion_profile` (`id`),
   CONSTRAINT `fk_jobexclusion` FOREIGN KEY (`jobexclusion_id`) REFERENCES `job_exclusion` (`id`)
-) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 


### PR DESCRIPTION
Since after bug 1182455, engine is now guaranteed to always the same for all projects, so we can just specify it in the schema directly.

As an added bonus, the templates are now valid SQL.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/748)
<!-- Reviewable:end -->
