### PR TITLE
Bug 1199078 - Add Help menu and useful menu entries

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,8 +31,8 @@ module.exports = function(grunt) {
                     dest:'dist'
                 }
             },
-            help: {
-                src:'ui/help.html',
+            userguide: {
+                src:'ui/userguide.html',
                 nonull: true,
                 options:{
                     dest:'dist'
@@ -54,7 +54,7 @@ module.exports = function(grunt) {
             },
         },
 
-        usemin:{ html:['dist/index.html', 'dist/help.html', 'dist/logviewer.html',
+        usemin:{ html:['dist/index.html', 'dist/userguide.html', 'dist/logviewer.html',
                        'dist/perf.html'] },
 
         'cache-busting': {
@@ -94,10 +94,10 @@ module.exports = function(grunt) {
                 file: 'dist/css/perf.min.css',
                 cleanup: true
             },
-            helpcss: {
+            userguidecss: {
                 replace: ['dist/**/*.html'],
-                replacement: 'help.min.css',
-                file: 'dist/css/help.min.css',
+                replacement: 'userguide.min.css',
+                file: 'dist/css/userguide.min.css',
                 cleanup: true
             }
         },
@@ -108,7 +108,7 @@ module.exports = function(grunt) {
                 files: [
                     { src:'ui/robots.txt', dest:'dist/robots.txt', nonull: true },
                     { src:'ui/index.html', dest:'dist/index.html', nonull: true },
-                    { src:'ui/help.html', dest:'dist/help.html', nonull: true },
+                    { src:'ui/userguide.html', dest:'dist/userguide.html', nonull: true },
                     { src:'ui/logviewer.html', dest:'dist/logviewer.html', nonull: true },
                     { src:'ui/perf.html', dest:'dist/perf.html', nonull: true }
                 ]

--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -81,7 +81,6 @@ input:focus::-moz-placeholder {
     max-height: 600px;
     overflow: auto;
     margin-top: 10px;
-    padding-left: 8px;
     padding-bottom: 8px;
 }
 
@@ -110,6 +109,12 @@ th-watched-repo {
 
 .repo-dropdown-menu {
     margin-right: 4px;
+    padding-left: 6px;
+}
+
+/* Spacing for all menu entries with adjacent icons */
+.icon-menu li a span {
+    width: 20px;
 }
 
 /* Override bootstrap for flush right navbar menus */
@@ -141,6 +146,7 @@ th-watched-repo {
 
 .nav-help-icon {
     font-size: 18px;
+    margin-right: 2px;
 }
 
 .nav-user-icon {
@@ -1987,20 +1993,20 @@ fieldset[disabled] .btn-repo.active {
     color: gray;
 }
 
-#help {
+#userguide {
     padding: 10px 10px 0px;
     overflow: auto;
 }
 
-#help.dt, #help.dd {
+#userguide.dt, #userguide.dd {
     text-align: center;
 }
 
-#help.panel {
+#userguide.panel {
     padding: 5px;
 }
 
-.help-footer {
+.userguide-footer {
     overflow: auto;
 }
 

--- a/ui/partials/main/thGlobalTopNavPanel.html
+++ b/ui/partials/main/thGlobalTopNavPanel.html
@@ -35,7 +35,7 @@
                 class="btn btn-view-nav btn-right-navbar nav-repo-btn">Infra
           <span class="fa fa-angle-down lightgray"></span>
         </button>
-        <ul class="dropdown-menu repo-dropdown-menu" role="menu" aria-labelledby="infraLabel"
+        <ul class="dropdown-menu" role="menu" aria-labelledby="infraLabel"
             ng-include="'partials/main/thInfraMenu.html'">
         </ul>
       </span>
@@ -71,10 +71,18 @@
            ng-show="isFilterPanelShowing"></i>
       </span>
 
-      <!-- Help Button -->
-      <a class="btn btn-view-nav nav-help-btn"
-         title="Treeherder help" href="help.html" target="_blank">
-        <span class="fa fa-question-circle lightgray nav-help-icon"></span></a>
+      <!-- Help Menu -->
+      <span class="repo-menu dropdown">
+        <button id="helpLabel" title="Treeherder help" role="button"
+                href="#" data-toggle="dropdown" data-target="#"
+                class="btn btn-view-nav btn-right-navbar nav-help-btn">
+          <span class="fa fa-question-circle lightgray nav-help-icon"></span>
+          <span class="fa fa-angle-down lightgray"></span>
+        </button>
+        <ul class="dropdown-menu icon-menu" role="menu" aria-labelledby="helpLabel"
+            ng-include="'partials/main/thHelpMenu.html'">
+        </ul>
+      </span>
 
       <!-- Settings Button - currently suppressed -->
       <span ng-show="false"

--- a/ui/partials/main/thHelpMenu.html
+++ b/ui/partials/main/thHelpMenu.html
@@ -1,0 +1,30 @@
+<li>
+  <a href="userguide.html" target="_blank">
+    <span class="fa fa-question-circle midgray"></span>
+    User Guide</a>
+</li>
+<li>
+  <a href="https://treeherder.readthedocs.org" target="_blank">
+    <span class="fa fa-file-code-o midgray"></span>
+    Development Documentation</a>
+</li>
+<li>
+  <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder" target="_blank">
+    <span class="fa fa-file-word-o midgray"></span>
+    Project Wiki</a>
+</li>
+<li>
+  <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&component=Treeherder" target="_blank">
+    <span class="fa fa-bug midgray"></span>
+    Report a Bug</a>
+</li>
+<li>
+  <a href="https://github.com/mozilla/treeherder" target="_blank">
+    <span class="fa fa-github midgray"></span>
+    Source</a>
+</li>
+<li>
+  <a href="https://whatsdeployed.paas.allizom.org/?owner=mozilla&repo=treeherder&name[]=Stage&url[]=https://treeherder.allizom.org/revision.txt&name[]=Prod&url[]=https://treeherder.mozilla.org/revision.txt" target="_blank">
+    <span class="fa fa-question midgray"></span>
+    What's Deployed?</a>
+</li>

--- a/ui/userguide.html
+++ b/ui/userguide.html
@@ -2,18 +2,18 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>Treeherder Help</title>
-    <!-- build:css css/help.min.css -->
+    <title>Treeherder User Guide</title>
+    <!-- build:css css/userguide.min.css -->
     <link href="vendor/css/bootstrap.css" rel="stylesheet" media="screen">
     <link href="css/treeherder.css" rel="stylesheet" media="screen">
     <link href="vendor/css/font-awesome.css" rel="stylesheet" media="screen">
     <!-- endbuild -->
     <link id="favicon" type="image/png" rel="shortcut icon" href="img/tree_open.png">
 </head>
-<body id="help">
+<body id="userguide">
 <div class="panel panel-default">
 <div class="panel-heading">
-    <h1>Treeherder Help</h1>
+    <h1>Treeherder User Guide</h1>
 
     <h5>
       Want to contribute?
@@ -603,7 +603,7 @@
 </div>
 </div>
 
-<div class="panel-footer help-footer">
+<div class="panel-footer userguide-footer">
   <div class="col-xs-6">
     <div>Some icons by
       <a href="http://www.freepik.com" title="Freepik">Freepik</a> from


### PR DESCRIPTION
This fixes the UI side of Bugzilla bug [1199078](https://bugzilla.mozilla.org/show_bug.cgi?id=1199078).

This adds a drop down menu for the Help icon for access to feature development news, and provides a variety of other useful entries for new/experienced users. The actual URL of the feed for Treeherder development news is still tbd. Presently it just points to the ATeam blog.

Current (no menu):
![current](https://cloud.githubusercontent.com/assets/3660661/9471852/44439d4c-4b20-11e5-908a-ee99f7eb56d0.jpg)

Proposed (dropdown added):
![proposed](https://cloud.githubusercontent.com/assets/3660661/9471867/5750da26-4b20-11e5-9b7c-81dfc8705481.jpg)

Proposed (dropdown open):
![proposed2](https://cloud.githubusercontent.com/assets/3660661/9471891/6dfc0ea8-4b20-11e5-997c-7d1b74e40f11.jpg)

I'm actually inclined to just call the 2nd entry "Developer Guide". I also left WhatsDeployed in the UserGuide footer, since users have experience with it being there, and I don't think it does harm to have it in two places.

The notable mappings are:
* User Guide (formerly help.html)
* Development Documentation (readthedocs)
* Development News (our feed, tbd)

Everything seems fine in local testing.

Tested on OSX 10.10.3:
Nightly **43.0a1 (2015-08-24)**
Chrome Latest Release **44.0.2403.157 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/906)
<!-- Reviewable:end -->
