### PR TITLE
Bug 1186918 - Set a custom user-agent for python client requests

### DIFF
--- a/treeherder/client/setup.py
+++ b/treeherder/client/setup.py
@@ -2,12 +2,34 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import io
+import os
+import re
+
 from setuptools import setup
 
-version = '1.6'
+
+def read(*names, **kwargs):
+    # Taken from https://packaging.python.org/en/latest/single_source_version.html
+    with io.open(
+        os.path.join(os.path.dirname(__file__), *names),
+        encoding=kwargs.get("encoding", "utf8")
+    ) as fp:
+        return fp.read()
+
+
+def find_version(*file_paths):
+    # Taken from https://packaging.python.org/en/latest/single_source_version.html
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
 
 setup(name='treeherder-client',
-      version=version,
+      version=find_version('thclient', 'client.py'),
       description="Python library to retrieve and submit data to the Treeherder API",
       long_description="""\
 """,

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -602,7 +602,9 @@ class TreeherderClient(object):
 
     PROTOCOLS = {'http', 'https'}  # supported protocols
     API_VERSION = '1.0'
-    ACCEPT_HEADER = 'application/json; version={0}'.format(API_VERSION)
+    REQUEST_HEADERS = {
+        'Accept': 'application/json; version={}'.format(API_VERSION),
+    }
 
     UPDATE_ENDPOINT = 'job-log-url/{}/update_parse_status'
     RESULTSET_ENDPOINT = 'resultset'
@@ -674,7 +676,7 @@ class TreeherderClient(object):
             uri = self._get_project_uri(project, endpoint)
 
         resp = requests.get(uri, timeout=timeout, params=params,
-                            headers={'Accept': self.ACCEPT_HEADER})
+                            headers=self.REQUEST_HEADERS)
         resp.raise_for_status()
         return resp.json()
 
@@ -688,8 +690,7 @@ class TreeherderClient(object):
         uri = self._get_project_uri(project, endpoint)
 
         resp = requests.post(uri, json=data,
-                             headers={'Content-Type': 'application/json',
-                                      'Accept': self.ACCEPT_HEADER},
+                             headers=self.REQUEST_HEADERS,
                              timeout=timeout, auth=auth)
 
         resp.raise_for_status()

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -8,6 +8,7 @@ import requests
 import logging
 import json
 
+__version__ = '1.6.0'
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -604,6 +604,7 @@ class TreeherderClient(object):
     API_VERSION = '1.0'
     REQUEST_HEADERS = {
         'Accept': 'application/json; version={}'.format(API_VERSION),
+        'User-Agent': 'treeherder-pyclient/{}'.format(__version__),
     }
 
     UPDATE_ENDPOINT = 'job-log-url/{}/update_parse_status'


### PR DESCRIPTION
* Make the version available at runtime …
So we can use it in the User-Agent later. Uses the suggestion from:
https://packaging.python.org/en/latest/single_source_version.html
* Use a constant for request headers …
In the next commit we'll be adding a custom user agent header, which will increase duplication. Therefore let's define the headers only once to avoid this. The `Content-Type` header is redundant for `.post()` since one is set automatically when using the `json` param:
https://github.com/kennethreitz/requests/blob/f5dacf84468ab7e0631cc61a3f1431a32e3e143c/requests/models.py#L418
* List client name+version in the User-Agent …
So we can more easily see which API requests are coming from which client type, and know how many people are on older versions of the client.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/835)
<!-- Reviewable:end -->
