### PR TITLE
Bug 1199179 - Remove default Django SECRET_KEY

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   global:
     - DATABASE_URL='mysql://root@localhost/treeherder'
     - DATABASE_URL_RO='mysql://root@localhost/treeherder'
+    - TREEHERDER_DJANGO_SECRET_KEY='secretkey-1234'
 services:
   - rabbitmq
   - memcached

--- a/docker/etc/profile.d/treeherder.sh
+++ b/docker/etc/profile.d/treeherder.sh
@@ -1,6 +1,6 @@
 # Mapping is taken from docker link assumptions
 export TREEHERDER_DEBUG='1'
-export TREEHERDER_DJANGO_SECRET_KEY='5up3r53cr3t'
+export TREEHERDER_DJANGO_SECRET_KEY='secretkey-1234'
 # Allow any host to be hit when running in development mode
 export TREEHERDER_ALLOWED_HOSTS='*'
 

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -13,7 +13,7 @@ $THELP_TEXT = 'Type \\"thelp\\" to see a list of Treeherder-specific helper alia
 # so it's not required.
 $DB_USER = "treeherder_user"
 $DB_PASS = "treeherder_pass"
-$DJANGO_SECRET_KEY = "5up3r53cr3t"
+$DJANGO_SECRET_KEY = "secretkey-1234"
 $RABBITMQ_USER = 'guest'
 $RABBITMQ_PASSWORD = 'guest'
 $RABBITMQ_VHOST = '/'

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -36,7 +36,7 @@ RABBITMQ_HOST = os.environ.get("TREEHERDER_RABBITMQ_HOST", "localhost")
 RABBITMQ_PORT = os.environ.get("TREEHERDER_RABBITMQ_PORT", "5672")
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = os.environ.get("TREEHERDER_DJANGO_SECRET_KEY", "my-secret-key")
+SECRET_KEY = os.environ.get("TREEHERDER_DJANGO_SECRET_KEY")
 
 ADMINS = []  # TBD
 MANAGERS = ADMINS


### PR DESCRIPTION
Previously if `TREEHERDER_DJANGO_SECRET_KEY` was not set, we'd silently fall back to a default value for `SECRET_KEY`, meaning we wouldn't realise we were using an insecure key on a live deployment instance (eg like we were on Heroku until now).

With this change, `TREEHERDER_DJANGO_SECRET_KEY` being missing from the environment is fatal, resulting in:
`ImproperlyConfigured: The SECRET_KEY setting must not be empty.`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/919)
<!-- Reviewable:end -->
