### PR TITLE
 	Bug 1188132 - Fix log parsing when logs have TALOSDATA in them

### DIFF
--- a/tests/log_parser/test_performance_log_parser.py
+++ b/tests/log_parser/test_performance_log_parser.py
@@ -13,6 +13,8 @@ def test_valid_talosdata():
     assert parser.artifact[0].keys()[0] == 'json'
 
 
+# Disabled because of bug 1188132.
+@pytest.mark.xfail
 def test_invalid_talosdata():
     invalid_line = '10:27:39     INFO -  INFO : TALOSDATA: [ { "json"'
     parser = TalosParser()

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -346,4 +346,5 @@ class TalosParser(ParserBase):
                 # that's the behaviour we want
                 self.artifact = json.loads(match.group(1))
             else:
-                raise ValueError('Invalid TALOSDATA: %s' % line)
+                # probably a line which just happens to contain talosdata, ignore
+                pass


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/812)
<!-- Reviewable:end -->
