### PR TITLE
Bug 1189481 - Convert logviewer markup to 2 space indent

### DIFF
--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -1,152 +1,152 @@
 <!DOCTYPE html>
 <html ng-controller="LogviewerCtrl" ng-init="init()" ng-app="logviewer">
-    <head>
-        <meta charset="utf-8">
-        <title ng-bind="::logViewerTitle">Log viewer</title>
-        <!-- build:css css/logviewer.min.css -->
-        <link href="vendor/css/bootstrap.css" rel="stylesheet" media="screen">
-        <link href="vendor/css/font-awesome.css" rel="stylesheet" media="screen">
-        <link href="css/treeherder.css" rel="stylesheet" type="text/css">
-        <link href="css/logviewer.css" rel="stylesheet" type="text/css">
-        <!-- endbuild -->
-        <link id="favicon" type="image/png" rel="shortcut icon" href="img/logviewerIcon.png">
-    </head>
-    <body class="body-logviewer">
-      <!-- Logviewer navbar -->
-      <nav class="navbar navbar-default" role="navigation">
-        <div class="container-fluid">
-          <ul class="nav navbar-nav">
+  <head>
+    <meta charset="utf-8">
+    <title ng-bind="::logViewerTitle">Log viewer</title>
+    <!-- build:css css/logviewer.min.css -->
+    <link href="vendor/css/bootstrap.css" rel="stylesheet" media="screen">
+    <link href="vendor/css/font-awesome.css" rel="stylesheet" media="screen">
+    <link href="css/treeherder.css" rel="stylesheet" type="text/css">
+    <link href="css/logviewer.css" rel="stylesheet" type="text/css">
+    <!-- endbuild -->
+    <link id="favicon" type="image/png" rel="shortcut icon" href="img/logviewerIcon.png">
+  </head>
+  <body class="body-logviewer">
+    <!-- Logviewer navbar -->
+    <nav class="navbar navbar-default" role="navigation">
+      <div class="container-fluid">
+        <ul class="nav navbar-nav">
 
-            <!-- Logo menu button -->
-            <li>
-              <span class="dropdown">
-                <button id="lv-logo" title="Treeherder services" role="button"
-                        href="#" data-toggle="dropdown" data-target="#">Logviewer
-                  <span class="fa fa-angle-down"></span>
-                </button>
-                <ul class="dropdown-menu" role="menu" aria-labelledby="lv-logo">
-                  <li><a href="/">Treeherder</a></li>
-                  <li><a href="perf.html">Perfherder</a></li>
-                </ul>
-              </span>
-            </li>
+          <!-- Logo menu button -->
+          <li>
+            <span class="dropdown">
+              <button id="lv-logo" title="Treeherder services" role="button"
+                      href="#" data-toggle="dropdown" data-target="#">Logviewer
+                <span class="fa fa-angle-down"></span>
+              </button>
+              <ul class="dropdown-menu" role="menu" aria-labelledby="lv-logo">
+                <li><a href="/">Treeherder</a></li>
+                <li><a href="perf.html">Perfherder</a></li>
+              </ul>
+            </span>
+          </li>
 
-            <!-- Job status -->
-            <li class="{{::resultStatusShading}}">
-              <div>
-                <span ng-cloak><strong>{{result.label}}: </strong></span>
-                <span ng-cloak class="break-word">{{result.value}}</span>
-              </div>
-            </li>
+          <!-- Job status -->
+          <li class="{{::resultStatusShading}}">
+            <div>
+              <span ng-cloak><strong>{{result.label}}: </strong></span>
+              <span ng-cloak class="break-word">{{result.value}}</span>
+            </div>
+          </li>
 
-            <!-- Raw log button -->
-            <li>
-              <a title="Open the raw log in a new window"
-                 target="_blank"
-                 href="{{::artifact.logurl}}">
-                <span class="fa fa-file-text-o actionbtn-icon"></span>
-                <span>open raw log</span>
-              </a>
-            </li>
+          <!-- Raw log button -->
+          <li>
+            <a title="Open the raw log in a new window"
+               target="_blank"
+               href="{{::artifact.logurl}}">
+              <span class="fa fa-file-text-o actionbtn-icon"></span>
+              <span>open raw log</span>
+            </a>
+          </li>
 
-            <!-- Ref test button -->
-            <li ng-if="isReftest()">
-              <a title="Open the Reftest Analyser in a new window"
-                 target="_blank"
-                 href="http://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl={{::artifact.logurl}}&only_show_unexpected=1">
-                <span class="fa fa-bar-chart-o actionbtn-icon"></span>
-                <span>open analyser</span>
-              </a>
-            </li>
+          <!-- Ref test button -->
+          <li ng-if="isReftest()">
+            <a title="Open the Reftest Analyser in a new window"
+               target="_blank"
+               href="http://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl={{::artifact.logurl}}&only_show_unexpected=1">
+              <span class="fa fa-bar-chart-o actionbtn-icon"></span>
+              <span>open analyser</span>
+            </a>
+          </li>
 
-            <!-- Show successful steps button -->
-            <li ng-if="artifact && hasFailedSteps()"
-                class="logviewer-actionbtn">
-              <div id="lv-successful-steps">
-                <input type="checkbox"
-                       ng-model="showSuccessful"
-                       ng-change="toggleSuccessfulSteps()" />
-                <span>show successful steps</span>
-              </div>
-            </li>
-          </ul>
-        </div>
-      </nav>
+          <!-- Show successful steps button -->
+          <li ng-if="artifact && hasFailedSteps()"
+              class="logviewer-actionbtn">
+            <div id="lv-successful-steps">
+              <input type="checkbox"
+                     ng-model="showSuccessful"
+                     ng-change="toggleSuccessfulSteps()" />
+              <span>show successful steps</span>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </nav>
 
-      <!-- Job header and steps navigation -->
-      <div class="run-data">
-        <div class="col-md-6" >
-          <div class="job-header">
-            <table class="table table-condensed" >
-              <tr ng-repeat="property in logProperties">
-                <th ng-cloak>{{property.label}}</th>
-                <td ng-if="property.label == 'Revision'" class="break-word">
-                  <a href="{{::logRevisionFilterUrl}}"
-                     title="Open resultset"
-                     class="repo-link"
-                     ng-cloak>{{property.value}}</a>
-                </td>
-                <td ng-if="property.label != 'Revision'"
-                    ng-cloak class="break-word">{{property.value}}</td>
-              </tr>
-              <tr ng-repeat="line in job_details | orderBy:'title'">
+    <!-- Job header and steps navigation -->
+    <div class="run-data">
+      <div class="col-md-6" >
+        <div class="job-header">
+          <table class="table table-condensed" >
+            <tr ng-repeat="property in logProperties">
+              <th ng-cloak>{{property.label}}</th>
+              <td ng-if="property.label == 'Revision'" class="break-word">
+                <a href="{{::logRevisionFilterUrl}}"
+                   title="Open resultset"
+                   class="repo-link"
+                   ng-cloak>{{property.value}}</a>
+              </td>
+              <td ng-if="property.label != 'Revision'"
+                  ng-cloak class="break-word">{{property.value}}</td>
+            </tr>
+            <tr ng-repeat="line in job_details | orderBy:'title'">
                 <th ng-cloak>{{line.title}}:</th>
                 <td ng-switch on="line.content_type">
                   <a ng-cloak ng-switch-when="link" title="{{line.value}}"
                      href="{{line.url}}" target="_blank">{{line.value}}</a>
                     <span ng-switch-when="raw_html" ng-bind-html="line.value"></span>
                 <td/>
-              </tr>
-            </table>
-          </div>
+            </tr>
+          </table>
         </div>
-        <div class="col-md-6" lv-log-steps></div>
       </div>
+      <div class="col-md-6" lv-log-steps></div>
+    </div>
 
-        <!-- Log lines -->
-        <div class="lv-log-container"
-             lv-infinite-scroll
-             lv-log-lines="displayedLogLines">
-        </div>
+    <!-- Log lines -->
+    <div class="lv-log-container"
+         lv-infinite-scroll
+         lv-log-lines="displayedLogLines">
+    </div>
 
-        <!-- build:js js/logviewer.min.js -->
-        <script src="vendor/jquery-2.1.3.js"></script>
-        <script src="vendor/angular/angular.js"></script>
-        <script src="vendor/angular/angular-route.js"></script>
-        <script src="vendor/angular/angular-resource.js"></script>
-        <script src="vendor/angular/angular-cookies.js"></script>
-        <script src="vendor/angular/angular-sanitize.js"></script>
-        <script src="vendor/angular-local-storage.min.js"></script>
-        <script src="vendor/ui-bootstrap-tpls-0.13.0.js"></script>
-        <script src="vendor/bootstrap.js"></script>
-        <script src="vendor/lodash.min.js"></script>
-        <script src="vendor/resizer.js"></script>
+    <!-- build:js js/logviewer.min.js -->
+    <script src="vendor/jquery-2.1.3.js"></script>
+    <script src="vendor/angular/angular.js"></script>
+    <script src="vendor/angular/angular-route.js"></script>
+    <script src="vendor/angular/angular-resource.js"></script>
+    <script src="vendor/angular/angular-cookies.js"></script>
+    <script src="vendor/angular/angular-sanitize.js"></script>
+    <script src="vendor/angular-local-storage.min.js"></script>
+    <script src="vendor/ui-bootstrap-tpls-0.13.0.js"></script>
+    <script src="vendor/bootstrap.js"></script>
+    <script src="vendor/lodash.min.js"></script>
+    <script src="vendor/resizer.js"></script>
 
-        <script src="js/treeherder.js"></script>
-        <script src="js/logviewer.js"></script>
-        <script src="js/providers.js"></script>
-        <script src="js/values.js"></script>
+    <script src="js/treeherder.js"></script>
+    <script src="js/logviewer.js"></script>
+    <script src="js/providers.js"></script>
+    <script src="js/values.js"></script>
 
-        <!-- Directives -->
-        <script src="js/directives/treeherder/log_viewer_infinite_scroll.js"></script>
-        <script src="js/directives/treeherder/log_viewer_lines.js"></script>
-        <script src="js/directives/treeherder/log_viewer_steps.js"></script>
+    <!-- Directives -->
+    <script src="js/directives/treeherder/log_viewer_infinite_scroll.js"></script>
+    <script src="js/directives/treeherder/log_viewer_lines.js"></script>
+    <script src="js/directives/treeherder/log_viewer_steps.js"></script>
 
-        <!-- Main services -->
-        <script src="js/services/main.js"></script>
-        <script src="js/services/log.js"></script>
+    <!-- Main services -->
+    <script src="js/services/main.js"></script>
+    <script src="js/services/log.js"></script>
 
-        <!-- Model services -->
-        <script src="js/models/job_artifact.js"></script>
-        <script src="js/models/job.js"></script>
-        <script src="js/models/resultset.js"></script>
-        <script src="js/models/log_slice.js"></script>
+    <!-- Model services -->
+    <script src="js/models/job_artifact.js"></script>
+    <script src="js/models/job.js"></script>
+    <script src="js/models/resultset.js"></script>
+    <script src="js/models/log_slice.js"></script>
 
-        <!-- Controllers -->
-        <script src="js/controllers/logviewer.js"></script>
-        <!-- endbuild -->
+    <!-- Controllers -->
+    <script src="js/controllers/logviewer.js"></script>
+    <!-- endbuild -->
 
-        <script src="js/config/local.conf.js"></script>
+    <script src="js/config/local.conf.js"></script>
 
-    </body>
+  </body>
 </html>

--- a/ui/partials/logviewer/lvLogLines.html
+++ b/ui/partials/logviewer/lvLogLines.html
@@ -7,13 +7,12 @@
      ng-if="loading"> Loading... </div>
 
 <div class="lv-log-msg lv-log-overlay lv-log-error"
-      ng-if="logError"> Log could not be found </div>
+     ng-if="logError"> Log could not be found </div>
 
 <div ng-repeat="lv_line in displayedLogLines"
      ng-class="{'text-danger': (lv_line.hasError == true),
                 'lv-selected-lines': (displayedStep.order === lv_line.index)}"
      class="lv-log-line"
      line="{{ ::lv_line.index }}">
-
-     <span class="lv-line-text">{{ ::lv_line.text }}</span>
+  <span class="lv-line-text">{{ ::lv_line.text }}</span>
 </div>

--- a/ui/partials/logviewer/lvLogSteps.html
+++ b/ui/partials/logviewer/lvLogSteps.html
@@ -1,36 +1,36 @@
 <div class="steps-data">
-    <div ng-repeat="step in artifact.step_data.steps"
-         ng-click="displayLog(step)"
-         ng-class="{'selected': (displayedStep.order === step.order)}"
-         ng-if="showSuccessful === true || step.result !== 'success'"
-         class="btn btn-block logviewer-step clearfix {{::getShadingClass(step.result)}}"
-         order="{{step.order}}">
-        <span class="pull-left clearfix text-left">
-            {{::step.order+1}}. {{::step.name}}
+  <div ng-repeat="step in artifact.step_data.steps"
+       ng-click="displayLog(step)"
+       ng-class="{'selected': (displayedStep.order === step.order)}"
+       ng-if="showSuccessful === true || step.result !== 'success'"
+       class="btn btn-block logviewer-step clearfix {{::getShadingClass(step.result)}}"
+       order="{{step.order}}">
+    <span class="pull-left clearfix text-left">
+      {{::step.order+1}}. {{::step.name}}
+    </span>
+
+    <span ng-init="time=formatTime(step.duration)"
+          ng-mouseover="time=displayTime(step.started, step.finished)"
+          ng-mouseleave="time=formatTime(step.duration)"
+          class="pull-right clearfix">
+      {{::time}}
+    </span>
+
+    <div ng-if="(step.error_count > 0)">
+      <div ng-repeat="error in step.errors"
+           ng-mouseover="check=(step==displayedStep)"
+           ng-mouseleave="check=false"
+           ng-class="{'lv-line-highlight': check}"
+           ng-click="scrollTo($event, step, error.linenumber);"
+           class="text-left pull-left lv-error-line">
+        <span class="label label-default lv-line-no text-left">
+          {{::error.linenumber}}
         </span>
 
-        <span ng-init="time=formatTime(step.duration)"
-              ng-mouseover="time=displayTime(step.started, step.finished)"
-              ng-mouseleave="time=formatTime(step.duration)"
-              class="pull-right clearfix">
-            {{::time}}
+        <span title="{{::error.line}}">
+          {{::error.line}}
         </span>
-
-        <div ng-if="(step.error_count > 0)">
-            <div ng-repeat="error in step.errors"
-                 ng-mouseover="check=(step==displayedStep)"
-                 ng-mouseleave="check=false"
-                 ng-class="{'lv-line-highlight': check}"
-                 ng-click="scrollTo($event, step, error.linenumber);"
-                 class="text-left pull-left lv-error-line">
-                <span class="label label-default lv-line-no text-left">
-                    {{::error.linenumber}}
-                </span>
-
-                <span title="{{::error.line}}">
-                    {{::error.line}}
-                </span>
-            </div>
-        </div>
+      </div>
     </div>
+  </div>
 </div>


### PR DESCRIPTION
This fixes Bugzilla bug [1189481](https://bugzilla.mozilla.org/show_bug.cgi?id=1189481) and converts logviewer markup from a mix of 4 and 2 space indentation, to 2 space indentation.

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-08-06)**
Chrome Latest Release **44.0.2403.130 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/843)
<!-- Reviewable:end -->
