### PR TITLE
Bug 1193216 - Improve log not found notifications in logviewer

### DIFF
--- a/ui/css/logviewer.css
+++ b/ui/css/logviewer.css
@@ -62,6 +62,11 @@ body {
     vertical-align: middle;
 }
 
+/* Override the position of the shared notification partial */
+#notification-box {
+    top: 285px;
+}
+
 .lv-line-no {
     width: 3em;
 }
@@ -162,6 +167,15 @@ body {
 
 .actionbtn-icon {
     padding-right: 5px;
+}
+
+.actionbtn-warning {
+    margin-right: 1px;
+    padding: 2px;
+    background-color: #fcf8e3;
+    border: 1px solid #fbd890;
+    border-radius: 2px;
+    color: #8a6d3b;
 }
 
 .lv-line-no.label {

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -6,11 +6,11 @@
 
 logViewerApp.controller('LogviewerCtrl', [
     '$anchorScroll', '$http', '$location', '$q', '$rootScope', '$scope',
-    '$timeout', 'ThJobArtifactModel', 'ThLog', 'ThLogSliceModel', 'ThJobModel',
+    '$timeout', 'ThJobArtifactModel', 'ThLog', 'ThLogSliceModel', 'ThJobModel', 'thNotify',
     'dateFilter', 'thJobSearchStr', 'ThResultSetModel', 'thDateFormat', 'thReftestStatus',
     function Logviewer(
         $anchorScroll, $http, $location, $q, $rootScope, $scope,
-        $timeout, ThJobArtifactModel, ThLog, ThLogSliceModel, ThJobModel,
+        $timeout, ThJobArtifactModel, ThLog, ThLogSliceModel, ThJobModel, thNotify,
         dateFilter, thJobSearchStr, ThResultSetModel, thDateFormat, thReftestStatus) {
 
         var $log = new ThLog('LogviewerCtrl');
@@ -148,6 +148,7 @@ logViewerApp.controller('LogviewerCtrl', [
                 }, function (error) {
                     $scope.loading = false;
                     $scope.logError = true;
+                    thNotify.send("The log no longer exists or has expired", 'warning', 'true');
                     deferred.reject();
                 });
             } else {

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -41,10 +41,12 @@
 
           <!-- Raw log button -->
           <li>
-            <a title="Open the raw log in a new window"
+            <a title="{{logError ? 'Raw log link no longer exists or has expired (click for path)' :
+                      'Open the raw log in a new window'}}"
                target="_blank"
                href="{{::artifact.logurl}}">
-              <span class="fa fa-file-text-o actionbtn-icon"></span>
+              <span ng-class="logError ? 'fa-warning actionbtn-warning' : 'fa-file-text-o actionbtn-icon'"
+                    class="fa"></span>
               <span>open raw log</span>
             </a>
           </li>
@@ -109,6 +111,8 @@
          lv-log-lines="displayedLogLines">
     </div>
 
+    <th-notification-box></th-notification-box>
+
     <!-- build:js js/logviewer.min.js -->
     <script src="vendor/jquery-2.1.3.js"></script>
     <script src="vendor/angular/angular.js"></script>
@@ -131,6 +135,7 @@
     <script src="js/directives/treeherder/log_viewer_infinite_scroll.js"></script>
     <script src="js/directives/treeherder/log_viewer_lines.js"></script>
     <script src="js/directives/treeherder/log_viewer_steps.js"></script>
+    <script src="js/directives/treeherder/main.js"></script>
 
     <!-- Main services -->
     <script src="js/services/main.js"></script>

--- a/ui/partials/logviewer/lvLogLines.html
+++ b/ui/partials/logviewer/lvLogLines.html
@@ -1,9 +1,6 @@
 <div class="lv-log-msg lv-log-overlay"
      ng-if="loading"> Loading... </div>
 
-<div class="lv-log-msg lv-log-overlay lv-log-error"
-     ng-if="logError"> Log could not be found </div>
-
 <div ng-repeat="lv_line in displayedLogLines"
      ng-class="{'text-danger': (lv_line.hasError == true),
                 'lv-selected-lines': (displayedStep.order === lv_line.index)}"


### PR DESCRIPTION
This work fixes Bugzilla bug [1193216](https://bugzilla.mozilla.org/show_bug.cgi?id=1193216).

This provides both a landing and navigation notification, and a persistent UI warning that the log is unavailable (ie. if the user had simply pinned the page and returned to it.)

I decided to not inject the domain into the error message or link to the log; but instead cue the user to click on the raw log link we already provide in the navbar, which implicitly contains both the domain and the link.

I'm also making the case here - that since we have valid data in the form of the job header it's not a completely invalid page, so our bootstrap warning color (yellow) is appropriate. I do fully intend to use our bootstrap error (red) for bug [1193222](https://bugzilla.mozilla.org/show_bug.cgi?id=1193222) when no log ***or*** job header exists.

This look and appearance for the yellow raw log warning icon wrapped in a styled span, also matches our upcoming 'unknown step result' warning, in PR https://github.com/mozilla/treeherder/pull/859.

Current production (failure case):
![current](https://cloud.githubusercontent.com/assets/3660661/9232015/52c4866e-40f9-11e5-894a-9f3976a2a1db.jpg)

Proposed (shows the brief period of the non-sticky notification):
![proposed](https://cloud.githubusercontent.com/assets/3660661/9232064/9521a1ae-40f9-11e5-9037-44d416780cb0.jpg)

Proposed (static appearance, and hover tooltip):
![proposedtooltip](https://cloud.githubusercontent.com/assets/3660661/9232145/f30666ba-40f9-11e5-9b6f-8787a4da25cc.jpg)

If we feel strongly notifications are overkill, I can omit them but I think it's reasonable rather than receiving complaints from users the UX is not prominent enough here :)

Tested on OSX 10.10.3:
Nightly **42.0a1 (2015-08-11)**
Chrome Latest Release **44.0.2403.155 (64-bit)**

Adding @camd for review and @edmorley for visibility and comments.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/867)
<!-- Reviewable:end -->
