### PR TITLE
Bug 1191632 - Use correct 'new' revision for hg.m.o link generation

### DIFF
--- a/ui/partials/perf/revisiondescribe.html
+++ b/ui/partials/perf/revisiondescribe.html
@@ -4,7 +4,7 @@
     <span>{{originalResultSet.comments}}</span>
   </li>
   <li>
-    <strong>New</strong> - <a href="{{newProject.getRevisionHref(originalRevision)}}">{{newRevision}}</a> ({{newProject.name}}) - {{newResultSet.author}} -
+    <strong>New</strong> - <a href="{{newProject.getRevisionHref(newRevision)}}">{{newRevision}}</a> ({{newProject.name}}) - {{newResultSet.author}} -
     <span>{{newResultSet.comments}}</span>
   </li>
 </ul>


### PR DESCRIPTION
Previously the link target was pointing at a different revision to that displayed in the link text.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/837)
<!-- Reviewable:end -->
