### PR TITLE
Bug 1159167 - Update to latest django-browserid

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -64,8 +64,8 @@ drf-extensions==0.2.7
 # sha256: _NluK-R8ju80xlDgB6bVRuGefuYQQbie27u-dhmqOYc
 django-cors-headers==1.1.0
 
-# sha256: DVwMS2xs2dJb59eoJqXAxEzwQKEn2Sb4pX6mvnTrypg
-django-browserid==0.10
+# sha256: -jPrQhcqGbcVrbp6ZJcJEftdj9G2nPjaepXyvH8PMDs
+django-browserid==1.0.0
 
 # sha256: gqOPZ02h-klsD8TfcUy7BYVAvtcqMMUKLjRLDZhMTSE
 oauth2==1.5.211

--- a/ui/js/models/user.js
+++ b/ui/js/models/user.js
@@ -22,7 +22,7 @@ treeherder.factory('ThUserModel', [
                     if(response.data.length > 0){
                         return new ThUserModel(response.data[0]);
                     }else{
-                        return $q.reject({"data": "User not found"});
+                        return {};
                     }
                 }, function(reason){
                     thNotify.send(reason.data,"danger");

--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -102,7 +102,6 @@ treeherder.factory('BrowserId', [
          * This is mostly inspired by the django_browserid jquery implementation.
          */
         var browserid = {
-            info: $http.get(thServiceDomain+'/browserid/info/'),
             requestDeferred: null,
             logoutDeferred: null,
 
@@ -111,12 +110,11 @@ treeherder.factory('BrowserId', [
              * and send it to the treeherder verification endpoints.
              *
              */
-            login: function(requestArgs){
-                return browserid.getAssertion(requestArgs)
+            login: function(){
+                return browserid.getAssertion()
                     .then(function(response) {
                         return browserid.verifyAssertion(response);
                     });
-
             },
             /*
              * Logout from persona and notify treeherder of the change
@@ -124,12 +122,10 @@ treeherder.factory('BrowserId', [
              * of navigator.id.watch
              */
             logout: function(){
-                return browserid.info.then(function(response){
-                    browserid.logoutDeferred = $q.defer();
-                    navigator.id.logout();
-                    return browserid.logoutDeferred.promise.then(function(){
-                        return $http.post(response.data.logoutUrl);
-                    });
+                browserid.logoutDeferred = $q.defer();
+                navigator.id.logout();
+                return browserid.logoutDeferred.promise.then(function(){
+                    return $http.post(thServiceDomain+'/browserid/logout/');
                 });
             },
             /*
@@ -137,25 +133,20 @@ treeherder.factory('BrowserId', [
              * The requestDeferred promise is resolved by the onLogin callback
              * of navigator.id.watch.
              */
-            getAssertion: function(requestArgs){
-                return browserid.info.then(function(response){
-                    requestArgs = _.extend({}, response.data.requestArgs, requestArgs);
-                    browserid.requestDeferred = $q.defer();
-                    navigator.id.request(requestArgs);
-                    return browserid.requestDeferred.promise;
-                });
+            getAssertion: function(){
+                browserid.requestDeferred = $q.defer();
+                navigator.id.request();
+                return browserid.requestDeferred.promise;
             },
             /*
              * Verify the assertion provided by persona against the treeherder verification endpoint.
              * The django_browserid endpoint accept a post request with form-urlencoded fields.
              */
             verifyAssertion: function(assertion){
-                return browserid.info.then(function(response){
-                    return $http.post(
-                        response.data.loginUrl, {assertion: assertion},{
-                            headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'},
-                            transformRequest: browserid.transform_data
-                        });
+                return $http.post(
+                    thServiceDomain+'/browserid/login/', {assertion: assertion},{
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'},
+                        transformRequest: browserid.transform_data
                 });
             },
 


### PR DESCRIPTION
The latest version of django-browserid removes a view that we used to fetch to retrieve
basig config params for the browserid client initialization. We now have loginUrl and logoutUrl
hardcoded in the client and we fetch the user login status from a dedicated endpoint.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/890)
<!-- Reviewable:end -->
