### PR TITLE
Bug 1195493 - Convert partials/main to 2 space indent

### DIFF
--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -1,67 +1,66 @@
+<!-- Load progress bar -->
 <div class="progress progress-striped active"
      ng-show="isLoadingRsBatch.prepending && result_sets.length === 0">
-    <div class="progress-bar"  role="progressbar" style="width: 100%"></div>
+  <div class="progress-bar"  role="progressbar" style="width: 100%"></div>
 </div>
 
+<!-- Main resultset template -->
 <div ng-repeat="resultset in result_sets track by resultset.id | orderBy:'-push_timestamp'"
      ng-controller="ResultSetCtrl"
      class="result-set"
      data-id="{{::resultset.id}}">
 
-    <div class="result-set-bar">
-      <span class="result-set-left">
-        <span class="result-set-title-left">
-          <span class="btn btn-default btn-sm glyphicon glyphicon-download" ng-show="isLoadingJobs"></span>
-          <span>
-            <a href="{{::revisionResultsetFilterUrl}}"
-               title="View only this resultset"
-               ignore-job-clear-on-click>{{::resultsetDateStr}}
-              <span class="fa fa-external-link icon-superscript"></span></a> - </span>
-          <th-author author="{{::resultset.author}}"></th-author>
-        </span>
+  <div class="result-set-bar">
+    <span class="result-set-left">
+      <span class="result-set-title-left">
+        <span class="btn btn-default btn-sm glyphicon glyphicon-download" ng-show="isLoadingJobs"></span>
+        <span>
+          <a href="{{::revisionResultsetFilterUrl}}"
+             title="View only this resultset"
+             ignore-job-clear-on-click>{{::resultsetDateStr}}
+            <span class="fa fa-external-link icon-superscript"></span></a> - </span>
+        <th-author author="{{::resultset.author}}"></th-author>
       </span>
-      <th-result-counts class="result-counts"></th-result-counts>
-      <span class="result-set-buttons">
-
-        <span class="btn btn-sm btn-resultset"
-              tabindex="0" role="button"
-              title="Cancel all jobs in this resultset"
-              ng-show="currentRepo.repository_group.name == 'try' || user.is_staff"
-              ignore-job-clear-on-click
-              ng-click="cancelAllJobs(resultset.revision)">
-          <span class="fa fa-times-circle cancel-job-icon dim-quarter"
-                ignore-job-clear-on-click></span>
-        </span>
-
-        <span class="btn btn-sm btn-resultset"
-              tabindex="0" role="button"
-              title="Pin all available jobs in this resultset"
-              ignore-job-clear-on-click
-              ng-click="pinAllShownJobs()">
-          <span class="glyphicon glyphicon-pushpin"
-                ignore-job-clear-on-click></span>
-        </span>
-
-        <th-action-button ng-hide="isLoadingJobs"></th-action-button>
-
+    </span>
+    <th-result-counts class="result-counts"></th-result-counts>
+    <span class="result-set-buttons">
+      <span class="btn btn-sm btn-resultset"
+            tabindex="0" role="button"
+            title="Cancel all jobs in this resultset"
+            ng-show="currentRepo.repository_group.name == 'try' || user.is_staff"
+            ignore-job-clear-on-click
+            ng-click="cancelAllJobs(resultset.revision)">
+        <span class="fa fa-times-circle cancel-job-icon dim-quarter"
+              ignore-job-clear-on-click></span>
       </span>
+      <span class="btn btn-sm btn-resultset"
+            tabindex="0" role="button"
+            title="Pin all available jobs in this resultset"
+            ignore-job-clear-on-click
+            ng-click="pinAllShownJobs()">
+        <span class="glyphicon glyphicon-pushpin"
+              ignore-job-clear-on-click></span>
+      </span>
+      <th-action-button ng-hide="isLoadingJobs"></th-action-button>
+    </span>
+  </div>
 
-    </div>
-    <div class="result-set-body-divider"></div>
-    <div class="result-set-body" th-clone-jobs ></div>
+  <div class="result-set-body-divider"></div>
+  <!-- Job table -->
+  <div class="result-set-body" th-clone-jobs ></div>
 </div>
 
+<!-- Resultset load errors -->
 <div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending &&
               !isLoadingJobs && locationHasSearchParam('revision') && currentRepo.url"
               class="result-set-body unknown-message-body">
   <span ng-init="revision=getSearchParamValue('revision')">
-      <span>Waiting for a push with revision <strong>{{revision}}</strong></span>
-      <a href="{{currentRepo.getPushLogHref(revision)}}"
-         target="_blank"
-         title="open revision {{revision}} on {{currentRepo.url}}">(view pushlog)</a>
+    <span>Waiting for a push with revision <strong>{{revision}}</strong></span>
+    <a href="{{currentRepo.getPushLogHref(revision)}}"
+       target="_blank"
+       title="open revision {{revision}} on {{currentRepo.url}}">(view pushlog)</a>
     <span class="fa fa-spinner fa-pulse th-spinner"></span>
-    <div>If the push exists, it will appear in a few minutes once it has been processed.
-    </div>
+    <div>If the push exists, it will appear in a few minutes once it has been processed.</div>
   </span>
 </div>
 
@@ -88,21 +87,20 @@
     </span>
   </span>
 </div>
+<!-- End resultset clone target -->
 
-<!-- END Revision clone target -->
-
+<!-- New resultsets progress bar -->
 <div class="progress progress-striped active"
      ng-show="isLoadingRsBatch.appending">
-    <div class="progress-bar"  role="progressbar" style="width: 100%"></div>
+  <div class="progress-bar"  role="progressbar" style="width: 100%"></div>
 </div>
 
 <!-- Get next resultsets footer -->
 <div class="well">
      get next:
-    <div class="btn-group">
-        <div class="btn btn-default btn-sm"
-             ng-click="getNextResultSets(count, true)"
-             ng-repeat="count in [10, 20, 50]">{{::count}}</div>
-        </div>
-    </div>
+  <div class="btn-group">
+    <div class="btn btn-default btn-sm"
+         ng-click="getNextResultSets(count, true)"
+         ng-repeat="count in [10, 20, 50]">{{::count}}</div>
+  </div>
 </div>

--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -1,34 +1,35 @@
-    <span class="btn-group" dropdown>
-        <button dropdown-toggle
-           class="btn btn-sm btn-resultset dropdown-toggle"
-           type="button"
-           title="Action menu"
-           data-hover="dropdown"
-           data-delay="1000">
-            <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu pull-right">
-            <li><a target="_blank" ignore-job-clear-on-click
-                   href="https://mcmerge.paas.allizom.org/?cset={{::resultset.revision}}&amp;tree={{::repoName}}"
-                   title="Use Bugherder to mark the bugs in this push">Mark with Bugherder</a></li>
-            <li><a target="_blank" ignore-job-clear-on-click
-                   href="https://secure.pub.build.mozilla.org/buildapi/self-serve/{{::repoName}}/rev/{{::resultset.revision}}">BuildAPI</a></li>
-            <li><a target="_blank" ignore-job-clear-on-click
-                   href="" prevent-default-on-left-click
-                   ng-show="user.is_staff"
-                   ng-click="triggerMissingJobs(resultset.revision)">Trigger Missing Jobs</a></li>
-            <li><a target="_blank" ignore-job-clear-on-click
-                   href="" prevent-default-on-left-click
-                   ng-show="user.is_staff"
-                   ng-click="triggerAllTalosJobs(resultset.revision)">Trigger All Talos Jobs</a></li>
-            <li><a target="_blank" ignore-job-clear-on-click
-                   href="" prevent-default-on-left-click
-                   ng-click="openRevisionListWindow()">Revision URL List</a></li>
-            <li><a target="_blank" ignore-job-clear-on-click
-                   href="" prevent-default-on-left-click
-                   ng-click="setLocationSearchParam('tochange', resultset.revision)">Set as top of range</a></li>
-            <li><a target="_blank" ignore-job-clear-on-click
-                   href="" prevent-default-on-left-click
-                   ng-click="setLocationSearchParam('fromchange', resultset.revision)">Set as bottom of range</a></li>
-        </ul>
-    </span>
+<span class="btn-group" dropdown>
+  <button dropdown-toggle
+          class="btn btn-sm btn-resultset dropdown-toggle"
+          type="button"
+          title="Action menu"
+          data-hover="dropdown"
+          data-delay="1000">
+    <span class="caret"></span>
+  </button>
+  <!-- Menu contents -->
+  <ul class="dropdown-menu pull-right">
+    <li><a target="_blank" ignore-job-clear-on-click
+           href="https://mcmerge.paas.allizom.org/?cset={{::resultset.revision}}&amp;tree={{::repoName}}"
+           title="Use Bugherder to mark the bugs in this push">Mark with Bugherder</a></li>
+    <li><a target="_blank" ignore-job-clear-on-click
+           href="https://secure.pub.build.mozilla.org/buildapi/self-serve/{{::repoName}}/rev/{{::resultset.revision}}">BuildAPI</a></li>
+    <li><a target="_blank" ignore-job-clear-on-click
+           href="" prevent-default-on-left-click
+           ng-show="user.is_staff"
+           ng-click="triggerMissingJobs(resultset.revision)">Trigger Missing Jobs</a></li>
+    <li><a target="_blank" ignore-job-clear-on-click
+           href="" prevent-default-on-left-click
+           ng-show="user.is_staff"
+           ng-click="triggerAllTalosJobs(resultset.revision)">Trigger All Talos Jobs</a></li>
+    <li><a target="_blank" ignore-job-clear-on-click
+           href="" prevent-default-on-left-click
+           ng-click="openRevisionListWindow()">Revision URL List</a></li>
+    <li><a target="_blank" ignore-job-clear-on-click
+           href="" prevent-default-on-left-click
+           ng-click="setLocationSearchParam('tochange', resultset.revision)">Set as top of range</a></li>
+    <li><a target="_blank" ignore-job-clear-on-click
+           href="" prevent-default-on-left-click
+           ng-click="setLocationSearchParam('fromchange', resultset.revision)">Set as bottom of range</a></li>
+  </ul>
+</span>

--- a/ui/partials/main/thFilterCheckbox.html
+++ b/ui/partials/main/thFilterCheckbox.html
@@ -1,6 +1,6 @@
 <label class="checkbox-inline {{::checkClass}}">
-    <input type="checkbox"
-           id="{{::filterName}}"
-           ng-model="resultStatusFilters[filterName]"
-           ng-change="toggleResultStatusFilter(filterName)">{{::filterName}}
+  <input type="checkbox"
+         id="{{::filterName}}"
+         ng-model="resultStatusFilters[filterName]"
+         ng-change="toggleResultStatusFilter(filterName)">{{::filterName}}
 </label>

--- a/ui/partials/main/thFilterPanel.html
+++ b/ui/partials/main/thFilterPanel.html
@@ -1,116 +1,120 @@
 <div id="filter"
      class="th-top-nav-options-panel model-body"
      ng-controller="FilterPanelCtrl">
-    <div class="nav-panel-help-text">Specify which jobs to show based on this filter criteria.
-        <span class="pull-right">
-            <span class="btn btn-default btn-xs"
-                  title="pin all jobs that pass the global filters"
-                  ng-click="pinAllShownJobs()"><i class="glyphicon glyphicon-pushpin"></i> pin all showing</span>
-            <span class="btn btn-default btn-xs"
-                  title="show only coalesced jobs"
-                  ng-click="thJobFilters.setOnlyCoalesced()">coalesced only</span>
-            <span class="btn btn-default btn-xs"
-                  title="reset to default status filters"
-                  ng-click="thJobFilters.resetNonFieldFilters()">reset</span>
-        </span>
-    </div>
-
-    <!-- result status filters -->
-    <span ng-repeat="group in filterGroups"
-          class="panel panel-default th-option-group th-inline-option-group">
-
-        <!--heading for each group-->
-        <div class="panel-heading th-option-heading">{{::group.name}}
-            <span class="pull-right">
-            <input type="checkbox"
-                   ng-model="group.allChecked"
-                   ng-change="toggleResultStatusGroup(group)"> all
-            </span>
-        </div>
-        <!--content for each group-->
-        <div class="panel-body">
-            <span ng-repeat="filterName in group.resultStatuses">
-                <th-filter-checkbox></th-filter-checkbox>
-            </span>
-        </div>
+  <div class="nav-panel-help-text">Specify which jobs to show based on this filter criteria.
+    <span class="pull-right">
+      <span class="btn btn-default btn-xs"
+            title="Pin all jobs that pass the global filters"
+            ng-click="pinAllShownJobs()"><i class="glyphicon glyphicon-pushpin"></i> pin all showing</span>
+      <span class="btn btn-default btn-xs"
+            title="Show only coalesced jobs"
+            ng-click="thJobFilters.setOnlyCoalesced()">coalesced only</span>
+      <span class="btn btn-default btn-xs"
+            title="Reset to default status filters"
+            ng-click="thJobFilters.resetNonFieldFilters()">reset</span>
     </span>
+  </div>
 
-    <!-- classified / unclassified -->
-    <span class="panel panel-default th-option-group th-inline-option-group">
-        <div class="panel-heading th-option-heading">classified</div>
-        <div class="panel-body">
-            <label class="checkbox-inline">
-                <input type="checkbox"
-                       id="classified"
-                       ng-model="classifiedFilter"
-                       ng-click="toggleClassifiedFilter()"> classified
-            </label>
-            <label class="checkbox-inline">
-                <input type="checkbox"
-                       id="unclassified"
-                       ng-model="unClassifiedFilter"
-                       ng-click="toggleUnClassifiedFilter()"> un-classified
-            </label>
-        </div>
-    </span>
-    <div class="panel panel-default th-option-group">
-        <div class="panel-heading th-option-heading">field filters
-            <span class="pull-right">
-                 <a ng-click="createFieldFilter()"
-                    title="create new field filter">new</a>
-                <span ng-show="fieldFilters.length"> | <a ng-click="removeAllFieldFilters()"
-                       title="delete all field filters">remove all</a>
-                </span>
-            </span>
-        </div>
-        <div class="panel-body">
-            <span class="field-filter-placeholder" ng-hide="fieldFilters.length">click <a ng-click="createFieldFilter()"
-                title="create new field filter">new</a> to filter by a specific job field</span>
-            <h4>
-                <div class="label label-default field-filter"
-                     ng-repeat="filter in fieldFilters">{{::fieldChoices[filter.field].name}}: "{{::getFilterValue(filter.field, filter.value)}}"
-                     <a ng-click="removeFilter($index)"
-                        title="delete this filter"><i class="glyphicon glyphicon-remove"></i></a>
-                </div>
-            </h4>
-        </div>
-        <div class="field-filter-form" ng-show="newFieldFilter">
-            <form novalidate class="form-inline" role="form">
-                <div class="form-group input-group-sm">
-                    <label class="sr-only" for="jobFilterField">Field</label>
-                    <select id="jobFilterField"
-                            class="form-control"
-                            ng-model="newFieldFilter.field"
-                            ng-change="setFieldMatchType()"
-                            placeholder="filter field"
-                            required>
-                        <option value="" disabled selected>select filter field</option>
-                        <option ng-repeat="(field, obj) in fieldChoices"
-                                value="{{::field}}">{{::obj.name}}</option>
-                    </select>
-                    <label class="sr-only" for="jobFilterValue">Value</label>
-                    <input ng-show="newFieldFilter.matchType!=='choice'"
-                           class="form-control"
-                           ng-model="newFieldFilter.value"
-                           id="jobFilterValue"
-                           type="text"
-                           placeholder="filter value">
-                    <label class="sr-only" for="jobFilterChoiceValue">Value</label>
-                    <select ng-show="newFieldFilter.matchType==='choice'"
-                            class="form-control"
-                            ng-model="newFieldFilter.value"
-                            id="jobFilterChoiceValue">
-                        <option value="" disabled selected>select value</option>
-                        <option ng-repeat="(fci, fci_obj) in newFieldFilter.choices"
-                                value="{{::fci}}">{{::fci_obj.name}}</option>
-                    </select>
-                    <button type="submit"
-                            class="btn btn-default btn-sm"
-                            ng-click="addFieldFilter()">add</button>
-                    <button class="btn btn-default btn-sm"
-                            ng-click="cancelFieldFilter()">cancel</button>
-                </div>
-            </form>
-        </div>
+  <!-- Result status filters -->
+  <span ng-repeat="group in filterGroups"
+        class="panel panel-default th-option-group th-inline-option-group">
+
+    <!-- Group heading -->
+    <div class="panel-heading th-option-heading">{{::group.name}}
+      <span class="pull-right">
+      <input type="checkbox"
+             ng-model="group.allChecked"
+             ng-change="toggleResultStatusGroup(group)"> all
+      </span>
     </div>
+    <!-- Group content -->
+    <div class="panel-body">
+      <span ng-repeat="filterName in group.resultStatuses">
+        <th-filter-checkbox></th-filter-checkbox>
+      </span>
+    </div>
+  </span>
+
+  <!-- Classified/Unclassified filters -->
+  <span class="panel panel-default th-option-group th-inline-option-group">
+    <div class="panel-heading th-option-heading">classified</div>
+    <div class="panel-body">
+      <label class="checkbox-inline">
+        <input type="checkbox"
+               id="classified"
+               ng-model="classifiedFilter"
+               ng-click="toggleClassifiedFilter()"> classified
+      </label>
+      <label class="checkbox-inline">
+        <input type="checkbox"
+               id="unclassified"
+               ng-model="unClassifiedFilter"
+               ng-click="toggleUnClassifiedFilter()"> un-classified
+      </label>
+    </div>
+  </span>
+
+  <!-- Field filters -->
+  <div class="panel panel-default th-option-group">
+    <div class="panel-heading th-option-heading">field filters
+      <span class="pull-right">
+        <a ng-click="createFieldFilter()"
+           title="Create new field filter">new</a>
+        <span ng-show="fieldFilters.length"> | <a ng-click="removeAllFieldFilters()"
+              title="Delete all field filters">remove all</a></span>
+      </span>
+    </div>
+    <div class="panel-body">
+      <span class="field-filter-placeholder"
+            ng-hide="fieldFilters.length">click
+        <a ng-click="createFieldFilter()"
+           title="Create new field filter">new</a> to filter by a specific job field
+      </span>
+      <h4>
+        <div class="label label-default field-filter"
+             ng-repeat="filter in fieldFilters">{{::fieldChoices[filter.field].name}}: "{{::getFilterValue(filter.field, filter.value)}}"
+          <a ng-click="removeFilter($index)"
+             title="Delete this filter"><i class="glyphicon glyphicon-remove"></i></a>
+        </div>
+      </h4>
+    </div>
+    <div class="field-filter-form" ng-show="newFieldFilter">
+      <form novalidate class="form-inline" role="form">
+        <div class="form-group input-group-sm">
+          <label class="sr-only" for="jobFilterField">Field</label>
+          <select id="jobFilterField"
+                  class="form-control"
+                  ng-model="newFieldFilter.field"
+                  ng-change="setFieldMatchType()"
+                  placeholder="filter field"
+                  required>
+            <option value="" disabled selected>select filter field</option>
+            <option ng-repeat="(field, obj) in fieldChoices"
+                    value="{{::field}}">{{::obj.name}}</option>
+          </select>
+          <label class="sr-only" for="jobFilterValue">Value</label>
+          <input ng-show="newFieldFilter.matchType!=='choice'"
+                 class="form-control"
+                 ng-model="newFieldFilter.value"
+                 id="jobFilterValue"
+                 type="text"
+                 placeholder="filter value">
+          <label class="sr-only" for="jobFilterChoiceValue">Value</label>
+          <select ng-show="newFieldFilter.matchType==='choice'"
+                  class="form-control"
+                  ng-model="newFieldFilter.value"
+                  id="jobFilterChoiceValue">
+            <option value="" disabled selected>select value</option>
+            <option ng-repeat="(fci, fci_obj) in newFieldFilter.choices"
+                    value="{{::fci}}">{{::fci_obj.name}}</option>
+          </select>
+          <button type="submit"
+                  class="btn btn-default btn-sm"
+                  ng-click="addFieldFilter()">add</button>
+          <button class="btn btn-default btn-sm"
+                  ng-click="cancelFieldFilter()">cancel</button>
+        </div>
+      </form>
+    </div>
+  </div>
 </div>

--- a/ui/partials/main/thGlobalTopNavPanel.html
+++ b/ui/partials/main/thGlobalTopNavPanel.html
@@ -1,99 +1,100 @@
 <nav id="th-global-navbar" class="navbar navbar-inverse">
-    <div id="th-global-navbar-top" class="navbar-collapse collapse">
-        <!-- Logo Menu -->
-        <span class="dropdown">
-            <button id="th-logo" title="Treeherder services" role="button"
-                    href="#" data-toggle="dropdown" data-target="#"
-                    class="btn btn-view-nav">Treeherder
-              <span class="fa fa-angle-down lightgray"></span>
-            </button>
-            <ul class="dropdown-menu" role="menu" aria-labelledby="th-logo">
-              <li><a href="perf.html">Perfherder</a></li>
-            </ul>
+  <div id="th-global-navbar-top" class="navbar-collapse collapse">
+
+    <!-- Logo Menu -->
+    <span class="dropdown">
+      <button id="th-logo" title="Treeherder services" role="button"
+              href="#" data-toggle="dropdown" data-target="#"
+              class="btn btn-view-nav">Treeherder
+        <span class="fa fa-angle-down lightgray"></span>
+      </button>
+      <ul class="dropdown-menu" role="menu" aria-labelledby="th-logo">
+        <li><a href="perf.html">Perfherder</a></li>
+      </ul>
+    </span>
+
+    <span class="navbar-right">
+      <!-- Sheriffing Button -->
+      <span ng-show="user.is_staff">
+        <span class="btn btn-view-nav btn-right-navbar nav-menu-btn"
+             ng-class="{'active': (isSheriffPanelShowing)}"
+             ng-click="setSheriffPanelShowing(!isSheriffPanelShowing)"
+             tabindex="0"
+             role="button"><span>Sheriffing</span>
+          <i class="fa fa-angle-down lightgray"
+             ng-hide="isSheriffPanelShowing"></i>
+          <i class="fa fa-angle-up lightgray"
+             ng-show="isSheriffPanelShowing"></i>
         </span>
-        <span class="navbar-right">
-            <!-- Sheriffing Button -->
-            <span ng-show="user.is_staff">
-                <span class="btn btn-view-nav btn-right-navbar nav-menu-btn"
-                      ng-class="{'active': (isSheriffPanelShowing)}"
-                      ng-click="setSheriffPanelShowing(!isSheriffPanelShowing)"
-                      tabindex="0"
-                      role="button"><span>Sheriffing</span>
-                    <i class="fa fa-angle-down lightgray"
-                       ng-hide="isSheriffPanelShowing"></i>
-                    <i class="fa fa-angle-up lightgray"
-                       ng-show="isSheriffPanelShowing"></i>
-                </span>
+      </span>
+
+      <!-- Infra Menu -->
+      <span class="repo-menu dropdown">
+        <button id="infraLabel" title="Infrastructure status" role="button"
+                href="#" data-toggle="dropdown" data-target="#"
+                class="btn btn-view-nav btn-right-navbar nav-repo-btn">Infra
+          <span class="fa fa-angle-down lightgray"></span>
+        </button>
+        <ul class="dropdown-menu repo-dropdown-menu" role="menu" aria-labelledby="infraLabel"
+            ng-include="'partials/main/thInfraMenu.html'">
+        </ul>
+      </span>
+
+      <!-- Repos Menu -->
+      <span ng-controller="RepositoryMenuCtrl" >
+        <span th-repo-dropdown-container class="repo-menu dropdown">
+          <button id="repoLabel" title="Watch a repo" role="button"
+                  href="#" data-toggle="dropdown" data-target="#"
+                  class="btn btn-view-nav btn-right-navbar nav-repo-btn">Repos
+            <span class="fa fa-angle-down lightgray"></span>
+          </button>
+          <ul class="dropdown-menu repo-dropdown-menu" role="menu" aria-labelledby="repoLabel">
+            <span ng-repeat="(group_order, group) in groupedRepos()">
+              <li role="presentation" class="divider" ng-hide="$first"></li>
+              <li role="presentation" class="dropdown-header">{{::group.name}}</li>
+              <th-repo-menu-item ng-repeat="repo in group.repos | orderBy : 'name'" ></th-repo-menu-item>
             </span>
-
-            <!-- Infra Menu -->
-            <span class="repo-menu dropdown">
-                <button id="infraLabel" title="Infrastructure status" role="button"
-                        href="#" data-toggle="dropdown" data-target="#"
-                        class="btn btn-view-nav btn-right-navbar nav-repo-btn">Infra
-                    <span class="fa fa-angle-down lightgray"></span>
-                </button>
-                <ul class="dropdown-menu repo-dropdown-menu" role="menu" aria-labelledby="infraLabel"
-                    ng-include="'partials/main/thInfraMenu.html'">
-                </ul>
-            </span>
-
-            <!-- Repos Menu -->
-            <span ng-controller="RepositoryMenuCtrl" >
-                <!--<span class="repo-menu dropdown keep-open">-->
-                <span th-repo-dropdown-container class="repo-menu dropdown">
-                    <button id="repoLabel" title="Watch a repo" role="button"
-                            href="#" data-toggle="dropdown" data-target="#"
-                            class="btn btn-view-nav btn-right-navbar nav-repo-btn">Repos
-                        <span class="fa fa-angle-down lightgray"></span>
-                    </button>
-                    <ul class="dropdown-menu repo-dropdown-menu" role="menu" aria-labelledby="repoLabel">
-                        <span ng-repeat="(group_order, group) in groupedRepos()">
-                            <li role="presentation" class="divider" ng-hide="$first"></li>
-                            <li role="presentation" class="dropdown-header">{{::group.name}}</li>
-                            <th-repo-menu-item ng-repeat="repo in group.repos | orderBy : 'name'" ></th-repo-menu-item>
-                        </span>
-                    </ul>
-                </span>
-            </span>
-
-            <!-- Global Filter Button -->
-            <span class="btn btn-view-nav btn-right-navbar nav-menu-btn"
-                  title="Global job filters"
-                  ng-class="{'active': (isFilterPanelShowing)}"
-                  ng-click="setFilterPanelShowing(!isFilterPanelShowing)"
-                  tabindex="0"
-                  role="button"><span>Filters</span>
-                <i class="fa fa-angle-down lightgray"
-                   ng-hide="isFilterPanelShowing"></i>
-                <i class="fa fa-angle-up lightgray"
-                   ng-show="isFilterPanelShowing"></i>
-            </span>
-
-            <!-- Help Button -->
-            <a class="btn btn-view-nav nav-help-btn"
-               title="Treeherder help" href="help.html" target="_blank">
-                <span class="fa fa-question-circle lightgray nav-help-icon"></span></a>
-
-            <!-- Settings Button - currently suppressed -->
-            <span ng-show="false"
-                  class="btn btn-view-nav btn-right-navbar nav-menu-btn"
-                  ng-class="{'active': (isSettingsPanelShowing)}"
-                  ng-click="setSettingsPanelShowing(!isSettingsPanelShowing)"
-                  tabindex="0"
-                  role="button"><span>Settings</span>
-                <i class="fa fa-angle-down lightgray"
-                   ng-hide="isSettingsPanelShowing"></i>
-                <i class="fa fa-angle-up lightgray"
-                   ng-show="isSettingsPanelShowing"></i>
-            </span>
-
-            <!-- Login/Register Button -->
-            <persona-buttons></persona-buttons>
+          </ul>
         </span>
+      </span>
 
-    </div>
-    <ng-include class="watched-repo-navbar" src="'partials/main/thWatchedRepoNavPanel.html'" ng-show="locationPath==='jobs'"></ng-include>
-    <ng-include src="'partials/main/thSheriffPanel.html'" ng-show="isSheriffPanelShowing"></ng-include>
-    <ng-include src="'partials/main/thFilterPanel.html'" ng-show="isFilterPanelShowing"></ng-include>
+      <!-- Global Filter Button -->
+      <span class="btn btn-view-nav btn-right-navbar nav-menu-btn"
+            title="Global job filters"
+            ng-class="{'active': (isFilterPanelShowing)}"
+            ng-click="setFilterPanelShowing(!isFilterPanelShowing)"
+            tabindex="0"
+            role="button"><span>Filters</span>
+        <i class="fa fa-angle-down lightgray"
+           ng-hide="isFilterPanelShowing"></i>
+        <i class="fa fa-angle-up lightgray"
+           ng-show="isFilterPanelShowing"></i>
+      </span>
+
+      <!-- Help Button -->
+      <a class="btn btn-view-nav nav-help-btn"
+         title="Treeherder help" href="help.html" target="_blank">
+        <span class="fa fa-question-circle lightgray nav-help-icon"></span></a>
+
+      <!-- Settings Button - currently suppressed -->
+      <span ng-show="false"
+            class="btn btn-view-nav btn-right-navbar nav-menu-btn"
+            ng-class="{'active': (isSettingsPanelShowing)}"
+            ng-click="setSettingsPanelShowing(!isSettingsPanelShowing)"
+            tabindex="0"
+            role="button"><span>Settings</span>
+        <i class="fa fa-angle-down lightgray"
+           ng-hide="isSettingsPanelShowing"></i>
+        <i class="fa fa-angle-up lightgray"
+           ng-show="isSettingsPanelShowing"></i>
+      </span>
+
+      <!-- Login/Register Button -->
+      <persona-buttons></persona-buttons>
+    </span>
+
+  </div>
+  <ng-include class="watched-repo-navbar" src="'partials/main/thWatchedRepoNavPanel.html'" ng-show="locationPath==='jobs'"></ng-include>
+  <ng-include src="'partials/main/thSheriffPanel.html'" ng-show="isSheriffPanelShowing"></ng-include>
+  <ng-include src="'partials/main/thFilterPanel.html'" ng-show="isFilterPanelShowing"></ng-include>
 </nav>

--- a/ui/partials/main/thInfraMenu.html
+++ b/ui/partials/main/thInfraMenu.html
@@ -1,47 +1,47 @@
 <li role="presentation" class="dropdown-header">Buildbot</li>
 <li>
-    <a href="https://secure.pub.build.mozilla.org/buildapi/pending"
-       target="_blank">BuildAPI: Pending</a>
+  <a href="https://secure.pub.build.mozilla.org/buildapi/pending"
+     target="_blank">BuildAPI: Pending</a>
 </li>
 <li>
-    <a href="https://secure.pub.build.mozilla.org/buildapi/running"
-       target="_blank">BuildAPI: Running</a>
+  <a href="https://secure.pub.build.mozilla.org/buildapi/running"
+     target="_blank">BuildAPI: Running</a>
 </li>
 <li>
-    <a href="http://builddata.pub.build.mozilla.org/reports/pending/pending.html"
-       target="_blank">Graphs: Pending</a>
+  <a href="http://builddata.pub.build.mozilla.org/reports/pending/pending.html"
+     target="_blank">Graphs: Pending</a>
 </li>
 <li>
-    <a href="http://builddata.pub.build.mozilla.org/reports/pending/running.html"
-       target="_blank">Graphs: Running</a>
+  <a href="http://builddata.pub.build.mozilla.org/reports/pending/running.html"
+     target="_blank">Graphs: Running</a>
 </li>
 <li>
-    <a href="https://www.hostedgraphite.com/da5c920d/grafana/#/dashboard/temp/5d509a54d0b496d184023bab35c17d0f41e6c607"
-       target="_blank">EC2 Dashboard</a>
+  <a href="https://www.hostedgraphite.com/da5c920d/grafana/#/dashboard/temp/5d509a54d0b496d184023bab35c17d0f41e6c607"
+     target="_blank">EC2 Dashboard</a>
 </li>
 <li>
-    <a href="https://secure.pub.build.mozilla.org/builddata/reports/slave_health/"
-       target="_blank">Slave Health</a>
+  <a href="https://secure.pub.build.mozilla.org/builddata/reports/slave_health/"
+     target="_blank">Slave Health</a>
 </li>
 <li>
-    <a href="https://api.pub.build.mozilla.org/clobberer/"
-       target="_blank">Clobberer</a>
+  <a href="https://api.pub.build.mozilla.org/clobberer/"
+     target="_blank">Clobberer</a>
 </li>
 <li role="presentation" class="divider"></li>
 <li role="presentation" class="dropdown-header">Other</li>
 <li>
-    <a href="https://treestatus.mozilla.org/"
-       target="_blank">TreeStatus</a>
+  <a href="https://treestatus.mozilla.org/"
+     target="_blank">TreeStatus</a>
 </li>
 <li>
-    <a href="https://nigelbabu.github.io/hgstats/"
-       target="_blank">HgStats</a>
+  <a href="https://nigelbabu.github.io/hgstats/"
+     target="_blank">HgStats</a>
 </li>
 <li>
-    <a href="http://status.taskcluster.net/"
-       target="_blank">TaskCluster</a>
+  <a href="http://status.taskcluster.net/"
+     target="_blank">TaskCluster</a>
 </li>
 <li>
-    <a href="http://futurama.theautomatedtester.co.uk"
-       target="_blank">Futurama</a>
+  <a href="http://futurama.theautomatedtester.co.uk"
+     target="_blank">Futurama</a>
 </li>

--- a/ui/partials/main/thLogoutMenu.html
+++ b/ui/partials/main/thLogoutMenu.html
@@ -1,3 +1,3 @@
 <li>
-    <a ng-click="logout()">Logout</a>
+  <a ng-click="logout()">Logout</a>
 </li>

--- a/ui/partials/main/thMultiSelect.html
+++ b/ui/partials/main/thMultiSelect.html
@@ -1,35 +1,37 @@
 <div class="th-multi-select">
-    <div class="form-group">
-        <input class="form-control input-sm" type="text" ng-model="query" placeholder="filter"/>
-    </div>
-    <div class="form-group-inline">
-        <div class="form-group">
-            <select class="form-control" multiple ng-model="leftSelected">
-                <option value="{{ ::left_elem }}"
-                        ng-repeat="left_elem in leftList| filter: query track by $id(left_elem)">
-                    {{ ::left_elem }}
-                </option>
-            </select>
-        </div>
-        <div class="btn-group-vertical ">
-            <button ng-click="move_left()"
-                    type="button"
-                    class="btn btn-xs btn-default">
-                <span class="glyphicon glyphicon-chevron-left"></span>
-            </button>
-            <button ng-click="move_right()" type="button"
-                    class="btn btn-xs btn-default">
-                <span class="glyphicon glyphicon-chevron-right"></span>
-            </button>
-        </div>
-        <div class="form-group">
-            <select class="form-control" ng-model="rightSelected" multiple>
-                <option value="{{ ::right_elem }}"
-                        ng-repeat="right_elem in rightList">
-                    {{ ::right_elem }}
-                </option>
-            </select>
-        </div>
-    </div>
-</div>
+  <div class="form-group">
+    <input class="form-control input-sm" type="text" ng-model="query" placeholder="filter"/>
+  </div>
 
+  <div class="form-group-inline">
+    <div class="form-group">
+      <select class="form-control" multiple ng-model="leftSelected">
+        <option value="{{ ::left_elem }}"
+                ng-repeat="left_elem in leftList| filter: query track by $id(left_elem)">
+          {{ ::left_elem }}
+        </option>
+      </select>
+    </div>
+
+    <div class="btn-group-vertical ">
+      <button ng-click="move_left()"
+              type="button"
+              class="btn btn-xs btn-default">
+        <span class="glyphicon glyphicon-chevron-left"></span>
+      </button>
+      <button ng-click="move_right()" type="button"
+              class="btn btn-xs btn-default">
+        <span class="glyphicon glyphicon-chevron-right"></span>
+      </button>
+    </div>
+
+    <div class="form-group">
+      <select class="form-control" ng-model="rightSelected" multiple>
+        <option value="{{ ::right_elem }}"
+                ng-repeat="right_elem in rightList">
+          {{ ::right_elem }}
+        </option>
+      </select>
+    </div>
+  </div>
+</div>

--- a/ui/partials/main/thPinboardPanel.html
+++ b/ui/partials/main/thPinboardPanel.html
@@ -16,7 +16,7 @@
     <a ng-click="toggleEnterBugNumber(!enteringBugNumber); allowKeys()"
        class="click-able-icon"
        title="Add a related bug">
-       <i class="fa fa-plus-square add-related-bugs-icon"></i>
+      <i class="fa fa-plus-square add-related-bugs-icon"></i>
     </a>
     <span class="pinboard-preload-txt pinboard-related-bug-preload-txt"
           ng-if="!hasRelatedBugs()"

--- a/ui/partials/main/thPinnedJob.html
+++ b/ui/partials/main/thPinnedJob.html
@@ -1,14 +1,12 @@
 <span class="btn-group">
-    <span class="btn pinned-job {{ ::job.display.btnClass }}"
-          ng-class="{'btn-lg selected-job': (selectedJob==job), 'btn-xs': (selectedJob!=job)}"
-          title="{{ hoverText }}"
-          ng-click="viewJob(job)"
-          ng-right-click="viewLog(job.resource_uri)"
-          data-job-id="{{ job.job_id }}">
-          {{ job.job_type_symbol }}
-    </span>
-    <span class="btn btn-ltgray pinned-job-close-btn"
-          ng-class="{'btn-lg selected-job': (selectedJob==job), 'btn-xs': (selectedJob!=job)}"
-          ng-click="unPinJob(job.id)"
-          title="un-pin this job"><i class="fa fa-times"></i></span>
+  <span class="btn pinned-job {{ ::job.display.btnClass }}"
+        ng-class="{'btn-lg selected-job': (selectedJob==job), 'btn-xs': (selectedJob!=job)}"
+        title="{{ hoverText }}"
+        ng-click="viewJob(job)"
+        ng-right-click="viewLog(job.resource_uri)"
+        data-job-id="{{ job.job_id }}">{{ job.job_type_symbol }}</span>
+  <span class="btn btn-ltgray pinned-job-close-btn"
+        ng-class="{'btn-lg selected-job': (selectedJob==job), 'btn-xs': (selectedJob!=job)}"
+        ng-click="unPinJob(job.id)"
+        title="un-pin this job"><i class="fa fa-times"></i></span>
 </span>

--- a/ui/partials/main/thRelatedBugQueued.html
+++ b/ui/partials/main/thRelatedBugQueued.html
@@ -1,10 +1,9 @@
 <span class="btn-group pinboard-related-bugs-btn">
-    <a class="btn btn-xs related-bugs-link"
-       title="{{::bug.summary}}"
-       href="{{:: getBugUrl(bug.id) }}"
-       target="_blank"
-       ><em>{{::bug.id}}</em></a>
-    <span class="btn btn-ltgray btn-xs pinned-job-close-btn"
-          ng-click="removeBug(bug.id)"
-          title="remove this bug"><i class="fa fa-times"></i></span>
+  <a class="btn btn-xs related-bugs-link"
+     title="{{::bug.summary}}"
+     href="{{:: getBugUrl(bug.id) }}"
+     target="_blank"><em>{{::bug.id}}</em></a>
+  <span class="btn btn-ltgray btn-xs pinned-job-close-btn"
+        ng-click="removeBug(bug.id)"
+        title="remove this bug"><i class="fa fa-times"></i></span>
 </span>

--- a/ui/partials/main/thRelatedBugSaved.html
+++ b/ui/partials/main/thRelatedBugSaved.html
@@ -1,12 +1,14 @@
 <span class="btn-group pinboard-related-bugs-btn">
-    <a class="btn btn-xs annotations-bug related-bugs-link"
-       href="{{:: getBugUrl(bug.bug_id) }}"
-       target="_blank"
-       title="View bug {{::bug.bug_id}}"
-       ><em>{{::bug.bug_id}}</em></a>
-    <span class="btn classification-delete-icon hover-warning btn-xs
-                 pinned-job-close-btn annotations-bug"
-          ng-click="deleteBug(bug)"
-          title="Delete relation to bug {{::bug.bug_id}}">
-      <i class="fa fa-times-circle"></i></span>
+  <a class="btn btn-xs annotations-bug related-bugs-link"
+     href="{{:: getBugUrl(bug.bug_id) }}"
+     target="_blank"
+     title="View bug {{::bug.bug_id}}">
+    <em>{{::bug.bug_id}}</em>
+  </a>
+  <span class="btn classification-delete-icon hover-warning btn-xs
+               pinned-job-close-btn annotations-bug"
+        ng-click="deleteBug(bug)"
+        title="Delete relation to bug {{::bug.bug_id}}">
+    <i class="fa fa-times-circle"></i>
+  </span>
 </span>

--- a/ui/partials/main/thRepoMenuItem.html
+++ b/ui/partials/main/thRepoMenuItem.html
@@ -1,9 +1,8 @@
 <li>
-    <input type="checkbox"
-           class="repo-checkbox"
-           ng-checked="repoModel.watchedRepos[repo.name]"
-           ng-click="repoModel.toggleWatched(repo.name)"
-           title="toggle watching this repo">
-        <a title="open repo"
-           class="repo-link">{{::repo.name}}</a>
+  <input type="checkbox"
+         class="repo-checkbox"
+         ng-checked="repoModel.watchedRepos[repo.name]"
+         ng-click="repoModel.toggleWatched(repo.name)"
+         title="toggle watching this repo">
+  <a title="Open repo" class="repo-link">{{::repo.name}}</a>
 </li>

--- a/ui/partials/main/thResultCounts.html
+++ b/ui/partials/main/thResultCounts.html
@@ -1,5 +1,5 @@
 <span class="result-set-progress">
-    <span ng-if="percentComplete == 100">- Complete -</span>
-    <span ng-if="percentComplete < 100"
-          title="Proportion of jobs that are complete">{{percentComplete}}% - {{inProgress}} in progress</span>
+  <span ng-if="percentComplete == 100">- Complete -</span>
+  <span ng-if="percentComplete < 100"
+        title="Proportion of jobs that are complete">{{percentComplete}}% - {{inProgress}} in progress</span>
 </span>

--- a/ui/partials/main/thSettingsPanel.html
+++ b/ui/partials/main/thSettingsPanel.html
@@ -1,3 +1,3 @@
 <div class="th-top-nav-options-panel" id="settings_panel" ng-controller="SettingsCtrl">
-    <span>{{user}}</span>
+  <span>{{user}}</span>
 </div>

--- a/ui/partials/main/thSheriffPanel.html
+++ b/ui/partials/main/thSheriffPanel.html
@@ -1,180 +1,211 @@
 <div class="th-top-nav-options-panel" id="sheriff_panel" ng-controller="SheriffCtrl">
-    <ul class="list-inline">
-        <li>
-            <a href="" prevent-default-on-left-click  ng-if="view != 'exclusion_profile_list'" ng-click="switchView('exclusion_profile_list')">Exclusion profiles</a>
-            <span ng-if="view =='exclusion_profile_list'">Exclusion profiles</span>
-        </li>
-        <li>
-            <a href="" prevent-default-on-left-click  ng-if="view != 'job_exclusion_list'" ng-click="switchView('job_exclusion_list')">Job exclusions</a>
-            <span ng-if="view =='job_exclusion_list'">Job exclusions</span>
-        </li>
-    </ul>
+  <ul class="list-inline">
+    <li>
+      <a href="" prevent-default-on-left-click
+         ng-if="view != 'exclusion_profile_list'"
+         ng-click="switchView('exclusion_profile_list')">Exclusion profiles</a>
+      <span ng-if="view =='exclusion_profile_list'">Exclusion profiles</span>
+    </li>
+    <li>
+      <a href="" prevent-default-on-left-click
+         ng-if="view != 'job_exclusion_list'"
+         ng-click="switchView('job_exclusion_list')">Job exclusions</a>
+      <span ng-if="view =='job_exclusion_list'">Job exclusions</span>
+    </li>
+  </ul>
 
-    <div ng-if="view == 'exclusion_profile_list'" class="panel panel-default th-option-group th-inline-option-group add-new-exclusion">
-        <div class="panel-heading th-option-heading">
-            Exclusion Profile list
-        </div>
-        <div class="panel-body">
-            <p ng-if="profiles.length==0">No profile available.</p>
-            <table ng-if="profiles.length>0" class="table table-condensed table-bordered">
-                <tr>
-                    <th>Profile name</th><th>Default</th><th>Exclusions</th><th>Actions</th>
-                </tr>
-                <tr ng-repeat="profile in profiles">
-                    <td>{{::profile.name}}</td>
-                    <td class="text-center">
-                        <span ng-if="profile.is_default" class="glyphicon glyphicon-ok-sign text-success">
-                        </span>
-                    </td>
-                    <td>
-                        <a ng-click="init_exclusion_update(exclusions_map[exclusion])" ng-repeat="exclusion in profile.exclusions">
-                            {{ ::exclusions_map[exclusion].name }}
-                        </a>
-                    </td>
-                    <td>
-                        <button ng-click="init_profile_update(profile)" type="button" class="btn btn-default btn-xs">
-                          <span class="glyphicon glyphicon-pencil"></span> Change
-                        </button>
-                        <button ng-click="delete_profile(profile)" type="button" class="btn btn-default btn-xs">
-                          <span class="glyphicon glyphicon-remove"></span> Delete
-                        </button>
-                        <button ng-click="set_default_profile(profile)" type="button" class="btn btn-default btn-xs">
-                          <span class="glyphicon  glyphicon glyphicon-ok-sign"></span> Make default
-                        </button>
-                    </td>
-                </tr>
-
-            </table>
-            <button ng-click="init_profile_add()" type="button" class="btn btn-sm btn-default">Add new</button>
-        </div>
+  <!-- Exclusion profiles -->
+  <div ng-if="view == 'exclusion_profile_list'"
+       class="panel panel-default th-option-group
+              th-inline-option-group add-new-exclusion">
+    <div class="panel-heading th-option-heading">
+      Exclusion Profile list
     </div>
+    <div class="panel-body">
+      <p ng-if="profiles.length == 0">No profile available</p>
+      <table ng-if="profiles.length > 0" class="table table-condensed table-bordered">
+        <tr>
+          <th>Profile name</th><th>Default</th><th>Exclusions</th><th>Actions</th>
+        </tr>
+        <tr ng-repeat="profile in profiles">
+          <td>{{::profile.name}}</td>
+          <td class="text-center">
+            <span ng-if="profile.is_default"
+                  class="glyphicon glyphicon-ok-sign text-success"></span>
+          </td>
+          <td>
+            <a ng-click="init_exclusion_update(exclusions_map[exclusion])"
+               ng-repeat="exclusion in profile.exclusions">
+              {{ ::exclusions_map[exclusion].name }}</a>
+          </td>
+          <td>
+            <button ng-click="init_profile_update(profile)"
+                    type="button" class="btn btn-default btn-xs">
+              <span class="glyphicon glyphicon-pencil"></span> Change
+            </button>
+            <button ng-click="delete_profile(profile)"
+                    type="button" class="btn btn-default btn-xs">
+              <span class="glyphicon glyphicon-remove"></span> Delete
+            </button>
+            <button ng-click="set_default_profile(profile)"
+                    type="button" class="btn btn-default btn-xs">
+              <span class="glyphicon glyphicon glyphicon-ok-sign"></span> Make default
+            </button>
+          </td>
+        </tr>
+      </table>
+      <button ng-click="init_profile_add()" type="button"
+              class="btn btn-sm btn-default">Add new</button>
+    </div>
+  </div>
 
-
-    <div ng-if="view == 'exclusion_profile_add'" class="panel panel-default th-option-group th-inline-option-group add-new-exclusion">
-        <div class="panel-heading th-option-heading">
-            Create/Update Exclusion Profile
+  <!-- Create/Update profile -->
+  <div ng-if="view == 'exclusion_profile_add'"
+       class="panel panel-default th-option-group
+              th-inline-option-group add-new-exclusion">
+    <div class="panel-heading th-option-heading">
+      Create/Update Exclusion Profile
+    </div>
+    <div class="panel-body">
+      <div class="form-group">
+        <label>Name</label>
+        <input class="form-control input-sm" type="text"
+               ng-model="form_profile.name" placeholder="Enter a name"/>
+      </div>
+      <form class="form">
+        <label>Select one or more exclusions to enable in your new profile</label>
+        <div ng-repeat="exclusion in exclusions" class="form-group">
+          <input type="checkbox" ng-model="form_profile_choices[exclusion.id]" />
+          <span title="{{::exclusion.description}}">{{::exclusion.name}}</span>
         </div>
-        <div class="panel-body">
-            <div class="form-group">
-                <label>Name</label><input class="form-control input-sm" type="text" ng-model="form_profile.name" placeholder="Enter a name"/>
-            </div>
-            <form class="form">
-                <label>Select one or more exclusions to enable in your new profile</label>
-                    <div ng-repeat="exclusion in exclusions" class="form-group">
-                            <input type="checkbox" ng-model="form_profile_choices[exclusion.id]" />
-                            <span title="{{::exclusion.description}}">
-                                {{::exclusion.name}}
-                            </span>
-                    </div>
-            </form>
+      </form>
+      <div class="form-group-inline">
+        <div class="form-group">
+          <button ng-click="reset_profile()" type="submit"
+                  class="btn btn-sm btn-default pull right">Reset</button>
+        </div>
+        <div class="form-group">
+          <button ng-click="save_profile(form_profile)" type="submit"
+                  class="btn btn-sm btn-default pull right">Save</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Exclusion list -->
+  <div ng-if="view == 'job_exclusion_list'"
+       class="panel panel-default th-option-group
+              th-inline-option-group add-new-exclusion">
+    <div class="panel-heading th-option-heading">
+      Job Exclusion list
+    </div>
+    <div class="panel-body">
+      <p ng-if="exclusions.length == 0">No exclusion available</p>
+      <table ng-if="exclusions.length>0"
+             class="table table-condensed table-bordered">
+        <tr>
+          <th>Name</th>
+          <th>Description</th>
+          <th>Repositories</th>
+          <th>Platform</th>
+          <th>Option Collections</th>
+          <th>Job Type</th>
+          <th>Actions</th>
+        </tr>
+        <tr ng-repeat="exclusion in exclusions">
+          <td>{{::exclusion.name}}</td>
+          <td>{{::exclusion.description}}</td>
+          <td><th-truncated-list numvisible="2" elements="exclusion.info.repos" /></td>
+          <td><th-truncated-list numvisible="2" elements="exclusion.info.platforms" /></td>
+          <td><th-truncated-list numvisible="2" elements="exclusion.info.option_collections" /></td>
+          <td><th-truncated-list numvisible="2" elements="exclusion.info.job_types" /></td>
+          <td>
+            <button ng-click="init_exclusion_update(exclusion)"
+                    type="button" class="btn btn-default btn-xs">
+              <span class="glyphicon glyphicon-pencil"></span> Change
+            </button>
+            <button ng-click="delete_exclusion(exclusion)"
+                    type="button" class="btn btn-default btn-xs">
+              <span class="glyphicon glyphicon-remove"></span> Delete
+            </button>
+          </td>
+        </tr>
+      </table>
+      <button ng-click="init_exclusion_add()" type="button"
+              class="btn btn-sm btn-default">Add new</button>
+    </div>
+  </div>
+
+
+  <!-- Create/Update exclusion -->
+  <div ng-if="view == 'job_exclusion_add'"
+       class="panel panel-default th-option-group
+              th-inline-option-group add-new-exclusion">
+    <div class="panel-heading th-option-heading">
+      Create/Update Job Exclusion
+    </div>
+    <div class="panel-body">
+      <form class="form" name="thJobExclusionsForm">
+        <div class="form-group">
+          <label>Name</label> <span class="text-danger">(required)</span>
+          <input class="form-control input-sm"
+                 type="text"
+                 ng-model="form_exclusion.name"
+                 placeholder="Enter a name"
+                 required/>
+        </div>
+        <div class="form-group">
+          <label class="sr-only control-label">Description</label>
+          <textarea class="form-control input-sm"
+                    ng-model="form_exclusion.description"
+                    placeholder="Enter a description"></textarea>
+        </div>
+        <div class="form-group-inline">
+
+          <div class="form-group">
+            <label>Repositories</label>
+            <th-multi-select left-list="form_repos"
+                             right-list="form_exclusion.info.repos">
+            </th-multi-select>
+          </div>
+          <div class="form-group">
+            <label>Platforms</label>
+            <th-multi-select left-list="form_platforms"
+                             right-list="form_exclusion.info.platforms">
+            </th-multi-select>
+          </div>
+          <div class="form-group">
+            <label>Option Collections</label>
+            <th-multi-select left-list="form_option_collections"
+                             right-list="form_exclusion.info.option_collections">
+            </th-multi-select>
+          </div>
+          <div class="form-group">
+            <label>Job Types</label>
+            <th-multi-select left-list="form_job_types"
+                             right-list="form_exclusion.info.job_types">
+            </th-multi-select>
+          </div>
+
+          <div class="form-group">
             <div class="form-group-inline">
-                <div class="form-group">
-                    <button ng-click="reset_profile()" type="submit" class="btn btn-sm btn-default pull right">reset</button>
-                </div>
-                <div class="form-group">
-                    <button ng-click="save_profile(form_profile)" type="submit" class="btn btn-sm btn-default pull right">Save</button>
-                </div>
+              <div class="form-group">
+                <a ng-click="switchView('job_exclusion_list')"
+                   class="btn btn-sm btn-default pull right">Back</a>
+              </div>
+              <div class="form-group">
+                <button ng-click="reset_exclusion()" type="submit"
+                        class="btn btn-sm btn-default pull right">Reset</button>
+              </div>
+              <div class="form-group">
+                <button ng-click="thJobExclusionsForm.$valid && save_exclusion(form_exclusion)"
+                        type="submit"
+                        class="btn btn-sm btn-default pull right">Save</button>
+              </div>
             </div>
+          </div>
         </div>
+      </form>
     </div>
-
-    <div ng-if="view == 'job_exclusion_list'" class="panel panel-default th-option-group th-inline-option-group add-new-exclusion">
-        <div class="panel-heading th-option-heading">
-            Job Exclusion list
-        </div>
-        <div class="panel-body">
-            <p ng-if="exclusions.length == 0">
-                No exclusion available
-            </p>
-            <table ng-if="exclusions.length>0" class="table table-condensed table-bordered">
-                <tr>
-                    <th>Name</th>
-                    <th>Description</th>
-                    <th>Repositories</th>
-                    <th>Platform</th>
-                    <th>Option Collections</th>
-                    <th>Job Type</th>
-                    <th>Actions</th>
-                </tr>
-                <tr ng-repeat="exclusion in exclusions">
-                    <td>{{::exclusion.name}}</td>
-                    <td>{{::exclusion.description}}</td>
-                    <td><th-truncated-list numvisible="2" elements="exclusion.info.repos" /></td>
-                    <td><th-truncated-list numvisible="2" elements="exclusion.info.platforms" /></td>
-                    <td><th-truncated-list numvisible="2" elements="exclusion.info.option_collections" /></td>
-                    <td><th-truncated-list numvisible="2" elements="exclusion.info.job_types" /></td>
-                    <td>
-                        <button ng-click="init_exclusion_update(exclusion)" type="button" class="btn btn-default btn-xs">
-                          <span class="glyphicon glyphicon-pencil"></span> Change
-                        </button>
-                        <button ng-click="delete_exclusion(exclusion)" type="button" class="btn btn-default btn-xs">
-                          <span class="glyphicon glyphicon-remove"></span> Delete
-                        </button>
-                    </td>
-
-                </tr>
-            </table>
-            <button ng-click="init_exclusion_add()" type="button" class="btn btn-sm btn-default">Add new</button>
-        </div>
-    </div>
-
-
-    <div ng-if="view == 'job_exclusion_add'" class="panel panel-default th-option-group th-inline-option-group add-new-exclusion">
-        <div class="panel-heading th-option-heading">
-            Create/Update Job Exclusion
-        </div>
-        <div class="panel-body">
-            <form class="form" name="thJobExclusionsForm">
-                <div class="form-group">
-                    <label>Name</label> <span class="text-danger">(required)</span>
-                    <input class="form-control input-sm"
-                           type="text"
-                           ng-model="form_exclusion.name"
-                           placeholder="Enter a name"
-                           required/>
-                </div>
-                <div class="form-group">
-                    <label class="sr-only control-label">Description</label>
-                    <textarea class="form-control input-sm" ng-model="form_exclusion.description" placeholder="Enter a description"></textarea>
-                </div>
-
-                <div class="form-group-inline">
-                    <div class="form-group">
-                        <label>Repositories</label>
-                        <th-multi-select left-list="form_repos" right-list="form_exclusion.info.repos"></th-multi-select>
-                    </div>
-                    <div class="form-group">
-                        <label>Platforms</label>
-                        <th-multi-select left-list="form_platforms" right-list="form_exclusion.info.platforms"></th-multi-select>
-                    </div>
-                    <div class="form-group">
-                        <label>Option Collections</label>
-                        <th-multi-select left-list="form_option_collections" right-list="form_exclusion.info.option_collections"></th-multi-select>
-                    </div>
-                    <div class="form-group">
-                        <label>Job Types</label>
-                        <th-multi-select left-list="form_job_types" right-list="form_exclusion.info.job_types"></th-multi-select>
-                    </div>
-                    <div class="form-group">
-                        <div class="form-group-inline">
-                            <div class="form-group">
-                                <a
-                                    ng-click="switchView('job_exclusion_list')"
-                                    class="btn btn-sm btn-default pull right">Back</a>
-                            </div>
-                            <div class="form-group">
-                                <button ng-click="reset_exclusion()" type="submit" class="btn btn-sm btn-default pull right">Reset</button>
-                            </div>
-                            <div class="form-group">
-                                <button ng-click="thJobExclusionsForm.$valid && save_exclusion(form_exclusion)"
-                                        type="submit"
-                                        class="btn btn-sm btn-default pull right"
-                                        >Save</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </form>
-        </div>
-    </div>
+  </div>
 </div>

--- a/ui/partials/main/thWatchedRepo.html
+++ b/ui/partials/main/thWatchedRepo.html
@@ -1,27 +1,28 @@
 <span class="btn-group">
-    <button ng-class="{'active': name===repoName}"
-            ng-click="changeRepo(name)"
-            type="button"
-            title="{{titleText|stripHtml}}"
-            class="watched-repo-main-btn btn btn-sm {{btnClass}}">
-        <i class="fa {{statusIcon}} {{statusColor}}"></i> {{::name}}
-    </button>
-    <button class="watched-repo-info-btn btn btn-sm {{btnClass}} dropdown-toggle"
-            ng-class="{'active': name===repoName}"
-            data-toggle="dropdown"
-            title="{{::name}} info"
-            type="button"
-            ng-click="setDropDownPull($event)">
-        <span class="fa fa-info-circle"></span>
-    </button>
-    <button class="watched-repo-unwatch-btn btn btn-sm {{btnClass}}"
-            ng-class="{'active': name===repoName}"
-            ng-hide="name===repoName"
-            ng-click="repoModel.unwatchRepo(name)"
-            title="unwatch {{::name}}"><span class="fa fa-times"></span></button>
-    <th-watched-repo-info-drop-down name="{{::name}}"
-                       reason="{{repoData.treeStatus.reason}}"
-                       message_of_the_day="{{repoData.treeStatus.message_of_the_day}}">
-    </th-watched-repo-info-drop-down>
+  <button class="watched-repo-main-btn btn btn-sm {{btnClass}}"
+          ng-class="{'active': name===repoName}"
+          ng-click="changeRepo(name)"
+          type="button"
+          title="{{titleText|stripHtml}}">
+    <i class="fa {{statusIcon}} {{statusColor}}"></i> {{::name}}
+  </button>
+  <button class="watched-repo-info-btn btn btn-sm {{btnClass}} dropdown-toggle"
+          ng-class="{'active': name===repoName}"
+          ng-click="setDropDownPull($event)"
+          type="button"
+          title="{{::name}} info"
+          data-toggle="dropdown">
+    <span class="fa fa-info-circle"></span>
+  </button>
+  <button class="watched-repo-unwatch-btn btn btn-sm {{btnClass}}"
+          ng-class="{'active': name===repoName}"
+          ng-click="repoModel.unwatchRepo(name)"
+          ng-hide="name===repoName"
+          title="unwatch {{::name}}">
+    <span class="fa fa-times"></span>
+  </button>
+  <th-watched-repo-info-drop-down name="{{::name}}"
+                                  reason="{{repoData.treeStatus.reason}}"
+                                  message_of_the_day="{{repoData.treeStatus.message_of_the_day}}">
+  </th-watched-repo-info-drop-down>
 </span>
-

--- a/ui/partials/main/thWatchedRepoInfoDropDown.html
+++ b/ui/partials/main/thWatchedRepoInfoDropDown.html
@@ -1,26 +1,21 @@
-    <ul class="dropdown-menu" role="menu">
-        <li ng-show="reason" class="watched-repo-dropdown-item">
-            <span ng-bind-html="reason|linkifyBugs"></span>
-        </li>
-
-        <li class="divider" ng-show="reason && message_of_the_day"></li>
-
-        <li ng-show="message_of_the_day" class="watched-repo-dropdown-item">
-            <span ng-bind-html="message_of_the_day"></span>
-        </li>
-
-        <li class="divider" ng-show="reason || message_of_the_day"></li>
-
-        <li class="watched-repo-dropdown-item">
-            <a href="https://treestatus.mozilla.org/{{::treeStatus}}" target="_blank">tree status</a>
-        </li>
-
-        <li class="watched-repo-dropdown-item">
-            <a href="{{::pushlog}}" target="_blank">pushlog</a>
-        </li>
-
-        <li class="watched-repo-dropdown-item">
-            <a href="https://api.pub.build.mozilla.org/clobberer/?branch={{::name}}" target="_blank">clobberer</a>
-        </li>
-
-    </ul>
+<ul class="dropdown-menu" role="menu">
+  <li ng-show="reason" class="watched-repo-dropdown-item">
+    <span ng-bind-html="reason|linkifyBugs"></span>
+  </li>
+  <li class="divider" ng-show="reason && message_of_the_day"></li>
+  <li ng-show="message_of_the_day" class="watched-repo-dropdown-item">
+    <span ng-bind-html="message_of_the_day"></span>
+  </li>
+  <li class="divider" ng-show="reason || message_of_the_day"></li>
+  <li class="watched-repo-dropdown-item">
+    <a href="https://treestatus.mozilla.org/{{::treeStatus}}"
+       target="_blank">tree status</a>
+  </li>
+  <li class="watched-repo-dropdown-item">
+    <a href="{{::pushlog}}" target="_blank">pushlog</a>
+  </li>
+  <li class="watched-repo-dropdown-item">
+    <a href="https://api.pub.build.mozilla.org/clobberer/?branch={{::name}}"
+       target="_blank">clobberer</a>
+  </li>
+</ul>

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -1,70 +1,75 @@
 <div id="watched-repo-navbar" class="th-context-navbar watched-repo-navbar clearfix">
-    <th-watched-repo ng-repeat="(name, repoData) in repoModel.watchedRepos"></th-watched-repo>
-    <div class="navbar-right">
-        <span>
-            <form role="search" class="form-inline">
+  <th-watched-repo ng-repeat="(name, repoData) in repoModel.watchedRepos"></th-watched-repo>
+  <div class="navbar-right">
+    <span>
+      <form role="search" class="form-inline">
 
-                <!--Unclassified Failures Button-->
-                <span class="btn btn-sm"
-                      ng-click="toggleUnclassifiedFailures()"
-                      title="Loaded failures / Toggle filtering for unclassified failures"
-                      tabindex="0" role="button"
-                      ng-class="{'btn-unclassified-failures': getUnclassifiedFailureCount(repoName), 'btn-view-nav': getUnclassifiedFailureCount(repoName)===0}">
-                    <span id="unclassified-failure-count">
-                        {{getUnclassifiedFailureCount(repoName)}}</span> unclassified
-                </span>
-
-                <!--Toggle Tier-1 jobs only Button-->
-                <span class="btn btn-view-nav btn-sm"
-                      title="Toggle Tier-1 jobs only mode"
-                      tabindex="0" role="button"
-                      ng-click="toggleTier1Only()">1</span>
-
-                <!--Hidden Jobs Button-->
-                <span class="btn btn-view-nav btn-sm btn-right-navbar"
-                      title="Show/hide excluded jobs"
-                      tabindex="0" role="button"
-                      ng-click="toggleExcludedJobs()">
-                    <i class="fa"
-                       th-exclusion-state
-                       ng-class="::exclusionStateClass"></i>
-                </span>
-
-                <!--Toggle Revisions Button-->
-                <span class="btn-group">
-                    <span class="btn btn-view-nav btn-sm btn-collapse-resultsets"
-                          title="Show/hide revision list"
-                          tabindex="0" role="button"
-                          ng-click="toggleAllRevisions()"><i class="fa fa-code-fork"></i>
-                    </span>
-                </span>
-
-                <!--Toggle Group State Button-->
-                <span class="btn-group">
-                    <span class="btn btn-view-nav btn-sm btn-toggle-group-state"
-                          tabindex="0" role="button"
-                          ng-click="toggleGroupState()">(
-                        <span ng-if="groupState==='collapsed'"
-                              class="group-state-nav-icon"
-                              title="Expand job groups">+</span>
-                        <span ng-if="groupState!=='collapsed'"
-                              class="group-state-nav-icon"
-                              title="Collapse job groups">-</span>
-                    )</span>
-                </span>
-
-                <!--Quick Filter Field-->
-                <span ng-controller="SearchCtrl" class="form-group form-inline" id="quick-filter-parent">
-                    <input id="quick-filter"
-                           title="Click to enter filter values"
-                           ng-model="searchQueryStr" ng-keydown="search($event)" type="text"
-                           class="form-control input-sm" required
-                           placeholder="Filter platforms & jobs"
-                           blur-this>
-                    <span id="quick-filter-clear-button" class="fa fa-times-circle"
-                          ng-click="clearFilterBox()" title="Clear this filter"></span>
-                </span>
-            </form>
+        <!--Unclassified Failures Button-->
+        <span class="btn btn-sm"
+              title="Loaded failures / Toggle filtering for unclassified failures"
+              tabindex="0" role="button"
+              ng-class="{'btn-unclassified-failures': getUnclassifiedFailureCount(repoName),
+                         'btn-view-nav': getUnclassifiedFailureCount(repoName)===0}"
+              ng-click="toggleUnclassifiedFailures()">
+          <span id="unclassified-failure-count">
+            {{getUnclassifiedFailureCount(repoName)}}</span> unclassified
         </span>
-    </div>
+
+        <!--Toggle Tier-1 jobs only Button-->
+        <span class="btn btn-view-nav btn-sm"
+              title="Toggle Tier-1 jobs only mode"
+              tabindex="0" role="button"
+              ng-click="toggleTier1Only()">1</span>
+
+        <!--Hidden Jobs Button-->
+        <span class="btn btn-view-nav btn-sm btn-right-navbar"
+              title="Show/hide excluded jobs"
+              tabindex="0" role="button"
+              ng-click="toggleExcludedJobs()">
+          <i class="fa"
+             th-exclusion-state
+             ng-class="::exclusionStateClass"></i>
+        </span>
+
+        <!--Toggle Revisions Button-->
+        <span class="btn-group">
+          <span class="btn btn-view-nav btn-sm btn-collapse-resultsets"
+                title="Show/hide revision list"
+                tabindex="0" role="button"
+                ng-click="toggleAllRevisions()"><i class="fa fa-code-fork"></i>
+          </span>
+        </span>
+
+        <!--Toggle Group State Button-->
+        <span class="btn-group">
+          <span class="btn btn-view-nav btn-sm btn-toggle-group-state"
+                tabindex="0" role="button"
+                ng-click="toggleGroupState()">(
+            <span ng-if="groupState === 'collapsed'"
+                  class="group-state-nav-icon"
+                  title="Expand job groups">+</span>
+            <span ng-if="groupState !== 'collapsed'"
+                  class="group-state-nav-icon"
+                  title="Collapse job groups">-</span>
+          )</span>
+        </span>
+
+        <!--Quick Filter Field-->
+        <span ng-controller="SearchCtrl"
+              id="quick-filter-parent"
+              class="form-group form-inline">
+          <input id="quick-filter"
+                 class="form-control input-sm" required
+                 title="Click to enter filter values"
+                 ng-model="searchQueryStr" ng-keydown="search($event)" type="text"
+                 placeholder="Filter platforms & jobs"
+                 blur-this>
+          <span id="quick-filter-clear-button"
+                class="fa fa-times-circle"
+                title="Clear this filter"
+                ng-click="clearFilterBox()"></span>
+        </span>
+      </form>
+    </span>
+  </div>
 </div>


### PR DESCRIPTION
This work fixes Bugzilla bug [1195493](https://bugzilla.mozilla.org/show_bug.cgi?id=1195493).

This converts all 4 space indent in partials/main to 2 space, and while there

* tidies up of long/wrapping lines to 80-100 chars
* consistently orders attributes in a few conspicuous cases
* removes dead closing tags
* adds a few more section comments for clarity

I need to do some blink testing of the affected areas comparing stage vs. this branch, and after that I think will be ready for merge.

Tested on OSX 10.10.3:
Nightly **43.0a1 (2015-08-18)**
Chrome Latest Release **44.0.2403.155 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/880)
<!-- Reviewable:end -->
