### PR TITLE
Bug 1186496 -  Improve the unclassified failure selection message

### DIFF
--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -103,7 +103,7 @@ treeherder.directive('thCloneJobs', [
                     if ($(".selected-job").css('display') === 'none') {
                         $rootScope.closeJob();
                     }
-                    thNotify.send("No more " + jobNavSelector.name + " to select", "warning");
+                    thNotify.send("No " + jobNavSelector.name + " to select", "warning");
                 }, 0);
             });
 


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1186496](https://bugzilla.mozilla.org/show_bug.cgi?id=1186496).

This change ensures thNotify isn't misleading during page load, since there aren't "more" available yet. Instead we omit it in the message to work for all cases.

Proposed:

![tweakunclassnavmsg](https://cloud.githubusercontent.com/assets/3660661/8832001/27683122-3074-11e5-815b-567bcabb067c.jpg)

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-07-21)**
Chrome Latest Release **44.0.2403.89 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/799)
<!-- Reviewable:end -->
