### PR TITLE
Bug 1184542 - enable browsable api

### DIFF
--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -697,7 +697,8 @@ class TreeherderClient(object):
         else:
             uri = self._get_project_uri(project, endpoint)
 
-        resp = requests.get(uri, timeout=timeout, params=params)
+        resp = requests.get(uri, timeout=timeout, params=params,
+                            headers={'Accept': 'application/json'})
         resp.raise_for_status()
         return resp.json()
 

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -284,6 +284,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer',
     ),
     'EXCEPTION_HANDLER': 'treeherder.webapp.api.exceptions.exception_handler',
     'DEFAULT_THROTTLE_CLASSES': (


### PR DESCRIPTION
I enabled the api html rendered so that if you fetch one of the endpoints using your browser
(i.e. with a 'Accept: text/html' header) it will return the right content type.
The default renderer is still the json one though, so it should be back-compatible.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/773)
<!-- Reviewable:end -->
