### PR TITLE
Bug 1198452 - Save the deployed revision to <site-root>/revision.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ ui/js/config/local.conf.js
 
 htmlcov/
 
+# Deployed revision file.
+dist/revision.txt
+
 #static files in deployment
 treeherder/webapp/static/
 

--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -37,6 +37,8 @@ def pre_update(ctx, ref=settings.UPDATE_REF):
         ctx.local('git reset --hard FETCH_HEAD')
         ctx.local('find . -type f -name "*.pyc" -delete')
         ctx.local('git status -s')
+        ctx.local('git rev-parse HEAD > dist/revision.txt')
+        # Remove me once IRC pushbot configs and What's Deployed link updated.
         ctx.local('git rev-parse HEAD > treeherder/webapp/media/revision')
 
 


### PR DESCRIPTION
Since WhiteNoise won't serve files from /media/, so the existing file in `treeherder/webapp/media/` 404s when accessed via:
https://treeherder.{mozilla,allizom}.org/media/revision

IMO the site root makes more sense for this file anyway, so let's just save it under `dist/`. Also adds a .txt extension for clarity.

The old file has been left for now to ease the transition, and will be deleted once the IRC pushbots config and What's Deployed URLs have been updated.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/908)
<!-- Reviewable:end -->
