### PR TITLE
Bug 1198053 - Add a .slugignore file to reduce Heroku slug size

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,4 @@
+/docker/
+/docs/
+/puppet/
+/tests/


### PR DESCRIPTION
https://devcenter.heroku.com/articles/slug-compiler#ignoring-files-with-slugignore

This reduces slug size from 68.5MB to 52.6MB.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/904)
<!-- Reviewable:end -->
