### PR TITLE
Bug 1165335 - Switch from urllib to requests for bugscache API query

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,12 +368,9 @@ def mock_post_json(monkeypatch, set_oauth_credentials):
 
 @pytest.fixture
 def mock_get_remote_content(monkeypatch):
-    def _get_remote_content(url):
-        response = TestApp(application).get(url)
-        if response.status_int != 200:
-            return None
-        else:
-            return response.json
+    def _get_remote_content(url, params=None):
+        response = TestApp(application).get(url, params=params, status=200)
+        return response.json
 
     import treeherder.etl.common
     monkeypatch.setattr(treeherder.etl.common,

--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -56,17 +56,6 @@ class JobData(dict):
         return value
 
 
-def retrieve_api_content(url):
-    req = urllib2.Request(url)
-    req.add_header('Content-Type', 'application/json')
-    conn = urllib2.urlopen(
-        req,
-        timeout=settings.TREEHERDER_REQUESTS_TIMEOUT
-    )
-    if conn.getcode() == 404:
-        return None
-
-
 def get_remote_content(url):
     """A thin layer of abstraction over urllib. """
     req = urllib2.Request(url)

--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -3,10 +3,10 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import hashlib
-import urllib2
 import simplejson as json
 import time
 
+import requests
 from django.conf import settings
 
 
@@ -56,25 +56,14 @@ class JobData(dict):
         return value
 
 
-def get_remote_content(url):
-    """A thin layer of abstraction over urllib. """
-    req = urllib2.Request(url)
-    req.add_header('Accept', 'application/json')
-    req.add_header('Content-Type', 'application/json')
-    conn = urllib2.urlopen(
-        req,
-        timeout=settings.TREEHERDER_REQUESTS_TIMEOUT)
-
-    if not conn.getcode() == 200:
-        return None
-    try:
-        content = json.loads(conn.read())
-    except:
-        content = None
-    finally:
-        conn.close()
-
-    return content
+def get_remote_content(url, params=None):
+    """A thin layer of abstraction over requests. """
+    resp = requests.get(url,
+                        params=params,
+                        headers={'Accept': 'application/json'},
+                        timeout=settings.TREEHERDER_REQUESTS_TIMEOUT)
+    resp.raise_for_status()
+    return resp.json()
 
 
 def lookup_revisions(revision_dict):

--- a/treeherder/model/error_summary.py
+++ b/treeherder/model/error_summary.py
@@ -4,7 +4,6 @@
 
 import logging
 import re
-import urllib
 import json
 
 from django.core.urlresolvers import reverse
@@ -189,12 +188,7 @@ def get_bugs_for_search_term(search, base_uri):
     params = {
         'search': search
     }
-    query_string = urllib.urlencode(params)
-    url = '{0}?{1}'.format(
-        base_uri,
-        query_string
-    )
-    return get_remote_content(url)
+    return get_remote_content(base_uri, params=params)
 
 
 def get_artifacts_that_need_bug_suggestions(artifact_list):


### PR DESCRIPTION
* Remove unused `etl.common.retrieve_api_content()`
* Switch from urllib to requests for bugscache API query. urllib isn't handling the unicode found in some log lines correctly, whereas requests does. This prevents UnicodeEncodeError exceptions when making the request to the bugscache API to find the bug suggestions for these log lines.

Note: webtest's TestApp raises if the HTTP status code is not 200, due to the `status=200` param, which makes the check of `response.status_int` redundant.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/825)
<!-- Reviewable:end -->
