### PR TITLE
Bug 1178300 - Add Windows-specific setup help & clean up troubleshooting section

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,6 +7,7 @@ Prerequisites
 * If you are new to Mozilla or the A-Team, read the `A-Team Bootcamp`_.
 * Install Git_, Virtualbox_ and Vagrant_ 1.5+ (recent versions recommended).
 * Clone the `treeherder repo`_ from Github.
+* Windows only: Ensure MSYS ssh (ships with Git for Windows) is on the PATH, so Vagrant can find it (using PuTTY is more hassle).
 
 Setting up Vagrant
 ------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,15 +1,15 @@
 Installation
 ================
 
-Cloning the Repo
-----------------
+Prerequisites
+-------------
 
+* If you are new to Mozilla or the A-Team, read the `A-Team Bootcamp`_.
+* Install Git_, Virtualbox_ and Vagrant_ 1.5+ (recent versions recommended).
 * Clone the `treeherder repo`_ from Github.
 
 Setting up Vagrant
 ------------------
-
-* Install Virtualbox_ and Vagrant_ 1.5+ if not present (recent versions of both is strongly recommended).
 
 * Open a shell, cd into the root of the project you just cloned and type
 
@@ -112,6 +112,9 @@ to enable the beat service for this though, so you can omit the "-B":
 
      (venv)vagrant@local:~/treeherder$ celery -A treeherder worker
 
-.. _treeherder repo: https://github.com/mozilla/treeherder
+
+.. _A-Team Bootcamp: https://ateam-bootcamp.readthedocs.org
+.. _Git: https://git-scm.com
 .. _Vagrant: https://www.vagrantup.com
 .. _Virtualbox: https://www.virtualbox.org
+.. _treeherder repo: https://github.com/mozilla/treeherder

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,36 +17,7 @@ Setting up Vagrant
 
      >vagrant up
 
-  **Troubleshooting**: The Vagrant provisioning process during ``vagrant up`` assumes the presence of a stable internet connection. In the event of a connection interruption during provision, you may see errors similar to *"Temporary failure resolving.."* or *"E: Unable to fetch some archives.."* after the process has completed. In that situation, you can attempt to re-provision using the command:
-
-  .. code-block:: bash
-
-     >vagrant provision
-
-  If that is still unsuccessful, you should attempt a ``vagrant destroy`` followed by another ``vagrant up``.
-
-  **Troubleshooting**: If you encounter an error saying *"It appears your machine doesn't support NFS, or there is not an adapter to enable NFS on this machine for Vagrant."*, then you need to install ``nfs-kernel-server`` using the command:
-
-  .. code-block:: bash
-
-    apt-get install nfs-kernel-server
-
-  **Troubleshooting**: If you encounter an error saying *"mount.nfs: requested NFS version or transport protocol is not supported"*, you should restart the kernel server service using this sequence of commands:
-
-  .. code-block:: bash
-
-    systemctl stop nfs-kernel-server.service
-    systemctl disable nfs-kernel-server.service
-    systemctl enable nfs-kernel-server.service
-    systemctl start nfs-kernel-server.service
-
-  **Troubleshooting**: If you encounter an error saying *"The guest machine entered an invalid state while waiting for it to boot. Valid states are 'starting, running'. The machine is in the 'poweroff' state. Please verify everything is configured properly and try again."* you should should check your host machine's virtualization technology (vt-x) is enabled in the BIOS (see this guide_), then continue with ``vagrant up``.
-
-  .. _guide: http://www.sysprobs.com/disable-enable-virtualization-technology-bios
-
-  For the full list of available Vagrant commands, please see their command line documentation_.
-
-  .. _documentation: http://docs.vagrantup.com/v2/cli/
+  If you experience any errors, see the :ref:`troubleshooting page <troubleshooting-vagrant>`.
 
 * It will typically take 5 to 30 minutes for the vagrant up to complete, depending on your network performance.
 
@@ -57,6 +28,10 @@ Setting up Vagrant
      >vagrant ssh
 
   A python virtual environment will be activated on login, and the working directory will be the treeherder source directory shared from the host machine.
+
+  For the full list of available Vagrant commands, please see their command line documentation_.
+
+  .. _documentation: http://docs.vagrantup.com/v2/cli/
 
 * If you just wish to :ref:`run the tests <running-tests>`, you can stop now without performing the remaining steps below.
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,6 +1,38 @@
 Troubleshooting
 ===============
 
+.. _troubleshooting-vagrant:
+
+Errors during Vagrant setup
+---------------------------
+
+* The Vagrant provisioning process during ``vagrant up`` assumes the presence of a stable internet connection. In the event of a connection interruption during provision, you may see errors similar to *"Temporary failure resolving.."* or *"E: Unable to fetch some archives.."* after the process has completed. In that situation, you can attempt to re-provision using the command:
+
+  .. code-block:: bash
+
+     >vagrant provision
+
+  If that is still unsuccessful, you should attempt a ``vagrant destroy`` followed by another ``vagrant up``.
+
+* If you encounter an error saying *"It appears your machine doesn't support NFS, or there is not an adapter to enable NFS on this machine for Vagrant."*, then you need to install ``nfs-kernel-server`` using the command:
+
+  .. code-block:: bash
+
+    apt-get install nfs-kernel-server
+
+* If you encounter an error saying *"mount.nfs: requested NFS version or transport protocol is not supported"*, you should restart the kernel server service using this sequence of commands:
+
+  .. code-block:: bash
+
+    systemctl stop nfs-kernel-server.service
+    systemctl disable nfs-kernel-server.service
+    systemctl enable nfs-kernel-server.service
+    systemctl start nfs-kernel-server.service
+
+* If you encounter an error saying *"The guest machine entered an invalid state while waiting for it to boot. Valid states are 'starting, running'. The machine is in the 'poweroff' state. Please verify everything is configured properly and try again."* you should should check your host machine's virtualization technology (vt-x) is enabled in the BIOS (see this guide_), then continue with ``vagrant up``.
+
+  .. _guide: http://www.sysprobs.com/disable-enable-virtualization-technology-bios
+
 Using supervisord for development
 ---------------------------------
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -33,6 +33,14 @@ Errors during Vagrant setup
 
   .. _guide: http://www.sysprobs.com/disable-enable-virtualization-technology-bios
 
+* On Windows, if upon running ``vagrant ssh`` you see the error *"/home/vagrant/.bash_aliases: line 1: syntax error near unexpected token `$'{\r''"* - it means your global Git line endings configuration is not correct. On the host machine run:
+
+  .. code-block:: bash
+
+    git config --global core.autocrlf input
+
+  You will then need to delete and reclone the repo (or else do a force checkout).
+
 Using supervisord for development
 ---------------------------------
 


### PR DESCRIPTION
* Move Vagrant troubleshooting steps to their own page - since most people will not require them, and the list is growing quite large.
* Add a prerequisites section which links to Bootcamp. Also mention the need for Git to be installed & link to Git website.
* Add Windows-specific setup help. Fixes #684.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/854)
<!-- Reviewable:end -->
