### PR TITLE
Bug 1182994 - Cast API offset parameter to int

### DIFF
--- a/treeherder/webapp/api/artifact.py
+++ b/treeherder/webapp/api/artifact.py
@@ -43,7 +43,7 @@ class ArtifactViewSet(viewsets.ViewSet):
         # @todo: change ``qparams`` back to ``request.QUERY_PARAMS``
         filter = UrlQueryFilter(qparams)
 
-        offset = filter.pop("offset", 0)
+        offset = int(filter.pop("offset", 0))
         count = min(int(filter.pop("count", 10)), 1000)
 
         with ArtifactsModel(project) as artifacts_model:

--- a/treeherder/webapp/api/bug.py
+++ b/treeherder/webapp/api/bug.py
@@ -71,7 +71,7 @@ class BugJobMapViewSet(viewsets.ViewSet):
     def list(self, request, project, jm):
         filter = UrlQueryFilter(request.QUERY_PARAMS)
 
-        offset = filter.pop("offset", 0)
+        offset = int(filter.pop("offset", 0))
         count = min(int(filter.pop("count", 10)), 1000)
 
         objs = jm.get_bug_job_map_list(

--- a/treeherder/webapp/api/performance_artifact.py
+++ b/treeherder/webapp/api/performance_artifact.py
@@ -32,7 +32,7 @@ class PerformanceArtifactViewSet(viewsets.ViewSet):
         """
         filter = UrlQueryFilter(request.QUERY_PARAMS)
 
-        offset = filter.pop("offset", 0)
+        offset = int(filter.pop("offset", 0))
         count = min(int(filter.pop("count", 10)), 1000)
 
         objs = jm.get_performance_artifact_list(offset, count, filter.conditions)

--- a/treeherder/webapp/api/resultset.py
+++ b/treeherder/webapp/api/resultset.py
@@ -66,7 +66,7 @@ class ResultSetViewSet(viewsets.ViewSet):
 
         filter = UrlQueryFilter(filter_params)
 
-        offset_id = filter.pop("id__lt", 0)
+        offset_id = int(filter.pop("id__lt", 0))
         count = min(int(filter.pop("count", 10)), 1000)
 
         full = filter.pop('full', 'true').lower() == 'true'


### PR DESCRIPTION
Since currently the datasource package does not validate the limit parameter correctly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/750)
<!-- Reviewable:end -->
