### PR TITLE
Bug 1168652 - Remove unused updateClassification and related code

### DIFF
--- a/treeherder/events/publisher.py
+++ b/treeherder/events/publisher.py
@@ -99,19 +99,3 @@ class ResultsetPublisher(EventsPublisher):
         super(ResultsetPublisher, self).publish(
             message,
             "events.{0}.resultset".format(branch))
-
-
-class JobClassificationPublisher(EventsPublisher):
-
-    def publish(self, job_id, who, branch):
-        message = {
-            "id": job_id,
-            "who": who,
-            "event": "job_classification",
-            "branch": branch
-        }
-
-        super(JobClassificationPublisher, self).publish(
-            message,
-            "events.{0}.job_classification".format(branch)
-        )

--- a/treeherder/webapp/api/note.py
+++ b/treeherder/webapp/api/note.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf import settings
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
@@ -11,7 +10,6 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
 from treeherder.webapp.api.utils import with_jobs
-from treeherder.events.publisher import JobClassificationPublisher
 
 
 class NoteViewSet(viewsets.ViewSet):
@@ -77,12 +75,6 @@ class NoteViewSet(viewsets.ViewSet):
         objs = jm.get_job_note(pk)
         if objs:
             jm.delete_job_note(pk, objs[0]['job_id'])
-            publisher = JobClassificationPublisher(settings.BROKER_URL)
-            try:
-                publisher.publish(objs[0]['job_id'], objs[0]['who'], project)
-            finally:
-                publisher.disconnect()
             return Response({"message": "Note deleted"})
-
         else:
             return Response("No note with id: {0}".format(pk), 404)

--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -79,32 +79,11 @@ treeherderApp.controller('JobsCtrl', [
                 true);
         }
 
-        $rootScope.$on(
-            thEvents.toggleAllRevisions, function(ev, expand){
-                _.forEach($scope.result_sets, function(rs) {
-                    $rootScope.$emit(thEvents.toggleRevisions, rs, expand);
-                });
+        $rootScope.$on(thEvents.toggleAllRevisions, function(ev, expand) {
+            _.forEach($scope.result_sets, function(rs) {
+                $rootScope.$emit(thEvents.toggleRevisions, rs, expand);
             });
-
-        var updateClassification = function(classification){
-            if(classification.who !== $scope.user.email){
-                // get a fresh version of the job
-                ThJobModel.get($scope.repoName, classification.id)
-                    .then(function(job){
-                        // get the list of jobs we know about
-                        var jobMap  = ThResultSetStore.getJobMap(classification.branch);
-                        var map_key = "key"+job.id;
-                        if(jobMap.hasOwnProperty(map_key)){
-                            // update the old job with the new info
-                            _.extend(jobMap[map_key].job_obj,job);
-                            var params = { jobs: {}};
-                            params.jobs[job.id] = jobMap[map_key].job_obj;
-                            // broadcast the job classification event
-                            $rootScope.$emit(thEvents.jobsClassified, params);
-                        }
-                    });
-            }
-        };
+        });
     }
 ]);
 


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1168652](https://bugzilla.mozilla.org/show_bug.cgi?id=1168652).

This removes what we believe to be dead code in updateClassification(). I have tested fairly exhaustively with saving/deleting classifications, deleting multiple classifications (shortcut and via Annotations panel) and everything seems to still be working correctly in vagrant w/runserver. I also did a full Moztrap run with the branch yesterday.

Some minor pseudo-eslint compliance was added in an adjacent but unrelated block.

Please add extra scrutiny to this PR if possible, but there is no rush for this change :)

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-07-16)**
Chrome Latest Release **43.0.2357.134 (64-bit)**

Adding @camd and @maurodoglio for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/778)
<!-- Reviewable:end -->
