### PR TITLE
Bug 1194142 - Use the default Celery BROKER_POOL_LIMIT on Heroku

### DIFF
--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -428,7 +428,6 @@ if "IS_HEROKU" in os.environ:
 
 if "CLOUDAMQP_URL" in os.environ:
     BROKER_URL = os.environ["CLOUDAMQP_URL"]
-    BROKER_POOL_LIMIT = 1
 
 CELERY_IGNORE_RESULT = True
 


### PR DESCRIPTION
The default value of 10 is currently used by stage/prod, however on Heroku it was set to 1, presumably since the guide here suggests it:
https://devcenter.heroku.com/articles/cloudamqp#celery

However, we're not using the free CloudAMQP plan mentioned by the guide, but instead use their 'Big Bunny' plan, which supports up to 5000 concurrent connections.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/918)
<!-- Reviewable:end -->
