### PR TITLE
Bug 1182068 - Load log content in Logviewer by default

### DIFF
--- a/ui/css/logviewer.css
+++ b/ui/css/logviewer.css
@@ -177,14 +177,6 @@ body {
     font-size: 11px;
 }
 
-.lv-log-msg-step {
-    padding: 2px 5px;
-    background: #fff;
-    border-style: solid;
-    border-width: 4px 2px 2px;
-    border-radius: 2px;
-}
-
 .lv-log-overlay {
     padding: 6px;
     border: 2px solid #4cae4c;

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -212,11 +212,30 @@ logViewerApp.controller('LogviewerCtrl', [
                 });
             });
 
+            // Make the log and job artifacts available
             ThJobArtifactModel.get_list({job_id: $scope.job_id, name__in: 'text_log_summary,Job Info'})
             .then(function(artifactList) {
                 artifactList.forEach(function(artifact) {
                     if (artifact.name === 'text_log_summary') {
                         $scope.artifact = artifact.blob;
+                        $scope.step_data = artifact.blob.step_data;
+
+                        // If the log contains no errors load the head otherwise
+                        // load the first failure step line in the artifact. We
+                        // also need to test for the 0th element for outlier jobs.
+                        if ($scope.step_data.steps[0]) {
+
+                            if ($scope.step_data.all_errors.length == 0) {
+                                angular.element(document).ready(function () {
+                                    $scope.displayLog($scope.step_data.steps[0], 'initialLoad');
+                                });
+                            } else {
+                                $timeout(function() {
+                                    angular.element('.lv-error-line').first().trigger('click');
+                                }, 100);
+                            }
+                        }
+
                     } else if (artifact.name === 'Job Info') {
                         $scope.job_details = artifact.blob.job_details;
                     }

--- a/ui/js/directives/treeherder/log_viewer_steps.js
+++ b/ui/js/directives/treeherder/log_viewer_steps.js
@@ -59,7 +59,7 @@ treeherder.directive('lvLogSteps', ['$timeout', '$q', function ($timeout, $q) {
                 });
             };
 
-            scope.displayLog = function(step) {
+            scope.displayLog = function(step, state) {
                 scope.displayedStep = step;
                 scope.currentLineNumber = step.started_linenumber;
 
@@ -67,8 +67,10 @@ treeherder.directive('lvLogSteps', ['$timeout', '$q', function ($timeout, $q) {
                     $timeout(function () {
                         var raw = $('.lv-log-container')[0];
                         var line = $('.lv-log-line[line="' + step.started_linenumber + '"]');
-                        raw.scrollTop += line.offset().top - $('.run-data').outerHeight() -
-                                         $('.navbar').outerHeight() - 9;
+                        if (state !== 'initialLoad') {
+                            raw.scrollTop += line.offset().top - $('.run-data').outerHeight() -
+                                             $('.navbar').outerHeight() - 9;
+                        }
                     });
                 });
             };

--- a/ui/partials/logviewer/lvLogLines.html
+++ b/ui/partials/logviewer/lvLogLines.html
@@ -1,8 +1,3 @@
-<div class="lv-log-msg"
-     ng-if="!loading && !logError && displayedLogLines.length == 0">
-     Click a <span class="{{::resultStatusShading}} lv-log-msg-step">log step</span> above to view
-</div>
-
 <div class="lv-log-msg lv-log-overlay"
      ng-if="loading"> Loading... </div>
 


### PR DESCRIPTION
This work fixes Bugzilla bug [1182068](https://bugzilla.mozilla.org/show_bug.cgi?id=1182068).

In this change we load the first failed step and error line available if one exists for the Logviewer, and if an error doesn't exist we load the head of the log.

Current:
![current](https://cloud.githubusercontent.com/assets/3660661/9066726/3a85c9c6-3aa7-11e5-9d41-8868b5a75d9c.jpg)

Proposed (failure):
![proposed](https://cloud.githubusercontent.com/assets/3660661/9066739/45352c04-3aa7-11e5-89e8-df6a1d9db2f1.jpg)

Proposed (success):
![proposedsuccess](https://cloud.githubusercontent.com/assets/3660661/9066786/905eec38-3aa7-11e5-9ccb-4b34b8226ad2.jpg)

There are a few outlier logs around where the artifact appears to be in conflict eg. a green success but the artifact contains failure lines (which are "Info"), but I think those may be issues for follow up bugs unrelated to Logviewer. I will try to isolate those later and enter bugs for them.

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-08-04)**
Chrome Latest Release **44.0.2403.125 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/828)
<!-- Reviewable:end -->
