### PR TITLE
Bug 1186936 - Add WhatsDeployed to the Help footer

### DIFF
--- a/ui/help.html
+++ b/ui/help.html
@@ -601,7 +601,7 @@
   </div>
   <div class="col-xs-6">
     <a class="midgray pull-right"
-       href="../media/revision">Build</a>
+       href="https://whatsdeployed.paas.allizom.org/?owner=mozilla&repo=treeherder&name[]=Stage&url[]=https://treeherder.allizom.org/media/revision&name[]=Prod&url[]=https://treeherder.mozilla.org/media/revision">What's Deployed?</a>
   </div>
 </div>
 


### PR DESCRIPTION
This fixes Bugzilla bug [1186936](https://bugzilla.mozilla.org/show_bug.cgi?id=1186936)

This switches our former 'Build' link to the new **WhatsDeployed** service at https://whatsdeployed.paas.allizom.org

Proposed:
<img width="756" alt="whatsdeployed" src="https://cloud.githubusercontent.com/assets/3660661/8858980/9129df64-3148-11e5-93bb-e99ffaf949c5.png">



Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-07-22)**
Chrome Latest Release **44.0.2403.89 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/803)
<!-- Reviewable:end -->
