### PR TITLE
Bug 1183847 - Style logviewer line errors for fast scrolling

### DIFF
--- a/ui/css/logviewer.css
+++ b/ui/css/logviewer.css
@@ -47,12 +47,13 @@ body {
     background: #fff;
 }
 
-.lv-log-line {
-    padding: 0 18px;
+/* Equal weight selector needs to follow the above nth-child() */
+.lv-log-container > div.text-danger {
+    background: #fbe3e3;
 }
 
-.text-danger {
-    color: #db0000;
+.lv-log-line {
+    padding: 0 18px;
 }
 
 .lv-line-highlight {


### PR DESCRIPTION
This fixes Bugzilla bug [1183847](https://bugzilla.mozilla.org/show_bug.cgi?id=1183847).

This provides a Github/Mozreview style pink background to error lines in logviewer, so when the user is scrolling quickly they are less likely to scroll past or miss the errors.

Current:
![currentbg_none](https://cloud.githubusercontent.com/assets/3660661/8751147/5bf852f4-2c79-11e5-9a23-8927437ff1de.jpg)

Proposed:
![proposedbg_fbe3e3](https://cloud.githubusercontent.com/assets/3660661/8751160/71c0bd4c-2c79-11e5-8aaf-ca5bfb4abf12.jpg)

It also works reasonably well with all colorblind conditions including the worst case,  Achromatopsia.
![colorblinding](https://cloud.githubusercontent.com/assets/3660661/8751509/76e326a0-2c7b-11e5-99b9-b831250e4951.jpg)

It also seems fine with line-errors both large and small.

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-07-16)**
Chrome Latest Release **43.0.2357.132 (64-bit)**

Adding @wlach for review and @jonallengriffin for visibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/783)
<!-- Reviewable:end -->
