### PR TITLE
Bug 1199139 - Prevent accidental job count group collapse

### DIFF
--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -178,17 +178,20 @@ treeherder.directive('thCloneJobs', [
          * jobs.  Collapsed shows counts and failed jobs.
          */
         var clickGroupCb = function(el) {
-            var groupMap =  ThResultSetStore.getGroupMap($rootScope.repoName);
-            var gi = getGroupInfo(el, groupMap);
-            if (gi) {
-                if (isGroupExpanded(gi.jgObj)) {
-                    gi.jgObj.groupState = "collapsed";
-                    addGroupJobsAndCounts(gi.jgObj, gi.platformGroupEl);
-                } else {
-                    gi.grpCountList.empty();
-                    gi.jgObj.groupState = "expanded";
-                    gi.grpJobList.empty();
-                    addJobBtnEls(gi.jgObj, gi.grpJobList);
+            var clickedEl = $(el);
+            if (clickedEl.hasClass('group-symbol') || clickedEl.hasClass('job-group-count')) {
+                var groupMap =  ThResultSetStore.getGroupMap($rootScope.repoName);
+                var gi = getGroupInfo(el, groupMap);
+                if (gi) {
+                    if (isGroupExpanded(gi.jgObj)) {
+                        gi.jgObj.groupState = "collapsed";
+                        addGroupJobsAndCounts(gi.jgObj, gi.platformGroupEl);
+                    } else {
+                        gi.grpCountList.empty();
+                        gi.jgObj.groupState = "expanded";
+                        gi.grpJobList.empty();
+                        addJobBtnEls(gi.jgObj, gi.grpJobList);
+                    }
                 }
             }
         };


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1199139](https://bugzilla.mozilla.org/show_bug.cgi?id=1199139).

This prevents accidental job count group collapse, when clicking in between jobs in an expanded job group.

The -ve right hand margins we used appeared to be allowing the element "behind" to be selected which triggers the collapse. So for the fix, we use -ve *left* hand margins (and compensate in a variety of places) and retain the same spacing and white space as before.

Maybe there's a better way of doing it, but it seems to be fine. There are a lot of layout inter-dependencies now, so touching one thing, means you have to compensate in one or several other places.

View of the job element post-fix (looks essentially the same):
![boundaryselection](https://cloud.githubusercontent.com/assets/3660661/9588098/4aec9aa8-4ff4-11e5-89bf-4f6b31fa98e7.jpg)

So when we hover over the "right hand" side of the green button below, it doesn't incorrectly select the Mochitest group list underneath, which would collapse it if clicked. Instead it switches hover styling to the adjacent job. Because they abut each other, that collapse target is no longer accessible in the expanded job row.
![boundaryselection2](https://cloud.githubusercontent.com/assets/3660661/9588110/5fd8714e-4ff4-11e5-8e3b-8160ea63dec4.jpg)

The layout remains the same except we surrender 3px in the `job-row`, which is now closer by that amount to its `platform` column:

Before:
![currentlayout](https://cloud.githubusercontent.com/assets/3660661/9588308/7ef16986-4ff5-11e5-8b05-2622b4234f59.jpg)

After (slightly tighter between the job tables and the platform labels):
![fixedlayout](https://cloud.githubusercontent.com/assets/3660661/9588315/8bd3f0ec-4ff5-11e5-82db-c5874bbe33b1.jpg)

I've done a lot of blink testing at 200% to 500% magnification in both Firefox Release and Chrome, and the elements seem to be correct and match what they were prior.

Tested on OSX 10.10.5:
Release **40.0.3**
Chrome Latest Release **44.0.2403.157 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/930)
<!-- Reviewable:end -->
