### PR TITLE
Bug 1192198 - Evaluate a skipped step as a non-failure

### DIFF
--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -51,7 +51,9 @@ logViewerApp.controller('LogviewerCtrl', [
                 // so we have to check the results property is present.
                 // TODO: Remove this when the old data has expired, so long as
                 // other data submitters also provide a step result.
-                if ('result' in steps[i] && steps[i].result !== "success") {
+                if ('result' in steps[i] && steps[i].result !== 'success' &&
+                    steps[i].result !== 'skipped') {
+
                     return true;
                 }
             }


### PR DESCRIPTION
This fixes Bugzilla bug [1192198](https://bugzilla.mozilla.org/show_bug.cgi?id=1192198).

This prevents a skipped step from being interpreted as a failed step, which undesirably suppresses successful steps and exposes the 'show successful steps' UI in the logviewer navbar.

A skipped step should be interpreted more as an 'info' step, in the sense it should be present everywhere, but not considered a failure.

Current (successful job):
![current](https://cloud.githubusercontent.com/assets/3660661/9142717/8eb669fa-3d0f-11e5-98b7-98ded93683b9.jpg)

Proposed:
![proposed](https://cloud.githubusercontent.com/assets/3660661/9142725/9c8a93a8-3d0f-11e5-9086-a70416dec1d2.jpg)

(same job above, scrolled to show the presence of the skipped step)
![proposedscrolled](https://cloud.githubusercontent.com/assets/3660661/9142749/b49cfeb8-3d0f-11e5-90b0-0f9a4d97fbc2.jpg)

And a testfailed example which will continue to display skipped steps also:
![testfailedexample](https://cloud.githubusercontent.com/assets/3660661/9142842/62f5c2b0-3d10-11e5-9876-68a6ed723d37.jpg)

Everything seems fine testing a variety of jobs containing skipped steps.

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-08-06)**
Chrome Latest Release **44.0.2403.130 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/847)
<!-- Reviewable:end -->
