### PR TITLE
Bug 1189479 - Fix angular template flicker in logviewer

### DIFF
--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -91,9 +91,9 @@
                     ng-cloak class="break-word">{{property.value}}</td>
               </tr>
               <tr ng-repeat="line in job_details | orderBy:'title'">
-                <th>{{line.title}}:</th>
+                <th ng-cloak>{{line.title}}:</th>
                 <td ng-switch on="line.content_type">
-                  <a ng-switch-when="link" title="{{line.value}}"
+                  <a ng-cloak ng-switch-when="link" title="{{line.value}}"
                      href="{{line.url}}" target="_blank">{{line.value}}</a>
                     <span ng-switch-when="raw_html" ng-bind-html="line.value"></span>
                 <td/>


### PR DESCRIPTION
This fixes Bugzilla bug [1189479](https://bugzilla.mozilla.org/show_bug.cgi?id=1189479).

This should remove any outstanding angular template flicker in logviewer during page load.

I tested the changes on my gh-pages since my macbook pro is so quick it's hard to locally test the failure condition. So now we correctly suppress the {{line.value}} row.

(mid-load apparance with the fix)
![proposedload](https://cloud.githubusercontent.com/assets/3660661/8994903/1a56f3a6-36dc-11e5-936b-e12b8aa43122.jpg)

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-07-30)**
Chrome Latest Release **44.0.2403.125 (64-bit)**

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/820)
<!-- Reviewable:end -->
