### PR TITLE
Bug 1179337 - Quiet logviewer error on first-click of a failure-step

### DIFF
--- a/ui/partials/logviewer/lvLogSteps.html
+++ b/ui/partials/logviewer/lvLogSteps.html
@@ -2,7 +2,7 @@
   <div ng-repeat="step in artifact.step_data.steps"
        ng-click="displayLog(step)"
        ng-class="{'selected': (displayedStep.order === step.order)}"
-       ng-if="showSuccessful === true || step.result !== 'success'"
+       ng-show="showSuccessful === true || step.result !== 'success'"
        class="btn btn-block lv-step clearfix {{::getShadingClass(step.result)}}"
        order="{{step.order}}">
     <span class="pull-left clearfix text-left">


### PR DESCRIPTION
This fixes Bugzilla bug [1179337](https://bugzilla.mozilla.org/show_bug.cgi?id=1179337).

World's shortest PR :)

Currently we suppress successful steps by default via `ng-if`. But in that condition the available `order=(n)` step attributes in the DOM is incomplete, and when selecting a step (the colored button boundary) we get the console error:

`TypeError: el.offset(...) is undefined`

![error](https://cloud.githubusercontent.com/assets/3660661/9284235/2b4d95d4-42a8-11e5-8f0a-47be3a06a088.jpg)

That related `getOffsetOfStep()` stuff is handled [here](https://github.com/mozilla/treeherder/blob/01beccbedafc9490da212cabb4bfc264065f7fe3/ui/js/directives/treeherder/log_viewer_lines.js#L26-L36).

It seems the simplest solution is to ensure the step count is always correct, by switching from `ng-if` to `ng-show`, so all steps are always available in the DOM, not just when showSuccessful() is true.

Everything seems fine in general testing on both browsers and successful steps behave as they did prior.

Tested on OSX 10.10.3:
Nightly **43.0a1 (2015-08-16)**
Chrome Latest Release **44.0.2403.155 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/876)
<!-- Reviewable:end -->
