### PR TITLE
Bug 1197796 - Make WhiteNoise serve the static assets gzipped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ htmlcov/
 # Deployed revision file.
 dist/revision.txt
 
+# Gzipped UI files created during deployment, for use with WhiteNoise.
+dist/**/*.gz
+
 #static files in deployment
 treeherder/static/
 

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+# Tasks run by the Heroku Python buildpack after the compile step.
+
+# Generate gzipped versions of files that would benefit from compression, that
+# WhiteNoise can then serve in preference to the originals. This is required
+# since WhiteNoise's Django storage backend only gzips assets handled by
+# collectstatic, and so does not affect files in the `dist/` directory.
+python -m whitenoise.gzip dist

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -68,6 +68,10 @@ STATICFILES_FINDERS = [
     # "django.contrib.staticfiles.finders.DefaultStorageFinder",
 ]
 
+# Create hashed+gzipped versions of assets during collectstatic,
+# which will then be served by WhiteNoise with a suitable max-age.
+STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
+
 TEMPLATE_LOADERS = [
     "django.template.loaders.filesystem.Loader",
     "django.template.loaders.app_directories.Loader",


### PR DESCRIPTION
**1) Make WhiteNoise serve the static assets gzipped:**

On Heroku, there is no load balancer or Varnish-like cache in front of gunicorn, so we must handle gzipping responses in the app. In order for WhiteNoise to serve gzipped static content, assets must be gzipped on disk in advance (doing so on-demand in Python would not be as performant). WhiteNoise will then serve the `.gz` version of files in preference to the original, if the client indicated it supported gzip.

For assets covered by Django's collectstatic, gzipping the assets only requires using WhiteNoise's `GzipManifestStaticFilesStorage` backend, which wraps Django's `ManifestStaticFilesStorage` to create hashed+gzipped versions of static assets:
http://whitenoise.evans.io/en/latest/django.html#add-gzip-and-caching-support

The collectstatic generated files will then contain the file hash in their filename, so WhiteNoise can also serve them with a large max-age to avoid further requests if the file contents have not changed.

For the UI files under `dist/`, we cannot rely on the Django storage backend, since the directory isn't covered by `STATICFILES_DIRS` (it is instead made known to WhiteNoise via `WHITENOISE_ROOT`). As such, files under `dist/` are gzipped via an additional step during deployment (in `update.py` and `post_compile`). See:
http://whitenoise.evans.io/en/latest/base.html#gzip-support

Files whose extension is on the blacklist, or that are not >5% smaller when compressed, are skipped during compression.

**2) Set appropriate max-age for collectstatic generated files:**

Now that we're using WhiteNoise's `GzipManifestStaticFilesStorage` to produce hashed (and gzipped) versions of Django static files, we need to modify `CustomWhiteNoise` so that it supports not only grunt-cache-busting's style of hash filenames, but those generated by `GzipManifestStaticFilesStorage` too. For the latter we fall back to the default `DjangoWhiteNoise.is_immutable_file()` method.

The grunt-cache-busting's regex has also been made more strict, to reduce the chance of false positives, since the hashes are always 32 characters in length.

--

Note: This PR needs bug 1124382 to land first, to avoid bug 1198265.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/913)
<!-- Reviewable:end -->