### PR TITLE
Bug 1184247 - Add celerybeat-schedule removal to RTD Troubleshooting

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -22,7 +22,18 @@ Feel free to comment one or more of those sections if you don't need that specif
 If you just want to access the restful api or the admin for example, comment all those sections but the one
 related to gunicorn.
 You can stop supervisord (and all processes he's taking care of) with ctrl+c.
-Please note that for some reason you may need to manually kill the celery worker when it's under heavy load.
+Please note that for some reasons you may need to manually kill the celery worker, for example when it's under heavy load.
+
+Why is my celery ingestion not running?
+---------------------------------------
+
+If after a ``celery -A treeherder worker -B --concurrency 5`` you experience a static celery console with no output, similar to:
+
+.. code-block:: bash
+
+   09:32:40,010: WARNING/MainProcess] celery@local ready.
+
+You should ctrl+c to shut down celery, remove the ``celerybeat-schedule`` file in the project root, and restart your worker.
 
 Where are my log files?
 -----------------------


### PR DESCRIPTION
This fixes Bugzilla bug [1184247](https://bugzilla.mozilla.org/show_bug.cgi?id=1184247).

This adds a small Troubleshooting entry for celerybeat-schedule removal for occasions where ingestion doesn't appear to be working.

![rtdcelerytroubleshooting](https://cloud.githubusercontent.com/assets/3660661/8707117/d91f2e84-2b01-11e5-8529-186dfa77df15.jpg)

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/765)
<!-- Reviewable:end -->
