### PR TITLE
Bug 1187403 - Improve resultset bar layout for bug 1136918

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -440,8 +440,12 @@ th-watched-repo {
     margin-top: 2px;
     white-space: normal;
     width: 100%;
-    border-top: 1px solid lightgrey;
     position: relative;
+}
+
+.result-set-body-divider {
+    margin-left: 34px;
+    border-bottom: 1px solid lightgrey;
 }
 
 .result-set-body {
@@ -475,7 +479,7 @@ th-watched-repo {
 
 .result-set-bar {
     border-top: 1px solid black;
-    padding: 2px 0px 0px 14px;
+    padding: 2px 0px 0px 34px;
     white-space: nowrap;
     display: flex;
     display: -webkit-flex;
@@ -573,7 +577,7 @@ th-watched-repo {
 }
 
 .result-set .job-list-nopad {
-    padding-left: 0;
+    padding-left: 20px;
     padding-right: 0;
     display: block;
 }

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -48,6 +48,7 @@
       </span>
 
     </div>
+    <div class="result-set-body-divider"></div>
     <div class="result-set-body" th-clone-jobs ></div>
 </div>
 


### PR DESCRIPTION
This fixes Bugzilla bug [1187403](https://bugzilla.mozilla.org/show_bug.cgi?id=1187403).

This improves the resultset bar layout post-bug 1136918, which added double-click space to the left of the revision column for copy-selection. So with this proposed change we have a clean layout again.

Current:

![current](https://cloud.githubusercontent.com/assets/3660661/8882929/02c2da88-3219-11e5-9b4d-c1b960471837.jpg)

Proposed:

![proposed](https://cloud.githubusercontent.com/assets/3660661/8882939/11d6e80c-3219-11e5-90d8-4cb86b3c01fa.jpg)

And our SHA selection still works fine:

![shaselection](https://cloud.githubusercontent.com/assets/3660661/8882947/2eb2bc8a-3219-11e5-95f9-76ee1d9f7900.jpg)

And our *Hide revision list* also aligns to the new location:

![collapserevisions](https://cloud.githubusercontent.com/assets/3660661/8882960/482047c8-3219-11e5-99ce-4361fd982fb0.jpg)

We only consume 20px in the adjustment and we still have plenty of space in the resultset bar for its contents. It just wraps the contents 20px earlier at extremely narrow browser widths.

We add one div per resultset, which seems low cost. The nature of the existing containers prevented using them for the light grey boundary, which Wes wanted to preserve.

Everything seems fine on both browsers.

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-07-24)**
Chrome Latest Release **44.0.2403.89 (64-bit)**

Adding @wlach for review and @KWierso for visibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/810)
<!-- Reviewable:end -->
