### PR TITLE
Bug 1190894 - Vagrant: Make it clearer that vagrant v1.5+ is required

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# We require 1.5+ due to specifying only the box name and not config.vm.box_url.
+Vagrant.require_version ">= 1.5.0"
+
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,7 +9,7 @@ Cloning the Repo
 Setting up Vagrant
 ------------------
 
-* Install Virtualbox_ and Vagrant_ if not present.
+* Install Virtualbox_ and Vagrant_ 1.5+ if not present (recent versions of both is strongly recommended).
 
 * Open a shell, cd into the root of the project you just cloned and type
 


### PR DESCRIPTION
We require 1.5+ due to the use of just the box name, without the box URL.

This is now listed in the setup docs, plus fails more with a clearer error message during `vagrant up`, thanks to `Vagrant.require_version`:
http://docs.vagrantup.com/v2/vagrantfile/vagrant_version.html

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/827)
<!-- Reviewable:end -->
