### PR TITLE
Bug 1092209 - Add tinderbox lines to logviewer

### DIFF
--- a/ui/css/logviewer.css
+++ b/ui/css/logviewer.css
@@ -9,7 +9,7 @@ body {
     bottom: 0;
     left: 0;
     min-width: 240px;
-    padding-top: 15px;
+    padding-top: 10px;
     display: flex;
     flex-flow: column;
 }
@@ -64,9 +64,9 @@ body {
     width: 100%;
     flex: none;
     background-color: #FFF;
-    padding: 20px 5px 4px;
+    padding: 10px 5px;
     display: table-row;
-    font-size: 12px;
+    font-size: 11px;
 }
 
 .run-data .break-word{
@@ -98,7 +98,7 @@ body {
     -o-user-select: text;
     user-select: text;
     white-space: normal;
-    font-size: 12px;
+    font-size: 11px;
 }
 
 .logviewer-step.selected {
@@ -152,7 +152,7 @@ body {
     padding: 26px 0 0 20px;
     font-weight: bold;
     font-family: sans-serif;
-    font-size: 12px;
+    font-size: 11px;
 }
 
 .lv-log-msg-step {
@@ -173,7 +173,14 @@ body {
 .lv-log-error {
     border: 2px solid #ff0000;
 }
-.job-header{
-    max-height:270px;
-    overflow-y:auto;
+
+.job-header {
+    max-height: 240px;
+    overflow-y: auto;
+    margin-bottom: 10px;
+    border-bottom: 1px solid #ececec;
+}
+
+.job-header > table {
+    margin-bottom: 0;
 }

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -210,12 +210,15 @@ logViewerApp.controller('LogviewerCtrl', [
                 });
             });
 
-            $log.debug(ThJobArtifactModel.get_uri());
-            ThJobArtifactModel.get_list({job_id: $scope.job_id, name: 'text_log_summary'})
-            .then(function(artifactList){
-                if(artifactList.length > 0){
-                    $scope.artifact = artifactList[0].blob;
-                }
+            ThJobArtifactModel.get_list({job_id: $scope.job_id, name__in: 'text_log_summary,Job Info'})
+            .then(function(artifactList) {
+                artifactList.forEach(function(artifact) {
+                    if (artifact.name === 'text_log_summary') {
+                        $scope.artifact = artifact.blob;
+                    } else if (artifact.name === 'Job Info') {
+                        $scope.job_details = artifact.blob.job_details;
+                    }
+                });
             });
         };
 

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -31,6 +31,14 @@
                             <td ng-if="property.label != 'Revision'"
                                 ng-cloak class="break-word">{{property.value}}</td>
                         </tr>
+                        <tr ng-repeat="line in job_details | orderBy:'title'">
+                            <th>{{line.title}}:</th>
+                            <td ng-switch on="line.content_type">
+                                <a ng-switch-when="link" title="{{line.value}}"
+                                   href="{{line.url}}" target="_blank">{{line.value}}</a>
+                                <span ng-switch-when="raw_html" ng-bind-html="line.value"></span>
+                            <td/>
+                        </tr>
                     </table>
                 </div>
             </div>


### PR DESCRIPTION
This work (hopefully) fixes Bugzilla bug [1092209](https://bugzilla.mozilla.org/show_bug.cgi?id=1092209).

In it we add the equivalent of the Treeherder *job_details* artifact content to logviewer so the user doesn't have to navigate back to Treeherder to find the same information. We decided not to bother including Buildbot artifacts since they will soon be retired. Here are examples of the new content (yellow highlights for the PR only):

![taskclusterexample](https://cloud.githubusercontent.com/assets/3660661/8830511/8710c666-306a-11e5-8464-d21d465ebb76.jpg)

![otherexample](https://cloud.githubusercontent.com/assets/3660661/8830520/97bf9d48-306a-11e5-9a4b-e8e6895ebfc3.jpg)

Basically anything that appears in our Treeherder **Job Info** tab, excluding 'Buildername', should show up here.

I also dropped the main header font size from 12 to 11px and tried to economize space a bit more since generally we'll have more content, and if the only item added is 'Inspect Task' it should fit without a scroll bar.

Everything seems fine in both browsers.

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-07-21)**
Chrome Latest Release **44.0.2403.89 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/798)
<!-- Reviewable:end -->
