### PR TITLE
 	Bug 1189826 - Don't recommend retriggering if we have full set of runs

### DIFF
--- a/ui/partials/perf/comparetable.html
+++ b/ui/partials/perf/comparetable.html
@@ -56,10 +56,20 @@
           {{compareResult.newRuns.length}}</span>
       </td>
       <td class="test-warning">
+        <!-- Show a hint that people should trigger more runs if:
+             * we only have 1 result for either base/new (can't draw any
+               strong conclusions from one result)
+             * we have less than 6 runs for either base/new AND our
+               confidence level isn't 'high' (6 runs is our gold standard
+               for confidence -- if we've done that many and we're still
+               not confident in a change, more are unlikely to help)
+          -->
         <span ng-if="compareResult.originalRuns.length && compareResult.newRuns.length &&
-                     (compareResult.originalRuns.length < 2 ||
-                      compareResult.newRuns.length < 2 ||
-                      compareResult.confidenceText !== 'high')"
+                     ((compareResult.originalRuns.length < 2 ||
+                       compareResult.newRuns.length < 2) ||
+                      (compareResult.originalRuns.length < 6 &&
+                       compareResult.newRuns.length < 6 &&
+                       compareResult.confidenceText !== 'high'))"
                 class="glyphicon glyphicon-warning-sign text-warning"
                 tooltip="More base / new runs recommended for increased confidence in comparison"
                 tooltip-placement="left"


### PR DESCRIPTION
If we already have 6 runs for base / new, more won't really help, even
if we have low/medium confidence.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/824)
<!-- Reviewable:end -->
