### PR TITLE
 	Bug 1183747 - Simplify ingestion of artifacts submitted with a job

### DIFF
--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -191,76 +191,43 @@ class ArtifactsModel(TreeherderModelBase):
 
     def load_job_artifacts(self, artifact_data, job_id_lookup):
         """
-        Determine what type of artifacts are contained in artifact_data and
-        store a list of job artifacts substituting job_guid with job_id. All
-        of the datums in artifact_data need to be one of the three
-        different tasty "flavors" described below.
+        Store a list of job artifacts substituting job_guid with job_id. All
+        of the datums in artifact_data need to be in the following format:
 
-        artifact_placeholders:
+            {
+                'type': 'json',
+                'name': 'my-artifact-name',
+                # blob can be any kind of structured data
+                'blob': { 'stuff': [1, 2, 3, 4, 5] },
+                'job_guid': 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
+            }
 
-            Comes in through the web service as the "artifacts" property
-            in a job in a job collection
-
-            A list of lists
-            [
-                [job_guid, name, artifact_type, blob, job_guid, name]
-            ]
-
-        job_artifact_collection:
-
-            Comes in  through the web service as an artifact collection.
-
-            A list of job artifacts:
-            [
-                {
-                    'type': 'json',
-                    'name': 'my-artifact-name',
-                    # blob can be any kind of structured data
-                    'blob': { 'stuff': [1, 2, 3, 4, 5] },
-                    'job_guid': 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
-                }
-            ]
-
-        performance_artifact:
-
-            Same structure as a job_artifact_collection but the blob contains
-            a specialized data structure designed for performance data.
         """
-        artifact_placeholders_list = []
         job_artifact_list = []
 
         performance_artifact_list = []
         performance_artifact_job_id_list = []
 
         for index, artifact in enumerate(artifact_data):
-
             # Determine what type of artifact we have received
             if artifact:
 
                 job_id = None
                 job_guid = None
 
-                if isinstance(artifact, list):
-                    job_guid = artifact[0]
-                    job_id = job_id_lookup.get(job_guid, {}).get('id', None)
+                artifact_name = artifact['name']
+                job_guid = artifact.get('job_guid', None)
+                job_id = job_id_lookup.get(
+                    artifact['job_guid'], {}
+                ).get('id', None)
 
-                    self._adapt_job_artifact_placeholders(
-                        artifact, artifact_placeholders_list, job_id)
-
+                if artifact_name in PerformanceDataAdapter.performance_types:
+                    self._adapt_performance_artifact_collection(
+                        artifact, performance_artifact_list,
+                        performance_artifact_job_id_list, job_id)
                 else:
-                    artifact_name = artifact['name']
-                    job_guid = artifact.get('job_guid', None)
-                    job_id = job_id_lookup.get(
-                        artifact['job_guid'], {}
-                    ).get('id', None)
-
-                    if artifact_name in PerformanceDataAdapter.performance_types:
-                        self._adapt_performance_artifact_collection(
-                            artifact, performance_artifact_list,
-                            performance_artifact_job_id_list, job_id)
-                    else:
-                        self._adapt_job_artifact_collection(
-                            artifact, job_artifact_list, job_id)
+                    self._adapt_job_artifact_collection(
+                        artifact, job_artifact_list, job_id)
 
                 if not job_id:
                     logger.error(
@@ -273,25 +240,12 @@ class ArtifactsModel(TreeherderModelBase):
                      'defined for {0}'.format(self.project)))
 
         # Store the various artifact types if we collected them
-        if artifact_placeholders_list:
-            self.store_job_artifact(artifact_placeholders_list)
-
         if job_artifact_list:
             self.store_job_artifact(job_artifact_list)
 
         if performance_artifact_list and performance_artifact_job_id_list:
             self.store_performance_artifact(
                 performance_artifact_job_id_list, performance_artifact_list)
-
-    def _adapt_job_artifact_placeholders(
-            self, artifact, artifact_placeholders_list, job_id):
-
-        if job_id:
-            # Replace job_guid with id in artifact data
-            artifact[0] = job_id
-            artifact[4] = job_id
-
-            artifact_placeholders_list.append(artifact)
 
     def _adapt_job_artifact_collection(
             self, artifact, artifact_data, job_id):
@@ -344,22 +298,3 @@ class ArtifactsModel(TreeherderModelBase):
                 artifact['blob'] = json.dumps(blob)
 
         return artifacts
-
-    @staticmethod
-    def populate_placeholders(artifacts, artifact_placeholders, job_guid):
-        for artifact in artifacts:
-            name = artifact.get('name')
-            artifact_type = artifact.get('type')
-            blob = artifact.get('blob')
-
-            if not (name and artifact_type and blob):
-                continue
-
-            artifact_placeholders.append([
-                job_guid,
-                name,
-                artifact_type,
-                zlib.compress(blob),
-                job_guid,
-                name
-            ])

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1453,9 +1453,16 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             tls_list = error_summary.get_artifacts_that_need_bug_suggestions(
                 artifacts)
             async_artifact_list.extend(tls_list)
-            ArtifactsModel.populate_placeholders(artifacts,
-                                                 artifact_placeholders,
-                                                 job_guid)
+
+            # need to add job guid to artifacts, since they likely weren't
+            # present in the beginning
+            for artifact in artifacts:
+                if not all(k in artifact for k in ("name", "type", "blob")):
+                    raise JobDataError(
+                        "Artifact missing properties: {}".format(artifact))
+                artifact_placeholder = artifact.copy()
+                artifact_placeholder['job_guid'] = job_guid
+                artifact_placeholders.append(artifact_placeholder)
 
             has_text_log_summary = any(x for x in artifacts
                                        if x['name'] == 'text_log_summary')


### PR DESCRIPTION
There's no need to have a gigantic codepath converting them into a
list-- all we need is some simple logic to add a guid to them.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/841)
<!-- Reviewable:end -->
