### PR TITLE
Bug 1184311 - Get classification looping correctly again with 1st/last pinned

### DIFF
--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -75,7 +75,17 @@ treeherder.directive('thCloneJobs', [
             };
         }
 
-        jobs = $(jobNavSelector.selector).filter(":visible, .selected-job");
+        // Filter the list of possible jobs down to ONLY ones in the .th-view-content
+        // div (excluding pinboard) and then to the specific selector passed
+        // in.  And then to only VISIBLE (not filtered away) jobs.  The exception
+        // is for the .selected-job.  If that's not visible, we still want to
+        // include it, because it is the anchor from which we find
+        // the next/previous job.
+        //
+        // The .selected-job can be invisible, for instance, when filtered to
+        // unclassified failures only, and you then classify the selected job.
+        // It's still selected, but no longer visible.
+        jobs = $(".th-view-content").find(jobNavSelector.selector).filter(":visible, .selected-job");
         if (jobs.length) {
             var selIdx = jobs.index(jobs.filter(".selected-job"));
             var idx = getIndex(selIdx, jobs);

--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -151,14 +151,14 @@ treeherder.value("thJobNavSelectors",
     {
         ALL_JOBS: {
             name: "jobs",
-            selector: ".th-view-content .job-btn"
+            selector: ".job-btn"
         },
         UNCLASSIFIED_FAILURES: {
             name: "unclassified failures",
             selector: ".selected-job, " +
-                      ".th-view-content .job-btn.btn-red, " +
-                      ".th-view-content .job-btn.btn-orange, " +
-                      ".th-view-content .job-btn.btn-purple"
+                      ".job-btn.btn-red, " +
+                      ".job-btn.btn-orange, " +
+                      ".job-btn.btn-purple"
         }
     }
 );


### PR DESCRIPTION
Fix to the fix: My earlier attempt used a JQuery ``filter`` where it should have used a
``find``

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/777)
<!-- Reviewable:end -->
