### PR TITLE
Bug 1192199 - Return a correct line count for logviewer navigation

### DIFF
--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -100,7 +100,6 @@ logViewerApp.controller('LogviewerCtrl', [
                 LogSlice.get_line_range(lineRangeParams, {
                     buffer_size: LINE_BUFFER_SIZE
                 }).then(function(data) {
-                    var slicedData, length;
 
                     drawErrorLines(data);
 
@@ -247,7 +246,7 @@ logViewerApp.controller('LogviewerCtrl', [
 
         function logFileLineCount () {
             var steps = $scope.artifact.step_data.steps;
-            return steps[ steps.length - 1 ].finished_linenumber;
+            return steps[ steps.length - 1 ].finished_linenumber + 1;
         }
 
         function moveLineNumber (bounds) {


### PR DESCRIPTION
This fixes Bugzilla bug [1192199](https://bugzilla.mozilla.org/show_bug.cgi?id=1192199)

This adjusts `logFileLineCount` so it produces a correct count for the scope variable `displayedLogLines`. The array was clipped and the last line omitted in Logviewer.

Current (misses the last line, it should be 'Finished'):
![current](https://cloud.githubusercontent.com/assets/3660661/9418362/70439da4-4821-11e5-9320-cf2e85f0bf34.jpg)

Proposed:
![proposed](https://cloud.githubusercontent.com/assets/3660661/9418376/84e666e2-4821-11e5-8a38-00475ac1da7c.jpg)

There were two unused variables in `loadMore` so I removed them at the same time. Everything seems find in local testing with:

* logviewer failure step preload
* step button navigation
* step failure line navigation
* freeform mouse/wheel/slider navigation
* show successful steps (enabling, disabling) with navigation

I might do a bit more testing before merge.

Tested on OSX 10.10.3:
Nightly **43.0a1 (2015-08-20)**
Chrome Latest Release **44.0.2403.157 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/898)
<!-- Reviewable:end -->
