### PR TITLE
Bug 1199770 - Clean up navbar menu button classes

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -84,6 +84,16 @@ input:focus::-moz-placeholder {
     padding-bottom: 8px;
 }
 
+/* Spacing for menus with adjacent checkboxes */
+.checkbox-dropdown-menu {
+    padding-left: 8px;
+}
+
+/* Spacing for menus with adjacent icons */
+.icon-menu li a span {
+    width: 20px;
+}
+
 .navbar-right {
     margin-right: 0px; /* override boostrap 3.3.5 behaviour -- doesn't work with the way we align our navbar */
 }
@@ -103,35 +113,9 @@ th-watched-repo {
     float: left;
 }
 
-.repo-menu {
-    margin-right: -4px;
-}
-
-.repo-dropdown-menu {
-    margin-right: 4px;
-    padding-left: 6px;
-}
-
-/* Spacing for all menu entries with adjacent icons */
-.icon-menu li a span {
-    width: 20px;
-}
-
 /* Override bootstrap for flush right navbar menus */
 .navbar-collapse {
     padding-right: 0;
-}
-
-.navbar .repo-menu-form {
-    padding: 5px 10px 0;
-    overflow-y: scroll;
-    top: inherit;
-    right: auto;
-}
-
-.nav-repo-btn {
-    padding-left: 14px;
-    padding-right: 14px;
 }
 
 .nav-menu-btn {
@@ -142,6 +126,8 @@ th-watched-repo {
 
 .nav-help-btn {
     margin-right: -4px;
+    padding-left: 12px;
+    padding-right: 8px;
 }
 
 .nav-help-icon {
@@ -167,6 +153,11 @@ th-watched-repo {
 .nav-login-btn {
     padding-left: 22px;
     padding-right: 27px;
+}
+
+.nav-persona-btn {
+    padding-left: 14px;
+    padding-right: 14px;
 }
 
 .watched-repo-main-btn {

--- a/ui/partials/main/persona_buttons.html
+++ b/ui/partials/main/persona_buttons.html
@@ -2,7 +2,7 @@
       ng-if="user.loggedin">
   <button id="logoutLabel" title="Logged in as: {{user.email}}" role="button"
           href="#" data-toggle="dropdown" data-target="#"
-          class="btn btn-view-nav btn-right-navbar nav-repo-btn">
+          class="btn btn-view-nav btn-right-navbar nav-persona-btn">
     <div class="nav-user-icon">
       <span class="fa fa-user pull-left"></span>
     </div>

--- a/ui/partials/main/thGlobalTopNavPanel.html
+++ b/ui/partials/main/thGlobalTopNavPanel.html
@@ -29,10 +29,10 @@
       </span>
 
       <!-- Infra Menu -->
-      <span class="repo-menu dropdown">
+      <span class="dropdown">
         <button id="infraLabel" title="Infrastructure status" role="button"
                 href="#" data-toggle="dropdown" data-target="#"
-                class="btn btn-view-nav btn-right-navbar nav-repo-btn">Infra
+                class="btn btn-view-nav btn-right-navbar nav-menu-btn">Infra
           <span class="fa fa-angle-down lightgray"></span>
         </button>
         <ul class="dropdown-menu" role="menu" aria-labelledby="infraLabel"
@@ -42,13 +42,14 @@
 
       <!-- Repos Menu -->
       <span ng-controller="RepositoryMenuCtrl" >
-        <span th-repo-dropdown-container class="repo-menu dropdown">
+        <span th-repo-dropdown-container class="dropdown">
           <button id="repoLabel" title="Watch a repo" role="button"
                   href="#" data-toggle="dropdown" data-target="#"
-                  class="btn btn-view-nav btn-right-navbar nav-repo-btn">Repos
+                  class="btn btn-view-nav btn-right-navbar nav-menu-btn">Repos
             <span class="fa fa-angle-down lightgray"></span>
           </button>
-          <ul class="dropdown-menu repo-dropdown-menu" role="menu" aria-labelledby="repoLabel">
+          <ul class="dropdown-menu checkbox-dropdown-menu"
+              role="menu" aria-labelledby="repoLabel">
             <span ng-repeat="(group_order, group) in groupedRepos()">
               <li role="presentation" class="divider" ng-hide="$first"></li>
               <li role="presentation" class="dropdown-header">{{::group.name}}</li>
@@ -72,7 +73,7 @@
       </span>
 
       <!-- Help Menu -->
-      <span class="repo-menu dropdown">
+      <span class="dropdown">
         <button id="helpLabel" title="Treeherder help" role="button"
                 href="#" data-toggle="dropdown" data-target="#"
                 class="btn btn-view-nav btn-right-navbar nav-help-btn">


### PR DESCRIPTION
This fixes Bugzilla bug [1199770](https://bugzilla.mozilla.org/show_bug.cgi?id=1199770).

This cleans up the right hand navbar menu buttons so we use the least amount of custom classes, stop abusing `.repo` classes for other buttons, and preserve the same computed dimensions for all.

There's no before/after since the UI is essentially the same:

![navbarmenusproposed](https://cloud.githubusercontent.com/assets/3660661/9583211/fe6d89ba-4fd7-11e5-931c-5bbe57c9d2f4.jpg)

Tested on OSX 10.10.5:
Release **40.0.3**
Chrome Latest Release **44.0.2403.157 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/929)
<!-- Reviewable:end -->
