### PR TITLE
Bug 1195381 - Provide an unclassified count ID for webqa testing

### DIFF
--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -10,7 +10,8 @@
                       title="Loaded failures / Toggle filtering for unclassified failures"
                       tabindex="0" role="button"
                       ng-class="{'btn-unclassified-failures': getUnclassifiedFailureCount(repoName), 'btn-view-nav': getUnclassifiedFailureCount(repoName)===0}">
-                    <span>{{ getUnclassifiedFailureCount(repoName) }}</span> unclassified
+                    <span id="unclassified-failure-count">
+                        {{getUnclassifiedFailureCount(repoName)}}</span> unclassified
                 </span>
 
                 <!--Toggle Tier-1 jobs only Button-->


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1195381](https://bugzilla.mozilla.org/show_bug.cgi?id=1195381).

This provides an ID for the unclassified failure count, so the webqa team can reliably access its value and ensure a failure exists in the DOM before a test proceeds.

![0592fa84-44c2-11e5-9072-b5eb9eb4a663](https://cloud.githubusercontent.com/assets/3660661/9310364/52b592ac-44dd-11e5-9117-9ee95c5fdcf7.jpg)

Tested on OSX 10.10.3:
Nightly **43.0a1 (2015-08-16)**
Chrome Latest Release **44.0.2403.155 (64-bit)**

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/877)
<!-- Reviewable:end -->
