### PR TITLE
Bug 1193951 - Improve the layout of the Sheriff panel

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -267,7 +267,7 @@ th-watched-repo {
 /* Options drop-downs*/
 
 .th-top-nav-options-panel {
-    background-color: lightgray;
+    background-color: white;
     padding: 10px;
     border: 1px solid black;
     max-height: 400px;
@@ -334,9 +334,39 @@ th-watched-repo {
 }
 
 /**
-  sheriff panel
+  Sheriff panel
 */
-.add-new-exclusion input.ng-invalid.ng-dirty{border-color: #B94A48;}
+
+.add-new-exclusion input.ng-invalid.ng-dirty {
+    border-color: #B94A48;
+}
+
+.exclusion-tabs {
+    border-bottom: none;
+}
+
+/* Preserve bootstrap unvisited link color */
+.exclusion-tabs li a:visited {
+    color: #337ab7;
+}
+
+.sheriff-panel-delete-icon {
+  padding-right: 25px;
+  font-size: 12px;
+  color: #bababa;
+}
+
+.sheriff-panel-excluded-job {
+  margin-right: 20px;
+}
+
+.sheriff-panel-exclusion-profiles-row td:first-child {
+  width: 133px;
+}
+
+.sheriff-panel-job-exclusions-row td:first-child {
+  width: 155px;
+}
 
 /**
   Failures
@@ -1261,7 +1291,7 @@ ul.failure-summary-list li .btn-xs {
     background-color: white;
 }
 
-.click-able-icon, .nav-tabs li {
+.pointable, .nav-tabs li {
     cursor: pointer;
 }
 
@@ -1974,6 +2004,10 @@ fieldset[disabled] .btn-repo.active {
 
 .white, .white a {
     color: white;
+}
+
+.xlightgray, .xlightgray a {
+    color: #e6e6e6;
 }
 
 .lightgray, .lightgray a {

--- a/ui/partials/main/thPinboardPanel.html
+++ b/ui/partials/main/thPinboardPanel.html
@@ -14,7 +14,7 @@
 <div id="pinboard-related-bugs">
   <div class="content">
     <a ng-click="toggleEnterBugNumber(!enteringBugNumber); allowKeys()"
-       class="click-able-icon"
+       class="pointable"
        title="Add a related bug">
       <i class="fa fa-plus-square add-related-bugs-icon"></i>
     </a>

--- a/ui/partials/main/thSheriffPanel.html
+++ b/ui/partials/main/thSheriffPanel.html
@@ -1,70 +1,66 @@
 <div class="th-top-nav-options-panel" id="sheriff_panel" ng-controller="SheriffCtrl">
-  <ul class="list-inline">
-    <li>
+  <ul class="nav nav-tabs exclusion-tabs">
+    <li ng-class="{'active': view == 'exclusion_profile_list'}">
       <a href="" prevent-default-on-left-click
-         ng-if="view != 'exclusion_profile_list'"
          ng-click="switchView('exclusion_profile_list')">Exclusion profiles</a>
-      <span ng-if="view =='exclusion_profile_list'">Exclusion profiles</span>
     </li>
-    <li>
+    <li ng-class="{'active': view == 'job_exclusion_list'}">
       <a href="" prevent-default-on-left-click
-         ng-if="view != 'job_exclusion_list'"
          ng-click="switchView('job_exclusion_list')">Job exclusions</a>
-      <span ng-if="view =='job_exclusion_list'">Job exclusions</span>
     </li>
   </ul>
 
   <!-- Exclusion profiles -->
   <div ng-if="view == 'exclusion_profile_list'"
-       class="panel panel-default th-option-group
-              th-inline-option-group add-new-exclusion">
-    <div class="panel-heading th-option-heading">
-      Exclusion Profile list
-    </div>
-    <div class="panel-body">
-      <p ng-if="profiles.length == 0">No profile available</p>
-      <table ng-if="profiles.length > 0" class="table table-condensed table-bordered">
-        <tr>
-          <th>Profile name</th><th>Default</th><th>Exclusions</th><th>Actions</th>
-        </tr>
-        <tr ng-repeat="profile in profiles">
-          <td>{{::profile.name}}</td>
-          <td class="text-center">
-            <span ng-if="profile.is_default"
-                  class="glyphicon glyphicon-ok-sign text-success"></span>
-          </td>
-          <td>
-            <a ng-click="init_exclusion_update(exclusions_map[exclusion])"
-               ng-repeat="exclusion in profile.exclusions">
-              {{ ::exclusions_map[exclusion].name }}</a>
-          </td>
-          <td>
-            <button ng-click="init_profile_update(profile)"
-                    type="button" class="btn btn-default btn-xs">
-              <span class="glyphicon glyphicon-pencil"></span> Change
-            </button>
-            <button ng-click="delete_profile(profile)"
-                    type="button" class="btn btn-default btn-xs">
-              <span class="glyphicon glyphicon-remove"></span> Delete
-            </button>
-            <button ng-click="set_default_profile(profile)"
-                    type="button" class="btn btn-default btn-xs">
-              <span class="glyphicon glyphicon glyphicon-ok-sign"></span> Make default
-            </button>
-          </td>
-        </tr>
-      </table>
-      <button ng-click="init_profile_add()" type="button"
-              class="btn btn-sm btn-default">Add new</button>
-    </div>
+       class="th-inline-option-group add-new-exclusion">
+    <p ng-if="profiles.length == 0">No profile available</p>
+    <table ng-if="profiles.length > 0" class="table table-condensed">
+      <tr>
+        <th>Profile</th><th></th><th>Excluded</th><th></th>
+      </tr>
+      <tr ng-repeat="profile in profiles"
+          class="sheriff-panel-exclusion-profiles-row">
+        <td>
+          <a ng-click="init_profile_update(profile)"
+             class="pointable"
+             title="Change the members in this profile">
+            {{::profile.name}}
+          </a>
+        </td>
+        <td class="text-center">
+          <span ng-click="set_default_profile(profile)"
+                ng-class="profile.is_default ? 'fa-check-circle text-success' :
+                          'fa-circle-o xlightgray'"
+                class="fa pointable"
+                title="{{profile.is_default ? 'Default profile' :
+                       'Set this as the default profile'}}">
+          </span>
+        </td>
+        <td>
+          <a ng-click="init_exclusion_update(exclusions_map[exclusion])"
+             ng-repeat="exclusion in profile.exclusions"
+             class="th-inline-option-group sheriff-panel-excluded-job pointable"
+             title="Modify this exclusion">
+            &#8226; {{::exclusions_map[exclusion].name}}</a>
+        </td>
+        <td>
+          <span ng-click="delete_profile(profile)"
+                class="sheriff-panel-delete-icon hover-warning pointable"
+                title="Delete this profile">
+            <i class="fa fa-times-circle"></i>
+          </span>
+        </td>
+      </tr>
+    </table>
+    <button ng-click="init_profile_add()" type="button"
+            class="btn btn-sm btn-primary">Add profile</button>
   </div>
 
-  <!-- Create/Update profile -->
+  <!-- Add/Update exclusion profile -->
   <div ng-if="view == 'exclusion_profile_add'"
-       class="panel panel-default th-option-group
-              th-inline-option-group add-new-exclusion">
+       class="panel panel-default th-inline-option-group add-new-exclusion">
     <div class="panel-heading th-option-heading">
-      Create/Update Exclusion Profile
+      Add/Update exclusion profile
     </div>
     <div class="panel-body">
       <div class="form-group">
@@ -81,68 +77,68 @@
       </form>
       <div class="form-group-inline">
         <div class="form-group">
+          <a ng-click="switchView('exclusion_profile_list')"
+             class="btn btn-sm btn-default pull right">Back</a>
+        </div>
+        <div class="form-group">
           <button ng-click="reset_profile()" type="submit"
-                  class="btn btn-sm btn-default pull right">Reset</button>
+                  class="btn btn-sm btn-danger pull right">Reset</button>
         </div>
         <div class="form-group">
           <button ng-click="save_profile(form_profile)" type="submit"
-                  class="btn btn-sm btn-default pull right">Save</button>
+                  class="btn btn-sm btn-success pull right">Save</button>
         </div>
       </div>
     </div>
   </div>
 
-  <!-- Exclusion list -->
+  <!-- Job exclusions -->
   <div ng-if="view == 'job_exclusion_list'"
-       class="panel panel-default th-option-group
-              th-inline-option-group add-new-exclusion">
-    <div class="panel-heading th-option-heading">
-      Job Exclusion list
-    </div>
-    <div class="panel-body">
-      <p ng-if="exclusions.length == 0">No exclusion available</p>
-      <table ng-if="exclusions.length>0"
-             class="table table-condensed table-bordered">
-        <tr>
-          <th>Name</th>
-          <th>Description</th>
-          <th>Repositories</th>
-          <th>Platform</th>
-          <th>Option Collections</th>
-          <th>Job Type</th>
-          <th>Actions</th>
-        </tr>
-        <tr ng-repeat="exclusion in exclusions">
-          <td>{{::exclusion.name}}</td>
-          <td>{{::exclusion.description}}</td>
-          <td><th-truncated-list numvisible="2" elements="exclusion.info.repos" /></td>
-          <td><th-truncated-list numvisible="2" elements="exclusion.info.platforms" /></td>
-          <td><th-truncated-list numvisible="2" elements="exclusion.info.option_collections" /></td>
-          <td><th-truncated-list numvisible="2" elements="exclusion.info.job_types" /></td>
-          <td>
-            <button ng-click="init_exclusion_update(exclusion)"
-                    type="button" class="btn btn-default btn-xs">
-              <span class="glyphicon glyphicon-pencil"></span> Change
-            </button>
-            <button ng-click="delete_exclusion(exclusion)"
-                    type="button" class="btn btn-default btn-xs">
-              <span class="glyphicon glyphicon-remove"></span> Delete
-            </button>
-          </td>
-        </tr>
-      </table>
-      <button ng-click="init_exclusion_add()" type="button"
-              class="btn btn-sm btn-default">Add new</button>
-    </div>
+       class="th-inline-option-group add-new-exclusion">
+    <p ng-if="exclusions.length == 0">No exclusion available</p>
+    <table ng-if="exclusions.length > 0"
+           class="table table-condensed">
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+        <th>Repositories</th>
+        <th>Platform</th>
+        <th>Option Collections</th>
+        <th>Job Type</th>
+      </tr>
+      <tr ng-repeat="exclusion in exclusions"
+          class="sheriff-panel-job-exclusions-row">
+        <td>
+          <a ng-click="init_exclusion_update(exclusion)"
+             class="pointable"
+             title="Modify this exclusion">
+            {{::exclusion.name}}
+          </a>
+        </td>
+        <td>{{::exclusion.description}}</td>
+        <td><th-truncated-list numvisible="2" elements="exclusion.info.repos" /></td>
+        <td><th-truncated-list numvisible="2" elements="exclusion.info.platforms" /></td>
+        <td><th-truncated-list numvisible="2" elements="exclusion.info.option_collections" /></td>
+        <td><th-truncated-list numvisible="2" elements="exclusion.info.job_types" /></td>
+        <td>
+          <span ng-click="delete_exclusion(exclusion)"
+                class="sheriff-panel-delete-icon hover-warning pointable"
+                title="Delete this exclusion">
+            <i class="fa fa-times-circle"></i>
+          </span>
+        </td>
+      </tr>
+    </table>
+    <button ng-click="init_exclusion_add()" type="button"
+            class="btn btn-sm btn-primary">Add exclusion</button>
   </div>
 
 
-  <!-- Create/Update exclusion -->
+  <!-- Add/Update exclusion -->
   <div ng-if="view == 'job_exclusion_add'"
-       class="panel panel-default th-option-group
-              th-inline-option-group add-new-exclusion">
+       class="panel panel-default th-inline-option-group add-new-exclusion">
     <div class="panel-heading th-option-heading">
-      Create/Update Job Exclusion
+      Add/Update job exclusion
     </div>
     <div class="panel-body">
       <form class="form" name="thJobExclusionsForm">
@@ -195,12 +191,12 @@
               </div>
               <div class="form-group">
                 <button ng-click="reset_exclusion()" type="submit"
-                        class="btn btn-sm btn-default pull right">Reset</button>
+                        class="btn btn-sm btn-danger pull right">Reset</button>
               </div>
               <div class="form-group">
                 <button ng-click="thJobExclusionsForm.$valid && save_exclusion(form_exclusion)"
                         type="submit"
-                        class="btn btn-sm btn-default pull right">Save</button>
+                        class="btn btn-sm btn-success pull right">Save</button>
               </div>
             </div>
           </div>

--- a/ui/plugins/annotations/main.html
+++ b/ui/plugins/annotations/main.html
@@ -20,7 +20,7 @@
                     </td>
                     <td>
                         <span ng-click="deleteClassification(classification)"
-                              class="classification-delete-icon hover-warning click-able-icon"
+                              class="classification-delete-icon hover-warning pointable"
                               title="Delete this classification">
                             <i class="fa fa-times-circle"></i>
                         </span>


### PR DESCRIPTION
This work fixes Bugzilla bug [1193951](https://bugzilla.mozilla.org/show_bug.cgi?id=1193951).

This addresses the UX issues described in the bug, and goes a ways further by generally improving the layout of the Sheriff panel, specifically:

* the "Set default", "Edit", and the destructive "Delete" action are now separated from each other
* extra UI has been removed (buttons, panels) and other de-cluttering to maximize space
* `title`'s have been added for all actions
* we use Bootstrap tabs for simplicity
* profile entries are separated by visible white space for readability
* profile entries are no longer split in half on new lines
* other alignment improvements
* wordsmithing

Here's current:
![current](https://cloud.githubusercontent.com/assets/3660661/9640361/3b68780e-517f-11e5-9571-bf40649e0c47.jpg)

Proposed:
![proposed](https://cloud.githubusercontent.com/assets/3660661/9640389/52196fa4-517f-11e5-845a-9b4559bf7987.jpg)

To edit a profile you just click on the name:
![editmembers](https://cloud.githubusercontent.com/assets/3660661/9640409/6dc76e9a-517f-11e5-93d9-22ea9a3a522b.jpg)

To change the default you just click on a radio button (we could add a bootstrap pale green-surround on the containing `td` element during hover if you like, to further call out the functionality):
![changedefaultprofile](https://cloud.githubusercontent.com/assets/3660661/9640422/7f0887d4-517f-11e5-814a-65ba08ff3c27.jpg)

To delete a profile you just click on the delete icon (same as Annotations):
![deleteprofile](https://cloud.githubusercontent.com/assets/3660661/9640434/91a67e28-517f-11e5-8e20-ddcbb26ff398.jpg)

Job Exclusions has received similar layout optimization:
![jobexclusions](https://cloud.githubusercontent.com/assets/3660661/9640448/a94145cc-517f-11e5-9ff5-e8b0a9f6f9c9.jpg)

I still have to do the respective 'Add' dialogues, and a couple of other nits.

Tested on OSX 10.10.5:
Release **40.0.3**
Chrome Latest Release **45.0.2454.85 (64-bit)**

I'll add someone for review when this PR is ready.

Adding @KWierso for feedback if there's anything of concern so far.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/933)
<!-- Reviewable:end -->
