### PR TITLE
Bug 1183137 - Remove unused in-repo SQL procs

### DIFF
--- a/treeherder/model/sql/generic.json
+++ b/treeherder/model/sql/generic.json
@@ -20,16 +20,6 @@
             "sql":"SELECT LAST_INSERT_ID() AS `id`",
 
             "host_type":"master_host"
-        },
-
-        "get_db_size":{
-            "sql":"SELECT table_schema as db_name,
-                round(sum( data_length + index_length ) / 1024 / 1024, 2) as size_mb
-                FROM information_schema.TABLES
-                WHERE TABLE_SCHEMA like ?
-                GROUP BY TABLE_SCHEMA",
-
-            "host_type":"read_host"
         }
     },
     "locks": {

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -737,12 +737,6 @@
 
             "host_type": "master_host"
         },
-        "get_revision_map_id":{
-            "sql":"SELECT `id` FROM `revision_map`
-                   WHERE `revision_id` = ?
-                    AND `result_set_id` = ?",
-            "host_type": "read_host"
-        },
         "get_result_set_list_by_ids":{
             "sql":"SELECT rs.id,
                           rs.author,
@@ -804,88 +798,6 @@
                    WHERE r.active_status = 'active' AND rm.result_set_id IN (REP0)
                    ORDER BY r.id DESC",
 
-            "host_type": "read_host"
-        },
-        "get_result_set_job_list":{
-            "sql":"SELECT
-                    j.`id`,
-                    j.`option_collection_hash`,
-                    j.failure_classification_id,
-                    j.job_coalesced_to_guid,
-                    j.signature,
-                    m.`name` as machine_name,
-                    mp.`platform` as platform,
-                    jt.`name` as job_type_name,
-                    jt.`symbol` as job_type_symbol,
-					jg.`name` as job_group_name,
-                    jg.`symbol` as job_group_symbol,
-                    j.`result_set_id`,
-                    j.`id` as job_id,
-                    j.`result`,
-                    j.`state`,
-                    j.`reason`
-                  FROM `job` as j
-                  LEFT JOIN `REP0`.`machine` as m
-                    ON j.`machine_id` = m.id
-                  LEFT JOIN `REP0`.`machine_platform` as mp
-                    ON j.`machine_platform_id` = mp.id
-                  LEFT JOIN `REP0`.`job_type` as jt
-                    ON j.`job_type_id` = jt.id
-				  LEFT JOIN `REP0`.`job_group` as jg
-                    ON jt.`job_group_id` = jg.id
-                  WHERE j.`result_set_id` IN (REP1)
-                  REP2
-                  REP3
-                  ",
-            "host_type": "read_host"
-        },
-        "get_result_set_job_list_full":{
-            "sql":"SELECT
-                    j.`job_guid`,
-                    j.`job_coalesced_to_guid`,
-                    j.signature,
-                    j.`build_platform_id`,
-                    j.`option_collection_hash`,
-                    j.failure_classification_id,
-                    m.`name` as machine_name,
-                    mp.`platform` as platform,
-                    mp.`os_name` as machine_platform_os,
-                    mp.`architecture` as machine_platform_architecture,
-                    bp.`platform` as build_platform,
-                    bp.`os_name` as build_os,
-                    bp.`architecture` as build_architecture,
-                    jt.`name` as job_type_name,
-                    jt.`symbol` as job_type_symbol,
-                    jt.`description` as job_type_description,
-					jg.`name` as job_group_name,
-                    jg.`symbol` as job_group_symbol,
-                    jg.`description` as job_group_description,
-                    j.`who`,
-                    j.`result_set_id`,
-                    j.`id` as job_id,
-                    j.`result`,
-                    j.`state`,
-                    j.`reason`,
-                    j.`start_timestamp`,
-                    j.`end_timestamp`,
-                    j.`submit_timestamp`,
-                    j.`pending_eta`,
-                    j.`running_eta`
-                  FROM `job` as j
-                  LEFT JOIN `REP0`.`machine` as m
-                    ON j.`machine_id` = m.id
-                  LEFT JOIN `REP0`.`machine_platform` as mp
-                    ON j.`machine_platform_id` = mp.id
-                  LEFT JOIN `REP0`.`build_platform` as bp
-                    ON j.`build_platform_id` = bp.id
-                  LEFT JOIN `REP0`.`job_type` as jt
-                    ON j.`job_type_id` = jt.id
-				  LEFT JOIN `REP0`.`job_group` as jg
-                    ON jt.`job_group_id` = jg.id
-                  WHERE j.`result_set_id` IN (REP1)
-                  REP2
-                  REP3
-                  ",
             "host_type": "read_host"
         },
         "get_all_log_urls":{

--- a/treeherder/model/sql/reference.json
+++ b/treeherder/model/sql/reference.json
@@ -123,17 +123,6 @@
                     )",
             "host_type":"master_host"
         },
-        "create_repository_group":{
-            "sql":"INSERT INTO `repository_group` (`name`, `description`)
-                   SELECT ?, 'fill me'
-                    FROM DUAL
-                    WHERE NOT EXISTS (
-                    SELECT `name`
-                    FROM `repository_group`
-                    WHERE `name` = ?
-                    )",
-            "host_type":"master_host"
-        },
         "create_bugscache":{
             "sql":"INSERT INTO `bugscache` (`id`, `status`, `resolution`, `summary`, `crash_signature`, `keywords`, `os`, `modified`)
                    SELECT ?, ?, ?, ?, ?, ?, ?, ?
@@ -213,28 +202,6 @@
 
             "host_type":"read_host"
         },
-        "get_max_collection_hash":{
-            "sql": "SELECT MAX(`option_collection_hash`) as 'max_id'
-                    FROM `option_collection`",
-            "host_type":"read_host"
-        },
-        "get_option_collection_hash":{
-            "sql": "SELECT `option_collection_hash`
-                    FROM `option_collection` oc
-                    INNER JOIN `option` o on o.id = oc.option_id
-                    GROUP BY `option_collection_hash`
-                    HAVING
-                        GROUP_CONCAT(o.name ORDER BY o.name ASC SEPARATOR ',') = ?",
-            "host_type":"read_host"
-        },
-        "get_option_names":{
-            "sql": "SELECT o.`name`
-                    FROM `option` o
-                    INNER JOIN `option_collection` oc
-                        on o.id = oc.option_id
-                    WHERE oc.option_collection_hash = ?",
-            "host_type":"read_host"
-        },
         "get_products":{
             "sql": "SELECT `id`, `name`
                     FROM `product`
@@ -266,12 +233,6 @@
                     FROM `repository`
                     WHERE
                         `active_status` = 'active'",
-            "host_type":"read_host"
-        },
-        "get_repository_group_id":{
-            "sql": "SELECT `id`
-                    FROM `repository_group`
-                    WHERE `name` = ?  AND `active_status` = 'active'",
             "host_type":"read_host"
         },
         "get_all_option_collections":{


### PR DESCRIPTION
These SQL procs are not used anywhere in the repo:

generic.selects.get_db_size
jobs.selects.get_result_set_job_list
jobs.selects.get_result_set_job_list_full
jobs.selects.get_revision_map_id
objectstore.selects.get_json_blob_for_test_run
objectstore.selects.get_error_metadata
objectstore.selects.get_all_errors
objectstore.selects.get_error_counts
reference.inserts.create_repository_group
reference.selects.get_option_collection_hash
reference.selects.get_max_collection_hash
reference.selects.get_option_names
reference.selects.get_repository_group_id

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/752)
<!-- Reviewable:end -->
