### PR TITLE
Bug 1189482 - Convert remainder of 'logviewer-' to 'lv-'

### DIFF
--- a/ui/css/logviewer.css
+++ b/ui/css/logviewer.css
@@ -136,7 +136,11 @@ body {
     border-style: solid none;
 }
 
-.logviewer-step {
+div.lv-step {
+    padding: 6px;
+}
+
+.lv-step {
     border-radius: 2px;
     overflow: hidden;
     -webkit-user-select: text;
@@ -148,20 +152,11 @@ body {
     font-size: 11px;
 }
 
-.logviewer-step.selected {
-    color: #232323;
+.lv-step.selected {
     background-color: #FFF;
 }
 
-.logviewer-step.btn-success.selected {
-    border-color: #398439;
-}
-
-.logviewer-step.btn-warning.selected {
-    border-color: #d58512;
-}
-
-.logviewer-actionbtn span {
+.lv-actionbtn span {
     color: #777;
 }
 

--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -2082,8 +2082,6 @@ div.similar_jobs .left_panel table tr { cursor: default; }
     text-overflow: ellipsis;
 }
 
-div.logviewer-step{ padding:6px 6px;}
-
 div.talos-panel {
   display: block !important; /* the important can be removed if/when bug 1094466 is fixed */
 }

--- a/ui/js/directives/treeherder/log_viewer_lines.js
+++ b/ui/js/directives/treeherder/log_viewer_lines.js
@@ -6,7 +6,7 @@
 
 treeherder.directive('lvLogLines', ['$timeout', '$parse', function ($timeout) {
     function getOffsetOfStep (order) {
-        var el = $('.logviewer-step[order="' + order + '"]');
+        var el = $('.lv-step[order="' + order + '"]');
         var parentOffset = el.parent().offset();
 
         return el.offset().top -

--- a/ui/js/directives/treeherder/log_viewer_steps.js
+++ b/ui/js/directives/treeherder/log_viewer_steps.js
@@ -6,7 +6,7 @@
 
 treeherder.directive('lvLogSteps', ['$timeout', '$q', function ($timeout, $q) {
     function getOffsetOfStep (order) {
-        var el = $('.logviewer-step[order="' + order + '"]');
+        var el = $('.lv-step[order="' + order + '"]');
         var parentOffset = el.parent().offset();
 
         return el.offset().top -

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -63,7 +63,7 @@
 
           <!-- Show successful steps button -->
           <li ng-if="artifact && hasFailedSteps()"
-              class="logviewer-actionbtn">
+              class="lv-actionbtn">
             <div id="lv-successful-steps">
               <input type="checkbox"
                      ng-model="showSuccessful"

--- a/ui/partials/logviewer/lvLogSteps.html
+++ b/ui/partials/logviewer/lvLogSteps.html
@@ -3,7 +3,7 @@
        ng-click="displayLog(step)"
        ng-class="{'selected': (displayedStep.order === step.order)}"
        ng-if="showSuccessful === true || step.result !== 'success'"
-       class="btn btn-block logviewer-step clearfix {{::getShadingClass(step.result)}}"
+       class="btn btn-block lv-step clearfix {{::getShadingClass(step.result)}}"
        order="{{step.order}}">
     <span class="pull-left clearfix text-left">
       {{::step.order+1}}. {{::step.name}}


### PR DESCRIPTION
This work fixes Bugzilla bug [1189482](https://bugzilla.mozilla.org/show_bug.cgi?id=1189482).

This converts the remaining `.logviewer-` classes to `.lv-` and also retires some dead classes and an unnecessary step property.

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-08-10)**
Chrome Latest Release **44.0.2403.130 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/860)
<!-- Reviewable:end -->
