### PR TITLE
Bug 1189498 - Provide a text value fallback for logviewer job details

### DIFF
--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -97,6 +97,7 @@
                   <a ng-cloak ng-switch-when="link" title="{{line.value}}"
                      href="{{line.url}}" target="_blank">{{line.value}}</a>
                     <span ng-switch-when="raw_html" ng-bind-html="line.value"></span>
+                    <span ng-switch-default>{{line.value}}</span>
                 <td/>
             </tr>
           </table>


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1189498](https://bugzilla.mozilla.org/show_bug.cgi?id=1189498).

This provides a fallback for the job details artifact property `content_type`, when it is neither **link** or **raw_html**.

Current (missing when **text**):
![current](https://cloud.githubusercontent.com/assets/3660661/9362309/bc6af124-466d-11e5-87b4-ed4d5c7658a0.jpg)

Proposed:
![proposed](https://cloud.githubusercontent.com/assets/3660661/9362313/c120e61a-466d-11e5-8b4b-0d5c8a765350.jpg)

We plan to consolidate the logviewer and treeherder partials if possible, in a separate fix.

Tested on OSX 10.10.3:
Nightly **43.0a1 (2015-08-18)**
Chrome Latest Release **44.0.2403.155 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/887)
<!-- Reviewable:end -->
