### PR TITLE
Bug 1188832 - Fix intermittent Travis test failure in test_note_api

### DIFF
--- a/tests/webapp/api/test_note_api.py
+++ b/tests/webapp/api/test_note_api.py
@@ -41,14 +41,14 @@ def test_note_list(webapp, sample_notes, jm):
     exp_notes = [
         {
             "job_id": job_id,
-            "failure_classification_id": 0,
+            "failure_classification_id": 1,
             "who": "kellyclarkson",
             "note": "you look like a man-o-lantern",
             "active_status": "active",
         },
         {
             "job_id": job_id,
-            "failure_classification_id": 1,
+            "failure_classification_id": 0,
             "who": "kellyclarkson",
             "note": "you look like a man-o-lantern",
             "active_status": "active",

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -692,7 +692,7 @@
         "get_job_note_list":{
             "sql":"SELECT * from `job_note`
                    WHERE `job_id` = ?
-                   ORDER BY `note_timestamp` DESC
+                   ORDER BY `note_timestamp` DESC, id DESC
                    ",
             "host_type": "read_host"
         },


### PR DESCRIPTION
The sample notes added for the test normally have the same timestamp for several notes, but not always. With the previous `ORDER BY`, this meant the list of notes retrieved could vary in order depending on if the timestamps were identical. We now additionally sort by id (descending, to match the timestamp sort), so the returned list is deterministic.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/815)
<!-- Reviewable:end -->
