### PR TITLE
Bug 1192801 - Remove per-file MPL boilerplate since it's unnecessary

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 test-warnings: false
 strictness: medium
 max-line-length: 140

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 sudo: false
 language: python
 python:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 FROM python:2.7
 MAINTAINER Mozilla
 RUN virtualenv /venv

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 module.exports = function(grunt) {

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,377 @@
-This Source Code Form is subject to the terms of the Mozilla Public
-License, v. 2.0. If a copy of the MPL was not distributed with this
-file, You can obtain one at http://mozilla.org/MPL/2.0/.
+Unless otherwise stated, this license applies to all files contained
+within this source code repository.
+
+
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/Procfile
+++ b/Procfile
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 web: newrelic-admin run-program gunicorn treeherder.webapp.wsgi:application --log-file - --timeout 29 --max-requests 2000
 worker_beat: newrelic-admin run-program celery -A treeherder beat
 worker_pushlog: newrelic-admin run-program celery -A treeherder worker -Q pushlog,fetch_missing_push_logs --maxtasksperchild=500 --concurrency=5

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 

--- a/bin/run_celery_worker
+++ b/bin/run_celery_worker
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
 cd $SRC_DIR
 

--- a/bin/run_celery_worker_buildapi
+++ b/bin/run_celery_worker_buildapi
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
 cd $SRC_DIR
 

--- a/bin/run_celery_worker_hp
+++ b/bin/run_celery_worker_hp
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
 cd $SRC_DIR
 

--- a/bin/run_celery_worker_log_parser
+++ b/bin/run_celery_worker_log_parser
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
 cd $SRC_DIR
 

--- a/bin/run_celery_worker_pushlog
+++ b/bin/run_celery_worker_pushlog
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
 cd $SRC_DIR
 

--- a/bin/run_celerybeat
+++ b/bin/run_celerybeat
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
 cd $SRC_DIR
 

--- a/bin/run_gunicorn
+++ b/bin/run_gunicorn
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 set -e
 
 SRC_DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")

--- a/deployment/supervisord/admin_node.conf
+++ b/deployment/supervisord/admin_node.conf
@@ -1,7 +1,3 @@
-; This Source Code Form is subject to the terms of the Mozilla Public
-; License, v. 2.0. If a copy of the MPL was not distributed with this
-; file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 [supervisord]
 http_port=/var/tmp/supervisor.sock ; (default is to run a UNIX domain socket server)
 loglevel=info               ; (logging level;default info; others: debug,warn)

--- a/deployment/supervisord/etl_node.conf
+++ b/deployment/supervisord/etl_node.conf
@@ -1,7 +1,3 @@
-; This Source Code Form is subject to the terms of the Mozilla Public
-; License, v. 2.0. If a copy of the MPL was not distributed with this
-; file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 [supervisord]
 http_port=/var/tmp/supervisor.sock ; (default is to run a UNIX domain socket server)
 loglevel=info               ; (logging level;default info; others: debug,warn)

--- a/deployment/supervisord/worker_node.conf
+++ b/deployment/supervisord/worker_node.conf
@@ -1,7 +1,3 @@
-; This Source Code Form is subject to the terms of the Mozilla Public
-; License, v. 2.0. If a copy of the MPL was not distributed with this
-; file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 [supervisord]
 http_port=/var/tmp/supervisor.sock ; (default is to run a UNIX domain socket server)
 loglevel=info               ; (logging level;default info; others: debug,warn)

--- a/deployment/update/commander_settings.py-example
+++ b/deployment/update/commander_settings.py-example
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # Example Commander configuration file for Chief deployment.
 # Copy to commander_settings.py & adjust as required.
 SRC_DIR = '/data/treeherder/src/treeherder.mozilla.org/'

--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 """
 Deploy this project in stage/production.
 

--- a/docker/etc/profile.d/treeherder.sh
+++ b/docker/etc/profile.d/treeherder.sh
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # Mapping is taken from docker link assumptions
 export TREEHERDER_DEBUG='1'
 export TREEHERDER_DJANGO_SECRET_KEY='5up3r53cr3t'

--- a/docker/generate_test_credentials.py
+++ b/docker/generate_test_credentials.py
@@ -1,9 +1,5 @@
 #! /usr/bin/env python
 
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # In many cases you want to hit treeherder services but it is difficult
 # particularly in tests if you don't know the oauth credentials. This file
 # rewrites the credentials for all projects so both user/pass are the same (the

--- a/docker/gunicorn.sh
+++ b/docker/gunicorn.sh
@@ -1,9 +1,5 @@
 #! /bin/bash -ex
 
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 source /etc/profile.d/treeherder.sh
 ./docker/generate_test_credentials.py
 

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,9 +1,5 @@
 #! /bin/bash -ex
 
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # Initialize the basics needed to run treeherder-service.
 
 source /etc/profile.d/treeherder.sh

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # -*- coding: utf-8 -*-
 #
 # treeherder documentation build configuration file, created by

--- a/fig.yml
+++ b/fig.yml
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 memcached:
   image: memcached:1.4
 

--- a/manage.py
+++ b/manage.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import os
 import sys
 

--- a/puppet/files/treeherder/local.vagrant.py
+++ b/puppet/files/treeherder/local.vagrant.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': True,

--- a/puppet/files/varnish/default.vcl
+++ b/puppet/files/varnish/default.vcl
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 # We use Varnish even for development, since gunicorn/runserver default to 127.0.0.1:8000,
 # and to be accessible from outside the VM we'd have to use 0.0.0.0. In addition, to serve
 # on port 80 we'd have to run gunicorn/runserver with sudo or use authbind.

--- a/puppet/manifests/classes/dev.pp
+++ b/puppet/manifests/classes/dev.pp
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 class dev{
   exec{"peep-install-dev":
     user => "${APP_USER}",

--- a/puppet/manifests/classes/init.pp
+++ b/puppet/manifests/classes/init.pp
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # Commands to run before all others in puppet.
 class init {
     group { "puppet":

--- a/puppet/manifests/classes/mysql.pp
+++ b/puppet/manifests/classes/mysql.pp
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # mysqldev and mysql service need to be parametrized
 # based on the OS
 $mysqldev = $operatingsystem ? {

--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # Install python and common packages for project
 
 $python_devel = $operatingsystem ? {

--- a/puppet/manifests/classes/rabbitmq.pp
+++ b/puppet/manifests/classes/rabbitmq.pp
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 class rabbitmq {
   package { "rabbitmq-server":
     ensure => installed;

--- a/puppet/manifests/classes/treeherder.pp
+++ b/puppet/manifests/classes/treeherder.pp
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 #any additional stuff goes here
 class treeherder {
     package{"memcached":

--- a/puppet/manifests/classes/utils.pp
+++ b/puppet/manifests/classes/utils.pp
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 define line($file, $line, $ensure = 'present') {
     case $ensure {
         default : { err ( "unknown ensure value ${ensure}" ) }

--- a/puppet/manifests/classes/varnish.pp
+++ b/puppet/manifests/classes/varnish.pp
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 $varnish_port_file = $operatingsystem ? {
   ubuntu => "/etc/default/varnish",
   default => "/etc/sysconfig/varnish",

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # Playdoh puppet magic for dev boxes
 import "classes/*.pp"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # HEROKU REQUIREMENTS
 
 -r requirements/common.txt

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # Packages that are shared between deployment and dev environments.
 
 # sha256: pRec3pItK04EXuWxHocyPud9NjrkApT8glLyXWoOrwY

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # Dependencies needed only for development/testing.
 
 # for the test suite and coverage metrics

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # Dependencies for building the documentation, intended to be used standalone
 # since doc generation does not need all of the requirements in common.txt.
 # These are intentionally not version-pinned & have implicit dependencies,

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 echo "Running flake8"
 flake8 || { echo "flake8 errors found!"; exit 1; }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 [pep8]
 exclude = .git,__pycache__,.vagrant,node_modules
 # E121,E123,E126,E226,E24,E704: Ignored in default pep8 config:

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from setuptools import setup
 
 setup(

--- a/tests/client/test_perfherder_client.py
+++ b/tests/client/test_perfherder_client.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import unittest
 
 from mock import patch

--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from __future__ import unicode_literals
 
 import json

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 import os
 import sys

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import os
 
 import pytest

--- a/tests/e2e/test_client_job_ingestion.py
+++ b/tests/e2e/test_client_job_ingestion.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 
 import pytest

--- a/tests/e2e/test_jobs_loaded.py
+++ b/tests/e2e/test_jobs_loaded.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from django.core.urlresolvers import reverse
 from webtest import TestApp
 

--- a/tests/etl/test_bugzilla.py
+++ b/tests/etl/test_bugzilla.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 import os
 

--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 import os
 

--- a/tests/etl/test_buildbot.py
+++ b/tests/etl/test_buildbot.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import pytest
 
 from treeherder.etl import buildbot

--- a/tests/etl/test_classification_mirroring.py
+++ b/tests/etl/test_classification_mirroring.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 from time import time
 

--- a/tests/etl/test_common.py
+++ b/tests/etl/test_common.py
@@ -1,8 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
-
 from django.conf import settings
 
 

--- a/tests/etl/test_perf_data_adapters.py
+++ b/tests/etl/test_perf_data_adapters.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 import zlib
 

--- a/tests/etl/test_pushlog.py
+++ b/tests/etl/test_pushlog.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 import os
 

--- a/tests/log_parser/conftest.py
+++ b/tests/log_parser/conftest.py
@@ -1,3 +1,0 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tests/log_parser/test_artifact_builder_collection.py
+++ b/tests/log_parser/test_artifact_builder_collection.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from datadiff import diff
 
 from treeherder.log_parser.artifactbuildercollection import ArtifactBuilderCollection

--- a/tests/log_parser/test_error_parser.py
+++ b/tests/log_parser/test_error_parser.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import pytest
 
 from treeherder.log_parser.parsers import ErrorParser

--- a/tests/log_parser/test_job_artifact_builder.py
+++ b/tests/log_parser/test_job_artifact_builder.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from tests import test_utils
 from treeherder.log_parser.artifactbuildercollection import ArtifactBuilderCollection
 from treeherder.log_parser.artifactbuilders import BuildbotJobArtifactBuilder

--- a/tests/log_parser/test_log_view_artifact_builder.py
+++ b/tests/log_parser/test_log_view_artifact_builder.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import pytest
 
 from tests import test_utils

--- a/tests/log_parser/test_performance_artifact_builder.py
+++ b/tests/log_parser/test_performance_artifact_builder.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from jsonschema import validate
 
 from treeherder.etl.perf_data_adapters import TalosDataAdapter

--- a/tests/log_parser/test_performance_log_parser.py
+++ b/tests/log_parser/test_performance_log_parser.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import pytest
 
 from treeherder.log_parser.parsers import TalosParser

--- a/tests/log_parser/test_step_parser.py
+++ b/tests/log_parser/test_step_parser.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from datetime import datetime
 
 from treeherder.log_parser.parsers import StepParser

--- a/tests/log_parser/test_tasks.py
+++ b/tests/log_parser/test_tasks.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import gzip
 import urllib2
 import zlib

--- a/tests/log_parser/test_tinderbox_print_parser.py
+++ b/tests/log_parser/test_tinderbox_print_parser.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import pytest
 
 from treeherder.log_parser.parsers import TinderboxPrintParser

--- a/tests/model/commands/test_init_datasource.py
+++ b/tests/model/commands/test_init_datasource.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import pytest
 from django.core.management import call_command
 

--- a/tests/model/derived/conftest.py
+++ b/tests/model/derived/conftest.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import pytest
 
 

--- a/tests/model/derived/sample_data_generator.py
+++ b/tests/model/derived/sample_data_generator.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 """
 Functions for flexible generation of sample input job JSON.
 

--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import copy
 import json
 import threading

--- a/tests/model/derived/test_refdata.py
+++ b/tests/model/derived/test_refdata.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 import os
 import time

--- a/tests/model/sql/test_models.py
+++ b/tests/model/sql/test_models.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from contextlib import contextmanager
 
 

--- a/tests/model/test_error_summary.py
+++ b/tests/model/test_error_summary.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import pytest
 
 from treeherder.model.error_summary import (get_crash_signature,

--- a/tests/perfalert/test_analyze.py
+++ b/tests/perfalert/test_analyze.py
@@ -1,6 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this file,
-# You can obtain one at http://mozilla.org/MPL/2.0/.
 import os
 import unittest
 

--- a/tests/sample_data_generator.py
+++ b/tests/sample_data_generator.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 """
 Functions for flexible generation of sample input job JSON.
 

--- a/tests/sampledata.py
+++ b/tests/sampledata.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 import os
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import MySQLdb
 import pytest
 from celery import current_app

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 
 from requests import Request

--- a/tests/ui/config/karma-e2e.conf.js
+++ b/tests/ui/config/karma-e2e.conf.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 module.exports = function (config) {
     config.set({
         frameworks: ['ng-scenario'],

--- a/tests/ui/config/karma.conf.js
+++ b/tests/ui/config/karma.conf.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 // NOTE:  IF TESTS WON'T RUN

--- a/tests/ui/e2e/scenarios.js
+++ b/tests/ui/e2e/scenarios.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 /* http://docs.angularjs.org/guide/dev_guide.e2e-testing */

--- a/tests/ui/unit/controllers/jobs.tests.js
+++ b/tests/ui/unit/controllers/jobs.tests.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 /* jasmine specs for controllers go here */

--- a/tests/ui/unit/controllersSpec.js
+++ b/tests/ui/unit/controllersSpec.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 /* jasmine specs for controllers go here */

--- a/tests/ui/unit/directivesSpec.js
+++ b/tests/ui/unit/directivesSpec.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 /* jasmine specs for directives go here */

--- a/tests/ui/unit/filtersSpec.js
+++ b/tests/ui/unit/filtersSpec.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 /* jasmine specs for filters go here */

--- a/tests/ui/unit/models/resultsets.tests.js
+++ b/tests/ui/unit/models/resultsets.tests.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 describe('ThResultSetStore', function(){

--- a/tests/ui/unit/servicesSpec.js
+++ b/tests/ui/unit/servicesSpec.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 /* jasmine specs for services go here */

--- a/tests/webapp/api/test_artifact_api.py
+++ b/tests/webapp/api/test_artifact_api.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 
 import pytest

--- a/tests/webapp/api/test_bug_job_map_api.py
+++ b/tests/webapp/api/test_bug_job_map_api.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 import random
 from time import time

--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 
 from django.contrib.auth.models import User

--- a/tests/webapp/api/test_note_api.py
+++ b/tests/webapp/api/test_note_api.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 
 from django.contrib.auth.models import User

--- a/tests/webapp/api/test_project_api.py
+++ b/tests/webapp/api/test_project_api.py
@@ -1,8 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
-
 def test_project_endpoint(webapp, eleven_jobs_stored, jm):
     """
     tests the project endpoint

--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 
 from django.contrib.auth.models import User

--- a/tests/webapp/api/test_utils.py
+++ b/tests/webapp/api/test_utils.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from treeherder.webapp.api.utils import UrlQueryFilter
 
 

--- a/tests/webapp/conftest.py
+++ b/tests/webapp/conftest.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 
 import pytest

--- a/treeherder/__init__.py
+++ b/treeherder/__init__.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import os
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.

--- a/treeherder/cache.py
+++ b/treeherder/cache.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from django.core.cache.backends import memcached
 
 

--- a/treeherder/celery.py
+++ b/treeherder/celery.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from __future__ import absolute_import
 
 import os

--- a/treeherder/client/setup.py
+++ b/treeherder/client/setup.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 import io
 import os
 import re

--- a/treeherder/client/thclient/__init__.py
+++ b/treeherder/client/thclient/__init__.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 from .client import *
 from .perfherder import *
 from .auth import *

--- a/treeherder/client/thclient/auth.py
+++ b/treeherder/client/thclient/auth.py
@@ -1,6 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import logging
 import time
 

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 from __future__ import unicode_literals
 
 import json

--- a/treeherder/client/thclient/perfherder.py
+++ b/treeherder/client/thclient/perfherder.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 from .client import TreeherderClient, TreeherderClientError
 
 

--- a/treeherder/embed/urls.py
+++ b/treeherder/embed/urls.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from django.conf.urls import patterns, url
 
 from .views import ResultsetStatusView

--- a/treeherder/embed/views.py
+++ b/treeherder/embed/views.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from django.http import Http404
 from django.views.generic.base import TemplateView
 

--- a/treeherder/etl/bugzilla.py
+++ b/treeherder/etl/bugzilla.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from urllib import urlencode
 
 from django.conf import settings

--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import logging
 from collections import defaultdict
 

--- a/treeherder/etl/buildbot.py
+++ b/treeherder/etl/buildbot.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import re
 
 RESULT_DICT = {

--- a/treeherder/etl/classification_mirroring.py
+++ b/treeherder/etl/classification_mirroring.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import logging
 from datetime import datetime
 

--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import hashlib
 import time
 

--- a/treeherder/etl/management/commands/export_project_credentials.py
+++ b/treeherder/etl/management/commands/export_project_credentials.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import os
 from optparse import make_option
 

--- a/treeherder/etl/management/commands/import_project_credentials.py
+++ b/treeherder/etl/management/commands/import_project_credentials.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import os
 
 import simplejson as json

--- a/treeherder/etl/management/commands/ingest_push.py
+++ b/treeherder/etl/management/commands/ingest_push.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from cProfile import Profile
 from optparse import make_option
 

--- a/treeherder/etl/management/commands/test_parse_log.py
+++ b/treeherder/etl/management/commands/test_parse_log.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import time
 from optparse import make_option
 

--- a/treeherder/etl/mixins.py
+++ b/treeherder/etl/mixins.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import gzip
 import logging
 import urllib2

--- a/treeherder/etl/oauth_utils.py
+++ b/treeherder/etl/oauth_utils.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import copy
 import logging
 import os

--- a/treeherder/etl/perf_data_adapters.py
+++ b/treeherder/etl/perf_data_adapters.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import logging
 import math
 import zlib

--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import logging
 
 import requests

--- a/treeherder/etl/tasks/buildapi_tasks.py
+++ b/treeherder/etl/tasks/buildapi_tasks.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 """
 This module contains
 """

--- a/treeherder/etl/tasks/classification_mirroring_tasks.py
+++ b/treeherder/etl/tasks/classification_mirroring_tasks.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from celery import task
 
 from treeherder.etl.classification_mirroring import BugzillaCommentRequest, ElasticsearchDocRequest

--- a/treeherder/etl/tasks/cleanup_tasks.py
+++ b/treeherder/etl/tasks/cleanup_tasks.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import logging
 import urllib
 

--- a/treeherder/etl/tasks/tasks.py
+++ b/treeherder/etl/tasks/tasks.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 """
 This module contains
 """

--- a/treeherder/etl/th_publisher.py
+++ b/treeherder/etl/th_publisher.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import logging
 import traceback
 

--- a/treeherder/events/publisher.py
+++ b/treeherder/events/publisher.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import logging
 
 from kombu import Connection, Exchange, Producer

--- a/treeherder/log_parser/artifactbuildercollection.py
+++ b/treeherder/log_parser/artifactbuildercollection.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import io
 import urllib2
 import zlib

--- a/treeherder/log_parser/artifactbuilders.py
+++ b/treeherder/log_parser/artifactbuilders.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import logging
 from contextlib import closing
 

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import datetime
 import json
 import re

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -1,8 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
-
 import logging
 
 from celery import task

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import logging
 import urllib2
 

--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import logging
 import zlib
 

--- a/treeherder/model/derived/base.py
+++ b/treeherder/model/derived/base.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 """
 ``TreeHerderModelBase`` (and subclasses) are the public interface for all data
 access.

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import logging
 import time
 import zlib

--- a/treeherder/model/derived/refdata.py
+++ b/treeherder/model/derived/refdata.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import logging
 import os
 import time

--- a/treeherder/model/error_summary.py
+++ b/treeherder/model/error_summary.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 import logging
 import re

--- a/treeherder/model/exchanges.py
+++ b/treeherder/model/exchanges.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from treeherder.model.pulse_publisher import Exchange, Key, PulsePublisher
 
 

--- a/treeherder/model/management/commands/calculate_eta.py
+++ b/treeherder/model/management/commands/calculate_eta.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from optparse import make_option
 
 from django.core.management.base import BaseCommand

--- a/treeherder/model/management/commands/clear_cache.py
+++ b/treeherder/model/management/commands/clear_cache.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from django.core.cache import cache
 from django.core.management.base import BaseCommand
 

--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import datetime
 from optparse import make_option
 

--- a/treeherder/model/management/commands/import_perf_data.py
+++ b/treeherder/model/management/commands/import_perf_data.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from optparse import make_option
 from urlparse import urlparse
 

--- a/treeherder/model/management/commands/init_datasources.py
+++ b/treeherder/model/management/commands/init_datasources.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from optparse import make_option
 
 from django.core.management.base import BaseCommand

--- a/treeherder/model/management/commands/init_master_db.py
+++ b/treeherder/model/management/commands/init_master_db.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import os
 from optparse import make_option
 

--- a/treeherder/model/management/commands/load_initial_data.py
+++ b/treeherder/model/management/commands/load_initial_data.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 

--- a/treeherder/model/management/commands/populate_performance_series.py
+++ b/treeherder/model/management/commands/populate_performance_series.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import sys
 from optparse import make_option
 

--- a/treeherder/model/management/commands/publish_result_set_to_pulse.py
+++ b/treeherder/model/management/commands/publish_result_set_to_pulse.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from optparse import make_option
 
 from django.core.management.base import BaseCommand

--- a/treeherder/model/management/commands/rewrite_perf_data.py
+++ b/treeherder/model/management/commands/rewrite_perf_data.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import copy
 from optparse import make_option
 

--- a/treeherder/model/management/commands/run_sql.py
+++ b/treeherder/model/management/commands/run_sql.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from optparse import make_option
 
 import MySQLdb

--- a/treeherder/model/management/commands/test_analyze_perf.py
+++ b/treeherder/model/management/commands/test_analyze_perf.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this file,
-# You can obtain one at http://mozilla.org/MPL/2.0/.
-
 from optparse import make_option
 from urlparse import urlparse
 

--- a/treeherder/model/migrations/0001_initial.py
+++ b/treeherder/model/migrations/0001_initial.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from __future__ import unicode_literals
 
 import os

--- a/treeherder/model/pulse_publisher.py
+++ b/treeherder/model/pulse_publisher.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import json
 import logging
 import os

--- a/treeherder/model/sql/template_schema/project.sql.tmpl
+++ b/treeherder/model/sql/template_schema/project.sql.tmpl
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 --
 -- Host: localhost    Database: project
 -- ------------------------------------------------------

--- a/treeherder/model/sql/template_schema/treeherder.sql.tmpl
+++ b/treeherder/model/sql/template_schema/treeherder.sql.tmpl
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 --
 -- Host: localhost    Database: treeherder
 -- ------------------------------------------------------

--- a/treeherder/model/sql/template_schema/treeherder_reference_1.sql.tmpl
+++ b/treeherder/model/sql/template_schema/treeherder_reference_1.sql.tmpl
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 --
 -- Host: localhost    Database: treeherder_reference_1
 -- ------------------------------------------------------

--- a/treeherder/model/tasks.py
+++ b/treeherder/model/tasks.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import os
 
 from celery import task

--- a/treeherder/model/utils.py
+++ b/treeherder/model/utils.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import random
 import time
 import zlib

--- a/treeherder/perfalert/__init__.py
+++ b/treeherder/perfalert/__init__.py
@@ -1,5 +1,1 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this file,
-# You can obtain one at http://mozilla.org/MPL/2.0/.
-
 from perfalert import *

--- a/treeherder/perfalert/perfalert/__init__.py
+++ b/treeherder/perfalert/perfalert/__init__.py
@@ -1,8 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this file,
-# You can obtain one at http://mozilla.org/MPL/2.0/.
-
-
 def analyze(data, weight_fn=None):
     """Returns the average and sample variance (s**2) of a list of floats.
 

--- a/treeherder/perfalert/setup.py
+++ b/treeherder/perfalert/setup.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 from setuptools import setup
 
 version = '0.1'

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # Django settings for webapp project.
 import os
 from datetime import timedelta

--- a/treeherder/settings/local.sample.py
+++ b/treeherder/settings/local.sample.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import os
 
 # Applications useful for development, e.g. debug_toolbar, django_extensions.

--- a/treeherder/webapp/admin.py
+++ b/treeherder/webapp/admin.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from django.contrib import admin
 from django_browserid.admin import site as browserid_admin
 

--- a/treeherder/webapp/api/artifact.py
+++ b/treeherder/webapp/api/artifact.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from rest_framework import viewsets
 from rest_framework.response import Response
 

--- a/treeherder/webapp/api/auth.py
+++ b/treeherder/webapp/api/auth.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import oauth2 as oauth
 from django.conf import settings
 from rest_framework import exceptions

--- a/treeherder/webapp/api/bug.py
+++ b/treeherder/webapp/api/bug.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from time import time
 
 from rest_framework import viewsets

--- a/treeherder/webapp/api/exceptions.py
+++ b/treeherder/webapp/api/exceptions.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import logging
 
 from django.conf import settings

--- a/treeherder/webapp/api/job_log_url.py
+++ b/treeherder/webapp/api/job_log_url.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import logging
 
 from rest_framework import viewsets

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -1,6 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
 from rest_framework import viewsets
 from rest_framework.decorators import detail_route, list_route
 from rest_framework.permissions import IsAuthenticated

--- a/treeherder/webapp/api/logslice.py
+++ b/treeherder/webapp/api/logslice.py
@@ -1,6 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
 import gzip
 import json
 import urllib2

--- a/treeherder/webapp/api/note.py
+++ b/treeherder/webapp/api/note.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from rest_framework import viewsets
 from rest_framework.exceptions import ParseError
 from rest_framework.permissions import IsAuthenticatedOrReadOnly

--- a/treeherder/webapp/api/performance_artifact.py
+++ b/treeherder/webapp/api/performance_artifact.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from rest_framework import viewsets
 from rest_framework.response import Response
 

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from django.core.cache import cache
 from rest_framework import viewsets
 from rest_framework.decorators import list_route

--- a/treeherder/webapp/api/permissions.py
+++ b/treeherder/webapp/api/permissions.py
@@ -1,6 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
 from rest_framework import permissions
 
 

--- a/treeherder/webapp/api/projects.py
+++ b/treeherder/webapp/api/projects.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import simplejson as json
 from django.http import HttpResponse, HttpResponseNotFound
 

--- a/treeherder/webapp/api/refdata.py
+++ b/treeherder/webapp/api/refdata.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from django.contrib.auth.models import User
 from rest_framework import viewsets
 from rest_framework.response import Response

--- a/treeherder/webapp/api/resultset.py
+++ b/treeherder/webapp/api/resultset.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from rest_framework import viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.exceptions import ParseError

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -1,6 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
 from django.contrib.auth.models import User
 from rest_framework import serializers
 

--- a/treeherder/webapp/api/throttling.py
+++ b/treeherder/webapp/api/throttling.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from rest_framework import throttling
 
 

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from django.conf.urls import include, patterns, url
 from rest_framework import routers
 

--- a/treeherder/webapp/api/utils.py
+++ b/treeherder/webapp/api/utils.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import datetime
 import functools
 import time

--- a/treeherder/webapp/urls.py
+++ b/treeherder/webapp/urls.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from django.conf.urls import include, patterns, url
 from django.contrib import admin
 from django_browserid.admin import site as browserid_admin

--- a/treeherder/webapp/whitenoise_custom.py
+++ b/treeherder/webapp/whitenoise_custom.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 import re
 
 from whitenoise.django import DjangoWhiteNoise

--- a/treeherder/webapp/wsgi.py
+++ b/treeherder/webapp/wsgi.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 """
 WSGI config for webapp project.
 

--- a/treeherder/workers/management/commands/shutdown_workers.py
+++ b/treeherder/workers/management/commands/shutdown_workers.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from celery.task.control import broadcast
 from django.core.management.base import BaseCommand
 

--- a/treeherder/workers/models.py
+++ b/treeherder/workers/models.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 from django.db import models  # noqa
 
 # Create your models here.

--- a/treeherder/workers/tests.py
+++ b/treeherder/workers/tests.py
@@ -1,7 +1,3 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 """
 This file demonstrates writing tests using the unittest module. These will pass
 when you run "manage.py test".

--- a/treeherder/workers/views.py
+++ b/treeherder/workers/views.py
@@ -1,5 +1,1 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
 # Create your views here.

--- a/ui/css/logviewer.css
+++ b/ui/css/logviewer.css
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 body {
     position: fixed;
     top: 0;

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 .blink {
 animation: blink 1s ease-in-out infinite alternate;
 -webkit-animation: blink 1s ease-in-out infinite alternate;

--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 html, body {
     height: 100%;
     overflow: hidden;

--- a/ui/js/compareperf.js
+++ b/ui/js/compareperf.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 perf.controller('CompareChooserCtrl', [

--- a/ui/js/config/sample.local.conf.js
+++ b/ui/js/config/sample.local.conf.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 /* window.thServiceDomain holds a reference to a back-end service

--- a/ui/js/controllers/filters.js
+++ b/ui/js/controllers/filters.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 treeherderApp.controller('FilterPanelCtrl', [

--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 treeherderApp.controller('JobsCtrl', [

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 logViewerApp.controller('LogviewerCtrl', [

--- a/ui/js/controllers/machines.js
+++ b/ui/js/controllers/machines.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 treeherderApp.controller('MachinesCtrl', [

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 treeherderApp.controller('MainCtrl', [

--- a/ui/js/controllers/repository.js
+++ b/ui/js/controllers/repository.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 treeherderApp.controller('RepositoryMenuCtrl', [

--- a/ui/js/controllers/settings.js
+++ b/ui/js/controllers/settings.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 treeherderApp.controller('SettingsCtrl', [
     '$scope', '$log',

--- a/ui/js/controllers/sheriff.js
+++ b/ui/js/controllers/sheriff.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 treeherderApp.controller('SheriffCtrl', [
     '$scope', '$rootScope', 'ThBuildPlatformModel', 'ThJobTypeModel',

--- a/ui/js/controllers/timeline.js
+++ b/ui/js/controllers/timeline.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 treeherderApp.controller('TimelineCtrl', [

--- a/ui/js/directives/perf/compare.js
+++ b/ui/js/directives/perf/compare.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.directive(

--- a/ui/js/directives/treeherder/bottom_nav_panel.js
+++ b/ui/js/directives/treeherder/bottom_nav_panel.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 /* Directives */

--- a/ui/js/directives/treeherder/log_viewer_infinite_scroll.js
+++ b/ui/js/directives/treeherder/log_viewer_infinite_scroll.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.directive('lvInfiniteScroll', ['$timeout', '$parse', function ($timeout, $parse) {

--- a/ui/js/directives/treeherder/log_viewer_lines.js
+++ b/ui/js/directives/treeherder/log_viewer_lines.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.directive('lvLogLines', ['$timeout', '$parse', function ($timeout) {

--- a/ui/js/directives/treeherder/log_viewer_steps.js
+++ b/ui/js/directives/treeherder/log_viewer_steps.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.directive('lvLogSteps', ['$timeout', '$q', function ($timeout, $q) {

--- a/ui/js/directives/treeherder/main.js
+++ b/ui/js/directives/treeherder/main.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.directive('ngRightClick', [

--- a/ui/js/directives/treeherder/persona.js
+++ b/ui/js/directives/treeherder/persona.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.directive('personaButtons', [

--- a/ui/js/directives/treeherder/resultsets.js
+++ b/ui/js/directives/treeherder/resultsets.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.directive('thActionButton', [

--- a/ui/js/directives/treeherder/top_nav_bar.js
+++ b/ui/js/directives/treeherder/top_nav_bar.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.directive('thFilterCheckbox', [

--- a/ui/js/filters.js
+++ b/ui/js/filters.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 /* Filters */

--- a/ui/js/graphs.js
+++ b/ui/js/graphs.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 perf.controller('GraphsCtrl', [

--- a/ui/js/logviewer.js
+++ b/ui/js/logviewer.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 var logViewerApp = angular.module('logviewer', ['treeherder']);

--- a/ui/js/models/bug_job_map.js
+++ b/ui/js/models/bug_job_map.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThBugJobMapModel', [

--- a/ui/js/models/build_platform.js
+++ b/ui/js/models/build_platform.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThBuildPlatformModel', [

--- a/ui/js/models/classification.js
+++ b/ui/js/models/classification.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThJobClassificationModel', [

--- a/ui/js/models/error.js
+++ b/ui/js/models/error.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 /**

--- a/ui/js/models/exclusion_profile.js
+++ b/ui/js/models/exclusion_profile.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThExclusionProfileModel', [

--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThJobModel', [

--- a/ui/js/models/job_artifact.js
+++ b/ui/js/models/job_artifact.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThJobArtifactModel', [

--- a/ui/js/models/job_exclusion.js
+++ b/ui/js/models/job_exclusion.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThJobExclusionModel', [

--- a/ui/js/models/job_group.js
+++ b/ui/js/models/job_group.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThJobGroupModel', [

--- a/ui/js/models/job_log_url.js
+++ b/ui/js/models/job_log_url.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThJobLogUrlModel', [

--- a/ui/js/models/job_type.js
+++ b/ui/js/models/job_type.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThJobTypeModel', [

--- a/ui/js/models/log_slice.js
+++ b/ui/js/models/log_slice.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThLogSliceModel', [

--- a/ui/js/models/option_collection.js
+++ b/ui/js/models/option_collection.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThOptionCollectionModel', [

--- a/ui/js/models/repository.js
+++ b/ui/js/models/repository.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThRepositoryModel', [

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory(

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThResultSetStore', [

--- a/ui/js/models/user.js
+++ b/ui/js/models/user.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThUserModel', [

--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 var perf = angular.module("perf", ['ui.router', 'ui.bootstrap', 'treeherder']);

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 perf.config(function($compileProvider, $stateProvider, $urlRouterProvider) {

--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 treeherder.provider('thServiceDomain', function() {

--- a/ui/js/services/buildapi.js
+++ b/ui/js/services/buildapi.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('thBuildApi', [

--- a/ui/js/services/classifications.js
+++ b/ui/js/services/classifications.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('thClassificationTypes', [

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 /**

--- a/ui/js/services/log.js
+++ b/ui/js/services/log.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('ThLog', [

--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 /* Services */

--- a/ui/js/services/pinboard.js
+++ b/ui/js/services/pinboard.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('thPinboard', [

--- a/ui/js/services/treestatus.js
+++ b/ui/js/services/treestatus.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('treeStatus', [

--- a/ui/js/treeherder.js
+++ b/ui/js/treeherder.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 var treeherder = angular.module('treeherder',

--- a/ui/js/treeherder_app.js
+++ b/ui/js/treeherder_app.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 var treeherderApp = angular.module('treeherder.app',

--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.value("thPlatformNameMap", {

--- a/ui/plugins/annotations/controller.js
+++ b/ui/plugins/annotations/controller.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 treeherder.controller('AnnotationsPluginCtrl', [

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 treeherder.controller('PluginCtrl', [

--- a/ui/plugins/failure_summary/controller.js
+++ b/ui/plugins/failure_summary/controller.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 treeherder.controller('BugsPluginCtrl', [

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 treeherder.controller('PinboardCtrl', [

--- a/ui/plugins/similar_jobs/controller.js
+++ b/ui/plugins/similar_jobs/controller.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 treeherder.controller('SimilarJobsPluginCtrl', [

--- a/ui/plugins/tabs.js
+++ b/ui/plugins/tabs.js
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
-
 'use strict';
 
 treeherder.factory('thTabs', [


### PR DESCRIPTION
The MPL 2.0 terms state that as long as a LICENSE file is present, the per-file header text is not required. See "Exhibit A" at the end of https://www.mozilla.org/MPL/2.0/

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/850)
<!-- Reviewable:end -->
