### PR TITLE
Bug 1192661 - Clean up Python import order

### DIFF
--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -14,8 +14,8 @@ import os
 import sys
 import urllib
 import urllib2
-from commander.deploy import task, hostgroups
 
+from commander.deploy import hostgroups, task
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 import commander_settings as settings  # noqa

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,8 +16,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/tests/client/test_perfherder_client.py
+++ b/tests/client/test_perfherder_client.py
@@ -5,6 +5,7 @@
 import unittest
 
 from mock import patch
+
 from treeherder.client import PerfherderClient, TreeherderClientError
 
 

--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -4,19 +4,20 @@
 
 from __future__ import unicode_literals
 
-import unittest
-import os
 import json
+import os
+import unittest
 
-from mock import patch
 import requests
+from mock import patch
 
-from treeherder.client import (TreeherderJob, TreeherderJobCollection,
-                               TreeherderRevision, TreeherderResultSet,
-                               TreeherderResultSetCollection,
+from treeherder.client import (TreeherderArtifact,
+                               TreeherderArtifactCollection, TreeherderAuth,
                                TreeherderClient, TreeherderClientError,
-                               TreeherderArtifact, TreeherderAuth,
-                               TreeherderArtifactCollection)
+                               TreeherderJob, TreeherderJobCollection,
+                               TreeherderResultSet,
+                               TreeherderResultSetCollection,
+                               TreeherderRevision)
 
 
 class DataSetup(unittest.TestCase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,17 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import os
-from os.path import dirname
-import sys
-
 import json
+import os
+import sys
+from os.path import dirname
+
 import kombu
 import pytest
-from django.core.management import call_command
-from webtest.app import TestApp
-from requests import Request
 import responses
+from django.core.management import call_command
+from requests import Request
+from webtest.app import TestApp
 
 from tests.sampledata import SampleData
 from treeherder.etl.oauth_utils import OAuthCredentials

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -7,9 +7,9 @@ import os
 import pytest
 import simplejson as json
 from django.template import Context, Template
-from treeherder.client import (TreeherderJobCollection)
 
 from tests import test_utils
+from treeherder.client import TreeherderJobCollection
 
 base_dir = os.path.dirname(__file__)
 

--- a/tests/e2e/test_client_job_ingestion.py
+++ b/tests/e2e/test_client_job_ingestion.py
@@ -2,16 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import pytest
-from mock import MagicMock
 import json
 
-from treeherder.client.thclient import client, TreeherderAuth
+import pytest
+from mock import MagicMock
 
+from treeherder.client.thclient import TreeherderAuth, client
 from treeherder.etl.oauth_utils import OAuthCredentials
 from treeherder.log_parser.parsers import StepParser
-from treeherder.model.derived import JobsModel, ArtifactsModel
 from treeherder.model import error_summary
+from treeherder.model.derived import ArtifactsModel, JobsModel
 
 
 @pytest.fixture

--- a/tests/e2e/test_jobs_loaded.py
+++ b/tests/e2e/test_jobs_loaded.py
@@ -4,6 +4,7 @@
 
 from django.core.urlresolvers import reverse
 from webtest import TestApp
+
 from treeherder.webapp.wsgi import application
 
 

--- a/tests/etl/test_bugzilla.py
+++ b/tests/etl/test_bugzilla.py
@@ -2,9 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import pytest
-import os
 import json
+import os
+
+import pytest
 
 from treeherder.etl.bugzilla import BzApiBugProcess
 

--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -2,18 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+import json
 import os
+
 import pytest
 import responses
-import json
-
 from django.conf import settings
 from django.core.cache import cache
 
-from treeherder.etl.buildapi import (PendingJobsProcess,
-                                     RunningJobsProcess,
-                                     Builds4hJobsProcess,
-                                     CACHE_KEYS)
+from treeherder.etl.buildapi import (CACHE_KEYS, Builds4hJobsProcess,
+                                     PendingJobsProcess, RunningJobsProcess)
 
 
 @pytest.fixture

--- a/tests/etl/test_buildbot.py
+++ b/tests/etl/test_buildbot.py
@@ -2,8 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from treeherder.etl import buildbot
 import pytest
+
+from treeherder.etl import buildbot
 
 slow = pytest.mark.slow
 

--- a/tests/etl/test_classification_mirroring.py
+++ b/tests/etl/test_classification_mirroring.py
@@ -4,8 +4,8 @@
 
 import json
 from time import time
-from datadiff import diff
 
+from datadiff import diff
 from django.conf import settings
 from treeherder.etl.classification_mirroring import ElasticsearchDocRequest, BugzillaCommentRequest
 from treeherder.model.derived import ArtifactsModel

--- a/tests/etl/test_pushlog.py
+++ b/tests/etl/test_pushlog.py
@@ -2,11 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import os
 import json
+import os
+
 import responses
-from treeherder.etl.pushlog import HgPushlogProcess, MissingHgPushlogProcess
 from django.core.cache import cache
+
+from treeherder.etl.pushlog import HgPushlogProcess, MissingHgPushlogProcess
 
 
 def test_ingest_hg_pushlog(jm, initial_data, test_base_dir,

--- a/tests/log_parser/test_artifact_builder_collection.py
+++ b/tests/log_parser/test_artifact_builder_collection.py
@@ -2,10 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+from datadiff import diff
+
 from treeherder.log_parser.artifactbuildercollection import ArtifactBuilderCollection
 from treeherder.log_parser.artifactbuilders import BuildbotLogViewArtifactBuilder
+
 from ..sampledata import SampleData
-from datadiff import diff
 
 
 def test_builders_as_list():

--- a/tests/log_parser/test_job_artifact_builder.py
+++ b/tests/log_parser/test_job_artifact_builder.py
@@ -2,11 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+from tests import test_utils
 from treeherder.log_parser.artifactbuildercollection import ArtifactBuilderCollection
 from treeherder.log_parser.artifactbuilders import BuildbotJobArtifactBuilder
 
 from ..sampledata import SampleData
-from tests import test_utils
 
 
 def do_test(log):

--- a/tests/log_parser/test_log_view_artifact_builder.py
+++ b/tests/log_parser/test_log_view_artifact_builder.py
@@ -5,11 +5,11 @@
 import pytest
 from mock import MagicMock
 
+from tests import test_utils
 from treeherder.log_parser.artifactbuildercollection import ArtifactBuilderCollection
 from treeherder.log_parser.artifactbuilders import BuildbotLogViewArtifactBuilder
 from treeherder.log_parser.parsers import ErrorParser
 
-from tests import test_utils
 from ..sampledata import SampleData
 
 slow = pytest.mark.slow

--- a/tests/log_parser/test_performance_log_parser.py
+++ b/tests/log_parser/test_performance_log_parser.py
@@ -3,6 +3,7 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
+
 from treeherder.log_parser.parsers import TalosParser
 
 

--- a/tests/log_parser/test_step_parser.py
+++ b/tests/log_parser/test_step_parser.py
@@ -2,8 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from treeherder.log_parser.parsers import StepParser
 from datetime import datetime
+
+from treeherder.log_parser.parsers import StepParser
 
 
 def test_date_with_milliseconds():

--- a/tests/log_parser/test_tasks.py
+++ b/tests/log_parser/test_tasks.py
@@ -2,18 +2,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import pytest
-import simplejson as json
-import urllib2
-from django.conf import settings
 import gzip
+import urllib2
 import zlib
 
+import pytest
+import simplejson as json
+from django.conf import settings
 from django.utils.six import BytesIO
 
-from ..sampledata import SampleData
-
 from treeherder.model.derived import ArtifactsModel
+
+from ..sampledata import SampleData
 
 
 @pytest.fixture

--- a/tests/log_parser/test_tinderbox_print_parser.py
+++ b/tests/log_parser/test_tinderbox_print_parser.py
@@ -3,8 +3,8 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from treeherder.log_parser.parsers import TinderboxPrintParser
 
+from treeherder.log_parser.parsers import TinderboxPrintParser
 
 # a list of test cases for the tinderbox printlines parser
 # every test case is composed by (input, output), where

--- a/tests/log_parser/test_utils.py
+++ b/tests/log_parser/test_utils.py
@@ -3,9 +3,9 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from treeherder.model.error_summary import (get_error_search_term,
-                                            get_crash_signature)
 
+from treeherder.model.error_summary import (get_crash_signature,
+                                            get_error_search_term)
 
 PIPE_DELIMITED_LINE_TEST_CASES = (
     (

--- a/tests/model/commands/test_init_datasource.py
+++ b/tests/model/commands/test_init_datasource.py
@@ -2,10 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.core.management import call_command
 import pytest
+from django.core.management import call_command
 
-from treeherder.model.models import Repository, RepositoryGroup, Datasource
+from treeherder.model.models import Datasource, Repository, RepositoryGroup
 
 
 @pytest.fixture

--- a/tests/model/derived/test_artifacts_model.py
+++ b/tests/model/derived/test_artifacts_model.py
@@ -1,8 +1,8 @@
 import json
+
 import pytest
 
 from treeherder.model.derived import ArtifactsModel, JobsModel
-
 
 xfail = pytest.mark.xfail
 

--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -2,20 +2,20 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import time
-import json
-import pytest
 import copy
+import json
 import threading
+import time
 import zlib
 
+import pytest
 from django.conf import settings
 from django.core.management import call_command
 
+from tests import test_utils
+from tests.sample_data_generator import job_data, result_set
 from treeherder.model.derived import ArtifactsModel
 from treeherder.model.derived.jobs import JobsModel
-from tests.sample_data_generator import job_data, result_set
-from tests import test_utils
 
 slow = pytest.mark.slow
 xfail = pytest.mark.xfail

--- a/tests/model/derived/test_refdata.py
+++ b/tests/model/derived/test_refdata.py
@@ -2,14 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+import json
 import os
 import time
-import json
 from datetime import datetime, timedelta
 
 import pytest
 
-from treeherder.model.models import RepositoryGroup, Repository
+from treeherder.model.models import Repository, RepositoryGroup
 
 
 @pytest.fixture

--- a/tests/perfalert/test_analyze.py
+++ b/tests/perfalert/test_analyze.py
@@ -1,8 +1,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
-import unittest
 import os
+import unittest
 
 from tests.sampledata import SampleData
 from treeherder.perfalert import *

--- a/tests/sample_data_generator.py
+++ b/tests/sample_data_generator.py
@@ -9,8 +9,9 @@ Functions for flexible generation of sample input job JSON.
 import json
 import os
 import time
-from django.conf import settings
 from datetime import timedelta
+
+from django.conf import settings
 
 
 def ref_data_json():

--- a/tests/sampledata.py
+++ b/tests/sampledata.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+
 from django.conf import settings
 
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2,11 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import pytest
-from django.conf import settings
 import MySQLdb
-from django.core.cache import cache
+import pytest
 from celery import current_app
+from django.conf import settings
+from django.core.cache import cache
 
 
 @pytest.fixture

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,15 +3,15 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
-from webtest.app import TestApp
+
 from requests import Request
+from webtest.app import TestApp
 
-from treeherder.model.derived.refdata import RefDataManager
-from treeherder.etl.oauth_utils import OAuthCredentials
-from treeherder.webapp.wsgi import application
-
-from treeherder.client import TreeherderClient, TreeherderAuth
 from tests.sampledata import SampleData
+from treeherder.client import TreeherderAuth, TreeherderClient
+from treeherder.etl.oauth_utils import OAuthCredentials
+from treeherder.model.derived.refdata import RefDataManager
+from treeherder.webapp.wsgi import application
 
 
 def post_collection(

--- a/tests/webapp/api/test_artifact_api.py
+++ b/tests/webapp/api/test_artifact_api.py
@@ -3,15 +3,13 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
-import pytest
 
+import pytest
 from django.core.urlresolvers import reverse
 
-from treeherder.client.thclient import client, TreeherderAuth
-
+from treeherder.client.thclient import TreeherderAuth, client
 from treeherder.etl.oauth_utils import OAuthCredentials
 from treeherder.model.derived import ArtifactsModel, JobsModel
-
 
 xfail = pytest.mark.xfail
 

--- a/tests/webapp/api/test_auth.py
+++ b/tests/webapp/api/test_auth.py
@@ -1,11 +1,11 @@
-from django.core.urlresolvers import resolve, reverse
 import oauth2 as oauth
+from django.core.urlresolvers import resolve, reverse
 from rest_framework.decorators import APIView
 from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory
 
-from treeherder.webapp.api.auth import TwoLeggedOauthAuthentication
 from treeherder.etl.oauth_utils import OAuthCredentials
+from treeherder.webapp.api.auth import TwoLeggedOauthAuthentication
 
 
 class AuthenticatedView(APIView):

--- a/tests/webapp/api/test_bug_job_map_api.py
+++ b/tests/webapp/api/test_bug_job_map_api.py
@@ -2,12 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+import json
+import random
+from time import time
+
+from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from rest_framework.test import APIClient
-from django.contrib.auth.models import User
-import random
-import json
-from time import time
 
 
 def test_create_bug_job_map_no_auth(eleven_jobs_stored, jm):

--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -2,11 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+import json
+
+from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from rest_framework.test import APIClient
-from django.contrib.auth.models import User
-
-import json
 
 
 def test_job_list(webapp, eleven_jobs_stored, jm):

--- a/tests/webapp/api/test_note_api.py
+++ b/tests/webapp/api/test_note_api.py
@@ -3,9 +3,10 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
+
+from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from rest_framework.test import APIClient
-from django.contrib.auth.models import User
 
 
 def test_note_list(webapp, sample_notes, jm):

--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -2,15 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+import json
+
+from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from rest_framework.test import APIClient
-from django.contrib.auth.models import User
 
-from treeherder.client import TreeherderResultSetCollection
 from tests import test_utils
-
+from treeherder.client import TreeherderResultSetCollection
 from treeherder.webapp.api import utils
-import json
 
 
 def test_resultset_list(webapp, eleven_jobs_stored, jm):

--- a/tests/webapp/api/test_version.py
+++ b/tests/webapp/api/test_version.py
@@ -1,8 +1,8 @@
+from django.conf import settings
 from rest_framework.decorators import APIView
+from rest_framework.exceptions import NotAcceptable
 from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory
-from rest_framework.exceptions import NotAcceptable
-from django.conf import settings
 
 
 class RequestVersionView(APIView):

--- a/tests/webapp/conftest.py
+++ b/tests/webapp/conftest.py
@@ -3,11 +3,13 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
-from treeherder.webapp import wsgi
-from treeherder.model.derived import ArtifactsModel
-from tests.sample_data_generator import job_data
+
 import pytest
 from webtest.app import TestApp
+
+from tests.sample_data_generator import job_data
+from treeherder.model.derived import ArtifactsModel
+from treeherder.webapp import wsgi
 
 
 @pytest.fixture

--- a/treeherder/celery.py
+++ b/treeherder/celery.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 import os
 
 from celery import Celery
-
 from django.conf import settings
 
 # set the default Django settings module for the 'celery' program.

--- a/treeherder/client/thclient/auth.py
+++ b/treeherder/client/thclient/auth.py
@@ -7,7 +7,6 @@ import time
 import oauth2 as oauth
 from requests.auth import AuthBase
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -4,10 +4,11 @@
 
 from __future__ import unicode_literals
 
+import json
+import logging
+
 import requests
 from requests.exceptions import HTTPError
-import logging
-import json
 
 # When releasing a new version to PyPI please also file a bug to request
 # that it is uploaded to http://pypi.pub.build.mozilla.org/pub/ too.

--- a/treeherder/embed/urls.py
+++ b/treeherder/embed/urls.py
@@ -3,6 +3,7 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.conf.urls import patterns, url
+
 from .views import ResultsetStatusView
 
 urlpatterns = patterns(

--- a/treeherder/embed/views.py
+++ b/treeherder/embed/views.py
@@ -2,8 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.views.generic.base import TemplateView
 from django.http import Http404
+from django.views.generic.base import TemplateView
+
 from treeherder.model.derived import JobsModel
 
 

--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -10,10 +10,9 @@ from django.conf import settings
 from django.core.cache import cache
 
 from treeherder.client import TreeherderJobCollection
-from treeherder.etl import common, buildbot
+from treeherder.etl import buildbot, common
 from treeherder.etl.mixins import JsonExtractorMixin, OAuthLoaderMixin
 from treeherder.model.models import Datasource
-
 
 logger = logging.getLogger(__name__)
 CACHE_KEYS = {

--- a/treeherder/etl/classification_mirroring.py
+++ b/treeherder/etl/classification_mirroring.py
@@ -2,13 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from datetime import datetime
 import logging
+from datetime import datetime
 
-import simplejson as json
 import requests
-from treeherder.model.derived import JobsModel, ArtifactsModel
+import simplejson as json
 from django.conf import settings
+
+from treeherder.model.derived import ArtifactsModel, JobsModel
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -3,10 +3,10 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import hashlib
-import simplejson as json
 import time
 
 import requests
+import simplejson as json
 from django.conf import settings
 
 

--- a/treeherder/etl/management/commands/export_project_credentials.py
+++ b/treeherder/etl/management/commands/export_project_credentials.py
@@ -3,13 +3,12 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-import simplejson as json
-
 from optparse import make_option
+
+import simplejson as json
 from django.core.management.base import BaseCommand
 
 from treeherder.model.derived.base import TreeherderModelBase
-
 
 DEFAULT_CREDENTIALS_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(__file__))),

--- a/treeherder/etl/management/commands/import_project_credentials.py
+++ b/treeherder/etl/management/commands/import_project_credentials.py
@@ -3,9 +3,10 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-import simplejson as json
 
+import simplejson as json
 from django.core.management.base import BaseCommand, CommandError
+
 from treeherder.model.models import Datasource
 
 

--- a/treeherder/etl/management/commands/ingest_push.py
+++ b/treeherder/etl/management/commands/ingest_push.py
@@ -2,16 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+from cProfile import Profile
 from optparse import make_option
+
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
+from treeherder.etl.buildapi import (Builds4hJobsProcess, PendingJobsProcess,
+                                     RunningJobsProcess)
 from treeherder.etl.pushlog import HgPushlogProcess
 from treeherder.model.derived import RefDataManager
-from treeherder.etl.buildapi import (RunningJobsProcess,
-                                     PendingJobsProcess,
-                                     Builds4hJobsProcess)
-from cProfile import Profile
 
 
 class Command(BaseCommand):

--- a/treeherder/etl/management/commands/test_parse_log.py
+++ b/treeherder/etl/management/commands/test_parse_log.py
@@ -2,14 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.core.management.base import BaseCommand, CommandError
+import time
 from optparse import make_option
+
+import simplejson as json
+from django.core.management.base import BaseCommand, CommandError
 
 from treeherder.log_parser.artifactbuildercollection import \
     ArtifactBuilderCollection
-
-import simplejson as json
-import time
 
 
 class Command(BaseCommand):

--- a/treeherder/etl/mixins.py
+++ b/treeherder/etl/mixins.py
@@ -2,18 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from StringIO import StringIO
 import gzip
-import urllib2
 import logging
+import urllib2
+from StringIO import StringIO
 
 import simplejson as json
-
-from django.core.urlresolvers import reverse
 from django.conf import settings
+from django.core.urlresolvers import reverse
 
 from treeherder.etl import th_publisher
-
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/etl/oauth_utils.py
+++ b/treeherder/etl/oauth_utils.py
@@ -2,11 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import simplejson as json
-import os
-from treeherder import path
 import copy
 import logging
+import os
+
+import simplejson as json
+
+from treeherder import path
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/etl/perf_data_adapters.py
+++ b/treeherder/etl/perf_data_adapters.py
@@ -2,16 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import simplejson as json
-from simplejson import encoder
-
-from hashlib import sha1
+import logging
 import math
 import zlib
+from hashlib import sha1
 
+import simplejson as json
 from jsonschema import validate
+from simplejson import encoder
 
-import logging
 logger = logging.getLogger(__name__)
 
 encoder.FLOAT_REPR = lambda o: format(o, '.2f')

--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -2,16 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.core.cache import cache
-from django.conf import settings
-import requests
 import logging
 
-from treeherder.client import TreeherderResultSetCollection
+import requests
+from django.conf import settings
+from django.core.cache import cache
 
-from .mixins import JsonExtractorMixin, OAuthLoaderMixin
+from treeherder.client import TreeherderResultSetCollection
 from treeherder.etl.common import generate_revision_hash, get_not_found_onhold_push
 
+from .mixins import JsonExtractorMixin, OAuthLoaderMixin
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/etl/tasks/buildapi_tasks.py
+++ b/treeherder/etl/tasks/buildapi_tasks.py
@@ -6,11 +6,11 @@
 This module contains
 """
 from celery import task
-from treeherder.model.derived import RefDataManager
-from treeherder.etl.buildapi import (RunningJobsProcess,
-                                     PendingJobsProcess,
-                                     Builds4hJobsProcess)
+
+from treeherder.etl.buildapi import (Builds4hJobsProcess, PendingJobsProcess,
+                                     RunningJobsProcess)
 from treeherder.etl.pushlog import HgPushlogProcess
+from treeherder.model.derived import RefDataManager
 
 
 @task(name='fetch-buildapi-pending', time_limit=3 * 60)

--- a/treeherder/etl/tasks/classification_mirroring_tasks.py
+++ b/treeherder/etl/tasks/classification_mirroring_tasks.py
@@ -3,7 +3,8 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 from celery import task
-from treeherder.etl.classification_mirroring import ElasticsearchDocRequest, BugzillaCommentRequest
+
+from treeherder.etl.classification_mirroring import BugzillaCommentRequest, ElasticsearchDocRequest
 
 
 @task(name="submit-elasticsearch-doc", max_retries=10, time_limit=30)

--- a/treeherder/etl/tasks/cleanup_tasks.py
+++ b/treeherder/etl/tasks/cleanup_tasks.py
@@ -2,12 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import urllib
 import logging
+import urllib
 
 from celery import task
-from treeherder.model.derived import RefDataManager
+
 from treeherder.etl.pushlog import MissingHgPushlogProcess
+from treeherder.model.derived import RefDataManager
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/etl/tasks/tasks.py
+++ b/treeherder/etl/tasks/tasks.py
@@ -6,6 +6,7 @@
 This module contains
 """
 from celery import task
+
 from treeherder.etl.bugzilla import BzApiBugProcess
 
 

--- a/treeherder/etl/th_publisher.py
+++ b/treeherder/etl/th_publisher.py
@@ -5,11 +5,10 @@
 import logging
 import traceback
 
-from django.utils.encoding import python_2_unicode_compatible
 from django.conf import settings
+from django.utils.encoding import python_2_unicode_compatible
 
-from treeherder.client import TreeherderClient, TreeherderAuth
-
+from treeherder.client import TreeherderAuth, TreeherderClient
 from treeherder.etl.oauth_utils import OAuthCredentials
 
 logger = logging.getLogger(__name__)

--- a/treeherder/events/publisher.py
+++ b/treeherder/events/publisher.py
@@ -3,8 +3,8 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import logging
-from kombu import Connection, Exchange, Producer
 
+from kombu import Connection, Exchange, Producer
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/log_parser/artifactbuildercollection.py
+++ b/treeherder/log_parser/artifactbuildercollection.py
@@ -6,10 +6,11 @@ import io
 import urllib2
 import zlib
 from contextlib import closing
+
 from django.conf import settings
 
-from .artifactbuilders import (BuildbotLogViewArtifactBuilder,
-                               BuildbotJobArtifactBuilder,
+from .artifactbuilders import (BuildbotJobArtifactBuilder,
+                               BuildbotLogViewArtifactBuilder,
                                BuildbotPerformanceDataArtifactBuilder)
 
 

--- a/treeherder/log_parser/artifactbuilders.py
+++ b/treeherder/log_parser/artifactbuilders.py
@@ -3,15 +3,14 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import logging
-import requests
 from contextlib import closing
 
-from django.utils.six import BytesIO
+import requests
 from django.conf import settings
-
+from django.utils.six import BytesIO
 from mozlog.structured import reader
 
-from .parsers import TinderboxPrintParser, StepParser, TalosParser
+from .parsers import StepParser, TalosParser, TinderboxPrintParser
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -2,11 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import re
 import datetime
 import json
+import re
 
 from django.conf import settings
+
 from treeherder.etl.buildbot import RESULT_DICT
 
 

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -7,11 +7,9 @@ import logging
 
 from celery import task
 
-from treeherder.log_parser.utils import (extract_text_log_artifacts,
-                                         extract_json_log_artifacts,
-                                         post_log_artifacts,
-                                         is_parsed
-                                         )
+from treeherder.log_parser.utils import (extract_json_log_artifacts,
+                                         extract_text_log_artifacts, is_parsed,
+                                         post_log_artifacts)
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -2,20 +2,19 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import urllib2
 import logging
+import urllib2
 
 import simplejson as json
 from django.conf import settings
 
+from treeherder.client import (TreeherderArtifactCollection, TreeherderAuth,
+                               TreeherderClient)
+from treeherder.etl.oauth_utils import OAuthCredentials
 from treeherder.log_parser.artifactbuildercollection import \
     ArtifactBuilderCollection
 from treeherder.log_parser.artifactbuilders import MozlogArtifactBuilder
-
 from treeherder.model.error_summary import get_error_summary_artifacts
-from treeherder.client import (TreeherderClient, TreeherderArtifactCollection,
-                               TreeherderAuth)
-from treeherder.etl.oauth_utils import OAuthCredentials
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -2,16 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import simplejson as json
 import logging
 import zlib
 
-from treeherder.model import utils
-
-from .base import TreeherderModelBase
+import simplejson as json
 
 from treeherder.etl.perf_data_adapters import (PerformanceDataAdapter,
                                                TalosDataAdapter)
+from treeherder.model import utils
+
+from .base import TreeherderModelBase
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/model/derived/base.py
+++ b/treeherder/model/derived/base.py
@@ -12,8 +12,8 @@ import logging
 from django.conf import settings
 from django.utils.encoding import python_2_unicode_compatible
 
-from treeherder.model.models import Datasource
 from treeherder.model.derived.refdata import RefDataManager
+from treeherder.model.models import Datasource
 
 
 @python_2_unicode_compatible

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -2,38 +2,30 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import simplejson as json
-import time
 import logging
+import time
 import zlib
 from collections import defaultdict
 from datetime import datetime
 from hashlib import sha1
-
 from operator import itemgetter
 
+import simplejson as json
 from _mysql_exceptions import IntegrityError
-
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 
-from treeherder.model.models import (Datasource,
-                                     ExclusionProfile)
-
-from treeherder.model import utils, error_summary
-from treeherder.model.tasks import (publish_resultset,
-                                    publish_job_action,
-                                    publish_resultset_action,
-                                    populate_error_summary)
-
-from treeherder.events.publisher import JobStatusPublisher
-
 from treeherder.etl.common import get_guid_root
+from treeherder.events.publisher import JobStatusPublisher
+from treeherder.model import error_summary, utils
+from treeherder.model.models import Datasource, ExclusionProfile
+from treeherder.model.tasks import (populate_error_summary, publish_job_action,
+                                    publish_resultset,
+                                    publish_resultset_action)
 
-from .base import TreeherderModelBase, ObjectNotFoundException
 from .artifacts import ArtifactsModel
-
+from .base import ObjectNotFoundException, TreeherderModelBase
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/model/derived/refdata.py
+++ b/treeherder/model/derived/refdata.py
@@ -2,14 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import os
 import logging
-from hashlib import sha1
+import os
 import time
-from datetime import timedelta, datetime
-from django.conf import settings
+from datetime import datetime, timedelta
+from hashlib import sha1
+
 from datasource.bases.BaseHub import BaseHub
 from datasource.DataHub import DataHub
+from django.conf import settings
 
 from treeherder.model import utils
 

--- a/treeherder/model/error_summary.py
+++ b/treeherder/model/error_summary.py
@@ -2,12 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+import json
 import logging
 import re
-import json
 
-from django.core.urlresolvers import reverse
 from django.conf import settings
+from django.core.urlresolvers import reverse
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/model/exchanges.py
+++ b/treeherder/model/exchanges.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from treeherder.model.pulse_publisher import PulsePublisher, Exchange, Key
+from treeherder.model.pulse_publisher import Exchange, Key, PulsePublisher
 
 
 class TreeherderPublisher(PulsePublisher):

--- a/treeherder/model/management/commands/calculate_eta.py
+++ b/treeherder/model/management/commands/calculate_eta.py
@@ -3,7 +3,9 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 from optparse import make_option
+
 from django.core.management.base import BaseCommand
+
 from treeherder.model.tasks import calculate_eta
 
 

--- a/treeherder/model/management/commands/clear_cache.py
+++ b/treeherder/model/management/commands/clear_cache.py
@@ -2,8 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.core.management.base import BaseCommand
 from django.core.cache import cache
+from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):

--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -2,12 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from optparse import make_option
 import datetime
+from optparse import make_option
+
+from django.conf import settings
 from django.core.management.base import BaseCommand
+
 from treeherder.model.derived import JobsModel
 from treeherder.model.models import Datasource
-from django.conf import settings
 
 
 class Command(BaseCommand):

--- a/treeherder/model/management/commands/import_perf_data.py
+++ b/treeherder/model/management/commands/import_perf_data.py
@@ -2,13 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.core.management.base import BaseCommand, CommandError
 from optparse import make_option
-from treeherder.client import PerfherderClient, PerformanceTimeInterval
-from treeherder.model.derived.jobs import JobsModel
 from urlparse import urlparse
 
 import concurrent.futures
+from django.core.management.base import BaseCommand, CommandError
+
+from treeherder.client import PerfherderClient, PerformanceTimeInterval
+from treeherder.model.derived.jobs import JobsModel
 
 
 def _add_series(server_params, project, time_intervals, signature_hash,

--- a/treeherder/model/management/commands/init_datasources.py
+++ b/treeherder/model/management/commands/init_datasources.py
@@ -3,9 +3,10 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 from optparse import make_option
-from django.utils.six.moves import input
 
 from django.core.management.base import BaseCommand
+from django.utils.six.moves import input
+
 from treeherder.model.models import Datasource, Repository
 
 

--- a/treeherder/model/management/commands/init_master_db.py
+++ b/treeherder/model/management/commands/init_master_db.py
@@ -5,9 +5,9 @@
 import os
 from optparse import make_option
 
+from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.db import connection
-from django.core.management import call_command
 from django.utils.six.moves import input
 
 from treeherder import path

--- a/treeherder/model/management/commands/load_initial_data.py
+++ b/treeherder/model/management/commands/load_initial_data.py
@@ -2,8 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.core.management.base import BaseCommand
 from django.core.management import call_command
+from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):

--- a/treeherder/model/management/commands/populate_performance_series.py
+++ b/treeherder/model/management/commands/populate_performance_series.py
@@ -2,11 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import simplejson as json
 import sys
-
 from optparse import make_option
+
+import simplejson as json
 from django.core.management.base import BaseCommand
+
 from treeherder.model.tasks import populate_performance_series
 
 

--- a/treeherder/model/management/commands/publish_result_set_to_pulse.py
+++ b/treeherder/model/management/commands/publish_result_set_to_pulse.py
@@ -3,7 +3,9 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 from optparse import make_option
+
 from django.core.management.base import BaseCommand
+
 from treeherder.model.tasks import publish_to_pulse
 
 

--- a/treeherder/model/management/commands/rewrite_perf_data.py
+++ b/treeherder/model/management/commands/rewrite_perf_data.py
@@ -3,14 +3,15 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import copy
+from optparse import make_option
 
 from django.core.management.base import BaseCommand
-from optparse import make_option
+
 from treeherder.client import PerformanceTimeInterval
+from treeherder.etl.perf_data_adapters import TalosDataAdapter
 from treeherder.model import utils
 from treeherder.model.derived.jobs import JobsModel
 from treeherder.model.models import Datasource
-from treeherder.etl.perf_data_adapters import TalosDataAdapter
 
 
 class Command(BaseCommand):

--- a/treeherder/model/management/commands/run_sql.py
+++ b/treeherder/model/management/commands/run_sql.py
@@ -2,13 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import MySQLdb
 from optparse import make_option
 
+import MySQLdb
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from treeherder.model.models import Datasource
-from django.conf import settings
 
 
 class Command(BaseCommand):

--- a/treeherder/model/management/commands/test_analyze_perf.py
+++ b/treeherder/model/management/commands/test_analyze_perf.py
@@ -2,13 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.core.management.base import BaseCommand, CommandError
-from django.conf import settings
 from optparse import make_option
 from urlparse import urlparse
 
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
 from treeherder.client import PerfherderClient, PerformanceTimeInterval
-from treeherder.perfalert import TalosAnalyzer, PerfDatum
+from treeherder.perfalert import PerfDatum, TalosAnalyzer
 
 
 class Command(BaseCommand):

--- a/treeherder/model/migrations/0001_initial.py
+++ b/treeherder/model/migrations/0001_initial.py
@@ -5,9 +5,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
 import jsonfield.fields
 from django.conf import settings
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -4,25 +4,22 @@
 
 from __future__ import unicode_literals
 
-import uuid
 import os
-
+import uuid
 from collections import defaultdict
+from warnings import filterwarnings, resetwarnings
 
 from datasource.bases.BaseHub import BaseHub
 from datasource.hubs.MySQL import MySQL
 from django.conf import settings
-from django.core.cache import cache
-from django.db import models, connection
-from django.db.models import Q
 from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.db import connection, models
+from django.db.models import Q
 from django.utils.encoding import python_2_unicode_compatible
-from warnings import filterwarnings, resetwarnings
-
 from jsonfield import JSONField
 
 from treeherder import path
-
 
 # the cache key is specific to the database name we're pulling the data from
 SOURCES_CACHE_KEY = "treeherder-datasources"

--- a/treeherder/model/pulse_publisher.py
+++ b/treeherder/model/pulse_publisher.py
@@ -2,12 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import kombu
-import re
 import json
-import os
-import jsonschema
 import logging
+import os
+import re
+
+import jsonschema
+import kombu
+
 logger = logging.getLogger(__name__)
 
 

--- a/treeherder/model/tasks.py
+++ b/treeherder/model/tasks.py
@@ -3,15 +3,15 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
+
 from celery import task
-from django.core.management import call_command
 from django.conf import settings
+from django.core.management import call_command
 
-from treeherder.model.models import Repository
-from treeherder.model.exchanges import TreeherderPublisher
-from treeherder.model.pulse_publisher import load_schemas
 from treeherder.model.error_summary import load_error_summary
-
+from treeherder.model.exchanges import TreeherderPublisher
+from treeherder.model.models import Repository
+from treeherder.model.pulse_publisher import load_schemas
 
 # Load schemas for validation of messages published on pulse
 SOURCE_FOLDER = os.path.dirname(os.path.realpath(__file__))

--- a/treeherder/model/utils.py
+++ b/treeherder/model/utils.py
@@ -2,11 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import time
-import simplejson as json
 import random
+import time
 import zlib
 
+import simplejson as json
 from _mysql_exceptions import OperationalError
 
 

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 
 import dj_database_url
 from kombu import Exchange, Queue
+
 from treeherder import path
 
 # These settings can all be optionally set via env vars, or in local.py:

--- a/treeherder/webapp/admin.py
+++ b/treeherder/webapp/admin.py
@@ -3,8 +3,9 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.contrib import admin
-from treeherder.model.models import *
 from django_browserid.admin import site as browserid_admin
+
+from treeherder.model.models import *
 
 
 class JobTypeAdmin(admin.ModelAdmin):

--- a/treeherder/webapp/api/artifact.py
+++ b/treeherder/webapp/api/artifact.py
@@ -4,11 +4,12 @@
 
 from rest_framework import viewsets
 from rest_framework.response import Response
-from treeherder.webapp.api.utils import UrlQueryFilter
-from treeherder.webapp.api import permissions
-from treeherder.model.derived import JobsModel, ArtifactsModel
-from treeherder.model.tasks import populate_error_summary
+
+from treeherder.model.derived import ArtifactsModel, JobsModel
 from treeherder.model.error_summary import get_artifacts_that_need_bug_suggestions
+from treeherder.model.tasks import populate_error_summary
+from treeherder.webapp.api import permissions
+from treeherder.webapp.api.utils import UrlQueryFilter
 
 
 class ArtifactViewSet(viewsets.ViewSet):

--- a/treeherder/webapp/api/auth.py
+++ b/treeherder/webapp/api/auth.py
@@ -2,8 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf import settings
 import oauth2 as oauth
+from django.conf import settings
 from rest_framework import exceptions
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.renderers import JSONRenderer

--- a/treeherder/webapp/api/bug.py
+++ b/treeherder/webapp/api/bug.py
@@ -5,11 +5,11 @@
 from time import time
 
 from rest_framework import viewsets
-from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.response import Response
 
 from treeherder.model.derived.jobs import JobDataIntegrityError
-from treeherder.webapp.api.utils import (UrlQueryFilter, with_jobs)
+from treeherder.webapp.api.utils import UrlQueryFilter, with_jobs
 
 
 class BugJobMapViewSet(viewsets.ViewSet):

--- a/treeherder/webapp/api/exceptions.py
+++ b/treeherder/webapp/api/exceptions.py
@@ -2,14 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
+
+from django.conf import settings
 from rest_framework import exceptions
 from rest_framework.response import Response
 from rest_framework.views import exception_handler as drf_exc_handler
-from django.conf import settings
 
 from treeherder.model.derived import DatasetNotFoundError, ObjectNotFoundException
-import logging
-
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/webapp/api/job_log_url.py
+++ b/treeherder/webapp/api/job_log_url.py
@@ -5,9 +5,9 @@
 import logging
 
 from rest_framework import viewsets
-from rest_framework.response import Response
-from rest_framework.exceptions import ParseError
 from rest_framework.decorators import detail_route
+from rest_framework.exceptions import ParseError
+from rest_framework.response import Response
 
 from treeherder.webapp.api import permissions
 from treeherder.webapp.api.utils import with_jobs

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -2,15 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 from rest_framework import viewsets
-from rest_framework.response import Response
 from rest_framework.decorators import detail_route, list_route
-from rest_framework.reverse import reverse
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
 
-from treeherder.webapp.api.permissions import (IsStaffOrReadOnly)
-from treeherder.webapp.api.utils import (UrlQueryFilter, with_jobs, get_option)
-from treeherder.webapp.api import permissions
 from treeherder.model.derived import ArtifactsModel
+from treeherder.webapp.api import permissions
+from treeherder.webapp.api.permissions import IsStaffOrReadOnly
+from treeherder.webapp.api.utils import UrlQueryFilter, get_option, with_jobs
 
 
 class JobsViewSet(viewsets.ViewSet):

--- a/treeherder/webapp/api/logslice.py
+++ b/treeherder/webapp/api/logslice.py
@@ -5,15 +5,14 @@ import gzip
 import json
 import urllib2
 
-from rest_framework import viewsets
-from rest_framework.response import Response
+from django.conf import settings
 from django.core.cache import caches
 from django.utils.six import BytesIO
-from django.conf import settings
+from rest_framework import viewsets
+from rest_framework.response import Response
 
-from treeherder.webapp.api.utils import with_jobs
 from treeherder.webapp.api.exceptions import ResourceNotFoundException
-
+from treeherder.webapp.api.utils import with_jobs
 
 filesystem = caches['filesystem']
 

--- a/treeherder/webapp/api/note.py
+++ b/treeherder/webapp/api/note.py
@@ -3,9 +3,9 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 from rest_framework import viewsets
-from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.response import Response
 
 from treeherder.webapp.api.utils import with_jobs
 

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -4,13 +4,12 @@
 
 from django.core.cache import cache
 from rest_framework import viewsets
-from rest_framework.response import Response
 from rest_framework.decorators import list_route
+from rest_framework.response import Response
 from rest_framework_extensions.etag.decorators import etag
 
-
 from treeherder.model.derived.jobs import JobsModel
-from treeherder.webapp.api.utils import (with_jobs)
+from treeherder.webapp.api.utils import with_jobs
 
 
 class PerformanceDataViewSet(viewsets.ViewSet):

--- a/treeherder/webapp/api/projects.py
+++ b/treeherder/webapp/api/projects.py
@@ -2,11 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.http import HttpResponse, HttpResponseNotFound
-from treeherder.model.derived import DatasetNotFoundError
 import simplejson as json
+from django.http import HttpResponse, HttpResponseNotFound
 
-from treeherder.model.derived import JobsModel, ArtifactsModel
+from treeherder.model.derived import ArtifactsModel, DatasetNotFoundError, JobsModel
 
 
 def project_info(request, project):

--- a/treeherder/webapp/api/refdata.py
+++ b/treeherder/webapp/api/refdata.py
@@ -2,16 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+from django.contrib.auth.models import User
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import CacheResponseAndETAGMixin
-from django.contrib.auth.models import User
 
 from treeherder.model import models
 from treeherder.model.derived import RefDataManager
 from treeherder.webapp.api import serializers as th_serializers
-from treeherder.webapp.api.permissions import (IsStaffOrReadOnly,
-                                               IsOwnerOrReadOnly)
+from treeherder.webapp.api.permissions import (IsOwnerOrReadOnly,
+                                               IsStaffOrReadOnly)
+
 
 #####################
 # Refdata ViewSets

--- a/treeherder/webapp/api/resultset.py
+++ b/treeherder/webapp/api/resultset.py
@@ -3,16 +3,16 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 from rest_framework import viewsets
-from rest_framework.response import Response
 from rest_framework.decorators import detail_route
-from rest_framework.reverse import reverse
 from rest_framework.exceptions import ParseError
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
 
-from treeherder.webapp.api.permissions import (IsStaffOrReadOnly,
-                                               HasLegacyOauthPermissionsOrReadOnly)
 from treeherder.model.derived import DatasetNotFoundError
-from treeherder.webapp.api.utils import (UrlQueryFilter, with_jobs, to_timestamp)
+from treeherder.webapp.api.permissions import (HasLegacyOauthPermissionsOrReadOnly,
+                                               IsStaffOrReadOnly)
+from treeherder.webapp.api.utils import UrlQueryFilter, to_timestamp, with_jobs
 
 
 class ResultSetViewSet(viewsets.ViewSet):

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -2,10 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 from django.contrib.auth.models import User
+from rest_framework import serializers
 
 from treeherder.model import models
-
-from rest_framework import serializers
 
 
 class NoOpSerializer(serializers.Serializer):

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -2,13 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf.urls import patterns, include, url
-from treeherder.webapp.api import (refdata, jobs, resultset,
-                                   artifact, note, bug, logslice,
-                                   performance_data, job_log_url,
-                                   performance_artifact, projects)
-
+from django.conf.urls import include, patterns, url
 from rest_framework import routers
+
+from treeherder.webapp.api import (artifact, bug, job_log_url, jobs, logslice,
+                                   note, performance_artifact, performance_data,
+                                   projects, refdata, resultset)
 
 # router for views that are bound to a project
 # i.e. all those views that don't involve reference data

--- a/treeherder/webapp/api/utils.py
+++ b/treeherder/webapp/api/utils.py
@@ -2,10 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from collections import defaultdict
-import time
 import datetime
 import functools
+import time
+from collections import defaultdict
 
 from treeherder.model.derived import JobsModel
 

--- a/treeherder/webapp/urls.py
+++ b/treeherder/webapp/urls.py
@@ -2,13 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, patterns, url
 from django.contrib import admin
+from django_browserid.admin import site as browserid_admin
 
-from .api import urls as api_urls
 from treeherder.embed import urls as embed_urls
 
-from django_browserid.admin import site as browserid_admin
+from .api import urls as api_urls
+
 browserid_admin.copy_registry(admin.site)
 
 urlpatterns = patterns('',

--- a/treeherder/webapp/whitenoise_custom.py
+++ b/treeherder/webapp/whitenoise_custom.py
@@ -3,6 +3,7 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import re
+
 from whitenoise.django import DjangoWhiteNoise
 
 

--- a/treeherder/workers/management/commands/shutdown_workers.py
+++ b/treeherder/workers/management/commands/shutdown_workers.py
@@ -2,8 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.core.management.base import BaseCommand
 from celery.task.control import broadcast
+from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
Created using isort (https://github.com/timothycrosley/isort/) - using `isort -p tests -rc .` and a couple of manual tweaks.

The order is:
* futures
* std library
* third party packages
* local imports
* relative local imports

...with each group ordered with "import x" before "from x import y", and then alphabetically.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/849)
<!-- Reviewable:end -->
