### PR TITLE
Bug 1198507 - Provide a minified notifications partial for Logviewer

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -180,7 +180,7 @@ module.exports = function(grunt) {
             },
             logviewer: {
                 cwd: 'ui',
-                src: 'partials/logviewer/*.html',
+                src: ['partials/main/thNotificationsBox.html', 'partials/logviewer/*.html'],
                 dest: 'dist/js/logviewer.min.js',
                 options: {
                     usemin: 'dist/js/logviewer.min.js',


### PR DESCRIPTION
This fixes Bugzilla bug [1198507](https://bugzilla.mozilla.org/show_bug.cgi?id=1198507).

This provides a minified thNotificationsBox.html for Logviewer. Previously stage and prod were serving some unminified assets prior to Whitenoise which until we switched, masked the problem.

With a local grunt build, and running gunicorn with `SERVE_MINIFIED_UI` it now appears to be ok:

![localgruntbuild](https://cloud.githubusercontent.com/assets/3660661/9496519/a8a3e102-4bde-11e5-882f-a1cdb0e0ade0.jpg)

Tested on OSX 10.10.3:
Nightly **43.0a1 (2015-08-25)**
Chrome Latest Release **44.0.2403.157 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/915)
<!-- Reviewable:end -->
