### PR TITLE
Bug 1189484 - Update disabled/help raw log icons

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -1975,8 +1975,8 @@ fieldset[disabled] .btn-repo.active {
 }
 
 #help-raw-log-icon {
-    font-size: 13px;
-    color: #9fa3a5;
+    font-size: 14px;
+    color: #666;
 }
 
 #help-logviewer-icon {

--- a/ui/help.html
+++ b/ui/help.html
@@ -6,6 +6,7 @@
     <!-- build:css css/help.min.css -->
     <link href="vendor/css/bootstrap.css" rel="stylesheet" media="screen">
     <link href="css/treeherder.css" rel="stylesheet" media="screen">
+    <link href="vendor/css/font-awesome.css" rel="stylesheet" media="screen">
     <!-- endbuild -->
     <link id="favicon" type="image/png" rel="shortcut icon" href="img/tree_open.png">
 </head>
@@ -167,7 +168,7 @@
                     <tr>
                       <td><span class="kbd">ctrl/cmd</span>+<span class="kbd">c</td>
                       <td>Copy job details
-                        <span id="help-raw-log-icon" class="glyphicon glyphicon-align-left">
+                        <span id="help-raw-log-icon" class="fa fa-file-text-o">
                         </span> raw log url on hover</td>
                     </tr>
                     <tr>

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -61,9 +61,9 @@
           </li>
           <li>
             <a ng-if="!job_log_urls.length"
-               class="disabled"
+               class="disabled raw-log-icon"
                title="No logs available for this job">
-              <span class="glyphicon glyphicon-align-left"></span>
+              <span class="fa fa-file-text-o"></span>
             </a>
           </li>
           <li>


### PR DESCRIPTION
This fixes Bugzilla bug [1189484](https://bugzilla.mozilla.org/show_bug.cgi?id=1189484).

This updates the raw log to our new `fa-file-text-o` in two additional cases:

* selecting a pending job when no raw log is available
* opening Help

The first case looks identical to our new raw log icon in https://github.com/mozilla/treeherder/pull/822 so I'm not including a screen grab, but here is the Help update:

![rawloghelp](https://cloud.githubusercontent.com/assets/3660661/9075674/8c50a558-3ae5-11e5-90de-9bb8ede8133d.jpg)

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-08-04)**
Chrome Latest Release **44.0.2403.125 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/832)
<!-- Reviewable:end -->
