### PR TITLE
Bug 1199659 - Remove 'unknown step result' step styling in Logviewer

### DIFF
--- a/ui/css/logviewer.css
+++ b/ui/css/logviewer.css
@@ -63,20 +63,6 @@ body {
     top: 285px;
 }
 
-.unknown-step-warning {
-    margin-bottom: 2px;
-    margin-right: 6px;
-    padding: 0 4px;
-    background-color: #fcf8e3;
-    border: 1px solid #fbd890;
-    border-radius: 2px;
-    color: #8a6d3b;
-}
-
-.step-title-unknown {
-    padding-top: 1px;
-}
-
 .lv-line-no {
     width: 3em;
 }

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -57,8 +57,7 @@ logViewerApp.controller('LogviewerCtrl', [
             return false;
         };
 
-        // get the css class for the result color
-        // used for the whole job, as well as for each step
+        // Get the css class for the result, step buttons and other general use
         $scope.getShadingClass = function(result) {
             return "result-status-shading-" + result;
         };

--- a/ui/partials/logviewer/lvLogSteps.html
+++ b/ui/partials/logviewer/lvLogSteps.html
@@ -5,18 +5,13 @@
        ng-show="showSuccessful === true || step.result !== 'success'"
        class="btn btn-block lv-step clearfix {{::getShadingClass(step.result)}}"
        order="{{step.order}}">
-    <span ng-if="(step.result === 'unknown')"
-          class="pull-left clearfix text-left unknown-step-warning"
-          title="Log artifact result property is 'unknown'">
-      unknown step result (!)</span>
-    <span ng-class="{'step-title-unknown': step.result === 'unknown'}"
-          class="pull-left clearfix text-left">
-      {{::step.order+1}}. {{::step.name}}</span>
+    <span class="pull-left clearfix text-left">
+      {{::step.order+1}}. {{::step.name}}
+    </span>
 
     <span ng-init="time=(step.duration !== null ? formatTime(step.duration) : 'Duration unknown')"
           ng-mouseover="time=displayTime(step.started, step.finished)"
           ng-mouseleave="time=(step.duration !== null ? formatTime(step.duration) : 'Duration unknown')"
-          ng-class="{'step-title-unknown': step.result === 'unknown'}"
           class="pull-right clearfix">
       {{time}}
     </span>


### PR DESCRIPTION
This fixes Bugzilla bug [1199659](https://bugzilla.mozilla.org/show_bug.cgi?id=1199659).

This returns the previous behavior of unstyled Taskcluster steps in Logviewer. They were styled yellow in bug [1192917](https://bugzilla.mozilla.org/show_bug.cgi?id=1192917).

I tried returning the behavior just with angular markup in this partial (since we now need to preserve the yellow styling for Unknown jobs in Treeherder job tables), but it became unwieldy looking. So I went with a stopgap method in the controller, if/until later on Taskcluster produces their own logs or more compliant ones where `step.result: unknown` has real meaning and should be flagged.

Current  (landed yesterday):
![currentsteps](https://cloud.githubusercontent.com/assets/3660661/9553594/0968bd90-4d8e-11e5-8697-70cd69eb4194.jpg)

Proposed (same as what we had):
![unknownstepsunstyled](https://cloud.githubusercontent.com/assets/3660661/9553479/5837f720-4d8d-11e5-9d16-f0284b3583aa.jpg)

This means that part of the intent of bug [1192917](https://bugzilla.mozilla.org/show_bug.cgi?id=1192917), to provide a color for unknown steps from any service (including potentially Buildbot) is no longer addressed, but we are ok with that.

Tested on OSX 10.10.3:
Nightly **43.0a1 (2015-08-24)**
Chrome Latest Release **44.0.2403.157 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/927)
<!-- Reviewable:end -->
