### PR TITLE
Bug 1166984 - Provide inspect-task link in Job details panel

### DIFF
--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -206,6 +206,10 @@
           <label>Log parsing status:</label>
           <span>No logs</span>
         </li>
+        <li class="small" ng-repeat="line in job_details" ng-if="line.value == 'Inspect Task'">
+          <label>Taskcluster:</label>
+          <span><a href="{{line.url}}" target="_blank">{{line.value}}</a></span>
+        </li>
       </ul>
 
       <div ng-if="job_detail_loading" class="overlay">


### PR DESCRIPTION
This fixes Bugzillla bug [1166984](https://bugzilla.mozilla.org/show_bug.cgi?id=1166984).

This provides a '**Taskcluster:** Inspect Task' link in the Job details panel, while preserving the current Inspect Task in the Job details tab, per the bug thread.

We are ok with the labels deviating for a more user friendly label in the Job details panel vs. the artifact blob name in the tab. Here's the new appearance:

![inspecttaskjobdetails](https://cloud.githubusercontent.com/assets/3660661/8674471/1e701d78-2a0c-11e5-82c5-31260720e80d.jpg)

Everything seems fine on both browsers, with both buildbot jobs (suppressed) and taskcluster jobs (displayed) in various repos, n/p navigation, refresh, and link navigation.

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-07-13)**
Chrome Latest Release **43.0.2357.132 (64-bit)**

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/755)
<!-- Reviewable:end -->
