### PR TITLE
Bug 1046229 - Fix operator for invalid revison url param

### DIFF
--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -55,7 +55,7 @@
               !isLoadingJobs && locationHasSearchParam('revision') && currentRepo.url"
               class="result-set-body unknown-message-body">
   <span ng-init="revision=getSearchParamValue('revision')">
-    <span ng-if="revision !=== 'undefined'">
+    <span ng-if="revision !== 'undefined'">
       <span>Waiting for a push with revision <strong>{{revision}}</strong></span>
       <a href="{{currentRepo.getPushLogHref(revision)}}"
          target="_blank"


### PR DESCRIPTION
This is a supplementary fix for Bugzilla bug [1046229](https://bugzilla.mozilla.org/show_bug.cgi?id=1046229).

This fixes the console errors resulting from the invalid operator.

`"Error: [$parse:syntax] Syntax Error: Token '=' not a primary expression at column 13 of the expression [revision !=== 'undefined'] starting at [= 'undefined'].`

Tested on OSX 10.10.3:
Nightly **43.0a1 (2015-08-24)**
Chrome Latest Release **44.0.2403.157 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/907)
<!-- Reviewable:end -->
