### PR TITLE
Bug 1194830 - Add button to trigger new buildbot jobs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -4,6 +4,6 @@ worker_pushlog: newrelic-admin run-program celery -A treeherder worker -Q pushlo
 worker_buildapi_pending: newrelic-admin run-program celery -A treeherder worker -Q buildapi_pending --maxtasksperchild=20 --concurrency=5
 worker_buildapi_running: newrelic-admin run-program celery -A treeherder worker -Q buildapi_running --maxtasksperchild=20 --concurrency=5
 worker_buildapi_4hr: newrelic-admin run-program celery -A treeherder worker -Q buildapi_4hr --maxtasksperchild=20 --concurrency=1
-worker_default: newrelic-admin run-program celery -A treeherder worker -Q default,cycle_data,calculate_eta,fetch_bugs --maxtasksperchild=50 --concurrency=3
+worker_default: newrelic-admin run-program celery -A treeherder worker -Q default,cycle_data,calculate_eta,fetch_bugs,fetch_allthethings --maxtasksperchild=50 --concurrency=3
 worker_hp: newrelic-admin run-program celery -A treeherder worker -Q classification_mirroring,publish_to_pulse --maxtasksperchild=50 --concurrency=1
 worker_log_parser: newrelic-admin run-program celery -A treeherder worker -Q log_parser_fail,log_parser,log_parser_hp,log_parser_json --maxtasksperchild=50 --concurrency=5

--- a/bin/run_celery_worker
+++ b/bin/run_celery_worker
@@ -19,6 +19,6 @@ if [ ! -f $LOGFILE ]; then
 fi
 
 exec $NEWRELIC_ADMIN celery -A treeherder worker -c 3 \
-     -Q default,cycle_data,calculate_eta,fetch_bugs,autoclassify,detect_intermittents \
+     -Q default,cycle_data,calculate_eta,fetch_bugs,autoclassify,detect_intermittents,fetch_allthethings \
      -E --maxtasksperchild=500 \
      --logfile=$LOGFILE -l INFO -n default.%h

--- a/schemas/resultset-runnable-job-action-message.json
+++ b/schemas/resultset-runnable-job-action-message.json
@@ -1,0 +1,35 @@
+{
+  "id":           "https://treeherder.mozilla.org/schemas/v1/resultset-runnable-job-action-message.json#",
+  "$schema":      "http://json-schema.org/draft-04/schema#",
+  "title":        "Notification of triggering runnable jobs on a resultset",
+  "description":  "Event is dispatched when user/service asks for new runnable jobs on a resultset",
+  "type":         "object",
+  "properties": {
+    "version": {
+      "title":                "Message-format version",
+      "enum":                 [1]
+    },
+    "project": {
+      "title":                "Project Name",
+      "description":          "Identifier for treeherder project, like `try` or `mozilla-central`.",
+      "type":                 "string"
+    },
+    "resultset_id": {
+      "title":                "Resultset ID",
+      "description":          "Project unique identifier for a resultset",
+      "type":                 "string"
+    },
+    "requester": {
+      "title":                "Requester",
+      "description":          "The requester of the action (usually an email)",
+      "type":                 "string"
+    },
+    "buildernames": {
+      "title":                "Buildernames",
+      "description":          "The buildernames that should be added to a job.",
+      "type":                 "array"
+    }
+  },
+  "additionalProperties":     false,
+  "required": ["version", "resultset_id", "project", "requester", "buildernames"]
+}

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -184,6 +184,7 @@ CELERY_QUEUES = (
     Queue('buildapi_pending', Exchange('default'), routing_key='buildapi_pending'),
     Queue('buildapi_running', Exchange('default'), routing_key='buildapi_running'),
     Queue('buildapi_4hr', Exchange('default'), routing_key='buildapi_4hr'),
+    Queue('fetch_allthethings', Exchange('default'), routing_key='fetch_allthethings'),
     Queue('cycle_data', Exchange('default'), routing_key='cycle_data'),
     Queue('calculate_eta', Exchange('default'), routing_key='calculate_eta'),
     Queue('fetch_bugs', Exchange('default'), routing_key='fetch_bugs'),
@@ -230,6 +231,14 @@ CELERYBEAT_SCHEDULE = {
         'relative': True,
         'options': {
             "queue": "buildapi_4hr"
+        }
+    },
+    'fetch-allthethings-every-day': {
+        'task': 'fetch-allthethings',
+        'schedule': timedelta(days=1),
+        'relative': True,
+        'options': {
+            'queue': "fetch_allthethings"
         }
     },
     'cycle-data-every-day': {
@@ -291,6 +300,7 @@ SITE_URL = os.environ.get("SITE_URL", "http://local.treeherder.mozilla.org")
 BUILDAPI_PENDING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-pending.js"
 BUILDAPI_RUNNING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-running.js"
 BUILDAPI_BUILDS4H_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-4hr.js.gz"
+ALLTHETHINGS_URL = "https://secure.pub.build.mozilla.org/builddata/reports/allthethings.json"
 
 # the max size of a posted request to treeherder client during Buildbot
 # data job ingestion.

--- a/treeherder/etl/allthethings.py
+++ b/treeherder/etl/allthethings.py
@@ -1,0 +1,109 @@
+import collections
+import logging
+from hashlib import sha1
+
+from django.conf import settings
+
+from treeherder.etl.buildbot import get_symbols_and_platforms
+from treeherder.etl.mixins import JsonExtractorMixin
+from treeherder.model.models import (BuildPlatform,
+                                     JobGroup,
+                                     JobType,
+                                     MachinePlatform,
+                                     Option,
+                                     OptionCollection,
+                                     Repository,
+                                     RunnableJob)
+
+logger = logging.getLogger(__name__)
+
+
+class AllthethingsTransformerMixin:
+
+    def transform(self, extracted_content):
+        logger.info('About to import allthethings.json builder data.')
+
+        jobs_per_branch = collections.defaultdict(list)
+
+        for builder, content in extracted_content['builders'].iteritems():
+            job = get_symbols_and_platforms(builder)
+
+            branch = content['properties']['branch']
+            job.update({'branch': branch})
+            jobs_per_branch[branch].append(job)
+
+        return jobs_per_branch
+
+
+class RunnableJobsProcess(JsonExtractorMixin,
+                          AllthethingsTransformerMixin):
+
+    # XXX: Copied from refdata.py. What is the best place for this?
+    def get_option_collection_hash(self, options):
+        """returns an option_collection_hash given a list of options"""
+
+        options = sorted(list(options))
+        sha_hash = sha1()
+        # equivalent to loop over the options and call sha_hash.update()
+        sha_hash.update(''.join(options))
+        return sha_hash.hexdigest()
+
+    def load(self, jobs_per_branch):
+        active_repositories = Repository.objects.all().filter(
+            active_status='active')
+
+        for repo in active_repositories:
+            # Some active repositories might not have any buildbot
+            # builders.
+            if repo.name not in jobs_per_branch:
+                continue
+
+            for datum in jobs_per_branch[repo.name]:
+                # XXX: refdata.py truncates those fields at 25 characters.
+                # Should we do the same?
+                build_platform, _ = BuildPlatform.objects.get_or_create(
+                    os_name=datum['build_os'],
+                    platform=datum['build_platform'],
+                    architecture=datum['build_architecture']
+                )
+
+                machine_platform, _ = MachinePlatform.objects.get_or_create(
+                    os_name=datum['machine_platform_os'],
+                    platform=datum['platform'],
+                    architecture=datum['machine_platform_architecture']
+                )
+
+                job_group, _ = JobGroup.objects.get_or_create(
+                    name=datum['job_group_name'],
+                    symbol=datum['job_group_symbol']
+                )
+
+                job_type, _ = JobType.objects.get_or_create(
+                    name=datum['job_type_name'],
+                    symbol=datum['job_type_symbol'],
+                    job_group=job_group
+                )
+
+                option_collection_hash = self.get_option_collection_hash(
+                    datum['option_collection'].keys())
+
+                for key in datum['option_collection'].keys():
+                    option, _ = Option.objects.get_or_create(name=key)
+                    OptionCollection.objects.get_or_create(
+                        option_collection_hash=option_collection_hash,
+                        option=option)
+
+                # This automatically updates the last_touched field.
+                RunnableJob.objects.update_or_create(
+                    ref_data_name=datum['ref_data_name'],
+                    build_system_type=datum['build_system_type'],
+                    defaults={'build_platform': build_platform,
+                              'machine_platform': machine_platform,
+                              'job_type': job_type,
+                              'option_collection_hash': option_collection_hash,
+                              'repository': repo})
+
+    def run(self):
+        extracted_content = self.extract(settings.ALLTHETHINGS_URL)
+        jobs_per_branch = self.transform(extracted_content)
+        self.load(jobs_per_branch)

--- a/treeherder/etl/buildbot.py
+++ b/treeherder/etl/buildbot.py
@@ -1072,3 +1072,29 @@ def get_symbol(name, bn):
         return n
 
     return "{0}{1}".format(s, n)
+
+
+def get_symbols_and_platforms(buildername):
+    """Return a dict with all the information we extract from the buildername."""
+    platform_info = extract_platform_info(buildername)
+    job_name_info = extract_name_info(buildername)
+
+    job = {
+        'job_type_name': job_name_info.get('name', ''),
+        'job_type_symbol': job_name_info.get('job_symbol', ''),
+        'job_group_name': job_name_info.get('group_name', ''),
+        'job_group_symbol': job_name_info.get('group_symbol', ''),
+        'ref_data_name': buildername,
+        'build_platform': platform_info.get('os_platform', ''),
+        'build_os': platform_info.get('os', ''),
+        'build_architecture': platform_info.get('arch', ''),
+        'build_system_type': 'buildbot',
+        'machine_platform_architecture': platform_info.get('arch', ''),
+        'machine_platform_os': platform_info.get('os', ''),
+        'option_collection': {
+            extract_build_type(buildername): True
+        },
+        'platform': platform_info.get('os_platform', ''),
+        'job_coalesced_to_guid': None
+    }
+    return job

--- a/treeherder/etl/tasks/buildapi_tasks.py
+++ b/treeherder/etl/tasks/buildapi_tasks.py
@@ -3,6 +3,7 @@ This module contains
 """
 from celery import task
 
+from treeherder.etl.allthethings import RunnableJobsProcess
 from treeherder.etl.buildapi import (Builds4hJobsProcess,
                                      PendingJobsProcess,
                                      RunningJobsProcess)
@@ -32,6 +33,14 @@ def fetch_buildapi_build4h():
     Fetches the buildapi running jobs api and load them
     """
     Builds4hJobsProcess().run()
+
+
+@task(name='fetch-allthethings', time_limit=10 * 60)
+def fetch_allthethings():
+    """
+    Fetches possible jobs from allthethings and load them
+    """
+    RunnableJobsProcess().run()
 
 
 @task(name='fetch-push-logs')

--- a/treeherder/model/exchanges.py
+++ b/treeherder/model/exchanges.py
@@ -50,6 +50,22 @@ class TreeherderPublisher(PulsePublisher):
         schema="https://treeherder.mozilla.org/schemas/v1/resultset-action-message.json#"
     )
 
+    resultset_runnable_job_action = Exchange(
+        exchange="resultset-runnable-job-actions",
+        title="Runnable job actions issued by resultset",
+        description="""
+            This action is published when a user asks for new runnable jobs (chosen
+            by name) on a resultset.
+        """,
+        routing_keys=[
+            Key(
+                name='project',
+                summary="Project (or branch) that this result-set belongs to"
+            ),
+        ],
+        schema="https://treeherder.mozilla.org/schemas/v1/resultset-runnable-job-action-message.json#"
+    )
+
     job_action = Exchange(
         exchange="job-actions",
         title="Actions issued by jobs",

--- a/treeherder/model/migrations/0004_add_runnable_job_table.py
+++ b/treeherder/model/migrations/0004_add_runnable_job_table.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0003_auto_20151111_0942'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RunnableJob',
+            fields=[
+                ('id', models.AutoField(serialize=False, primary_key=True)),
+                ('option_collection_hash', models.CharField(max_length=64L)),
+                ('ref_data_name', models.CharField(max_length=255L)),
+                ('build_system_type', models.CharField(max_length=25L)),
+                ('last_touched', models.DateTimeField(auto_now=True)),
+                ('build_platform', models.ForeignKey(to='model.BuildPlatform')),
+                ('job_type', models.ForeignKey(to='model.JobType')),
+                ('machine_platform', models.ForeignKey(to='model.MachinePlatform')),
+                ('repository', models.ForeignKey(to='model.Repository')),
+            ],
+            options={
+                'db_table': 'runnable_job',
+            },
+        ),
+        migrations.AlterUniqueTogether(
+            name='runnablejob',
+            unique_together=set([('ref_data_name', 'build_system_type')]),
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -671,3 +671,27 @@ class FailureMatch(models.Model):
         unique_together = (
             ('failure_line', 'classified_failure', 'matcher')
         )
+
+
+@python_2_unicode_compatible
+class RunnableJob(models.Model):
+    id = models.AutoField(primary_key=True)
+    build_platform = models.ForeignKey(BuildPlatform)
+    machine_platform = models.ForeignKey(MachinePlatform)
+    job_type = models.ForeignKey(JobType)
+    option_collection_hash = models.CharField(max_length=64L)
+    ref_data_name = models.CharField(max_length=255L)
+    build_system_type = models.CharField(max_length=25L)
+    repository = models.ForeignKey(Repository)
+    last_touched = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = 'runnable_job'
+        unique_together = (
+            ('ref_data_name', 'build_system_type')
+        )
+
+    def __str__(self):
+        return "{0} {1} {2}".format(self.id,
+                                    self.ref_data_name,
+                                    self.build_system_type)

--- a/treeherder/model/tasks.py
+++ b/treeherder/model/tasks.py
@@ -108,6 +108,22 @@ def publish_resultset_action(project, action, resultset_id, requester, times=1):
     )
 
 
+@task(name='publish-resultset-runnable-job-action')
+def publish_resultset_runnable_job_action(project, resultset_id, requester,
+                                          buildernames):
+    publisher = pulse_connection.get_publisher()
+    if not publisher:
+        return
+
+    publisher.resultset_runnable_job_action(
+        version=1,
+        project=project,
+        requester=requester,
+        resultset_id=resultset_id,
+        buildernames=buildernames
+    )
+
+
 @task(name='publish-resultset')
 def publish_resultset(project, ids):
     # If we don't have a publisher (because of missing configs), then we can't

--- a/treeherder/webapp/api/resultset.py
+++ b/treeherder/webapp/api/resultset.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
 from treeherder.model.derived import DatasetNotFoundError
+from treeherder.model.tasks import publish_resultset_runnable_job_action
 from treeherder.webapp.api import permissions
 from treeherder.webapp.api.utils import (UrlQueryFilter,
                                          to_timestamp,
@@ -181,6 +182,35 @@ class ResultSetViewSet(viewsets.ViewSet):
 
         except Exception as ex:
             return Response("Exception: {0}".format(ex), 404)
+
+    @detail_route(methods=['post'], permission_classes=[IsAuthenticated])
+    @with_jobs
+    def trigger_runnable_jobs(self, request, project, jm, pk=None):
+        """
+        Add new jobs to a resultset.
+        """
+        if not pk:
+            return Response({"message": "resultset id required"}, status=400)
+
+        # Making sure a resultset with this id exists
+        filter = UrlQueryFilter({"id": pk})
+        full = filter.pop('full', 'true').lower() == 'true'
+        result_set_list = jm.get_result_set_list(0, 1, full, filter.conditions)
+        if not result_set_list:
+            return Response({"message": "No resultset with id: {0}".format(pk)},
+                            status=404)
+
+        buildernames = request.data.get('buildernames', [])
+        if len(buildernames) == 0:
+            Response({"message": "The list of buildernames cannot be empty"},
+                     status=400)
+
+        publish_resultset_runnable_job_action.apply_async(
+            args=[project, pk, request.user.email, buildernames],
+            routing_key='publish_to_pulse'
+        )
+
+        return Response({"message": "New jobs added for push '{0}'".format(pk)})
 
     @with_jobs
     def create(self, request, project, jm):

--- a/treeherder/webapp/api/runnable_jobs.py
+++ b/treeherder/webapp/api/runnable_jobs.py
@@ -1,0 +1,65 @@
+import datetime
+
+from rest_framework import viewsets
+from rest_framework.response import Response
+
+from treeherder.model import models
+
+
+class RunnableJobsViewSet(viewsets.ViewSet):
+    """
+    This viewset is responsible for the runnable_jobs endpoint.
+
+    """
+
+    def list(self, request, project):
+        """
+        GET method implementation for list of all runnable buildbot jobs
+        """
+        repository = models.Repository.objects.get(name=project)
+
+        options_by_hash = models.OptionCollection.objects.all().select_related(
+            'option').values_list('option__name', 'option_collection_hash')
+
+        runnable_jobs = models.RunnableJob.objects.filter(
+            repository=repository,
+            last_touched__gte=datetime.datetime.now() - datetime.timedelta(weeks=1)
+        ).select_related('build_platform', 'machine_platform',
+                         'job_type', 'job_type__job_group')
+
+        ret = []
+        for datum in runnable_jobs:
+            options = ' '.join(option_name for (option_name, col_hash) in options_by_hash
+                               if col_hash == datum.option_collection_hash)
+
+            ret.append({
+                'build_platform_id': datum.build_platform.id,
+                'build_platform': datum.build_platform.platform,
+                'build_os': datum.build_platform.os_name,
+                'build_architecture': datum.build_platform.architecture,
+                'machine_platform_id': datum.machine_platform.id,
+                'platform': datum.machine_platform.platform,
+                'machine_platform_os': datum.machine_platform.os_name,
+                'machine_platform_architecture': datum.machine_platform.architecture,
+                'job_group_id': datum.job_type.job_group.id,
+                'job_group_name': datum.job_type.job_group.name,
+                'job_group_symbol': datum.job_type.job_group.symbol,
+                'job_group_description': datum.job_type.job_group.description,
+                'job_type_id': datum.job_type.id,
+                'job_type_name': datum.job_type.name,
+                'job_type_symbol': datum.job_type.symbol,
+                'job_type_description': datum.job_type.description,
+                'option_collection_hash': datum.option_collection_hash,
+                'ref_data_name': datum.ref_data_name,
+                'build_system_type': datum.build_system_type,
+                'platform_option': options,
+                'job_coalesced_to_guid': None,
+                'state': 'runnable',
+                'result': 'runnable'})
+
+        response_body = dict(meta={"repository": project,
+                                   "offset": 0,
+                                   "count": len(ret)},
+                             results=ret)
+
+        return Response(response_body)

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -11,7 +11,8 @@ from treeherder.webapp.api import (artifact,
                                    note,
                                    performance_data,
                                    refdata,
-                                   resultset)
+                                   resultset,
+                                   runnable_jobs)
 
 # router for views that are bound to a project
 # i.e. all those views that don't involve reference data
@@ -21,6 +22,12 @@ project_bound_router.register(
     r'jobs',
     jobs.JobsViewSet,
     base_name='jobs',
+)
+
+project_bound_router.register(
+    r'runnable_jobs',
+    runnable_jobs.RunnableJobsViewSet,
+    base_name='runnable_jobs',
 )
 
 project_bound_router.register(

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -57,6 +57,28 @@
   margin-left: -3px;
 }
 
+.runnable-job-btn {
+    display: none;
+    color: rgba(128, 128, 0, 0.5);
+    margin: 0 -5px 0 -1px;
+    background: transparent;
+    padding: 0 2px;
+    vertical-align: 0;
+    line-height: 1.32;
+    font-size: 12px;
+    border-radius: 0px;
+    text-align: center;
+    white-space: nowrap;
+}
+
+.runnable-job-btn-selected {
+    border: 1px solid;
+    padding: 0 -1;
+    border-radius: 3px;
+    margin: 0px -3px 1px 0px;
+    overflow: visible;
+}
+
 .selected-job {
   border: 4px solid;
   background-color: #fff;

--- a/ui/index.html
+++ b/ui/index.html
@@ -97,6 +97,7 @@
         <script src="js/models/bug_job_map.js"></script>
         <script src="js/models/classification.js"></script>
         <script src="js/models/job.js"></script>
+        <script src="js/models/runnable_job.js"></script>
         <script src="js/models/job_exclusion.js"></script>
         <script src="js/models/exclusion_profile.js"></script>
         <script src="js/models/build_platform.js"></script>
@@ -216,6 +217,15 @@
         <script type="'text/ng-template'" id="jobBtnClone.html">
             <button class="btn job-btn btn-xs {{ btnClass }} {{ key }}"
                   data-jmkey="{{ key }}"
+                  ignore-job-clear-on-click
+                  title="{{ title }}">{{ value }}</button>
+        </script>
+
+        <!-- Runnable Job Btn span -->
+        <script type="'text/ng-template'" id="runnableJobBtnClone.html">
+            <button class="btn runnable-job-btn {{ key }}"
+                  data-jmkey="{{ key }}"
+                  data-buildername="{{ buildername }}"
                   ignore-job-clear-on-click
                   title="{{ title }}">{{ value }}</button>
         </script>

--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -169,6 +169,14 @@ treeherderApp.controller('ResultSetCtrl', [
 
         };
 
+        $scope.showRunnableJobs = function() {
+            $rootScope.$emit(thEvents.showRunnableJobs, $scope.resultset);
+        };
+
+        $scope.deleteRunnableJobs = function() {
+            $rootScope.$emit(thEvents.deleteRunnableJobs, $scope.resultset);
+        };
+
         $scope.cancelAllJobs = function(revision) {
             if (!window.confirm('This will cancel all pending and running jobs for revision ' + revision + '!\n\nAre you sure?')) {
                 return;
@@ -217,6 +225,31 @@ treeherderApp.controller('ResultSetCtrl', [
                     'danger', true
                 );
             });
+        };
+
+        $scope.showTriggerButton = function() {
+            var buildernames = ThResultSetStore.getSelectedRunnableJobs($rootScope.repoName, $scope.resultset.id);
+            return buildernames.length > 0;
+        };
+
+        $scope.triggerNewJobs = function() {
+            if (!window.confirm(
+                'This will trigger all selected jobs. Do you want to proceed?')) {
+                return;
+            }
+            if ($scope.user.loggedin) {
+                var buildernames = ThResultSetStore.getSelectedRunnableJobs($rootScope.repoName, $scope.resultset.id);
+                ThResultSetModel.triggerNewJobs($scope.repoName, $scope.resultset.id, buildernames).then(function() {
+                    thNotify.send("Trigger request sent", "success");
+                    ThResultSetStore.deleteRunnableJobs($scope.repoName, $scope.resultset);
+                }, function(e) {
+                    // Generic error eg. the user doesn't have permission
+                    thNotify.send(
+                        ThModelErrors.format(e, "Unable to send trigger"), 'danger');
+                });
+            } else {
+                thNotify.send("Must be logged in to trigger a job", 'danger');
+            }
         };
 
         $scope.revisionResultsetFilterUrl = $scope.urlBasePath + "?repo=" +

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -34,6 +34,7 @@ treeherder.directive('thCloneJobs', [
 
         // Custom Attributes
         var jobKeyAttr = 'data-jmkey';
+        var runnableJobBuildernameAttr = 'data-buildername';
         var groupKeyAttr = 'data-grkey';
 
         var tableInterpolator = thCloneHtml.get('resultsetClone').interpolator;
@@ -49,6 +50,9 @@ treeherder.directive('thCloneJobs', [
 
         //Instantiate job btn interpolator
         var jobBtnInterpolator = thCloneHtml.get('jobBtnClone').interpolator;
+
+        //Instantiate job btn interpolator
+        var runnableJobBtnInterpolator = thCloneHtml.get('runnableJobBtnClone').interpolator;
 
         var getJobMapKey = function(job){
             return 'key' + job.id;
@@ -196,8 +200,23 @@ treeherder.directive('thCloneJobs', [
             }
         };
 
+        var clickRunnableJobCb = function(el, resultset_id) {
+            var buildername = el.attr(runnableJobBuildernameAttr);
+            ThResultSetStore.toggleSelectedRunnableJob($rootScope.repoName, resultset_id, buildername);
+            el.toggleClass("runnable-job-btn-selected");
+        };
+
         var togglePinJobCb = function(ev, el, job){
             $rootScope.$emit(thEvents.jobPin, job);
+        };
+
+        var filterWithRunnable = function(job) {
+            var visible = thJobFilters.showJob(job);
+            if (job.state === "runnable") {
+                var rsMap = ThResultSetStore.getResultSetsMap($rootScope.repoName);
+                visible = visible && rsMap[job.result_set_id].rs_obj.isRunnableVisible;
+            }
+            return visible;
         };
 
         var addJobBtnEls = function(jgObj, jobList) {
@@ -216,7 +235,7 @@ treeherder.directive('thCloneJobs', [
                 // Keep track of visibility with this property. This
                 // way down stream job consumers don't need to repeatedly
                 // call showJob
-                job.visible = thJobFilters.showJob(job);
+                job.visible = filterWithRunnable(job);
 
                 addJobBtnToArray(job, lastJobSelected, jobBtnArray);
             }
@@ -230,7 +249,19 @@ treeherder.directive('thCloneJobs', [
             jobStatus.key = getJobMapKey(job);
             jobStatus.value = job.job_type_symbol;
             jobStatus.title = getHoverText(job);
-            jobBtn = $(jobBtnInterpolator(jobStatus));
+
+            if (thResultStatus(job) === "runnable") {
+                jobStatus.buildername = job.ref_data_name;
+                jobBtn = $(runnableJobBtnInterpolator(jobStatus));
+
+                if (ThResultSetStore.isRunnableJobSelected($rootScope.repoName,
+                                                           job.result_set_id,
+                                                           jobStatus.buildername)) {
+                    jobBtn.addClass("runnable-job-btn-selected");
+                }
+            } else {
+                jobBtn = $(jobBtnInterpolator(jobStatus));
+            }
 
             // If the job is currently selected make sure to re-apply
             // the job selection styles
@@ -285,7 +316,7 @@ treeherder.directive('thCloneJobs', [
                 var countInfo = thResultStatusInfo(resultStatus,
                                                 job.failure_classification_id);
 
-                job.visible = thJobFilters.showJob(job);
+                job.visible = filterWithRunnable(job);
 
                 // Even if a job is not visible, add it to the DOM as hidden.  This is
                 // important because it can still be "selected" when not visible
@@ -344,8 +375,11 @@ treeherder.directive('thCloneJobs', [
 
             var el = $(ev.target);
             var key = el.attr(jobKeyAttr);
+            var buildername = el.attr(runnableJobBuildernameAttr);
             //Confirm user selected a job
-            if(key && !_.isEmpty(this.job_map[key])){
+            if (buildername) {
+                _.bind(clickRunnableJobCb, this, el, resultset.id)();
+            } else if (key && !_.isEmpty(this.job_map[key])) {
 
                 var job = this.job_map[key].job_obj;
 
@@ -529,15 +563,16 @@ treeherder.directive('thCloneJobs', [
             var job, jmKey, show;
             var jobMap = ThResultSetStore.getJobMap($rootScope.repoName);
 
-            element.find('.job-list .job-btn').each(function internalFilterJob() {
-                // using jquery to do these things was quite a bit slower,
-                // so just using raw JS for speed.
-                jmKey = this.dataset.jmkey;
-                job = jobMap[jmKey].job_obj;
-                show = thJobFilters.showJob(job);
-                job.visible = show;
-                showHideElement($(this), show);
-            });
+            element.find('.job-list .job-btn, .job-list .runnable-job-btn').each(
+                function internalFilterJob() {
+                    // using jquery to do these things was quite a bit slower,
+                    // so just using raw JS for speed.
+                    jmKey = this.dataset.jmkey;
+                    job = jobMap[jmKey].job_obj;
+                    show = filterWithRunnable(job);
+                    job.visible = show;
+                    showHideElement($(this), show);
+                });
 
             renderGroups(element, false);
 
@@ -816,6 +851,26 @@ treeherder.directive('thCloneJobs', [
                             rsMap[resultSetId].rs_obj);
                     }
                 });
+
+            // Show runnable jobs when users press 'Add new jobs'
+            $rootScope.$on(thEvents.showRunnableJobs, function(ev, rs) {
+                if(scope.resultset.id === rs.id) {
+                    var resultSetAggregateId = thAggregateIds.getResultsetTableId(
+                        $rootScope.repoName, scope.resultset.id, scope.resultset.revision
+                    );
+                    rs.isRunnableVisible = true;
+
+                    ThResultSetStore.addRunnableJobs($rootScope.repoName, rs);
+                }
+            });
+
+            // Hide runnable jobs when users press 'Hide runnable jobs'
+            $rootScope.$on(thEvents.deleteRunnableJobs, function(ev, rs) {
+                if(scope.resultset.id === rs.id) {
+                    ThResultSetStore.deleteRunnableJobs($rootScope.repoName, rs);
+                }
+            });
+
         };
 
         var generateJobElements = function(resultsetAggregateId, resultset) {

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -199,6 +199,12 @@ treeherder.factory(
              triggerAllTalosJobs: function(resultset_id, repoName, times) {
                  var uri = resultset_id + '/trigger_all_talos_jobs/?times=' + times;
                  return $http.post(thUrl.getProjectUrl("/resultset/", repoName) + uri);
+             },
+
+             triggerNewJobs: function(repoName, resultset_id, buildernames) {
+                 var uri = resultset_id + '/trigger_runnable_jobs/';
+                 var data = {buildernames: buildernames};
+                 return $http.post(thUrl.getProjectUrl("/resultset/", repoName) + uri, data);
              }
          };
      }]);

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -5,10 +5,12 @@ treeherder.factory('ThResultSetStore', [
     'ThResultSetModel', 'ThJobModel', 'thEvents', 'thResultStatusObject',
     'thAggregateIds', 'ThLog', 'thNotify', 'thJobFilters', 'thOptionOrder',
     'ThRepositoryModel', '$timeout', 'ThJobTypeModel', 'ThJobGroupModel',
+    'ThRunnableJobModel',
     function(
         $rootScope, $q, $location, $interval, thPlatformOrder, ThResultSetModel,
         ThJobModel, thEvents, thResultStatusObject, thAggregateIds, ThLog, thNotify,
-        thJobFilters, thOptionOrder, ThRepositoryModel, $timeout, ThJobTypeModel, ThJobGroupModel) {
+        thJobFilters, thOptionOrder, ThRepositoryModel, $timeout, ThJobTypeModel,
+        ThJobGroupModel, ThRunnableJobModel) {
 
         var $log = new ThLog("ThResultSetStore");
 
@@ -270,6 +272,28 @@ treeherder.factory('ThResultSetStore', [
                 key += option;
             }
             return key;
+        };
+
+        var addRunnableJobs = function(repoName, resultSet) {
+            return ThRunnableJobModel.get_list(repoName).then(function(jobList) {
+                var id = resultSet.id;
+                _.each(jobList, function(job) {
+                    job.result_set_id = id;
+                    job.id = thAggregateIds.escape(job.result_set_id + job.ref_data_name);
+                });
+
+                if (jobList.length === 0) {
+                    thNotify.send("No new jobs available");
+                };
+
+                mapResultSetJobs(repoName, jobList);
+            });
+        };
+
+        var deleteRunnableJobs = function(repoName, resultSet) {
+            repositories[repoName].rsMap[resultSet.id].selected_runnable_jobs = [];
+            resultSet.isRunnableVisible = false;
+            $rootScope.$emit(thEvents.globalFilterChanged);
         };
 
         /******
@@ -786,6 +810,29 @@ treeherder.factory('ThResultSetStore', [
             return repositories[repoName].rsMap[resultsetId].rs_obj;
         };
 
+        var getSelectedRunnableJobs = function(repoName, resultsetId) {
+            if (!repositories[repoName].rsMap[resultsetId].selected_runnable_jobs) {
+                repositories[repoName].rsMap[resultsetId].selected_runnable_jobs = [];
+            }
+            return repositories[repoName].rsMap[resultsetId].selected_runnable_jobs;
+        };
+
+        var toggleSelectedRunnableJob = function(repoName, resultsetId, buildername) {
+            var selectedRunnableJobs = getSelectedRunnableJobs(repoName, resultsetId);
+            var jobIndex = selectedRunnableJobs.indexOf(buildername);
+
+            if (jobIndex === -1) {
+                selectedRunnableJobs.push(buildername);
+            } else {
+                selectedRunnableJobs.splice(jobIndex, 1);
+            }
+        };
+
+        var isRunnableJobSelected = function(repoName, resultsetId, buildername) {
+            var selectedRunnableJobs = getSelectedRunnableJobs(repoName, resultsetId);
+            return _.includes(selectedRunnableJobs, buildername);
+        };
+
         var getJobMap = function(repoName){
             // this is a "watchable" for jobs
             return repositories[repoName].jobMap;
@@ -1090,6 +1137,7 @@ treeherder.factory('ThResultSetStore', [
 
             addRepository: addRepository,
             aggregateJobPlatform: aggregateJobPlatform,
+            deleteRunnableJobs: deleteRunnableJobs,
             fetchJobs: fetchJobs,
             fetchResultSets: fetchResultSets,
             getAllShownJobs: getAllShownJobs,
@@ -1097,6 +1145,10 @@ treeherder.factory('ThResultSetStore', [
             getGroupMap: getGroupMap,
             getLoadingStatus: getLoadingStatus,
             getPlatformKey: getPlatformKey,
+            addRunnableJobs: addRunnableJobs,
+            isRunnableJobSelected: isRunnableJobSelected,
+            getSelectedRunnableJobs: getSelectedRunnableJobs,
+            toggleSelectedRunnableJob: toggleSelectedRunnableJob,
             getResultSet: getResultSet,
             getResultSetsArray: getResultSetsArray,
             getResultSetsMap: getResultSetsMap,

--- a/ui/js/models/runnable_job.js
+++ b/ui/js/models/runnable_job.js
@@ -1,0 +1,20 @@
+'use strict';
+
+treeherder.factory('ThRunnableJobModel', [
+    'thUrl', 'ThJobModel',
+    function(thUrl, ThJobModel) {
+        var ThRunnableJobModel = function(data) {
+            angular.extend(this, data);
+        };
+
+        ThRunnableJobModel.get_runnable_uri = function(repoName) {
+            return thUrl.getProjectUrl("/runnable_jobs/", repoName);
+        };
+
+        ThRunnableJobModel.get_list = function(repoName, params) {
+            return ThJobModel.get_list(
+                repoName, params, {uri: ThRunnableJobModel.get_runnable_uri(repoName)});
+        };
+
+        return ThRunnableJobModel;
+    }]);

--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -12,11 +12,11 @@ treeherder.provider('thServiceDomain', function() {
 
 treeherder.provider('thResultStatusList', function() {
     var all = function() {
-        return ['success', 'testfailed', 'busted', 'exception', 'retry', 'usercancel', 'running', 'pending', 'coalesced'];
+        return ['success', 'testfailed', 'busted', 'exception', 'retry', 'usercancel', 'running', 'pending', 'coalesced', 'runnable'];
     };
 
     var defaultFilters = function() {
-        return ['success', 'testfailed', 'busted', 'exception', 'retry', 'usercancel', 'running', 'pending'];
+        return ['success', 'testfailed', 'busted', 'exception', 'retry', 'usercancel', 'running', 'pending', 'runnable'];
     };
 
     this.$get = function() {
@@ -196,6 +196,10 @@ treeherder.provider('thEvents', function() {
             groupStateChanged: "group-state-changed-EVT",
 
             toggleRevisions: "toggle-revisions-EVT",
+
+            showRunnableJobs: "show-runnable-jobs-EVT",
+
+            deleteRunnableJobs: "delete-runnable-jobs-EVT",
 
             toggleAllRevisions: "toggle-all-revisions-EVT",
 

--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -45,6 +45,7 @@ treeherder.factory('thCloneHtml', [
             'jobGroupClone.html',
             'jobGroupCountClone.html',
             'jobBtnClone.html',
+            'runnableJobBtnClone.html',
             'revisionUrlClone.html',
             'pushlogRevisionsClone.html'
         ];

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -150,6 +150,7 @@
     <!-- Model services -->
     <script src="js/models/job_artifact.js"></script>
     <script src="js/models/job.js"></script>
+    <script src="js/models/runnable_job.js"></script>
     <script src="js/models/resultset.js"></script>
     <script src="js/models/log_slice.js"></script>
 

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -41,6 +41,14 @@
         <span class="glyphicon glyphicon-pushpin"
               ignore-job-clear-on-click></span>
       </span>
+      <span class="btn btn-sm btn-resultset"
+            tabindex="0" role="button"
+            title="Trigger new jobs"
+            ng-show="showTriggerButton()"
+            ignore-job-clear-on-click
+            ng-click="triggerNewJobs()">
+           Trigger New Jobs
+      </span>
       <th-action-button ng-hide="isLoadingJobs"></th-action-button>
     </span>
   </div>

--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -10,6 +10,16 @@
   <!-- Menu contents -->
   <ul class="dropdown-menu pull-right">
     <li><a target="_blank" ignore-job-clear-on-click
+           title="Add new jobs to this resultset"
+           href="" prevent-default-on-left-click
+           ng-hide="resultset.isRunnableVisible"
+           ng-click="showRunnableJobs()">Add new Jobs</a></li>
+    <li><a target="_blank" ignore-job-clear-on-click
+           title="Hide Runnable Jobs"
+           href="" prevent-default-on-left-click
+           ng-show="resultset.isRunnableVisible"
+           ng-click="deleteRunnableJobs()">Hide Runnable Jobs</a></li>
+    <li><a target="_blank" ignore-job-clear-on-click
            href="https://bugherder.mozilla.org/?cset={{::resultset.revision}}&amp;tree={{::repoName}}"
            title="Use Bugherder to mark the bugs in this push">Mark with Bugherder</a></li>
     <li><a target="_blank" ignore-job-clear-on-click

--- a/ui/perf.html
+++ b/ui/perf.html
@@ -67,6 +67,7 @@
   <script src="js/services/log.js"></script>
   <script src="js/models/repository.js"></script>
   <script src="js/models/job.js"></script>
+  <script src="js/models/runnable_job.js"></script>
   <script src="js/models/resultset.js"></script>
   <script src="js/perf.js"></script>
   <script src="js/controllers/perf/compare.js"></script>


### PR DESCRIPTION
This adds a '+' button to resultsets that allows users to trigger new buildbot jobs.

Screenshots of this in action are in: https://drive.google.com/folderview?id=0B7rHgvgC7s4ZflY4cmtSSUJjcHVqQktIMGljcE5nLW9jaWx5T21CQ3F5QllSVGtDQl9sSGM&usp=sharing

When users click on '+' TH renders every possible job. Users can then click on the jobs they want and then click on 'Trigger New Jobs' to trigger the selected jobs. This will send a pulse message that Pulse Actions will use to trigger the jobs.

Currently it takes a long time (~ 7 seconds) for the full list of possible jobs to show up, because it is downloading and processing the list of builders every time. I'm working on adding this info to the TH database by adding a table and running an ETL job to fill it.

I'm planning on dealing with authentication on the Pulse Actions side using the same logic as in Try Extender, that is, only triggering jobs if the user is the commit author or has a '@mozilla.com' address, but if there is a solution on TH side I would be happy to use it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/892)
<!-- Reviewable:end -->
