### PR TITLE
Bug 1220716 - Simplify storage of talos data in perfherder

### DIFF
--- a/tests/etl/test_perf_data_adapters.py
+++ b/tests/etl/test_perf_data_adapters.py
@@ -63,16 +63,14 @@ class TalosDataAdapterTest(unittest.TestCase):
                 if talos_datum.get('summary'):
                     # if we have a summary, ensure the subtest summary values made
                     # it in
-                    for measure in ['min', 'max', 'std', 'mean', 'median']:
-                        self.assertEqual(
-                            round(talos_datum['summary']['subtests'][testname][measure], 2),
-                            perfdata[measure])
+                    self.assertEqual(
+                        round(talos_datum['summary']['subtests'][testname]['filtered'], 2),
+                        perfdata['value'])
                 else:
                     # this is an old style talos blob without a summary. these are going
                     # away, so I'm not going to bother testing the correctness. however
                     # let's at least verify that some values are being generated here
-                    for measure in ['min', 'max', 'std', 'mean', 'median']:
-                        self.assertTrue(perfdata[measure])
+                    self.assertTrue(perfdata['value'])
 
                 # filter out this signature from data to process
                 signature_placeholders = filter(
@@ -86,9 +84,8 @@ class TalosDataAdapterTest(unittest.TestCase):
                 self.assertEqual(len(signature_placeholder), 1)
                 signature_hash = signature_placeholder[0][0]
                 perfdata = tda.signatures[signature_hash][0]
-                for measure in ['max', 'mean']:
-                    self.assertEqual(round(float(results[measure]), 2),
-                                     perfdata[measure])
+                self.assertEqual(round(float(results['mean']), 2),
+                                 perfdata['value'])
                 # filter out this signature from data to process
                 signature_placeholders = filter(
                     lambda p: p[0] != signature_hash, signature_placeholders)
@@ -98,9 +95,9 @@ class TalosDataAdapterTest(unittest.TestCase):
             perfdata = tda.signatures[signature_placeholders[0][0]][0]
             if talos_datum.get('summary'):
                 self.assertEqual(round(talos_datum['summary']['suite'], 2),
-                                 perfdata['geomean'])
+                                 perfdata['value'])
             else:
                 # old style talos blob without summary. again, going away,
                 # but let's at least test that we have the 'geomean' value
                 # generated
-                self.assertTrue(perfdata['geomean'])
+                self.assertTrue(perfdata['value'])

--- a/tests/sample_data/artifacts/performance/talos_perf.json
+++ b/tests/sample_data/artifacts/performance/talos_perf.json
@@ -29,8 +29,8 @@
         "summary": {
             "suite": 3141.00,
             "subtests": {
-                "dhtml.html": {"min": 1, "max": 100, "std": 0.75, "mean": 50, "median": 50},
-                "tablemutation.html": {"min": 1, "max": 100, "std": 0.75, "mean": 50, "median": 50, "value": 50}
+                "dhtml.html": {"min": 1, "max": 100, "std": 0.75, "mean": 50, "median": 50, "filtered": 51},
+                "tablemutation.html": {"min": 1, "max": 100, "std": 0.75, "mean": 50, "median": 50, "value": 50, "filtered": 52}
             }
         },
         "results": {

--- a/ui/js/graphs.js
+++ b/ui/js/graphs.js
@@ -16,7 +16,6 @@ perf.controller('GraphsCtrl', [
         $scope.highlightedRevisions = [ undefined, undefined ];
         $scope.timeranges = phTimeRanges;
         $scope.myTimerange = _.find(phTimeRanges, {'value': parseInt($stateParams.timerange)});
-        $scope.myMeasure = "mean";
         $scope.ttHideTimer = null;
         $scope.selectedDataPoint = null;
         $scope.showToolTipTimeout = null;
@@ -101,7 +100,6 @@ perf.controller('GraphsCtrl', [
                     revisionUrl: thServiceDomain + '#/jobs?repo=' + phSeries.projectName,
                     test: phSeries.name,
                     platform: phSeries.platform,
-                    machine: phSeries.machine || 'mean',
                     value: Math.round(v*1000)/1000,
                     deltaValue: dv.toFixed(1),
                     deltaPercentValue: (100 * dvp).toFixed(1),
@@ -310,7 +308,7 @@ perf.controller('GraphsCtrl', [
             // synchronize series visibility with flot, in case it's changed
             $scope.seriesList.forEach(function(series) {
                 series.flotSeries.points.show = series.visible;
-                series.active = (!series.subtestSignatures || $scope.myMeasure === 'mean');
+                series.active = true;
                 series.blockColor = series.active ? series.color : "grey";
             });
 
@@ -436,16 +434,6 @@ perf.controller('GraphsCtrl', [
             });
         };
 
-        $scope.myMeasureChanged = function() {
-            $scope.zoom = {};
-            deselectDataPoint();
-
-            updateDocument();
-            $q.all($scope.seriesList.map(getSeriesData)).then(function() {
-                plotGraph();
-            });
-        };
-
         $scope.repoName = $stateParams.projectId;
 
         function updateDocument() {
@@ -504,22 +492,9 @@ perf.controller('GraphsCtrl', [
                                          thSeries: jQuery.extend({}, series)
                                      };
                                      response.data[0].blob.forEach(function(dataPoint) {
-                                         var measure = dataPoint.mean;
-                                         if ($scope.myMeasure === "min") {
-                                             measure = dataPoint.min;
-                                         } else if ($scope.myMeasure === "max") {
-                                             measure = dataPoint.max;
-                                         } else if ($scope.myMeasure === "median") {
-                                             measure = dataPoint.median;
-                                         } else if ($scope.myMeasure === "mean") {
-                                             measure = dataPoint.mean;
-                                             if (measure === undefined) {
-                                                 measure = dataPoint.geomean;
-                                             }
-                                         }
                                          flotSeries.data.push([
                                              new Date(dataPoint.push_timestamp*1000),
-                                             measure]);
+                                             dataPoint.value]);
                                          flotSeries.resultSetData.push(
                                              dataPoint.result_set_id);
                                      });

--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -281,7 +281,7 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                     // The result object has the following properties:
                                     // - .isEmpty: true if no data for either side.
                                     // If !isEmpty, for originalData/newData (if the data exists)
-                                    // - .[original|new]GeoMean    // Average of the values (where each is a geomean)
+                                    // - .[original|new]Value      // Average of the values
                                     // - .[original|new]Stddev     // stddev
                                     // - .[original|new]StddevPct  // stddev as percentage of the average
                                     // - .[original|new]Runs       // Display data: number of runs and their values
@@ -316,9 +316,7 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                                 stddev = math.stddev(values, average);
 
                                             return {
-                                                // Called 'geomeans' because each value is a geomean (of the subtests)
-                                                // but we then average those values plainly.
-                                                geomean: average,
+                                                average: average,
                                                 stddev: stddev,
                                                 stddevPct: math.percentOf(stddev, average),
 
@@ -350,7 +348,7 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
 
                                         if (hasOrig) {
                                             var orig = analyzeSet(originalData.values);
-                                            cmap.originalGeoMean = orig.geomean;
+                                            cmap.originalValue = orig.average;
                                             cmap.originalRuns = orig.runs;
                                             cmap.originalStddev = orig.stddev;
                                             cmap.originalStddevPct = orig.stddevPct;
@@ -359,7 +357,7 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                         }
                                         if (hasNew) {
                                             var newd = analyzeSet(newData.values);
-                                            cmap.newGeoMean = newd.geomean;
+                                            cmap.newValue = newd.average;
                                             cmap.newRuns = newd.runs;
                                             cmap.newStddev = newd.stddev;
                                             cmap.newStddevPct = newd.stddevPct;
@@ -372,12 +370,12 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
 
                                         // Compare the sides.
                                         // "Normal" tests are "lower is better". Reversed is.. reversed.
-                                        cmap.delta = (cmap.newGeoMean - cmap.originalGeoMean);
+                                        cmap.delta = (cmap.newValue - cmap.originalValue);
                                         var newIsBetter = cmap.delta < 0; // New value is lower than orig value
                                         if (isReverseTest(testName))
                                             newIsBetter = !newIsBetter;
 
-                                        cmap.deltaPercentage = math.percentOf(cmap.delta, cmap.originalGeoMean);
+                                        cmap.deltaPercentage = math.percentOf(cmap.delta, cmap.originalValue);
 
                                         // arbitrary scale from 0-20% multiplied by 5, capped
                                         // at 100 (so 20% regression == 100% bad)
@@ -385,7 +383,7 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                         cmap.newIsBetter = newIsBetter;
 
                                         var abs_t_value = Math.abs(math.t_test(originalData.values, newData.values, STDDEV_DEFAULT_FACTOR));
-                                        cmap.className = getClassName(newIsBetter, cmap.originalGeoMean, cmap.newGeoMean, abs_t_value);
+                                        cmap.className = getClassName(newIsBetter, cmap.originalValue, cmap.newValue, abs_t_value);
                                         cmap.confidence = abs_t_value;
                                         cmap.confidenceText = abs_t_value < T_VALUE_CARE_MIN ? "low" :
                                             abs_t_value < T_VALUE_CONFIDENT ? "med" :
@@ -457,12 +455,7 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                                             // The values are later processed at getCounterMap as the data arguments.
                                                             var values = [];
                                                             _.where(data.blob, { result_set_id: resultSetId }).forEach(function(pdata) {
-                                                                //summary series have geomean, individual pages have mean
-                                                                if (pdata.geomean === undefined) {
-                                                                    values.push(pdata.mean);
-                                                                } else {
-                                                                    values.push(pdata.geomean);
-                                                                }
+                                                                values.push(pdata.value);
                                                             });
 
                                                             var seriesData = _.find(seriesChunk, {'signature': data.series_signature});

--- a/ui/partials/perf/comparetable.html
+++ b/ui/partials/perf/comparetable.html
@@ -19,21 +19,21 @@
         </span>
       </td>
       <td>
-        <ph-average value="{{compareResult.originalGeoMean}}"
+        <ph-average value="{{compareResult.originalValue}}"
                     stddev="{{compareResult.originalStddev}}"
                     stddevpct="{{compareResult.originalStddevPct}}"
                     replicates="compareResult.originalRuns"></ph-average>
       </td>
       <td>
-        <span ng-class="getCompareClasses(compareResult)" ng-if="compareResult.originalGeoMean < compareResult.newGeoMean">
+        <span ng-class="getCompareClasses(compareResult)" ng-if="compareResult.originalValue < compareResult.newValue">
           &lt;
         </span>
-        <span ng-class="getCompareClasses(compareResult)" ng-if="compareResult.originalGeoMean > compareResult.newGeoMean">
+        <span ng-class="getCompareClasses(compareResult)" ng-if="compareResult.originalValue > compareResult.newValue">
           &gt;
         </span>
       </td>
       <td>
-        <ph-average value="{{compareResult.newGeoMean}}"
+        <ph-average value="{{compareResult.newValue}}"
                     stddev="{{compareResult.newStddev}}"
                     stddevpct="{{compareResult.newStddevPct}}"
                     replicates="compareResult.newRuns"></ph-average>

--- a/ui/partials/perf/graphsctrl.html
+++ b/ui/partials/perf/graphsctrl.html
@@ -32,12 +32,6 @@
     <div id="data-display">
       <select ng-model="myTimerange" ng-options="timerange.text for timerange in timeranges track by timerange.value" ng-change="timeRangeChanged()" ng-disabled="seriesList.length == 0">
       </select>
-      <select ng-model="myMeasure" ng-change="myMeasureChanged()" ng-disabled="seriesList.length == 0">
-        <option value="mean">Mean</option>
-        <option value="median">Median</option>
-        <option value="min">Minimum</option>
-        <option value="max">Maximum</option>
-      </select>
       <hr/>
       <div id="overview-plot"></div>
       <div id="graph"></div>
@@ -60,8 +54,7 @@
       <div>
         <p id="tt-series"><span ng-bind="tooltipContent.test"/>
           (<span ng-bind="tooltipContent.project.name"/>)</p>
-        <p id="tt-series2" class="small"><span ng-bind="tooltipContent.platform"/>
-          (<span ng-bind="tooltipContent.machine"/>)</p>
+        <p id="tt-series2" class="small"><span ng-bind="tooltipContent.platform"/></p>
       </div>
       <div>
         <p id="tt-v" ng-bind="tooltipContent.value"></p>


### PR DESCRIPTION
* Stop storing mean/median/max/min for subtests as they're not always on the
  same scale as the summary value
* Always use "filtered" value provided by Talos for subtest summary values
* Store value for tests as a "value" property for the series data

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/934)
<!-- Reviewable:end -->
