### PR TITLE
Bug 1188508 - logviewer could use new getRevisionUrl filter

### DIFF
--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -203,9 +203,6 @@ logViewerApp.controller('LogviewerCtrl', [
                 ThResultSetModel.getResultSet($scope.repoName, job.result_set_id).then(function(data){
                     var revision = data.data.revision;
                     $scope.logProperties.push({label: "Revision", value: revision});
-                    $scope.logRevisionFilterUrl = $scope.urlBasePath +
-                        "#/jobs?repo=" + $scope.repoName + "&revision=" +
-                        revision;
                 });
             });
 

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -83,7 +83,7 @@
             <tr ng-repeat="property in logProperties">
               <th ng-cloak>{{property.label}}</th>
               <td ng-if="property.label == 'Revision'" class="break-word">
-                <a href="{{::logRevisionFilterUrl}}"
+                <a href="{{::property.value|getRevisionUrl:repoName}}"
                    title="Open resultset"
                    class="repo-link"
                    ng-cloak>{{property.value}}</a>
@@ -146,6 +146,9 @@
     <script src="js/models/job.js"></script>
     <script src="js/models/resultset.js"></script>
     <script src="js/models/log_slice.js"></script>
+
+    <!-- Filter -->
+    <script src="js/filters.js"></script>
 
     <!-- Controllers -->
     <script src="js/controllers/logviewer.js"></script>


### PR DESCRIPTION
Had tested on OS X 10.10.4 and Firefox 40.0, seems works fine locally :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/883)
<!-- Reviewable:end -->
