### PR TITLE
Bug 1193715 - Mark TalosParser complete once the TALOSDATA log line seen

### DIFF
--- a/treeherder/log_parser/artifactbuilders.py
+++ b/treeherder/log_parser/artifactbuilders.py
@@ -55,6 +55,9 @@ class ArtifactBuilderBase(object):
             line = line[:self.MAX_LINE_LENGTH]
 
         for parser in self.parsers:
+            # Some parsers only need to run until they've seen a specific line.
+            # Once that's occurred, they mark themselves as complete, to save
+            # being included in the set of parsers run against later log lines.
             if not parser.complete:
                 parser.parse_line(line, self.lineno)
 

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -347,3 +347,6 @@ class TalosParser(ParserBase):
             # this will throw an exception if the json parsing breaks, but
             # that's the behaviour we want
             self.artifact = json.loads(match.group(1))
+            # Mark this parser as complete, so we don't continue to run
+            # it against every remaining line in the log.
+            self.complete = True


### PR DESCRIPTION
There is only ever one TALOSDATA line in a log file, so once it has been seen there is no need to run TalosParser against later log lines.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/864)
<!-- Reviewable:end -->
