### PR TITLE
Bug 1077338 - Open logviewer on middle-mouse job click

### DIFF
--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -274,10 +274,9 @@ treeherder.directive('thCloneJobs', [
                     ev.preventDefault();
                     //Middle mouse button pressed
                     ThJobModel.get(this.repoName, job.id).then(function(data){
-                        //Retrieve the job reference data and open a new
-                        //window on the job's log file
-                        if(data.logs.length > 0){
-                            window.open(data.logs[0].url, "Log");
+                        // Open the logviewer in a new window
+                        if (data.logs.length > 0) {
+                            window.open(location.origin + "/" + thUrl.getLogViewerUrl(job.id));
                         }
                     });
 


### PR DESCRIPTION
This fixes Bugzilla bug [1077338](https://bugzilla.mozilla.org/show_bug.cgi?id=1077338).

In the change we open Logviewer for a completed job, when the user selects a job via middle-mouse click. So we start here:

![mmbclick](https://cloud.githubusercontent.com/assets/3660661/9119398/71b774e6-3c44-11e5-9666-fce1fbe578f6.jpg)

We land here:

![landingproposed](https://cloud.githubusercontent.com/assets/3660661/9119410/7c0462b0-3c44-11e5-92f7-b5c6a40e6b37.jpg)

Everything seems fine on both browsers, testing a variety of jobs (testfailed, busted, success, retry) where we launch, and pending and running where we will do nothing on the click event, the same as we do now when a raw log doesn't exist.

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-08-05)**
Chrome Latest Release **44.0.2403.130 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/839)
<!-- Reviewable:end -->
