### PR TITLE
Bug 1197265 - Remove frontend code for 'timeline' and 'machines'

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -96,8 +96,6 @@
         <script src="js/controllers/repository.js"></script>
         <script src="js/controllers/filters.js"></script>
         <script src="js/controllers/jobs.js"></script>
-        <script src="js/controllers/machines.js"></script>
-        <script src="js/controllers/timeline.js"></script>
         <!-- Plugins -->
         <script src="plugins/tabs.js"></script>
         <script src="plugins/controller.js"></script>

--- a/ui/js/controllers/machines.js
+++ b/ui/js/controllers/machines.js
@@ -1,6 +1,0 @@
-"use strict";
-
-treeherderApp.controller('MachinesCtrl', [
-    '$scope',
-    function MachinesCtrl($scope){}
-]);

--- a/ui/js/controllers/timeline.js
+++ b/ui/js/controllers/timeline.js
@@ -1,6 +1,0 @@
-"use strict";
-
-treeherderApp.controller('TimelineCtrl', [
-	'$scope',
-	function TimelineCtrl($scope){}
-]);

--- a/ui/js/treeherder_app.js
+++ b/ui/js/treeherder_app.js
@@ -33,13 +33,5 @@ treeherderApp.config(function($compileProvider, $routeProvider, $httpProvider, $
             templateUrl: 'partials/main/jobs.html',
             reloadOnSearch: false
         }).
-        when('/timeline', {
-            controller: 'TimelineCtrl',
-            templateUrl: 'partials/main/timeline.html'
-        }).
-        when('/machines', {
-            controller: 'MachinesCtrl',
-            templateUrl: 'partials/main/machines.html'
-        }).
         otherwise({redirectTo: '/jobs'});
 });

--- a/ui/partials/main/machines.html
+++ b/ui/partials/main/machines.html
@@ -1,1 +1,0 @@
-<p>machines view</p>

--- a/ui/partials/main/timeline.html
+++ b/ui/partials/main/timeline.html
@@ -1,1 +1,0 @@
-<p>timeline view</p>


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1197265](https://bugzilla.mozilla.org/show_bug.cgi?id=1197265).

This removes the remaining front end code for the 'timeline' and 'machines' tabs removed last year in bug [1032470](https://bugzilla.mozilla.org/show_bug.cgi?id=1032470). The back end code will still remain for data ingestion.

I ingested and ran the UI with a local vagrant and both browser consoles seem fine.

Tested on OSX 10.10.3:
Nightly **43.0a1 (2015-08-20)**
Chrome Latest Release **44.0.2403.157 (64-bit)**

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/896)
<!-- Reviewable:end -->
