### PR TITLE
Bug 1182994 - Use datasource v0.9's fixed offset parameter

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -77,8 +77,8 @@ mozlog==2.11
 # sha256: BK-ioGq33MqdgXF7Qgp6FIJgYemyYUpcd90kx1zPl-Q
 futures==3.0.3
 
-# sha256: MhRX6kzPa87tEyFMM79QWG3PVvj-g6IIrU8a5hfgqiM
-https://github.com/jeads/datasource/archive/v0.8.tar.gz#egg=datasource==0.8
+# sha256: Vsi_w_4K-L4pRwKWLo2Gcj1RN8ldLbFkQel1BWZF6Xs
+https://github.com/jeads/datasource/archive/v0.9.tar.gz#egg=datasource==0.9
 
 # Required by jsonschema
 # sha256: ajt0IEMrCBfvGSrvNBzXZuGZgBqQyn_jGfnV_KQO3aI

--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -83,7 +83,8 @@ class ArtifactsModel(TreeherderModelBase):
             proc=proc,
             replace=repl,
             placeholders=placeholders,
-            limit="{0},{1}".format(offset, limit),
+            limit=limit,
+            offset=offset,
             debug_show=self.DEBUG,
         )
         for artifact in data:
@@ -115,7 +116,8 @@ class ArtifactsModel(TreeherderModelBase):
             proc=proc,
             replace=repl,
             placeholders=placeholders,
-            limit="{0},{1}".format(offset, limit),
+            limit=limit,
+            offset=offset,
             debug_show=self.DEBUG,
         )
 

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -255,7 +255,8 @@ class JobsModel(TreeherderModelBase):
             proc="jobs.selects.get_job_list",
             replace=repl,
             placeholders=placeholders,
-            limit="{0},{1}".format(offset, limit),
+            limit=limit,
+            offset=offset,
             debug_show=self.DEBUG,
         )
         return data
@@ -796,7 +797,8 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             proc=proc,
             replace=repl,
             placeholders=placeholders,
-            limit="{0},{1}".format(offset, limit),
+            limit=limit,
+            offset=offset,
             debug_show=self.DEBUG,
         )
         return data


### PR DESCRIPTION
* Update to Datasource v0.9, to get the SQL injection and `offset` parameter fixes (https://github.com/jeads/datasource/compare/v0.8...v0.9)
* Use datasource's `offset` parameter. As part of Datasource v0.9's SQL injection fix, it no longer supports passing comma-delimited strings to the `limit` parameter, to denote the SQL LIMIT/OFFSET. Instead we need to pass integers to Datasource's `limit` and `offset` params separately. The `offset` param now actually works in Datasource v0.9, unlike previous releases.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/751)
<!-- Reviewable:end -->
