### PR TITLE
Bug 1192195 - Provide a style for result-status skipped

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -1180,34 +1180,47 @@ ul.failure-summary-list li .btn-xs {
     background-color: rgba(2, 131, 44, 0.24);
     border-color: rgba(2, 131, 44, 0.24);
 }
+
 .result-status-shading-testfailed {
     background-color: rgba(221, 102, 2, 0.25);
     border-color: rgba(221, 102, 2, 0.25);
- }
+}
+
 .result-status-shading-busted {
     background-color: rgba(144, 0, 0, 0.25);
     border-color: rgba(144, 0, 0, 0.25);
- }
+}
+
+.result-status-shading-skipped {
+    background-color: rgba(101, 191, 221, 0.25);
+    border-color: rgba(101, 191, 221, 0.25);
+}
+
 .result-status-shading-exception {
     background-color: rgba(61, 2, 85, 0.25);
     border-color: rgba(61, 2, 85, 0.25);
- }
+}
+
 .result-status-shading-retry {
     background-color: rgba(38, 63, 195, 0.25);
     border-color: rgba(38, 63, 195, 0.25);
 }
+
 .result-status-shading-usercancel {
     background-color: rgba(250, 115, 172, 0.25);
     border-color: rgba(250, 115, 172, 0.25);
 }
+
 .result-status-shading-pending {
     background-color: rgba(160, 160, 160, 0.2);
     border-color: rgba(160, 160, 160, 0.2);
 }
+
 .result-status-shading-running {
     background-color: rgba(70, 70, 70, 0.25);
     border-color: rgba(70, 70, 70, 0.25);
 }
+
 .result-status-shading-coalesced {background-color: white;}
 
 .click-able-icon, .nav-tabs li {


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1192195 ](https://bugzilla.mozilla.org/show_bug.cgi?id=1192195).

In it we provide a style and Bootstrap-esqe 'info' color for skipped steps.

Bootstrap [alert info](http://getbootstrap.com/components/#alerts) is **rgb**(208, 232, 246) and the proposed PR computed color with our 0.25 transparency over white, is **rgb**(207, 235, 244) which is very close.

Current (missed styling on skipped step):
![current](https://cloud.githubusercontent.com/assets/3660661/9140777/8559bd48-3d01-11e5-9dbd-354d3c49bfdd.jpg)

Proposed:
![skippedstepproposed](https://cloud.githubusercontent.com/assets/3660661/9140791/987ffaa4-3d01-11e5-93fb-da339575cd6f.jpg)

Everything seems ok on both browsers. I did some minor linting during the change.

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-08-06)**
Chrome Latest Release **44.0.2403.130 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/845)
<!-- Reviewable:end -->
