### PR TITLE
Bug 1191080 - Initialise the New Relic agent correctly

### DIFF
--- a/treeherder/webapp/wsgi.py
+++ b/treeherder/webapp/wsgi.py
@@ -17,6 +17,14 @@ middleware here, or combine a Django application with an application of another
 framework.
 
 """
+try:
+    import newrelic.agent
+except ImportError:
+    newrelic = False
+
+if newrelic:
+    newrelic.agent.initialize()
+
 import os
 
 # We defer to a DJANGO_SETTINGS_MODULE already in the environment. This breaks
@@ -27,14 +35,6 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "treeherder.settings")
 
 from django.core.wsgi import get_wsgi_application
 from treeherder.webapp.whitenoise_custom import CustomWhiteNoise
-
-try:
-    import newrelic.agent
-except ImportError:
-    newrelic = False
-
-if newrelic:
-    newrelic.agent.initialize()
 
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
@@ -48,7 +48,7 @@ application = get_wsgi_application()
 application = CustomWhiteNoise(application)
 
 if newrelic:
-    application = newrelic.agent.wsgi_application()(application)
+    application = newrelic.agent.WSGIApplicationWrapper(application)
 
 # Fix django closing connection to MemCachier after every request:
 # https://code.djangoproject.com/ticket/11331


### PR DESCRIPTION
The agent is supposed to be initialised before any other imports. In addition, we're supposed to use WSGIApplicationWrapper() if we're not using it as a decorator.

This unfortunately doesn't fix bug 1191080 itself, or answer the question of whether we should instead be using the wrapper scripts (which incidentally don't fix the bug either), but if we're going to initialise the agent manually, then at least let's do it the way the docs recommend.

See:
https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/python-agent-integration#wsgi-application
https://docs.newrelic.com/docs/agents/python-agent/customization-extension/python-instrumentation-api#WSGIApplicationWrapper

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/857)
<!-- Reviewable:end -->
