### PR TITLE
Bug 1184966 - perfherder should let harness do summarization

### DIFF
--- a/tests/etl/test_perf_data_adapters.py
+++ b/tests/etl/test_perf_data_adapters.py
@@ -3,6 +3,7 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
+import zlib
 
 from tests.sampledata import SampleData
 from treeherder.etl.perf_data_adapters import TalosDataAdapter
@@ -49,5 +50,28 @@ def test_adapt_and_load():
         # when the web service receives them
         datum['blob'] = json.dumps({'talos_data': [datum['blob']]})
         tda.adapt_and_load(reference_data, job_data, datum)
+
+        # we upload a summary with a suite and subtest values, +1 for suite
+        if 'summary' in datum['blob']:
+            results = json.loads(zlib.decompress(tda.performance_artifact_placeholders[-1][4]))
+            data = json.loads(datum['blob'])['talos_data'][0]
+            assert results["blob"]["performance_series"]["geomean"] == data['summary']['suite']
+
+            # deal with the subtests now
+            subtests = len(data['summary']['subtests'])
+            for iter in range(0, subtests):
+                subresults = json.loads(zlib.decompress(tda.performance_artifact_placeholders[-1 - iter][4]))
+                if 'subtest_signatures' in subresults["blob"]['signature_properties']:
+                    # ignore summary signatures
+                    continue
+
+                subdata = data['summary']['subtests'][subresults["blob"]['signature_properties']['test']]
+                for datatype in ['min', 'max', 'mean', 'median', 'std']:
+                    print datatype
+                    assert subdata[datatype] == subresults["blob"]["performance_series"][datatype]
+        else:
+            # FIXME: the talos data blob we're currently using contains datums with summaries and those without
+            # we should probably test non-summarized data as well
+            pass
 
     assert result_count == len(tda.performance_artifact_placeholders)

--- a/tests/sample_data/artifacts/performance/talos_perf.json
+++ b/tests/sample_data/artifacts/performance/talos_perf.json
@@ -26,6 +26,13 @@
                 "rss": false
             }
         },
+        "summary": {
+            "suite": 3141.00,
+            "subtests": {
+                "dhtml.html": {"min": 1, "max": 100, "std": 0.75, "mean": 50, "median": 50},
+                "tablemutation.html": {"min": 1, "max": 100, "std": 0.75, "mean": 50, "median": 50}
+            }
+        },
         "results": {
             "dhtml.html": [
                 1273,


### PR DESCRIPTION
support for:
* old format
* current format (suite: val, subtests: {page: val, page: val}
* new format {suite: val, subtests: {page: {min: val, max: val, mean: val, median: val, std: val}...}}

and tests to validate the raw data.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/836)
<!-- Reviewable:end -->
