### PR TITLE
Json-pushes version 2

### DIFF
--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -279,21 +279,24 @@ def test_ingest_builds4h_jobs_missing_branch(jm, initial_data,
 def _do_missing_resultset_test(jm, etl_process):
     new_revision = '222222222222'
     pushlog_content = json.dumps(
-        {"33270": {
-            "date": 1378288232,
-            "changesets": [
-                {
-                    "node": new_revision + "b344655ed7be9a408d2970a736c4",
-                    "tags": [],
-                    "author": "John Doe <jdoe@mozilla.com>",
-                    "branch": "default",
-                    "desc": "bug 909264 - control characters"
-                }
-            ],
-            "user": "jdoe@mozilla.com"
-        }}
+        {
+            "pushes":
+                {"33270": {
+                    "date": 1378288232,
+                    "changesets": [
+                        {
+                            "node": new_revision + "b344655ed7be9a408d2970a736c4",
+                            "tags": [],
+                            "author": "John Doe <jdoe@mozilla.com>",
+                            "branch": "default",
+                            "desc": "bug 909264 - control characters"
+                        }
+                    ],
+                    "user": "jdoe@mozilla.com"
+                }}
+        }
     )
-    pushlog_fake_url = "https://hg.mozilla.org/mozilla-central/json-pushes/?full=1&changeset=" + new_revision
+    pushlog_fake_url = "https://hg.mozilla.org/mozilla-central/json-pushes/?full=1&version=2&changeset=" + new_revision
     responses.add(responses.GET, pushlog_fake_url,
                   body=pushlog_content, status=200,
                   match_querystring=True,

--- a/tests/sample_data/hg_pushlog.json
+++ b/tests/sample_data/hg_pushlog.json
@@ -1,169 +1,172 @@
 {
- "33268": {
-  "date": 1378287123, 
-  "changesets": [
-   {
-    "node": "1a046ece14db3801ab5ebaa3bb85b196ed3bbae3", 
-    "tags": [], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "Bug 912385 - Include a trailing slash in File.path. r=sicking"
-   }
-  ], 
-  "user": "jdoe@mozilla.com"
- }, 
- "33269": {
-  "date": 1378287663, 
-  "changesets": [
-   {
-    "node": "5371262398a0c4d194832052ca932c1e44279758", 
-    "tags": [], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "Bug 910486 - Disable a slow jit-test under ASan+debug. r=h4writer"
-   }
-  ], 
-  "user": "jdoe@mozilla.com"
- }, 
- "33270": {
-  "date": 1378288232, 
-  "changesets": [
-   {
-    "node": "47b8ffe6ecc4b344655ed7be9a408d2970a736c4", 
-    "tags": [], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "bug 909264 - control characters in the location bar should be %-encoded for visibility. r=gavin"
-   }
-  ], 
-  "user": "jdoe@mozilla.com"
- }, 
- "33271": {
-  "date": 1378290798, 
-  "changesets": [
-   {
-    "node": "e1976a0ce384ed6601cfbf2903dfc6f5aa638547", 
-    "tags": [], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "Backed out changeset 69be1a2ffd39 (bug 912244) for Marionette failures on a CLOSED TREE"
-   }
-  ], 
-  "user": "jdoe@mozilla.com"
- }, 
- "33272": {
-  "date": 1378291222, 
-  "changesets": [
-   {
-    "node": "f12a3d9e4cd6426ad9579b572281aa6327d99527", 
-    "tags": [], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "Bug 911862 - Make VectorImage use the refresh driver to send out frame change notifications. r=dholbert"
-   }, 
-   {
-    "node": "8d8c2ce395a10f9dc7927332c2ba8bfc502044c6", 
-    "tags": [], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "Bug 907503 - Fix invalidation for SMIL animation in SVG-as-an-image. r=roc"
-   }, 
-   {
-    "node": "1c690d9998f7dfd50cce7129432d9f6ee9f267a5", 
-    "tags": [], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "Bug 907503 - Test that invalidation works for SMIL animation in SVG-as-an-image. r=longsonr"
-   }
-  ], 
-  "user": "jdoe@mozilla.com"
- }, 
- "33273": {
-  "date": 1378291714, 
-  "changesets": [
-   {
-    "node": "bb1d06db46ebc7a1f9e114c11f99172ffb4a5fe8", 
-    "tags": [], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "Bug 912302 - Slim down TraceLogging output by shortening entry keys and timestamps. r=h4writer"
-   }
-  ], 
-  "user": "jdoe@mozilla.com"
- }, 
- "33274": {
-  "date": 1378291978, 
-  "changesets": [
-   {
-    "node": "f5743e7da43667013c15cb3796cffebd5c723fe0", 
-    "tags": [], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "Bug 892203 - Minor cleanups in sandbox.cpp. r=bholley"
-   }, 
-   {
-    "node": "365f2aca45cf51fc85184c09ed844744ee68ab46", 
-    "tags": [], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "Bug 892203 - DOMConstructors for SandboxOptions. r=bholley"
-   }, 
-   {
-    "node": "f186c97c90117a68f1dc91793e5a9e6e8f07b1a4", 
-    "tags": [], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "Bug 892203 - TextEncoder and TextDecoder for sandbox. r=bholley"
-   }
-  ], 
-  "user": "jdoe@mozilla.com"
- }, 
- "33275": {
-  "date": 1378293144, 
-  "changesets": [
-   {
-    "node": "43566dc5dfbbdc3d31653623ac131d9461854c97", 
-    "tags": [], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "Bug 904926. Remove unnecessary lock. r=cpearce"
-   }, 
-   {
-    "node": "b48f9c8d7aff27f9b072a59a1fd3694cfde29f06", 
-    "tags": [], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "Bug 909157. Invalidate rendering observers when an image changes. r=mattwoodrow"
-   }
-  ], 
-  "user": "jdoe@mozilla.com"
- }, 
- "33276": {
-  "date": 1378293452, 
-  "changesets": [
-   {
-    "node": "1250c160eaec3d19764d0dc7ab32d81dc320c106", 
-    "tags": [], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "bug 906646 - glyphs with an SVG representation should never be considered \"contained\". r=roc"
-   }
-  ], 
-  "user": "jdoe@mozilla.com"
- }, 
- "33277": {
-  "date": 1378293517, 
-  "changesets": [
-   {
-    "node": "2c25d2bbbcd6ddbd45962606911fd429e366b8e1", 
-    "tags": [
-     "tip"
-    ], 
-    "author": "John Doe <jdoe@mozilla.com>", 
-    "branch": "default", 
-    "desc": "Bug 911954 - Add forward declaration of JSScript to TraceLogging.h, r=h4writer"
-   }
-  ], 
-  "user": "jdoe@mozilla.com"
- }
+    "lastpushid": 33277,
+    "pushes": {
+        "33268": {
+            "date": 1378287123,
+            "changesets": [
+                {
+                    "node": "1a046ece14db3801ab5ebaa3bb85b196ed3bbae3",
+                    "tags": [],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "Bug 912385 - Include a trailing slash in File.path. r=sicking"
+                }
+            ],
+            "user": "jdoe@mozilla.com"
+        },
+        "33269": {
+            "date": 1378287663,
+            "changesets": [
+                {
+                    "node": "5371262398a0c4d194832052ca932c1e44279758",
+                    "tags": [],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "Bug 910486 - Disable a slow jit-test under ASan+debug. r=h4writer"
+                }
+            ],
+            "user": "jdoe@mozilla.com"
+        },
+        "33270": {
+            "date": 1378288232,
+            "changesets": [
+                {
+                    "node": "47b8ffe6ecc4b344655ed7be9a408d2970a736c4",
+                    "tags": [],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "bug 909264 - control characters in the location bar should be %-encoded for visibility. r=gavin"
+                }
+            ],
+            "user": "jdoe@mozilla.com"
+        },
+        "33271": {
+            "date": 1378290798,
+            "changesets": [
+                {
+                    "node": "e1976a0ce384ed6601cfbf2903dfc6f5aa638547",
+                    "tags": [],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "Backed out changeset 69be1a2ffd39 (bug 912244) for Marionette failures on a CLOSED TREE"
+                }
+            ],
+            "user": "jdoe@mozilla.com"
+        },
+        "33272": {
+            "date": 1378291222,
+            "changesets": [
+                {
+                    "node": "f12a3d9e4cd6426ad9579b572281aa6327d99527",
+                    "tags": [],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "Bug 911862 - Make VectorImage use the refresh driver to send out frame change notifications. r=dholbert"
+                },
+                {
+                    "node": "8d8c2ce395a10f9dc7927332c2ba8bfc502044c6",
+                    "tags": [],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "Bug 907503 - Fix invalidation for SMIL animation in SVG-as-an-image. r=roc"
+                },
+                {
+                    "node": "1c690d9998f7dfd50cce7129432d9f6ee9f267a5",
+                    "tags": [],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "Bug 907503 - Test that invalidation works for SMIL animation in SVG-as-an-image. r=longsonr"
+                }
+            ],
+            "user": "jdoe@mozilla.com"
+        },
+        "33273": {
+            "date": 1378291714,
+            "changesets": [
+                {
+                    "node": "bb1d06db46ebc7a1f9e114c11f99172ffb4a5fe8",
+                    "tags": [],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "Bug 912302 - Slim down TraceLogging output by shortening entry keys and timestamps. r=h4writer"
+                }
+            ],
+            "user": "jdoe@mozilla.com"
+        },
+        "33274": {
+            "date": 1378291978,
+            "changesets": [
+                {
+                    "node": "f5743e7da43667013c15cb3796cffebd5c723fe0",
+                    "tags": [],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "Bug 892203 - Minor cleanups in sandbox.cpp. r=bholley"
+                },
+                {
+                    "node": "365f2aca45cf51fc85184c09ed844744ee68ab46",
+                    "tags": [],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "Bug 892203 - DOMConstructors for SandboxOptions. r=bholley"
+                },
+                {
+                    "node": "f186c97c90117a68f1dc91793e5a9e6e8f07b1a4",
+                    "tags": [],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "Bug 892203 - TextEncoder and TextDecoder for sandbox. r=bholley"
+                }
+            ],
+            "user": "jdoe@mozilla.com"
+        },
+        "33275": {
+            "date": 1378293144,
+            "changesets": [
+                {
+                    "node": "43566dc5dfbbdc3d31653623ac131d9461854c97",
+                    "tags": [],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "Bug 904926. Remove unnecessary lock. r=cpearce"
+                },
+                {
+                    "node": "b48f9c8d7aff27f9b072a59a1fd3694cfde29f06",
+                    "tags": [],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "Bug 909157. Invalidate rendering observers when an image changes. r=mattwoodrow"
+                }
+            ],
+            "user": "jdoe@mozilla.com"
+        },
+        "33276": {
+            "date": 1378293452,
+            "changesets": [
+                {
+                    "node": "1250c160eaec3d19764d0dc7ab32d81dc320c106",
+                    "tags": [],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "bug 906646 - glyphs with an SVG representation should never be considered \"contained\". r=roc"
+                }
+            ],
+            "user": "jdoe@mozilla.com"
+        },
+        "33277": {
+            "date": 1378293517,
+            "changesets": [
+                {
+                    "node": "2c25d2bbbcd6ddbd45962606911fd429e366b8e1",
+                    "tags": [
+                        "tip"
+                    ],
+                    "author": "John Doe <jdoe@mozilla.com>",
+                    "branch": "default",
+                    "desc": "Bug 911954 - Add forward declaration of JSScript to TraceLogging.h, r=h4writer"
+                }
+            ],
+            "user": "jdoe@mozilla.com"
+        }
+    }
 }

--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -175,18 +175,20 @@ def get_resultset(project, revisions_lookup, revision, missing_resultsets, logge
 
 def get_not_found_onhold_push(url, revision):
     return {
-        "00001": {
-            "date": int(time.time()),
-            "changesets": [
-                {
-                    "node": revision,
-                    "tags": [],
-                    "author": "Unknown",
-                    "branch": "default",
-                    "desc": "Pushlog not found at {0}".format(url)
-                }
-            ],
-            "user": "Unknown",
-            "active_status": "onhold"
+        "pushes": {
+            "00001": {
+                "date": int(time.time()),
+                "changesets": [
+                    {
+                        "node": revision,
+                        "tags": [],
+                        "author": "Unknown",
+                        "branch": "default",
+                        "desc": "Pushlog not found at {0}".format(url)
+                    }
+                ],
+                "user": "Unknown",
+                "active_status": "onhold"
+            }
         }
     }

--- a/treeherder/etl/management/commands/ingest_push.py
+++ b/treeherder/etl/management/commands/ingest_push.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
         settings.CELERY_ALWAYS_EAGER = True
 
         # get hg pushlog
-        pushlog_url = '%s/json-pushes/?full=1' % repo['url']
+        pushlog_url = '%s/json-pushes/?full=1&version=2' % repo['url']
 
         # ingest this particular revision for this project
         process = HgPushlogProcess()

--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -65,6 +65,8 @@ class HgPushlogTransformerMixin(object):
 
 class HgPushlogProcess(HgPushlogTransformerMixin,
                        OAuthLoaderMixin):
+    # For more info on Mercurial Pushes, see:
+    #   https://mozilla-version-control-tools.readthedocs.org/en/latest/hgmo/pushlog.html
 
     def extract(self, url):
         response = requests.get(url, timeout=settings.TREEHERDER_REQUESTS_TIMEOUT)
@@ -79,27 +81,34 @@ class HgPushlogProcess(HgPushlogTransformerMixin,
 
         # get the last object seen from cache. this will
         # reduce the number of pushes processed every time
-        last_push = cache.get("{0}:last_push".format(repository))
-        if not changeset and last_push:
+        last_push_id = cache.get("{0}:last_push_id".format(repository))
+        if not changeset and last_push_id:
+            startid_url = "{}&startID={}".format(source_url, last_push_id)
             logger.info("Extracted last push for '%s', '%s', from cache, "
-                        "attempting to get changes only from that point" %
-                        (repository, last_push))
-            try:
-                # make an attempt to use the last revision cached
-                extracted_content = self.extract(
-                    source_url + "&fromchange=" + last_push
-                )
-            except requests.exceptions.HTTPError as e:
-                # in case of a 404 error, delete the cache key
-                # and try it without any parameter
-                if e.response.status_code == 404:
-                    logger.warning("Got a 404 fetching changes since '%s', "
-                                   "getting all changes for '%s' instead" %
-                                   (last_push, repository))
-                    cache.delete("{0}:last_push".format(repository))
-                    extracted_content = self.extract(source_url)
-                else:
-                    raise e
+                        "attempting to get changes only from that point at: %s" %
+                        (repository, last_push_id, startid_url))
+            # Use the cached ``last_push_id`` value (saved from the last time
+            # this API was called) for this repo.  Use that value as the
+            # ``startID`` to get all new pushes from that point forward.
+            extracted_content = self.extract(startid_url)
+
+            if extracted_content['lastpushid'] < last_push_id:
+                # Push IDs from Mercurial are incremental.  If we cached a value
+                # from one call to this API, and a subsequent call told us that
+                # the ``lastpushid`` is LOWER than the one we have cached, then
+                # the Mercurial IDs were reset.
+                # In this circumstance, we can't rely on the cached id, so must
+                # throw it out and get the latest 10 pushes.
+                logger.warning(("Got a ``lastpushid`` value of {} lower than "
+                                "the cached value of {} due to Mercurial repo reset.  "
+                                "Getting latest changes for '{}' instead").format(
+                                    extracted_content['lastpushid'],
+                                    last_push_id,
+                                    repository
+                                    )
+                               )
+                cache.delete("{0}:last_push_id".format(repository))
+                extracted_content = self.extract(source_url)
         else:
             if changeset:
                 logger.info("Getting all pushes for '%s' corresponding to "
@@ -111,25 +120,25 @@ class HgPushlogProcess(HgPushlogTransformerMixin,
                                "getting all pushes" % repository)
                 extracted_content = self.extract(source_url)
 
-        if extracted_content:
-            last_push_id = max(map(lambda x: int(x), extracted_content.keys()))
-            last_push = extracted_content[str(last_push_id)]
-            top_revision = last_push["changesets"][-1]["node"]
+        # ``pushes`` could be empty if there are no new ones since we last
+        # fetched
+        pushes = extracted_content['pushes']
 
-            transformed = self.transform(
-                extracted_content,
-                repository
-            )
-            self.load(transformed)
+        if not pushes:
+            return None
 
-            if not changeset:
-                # only cache the last push if we're not fetching a specific
-                # changeset
-                cache.set("{0}:last_push".format(repository), top_revision)
+        last_push_id = max(map(lambda x: int(x), pushes.keys()))
+        last_push = pushes[str(last_push_id)]
+        top_revision = last_push["changesets"][-1]["node"]
+        transformed = self.transform(pushes, repository)
+        self.load(transformed)
 
-            return top_revision
+        if not changeset:
+            # only cache the last push if we're not fetching a specific
+            # changeset
+            cache.set("{0}:last_push_id".format(repository), last_push_id)
 
-        return None
+        return top_revision
 
 
 class MissingHgPushlogProcess(HgPushlogTransformerMixin,
@@ -174,7 +183,7 @@ class MissingHgPushlogProcess(HgPushlogTransformerMixin,
             if extracted_content:
 
                 transformed = self.transform(
-                    extracted_content,
+                    extracted_content['pushes'],
                     repository
                 )
 

--- a/treeherder/etl/tasks/buildapi_tasks.py
+++ b/treeherder/etl/tasks/buildapi_tasks.py
@@ -54,4 +54,4 @@ def fetch_hg_push_log(repo_name, repo_url):
     Run a HgPushlog etl process
     """
     process = HgPushlogProcess()
-    process.run(repo_url + '/json-pushes/?full=1', repo_name)
+    process.run(repo_url + '/json-pushes/?full=1&version=2', repo_name)

--- a/treeherder/etl/tasks/cleanup_tasks.py
+++ b/treeherder/etl/tasks/cleanup_tasks.py
@@ -40,7 +40,7 @@ def fetch_missing_hg_push_logs(repo_name, repo_url, resultset):
     process = MissingHgPushlogProcess()
 
     changesetParam = urllib.urlencode({"changeset": resultset}, True)
-    url_str = repo_url + '/json-pushes/?full=1&' + changesetParam
+    url_str = repo_url + '/json-pushes/?full=1&version=2&' + changesetParam
 
     logger.info("fetching missing resultsets: {0}".format(url_str))
     process.run(url_str, repo_name, resultset)


### PR DESCRIPTION
This fixes [Bug 1076826](https://bugzilla.mozilla.org/show_bug.cgi?id=1076826)

This moves us to using ``version=2`` with our calls to json-pushes to fetch ``resultsets`` from Mercurial.  In doing this, we can call to the server more often than once perminute.  GPS says every 15 seconds is fine.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/881)
<!-- Reviewable:end -->
