### PR TITLE
Bug 1147676 - Exclude local.conf.js from grunt build to avoid 404s

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -109,7 +109,10 @@
         <script src="js/filters.js"></script>
         <!-- endbuild -->
 
+        <!-- build:dontbuild -->
         <script src="js/config/local.conf.js"></script>
+        <!-- endbuild -->
+
         <script src="https://login.persona.org/include.js"></script>
 
         <!-- Clone targets -->

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -151,7 +151,8 @@
     <script src="js/controllers/logviewer.js"></script>
     <!-- endbuild -->
 
+    <!-- build:dontbuild -->
     <script src="js/config/local.conf.js"></script>
-
+    <!-- endbuild -->
   </body>
 </html>

--- a/ui/perf.html
+++ b/ui/perf.html
@@ -38,7 +38,9 @@
   <section ui-view>
   </section>
 
+  <!-- build:dontbuild -->
   <script src="js/config/local.conf.js"></script>
+  <!-- endbuild -->
 
   <!-- build:js js/perf.min.js -->
   <script src="vendor/jquery-2.1.3.js"></script>


### PR DESCRIPTION
The parameter after "build:" is the block type, which is normally 'js', 'css' or a custom type. If we use a non-existent custom type (such as "dontbuild"), grunt-usemin will just exclude the block, which is just what we need to exclude this development-only file from the generated assets used on stage/production.

See:
https://github.com/yeoman/grunt-usemin#blocks

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/882)
<!-- Reviewable:end -->
