### PR TITLE
 	Bug 1201615 - Exclude macosx 10.10 from compareperf by default

### DIFF
--- a/ui/js/compareperf.js
+++ b/ui/js/compareperf.js
@@ -113,7 +113,8 @@ perf.controller('CompareResultsCtrl', [
                 $scope.originalProject.name,
                 timeRange,
                 optionCollectionMap,
-                {e10s: $scope.e10s}).then(
+                {e10s: $scope.e10s,
+                 excludedPlatforms: $scope.excludedPlatforms }).then(
                     function(originalSeriesData) {
                         $scope.platformList = originalSeriesData.platformList;
                         $scope.testList = originalSeriesData.testList;
@@ -239,6 +240,9 @@ perf.controller('CompareResultsCtrl', [
             }
 
             $scope.e10s = Boolean($stateParams.e10s);
+            // we are excluding macosx 10.10 by default for now, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1201615
+            $scope.excludedPlatforms = Boolean($stateParams.showExcludedPlatforms) ?
+                [] : [ 'osx-10-10' ];
             $scope.hideMinorChanges = Boolean($stateParams.hideMinorChanges);
             $scope.originalProject = ThRepositoryModel.getRepo(
                 $stateParams.originalProject);

--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -180,6 +180,8 @@ perf.factory('PhSeries', ['$http', 'thServiceDomain', function($http, thServiceD
                         // We don't generate number for tp5n, this is xperf and we collect counters
                         if (_.contains(seriesSummary.name, "tp5n"))
                             return;
+                        if (_.contains(userOptions.excludedPlatforms, seriesSummary.platform))
+                            return;
 
                         seriesList.push(seriesSummary);
 

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -12,7 +12,7 @@ perf.config(function($compileProvider, $stateProvider, $urlRouterProvider) {
         controller: 'GraphsCtrl'
     }).state('compare', {
         templateUrl: 'partials/perf/comparectrl.html',
-        url: '/compare?originalProject&originalRevision&newProject&newRevision&hideMinorChanges&e10s',
+        url: '/compare?originalProject&originalRevision&newProject&newRevision&hideMinorChanges&e10s&showExcludedPlatforms',
         controller: 'CompareResultsCtrl'
     }).state('comparesubtest', {
         templateUrl: 'partials/perf/comparesubtestctrl.html',


### PR DESCRIPTION
You can force display by adding &showExcludedPlatforms=1 to your URL

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/937)
<!-- Reviewable:end -->
