### PR TITLE
Bug 1189475 - Match logviewer navbar action buttons w/bootstrap

### DIFF
--- a/ui/css/logviewer.css
+++ b/ui/css/logviewer.css
@@ -59,6 +59,7 @@ body {
 
 #lv-successful-steps > input {
     margin: 0;
+    vertical-align: middle;
 }
 
 .lv-line-no {
@@ -156,15 +157,10 @@ body {
 }
 
 .logviewer-actionbtn span {
-    color: #9fa3a5;
+    color: #777;
 }
 
-.logviewer-actionbtn a:hover,
-.logviewer-actionbtn a:focus {
-    text-decoration: none;
-}
-
-.logviewer-actionbtn .actionbtn-icon {
+.actionbtn-icon {
     padding-right: 5px;
 }
 

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -40,7 +40,7 @@
             </li>
 
             <!-- Raw log button -->
-            <li class="logviewer-actionbtn">
+            <li>
               <a title="Open the raw log in a new window"
                  target="_blank"
                  href="{{::artifact.logurl}}">
@@ -50,8 +50,7 @@
             </li>
 
             <!-- Ref test button -->
-            <li ng-if="isReftest()"
-                class="logviewer-actionbtn">
+            <li ng-if="isReftest()">
               <a title="Open the Reftest Analyser in a new window"
                  target="_blank"
                  href="http://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl={{::artifact.logurl}}&only_show_unexpected=1">


### PR DESCRIPTION
This fixes Bugzilla bug [1189475](https://bugzilla.mozilla.org/show_bug.cgi?id=1189475).

This improves our Logviewer navbar action buttons by removing the perception they may be disabled, and using the same Perfherder colors ie. bootstrap behavior.

Current ( appears somewhat disabled at `#9fa3a5` now that it is in the navbar ):
![current](https://cloud.githubusercontent.com/assets/3660661/9011522/cc9457bc-377b-11e5-85aa-8fa963c26987.jpg)

Proposed ( matches Perfherder's navbar aka. bootstrap, `#777` ):
![proposed](https://cloud.githubusercontent.com/assets/3660661/9011526/d1d8eb66-377b-11e5-9dad-dfcc11318f7c.jpg)

And on hover, the same matching behavior and color styles:
![hover](https://cloud.githubusercontent.com/assets/3660661/9011542/e82791ba-377b-11e5-8af3-5da774b227d4.jpg)

I needed to leave one `#777` targeting the child span of show successful steps, since bootstrap only targets the anchors and for that button there isn't one. I also vertically aligned the checkbox with show successful steps while there.

Everything seems fine on both browsers.

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-07-31)**
Chrome Latest Release **44.0.2403.125 (64-bit)**

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/821)
<!-- Reviewable:end -->
