### PR TITLE
Bug 1189599 - subtest compare view doesn't show error message

### DIFF
--- a/ui/partials/perf/comparesubtestctrl.html
+++ b/ui/partials/perf/comparesubtestctrl.html
@@ -4,13 +4,13 @@
     <img src="img/dancing_cat.gif" />
     <img src="img/dancing_cat.gif" ng-repeat="x in [0,1,2,3]" style="transform:scale(0.5); margin-left:-40px; margin-top:40px;"/>
   </div>
+  <div id="error" ng-if="!dataLoading && errors.length">
+    <compare-error errors="errors" original-revision="originalRevision" original-project="originalProject" new-revision="newRevision" new-project="newProject"></compare-error>
+  </div>
   <div id="subtest-summary" ng-if="!dataLoading && !errors.length">
     <h1>{{subtestTitle}} subtest summary</h1>
     <revision-information original-project="originalProject" original-revision="originalRevision" original-result-set="originalResultSet" new-project="newProject" new-revision="newRevision" new-result-set="newResultSet"></revision-information>
     <p><a href="perf.html#/compare?originalProject={{originalProject.name}}&originalRevision={{originalRevision}}&newProject={{newProject.name}}&newRevision={{newRevision}}">Show all tests and platforms</a></p>
-    <div id="error" ng-if="!dataLoading && errors.length" ng-repeat="error in errors">
-      <compare-error errors="errors" original-revision="originalRevision" original-project="originalProject" new-revision="newRevision" new-project="newProject"></compare-error>
-    </div>
     <ph-compare-table
        titles="titles"
        test-list="testList"


### PR DESCRIPTION
The reason why subtest compare doesn't show error message is because somehow the error message part been nested into the dataLoading block. So it doesn't shows up if the dataLoading is false because error list wasn't empty. ;)
Now the error can shows up normally.

<img width="1277" alt="screen shot 2015-08-12 at 10 03 11 am" src="https://cloud.githubusercontent.com/assets/2166227/9215367/1495d34c-40dc-11e5-865c-b62bdfc9ba6e.png">

Test on OS X 10.10.4
Firefox 39.0

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/862)
<!-- Reviewable:end -->
