### PR TITLE
Bug 1199341 - Add job counts to the Help notations table

### DIFF
--- a/ui/help.html
+++ b/ui/help.html
@@ -36,67 +36,73 @@
             <div class="panel-body">
                 <table id="legend-other">
                   <tr>
-                    <th class="jobgroup">
+                    <th>
+                      <button class="btn btn-green help-btn help-btn-comment">+n</button>
+                    </th>
+                    <td>Collapsed job count</td>
+                  </tr>
+                  <tr>
+                    <th>
                       <button class="btn btn-dkgray help-btn help-btn-comment">Th( )</button>
                     </th>
                     <td>Wrapped job group</td>
                   </tr>
                   <tr>
-                    <th class="classified">
-                      <button class="btn btn-dkgray help-btn help-btn-comment">Th*</button>
+                    <th>
+                      <button class="btn btn-orange-classified help-btn help-btn-comment">Th</button>
                     </th>
                     <td>Asterisk, classified</td>
                   </tr>
                   <tr>
-                    <th class="pending">
+                    <th>
                       <button class="btn btn-ltgray help-btn help-btn-bg">Th</button>
                     </th>
                     <td>Light gray, pending</td>
                   </tr>
                   <tr>
-                    <th class="running">
+                    <th>
                       <button class="btn btn-dkgray help-btn help-btn-bg">Th</button>
                     </th>
                     <td>Gray, running</td>
                   </tr>
                   <tr>
-                    <th class="success">
+                    <th>
                       <button class="btn btn-green help-btn help-btn-bg">Th</button>
                     </th>
                     <td>Green, success</td>
                   </tr>
                   <tr>
-                    <th class="testfailed">
+                    <th>
                       <button class="btn btn-orange help-btn help-btn-orange">Th</button>
                     </th>
                     <td>Orange, tests failed</td>
                   </tr>
                   <tr>
-                    <th class="exception">
+                    <th>
                       <button class="btn btn-purple help-btn help-btn-purple">Th</button>
                     </th>
                     <td>Purple, infrastructure exception</td>
                   </tr>
                   <tr>
-                    <th class="busted">
+                    <th>
                       <button class="btn btn-red help-btn help-btn-red">Th</button>
                     </th>
                     <td>Red, build error</td>
                   </tr>
                   <tr>
-                    <th class="retry">
+                    <th>
                       <button class="btn btn-dkblue help-btn help-btn-bg">Th</button>
                     </th>
                     <td>Dark blue, build restarted</td>
                   </tr>
                   <tr>
-                    <th class="usercancel">
+                    <th>
                       <button class="btn btn-pink help-btn help-btn-bg">Th</button>
                     </th>
                     <td>Pink, build cancelled</td>
                   </tr>
                   <tr>
-                    <th class="unknown">
+                    <th>
                       <button class="btn btn-yellow help-btn help-btn-yellow">Th</button>
                     </th>
                     <td>Yellow, unknown</td>


### PR DESCRIPTION
This fixes Bugzilla bug [1199341](https://bugzilla.mozilla.org/show_bug.cgi?id=1199341).

This adds a row to illustrate collapsed job counts to the Help notations table, now that bug [1163064](https://bugzilla.mozilla.org/show_bug.cgi?id=1163064) has landed. I also adjusted the classified style so it looks more like a typically classified job, the same with counts, and also removed some unused `th` classes while there.

Current:
![current](https://cloud.githubusercontent.com/assets/3660661/9528062/c2972eba-4cc0-11e5-81c9-5bf9a8d9f26c.jpg)

Proposed:
![proposed](https://cloud.githubusercontent.com/assets/3660661/9528083/d6f9a8f6-4cc0-11e5-92e7-576560b0a870.jpg)


Tested on OSX 10.10.3:
Nightly **43.0a1 (2015-08-26)**
Chrome Latest Release **44.0.2403.157 (64-bit)**

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/921)
<!-- Reviewable:end -->
