### PR TITLE
Bug 1197827 - Treeherder unclassified failure count is off

### DIFF
--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -187,6 +187,7 @@ treeherder.directive('thCloneJobs', [
                 } else {
                     gi.grpCountList.empty();
                     gi.jgObj.groupState = "expanded";
+                    gi.grpJobList.empty();
                     addJobBtnEls(gi.jgObj, gi.grpJobList);
                 }
             }
@@ -200,7 +201,6 @@ treeherder.directive('thCloneJobs', [
             var lastJobSelected = ThResultSetStore.getSelectedJob($rootScope.repoName);
             var job, l;
             var jobBtnArray = [];
-            jobList.empty();
 
             for(l=0; l<jgObj.jobs.length; l++){
 

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -322,14 +322,14 @@ treeherder.factory('ThResultSetStore', [
                 // groups
                 for (var gp_i = 0; gp_i < pl_obj.groups.length; gp_i++) {
                     var gr_obj = pl_obj.groups[gp_i];
-                    gr_obj.mapKey = thAggregateIds.getGroupMapKey(rs_obj.id, gr_obj.name, gr_obj.symbol, pl_obj.name, pl_obj.option);
+                    gr_obj.mapKey = thAggregateIds.getGroupMapKey(rs_obj.id, gr_obj.symbol, pl_obj.name, pl_obj.option);
 
                     var grMapElement = {
                         grp_obj: gr_obj,
                         parent: plMapElement,
                         jobs: {}
                     };
-                    plMapElement.groups[gr_obj.name] = grMapElement;
+                    plMapElement.groups[gr_obj.symbol] = grMapElement;
 
                     // check if we need to copy groupState from an existing group
                     // object.  This would be set if a user explicitly clicked
@@ -440,7 +440,7 @@ treeherder.factory('ThResultSetStore', [
 
                 var groupInfo = getJobGroupInfo(newJob);
 
-                grMapElement = plMapElement.groups[groupInfo.name];
+                grMapElement = plMapElement.groups[groupInfo.symbol];
                 if (!grMapElement) {
                     $log.debug("adding new group");
                     var grp_obj = {
@@ -454,13 +454,13 @@ treeherder.factory('ThResultSetStore', [
                     plMapElement.pl_obj.groups.push(grp_obj);
 
                     // add the new group to the platform map
-                    plMapElement.groups[grp_obj.name] = {
+                    plMapElement.groups[grp_obj.symbol] = {
                         grp_obj: grp_obj,
                         parent: plMapElement,
                         jobs: {}
                     };
 
-                    grMapElement = plMapElement.groups[groupInfo.name];
+                    grMapElement = plMapElement.groups[groupInfo.symbol];
                 }
             }
             return grMapElement;
@@ -904,7 +904,7 @@ treeherder.factory('ThResultSetStore', [
 
             var name = job.job_group_name;
             var symbol = job.job_group_symbol;
-            var mapKey = thAggregateIds.getGroupMapKey(job.result_set_id, name, job.platform, job.platform_option);
+            var mapKey = thAggregateIds.getGroupMapKey(job.result_set_id, symbol, job.platform, job.platform_option);
 
             if (job.tier && job.tier !== 1) {
                 if (symbol === "?") {
@@ -951,8 +951,7 @@ treeherder.factory('ThResultSetStore', [
                 var groupInfo = getJobGroupInfo(job);
                 // search for the right group
                 var group = _.find(platform.groups, function(group){
-                    return groupInfo.name === group.name &&
-                        groupInfo.symbol === group.symbol;
+                    return groupInfo.symbol === group.symbol;
                 });
                 if(_.isUndefined(group)){
                     group = {

--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -245,9 +245,9 @@ treeherder.provider('thAggregateIds', function() {
         return escape(repoName + resultsetId + revision);
     };
 
-    var getGroupMapKey = function(result_set_id, grName, grSymbol, plName, plOpt) {
+    var getGroupMapKey = function(result_set_id, grSymbol, plName, plOpt) {
         //Build string key for groupMap entires
-        return escape(result_set_id + grName + grSymbol + plName + plOpt);
+        return escape(result_set_id + grSymbol + plName + plOpt);
     };
 
     var getJobMapKey = function(job) {


### PR DESCRIPTION
The issue with this bug was grouping, as it turns out.  ``resultset_store`` was grouping jobs by their ``name`` and ``symbol``.  However, we had the same ``symbol`` with two different names (one from Task Cluster, one from Buildbot).  In this case, it was the ``?`` group which shows as not within any group.

Since the name from each source was different, we had 2 groups both with the symbol of ``?``.  We would render the first one, then see another group named ``?`` and empty the first one, and add the new jobs.  

What I've done is to fix both parts of that.  

1. We group in ``resultset_store`` by *only* the group symbol to prevent conflicts there.  
2. But if we DO, by magic, get two groups with the same symbol, then ``clonejobs.js`` can handle that.  The fix for this is actually an optimization in that we didn't need to call ``.empty()`` where we did.  Only in one circumstance did it actually make sense to do so.  So I moved the call to ``.empty()`` there.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/903)
<!-- Reviewable:end -->
