### PR TITLE
Bug 1192375 - Refactor save classification to update Annotations correctly

### DIFF
--- a/ui/plugins/annotations/controller.js
+++ b/ui/plugins/annotations/controller.js
@@ -27,10 +27,6 @@ treeherder.controller('AnnotationsPluginCtrl', [
                 for (var i = 0; i < $scope.bugs.length; i++) {
                     $scope.deleteBug($scope.bugs[i]);
                 }
-
-                // We reselect job in place ensuring a correct state for other actions
-                // Potential update with follow up 1181271
-                $rootScope.$emit(thEvents.selectJob, $rootScope.selectedJob, 'passive');
             } else {
                 thNotify.send("No classification on this job to delete", 'warning');
             }
@@ -42,7 +38,9 @@ treeherder.controller('AnnotationsPluginCtrl', [
             var jobMap = ThResultSetStore.getJobMap($rootScope.repoName);
             var job = jobMap[key].job_obj;
 
-            job.failure_classification_id = 1;
+            // this $evalAsync will be sure that the * is added or removed in
+            // the job in the jobs table when this change takes place.
+            $scope.$evalAsync(function() {job.failure_classification_id = 1;});
             ThResultSetStore.updateUnclassifiedFailureMap($rootScope.repoName, job);
 
             classification.delete()

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -76,9 +76,6 @@ treeherder.controller('PinboardCtrl', [
                 $scope.completeClassification();
                 $scope.classification = thPinboard.createNewClassification();
 
-                // We reselect job in place ensuring a correct state for other actions
-                // Potential update with follow up 1181271
-                $rootScope.$emit(thEvents.selectJob, $rootScope.selectedJob, 'passive');
             } else {
                 thNotify.send("Must be logged in to save job classifications", "danger");
             }


### PR DESCRIPTION
Need this change for the Collapsed Job Groups PR.  Certain circumstances had an issue when the extra select happened.  This removes the requirement to re-select the job after classifying/declassifying.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/861)
<!-- Reviewable:end -->
