### PR TITLE
Bug 1187267 - Handle invalid builds-4hr blobber_files json gracefully

### DIFF
--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -191,13 +191,17 @@ class Builds4hTransformerMixin(object):
 
             # add structured logs to the list of log references
             if 'blobber_files' in prop:
-                blobber_files = json.loads(prop['blobber_files'])
-                for bf, url in blobber_files.items():
-                    if bf and url and bf.endswith('_raw.log'):
-                        log_reference.append({
-                            'url': url,
-                            'name': 'mozlog_json'
-                        })
+                try:
+                    blobber_files = json.loads(prop['blobber_files'])
+                    for bf, url in blobber_files.items():
+                        if bf and url and bf.endswith('_raw.log'):
+                            log_reference.append({
+                                'url': url,
+                                'name': 'mozlog_json'
+                            })
+                except Exception as e:
+                    logger.warning("invalid blobber_files json for build id %s (%s): %s",
+                                   build['id'], prop['buildername'], e)
 
             try:
                 job_guid_data = self.find_job_guid(build)


### PR DESCRIPTION
The blobber_files property on jobs in builds-4hr is a json blob, containing a number of name-url pairs. In some cases this blob is truncated, so fails to decode. This change makes us handle these failures more gracefully (by treating it as though the blobber_files property was not set for that job), rather than causing the entire builds-4hr task to fail.

Bug 1187284 is filed to try and make mozharness never output truncated json in the first place.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/809)
<!-- Reviewable:end -->
