### PR TITLE
Bug 1193222 - Handle invalid logviewer jobs in the UI

### DIFF
--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -29,6 +29,7 @@ logViewerApp.controller('LogviewerCtrl', [
         $scope.displayedLogLines = [];
         $scope.loading = false;
         $scope.logError = false;
+        $scope.jobExists = true;
         $scope.currentLineNumber = 0;
         $scope.highestLine = 0;
         $scope.showSuccessful = true;
@@ -144,7 +145,7 @@ logViewerApp.controller('LogviewerCtrl', [
                 }, function (error) {
                     $scope.loading = false;
                     $scope.logError = true;
-                    thNotify.send("The log no longer exists or has expired", 'warning', 'true');
+                    thNotify.send("The log no longer exists or has expired", 'warning', true);
                     deferred.reject();
                 });
             } else {
@@ -204,6 +205,11 @@ logViewerApp.controller('LogviewerCtrl', [
                     var revision = data.data.revision;
                     $scope.logProperties.push({label: "Revision", value: revision});
                 });
+
+            }, function (error) {
+                $scope.loading = false;
+                $scope.jobExists = false;
+                thNotify.send("The job does not exist or has expired", 'danger', true);
             });
 
             // Make the log and job artifacts available

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -32,15 +32,20 @@
           </li>
 
           <!-- Job status -->
-          <li class="{{::resultStatusShading}}">
+          <li ng-if="jobExists" class="{{::resultStatusShading}}">
             <div>
               <span ng-cloak><strong>{{result.label}}: </strong></span>
-              <span ng-cloak class="break-word">{{result.value}}</span>
+              <span ng-cloak>{{result.value}}</span>
+            </div>
+          </li>
+          <li ng-if="!jobExists" class="alert-danger">
+            <div>
+              <span title="The job does not exist or has expired">Unavailable</span>
             </div>
           </li>
 
           <!-- Raw log button -->
-          <li>
+          <li ng-if="jobExists">
             <a title="{{logError ? 'Raw log link no longer exists or has expired (click for path)' :
                       'Open the raw log in a new window'}}"
                target="_blank"


### PR DESCRIPTION
This fixes Bugzilla bug [1193222](https://bugzilla.mozilla.org/show_bug.cgi?id=1193222)

This provides a suitable display state when a job and/or its related logviewer url is not available the job has been expired.

Current:
![jobexpiredcurrent](https://cloud.githubusercontent.com/assets/3660661/9411379/9f080f4a-47f3-11e5-9e88-7ff99b22f388.jpg)

Proposed (with tooltip if the user had closed the notification, same as our log not available):
![jobexpiredproposed](https://cloud.githubusercontent.com/assets/3660661/9411411/cfce4d42-47f3-11e5-8828-0f6a12554e31.jpg)

Tested on OSX 10.10.3:
Nightly **43.0a1 (2015-08-20)**
Chrome Latest Release **44.0.2403.157 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/895)
<!-- Reviewable:end -->
