### PR TITLE
Bug 1178240 - Cache previously seen builds-{pending,running,4hr} jobs

### DIFF
--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -117,11 +117,8 @@ def test_ingest_pending_jobs(jm, initial_data,
     etl_process = PendingJobsProcess()
     etl_process.run()
 
-    stored_obj = jm.get_dhub().execute(
-        proc="jobs_test.selects.jobs")
-
+    stored_obj = jm.get_dhub().execute(proc="jobs_test.selects.jobs")
     jm.disconnect()
-
     assert len(stored_obj) == 1
 
 
@@ -137,11 +134,8 @@ def test_ingest_running_jobs(jm, initial_data,
     etl_process = RunningJobsProcess()
     etl_process.run()
 
-    stored_obj = jm.get_dhub().execute(
-        proc="jobs_test.selects.jobs")
-
+    stored_obj = jm.get_dhub().execute(proc="jobs_test.selects.jobs")
     jm.disconnect()
-
     assert len(stored_obj) == 1
 
 
@@ -157,11 +151,8 @@ def test_ingest_builds4h_jobs(jm, initial_data,
     etl_process = Builds4hJobsProcess()
     etl_process.run()
 
-    stored_obj = jm.get_dhub().execute(
-        proc="jobs_test.selects.jobs")
-
+    stored_obj = jm.get_dhub().execute(proc="jobs_test.selects.jobs")
     jm.disconnect()
-
     assert len(stored_obj) == 32
 
 
@@ -179,8 +170,7 @@ def test_ingest_running_to_complete_job(jm, initial_data,
     etl_process = RunningJobsProcess()
     etl_process.run()
 
-    stored_running = jm.get_dhub().execute(
-        proc="jobs_test.selects.jobs")
+    stored_running = jm.get_dhub().execute(proc="jobs_test.selects.jobs")
 
     assert len(stored_running) == 1
 
@@ -189,9 +179,7 @@ def test_ingest_running_to_complete_job(jm, initial_data,
     etl_process = Builds4hJobsProcess()
     etl_process.run()
 
-    stored_obj = jm.get_dhub().execute(
-        proc="jobs_test.selects.jobs")
-
+    stored_obj = jm.get_dhub().execute(proc="jobs_test.selects.jobs")
     jm.disconnect()
 
     assert len(stored_obj) == 32
@@ -214,9 +202,7 @@ def test_ingest_running_job_fields(jm, initial_data,
     etl_process = RunningJobsProcess()
     etl_process.run()
 
-    stored_obj = jm.get_dhub().execute(
-        proc="jobs_test.selects.jobs")
-
+    stored_obj = jm.get_dhub().execute(proc="jobs_test.selects.jobs")
     jm.disconnect()
 
     assert len(stored_obj) == 1
@@ -271,8 +257,7 @@ def test_ingest_builds4h_jobs_missing_branch(jm, initial_data,
 
     etl_process.run()
 
-    stored_obj = jm.get_dhub().execute(
-        proc="jobs_test.selects.jobs")
+    stored_obj = jm.get_dhub().execute(proc="jobs_test.selects.jobs")
 
     assert len(stored_obj) == 0
 
@@ -302,8 +287,7 @@ def _do_missing_resultset_test(jm, etl_process):
 
     etl_process.run()
 
-    stored_obj = jm.get_dhub().execute(
-        proc="jobs_test.selects.jobs")
+    stored_obj = jm.get_dhub().execute(proc="jobs_test.selects.jobs")
 
     assert len(stored_obj) == 1
 

--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -9,6 +9,10 @@ import json
 
 from django.conf import settings
 
+from treeherder.etl.buildapi import (PendingJobsProcess,
+                                     RunningJobsProcess,
+                                     Builds4hJobsProcess)
+
 
 @pytest.fixture
 def mock_buildapi_pending_url(monkeypatch):
@@ -110,7 +114,6 @@ def test_ingest_pending_jobs(jm, initial_data,
     """
     a new buildapi pending job creates a new obj in the job table
     """
-    from treeherder.etl.buildapi import PendingJobsProcess
     etl_process = PendingJobsProcess()
     etl_process.run()
 
@@ -131,7 +134,6 @@ def test_ingest_running_jobs(jm, initial_data,
     """
     a new buildapi running job creates a new obj in the job table
     """
-    from treeherder.etl.buildapi import RunningJobsProcess
     etl_process = RunningJobsProcess()
     etl_process.run()
 
@@ -152,7 +154,6 @@ def test_ingest_builds4h_jobs(jm, initial_data,
     """
     a new buildapi completed job creates a new obj in the job table
     """
-    from treeherder.etl.buildapi import Builds4hJobsProcess
     etl_process = Builds4hJobsProcess()
     etl_process.run()
 
@@ -175,9 +176,6 @@ def test_ingest_running_to_complete_job(jm, initial_data,
     a new buildapi running job transitions to a new completed job
 
     """
-    from treeherder.etl.buildapi import RunningJobsProcess
-    from treeherder.etl.buildapi import Builds4hJobsProcess
-
     etl_process = RunningJobsProcess()
     etl_process.run()
 
@@ -213,7 +211,6 @@ def test_ingest_running_job_fields(jm, initial_data,
     """
     a new buildapi running job creates a new obj in the job table
     """
-    from treeherder.etl.buildapi import RunningJobsProcess
     etl_process = RunningJobsProcess()
     etl_process.run()
 
@@ -237,7 +234,6 @@ def test_ingest_pending_jobs_1_missing_resultset(jm, initial_data,
     """
     Ensure the pending job with the missing resultset is queued for refetching
     """
-    from treeherder.etl.buildapi import PendingJobsProcess
     etl_process = PendingJobsProcess()
     _do_missing_resultset_test(jm, etl_process)
 
@@ -249,7 +245,6 @@ def test_ingest_running_jobs_1_missing_resultset(jm, initial_data,
     """
     Ensure the running job with the missing resultset is queued for refetching
     """
-    from treeherder.etl.buildapi import RunningJobsProcess
     etl_process = RunningJobsProcess()
     _do_missing_resultset_test(jm, etl_process)
 
@@ -261,7 +256,6 @@ def test_ingest_builds4h_jobs_1_missing_resultset(jm, initial_data,
     """
     Ensure the builds4h job with the missing resultset is queued for refetching
     """
-    from treeherder.etl.buildapi import Builds4hJobsProcess
     etl_process = Builds4hJobsProcess()
     _do_missing_resultset_test(jm, etl_process)
 
@@ -273,7 +267,6 @@ def test_ingest_builds4h_jobs_missing_branch(jm, initial_data,
     """
     Ensure the builds4h job with the missing resultset is queued for refetching
     """
-    from treeherder.etl.buildapi import Builds4hJobsProcess
     etl_process = Builds4hJobsProcess()
 
     etl_process.run()

--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -3,12 +3,12 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import logging
-import simplejson as json
-
 from collections import defaultdict
-from django.conf import settings
-from treeherder.client import TreeherderJobCollection
 
+import simplejson as json
+from django.conf import settings
+
+from treeherder.client import TreeherderJobCollection
 from treeherder.etl import common, buildbot
 from treeherder.etl.mixins import JsonExtractorMixin, OAuthLoaderMixin
 from treeherder.model.models import Datasource

--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -417,14 +417,13 @@ class Builds4hJobsProcess(JsonExtractorMixin,
     def run(self, filter_to_revision=None, filter_to_project=None,
             filter_to_job_group=None):
         extracted_content = self.extract(settings.BUILDAPI_BUILDS4H_URL)
-        if extracted_content:
-            self.load(
-                self.transform(extracted_content,
-                               filter_to_revision=filter_to_revision,
-                               filter_to_project=filter_to_project,
-                               filter_to_job_group=filter_to_job_group),
-                chunk_size=settings.BUILDAPI_BUILDS4H_CHUNK_SIZE
-            )
+        self.load(
+            self.transform(extracted_content,
+                           filter_to_revision=filter_to_revision,
+                           filter_to_project=filter_to_project,
+                           filter_to_job_group=filter_to_job_group),
+            chunk_size=settings.BUILDAPI_BUILDS4H_CHUNK_SIZE
+        )
 
 
 class PendingJobsProcess(JsonExtractorMixin,
@@ -434,15 +433,14 @@ class PendingJobsProcess(JsonExtractorMixin,
     def run(self, filter_to_revision=None, filter_to_project=None,
             filter_to_job_group=None):
         extracted_content = self.extract(settings.BUILDAPI_PENDING_URL)
-        if extracted_content:
-            self.load(
-                self.transform(extracted_content,
-                               'pending',
-                               filter_to_revision=filter_to_revision,
-                               filter_to_project=filter_to_project,
-                               filter_to_job_group=filter_to_job_group),
-                chunk_size=settings.BUILDAPI_PENDING_CHUNK_SIZE
-            )
+        self.load(
+            self.transform(extracted_content,
+                           'pending',
+                           filter_to_revision=filter_to_revision,
+                           filter_to_project=filter_to_project,
+                           filter_to_job_group=filter_to_job_group),
+            chunk_size=settings.BUILDAPI_PENDING_CHUNK_SIZE
+        )
 
 
 class RunningJobsProcess(JsonExtractorMixin,
@@ -452,12 +450,11 @@ class RunningJobsProcess(JsonExtractorMixin,
     def run(self, filter_to_revision=None, filter_to_project=None,
             filter_to_job_group=None):
         extracted_content = self.extract(settings.BUILDAPI_RUNNING_URL)
-        if extracted_content:
-            self.load(
-                self.transform(extracted_content,
-                               'running',
-                               filter_to_revision=filter_to_revision,
-                               filter_to_project=filter_to_project,
-                               filter_to_job_group=filter_to_job_group),
-                chunk_size=settings.BUILDAPI_RUNNING_CHUNK_SIZE
-            )
+        self.load(
+            self.transform(extracted_content,
+                           'running',
+                           filter_to_revision=filter_to_revision,
+                           filter_to_project=filter_to_project,
+                           filter_to_job_group=filter_to_job_group),
+            chunk_size=settings.BUILDAPI_RUNNING_CHUNK_SIZE
+        )

--- a/treeherder/etl/mixins.py
+++ b/treeherder/etl/mixins.py
@@ -91,4 +91,5 @@ class ResultSetsLoaderMixin(JsonLoaderMixin):
 class OAuthLoaderMixin(object):
 
     def load(self, th_collections, chunk_size=1):
-        th_publisher.post_treeherder_collections(th_collections, chunk_size)
+        if th_collections:
+            th_publisher.post_treeherder_collections(th_collections, chunk_size)


### PR DESCRIPTION
To avoid continually attempting to re-ingest them, thereby reducing task runtime and database load.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/767)
<!-- Reviewable:end -->
