### PR TITLE
Bug 1201235 - Preserve white space in Logviewer loglines

### DIFF
--- a/ui/css/logviewer.css
+++ b/ui/css/logviewer.css
@@ -67,6 +67,10 @@ body {
     width: 3em;
 }
 
+.lv-line-text {
+    white-space: pre;
+}
+
 .lv-error-line {
     background-color: white;
     color: #333333;


### PR DESCRIPTION
This fixes Bugzilla bug [1201235](https://bugzilla.mozilla.org/show_bug.cgi?id=1201235).

This change preserves white space on loaded log lines in Logviewer, so various text blocks are more readable.

Before:
![currentloglines](https://cloud.githubusercontent.com/assets/3660661/9648814/9e8d997e-51ba-11e5-94e0-98490942861c.jpg)

Proposed:
![proposedloglines](https://cloud.githubusercontent.com/assets/3660661/9648819/a829b2f6-51ba-11e5-8301-d9219aacb11c.jpg)

And another example showing the benefit:
![proposedotherexample](https://cloud.githubusercontent.com/assets/3660661/9648905/a1c98ee4-51bb-11e5-8cad-9a46bc6a3c1f.jpg)

In some cases we consume more horizontal space and in other cases we save space. We are faithful to the logs produced upstream, which seems reasonable.

Historical note: back in May @wlach made [this change](https://github.com/mozilla/treeherder/commit/afc3d2f5011f629e853991f5358b33381b763e4c) in [bug 1163083](https://bugzilla.mozilla.org/show_bug.cgi?id=1163083) and we were going to trim extraneous white space off the end of lines, but we ended up not doing so.

Tested on OSX 10.10.5:
Nightly **43.0a1 (2015-09-01)**
Chrome Latest Release **45.0.2454.85 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/935)
<!-- Reviewable:end -->
