### PR TITLE
Bug 1185520 make the oauth check backward compatible

### DIFF
--- a/tests/webapp/api/test_auth.py
+++ b/tests/webapp/api/test_auth.py
@@ -1,0 +1,91 @@
+from django.core.urlresolvers import resolve, reverse
+import oauth2 as oauth
+from rest_framework.decorators import APIView
+from rest_framework.response import Response
+from rest_framework.test import APIRequestFactory
+
+from treeherder.webapp.api.auth import TwoLeggedOauthAuthentication
+from treeherder.etl.oauth_utils import OAuthCredentials
+
+
+class AuthenticatedView(APIView):
+    authentication_classes = [TwoLeggedOauthAuthentication]
+
+    def get(self, request, *args, **kwargs):
+        return Response({'authenticated': hasattr(request, 'legacy_oauth_authenticated')})
+
+
+factory = APIRequestFactory()
+
+
+def test_two_legged_oauth_authentication_not_detected():
+    view = AuthenticatedView.as_view()
+    request = factory.get('/')
+    view(request)
+    assert not hasattr(request, 'legacy_oauth_authenticated')
+
+
+def test_two_legged_oauth_wrong_project():
+    view = AuthenticatedView.as_view()
+    test_url = '/api/'
+    request = factory.get(test_url, {
+        'oauth_body_hash': '',
+        'oauth_consumer_key': '',
+        'oauth_nonce': '',
+        'oauth_signature_method': '',
+        'oauth_timestamp': '',
+        'oauth_token': '',
+        'oauth_version': '',
+        'oauth_signature': '',
+        'user': 'foo'
+    })
+    request.resolver_match = resolve(test_url)
+    response = view(request)
+
+    assert response.status_code == 400
+
+
+def test_two_legged_oauth_project_via_uri(monkeypatch, jm, set_oauth_credentials):
+    view = AuthenticatedView.as_view()
+    credentials = OAuthCredentials.get_credentials(jm.project)
+
+    test_url = reverse('jobs-list', kwargs={'project': jm.project})
+    request = factory.get(test_url, {
+        'oauth_body_hash': '',
+        'oauth_consumer_key': credentials['consumer_key'],
+        'oauth_nonce': '',
+        'oauth_signature_method': '',
+        'oauth_timestamp': '',
+        'oauth_token': '',
+        'oauth_version': '',
+        'oauth_signature': '',
+        'user': 'foo'
+    })
+    request.resolver_match = resolve(test_url)
+    monkeypatch.setattr(oauth.Server, 'verify_request', lambda *x, **y: True)
+    response = view(request)
+
+    assert response.data == {'authenticated': True}
+
+
+def test_two_legged_oauth_project_via_user(monkeypatch, jm, set_oauth_credentials):
+    view = AuthenticatedView.as_view()
+    credentials = OAuthCredentials.get_credentials(jm.project)
+
+    test_url = '/api/'
+    request = factory.get(test_url, {
+        'oauth_body_hash': '',
+        'oauth_consumer_key': credentials['consumer_key'],
+        'oauth_nonce': '',
+        'oauth_signature_method': '',
+        'oauth_timestamp': '',
+        'oauth_token': '',
+        'oauth_version': '',
+        'oauth_signature': '',
+        'user': jm.project
+    })
+    monkeypatch.setattr(oauth.Server, 'verify_request', lambda *x, **y: True)
+    request.resolver_match = resolve(test_url)
+    response = view(request)
+
+    assert response.data == {'authenticated': True}

--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -263,8 +263,7 @@ def test_resultset_with_bad_secret(sample_resultset, jm, initial_data):
     )
 
     assert resp.status_int == 403
-    assert resp.json['detail'] == "Client authentication failed for project, {0}".format(jm.project)
-    assert resp.json['response'] == "invalid_client"
+    assert resp.json['detail'] == "Client authentication failed for project {0}".format(jm.project)
 
 
 def test_resultset_with_bad_key(sample_resultset, jm, initial_data):
@@ -279,8 +278,7 @@ def test_resultset_with_bad_key(sample_resultset, jm, initial_data):
     )
 
     assert resp.status_int == 403
-    assert resp.json['response'] == "access_denied"
-    assert resp.json['detail'] == "oauth_consumer_key does not match project, {0}, credentials".format(jm.project)
+    assert resp.json['detail'] == 'oauth_consumer_key does not match credentials for project {0}'.format(jm.project)
 
 
 def test_resultset_cancel_all(jm, resultset_with_three_jobs, pulse_action_consumer):

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -286,7 +286,11 @@ REST_FRAMEWORK = {
     },
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.AcceptHeaderVersioning',
     'DEFAULT_VERSION': '1.0',
-    'ALLOWED_VERSIONS': ('1.0',)
+    'ALLOWED_VERSIONS': ('1.0',),
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.SessionAuthentication',
+        'treeherder.webapp.api.auth.TwoLeggedOauthAuthentication',
+    )
 }
 
 SITE_URL = os.environ.get("TREEHERDER_SITE_URL", "http://local.treeherder.mozilla.org")

--- a/treeherder/webapp/api/artifact.py
+++ b/treeherder/webapp/api/artifact.py
@@ -4,13 +4,15 @@
 
 from rest_framework import viewsets
 from rest_framework.response import Response
-from treeherder.webapp.api.utils import UrlQueryFilter, oauth_required
+from treeherder.webapp.api.utils import UrlQueryFilter
+from treeherder.webapp.api import permissions
 from treeherder.model.derived import JobsModel, ArtifactsModel
 from treeherder.model.tasks import populate_error_summary
 from treeherder.model.error_summary import get_artifacts_that_need_bug_suggestions
 
 
 class ArtifactViewSet(viewsets.ViewSet):
+    permission_classes = (permissions.HasLegacyOauthPermissionsOrReadOnly,)
 
     """
     This viewset is responsible for the artifact endpoint.
@@ -54,7 +56,6 @@ class ArtifactViewSet(viewsets.ViewSet):
             )
             return Response(objs)
 
-    @oauth_required
     def create(self, request, project):
         artifacts = ArtifactsModel.serialize_artifact_json_blobs(request.DATA)
 

--- a/treeherder/webapp/api/auth.py
+++ b/treeherder/webapp/api/auth.py
@@ -1,0 +1,86 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+from django.conf import settings
+import oauth2 as oauth
+from rest_framework import exceptions
+from rest_framework.authentication import BaseAuthentication
+from rest_framework.renderers import JSONRenderer
+
+from treeherder.etl.oauth_utils import OAuthCredentials
+
+
+class DummyUser(object):
+    pass
+
+
+class TwoLeggedOauthAuthentication(BaseAuthentication):
+
+    def auth_detected(self, request):
+        oauth_parameters = (
+            'oauth_body_hash',
+            'oauth_nonce',
+            'oauth_timestamp',
+            'oauth_consumer_key',
+            'oauth_signature_method',
+            'oauth_version',
+            'oauth_token',
+            'user',
+            'oauth_signature',
+        )
+        return all(param in request.query_params for param in oauth_parameters)
+
+    def authenticate(self, request):
+
+        if not self.auth_detected(request):
+            return None
+
+        user = request.resolver_match.kwargs.get('project') or request.query_params['user']
+        project_credentials = OAuthCredentials.get_credentials(user)
+
+        if not project_credentials:
+            raise exceptions.ValidationError(
+                'project {0} has no OAuth credentials'.format(user)
+            )
+        parameters = OAuthCredentials.get_parameters(request.query_params)
+
+        oauth_consumer_key = parameters['oauth_consumer_key']
+
+        if oauth_consumer_key != project_credentials['consumer_key']:
+            raise exceptions.AuthenticationFailed(
+                'oauth_consumer_key does not match credentials for project {0}'.format(user)
+            )
+
+        uri = '{0}://{1}{2}'.format(
+            settings.TREEHERDER_REQUEST_PROTOCOL,
+            request.get_host(),
+            request.path
+        )
+        # Construct the OAuth request based on the django request object
+        json_renderer = JSONRenderer()
+        req_obj = oauth.Request(
+            method=request.method,
+            url=uri,
+            parameters=parameters,
+            body=json_renderer.render(request.DATA),
+        )
+        server = oauth.Server()
+        token = oauth.Token(key='', secret='')
+        # Get the consumer object
+        cons_obj = oauth.Consumer(
+            oauth_consumer_key,
+            project_credentials['consumer_secret']
+        )
+        # Set the signature method
+        server.add_signature_method(oauth.SignatureMethod_HMAC_SHA1())
+
+        try:
+            # verify oauth django request and consumer object match
+            server.verify_request(req_obj, cons_obj, token)
+        except oauth.Error:
+            raise exceptions.AuthenticationFailed(
+                'Client authentication failed for project {0}'.format(user)
+            )
+        request.legacy_oauth_authenticated = True
+        return (DummyUser(), None)

--- a/treeherder/webapp/api/bug.py
+++ b/treeherder/webapp/api/bug.py
@@ -3,18 +3,17 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 from time import time
-from treeherder.model.derived.jobs import JobDataIntegrityError
+
 from rest_framework import viewsets
 from rest_framework.response import Response
-
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
+
+from treeherder.model.derived.jobs import JobDataIntegrityError
 from treeherder.webapp.api.utils import (UrlQueryFilter, with_jobs)
 
 
 class BugJobMapViewSet(viewsets.ViewSet):
-    authentication_classes = (SessionAuthentication,)
-    permission_classes = (IsAuthenticatedOrReadOnly, )
+    permission_classes = (IsAuthenticatedOrReadOnly,)
 
     @with_jobs
     def create(self, request, project, jm):

--- a/treeherder/webapp/api/job_log_url.py
+++ b/treeherder/webapp/api/job_log_url.py
@@ -3,12 +3,14 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import logging
+
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 from rest_framework.decorators import detail_route
 
-from treeherder.webapp.api.utils import with_jobs, oauth_required
+from treeherder.webapp.api import permissions
+from treeherder.webapp.api.utils import with_jobs
 
 logger = logging.getLogger(__name__)
 
@@ -47,9 +49,9 @@ class JobLogUrlViewSet(viewsets.ViewSet):
 
         return Response(job_log_url_list)
 
-    @detail_route(methods=['post'])
+    @detail_route(methods=['post'],
+                  permission_classes=(permissions.HasLegacyOauthPermissions,))
     @with_jobs
-    @oauth_required
     def update_parse_status(self, request, project, jm, pk=None):
         """
         Change the state of a job.

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -1,16 +1,15 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.decorators import detail_route
 from rest_framework.reverse import reverse
 from rest_framework.permissions import IsAuthenticated
-from treeherder.webapp.api.permissions import IsStaffOrReadOnly
 
-from treeherder.webapp.api.utils import (UrlQueryFilter, with_jobs,
-                                         oauth_required, get_option)
+from treeherder.webapp.api.permissions import (IsStaffOrReadOnly)
+from treeherder.webapp.api.utils import (UrlQueryFilter, with_jobs, get_option)
+from treeherder.webapp.api import permissions
 from treeherder.model.derived import ArtifactsModel
 
 
@@ -21,6 +20,7 @@ class JobsViewSet(viewsets.ViewSet):
 
     """
     throttle_scope = 'jobs'
+    permission_classes = (permissions.HasLegacyOauthPermissionsOrReadOnly,)
 
     @with_jobs
     def retrieve(self, request, project, jm, pk=None):
@@ -92,7 +92,7 @@ class JobsViewSet(viewsets.ViewSet):
 
         return Response(response_body)
 
-    @detail_route(methods=['post'], permission_classes=[IsAuthenticated])
+    @detail_route(methods=['post'])
     @with_jobs
     def update_state(self, request, project, jm, pk=None):
         """
@@ -163,7 +163,6 @@ class JobsViewSet(viewsets.ViewSet):
             return Response("No job with id: {0}".format(pk), 404)
 
     @with_jobs
-    @oauth_required
     def create(self, request, project, jm):
         """
         This method adds a job to a given resultset.

--- a/treeherder/webapp/api/logslice.py
+++ b/treeherder/webapp/api/logslice.py
@@ -1,19 +1,19 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
+import gzip
+import json
+import urllib2
 
 from rest_framework import viewsets
 from rest_framework.response import Response
 from django.core.cache import caches
 from django.utils.six import BytesIO
-
-from treeherder.webapp.api.utils import (with_jobs)
-from treeherder.webapp.api.exceptions import ResourceNotFoundException
 from django.conf import settings
 
-import urllib2
-import gzip
-import json
+from treeherder.webapp.api.utils import with_jobs
+from treeherder.webapp.api.exceptions import ResourceNotFoundException
+
 
 filesystem = caches['filesystem']
 

--- a/treeherder/webapp/api/note.py
+++ b/treeherder/webapp/api/note.py
@@ -5,16 +5,13 @@
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
-
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
 from treeherder.webapp.api.utils import with_jobs
 
 
 class NoteViewSet(viewsets.ViewSet):
-    authentication_classes = (SessionAuthentication,)
-    permission_classes = (IsAuthenticatedOrReadOnly, )
+    permission_classes = (IsAuthenticatedOrReadOnly,)
 
     """
     This viewset is responsible for the note endpoint.

--- a/treeherder/webapp/api/performance_artifact.py
+++ b/treeherder/webapp/api/performance_artifact.py
@@ -4,6 +4,7 @@
 
 from rest_framework import viewsets
 from rest_framework.response import Response
+
 from treeherder.webapp.api.utils import UrlQueryFilter, with_jobs
 
 

--- a/treeherder/webapp/api/permissions.py
+++ b/treeherder/webapp/api/permissions.py
@@ -1,7 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from rest_framework import permissions
 
 
@@ -33,3 +32,18 @@ class IsOwnerOrReadOnly(permissions.BasePermission):
 
         # Instance must have an attribute named `user`.
         return obj.user == request.user
+
+
+class HasLegacyOauthPermissions(permissions.BasePermission):
+
+    def has_permission(self, request, view):
+        return hasattr(request, 'legacy_oauth_authenticated')
+
+
+class HasLegacyOauthPermissionsOrReadOnly(permissions.BasePermission):
+
+    def has_permission(self, request, view):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        return hasattr(request, 'legacy_oauth_authenticated')

--- a/treeherder/webapp/api/refdata.py
+++ b/treeherder/webapp/api/refdata.py
@@ -4,9 +4,7 @@
 
 from rest_framework import viewsets
 from rest_framework.response import Response
-from rest_framework.authentication import SessionAuthentication
 from rest_framework_extensions.mixins import CacheResponseAndETAGMixin
-
 from django.contrib.auth.models import User
 
 from treeherder.model import models
@@ -130,7 +128,6 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
     Used by Treeherder's UI to inspect user properties like the exclusion profile
     """
     serializer_class = th_serializers.UserSerializer
-    authentication_classes = (SessionAuthentication,)
 
     def get_queryset(self):
         return User.objects.filter(id=self.request.user.id)
@@ -138,14 +135,12 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
 
 class UserExclusionProfileViewSet(viewsets.ModelViewSet):
     queryset = models.UserExclusionProfile.objects.all()
-    authentication_classes = (SessionAuthentication,)
     permission_classes = (IsOwnerOrReadOnly,)
     serializer_class = th_serializers.UserExclusionProfileSerializer
 
 
 class JobExclusionViewSet(viewsets.ModelViewSet):
     queryset = models.JobExclusion.objects.all()
-    authentication_classes = (SessionAuthentication,)
     permission_classes = (IsStaffOrReadOnly,)
     serializer_class = th_serializers.JobExclusionSerializer
 
@@ -165,7 +160,6 @@ class ExclusionProfileViewSet(viewsets.ModelViewSet):
 
     """
     queryset = models.ExclusionProfile.objects.all()
-    authentication_classes = (SessionAuthentication,)
     permission_classes = (IsStaffOrReadOnly,)
     serializer_class = th_serializers.ExclusionProfileSerializer
 

--- a/treeherder/webapp/api/resultset.py
+++ b/treeherder/webapp/api/resultset.py
@@ -8,11 +8,11 @@ from rest_framework.decorators import detail_route
 from rest_framework.reverse import reverse
 from rest_framework.exceptions import ParseError
 from rest_framework.permissions import IsAuthenticated
-from treeherder.webapp.api.permissions import IsStaffOrReadOnly
+
+from treeherder.webapp.api.permissions import (IsStaffOrReadOnly,
+                                               HasLegacyOauthPermissionsOrReadOnly)
 from treeherder.model.derived import DatasetNotFoundError
-from treeherder.webapp.api.utils import (UrlQueryFilter, with_jobs,
-                                         oauth_required,
-                                         to_timestamp)
+from treeherder.webapp.api.utils import (UrlQueryFilter, with_jobs, to_timestamp)
 
 
 class ResultSetViewSet(viewsets.ViewSet):
@@ -23,6 +23,7 @@ class ResultSetViewSet(viewsets.ViewSet):
     ``result sets`` are synonymous with ``pushes`` in the ui
     """
     throttle_scope = 'resultset'
+    permission_classes = (HasLegacyOauthPermissionsOrReadOnly,)
 
     @with_jobs
     def list(self, request, project, jm):
@@ -172,7 +173,6 @@ class ResultSetViewSet(viewsets.ViewSet):
             return Response("Exception: {0}".format(ex), 404)
 
     @with_jobs
-    @oauth_required
     def create(self, request, project, jm):
         """
         POST method implementation

--- a/treeherder/webapp/api/utils.py
+++ b/treeherder/webapp/api/utils.py
@@ -7,13 +7,7 @@ import time
 import datetime
 import functools
 
-import simplejson as json
-import oauth2 as oauth
-from django.conf import settings
-from rest_framework.response import Response
-
 from treeherder.model.derived import JobsModel
-from treeherder.etl.oauth_utils import OAuthCredentials
 
 
 class UrlQueryFilter(object):
@@ -98,91 +92,6 @@ class UrlQueryFilter(object):
             if default is not None:
                 return default
             raise e
-
-
-def oauth_required(func):
-
-    @functools.wraps(func)
-    def wrap_oauth(cls, *args, **kwargs):
-
-        # First argument must be request object
-        request = args[0]
-
-        # Get the project keyword argumet
-        project = kwargs.get('project', None)
-
-        # Get the project credentials
-        project_credentials = OAuthCredentials.get_credentials(project)
-
-        if not project_credentials:
-            msg = {
-                'response': "invalid_request",
-                'detail': "project, {0}, has no OAuth credentials".format(project)
-            }
-            return Response(msg, 500)
-
-        parameters = OAuthCredentials.get_parameters(request.QUERY_PARAMS)
-
-        oauth_body_hash = parameters.get('oauth_body_hash', None)
-        oauth_signature = parameters.get('oauth_signature', None)
-        oauth_consumer_key = parameters.get('oauth_consumer_key', None)
-
-        if not oauth_body_hash or not oauth_signature or not oauth_consumer_key:
-
-            msg = {
-                'response': "invalid_request",
-                'detail': "Required oauth parameters not provided in the uri"
-            }
-
-            return Response(msg, 500)
-
-        if oauth_consumer_key != project_credentials['consumer_key']:
-            msg = {
-                'response': "access_denied",
-                'detail': "oauth_consumer_key does not match project, {0}, credentials".format(project)
-            }
-
-            return Response(msg, 403)
-
-        uri = '{0}://{1}{2}'.format(
-            settings.TREEHERDER_REQUEST_PROTOCOL, request.get_host(),
-            request.path
-        )
-
-        # Construct the OAuth request based on the django request object
-        req_obj = oauth.Request(
-            method=request.method,
-            url=uri,
-            parameters=parameters,
-            body=json.dumps(request.DATA),
-        )
-
-        server = oauth.Server()
-        token = oauth.Token(key='', secret='')
-
-        # Get the consumer object
-        cons_obj = oauth.Consumer(
-            oauth_consumer_key,
-            project_credentials['consumer_secret']
-        )
-
-        # Set the signature method
-        server.add_signature_method(oauth.SignatureMethod_HMAC_SHA1())
-
-        try:
-            # verify oauth django request and consumer object match
-            server.verify_request(req_obj, cons_obj, token)
-        except oauth.Error:
-            msg = {
-                'response': "invalid_client",
-                'detail': "Client authentication failed for project, {0}".format(project)
-            }
-
-            return Response(msg, 403)
-
-        return func(request, *args, **kwargs)
-
-    return wrap_oauth
 
 
 def with_jobs(model_func):


### PR DESCRIPTION
The changes in the first version of this patch introduced a regression due to the different way the oauth user parameter is interpreted by the python client vs the nodejs client. To maintain backward compatibility now we first look at the project name provided in the uri, and then we fallback to the user parameter on the querystring

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/826)
<!-- Reviewable:end -->
