### PR TITLE
Bug 1046229 - Handle invalid values for 'revision' in the URL (eg "%s")

### DIFF
--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -4,11 +4,11 @@ treeherderApp.controller('JobsCtrl', [
     '$scope', '$http', '$rootScope', '$routeParams', 'ThLog',
     'thUrl', 'ThRepositoryModel', 'thDefaultRepo',
     'ThResultSetStore', 'thResultStatusList', '$location', 'thEvents',
-    'ThJobModel',
+    'ThJobModel', 'thNotify',
     function JobsCtrl(
         $scope, $http, $rootScope, $routeParams, ThLog,
         thUrl, ThRepositoryModel, thDefaultRepo,
-        ThResultSetStore, thResultStatusList, $location, thEvents, ThJobModel) {
+        ThResultSetStore, thResultStatusList, $location, thEvents, ThJobModel, thNotify) {
 
         var $log = new ThLog(this.constructor.name);
 
@@ -67,7 +67,11 @@ treeherderApp.controller('JobsCtrl', [
             }
         };
 
-        if(ThResultSetStore.isNotLoaded($scope.repoName)){
+        if ($location.search().revision === 'undefined') {
+            thNotify.send("Invalid value for revision parameter.", 'danger');
+        }
+
+        if (ThResultSetStore.isNotLoaded($scope.repoName)) {
             // get our first set of resultsets
             ThResultSetStore.fetchResultSets(
                 $scope.repoName,
@@ -232,4 +236,3 @@ treeherderApp.controller('ResultSetCtrl', [
         });
     }
 ]);
-

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -55,12 +55,19 @@
               !isLoadingJobs && locationHasSearchParam('revision') && currentRepo.url"
               class="result-set-body unknown-message-body">
   <span ng-init="revision=getSearchParamValue('revision')">
-    <span>Waiting for a push with revision <strong>{{revision}}</strong></span>
-    <a href="{{currentRepo.getPushLogHref(revision)}}"
-       target="_blank"
-       title="open revision {{revision}} on {{currentRepo.url}}">(view pushlog)</a>
-    <span class="fa fa-spinner fa-pulse th-spinner"></span>
-    <div>If the push exists, it will appear in a few minutes once it has been processed.</div>
+    <span ng-if="revision !=== 'undefined'">
+      <span>Waiting for a push with revision <strong>{{revision}}</strong></span>
+      <a href="{{currentRepo.getPushLogHref(revision)}}"
+         target="_blank"
+         title="open revision {{revision}} on {{currentRepo.url}}">(view pushlog)</a>
+      <span class="fa fa-spinner fa-pulse th-spinner"></span>
+      <div>If the push exists, it will appear in a few minutes once it has been processed.</div>
+    </span>
+    <span ng-if="revision ==='undefined'">
+      <span>This is an invalid revision parameter. Please change it, or click
+        <a ng-click="changeRepo(repoName)" href="{{::repoName.URL}}">here</a> to reload the latest revisions from {{repoName}}.
+      </span>
+    </span>
   </span>
 </div>
 


### PR DESCRIPTION
This first pull request is not working properly.
When the link http://local.treeherder.mozilla.org/index.html#/jobs?repo=mozilla-inbound&revision=%s
is clicked, it is redirected to 
http://local.treeherder.mozilla.org/index.html#/jobs?repo=mozilla-inbound&revision=undefined
without any error alert.

However, when the link
http://local.treeherder.mozilla.org/index.html#/jobs?repo=mozilla-inbound&revision=undefined
is clicked. An error is showed.

Besides, the error messages are not completely right.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/830)
<!-- Reviewable:end -->
