### PR TITLE
Bug 1198978 - Make sure the Save button doesn't do anything if the pinboard is empty

### DIFF
--- a/ui/partials/main/thPinboardPanel.html
+++ b/ui/partials/main/thPinboardPanel.html
@@ -69,7 +69,7 @@
   <div class="btn-group">
     <span class="btn btn-default btn-xs save-btn"
           title="Save all classification data"
-          ng-click="save()"
+          ng-click="!hasPinnedJobs() || save()"
           ng-disabled="!hasPinnedJobs()">save
     </span>
     <span class="btn btn-default btn-xs dropdown-toggle save-btn-dropdown"


### PR DESCRIPTION
Previously, if you entered things into the bug or classification fields
and then hit the "Save" button without first actually pinning a job to the
pinboard, your bug/classification information was wiped away because the
save function only verified that you were logged in, not that there was
anything in the pinboard that needed saved.

The save function now checks that there's something pinned as well before
continuing on with the save function.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/925)
<!-- Reviewable:end -->
