### PR TITLE
Bug 1193419 - Changes to how cycle data will now be read

### DIFF
--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -58,13 +58,15 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.is_debug = options['debug']
 
-        if options['revision_data_cycle_interval'] and options['resultset_data_cycle_interval']:
-            cycle_interval = {
-                "revisiondata": timedelta(days=options['revision_data_cycle_interval']),
-                "resultset": timedelta(days=options['resultset_data_cycle_interval'])
-            }
+        cycle_interval = {}
+        if options['revision_data_cycle_interval']:
+            cycle_interval["revisiondata"] = timedelta(days=options['revision_data_cycle_interval'])
         else:
-            cycle_interval = settings.DATA_CYCLE_INTERVAL
+            cycle_interval["revisiondata"] = settings.DATA_CYCLE_INTERVAL["revisiondata"]
+        if options['resultset_data_cycle_interval']:
+            cycle_interval["resultset"] = timedelta(days=options['resultset_data_cycle_interval'])
+        else:
+            cycle_interval["resultset"] = settings.DATA_CYCLE_INTERVAL["resultset"]
 
         self.debug("cycle interval... jobs: {}".format(cycle_interval))
 

--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -1,5 +1,6 @@
 import datetime
 from optparse import make_option
+from datetime import timedelta
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -21,12 +22,20 @@ class Command(BaseCommand):
             help='Write debug messages to stdout'),
 
         make_option(
-            '--cycle-interval',
+            '--resultset-data-cycle-interval',
             action='store',
-            dest='cycle_interval',
+            dest='resultset_data_cycle_interval',
             default=0,
             type='int',
-            help='Data cycle interval expressed in days'),
+            help='Reultsetdata cycle interval expressed in days'),
+
+        make_option(
+            '--revision-data-cycle-interval',
+            action='store',
+            dest='revision_data_cycle_interval',
+            default=0,
+            type='int',
+            help='Revision data cycle interval expressed in days'),
 
         make_option(
             '--chunk-size',
@@ -49,8 +58,11 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.is_debug = options['debug']
 
-        if options['cycle_interval']:
-            cycle_interval = datetime.timedelta(days=options['cycle_interval'])
+        if options['revision_data_cycle_interval'] and options['resultset_data_cycle_interval']:
+            cycle_interval = {
+                "revisiondata": timedelta(days=options['revision_data_cycle_interval']),
+                "resultset": timedelta(days=options['resultset_data_cycle_interval'])
+            }
         else:
             cycle_interval = settings.DATA_CYCLE_INTERVAL
 

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -27,7 +27,11 @@ TREEHERDER_PERF_SERIES_TIME_RANGES = [
     {"seconds": 31536000, "days": 365},
 ]
 
-DATA_CYCLE_INTERVAL = timedelta(days=30 * 4)
+# DATA_CYCLE_INTERVAL = timedelta(days=30 * 4)
+DATA_CYCLE_INTERVAL = {
+    "resultset": timedelta(days=30*12),
+    "revisiondata": timedelta(days=30*4)
+}
 
 RABBITMQ_USER = os.environ.get("TREEHERDER_RABBITMQ_USER", "guest")
 RABBITMQ_PASSWORD = os.environ.get("TREEHERDER_RABBITMQ_PASSWORD", "guest")

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -27,7 +27,6 @@ TREEHERDER_PERF_SERIES_TIME_RANGES = [
     {"seconds": 31536000, "days": 365},
 ]
 
-# DATA_CYCLE_INTERVAL = timedelta(days=30 * 4)
 DATA_CYCLE_INTERVAL = {
     "resultset": timedelta(days=30*12),
     "revisiondata": timedelta(days=30*4)


### PR DESCRIPTION
This is some initial work on Bug 1193419. Looking forward to your inputs on this.

The --cycle-data option would be replaced with 2 new options:
--resultset-data-cycle-interval : This will take the time interval in days for recycling resultset data
--revision-data-cycle-interval : This will take the time interval in days for recycling revision data

One other option I can think of is keeping the --cycle-data option but having it take as input a tuple/list/dict (dictionary would be preferred). This way the cli would be only slightly changed.

The cycle_data method in model/derived/jobs.py's JobsModel class would receive a dictionary instead of a an int. Thereby, it would have to read the appropriate time interval. I'll add this change soon.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/928)
<!-- Reviewable:end -->
