### PR TITLE
Bug 1199046 - Add an in-repo robots.txt to be served by WhiteNoise

### DIFF
--- a/ui/robots.txt
+++ b/ui/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Stage/prod's robots.txt is currently served by Apache, and is in the private puppet repo. Since Heroku can't use it, we need to check one into our repo, that will then be served by WhiteNoise along with the other static files.

The robots.txt file here is a direct copy of that currently at:
https://treeherder.mozilla.org/robots.txt

Once this change is deployed, we can remove the alias in the stage/prod Apache config, leaving WhiteNoise to serve this file. As an added bonus, it will also then be much easier for us to alter it in the future.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/920)
<!-- Reviewable:end -->
