### PR TITLE
Bug 1188346 - Disable the mozilla-b2g32_v2_0 & mozilla-b2g34_v2_1 repos

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -643,7 +643,7 @@
         "dvcs_type": "hg",
         "name": "mozilla-b2g32_v2_0",
         "url": "https://hg.mozilla.org/releases/mozilla-b2g32_v2_0",
-        "active_status": "active",
+        "active_status": "onhold",
         "codebase": "gecko",
         "repository_group": 2,
         "description": ""
@@ -695,7 +695,7 @@
         "dvcs_type": "hg",
         "name": "mozilla-b2g34_v2_1",
         "url": "https://hg.mozilla.org/releases/mozilla-b2g34_v2_1",
-        "active_status": "active",
+        "active_status": "onhold",
         "codebase": "gecko",
         "repository_group": 2,
         "description": ""


### PR DESCRIPTION
Since they are EOL.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/813)
<!-- Reviewable:end -->
