### PR TITLE
Bug 1160561 - Use correct env variable for PULSE_URI

### DIFF
--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -348,11 +348,8 @@ TREEHERDER_REQUESTS_TIMEOUT = 30
 # timeout for acquiring lock to update performance series
 PERFHERDER_UPDATE_SERIES_LOCK_TIMEOUT = 60
 
-# Build the default pulse uri this is passed to kombu
-PULSE_URI = 'amqps://{}:{}@pulse.mozilla.org/'.format(
-    os.environ.get('PULSE_USERNAME', 'guest'),
-    os.environ.get('PULSE_PASSWORD', 'guest')
-)
+# The pulse uri that is passed to kombu
+PULSE_URI = os.environ.get("PULSE_URI", "amqps://guest:guest@pulse.mozilla.org/")
 
 # Note we will never publish any pulse messages unless the exchange namespace is
 # set this normally is your pulse username.


### PR DESCRIPTION
PULSE_USERNAME and PULSE_PASSWORD are not actually defined anywhere, including in production. Instead we're relying on production's local.py to set the value, rather than prod's PULSE_URI, which _is_ set. By switching to use PULSE_URI, we're one step closer to not needing local.py on prod.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/871)
<!-- Reviewable:end -->
