### PR TITLE
Bug 1189484 - Match treeherder raw log icon to logviewer's

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -531,6 +531,10 @@ th-watched-repo {
     opacity: 0.9;
 }
 
+.raw-log-icon {
+    font-size: 14px;
+}
+
 .cancel-job-icon {
     font-size: 13px;
 }

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -51,11 +51,12 @@
           </li>
 
           <li ng-repeat="job_log_url in job_log_urls">
-            <a title="Open the raw log in a new window"
+            <a class="raw-log-icon"
+               title="Open the raw log in a new window"
                target="_blank"
                href="{{::job_log_url.url}}"
                copy-value="{{::job_log_url.url}}">
-              <span class="glyphicon glyphicon-align-left"></span>
+              <span class="fa fa-file-text-o"></span>
             </a>
           </li>
           <li>


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1189484](https://bugzilla.mozilla.org/show_bug.cgi?id=1189484).

In Bug [1183880](https://bugzilla.mozilla.org/show_bug.cgi?id=1183880) we adjusted the raw log icon in Logviewer's navbar to `fa-file-text-o`:

![logviewer](https://cloud.githubusercontent.com/assets/3660661/9012272/8a825c38-3781-11e5-9ffb-6bfe001e17a6.jpg)

So this PR applies the same treatment in Treeherder's job details action bar.

Current:
![current](https://cloud.githubusercontent.com/assets/3660661/9012280/989a2260-3781-11e5-9cc2-02c28f178441.jpg)

Proposed:
![proposed](https://cloud.githubusercontent.com/assets/3660661/9012282/9cadd20c-3781-11e5-9a39-bac8f780344d.jpg)

I split the difference between our larger Logviewer .svg icon (which we emphasize to users), and the default 12px icons for the rest of the action bar, at `14px`. The interior lines of the icon seem to hold up well at that size on both my OSX retina and my ancient windows PC :)

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-07-31)**
Chrome Latest Release **44.0.2403.125 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/822)
<!-- Reviewable:end -->
