### PR TITLE
Bug 1198284 - Add error regex to better match taskcluster errors

### DIFF
--- a/tests/log_parser/test_error_parser.py
+++ b/tests/log_parser/test_error_parser.py
@@ -17,6 +17,8 @@ ERROR_TEST_CASES = (
     "[taskcluster] Error: Task run time exceeded 7200 seconds.",
     "foo.js: line 123, col 321, Error - ESLint bar",
     "2014-04-04 06:37:57 ERROR 403: Forbidden.",
+    "[taskcluster:error] Could not upload artifact",
+    "[taskcluster-vcs:error] Could not extract archive"
 )
 
 NON_ERROR_TEST_CASES = (
@@ -24,6 +26,8 @@ NON_ERROR_TEST_CASES = (
     "07:42:02     INFO -  Exception:",
     "07:51:08     INFO -  Caught Exception: Remote Device Error: unable to connect to panda-0501 after 5 attempts",
     "06:21:18     INFO -  I/GeckoDump(  730): 110 INFO TEST-UNEXPECTED-FAIL | foo | bar",
+    "[taskcluster:info] Starting task",
+    "[taskcluster] Starting task"
 )
 
 

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -388,6 +388,7 @@ class ErrorParser(ParserBase):
         r"|^The web-page 'stop build' button was pressed"
         r"|.*\.js: line \d+, col \d+, Error -"
         r"|^\[taskcluster\] Error:"
+        r"|^\[[\w-]+:(?:error|exception)\]"
     ))
 
     RE_ERR_SEARCH = re.compile((


### PR DESCRIPTION
The goal of this is to start standardizing the way taskcluster infrastructure and taskcluster related tools insert log messages into the task logs.  The previous regex was a little restrictive and missed some things.  We would like to leave the old one in for now so that while things transition over we at least do not miss those old style error messages.

This new regex should match things like:
[taskcluster:error]
[taskcluster-vcs:error]
but not just [taskcluster] or [taskcluster:info]

Also, I made sure these work with:
https://gist.github.com/gregarndt/97caa54a006ae76e235b

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/905)
<!-- Reviewable:end -->
