### PR TITLE
 	Bug 1181686 - Make nature of revisions in perfcompare more clear

### DIFF
--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -188,6 +188,11 @@ to { opacity: 0; }
 
 /* Compare interface stuff */
 
+.push-information {
+    font-size: 18px;
+    color: #777;
+}
+
 .vertical-box {
   display: flex;
   flex-flow: column;

--- a/ui/partials/perf/comparectrl.html
+++ b/ui/partials/perf/comparectrl.html
@@ -8,14 +8,11 @@
       <div>{{error}}</div>
     </div>
     <div id="subtest-summary" ng-if="!dataLoading && !errors.length">
-      <h1>Perfherder Compare Revisions<br/>
-      <small>Compare all data for revision
-        <a href="{{originalProject.getRevisionHref(originalRevision)}}">
-          {{originalRevision}}</a> ({{originalProject.name}}) to
-        <a href="{{newProject.getRevisionHref(newRevision)}}">
-          {{newRevision}}</a> ({{newProject.name}})
-        </small>
-      </h1>
+      <h1>Perfherder Compare Revisions</h1>
+      <ul class="list-inline push-information">
+        <li><strong>Base</strong> - <a href="{{originalProject.getRevisionHref(originalRevision)}}">{{originalRevision}}</a> ({{originalProject.name}})</li>
+        <li><strong>New</strong> - <a href="{{newProject.getRevisionHref(newRevision)}}">{{newRevision}}</a> ({{newProject.name}})</li>
+      </ul>
       <div class="alert alert-warning" role="alert" ng-if="testNoResults">
         <strong>tests with no results:</strong>
         {{testNoResults}}
@@ -23,7 +20,7 @@
       <table class="table">
         <tbody ng-repeat="testName in testList">
           <tr class="subtest-header">
-            <td>{{titles[testName]}}</td><td>Old Geomean</td><td>Old StdDev</td><td>New Geomean</td><td>New StdDev</td><td>Delta</td><td>Delta %</td><td></td><td>Confidence</td>
+            <td>{{titles[testName]}}</td><td>Base Geomean</td><td>Base StdDev</td><td>New Geomean</td><td>New StdDev</td><td>Delta</td><td>Delta %</td><td></td><td>Confidence</td>
           </tr>
           <tr ng-class="getCompareClasses(compareResult, 'row')" ng-repeat="compareResult in compareResults[testName]">
             <td>{{compareResult.name}} (<a ng-href="{{compareResult.detailsLink}}">subtests</a>)</td>

--- a/ui/partials/perf/comparesubtestctrl.html
+++ b/ui/partials/perf/comparesubtestctrl.html
@@ -5,8 +5,11 @@
     <img src="img/dancing_cat.gif" ng-repeat="x in [0,1,2,3]" style="transform:scale(0.5); margin-left:-40px; margin-top:40px;"/>
   </div>
   <div id="subtest-summary" ng-if="!dataLoading && !errors.length">
-    <h1>{{subtestTitle}} subtest summary<br/>
-      <small><a href="{{originalProject.getRevisionHref(originalRevision)}}">{{originalRevision}}</a> ({{originalProject.name}}) compared to <a href="{{newProject.getRevisionHref(newRevision)}}">{{newRevision}}</a> ({{newProject.name}})</small></h1>
+    <h1>{{subtestTitle}} subtest summary</h1>
+    <ul class="list-inline push-information">
+      <li><strong>Base</strong> - <a href="{{originalProject.getRevisionHref(originalRevision)}}">{{originalRevision}}</a> ({{originalProject.name}})</li>
+      <li><strong>New</strong> - <a href="{{newProject.getRevisionHref(newRevision)}}">{{newRevision}}</a> ({{newProject.name}})</li>
+    </ul>
     <p><a href="perf.html#/compare?originalProject={{originalProject.name}}&originalRevision={{originalRevision}}&newProject={{newProject.name}}&newRevision={{newRevision}}">Show all tests and platforms</a></p>
     <div id="error" ng-if="!dataLoading && errors.length" ng-repeat="error in errors">
       <div>{{error}}</div>
@@ -14,7 +17,7 @@
     <table class="table">
       <tbody ng-repeat="testName in testList">
         <tr class="subtest-header">
-          <td>{{platformList[0]}} : {{titles[testName]}}</td><td>Old Geomean</td><td>Old StdDev</td><td>New Geomean</td><td>New StdDev</td><td>Delta</td><td>Delta %</td><td></td><td>Confidence</td>
+          <td>{{platformList[0]}} : {{titles[testName]}}</td><td>Base Geomean</td><td>Base StdDev</td><td>New Geomean</td><td>New StdDev</td><td>Delta</td><td>Delta %</td><td></td><td>Confidence</td>
         </tr>
         <tr ng-class="getCompareClasses(compareResult, 'row')" ng-repeat="compareResult in compareResults[testName]">
           <td>{{compareResult.name}} (<a ng-href="{{compareResult.detailsLink}}">graph</a>)</td>


### PR DESCRIPTION
Use "base" as opposed to "old". Reformat revision information into
clearer list form

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/758)
<!-- Reviewable:end -->
