### PR TITLE
Bug 1191602 - Docs: Clarify which commands should be run inside the VM

### DIFF
--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -17,7 +17,7 @@ In order to make the various services aware of a change in the code you need to 
 Running the tests
 -----------------
 
-* You can run flake8 and the py.test suite using
+* You can run flake8 and the py.test suite inside the Vagrant instance, using
 
   .. code-block:: bash
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -73,7 +73,7 @@ Setting up a local Treeherder instance
 Viewing the local server
 ------------------------
 
-* Start a gunicorn instance, to serve the static UI and API requests:
+* Start a gunicorn instance inside the Vagrant instance, to serve the static UI and API requests:
 
   .. code-block:: bash
 


### PR DESCRIPTION
The shell prompts for each command example already mention vagrant, but this can still be missed, so make the distinction extra clear.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/852)
<!-- Reviewable:end -->
