### PR TITLE
Bug 1062995 - Fix test creation in test_log_view_artifact_builder.py

### DIFF
--- a/tests/log_parser/test_log_view_artifact_builder.py
+++ b/tests/log_parser/test_log_view_artifact_builder.py
@@ -30,17 +30,17 @@ def do_test(log, check_errors=True):
     lpc = ArtifactBuilderCollection(url, builders=builder)
     lpc.parse()
     act = lpc.artifacts[builder.name]
-
-    # we can't compare the "logurl" field, because it's a fully qualified url,
-    # so it will be different depending on the config it's run in.
-    assert "logurl" in act
-    del(act["logurl"])
-
     exp = test_utils.load_exp("{0}.logview.json".format(log))
 
-    # :: use to create the ``exp`` files, if you're making a lot of them
+    # :: Uncomment to create the ``exp`` files, if you're making a lot of them
+    # import json
     # with open(SampleData().get_log_path("{0}.logview.json".format(log)), "w") as f:
     #     f.write(json.dumps(act, indent=4))
+
+    # we can't compare the "logurl" field, because it's a fully qualified url,
+    # so it will be different depending on the machine it's run on.
+    assert "logurl" in act
+    del(act["logurl"])
 
     # log urls won't match in tests, since they're machine specific
     # but leave it in the exp file as an example of what the real structure


### PR DESCRIPTION
Previously the tests were created after `act["logurl"]` was deleted, so the resultant expected output .json file was missing the "logurl" key. The json import was also missing - people now just have to uncomment the test creation block, and not also add the missing import each time.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/874)
<!-- Reviewable:end -->
