### PR TITLE
Bug 1163064 - Collapse test group chunks down to counts by result and state

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -594,6 +594,11 @@ th-watched-repo {
     display: block;
 }
 
+.group-state-nav-icon {
+    width: 7px;
+    display: inline-block;
+}
+
 .job-group {
     margin: 0 -3px 0 3px;
 }
@@ -606,8 +611,49 @@ th-watched-repo {
   display: none;
 }
 
+.group-btn {
+  background: transparent;
+  padding: 0 2px 0 2px;
+  vertical-align: 0;
+  line-height: 1.32;
+  cursor: pointer;
+}
+.group-btn::before {
+    content: "+";
+}
+
+.group-symbol:hover {
+    background-color: rgba(208, 228, 250, 0.51);
+    cursor: pointer;
+}
+
+.group-content {
+    margin-left: -3px;
+    cursor: pointer;
+}
+
+.group-content::before {
+    content: "("
+}
+
+.group-content::after {
+    content: ")"
+}
+
+.group-count-list:hover {
+    background-color: rgba(208, 228, 250, 0.51);
+}
+
+.group-job-list {
+    margin-left: -3px;
+}
+
 .selected-job {
     border: 4px solid;
+    background-color: #fff;
+}
+
+.selected-count.btn-lg-xform {
     background-color: #fff;
 }
 
@@ -1255,7 +1301,14 @@ ul.failure-summary-list li .btn-xs {
  .job-btn.btn-ltgray,
  .job-btn.btn-green,
  .job-btn.btn-dkblue,
- .job-btn.btn-pink {
+ .job-btn.btn-yellow,
+ .job-btn.btn-pink,
+ .group-btn.btn-dkgray-count,
+ .group-btn.btn-ltgray-count,
+ .group-btn.btn-green-count,
+ .group-btn.btn-dkblue-count,
+ .group-btn.btn-yellow-count,
+ .group-btn.btn-pink-count {
     margin: 0 -5px 0 -1px;
  }
 
@@ -1264,6 +1317,29 @@ ul.failure-summary-list li .btn-xs {
  .job-btn.btn-purple {
     margin: 0 -3px 1px 0;
  }
+
+.btn-orange-classified::after,
+.btn-orange-classified-count::after,
+.btn-red-classified::after,
+.btn-red-classified-count::after,
+.btn-black-classified::after,
+.btn-black-classified-count::after,
+.btn-green-classified::after,
+.btn-green-classified-count::after,
+.btn-dkblue-classified::after,
+.btn-dkblue-classified-count::after,
+.btn-dkgray-classified::after,
+.btn-dkgray-classified-count::after,
+.btn-ltgray-classified::after,
+.btn-ltgray-classified-count::after,
+.btn-yellow-classified::after,
+.btn-yellow-classified-count::after,
+.btn-pink-classified::after,
+.btn-pink-classified-count::after,
+.btn-purple-classified::after,
+.btn-purple-classified-count::after {
+    content: "*";
+}
 
 .btn-view-nav {
   background-color: transparent;
@@ -1402,10 +1478,12 @@ fieldset[disabled] .btn-orange.active {
   border-color: #dd6602;
 }
 
-.btn-orange-classified {
+.btn-orange-classified,
+.btn-orange-classified-count {
   color: #dd6602;
 }
 .btn-orange-classified:hover,
+.btn-orange-classified-count:hover,
 .btn-orange-classified:focus,
 .btn-orange-classified:active,
 .btn-orange-classified.active {
@@ -1459,10 +1537,12 @@ fieldset[disabled] .btn-red.active {
   border-color: #c2020e;
 }
 
-.btn-red-classified {
+.btn-red-classified,
+.btn-red-classified-count {
   color: #90010a;
 }
 .btn-red-classified:hover,
+.btn-red-classified-count:hover,
 .btn-red-classified:focus,
 .btn-red-classified:active,
 .btn-red-classified.active {
@@ -1487,11 +1567,17 @@ fieldset[disabled] .btn-red-classified.active {
   color: white;
 }
 
-.btn-dkblue {
+.btn-dkblue,
+.btn-dkblue-count,
+.btn-dkblue-classified,
+.btn-dkblue-classified-count {
   color: #283aa2;
   font-weight: bold;
 }
 .btn-dkblue:hover,
+.btn-dkblue-count:hover,
+.btn-dkblue-classified:hover,
+.btn-dkblue-classified-count:hover,
 .btn-dkblue:focus,
 .btn-dkblue:active,
 .btn-dkblue.active {
@@ -1516,11 +1602,17 @@ fieldset[disabled] .btn-dkblue.active {
   border-color: #2d48d6;
 }
 
-.btn-green {
+.btn-green,
+.btn-green-count,
+.btn-green-classified,
+.btn-green-classified-count {
   color: rgba(2, 130, 51, 0.75);
   font-weight: bold;
 }
 .btn-green:hover,
+.btn-green-count:hover,
+.btn-green-classified:hover,
+.btn-green-classified-count:hover,
 .btn-green:focus,
 .btn-green:active,
 .btn-green.active {
@@ -1573,10 +1665,12 @@ fieldset[disabled] .btn-purple.active {
   color: white;
 }
 
-.btn-purple-classified {
+.btn-purple-classified,
+.btn-purple-classified-count {
   color: #6f0296;
 }
 .btn-purple-classified:hover,
+.btn-purple-classified-count:hover,
 .btn-purple-classified:focus,
 .btn-purple-classified:active,
 .btn-purple-classified.active {
@@ -1601,11 +1695,17 @@ fieldset[disabled] .btn-purple-classified.active {
   color: white;
 }
 
-.btn-yellow {
+.btn-yellow,
+.btn-yellow-count,
+.btn-yellow-classified,
+.btn-yellow-classified-count {
   color: #cdce1d;
   font-weight: bold;
 }
 .btn-yellow:hover,
+.btn-yellow-count:hover,
+.btn-yellow-classified:hover,
+.btn-yellow-classified-count:hover,
 .btn-yellow:focus,
 .btn-yellow:active,
 .btn-yellow.active {
@@ -1627,10 +1727,16 @@ fieldset[disabled] .btn-yellow.active {
   border-color: #cdce1d;
 }
 
-.btn-ltgray {
+.btn-ltgray,
+.btn-ltgray-count,
+.btn-ltgray-classified,
+.btn-ltgray-classified-count {
   color: #e0e0e0;
 }
 .btn-ltgray:hover,
+.btn-ltgray-count:hover,
+.btn-ltgray-classified:hover,
+.btn-ltgray-classified-count:hover,
 .btn-ltgray:focus,
 .btn-ltgray:active,
 .btn-ltgray.active {
@@ -1653,11 +1759,18 @@ fieldset[disabled] .btn-ltgray.active {
   border-color: #e0e0e0;
 }
 
-.btn-mdgray {
+.btn-mdgray,
+.btn-mdgray-count,
+.btn-mdgray-classified,
+.btn-mdgray-classified-count
+ {
   background-color: #bfbfbf;
   border-color: #bfbfbf;
 }
 .btn-mdgray:hover,
+.btn-mdgray-count:hover,
+.btn-mdgray-classified:hover,
+.btn-mdgray-classified-count:hover,
 .btn-mdgray:focus,
 .btn-mdgray:active,
 .btn-mdgray.active {
@@ -1700,10 +1813,16 @@ fieldset[disabled] .btn-resultset:hover {
   color: white;
 }
 
-.btn-dkgray {
+.btn-dkgray,
+.btn-dkgray-count,
+.btn-dkgray-classified,
+.btn-dkgray-classified-count {
   color: #7c7a7d;
 }
 .btn-dkgray:hover,
+.btn-dkgray-count:hover,
+.btn-dkgray-classified:hover,
+.btn-dkgray-classified-count:hover,
 .btn-dkgray:focus,
 .btn-dkgray:active,
 .btn-dkgray.active {
@@ -1728,12 +1847,18 @@ fieldset[disabled] .btn-dkgray.active {
   color: white;
 }
 
-.btn-black {
+.btn-black
+.btn-black-count,
+.btn-black-classified,
+.btn-black-classified-count {
   background-color: #4a4a4a;
   border-color: #000000;
   color: white;
 }
 .btn-black:hover,
+.btn-black-count:hover,
+.btn-black-classified:hover,
+.btn-black-classified-count:hover,
 .btn-black:focus,
 .btn-black:active,
 .btn-black.active {
@@ -1781,11 +1906,17 @@ fieldset[disabled] .btn-black.active {
   border-color: #000000;
 }
 
-.btn-pink {
+.btn-pink,
+.btn-pink-count,
+.btn-pink-classified,
+.btn-pink-classified-count {
   color: #ff40d9;
   font-weight: bold;
 }
 .btn-pink:hover,
+.btn-pink-count:hover,
+.btn-pink-classified:hover,
+.btn-pink-classified-count:hover,
 .btn-pink:focus,
 .btn-pink:active,
 .btn-pink.active {

--- a/ui/index.html
+++ b/ui/index.html
@@ -171,11 +171,24 @@
         </script>
 
         <!-- Start span for job groups -->
-        <script type="'text/ng-template'" id="jobGroupBeginClone.html">
+        <script type="'text/ng-template'" id="jobGroupClone.html">
             <span class="platform-group">
-                <span class="disabled job-group" title="{{ name }}">{{ symbol }}(</span>
-                <span class="job-group-list"></span>)
+                <span class="disabled job-group" title="{{ name }}"
+                      data-grkey="{{ grkey }}">
+                    <span class="group-symbol"
+                          ignore-job-clear-on-click>{{ symbol }}</span>
+                    <span class="group-content">
+                        <span class="group-job-list"></span>
+                        <span class="group-count-list"></span>
+                    </span>
+                </span>
             </span>
+        </script>
+
+        <!-- Job group count span for each count item -->
+        <script type="'text/ng-template'" id="jobGroupCountClone.html">
+            <button class="btn {{ selectedClasses }} group-btn btn-xs job-group-count {{ btnClass }}"
+                    title="{{ title }}">{{ value }}</button>
         </script>
 
         <!-- Job Btn span -->

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -319,6 +319,17 @@ treeherderApp.controller('MainCtrl', [
 
         };
 
+        $scope.getGroupState = function() {
+            return $location.search().group_state || "collapsed";
+        };
+
+        $scope.groupState = $scope.getGroupState();
+
+        $scope.toggleGroupState = function() {
+            var newGroupState = $scope.groupState === "collapsed" ? "expanded" : null;
+            $location.search("group_state", newGroupState);
+        };
+
         var getNewReloadTriggerParams = function() {
             return _.pick(
                 $location.search(),
@@ -364,6 +375,13 @@ treeherderApp.controller('MainCtrl', [
             }
             $rootScope.skipNextPageReload = false;
 
+            // handle a change in the groupState whether it was by the button
+            // or directly in the url.
+            var newGroupState = $scope.getGroupState();
+            if (newGroupState !== $scope.groupState) {
+                $scope.groupState = newGroupState;
+                $rootScope.$emit(thEvents.groupStateChanged);
+            }
         });
 
         $scope.changeRepo = function(repo_name) {

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -10,13 +10,13 @@ treeherder.directive('thCloneJobs', [
     'thServiceDomain', 'thResultStatusInfo', 'thEvents', 'thAggregateIds',
     'thJobFilters', 'thResultStatusObject', 'ThResultSetStore',
     'ThJobModel', 'linkifyBugsFilter', 'thResultStatus', 'thPlatformName',
-    'thJobSearchStr', 'thNotify', '$timeout', '$location',
+    'thJobSearchStr', 'thNotify', '$timeout',
     function(
         $rootScope, $http, ThLog, thUrl, thCloneHtml,
         thServiceDomain, thResultStatusInfo, thEvents, thAggregateIds,
         thJobFilters, thResultStatusObject, ThResultSetStore,
         ThJobModel, linkifyBugsFilter, thResultStatus, thPlatformName,
-        thJobSearchStr, thNotify, $timeout, $location){
+        thJobSearchStr, thNotify, $timeout){
 
         var $log = new ThLog("thCloneJobs");
 
@@ -225,17 +225,12 @@ treeherder.directive('thCloneJobs', [
         };
 
         var addJobBtnToArray = function(job, lastJobSelected, jobBtnArray) {
-            var hText, key, resultState, jobStatus, jobBtn, l;
+            var jobStatus, jobBtn;
 
-            hText = getHoverText(job);
-            key = getJobMapKey(job);
-            //Set the resultState
-            resultState = thResultStatus(job);
-
-            jobStatus = thResultStatusInfo(resultState, job.failure_classification_id);
-            jobStatus.key = key;
+            jobStatus = thResultStatusInfo(thResultStatus(job), job.failure_classification_id);
+            jobStatus.key = getJobMapKey(job);
             jobStatus.value = job.job_type_symbol;
-            jobStatus.title = hText;
+            jobStatus.title = getHoverText(job);
             jobBtn = $(jobBtnInterpolator(jobStatus));
 
             //If the job is currently selected make sure to re-apply
@@ -246,8 +241,7 @@ treeherder.directive('thCloneJobs', [
                 setSelectJobStyles(jobBtn);
 
                 //Update the selected job element to the current one
-                ThResultSetStore.setSelectedJob(
-                    $rootScope.repoName, jobBtn, job);
+                ThResultSetStore.setSelectedJob($rootScope.repoName, jobBtn, job);
             }
             showHideElement(jobBtn, job.visible);
 

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -10,19 +10,20 @@ treeherder.directive('thCloneJobs', [
     'thServiceDomain', 'thResultStatusInfo', 'thEvents', 'thAggregateIds',
     'thJobFilters', 'thResultStatusObject', 'ThResultSetStore',
     'ThJobModel', 'linkifyBugsFilter', 'thResultStatus', 'thPlatformName',
-    'thJobSearchStr', 'thNotify', '$timeout',
+    'thJobSearchStr', 'thNotify', '$timeout', '$location',
     function(
         $rootScope, $http, ThLog, thUrl, thCloneHtml,
         thServiceDomain, thResultStatusInfo, thEvents, thAggregateIds,
         thJobFilters, thResultStatusObject, ThResultSetStore,
         ThJobModel, linkifyBugsFilter, thResultStatus, thPlatformName,
-        thJobSearchStr, thNotify, $timeout){
+        thJobSearchStr, thNotify, $timeout, $location){
 
         var $log = new ThLog("thCloneJobs");
 
         // CSS classes
         var btnCls = 'btn-xs';
         var selectedBtnCls = 'selected-job';
+        var selectedCountCls = 'selected-count';
         var largeBtnCls = 'btn-lg-xform';
 
         var col5Cls = 'col-xs-5';
@@ -31,8 +32,13 @@ treeherder.directive('thCloneJobs', [
         var jobListNoPadCls = 'job-list-nopad';
         var jobListPadCls = 'job-list-pad';
 
+        var viewContentSel = ".th-view-content";
+
+        var failResults = ["testfailed", "busted", "exception"];
+
         // Custom Attributes
         var jobKeyAttr = 'data-jmkey';
+        var groupKeyAttr = 'data-grkey';
 
         var tableInterpolator = thCloneHtml.get('resultsetClone').interpolator;
 
@@ -40,7 +46,10 @@ treeherder.directive('thCloneJobs', [
         var platformInterpolator = thCloneHtml.get('platformClone').interpolator;
 
         //Instantiate job group interpolator
-        var jobGroupInterpolator = thCloneHtml.get('jobGroupBeginClone').interpolator;
+        var jobGroupInterpolator = thCloneHtml.get('jobGroupClone').interpolator;
+
+        //Instantiate job group count interpolator
+        var jobGroupCountInterpolator = thCloneHtml.get('jobGroupCountClone').interpolator;
 
         //Instantiate job btn interpolator
         var jobBtnInterpolator = thCloneHtml.get('jobBtnClone').interpolator;
@@ -85,9 +94,9 @@ treeherder.directive('thCloneJobs', [
                 // The .selected-job can be invisible, for instance, when filtered to
                 // unclassified failures only, and you then classify the selected job.
                 // It's still selected, but no longer visible.
-                jobs = $(".th-view-content").find(jobNavSelector.selector).filter(":visible, .selected-job");
+                jobs = $(viewContentSel).find(jobNavSelector.selector).filter(":visible, .selected-job, .selected-count");
                 if (jobs.length) {
-                    var selIdx = jobs.index(jobs.filter(".selected-job"));
+                    var selIdx = jobs.index(jobs.filter(".selected-job, .selected-count").first());
                     var idx = getIndex(selIdx, jobs);
 
                     el = $(jobs[idx]);
@@ -126,20 +135,12 @@ treeherder.directive('thCloneJobs', [
         };
 
         var setSelectJobStyles = function(el){
-
-            var lastJobSelected = ThResultSetStore.getSelectedJob(
-                $rootScope.repoName);
-
-            if(!_.isEmpty(lastJobSelected.el)){
-                lastJobSelected.el.removeClass(selectedBtnCls);
-                lastJobSelected.el.removeClass(largeBtnCls);
-                lastJobSelected.el.addClass(btnCls);
-            }
+            // clear the styles from the previously selected job, if any.
+            clearSelectJobStyles();
 
             el.removeClass(btnCls);
             el.addClass(largeBtnCls);
             el.addClass(selectedBtnCls);
-
         };
 
         var clearSelectJobStyles = function() {
@@ -150,6 +151,16 @@ treeherder.directive('thCloneJobs', [
                 lastJobSelected.el.removeClass(selectedBtnCls);
                 lastJobSelected.el.removeClass(largeBtnCls);
                 lastJobSelected.el.addClass(btnCls);
+            }
+
+            // if a job was previously selected that is now inside a count,
+            // then the count will have the ``.selected-count`` class.  Since
+            // we are now selecting a job, we need to remove that class from the
+            // count.
+            var selectedCount = $(viewContentSel).find("."+selectedCountCls);
+            if (selectedCount.length) {
+                selectedCount.removeClass(selectedCountCls);
+                selectedCount.removeClass(largeBtnCls);
             }
         };
 
@@ -166,87 +177,181 @@ treeherder.directive('thCloneJobs', [
             }, 200);
         };
 
+        /**
+         * Clicking a group will expand or collapse it.  Expanded shows all
+         * jobs.  Collapsed shows counts and failed jobs.
+         */
+        var clickGroupCb = function(el) {
+            var groupMap =  ThResultSetStore.getGroupMap($rootScope.repoName);
+            var gi = getGroupInfo(el, groupMap);
+            if (gi) {
+                if (isGroupExpanded(gi.jgObj)) {
+                    gi.jgObj.groupState = "collapsed";
+                    addGroupJobsAndCounts(gi.jgObj, gi.platformGroupEl);
+                } else {
+                    gi.grpCountList.empty();
+                    gi.jgObj.groupState = "expanded";
+                    addJobBtnEls(gi.jgObj, gi.grpJobList);
+                }
+            }
+        };
+
         var togglePinJobCb = function(ev, el, job){
             $rootScope.$emit(thEvents.jobPin, job);
         };
 
-        var addJobBtnEls = function(
-            jgObj, jobBtnInterpolator, jobTdEl){
-
-            var jobsShown = 0;
-
-            var lastJobSelected = ThResultSetStore.getSelectedJob(
-                $rootScope.repoName
-            );
-
-            var hText, key, resultState, job, jobStatus, jobBtn, l;
+        var addJobBtnEls = function(jgObj, jobList) {
+            var lastJobSelected = ThResultSetStore.getSelectedJob($rootScope.repoName);
+            var job, l;
             var jobBtnArray = [];
+            jobList.empty();
 
             for(l=0; l<jgObj.jobs.length; l++){
 
                 job = jgObj.jobs[l];
 
-                //Set the resultState
-                resultState = thResultStatus(job);
 
                 job.searchStr = thJobSearchStr(job) + ' ' + job.ref_data_name  + ' ' +
                     job.signature;
 
+                //Keep track of visibility with this property. This
+                //way down stream job consumers don't need to repeatedly
+                //call showJob
+                job.visible = thJobFilters.showJob(job);
+
+                addJobBtnToArray(job, lastJobSelected, jobBtnArray);
+            }
+            jobList.append(jobBtnArray);
+        };
+
+        var addJobBtnToArray = function(job, lastJobSelected, jobBtnArray) {
+            var hText, key, resultState, jobStatus, jobBtn, l;
+
+            hText = getHoverText(job);
+            key = getJobMapKey(job);
+            //Set the resultState
+            resultState = thResultStatus(job);
+
+            jobStatus = thResultStatusInfo(resultState, job.failure_classification_id);
+            jobStatus.key = key;
+            jobStatus.value = job.job_type_symbol;
+            jobStatus.title = hText;
+            jobBtn = $(jobBtnInterpolator(jobStatus));
+
+            //If the job is currently selected make sure to re-apply
+            //the job selection styles
+            if( !_.isEmpty(lastJobSelected.job) &&
+                (lastJobSelected.job.id === job.id)){
+
+                setSelectJobStyles(jobBtn);
+
+                //Update the selected job element to the current one
+                ThResultSetStore.setSelectedJob(
+                    $rootScope.repoName, jobBtn, job);
+            }
+            showHideElement(jobBtn, job.visible);
+
+            jobBtnArray.push(jobBtn);
+            // add a zero-width space between spans so they can wrap
+            jobBtnArray.push(' ');
+        };
+
+        var getGroupInfo = function(el, groupMap) {
+            var gi = {};
+            try {
+                gi.platformGroupEl = $(el).closest(".platform-group");
+                gi.grpJobList = gi.platformGroupEl.find(".group-job-list");
+                gi.grpCountList = gi.platformGroupEl.find(".group-count-list");
+                gi.key = gi.platformGroupEl.find(".job-group").attr(groupKeyAttr);
+                gi.jgObj = groupMap[gi.key].grp_obj;
+                return gi;
+            } catch(TypeError) {
+                return null;
+            }
+        };
+
+        /**
+         * Group most resultStates as just counts.  Keep "failed" as job-btns
+         */
+        var addGroupJobsAndCounts = function(jgObj, platformGroup) {
+            var ct, job, jobCountBtn, l;
+            var countAdded = false;
+            var jobCountBtnArray = [];
+            var jobBtnArray = [];
+            var stateCounts = {};
+            var lastJobSelected = ThResultSetStore.getSelectedJob($rootScope.repoName);
+
+            var jobList = platformGroup.find(".group-job-list");
+            var countList = platformGroup.find(".group-count-list");
+            jobList.empty();
+            countList.empty();
+
+            for (l = 0; l < jgObj.jobs.length; l++) {
+
+                job = jgObj.jobs[l];
+                job.searchStr = thJobSearchStr(job) + ' ' + job.ref_data_name  + ' ' +
+                    job.signature;
+
+                //Set the resultState
+                var resultStatus = thResultStatus(job);
+                var countInfo = thResultStatusInfo(resultStatus,
+                                                job.failure_classification_id);
+
                 //Make sure that filtering doesn't effect the resultset counts
                 //displayed
-                if(thJobFilters.showJob(job) === false){
-                    //Keep track of visibility with this property. This
-                    //way down stream job consumers don't need to repeatedly
-                    //call showJob
-                    job.visible = false;
-                } else {
-                    jobsShown++;
+                if (thJobFilters.showJob(job)) {
                     job.visible = true;
-                }
 
-                hText = getHoverText(job);
-                key = getJobMapKey(job);
+                    if (_.contains(failResults, resultStatus) && job.failure_classification_id === 1) {
+                        // render the job itself, not a count
+                        addJobBtnToArray(job, lastJobSelected, jobBtnArray);
+                    } else {
+                        _.extend(countInfo, stateCounts[countInfo.btnClass]);
+                        if( !_.isEmpty(lastJobSelected.job) &&
+                            (lastJobSelected.job.id === job.id)) {
+                            // these clases are applied in the interpolator
+                            // to designate this count as having one of its
+                            // jobs selected.
+                            countInfo.selectedClasses = selectedCountCls + " " + largeBtnCls;
+                        }
 
-                jobStatus = thResultStatusInfo(resultState);
-
-                //Add a visual indicator for a failure classification
-                jobStatus.key = key;
-                if(parseInt(job.failure_classification_id, 10) > 1){
-                    jobStatus.value = job.job_type_symbol + '*';
-                    if (jobStatus.btnClassClassified) {
-                        // For result types that are displayed more prominently
-                        // when unclassified, switch to the more subtle classified
-                        // style.
-                        jobStatus.btnClass = jobStatus.btnClassClassified;
+                        ct = _.get(_.get(stateCounts, countInfo.btnClass, countInfo),
+                                   "count", 0);
+                        countInfo.count = ct+1;
+                        // keep a reference to the job.  If there ends up being
+                        // only one for this status, then just add the job itself
+                        // rather than a count.
+                        countInfo.lastJob = job;
+                        stateCounts[countInfo.btnClass] = countInfo;
                     }
-                } else {
-                    jobStatus.value = job.job_type_symbol;
-                }
-
-                jobStatus.title = hText;
-
-                jobBtn = $( jobBtnInterpolator(jobStatus));
-                jobBtnArray.push(jobBtn);
-                // add a zero-width space between spans so they can wrap
-                jobBtnArray.push(' ');
-
-                showHideJob(jobBtn, job.visible);
-
-                //If the job is currently selected make sure to re-apply
-                //the job selection styles
-                if( !_.isEmpty(lastJobSelected.job) &&
-                    (lastJobSelected.job.id === job.id)){
-
-                    setSelectJobStyles(jobBtn);
-
-                    //Update the selected job element to the current one
-                    ThResultSetStore.setSelectedJob(
-                        $rootScope.repoName, jobBtn, job);
                 }
             }
-            jobTdEl.append(jobBtnArray);
 
-            return jobsShown;
+            _.forEach(stateCounts, function(countInfo) {
+                if (countInfo.count === 1) {
+                    // if there is only 1 job for this status, then just add
+                    // the job, rather than the count
+                    addJobBtnToArray(countInfo.lastJob, lastJobSelected, jobBtnArray);
+                } else {
+                    // with more than 1 job for the status, add it as a count
+                    countAdded = true;
+                    countInfo.value = countInfo.count;
+                    countInfo.title = countInfo.count + " " +
+                                      countInfo.countText +
+                                      " jobs in group";
+                    countInfo.btnClass = countInfo.btnClass + "-count";
+                    jobCountBtn = $(jobGroupCountInterpolator(countInfo));
+                    jobCountBtnArray.push(jobCountBtn);
+                    jobCountBtnArray.push(' ');
+                    showHideElement(jobCountBtn, true);
+                }
+            });
+
+            jobList.append(jobBtnArray);
+
+            if (countAdded) {
+                countList.append(jobCountBtnArray);
+            }
         };
 
         var jobMouseDown = function(resultset, ev){
@@ -292,6 +397,8 @@ treeherder.directive('thCloneJobs', [
 
                 ThResultSetStore.setSelectedJob($rootScope.repoName, el, job);
 
+            } else {
+                _.bind(clickGroupCb, this, el)();
             }
         };
 
@@ -400,29 +507,26 @@ treeherder.directive('thCloneJobs', [
             //Empty the job column before populating it
             jobTdEl.empty();
 
-            var jgObj, jobGroup, jobsShown, i;
-            for(i=0; i<jobGroups.length; i++){
+            var jgObj, jobGroup, i;
+            for(i=0; i<jobGroups.length; i++) {
 
                 jgObj = jobGroups[i];
 
-                jobsShown = 0;
-                if(jgObj.symbol !== '?'){
+                if (jgObj.symbol !== '?') {
                     // Job group detected, add job group symbols
-                    jobGroup = $( jobGroupInterpolator(jobGroups[i]) );
-
+                    jobGroups[i].grkey = jgObj.mapKey;
+                    jobGroups[i].collapsed = true;
+                    jobGroup = $(jobGroupInterpolator(jobGroups[i]));
                     jobTdEl.append(jobGroup);
 
+                    if (isGroupExpanded(jgObj)) {
+                        addJobBtnEls(jgObj, jobGroup.find(".group-job-list"));
+                    } else {
+                        addGroupJobsAndCounts(jgObj, jobGroup);
+                    }
+                } else {
                     // Add the job btn spans
-                    jobsShown = addJobBtnEls(
-                        jgObj, jobBtnInterpolator, jobGroup.find(".job-group-list"));
-                    jobGroup.css("display", jobsShown? "inline": "none");
-
-                }else{
-
-                    // Add the job btn spans
-                    jobsShown = addJobBtnEls(
-                        jgObj, jobBtnInterpolator, jobTdEl);
-
+                    addJobBtnEls(jgObj, jobTdEl);
                 }
             }
             row.append(jobTdEl);
@@ -446,9 +550,10 @@ treeherder.directive('thCloneJobs', [
                 job = jobMap[jmKey].job_obj;
                 show = thJobFilters.showJob(job);
                 job.visible = show;
-
-                showHideJob($(this), show);
+                showHideElement($(this), show);
             });
+
+            renderGroups(element, false);
 
             // hide platforms and groups where all jobs are hidden
             element.find(".platform").each(function internalFilterPlatform() {
@@ -457,7 +562,52 @@ treeherder.directive('thCloneJobs', [
             });
 
         };
-        var showHideJob = function(job, show) {
+
+        var isGroupExpanded = function(group) {
+            var singleGroupState = group.groupState || $scope.groupState;
+            return singleGroupState === "expanded";
+        };
+
+        /**
+         * Render all the job groups for a resultset.  Make decisions on whether
+         * to render all the jobs in the group, or to collapse them as counts.
+         *
+         * If ``resetGroupState`` is set to true, then clear the ``groupState``
+         * for each group that may have been set when a user clicked on it.
+         * If false, then honor the choice to expand or collapse an individual
+         * group and ignore the global setting.
+         *
+         * @param element The resultset for which to render the groups.
+         * @param resetGroupState Whether to reset groups individual expanded
+         *                        or collapsed states.
+         */
+        var renderGroups = function(element, resetGroupState) {
+            var groupMap =  ThResultSetStore.getGroupMap($rootScope.repoName);
+            // with items in the group, it's not as simple as just hiding or
+            // showing a job or count.  Since there can be lots of criteria for whether to show
+            // or hide a job, and any job hidden or shown will change the counts,
+            // the counts must be re-created each time.
+            element.find(".group-job-list").each(function internalFilterGroup(idx, el) {
+                var gi = getGroupInfo(el, groupMap);
+                gi.grpJobList.empty();
+                gi.grpCountList.empty();
+
+                if (resetGroupState) {
+                    delete gi.jgObj.groupState;
+                }
+
+                if (isGroupExpanded(gi.jgObj)) {
+                    addJobBtnEls(gi.jgObj, gi.platformGroupEl.find(".group-job-list"));
+                } else {
+                    addGroupJobsAndCounts(gi.jgObj, gi.platformGroupEl);
+                }
+            });
+        };
+
+        /**
+         * Can be used to show/hide a job or a count of jobs
+         */
+        var showHideElement = function(el, show) {
             // Note: I was using
             //     jobEl.style.display = "inline";
             //     jobEl.className += " filter-shown";
@@ -468,9 +618,9 @@ treeherder.directive('thCloneJobs', [
             //
             // It would be great to be able to do this without adding/removing a class
             if (show) {
-                job[0].classList.add("filter-shown");
+                el[0].classList.add("filter-shown");
             } else {
-                job[0].classList.remove("filter-shown");
+                el[0].classList.remove("filter-shown");
             }
         };
 
@@ -482,7 +632,7 @@ treeherder.directive('thCloneJobs', [
                 platform[0].style.display ="table-row";
                 platform.find(".platform-group").each(function internalFilterGroup() {
                     var grp = $(this);
-                    showGrp = grp.find('.job-group-list .filter-shown').length !== 0;
+                    showGrp = grp.find('.group-job-list .filter-shown, .group-count-list .filter-shown').length !== 0;
                     grp[0].style.display = showGrp ? "inline" : "none";
                 });
 
@@ -581,10 +731,12 @@ treeherder.directive('thCloneJobs', [
             }, this);
         };
 
-        var scrollToElement = function(el){
-
+        var scrollToElement = function(el, duration){
+            if (_.isUndefined(duration)) {
+                duration = 50;
+            }
             if(el.position() !== undefined){
-                $('.th-global-content').scrollTo(el, 100, {offset: -40});
+                $('.th-global-content').scrollTo(el, duration, {offset: -40});
             }
 
         };
@@ -616,6 +768,12 @@ treeherder.directive('thCloneJobs', [
             $rootScope.$on(
                 thEvents.globalFilterChanged, function(ev, filterData){
                     _.bind(filterJobs, scope, element)();
+                });
+
+            $rootScope.$on(
+                thEvents.groupStateChanged, function(ev, filterData){
+                    _.bind(renderGroups, scope, element, true)();
+                    scrollToElement($(viewContentSel).find(".selected-job, .selected-count"), 1);
                 });
 
             $rootScope.$on(
@@ -734,7 +892,10 @@ treeherder.directive('thCloneJobs', [
             }
         };
 
+        var $scope = null;
         var linker = function(scope, element, attrs){
+
+            $scope = scope;
 
             //Remove any jquery on() bindings
             element.off();

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -217,6 +217,7 @@ treeherder.factory('ThResultSetStore', [
                     // maps to help finding objects to update/add
                     rsMap:{},
                     jobMap:{},
+                    grpMap:{},
                     unclassifiedFailureMap: {},
                     //used as the offset in paging
                     rsMapOldestTimestamp:null,
@@ -253,11 +254,6 @@ treeherder.factory('ThResultSetStore', [
             _.detect(getJobMap(repoName), addIfShown);
 
             return shownJobs;
-        };
-
-        var getJobMapKey = function(job) {
-            //Build string key for jobMap entires
-            return 'key' + job.id;
         };
 
         var getSelectedJob = function(repoName){
@@ -330,6 +326,7 @@ treeherder.factory('ThResultSetStore', [
                 // groups
                 for (var gp_i = 0; gp_i < pl_obj.groups.length; gp_i++) {
                     var gr_obj = pl_obj.groups[gp_i];
+                    gr_obj.mapKey = thAggregateIds.getGroupMapKey(rs_obj.id, gr_obj.name, gr_obj.symbol, pl_obj.name, pl_obj.option);
 
                     var grMapElement = {
                         grp_obj: gr_obj,
@@ -338,10 +335,21 @@ treeherder.factory('ThResultSetStore', [
                     };
                     plMapElement.groups[gr_obj.name] = grMapElement;
 
+                    // check if we need to copy groupState from an existing group
+                    // object.  This would be set if a user explicitly clicked
+                    // a group to toggle it expanded/collapsed.
+                    // This value will have been overwritten by the _.extend
+                    // in mapResultSetJobs.
+                    var oldGroup = repositories[repoName].grpMap[gr_obj.mapKey];
+                    if (oldGroup) {
+                        gr_obj.groupState = oldGroup.grp_obj.groupState;
+                    }
+                    repositories[repoName].grpMap[gr_obj.mapKey] = grMapElement;
+
                     // jobs
                     for (var j_i = 0; j_i < gr_obj.jobs.length; j_i++) {
                         var job_obj = gr_obj.jobs[j_i];
-                        var key = getJobMapKey(job_obj);
+                        var key = thAggregateIds.getJobMapKey(job_obj);
 
                         var jobMapElement = {
                             job_obj: job_obj,
@@ -442,6 +450,7 @@ treeherder.factory('ThResultSetStore', [
                     var grp_obj = {
                         symbol: groupInfo.symbol,
                         name: groupInfo.name,
+                        mapKey: groupInfo.mapKey,
                         jobs: []
                     };
 
@@ -620,7 +629,7 @@ treeherder.factory('ThResultSetStore', [
          */
         var updateJob = function(repoName, newJob) {
 
-            var key = getJobMapKey(newJob);
+            var key = thAggregateIds.getJobMapKey(newJob);
             var loadedJobMap = repositories[repoName].jobMap[key];
             var loadedJob = loadedJobMap? loadedJobMap.job_obj: null;
             var rsMapElement = repositories[repoName].rsMap[newJob.result_set_id];
@@ -785,6 +794,9 @@ treeherder.factory('ThResultSetStore', [
             // this is a "watchable" for jobs
             return repositories[repoName].jobMap;
         };
+        var getGroupMap = function(repoName){
+            return repositories[repoName].grpMap;
+        };
         var getLoadingStatus = function(repoName){
             return repositories[repoName].loadingStatus;
         };
@@ -896,6 +908,8 @@ treeherder.factory('ThResultSetStore', [
 
             var name = job.job_group_name;
             var symbol = job.job_group_symbol;
+            var mapKey = thAggregateIds.getGroupMapKey(job.result_set_id, name, job.platform, job.platform_option);
+
             if (job.tier && job.tier !== 1) {
                 if (symbol === "?") {
                     symbol = "";
@@ -905,7 +919,7 @@ treeherder.factory('ThResultSetStore', [
                 symbol = tierLabel;
             }
 
-            return {name: name, symbol: symbol};
+            return {name: name, symbol: symbol, mapKey: mapKey};
         };
 
         /*
@@ -1034,6 +1048,7 @@ treeherder.factory('ThResultSetStore', [
             fetchResultSets: fetchResultSets,
             getAllShownJobs: getAllShownJobs,
             getJobMap: getJobMap,
+            getGroupMap: getGroupMap,
             getLoadingStatus: getLoadingStatus,
             getPlatformKey: getPlatformKey,
             getResultSet: getResultSet,

--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -64,12 +64,11 @@ treeherder.provider('thResultStatusObject', function() {
 
 treeherder.provider('thResultStatusInfo', function() {
     this.$get = function() {
-        return function(resultState) {
+        return function(resultState, failure_classification_id) {
             // default if there is no match, used for pending
             var resultStatusInfo = {
                 severity: 100,
-                btnClass: "btn-default",
-                jobButtonIcon: ""
+                btnClass: "btn-default"
             };
 
             switch (resultState) {
@@ -77,8 +76,6 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 1,
                         btnClass: "btn-red",
-                        btnClassClassified: "btn-red-classified",
-                        jobButtonIcon: "glyphicon glyphicon-fire",
                         countText: "busted"
                     };
                     break;
@@ -86,8 +83,6 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 2,
                         btnClass: "btn-purple",
-                        btnClassClassified: "btn-purple-classified",
-                        jobButtonIcon: "glyphicon glyphicon-fire",
                         countText: "exception"
                     };
                     break;
@@ -95,8 +90,6 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 3,
                         btnClass: "btn-orange",
-                        btnClassClassified: "btn-orange-classified",
-                        jobButtonIcon: "glyphicon glyphicon-warning-sign",
                         countText: "failed"
                     };
                     break;
@@ -104,8 +97,6 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 4,
                         btnClass: "btn-black",
-                        btnClassClassified: "btn-black-classified",
-                        jobButtonIcon: "",
                         countText: "unknown"
                     };
                     break;
@@ -113,7 +104,6 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 5,
                         btnClass: "btn-pink",
-                        jobButtonIcon: "",
                         countText: "cancel"
                     };
                     break;
@@ -121,7 +111,6 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 6,
                         btnClass: "btn-dkblue",
-                        jobButtonIcon: "",
                         countText: "retry"
                     };
                     break;
@@ -129,7 +118,6 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 7,
                         btnClass: "btn-green",
-                        jobButtonIcon: "",
                         countText: "success"
                     };
                     break;
@@ -137,7 +125,6 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 8,
                         btnClass: "btn-dkgray",
-                        jobButtonIcon: "",
                         countText: "running"
                     };
                     break;
@@ -145,7 +132,6 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 100,
                         btnClass: "btn-ltgray",
-                        jobButtonIcon: "",
                         countText: "pending"
                     };
                     break;
@@ -153,12 +139,16 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 101,
                         btnClass: "btn-yellow",
-                        jobButtonIcon: "",
                         countText: "coalesced"
                     };
                     break;
             }
 
+            // handle if a job is classified
+            if(parseInt(failure_classification_id, 10) > 1){
+                resultStatusInfo.btnClass = resultStatusInfo.btnClass + "-classified";
+                resultStatusInfo.countText = "classified " + resultStatusInfo.countText;
+            }
             return resultStatusInfo;
         };
 
@@ -206,6 +196,8 @@ treeherder.provider('thEvents', function() {
 
             // fired when a global filter has changed
             globalFilterChanged: "status-filter-changed-EVT",
+
+            groupStateChanged: "group-state-changed-EVT",
 
             toggleRevisions: "toggle-revisions-EVT",
 
@@ -257,10 +249,23 @@ treeherder.provider('thAggregateIds', function() {
         return escape(repoName + resultsetId + revision);
     };
 
+    var getGroupMapKey = function(result_set_id, grName, grSymbol, plName, plOpt) {
+        //Build string key for groupMap entires
+        return escape(result_set_id + grName + grSymbol + plName + plOpt);
+    };
+
+    var getJobMapKey = function(job) {
+        //Build string key for jobMap entires
+        return 'key' + job.id;
+    };
+
     this.$get = function() {
         return {
             getPlatformRowId:getPlatformRowId,
-            getResultsetTableId:getResultsetTableId
+            getResultsetTableId:getResultsetTableId,
+            getJobMapKey: getJobMapKey,
+            getGroupMapKey: getGroupMapKey,
+            escape: escape
             };
     };
 });

--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -42,7 +42,8 @@ treeherder.factory('thCloneHtml', [
             'resultsetClone.html',
             'platformClone.html',
             'jobTdClone.html',
-            'jobGroupBeginClone.html',
+            'jobGroupClone.html',
+            'jobGroupCountClone.html',
             'jobBtnClone.html',
             'revisionUrlClone.html',
             'pushlogRevisionsClone.html'

--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -162,11 +162,11 @@ treeherder.value("thJobNavSelectors",
     {
         ALL_JOBS: {
             name: "jobs",
-            selector: ".job-btn"
+            selector: ".job-btn, .selected-job, .selected-count"
         },
         UNCLASSIFIED_FAILURES: {
             name: "unclassified failures",
-            selector: ".selected-job, " +
+            selector: ".selected-job, .selected-count, " +
                       ".job-btn.btn-red, " +
                       ".job-btn.btn-orange, " +
                       ".job-btn.btn-purple"

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -36,7 +36,7 @@
 
         <span class="btn btn-sm btn-resultset"
               tabindex="0" role="button"
-              title="Pin all visible jobs in this resultset"
+              title="Pin all available jobs in this resultset"
               ignore-job-clear-on-click
               ng-click="pinAllShownJobs()">
           <span class="glyphicon glyphicon-pushpin"

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -38,7 +38,21 @@
                     </span>
                 </span>
 
-                <!--Quick Filter Field-->
+                <!--Toggle Group State Button-->
+                <span class="btn-group">
+                    <span class="btn btn-view-nav btn-sm btn-toggle-group-state"
+                          tabindex="0" role="button"
+                          ng-click="toggleGroupState()">(
+                        <span ng-if="groupState==='collapsed'"
+                              class="group-state-nav-icon"
+                              title="Expand job groups">+</span>
+                        <span ng-if="groupState!=='collapsed'"
+                              class="group-state-nav-icon"
+                              title="Collapse job groups">-</span>
+                    )</span>
+                </span>
+
+                <!--Search Field-->
                 <span ng-controller="SearchCtrl" class="form-group form-inline" id="quick-filter-parent">
                     <input id="quick-filter"
                            title="Click to enter filter values"

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -353,7 +353,7 @@ treeherder.controller('PluginCtrl', [
             }
         };
 
-        var selectJobAndRender = function(job_id){
+        var selectJobAndRender = function(job_id) {
             $scope.jobLoadedPromise = selectJob(job_id);
             $scope.jobLoadedPromise.then(function(){
                 thTabs.showTab(thTabs.selectedTab, job_id);


### PR DESCRIPTION
This is take 2 on this feature.  This is a new branch, and is rebased on new commits - one of which fixed interactions between groups when classifying/unclassifying.

This branch aggregates non-failed jobs within groups and shows the counts of each result/state within.
A ``+`` precedes each count to indicate that's what it is.

A few points of interest:
* Clicking any group or count will expand or collapse the group.  This choice is
remembered as jobs are updated and filters are changed.  Page reload resets it.
* Clicking on the ``( + )`` and ``( - )`` buttons will toggle groups expanded/collapsed
globally.  This is persisted in the URL.  Clicking this button will reset any group
expand/collapse state that was set individually.
* Failed Unclassified jobs are never put into "counts".  They show as top-level
jobs and are still hit with the ``n`` and ``p`` hot keys, etc.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/865)
<!-- Reviewable:end -->
