### PR TITLE
Bug 1195886 - Remove unused .revision-button CSS class

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -551,12 +551,6 @@ th-watched-repo {
     opacity: 0.75;
 }
 
-.revision-button {
-    flex: 0 0 60px;
-    margin-right: 4px;
-    margin-left: 4px;
-}
-
 .revision-list {
     overflow: hidden;
     white-space: nowrap;


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/885)
<!-- Reviewable:end -->
