### PR TITLE
Bug 1169944 - Always install the New Relic package, not just on prod

### DIFF
--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -56,7 +56,7 @@ def update(ctx):
         execfile(activate_script, dict(__file__=activate_script))
         # Install requirements using peep, so hashes are verified.
         with ctx.lcd(th_service_src):
-            ctx.local('python2.7 bin/peep.py install -r requirements/common.txt -r requirements/prod.txt')
+            ctx.local('python2.7 bin/peep.py install -r requirements/common.txt')
         # Make the virtualenv relocatable since paths are hard-coded by default.
         ctx.local('virtualenv --relocatable venv')
         # Fix lib64 symlink to be relative instead of absolute.

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -38,6 +38,7 @@ export DATABASE_URL='mysql://${DB_USER}:${DB_PASS}@localhost/treeherder'
 export DATABASE_URL_RO='mysql://${DB_USER}:${DB_PASS}@localhost/treeherder'
 export TREEHERDER_DEBUG='1'
 export TREEHERDER_DJANGO_SECRET_KEY='${DJANGO_SECRET_KEY}'
+export NEW_RELIC_DEVELOPER_MODE='True'
 "
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@
 # HEROKU REQUIREMENTS
 
 -r requirements/common.txt
--r requirements/prod.txt
 
 # Pylibmc must be in this file so that heroku knows it has to install
 # libmemcached when bootstrapping the containers.

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -25,6 +25,9 @@ kombu==3.0.26
 # sha256: Y9f3sUog8p90Mlpp5ttFkl6vbjoAPqtGwCNP0FCoyT8
 simplejson==3.7.3
 
+# sha256: WbUVu327zdMH-BesOIVOgIOev6M8XbeX9lRQeTyUXA0
+newrelic==2.52.0.40
+
 # Required by datasource
 # sha256: gRBAtkfl1WhvhNtBXv1pfmJQAIsRK2kJunesBZ4UDHQ
 MySQL-python==1.2.5

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,5 +2,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-# sha256: WbUVu327zdMH-BesOIVOgIOev6M8XbeX9lRQeTyUXA0
-newrelic==2.52.0.40
+# Delete this file once we've done at least one deploy after bug 1169944 (since update.py needed updating)

--- a/treeherder/webapp/wsgi.py
+++ b/treeherder/webapp/wsgi.py
@@ -9,13 +9,6 @@ This module contains the WSGI application used by Django's development server
 and any production WSGI deployments. It should expose a module-level variable
 named ``application``. Django's ``runserver`` and ``runfcgi`` commands discover
 this application via the ``WSGI_APPLICATION`` setting.
-
-Usually you will have the standard Django WSGI application here, but it also
-might make sense to replace the whole Django WSGI application with a custom one
-that later delegates to the Django one. For example, you could introduce WSGI
-middleware here, or combine a Django application with an application of another
-framework.
-
 """
 try:
     import newrelic.agent
@@ -33,7 +26,9 @@ import os
 # os.environ["DJANGO_SETTINGS_MODULE"] = "webapp.settings"
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "treeherder.settings")
 
+from django.core.cache.backends.memcached import BaseMemcachedCache
 from django.core.wsgi import get_wsgi_application
+
 from treeherder.webapp.whitenoise_custom import CustomWhiteNoise
 
 # This application object is used by any WSGI server configured to use this
@@ -53,5 +48,4 @@ if newrelic:
 # Fix django closing connection to MemCachier after every request:
 # https://code.djangoproject.com/ticket/11331
 # Remove when https://github.com/django/django/pull/4866 fixed.
-from django.core.cache.backends.memcached import BaseMemcachedCache
 BaseMemcachedCache.close = lambda self, **kwargs: None

--- a/treeherder/webapp/wsgi.py
+++ b/treeherder/webapp/wsgi.py
@@ -10,13 +10,10 @@ and any production WSGI deployments. It should expose a module-level variable
 named ``application``. Django's ``runserver`` and ``runfcgi`` commands discover
 this application via the ``WSGI_APPLICATION`` setting.
 """
-try:
-    import newrelic.agent
-except ImportError:
-    newrelic = False
+import newrelic.agent
 
-if newrelic:
-    newrelic.agent.initialize()
+# The New Relic agent must be initialised before anything else is imported.
+newrelic.agent.initialize()
 
 import os
 
@@ -42,8 +39,8 @@ application = get_wsgi_application()
 # referenced by WHITENOISE_ROOT at the site root.
 application = CustomWhiteNoise(application)
 
-if newrelic:
-    application = newrelic.agent.WSGIApplicationWrapper(application)
+# Wrap with the New Relic agent.
+application = newrelic.agent.WSGIApplicationWrapper(application)
 
 # Fix django closing connection to MemCachier after every request:
 # https://code.djangoproject.com/ticket/11331


### PR DESCRIPTION
For bug 1124278, we're going to want to sprinkle new relic annotations around the codebase, so by always installing it, we save having to stub these out in development/on Travis. It also seems wise to have prod running as close to the same packages as in development.

Since NEW_RELIC_LICENSE_KEY isn't set locally, plus NEW_RELIC_DEVELOPER_MODE is set to true, the New Relic agent doesn't submit anything.

See:
https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/python-agent-configuration#developer_mode

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/858)
<!-- Reviewable:end -->
