### PR TITLE
Bug 1176412 - Override the hostname reported by New Relic on Heroku

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -6,3 +6,17 @@
 # since WhiteNoise's Django storage backend only gzips assets handled by
 # collectstatic, and so does not affect files in the `dist/` directory.
 python -m whitenoise.gzip dist
+
+# The post_compile script is run in a sub-shell, so we need to source the
+# buildpack's utils script again, so we can use set-env/set-default-env:
+# https://github.com/heroku/heroku-buildpack-python/blob/master/bin/utils
+source $BIN_DIR/utils
+
+# Add environment variables to the profile script run on Dyno startup.
+# Only variables that are rarely changed and not site-specific should
+# be set here. Set everything else using Heroku's CLI / dashboard.
+
+# Override the hostname that is displayed in New Relic, so the Dyno name
+# (eg "web.1") is shown, rather than "Dynamic Hostname". $DYNO is quoted
+# so that it's expanded at runtime on each dyno, rather than now.
+set-env NEW_RELIC_PROCESS_HOST_DISPLAY_NAME '$DYNO'

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -16,6 +16,8 @@ source $BIN_DIR/utils
 # Only variables that are rarely changed and not site-specific should
 # be set here. Set everything else using Heroku's CLI / dashboard.
 
+set-env IS_HEROKU 1
+
 # Override the hostname that is displayed in New Relic, so the Dyno name
 # (eg "web.1") is shown, rather than "Dynamic Hostname". $DYNO is quoted
 # so that it's expanded at runtime on each dyno, rather than now.


### PR DESCRIPTION
**1) Override the hostname reported by New Relic on Heroku:**

On Heroku, the hostname is just a bunch of hex characters, which the New Relic dashboard displays as "Dynamic Hostname". The New Relic Python agent (as of v2.52.0.40) supports overriding this, by setting the environment variable `NEW_RELIC_PROCESS_HOST_DISPLAY_NAME`:
https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/python-agent-configuration#process_host-display_name

We use the value of `DYNO`, since this is set for us in each dyno's environment, and is of form "web.2", "worker_pushlog.1" etc. Rather than prefixing every line in the Procfile, we instead append the export to the profile script created by the Python buildpack, so it's populated at runtime on every dyno. See:
https://devcenter.heroku.com/articles/profiled

To do this we make use of the Python buildpack's `set-env` function:
https://github.com/heroku/heroku-buildpack-python/blob/ce3bdb37bafa3f56c54346d28ee5ef138cbc1893/bin/utils#L29-L32

Similar to what the buildpack does for its own env defines:
https://github.com/heroku/heroku-buildpack-python/blob/ce3bdb37bafa3f56c54346d28ee5ef138cbc1893/bin/compile#L190-L198

**2) Define `IS_HEROKU` in the dyno profile script rather than Heroku env:**

`IS_HEROKU` isn't something that will differ between stage/prod, and is not going to change any time soon. So let's just get post_compile to add it to the dyno profile script, so it's one less variable to have to remember to set via the Heroku CLI/dashboard.

Quoting from:
http://blog.doismellburning.co.uk/2014/10/06/twelve-factor-config-misunderstandings-and-advice/

> 12factor says your applications should read their config from the environment; it has very little to say about how you populate the environment – use whatever works for you.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/923)
<!-- Reviewable:end -->
