### PR TITLE
Bug 1198452 - Stop creating treeherder.*.org/media/revision

### DIFF
--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -38,8 +38,6 @@ def pre_update(ctx, ref=settings.UPDATE_REF):
         ctx.local('find . -type f -name "*.pyc" -delete')
         ctx.local('git status -s')
         ctx.local('git rev-parse HEAD > dist/revision.txt')
-        # Remove me once IRC pushbot configs and What's Deployed link updated.
-        ctx.local('git rev-parse HEAD > treeherder/webapp/media/revision')
 
 
 @task


### PR DESCRIPTION
Once the IRC pushbot configs/What's Deployed links have been updated to use the new revision.txt file location, we can stop creating the file in the old location.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/912)
<!-- Reviewable:end -->
