### PR TITLE
Bug 1169320 - Add support to ingest jobs via Pulse

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Contents:
 
    installation
    dataload
+   pulseload
    deployment
    list_of_services
    common_tasks

--- a/docs/pulseload.rst
+++ b/docs/pulseload.rst
@@ -1,0 +1,79 @@
+Loading Pulse data
+==================
+
+For ingestion from Pulse exchanges, on your local machine, you can choose
+to ingest from any exchange you like.  Some exchanges will be registered in
+``base.py`` for use by the Treeherder servers.  You can use those to get the
+same data as Treeherder.  Or you can specify your own and experiment with
+posting your own data.
+
+Configuration
+-------------
+
+To specify the exchanges to read from, you can set environment variables in
+Vagrant, or in your ``settings/local.py`` file.  For example::
+
+    PULSE_DATA_INGESTION_EXCHANGES = [
+        {
+            "name": "exchange/treeherder-test/jobs",
+            "projects": [
+                'mozilla-inbound'
+            ],
+            "destinations": [
+                'production',
+                'staging'
+            ]
+        }
+    ]
+
+To be able to ingest from exchanges, you need to create a Pulse user with
+`Pulse Guardian`_, so
+Treeherder can create your Queues for listening to the Pulse exchanges.  For
+this, you must specify the connection URL in your environment variables or
+``local.py``.  For example::
+
+    PULSE_DATA_INGESTION_CONFIG = "amqp://mypulseuserid:mypassword@pulse.mozilla.org:5672/"
+
+Ingesting Data
+--------------
+
+First, you need to begin the *Celery* queue processing.
+Then to get those jobs loaded into Treeherder, start the periodic tasks with
+*Celery*.  At the minimum, you will need::
+
+    celery -A treeherder worker -B -Q pushlog,store_pulse_jobs --concurrency 5
+
+.. note::  It is important to run the ``pushlog`` queue processing as well as ``store_pulse_jobs`` because jobs that come in from pulse for which Treeherder does not already have a resultset will be skipped.
+
+If you want to just run all the Treeherder *Celery* tasks to enable things like
+log parsing, etc, then don't specify the ``-Q`` param and it will default to
+all::
+
+    celery -A treeherder worker -B --concurrency 5
+
+To begin listening to the Pulse exchanges specified above, run this management
+command::
+
+    ./manage.py ingest_from_pulse
+
+Once that is running, you will see jobs start to appear from the Pulse
+exchanges.
+
+
+Posting Data
+------------
+
+To post data to your own pulse exchange, you can use the ``publish_to_pulse``
+management command.  This command takes the ``routing_key``, ``connection_url``
+and ``payload_file``.  The payload file must be a ``JSON`` representation of
+a job as specified in the `YML Schema`_.
+
+Here is a set of example parameters that could be used to run it::
+
+    ./manage.py publish_to_pulse mozilla-inbound.staging amqp://treeherder-test:mypassword@pulse.mozilla.org:5672/ ./scratch/test_job.json
+
+You can use the handy `Pulse Inspector`_ to view messages in your exchange to
+test that they are arriving at Pulse the way you expect.
+
+.. _Pulse Guardian: https://pulse.mozilla.org/whats_pulse
+.. _Pulse Inspector: https://tools.taskcluster.net/pulse-inspector/

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -112,3 +112,10 @@ sqlparse==0.1.16
 
 # sha256: s3x2UackVMLdR-MjrY1iKbaquQUMWFgKO0mJ2HyV0J0
 django-environ==0.3.0
+
+# Required by django-extensions, WebTest, responses & python-dateutil
+# sha256: QYqTw5en7asj5ViNvAZ6x0pyPts9VBvUk295R252Rdo
+six==1.9.0
+
+# sha256: KuY89HXwvQSbci-sIIE9Yq7cFJV91aO_ANEg0rVARGA
+python-dateutil==2.4.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -50,10 +50,6 @@ WebOb==1.4.1
 # sha256: Fb7nUwAt_2hJh7jfjCNSiOuNRfgZGuBWJUgS39QsgdM
 cookies==2.2.1
 
-# Required by django-extensions, WebTest & responses
-# sha256: QYqTw5en7asj5ViNvAZ6x0pyPts9VBvUk295R252Rdo
-six==1.9.0
-
 # Required by flake8
 # sha256: vWwID7NyrrywzhnjXdrHRPKr9ae--iB9stEJfUjv5jo
 mccabe==0.3.1

--- a/schemas/pulse-job.yml
+++ b/schemas/pulse-job.yml
@@ -1,0 +1,282 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+title: "Job Definition"
+description: |
+  Definition of a single job that can be added to Treeherder
+  Project is determined by the routing key, so we don't need to specify it here.
+id: "jobDefinition"
+type: "object"
+properties:
+  jobGuid:
+    title: "jobGuid"
+    type: "string"
+    pattern: "^[A-Za-z0-9_/+-]+$"
+    minLength: 1
+    maxLength: 50
+
+  origin:
+    anyOf:
+      - type: "object"
+        properties:
+          kind:
+            type: "string"
+            enum: ['hg.mozilla.org']
+          project:
+            type: "string"
+            pattern: "^[A-Za-z0-9_-]+$"
+            minLength: 1
+            maxLength: 50
+          revision:
+            type: "string"
+            pattern: "^[0-9a-f]+$"
+            minLength: 12
+            maxLength: 40
+          pushLogID:
+            type: "integer"
+        required: [kind, project, revision]
+
+      - type: "object"
+        properties:
+          kind:
+            type: "string"
+            enum: ['github.com']
+          project:
+            type: "string"
+            pattern: "^[0-9a-f]+$"
+            minLength: 1
+            maxLength: 50
+          revision:
+            type: "string"
+            minLength: 40
+            maxLength: 40
+          pullRequestID:
+            type: "integer"
+        required: [kind, project, revision]
+
+  display:
+    type: "object"
+    properties:
+      jobSymbol:
+        title: "jobSymbol"
+        type: "string"
+        # spaces and "?" are not valid for job symbols
+        pattern: "^[A-Za-z0-9._-]+$"
+        minLength: 1
+        maxLength: 25
+      groupSymbol:
+        title: "group symbol"
+        type: "string"
+        # spaces not valid for group symbols
+        pattern: "^[A-Za-z0-9/?_-]+$"
+        minLength: 1
+        maxLength: 25
+      # could do without these if we require job type and group to exist prior
+      jobName:
+        title: "job name"
+        type: "string"
+        minLength: 1
+        maxLength: 100
+      groupName:
+        title: "group name"
+        type: "string"
+        pattern: "^[A-Za-z0-9_-]+$"
+        minLength: 1
+        maxLength: 100
+    required:
+      - jobSymbol
+      - groupSymbol
+
+
+  state:
+    title: "state"
+    description: |
+      unscheduled: not yet scheduled
+      pending: not yet started
+      running: currently in progress
+      completed: Job ran through to completion
+    type: "string"
+    enum:
+      - unscheduled
+      - pending
+      - running
+      - completed
+  result:
+    title: "result"
+    description: |
+      fail: A failure
+      exception: An infrastructure error/exception
+      success: Build/Test executed without error or failure
+      canceled: The job was cancelled by a user
+      unknown: When the job is not yet completed
+    type: "string"
+    enum:
+      - success
+      - fail
+      - exception
+      - canceled
+      - unknown
+  jobKind:
+    type: "string"
+    enum:
+      - build
+      - test
+  tier:
+    type: "integer"
+    minimum: 1
+    maximum: 3
+
+  isRetried:
+    description: True indicates this job has been retried.
+    type: "boolean"
+
+  coalesced:
+    title: "coalesced"
+    type: "array"
+    items:
+      title: "job guid"
+      type: "string"
+      pattern: "^[A-Za-z0-9_/+-]+$"
+      minLength: 1
+      maxLength: 50
+
+
+  # time data
+  timeScheduled:
+    type: "string"
+    format: "date-time"
+  timeStarted:
+    type: "string"
+    format: "date-time"
+  timeCompleted:
+    type: "string"
+    format: "date-time"
+
+  optionCollection:
+    title: "option collection"
+    description: |
+      Options are a dimension of a platform.  The values here can vary wildly,
+      so most strings are valid for this.  The list of options that are used
+      is maleable going forward.
+
+      Some examples of options that have been used:
+        opt    Optimize Compiler GCC optimize flags
+        debug  Debug flags passed in
+        pgo    Profile Guided Optimization - Like opt, but runs with profiling, then builds again using that profiling
+        asan   Address Sanitizer
+        tsan   Thread Sanitizer Build
+    type: "array"
+    items:
+      type: "string"
+      minLength: 1
+      maxLength: 50
+      pattern: "^[A-Za-z0-9_-]+$"
+
+  who:
+    title: "who"
+    format: "email"
+    type: "string"
+    minLength: 1
+    maxLength: 50
+  reason:
+    description: |
+      Examples include:
+      - scheduled
+      - scheduler
+      - Self-serve: Rebuilt by foo@example.com
+      - Self-serve: Requested by foo@example.com
+      - The Nightly scheduler named 'b2g_mozilla-inbound periodic' triggered this build
+      - unknown
+    type: "string"
+    minLength: 1
+    maxLength: 125
+  productName:
+    description: |
+      Examples include:
+      -  'b2g'
+      -  'firefox'
+      -  'taskcluster'
+      -  'xulrunner'
+    type: "string"
+    minLength: 1
+    maxLength: 125
+
+  buildMachine:
+    $ref: "#/definitions/machine"
+  runMachine:
+    $ref: "#/definitions/machine"
+
+  artifacts:
+    type: "array"
+    items:
+      type: "object"
+      properties:
+        type:
+          type: "string"
+          enum: ["json", "text"]
+        name:
+          description: |
+            The artifact name can be anything.  But when the name ``text_log_summary`` is used
+            then treeherder uses that as the summary file for the Log Viewer in the UI.
+          type: "string"
+          minLength: 1
+          maxLength: 50
+        blob:
+          type: "string"
+          minLength: 1
+      required:
+        - type
+        - name
+        - blob
+
+  logs:
+    type: "array"
+    items:
+      type: "object"
+      properties:
+        url:
+          type: "string"
+          format: "uri"
+          minLength: 1
+          maxLength: 255
+        name:
+          type: "string"
+          minLength: 1
+          maxLength: 50
+      required: [url, name]
+
+additionalProperties: false
+required:
+  - jobGuid
+  - origin
+  - display
+  - state
+  - jobKind
+
+definitions:
+  machine:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+        pattern: "^[A-Za-z0-9_-]+$"
+        minLength: 1
+        maxLength: 50
+      platform:
+        type: "string"
+        pattern: "^[A-Za-z0-9_-]+$"
+        minLength: 1
+        maxLength: 25
+      os:
+        type: "string"
+        pattern: "^[A-Za-z0-9_-]+$"
+        minLength: 1
+        maxLength: 25
+      architecture:
+        type: "string"
+        pattern: "^[A-Za-z0-9_-]+$"
+        minLength: 1
+        maxLength: 25
+    required:
+      - name
+      - platform
+      - os
+      - architecture

--- a/tests/etl/test_job_loader.py
+++ b/tests/etl/test_job_loader.py
@@ -1,0 +1,103 @@
+import copy
+import pytest
+
+from treeherder.etl.job_loader import JobLoader
+from treeherder.model.derived.artifacts import ArtifactsModel
+
+
+@pytest.fixture
+def first_job(sample_data, test_project, result_set_stored):
+    revision = result_set_stored[0]["revisions"][0]["revision"]
+    job = copy.deepcopy(sample_data.pulse_jobs[0])
+    job["origin"]["project"] = test_project
+    job["origin"]["revision"] = revision
+    return job
+
+
+def test_ingest_pulse_job(sample_data, test_project, jm, result_set_stored):
+    """
+    Ingest a job through the JSON Schema validated JobLoader used by Pulse
+    """
+    revision = result_set_stored[0]["revisions"][0]["revision"]
+    sample_jobs = sample_data.pulse_jobs
+    for job in sample_jobs:
+        job["origin"]["project"] = test_project
+        job["origin"]["revision"] = revision
+
+    jl = JobLoader()
+    jl.process_job_list(sample_jobs, raise_errors=True)
+
+    jobs = jm.get_job_list(0, 10)
+    assert len(jobs) == 3
+
+    logs = jm.get_job_log_url_list([jobs[0]["id"]])
+    assert len(logs) == 1
+    with ArtifactsModel(test_project) as am:
+        artifacts = am.get_job_artifact_list(0, 10)
+        assert len(artifacts) == 2
+
+
+def test_transition_pending_running_complete(first_job, jm):
+    jl = JobLoader()
+
+    change_state_result(first_job, jl, jm, "pending", "unknown", "pending", "unknown")
+    change_state_result(first_job, jl, jm, "running", "unknown", "running", "unknown")
+    change_state_result(first_job, jl, jm, "completed", "fail", "completed", "testfailed")
+
+
+def test_transition_complete_pending_stays_complete(first_job, jm):
+    jl = JobLoader()
+
+    change_state_result(first_job, jl, jm, "completed", "fail", "completed", "testfailed")
+    change_state_result(first_job, jl, jm, "pending", "unknown", "completed", "testfailed")
+
+
+def test_transition_complete_running_stays_complete(first_job, jm):
+    jl = JobLoader()
+
+    change_state_result(first_job, jl, jm, "completed", "fail", "completed", "testfailed")
+    change_state_result(first_job, jl, jm, "running", "unknown", "completed", "testfailed")
+
+
+def test_transition_running_pending_stays_running(first_job, jm):
+    jl = JobLoader()
+
+    change_state_result(first_job, jl, jm, "running", "unknown", "running", "unknown")
+    change_state_result(first_job, jl, jm, "pending", "unknown", "running", "unknown")
+
+
+def test_transition_pending_retry_fail_stays_retry(first_job, jm):
+    jl = JobLoader()
+
+    change_state_result(first_job, jl, jm, "pending", "unknown", "pending", "unknown")
+    first_job["isRetried"] = True
+    change_state_result(first_job, jl, jm, "completed", "fail", "completed", "retry")
+    first_job["isRetried"] = False
+    change_state_result(first_job, jl, jm, "completed", "fail", "completed", "retry")
+
+
+def test_skip_unscheduled(first_job, jm):
+    jl = JobLoader()
+    first_job["state"] = "unscheduled"
+    jl.process_job_list([first_job], raise_errors=True)
+
+    jobs = jm.get_job_list(0, 10)
+    assert len(jobs) == 0
+
+
+def change_state_result(job, job_loader, jm, new_state, new_result, exp_state, exp_result):
+    # make a copy so we can modify it and not affect other tests
+    job = copy.deepcopy(job)
+    job["state"] = new_state
+    job["result"] = new_result
+    if new_state == 'pending':
+        # pending jobs wouldn't have logs and our store_job_data doesn't
+        # support it.
+        del job['logs']
+
+    job_loader.process_job_list([job], raise_errors=True)
+
+    jobs = jm.get_job_list(0, 10)
+    assert len(jobs) == 1
+    assert jobs[0]['state'] == exp_state
+    assert jobs[0]['result'] == exp_result

--- a/tests/etl/test_job_schema.py
+++ b/tests/etl/test_job_schema.py
@@ -1,0 +1,28 @@
+import pytest
+import jsonschema
+
+from treeherder.etl.schema import job_json_schema
+
+# The test data in this file are a representative sample-set from
+# production Treeherder
+
+@pytest.mark.parametrize("group_symbol", ['?','A','Aries','Buri/Hamac','L10n','M-e10s'])
+def test_group_symbols(sample_data, group_symbol):
+    """
+    Validate jobs against the schema with different group_symbol values
+    """
+    job = sample_data.pulse_jobs[0]
+    job["origin"]["project"] = "proj"
+    job["display"]["groupSymbol"] = group_symbol
+    jsonschema.validate(job, job_json_schema)
+
+
+@pytest.mark.parametrize("job_symbol", ['1.1g','1g','20','A','GBI10','en-US-1'])
+def test_job_symbols(sample_data, job_symbol):
+    """
+        Validate jobs against the schema with different job_symbol values
+    """
+    job = sample_data.pulse_jobs[0]
+    job["origin"]["project"] = "proj"
+    job["display"]["jobSymbol"] = job_symbol
+    jsonschema.validate(job, job_json_schema)

--- a/tests/sample_data/pulse_consumer/job_data.json
+++ b/tests/sample_data/pulse_consumer/job_data.json
@@ -1,0 +1,150 @@
+[
+  {
+    "jobGuid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33",
+    "origin": {
+      "kind": "hg.mozilla.org",
+      "project": "set by test",
+      "revision": "set by test"
+    },
+
+    "display": {
+      "jobSymbol": "P1",
+      "jobName": "Pulse Ingestion Test",
+      "groupSymbol": "PI",
+      "groupName": "PulseIngestion"
+    },
+
+    "state": "completed",
+    "result": "success",
+    "jobKind": "test",
+
+    "runMachine": {
+      "name": "bld-linux64-ec2-104",
+      "platform": "linux64",
+      "os": "linux",
+      "architecture": "x86_64"
+    },
+    "buildMachine": {
+      "name": "bld-linux64-ec2-104",
+      "platform": "linux64",
+      "os": "linux",
+      "architecture": "x86_64"
+    },
+
+    "who": "thedude@lebowski.com",
+    "reason": "scheduler",
+    "productName": "Oscillation Overthruster",
+
+    "timeScheduled": "2014-12-19T16:39:57-08:00",
+    "timeStarted": "2014-12-19T17:39:57-08:00",
+    "timeCompleted": "2014-12-19T18:39:57-08:00",
+
+    "logs": [
+      {
+        "url": "http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/tinderbox-builds/mozilla-inbound-linux64/mozilla-inbound_linux64_spidermonkey-warnaserr-bm57-build1-build352.txt.gz",
+        "parseStatus": "parsed",
+        "name": "builds-4h"
+      }
+    ],
+    "artifacts": [
+      {
+        "type": "json",
+        "name": "Artie Fact",
+        "blob": "{\"some\": \"value\"}"
+      }
+    ]
+  },
+  {
+    "jobGuid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf34",
+    "origin": {
+      "kind": "hg.mozilla.org",
+      "project": "set by test",
+      "revision": "set by test"
+    },
+
+    "display": {
+      "jobSymbol": "P2",
+      "jobName": "Pulse Ingestion Test",
+      "groupSymbol": "?",
+      "groupName": "unknown"
+    },
+
+    "state": "running",
+    "jobKind": "test",
+
+    "runMachine": {
+      "name": "bld-linux64-ec2-104",
+      "platform": "linux64",
+      "os": "linux",
+      "architecture": "x86_64"
+    },
+    "buildMachine": {
+      "name": "bld-linux64-ec2-104",
+      "platform": "linux64",
+      "os": "linux",
+      "architecture": "x86_64"
+    },
+
+    "who": "thedude@lebowski.com",
+    "reason": "scheduler",
+    "productName": "Oscillation Overthruster",
+
+    "timeScheduled": "2014-12-19T16:39:57-08:00",
+    "timeStarted": "2014-12-19T17:39:57-08:00",
+    "timeCompleted": "2014-12-19T18:39:57-08:00"
+  },
+  {
+    "jobGuid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35",
+    "origin": {
+      "kind": "hg.mozilla.org",
+      "project": "set by test",
+      "revision": "set by test"
+    },
+
+    "display": {
+      "jobSymbol": "P3",
+      "jobName": "Pulse Ingestion Test",
+      "groupSymbol": "PI",
+      "groupName": "PulseIngestion"
+    },
+
+    "state": "completed",
+    "result": "fail",
+    "jobKind": "test",
+
+    "runMachine": {
+      "name": "bld-linux64-ec2-104",
+      "platform": "linux64",
+      "os": "linux",
+      "architecture": "x86_64"
+    },
+    "buildMachine": {
+      "name": "bld-linux64-ec2-104",
+      "platform": "linux64",
+      "os": "linux",
+      "architecture": "x86_64"
+    },
+
+    "who": "thedude@lebowski.com",
+    "reason": "scheduler",
+
+    "timeScheduled": "2014-12-19T16:39:57-08:00",
+    "timeStarted": "2014-12-19T17:39:57-08:00",
+    "timeCompleted": "2014-12-19T18:39:57-08:00",
+
+    "logs": [
+      {
+        "url": "http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/tinderbox-builds/mozilla-inbound-linux64/mozilla-inbound_linux64_spidermonkey-warnaserr-bm57-build1-build352.txt.gz",
+        "parseStatus": "parsed",
+        "name": "builds-4h"
+      }
+    ],
+    "artifacts": [
+      {
+        "type": "json",
+        "name": "Artie Fact",
+        "blob": "{\"some\": \"value\"}"
+      }
+    ]
+  }
+]

--- a/tests/sampledata.py
+++ b/tests/sampledata.py
@@ -48,6 +48,7 @@ class SampleData(object):
         self.logs_dir = "{0}/sample_data/logs".format(
             os.path.dirname(__file__)
         )
+
         self.performance_logs_dir = "{0}/sample_data/artifacts/performance/perf_logs".format(
             os.path.dirname(__file__)
         )
@@ -63,6 +64,10 @@ class SampleData(object):
         with open("{0}/sample_data/artifacts/text_log_summary.json".format(
                   os.path.dirname(__file__))) as f:
             self.text_log_summary = json.load(f)
+
+        with open("{0}/sample_data/pulse_consumer/job_data.json".format(
+                  os.path.dirname(__file__))) as f:
+            self.pulse_jobs = json.load(f)
 
         self.job_data = []
         self.resultset_data = []

--- a/treeherder/etl/job_loader.py
+++ b/treeherder/etl/job_loader.py
@@ -1,0 +1,158 @@
+import logging
+import jsonschema
+import time
+from dateutil import parser
+from collections import defaultdict
+
+from treeherder.model.derived.jobs import JobsModel
+from treeherder.etl.schema import job_json_schema
+
+logger = logging.getLogger(__name__)
+
+
+class JobLoader:
+    """Validate, transform and load a list of Jobs"""
+    jobs_schema = None
+    artifact_schema = None
+
+    TEST_RESULT_MAP = {
+        "success": "success",
+        "fail": "testfailed",
+        "exception": "exception",
+        "canceled": "usercancel",
+        "unknown": "unknown"
+    }
+    BUILD_RESULT_MAP = {
+        "success": "success",
+        "fail": "busted",
+        "exception": "exception",
+        "canceled": "usercancel",
+        "unknown": "unknown"
+    }
+
+    def process_job_list(self, all_jobs_list, raise_errors=False):
+        if not isinstance(all_jobs_list, list):
+            all_jobs_list = [all_jobs_list]
+
+        validated_jobs = self._get_validated_jobs_by_project(all_jobs_list)
+
+        for project, job_list in validated_jobs.items():
+            with JobsModel(project) as jobs_model:
+                rs_lookup = jobs_model.get_revision_resultset_lookup(
+                    [x["origin"]["revision"] for x in job_list])
+                storeable_job_list = []
+                for pulse_job in job_list:
+                    if pulse_job["state"] != "unscheduled":
+                        try:
+                            storeable_job_list.append(
+                                self.transform(pulse_job, rs_lookup)
+                            )
+                        except AttributeError:
+                            logger.warn("Skipping job due to bad attribute",
+                                        exc_info=1)
+
+                jobs_model.store_job_data(storeable_job_list,
+                                          raise_errors=raise_errors)
+
+    def transform(self, pulse_job, rs_lookup):
+        """
+        Transform a pulse job into a job that can be written to disk.  Log
+        References and artifacts will also be transformed and loaded with the
+        job.
+
+        We can rely on the structure of ``pulse_job`` because it will
+        already have been validated against the JSON Schema at this point.
+        """
+        return {
+            "revision_hash": rs_lookup[pulse_job["origin"]["revision"]]["revision_hash"],
+            "job": {
+                "job_guid": pulse_job["jobGuid"],
+                "name": pulse_job["display"].get("jobName", "unknown"),
+                "job_symbol": pulse_job["display"].get("jobSymbol"),
+                "group_name": pulse_job["display"].get("groupName", "unknown"),
+                "group_symbol": pulse_job["display"].get("groupSymbol"),
+                "product_name": pulse_job.get("productName", "unknown"),
+                "state": pulse_job["state"],
+                "result": self._get_result(pulse_job),
+                "reason": pulse_job.get("reason", "unknown"),
+                "who": pulse_job.get("who", "unknown"),
+                "tier": pulse_job.get("tier", 1),
+                "submit_timestamp": self._to_timestamp(pulse_job["timeScheduled"]),
+                "start_timestamp": self._to_timestamp(pulse_job["timeStarted"]),
+                "end_timestamp": self._to_timestamp(pulse_job["timeCompleted"]),
+                "machine": self._get_machine(pulse_job),
+                "build_platform": self._get_platform(pulse_job.get("buildMachine", None)),
+                "machine_platform": self._get_platform(pulse_job.get("runMachine", None)),
+                "option_collection": self._get_option_collection(pulse_job),
+                "log_references": self._get_log_references(pulse_job),
+                "artifacts": self._get_artifacts(pulse_job),
+            },
+            "coalesced": pulse_job.get("coalesced", [])
+        }
+
+    def _get_artifacts(self, job):
+        pulse_artifacts = job.get("artifacts", [])
+        for artifact in pulse_artifacts:
+            artifact["job_guid"] = job["jobGuid"]
+        return pulse_artifacts
+
+    def _get_log_references(self, job):
+        log_references = []
+        for logref in job.get("logs", []):
+            log_references.append({
+                "name": logref["name"],
+                "url": logref["url"],
+                "parse_status": logref.get("parseStatus", "pending")
+            })
+        return log_references
+
+    def _get_option_collection(self, job):
+        option_collection = {"opt": True}
+        if "optionCollection" in job:
+            option_collection = {}
+            for option in job["optionCollection"]:
+                option_collection[option] = True
+        return option_collection
+
+    def _get_platform(self, platform_src):
+        platform = None
+        if platform_src:
+            platform = {
+                "platform": platform_src["platform"],
+                "os_name": platform_src["os"],
+                "architecture": platform_src["architecture"]
+            }
+        return platform
+
+    def _get_machine(self, job):
+        machine = "unknown"
+        if "buildMachine" in job:
+            machine = job["buildMachine"]["name"]
+        if "runMachine" in job:
+            machine = job["runMachine"]["name"]
+        return machine
+
+    def _get_result(self, job):
+        if job["state"] == "completed":
+            resmap = self.BUILD_RESULT_MAP if job["jobKind"] == "build" else self.TEST_RESULT_MAP
+            result = job.get("result", "unknown")
+            if job.get("isRetried", False):
+                return "retry"
+            else:
+                return resmap[result]
+        return "unknown"
+
+    def _get_validated_jobs_by_project(self, jobs_list):
+        validated_jobs = defaultdict(list)
+        for pulse_job in jobs_list:
+            try:
+                jsonschema.validate(pulse_job, job_json_schema)
+                validated_jobs[pulse_job["origin"]["project"]].append(pulse_job)
+            except (jsonschema.ValidationError, jsonschema.SchemaError) as e:
+                logger.error(
+                    "JSON Schema validation error during job ingestion: {}".format(e))
+
+        return validated_jobs
+
+    def _to_timestamp(self, datestr):
+        return time.mktime(parser.parse(datestr).timetuple())

--- a/treeherder/etl/management/commands/ingest_from_pulse.py
+++ b/treeherder/etl/management/commands/ingest_from_pulse.py
@@ -1,0 +1,52 @@
+import logging
+from urlparse import urlparse
+from kombu import Connection, Exchange
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+from treeherder.etl.pulse_consumer import JobConsumer
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+
+    """Management command to ingest jobs from a set of pulse exchanges."""
+
+    help = "Ingest jobs from a set of pulse exchanges"
+
+    def handle(self, *args, **options):
+        config = settings.PULSE_DATA_INGESTION_CONFIG
+        userid = urlparse(config).username
+        durable = settings.PULSE_DATA_INGESTION_QUEUES_DURABLE
+        auto_delete = settings.PULSE_DATA_INGESTION_QUEUES_AUTO_DELETE
+        connection = Connection(config)
+        consumer = JobConsumer(connection)
+
+        try:
+            for exchange_obj in settings.PULSE_DATA_INGESTION_EXCHANGES:
+                exchange = Exchange(exchange_obj["name"], type="topic")
+                exchange(connection).declare(passive=True)
+                self.stdout.write("Connected to Pulse Exchange: {}".format(
+                    exchange_obj["name"]))
+
+                for project in exchange_obj["projects"]:
+                    queue_name = "queue/{}/".format(userid)
+                    for destination in exchange_obj['destinations']:
+                        routing_key = "{}.{}".format(project, destination)
+                        consumer.listen_to(
+                            exchange,
+                            routing_key,
+                            queue_name,
+                            durable,
+                            auto_delete)
+                        self.stdout.write(
+                            "Pulse message consumer listening to : {} {}".format(
+                                exchange.name,
+                                routing_key
+                            ))
+
+            consumer.run()
+        finally:
+            consumer.close()

--- a/treeherder/etl/management/commands/publish_to_pulse.py
+++ b/treeherder/etl/management/commands/publish_to_pulse.py
@@ -1,0 +1,51 @@
+import logging
+
+from kombu.messaging import Producer
+from kombu import Connection, Exchange
+from urlparse import urlparse
+
+from django.core.management.base import BaseCommand
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+
+    """
+    Management command to publish a job to a pulse exchange.
+
+    This is primarily intended as a mechanism to test new or changed jobs
+    to ensure they validate and will show as expected in the Treeherder UI.
+    """
+
+    help = "Publish jobs to a pulse exchange"
+
+    def add_arguments(self, parser):
+        parser.add_argument('routing_key', help="The routing key for publishing. Ex: 'mozilla-inbound.staging'")
+        parser.add_argument('connection_url', help="The Pulse url. Ex: 'amqp://guest:guest@localhost:5672/'")
+        parser.add_argument('payload_file', help="Path to the file that holds the job payload JSON")
+
+    def handle(self, *args, **options):
+        routing_key = options["routing_key"]
+        connection_url = options["connection_url"]
+        userid = urlparse(connection_url).username
+        payload_file = options["payload_file"]
+
+        exchange_name = "exchange/{}/jobs".format(userid)
+
+        connection = Connection(connection_url)
+        exchange = Exchange(exchange_name, type="topic")
+        producer = Producer(connection,
+                            exchange,
+                            routing_key=routing_key,
+                            auto_declare=True)
+
+        self.stdout.write("Published to exchange: {}".format(exchange_name))
+
+        with open(payload_file) as f:
+            body = f.read()
+
+            try:
+                producer.publish(body)
+            finally:
+                connection.release()

--- a/treeherder/etl/pulse_consumer.py
+++ b/treeherder/etl/pulse_consumer.py
@@ -1,0 +1,52 @@
+import logging
+import json
+
+from kombu import Queue
+from kombu.mixins import ConsumerMixin
+
+from treeherder.etl.tasks.pulse_tasks import store_pulse_jobs
+
+
+logger = logging.getLogger(__name__)
+
+
+class JobConsumer(ConsumerMixin):
+    """
+    Consume jobs from Pulse exchanges
+    """
+    def __init__(self, connection):
+        self.connection = connection
+        self.consumers = []
+
+    def get_consumers(self, Consumer, channel):
+        return [
+            Consumer(**c) for c in self.consumers
+        ]
+
+    def listen_to(self, exchange, routing_key, queue_name,
+                  durable=True, auto_delete=False):
+        queue = Queue(
+            name=queue_name,
+            channel=self.connection.channel(),
+            exchange=exchange,
+            routing_key=routing_key,
+            durable=durable,
+            auto_delete=auto_delete
+        )
+
+        self.consumers.append(dict(queues=queue, callbacks=[self.on_message]))
+
+    def on_message(self, body, message):
+        try:
+            jobs = json.loads(body)
+            store_pulse_jobs.apply_async(
+                args=[jobs],
+                routing_key='store_pulse_jobs'
+            )
+            message.ack()
+
+        except Exception:
+            logger.error("Unable to load jobs: {}".format(message), exc_info=1)
+
+    def close(self):
+        self.connection.release()

--- a/treeherder/etl/schema.py
+++ b/treeherder/etl/schema.py
@@ -1,0 +1,15 @@
+import os
+import yaml
+
+
+def get_json_schema(filename):
+    """
+    Get a JSON Schema by filename.
+
+    """
+    file_path = os.path.join("schemas", filename)
+    with open(file_path) as f:
+        schema = yaml.load(f)
+    return schema
+
+job_json_schema = get_json_schema("pulse-job.yml")

--- a/treeherder/etl/tasks/__init__.py
+++ b/treeherder/etl/tasks/__init__.py
@@ -1,4 +1,5 @@
 from .buildapi_tasks import *
+from .pulse_tasks import *
 from .cleanup_tasks import *
 from .classification_mirroring_tasks import *
 from .tasks import *

--- a/treeherder/etl/tasks/pulse_tasks.py
+++ b/treeherder/etl/tasks/pulse_tasks.py
@@ -1,0 +1,14 @@
+"""
+This module contains tasks related to pulse job ingestion
+"""
+from celery import task
+
+from treeherder.etl.job_loader import JobLoader
+
+
+@task(name='store-pulse-jobs')
+def store_pulse_jobs(job_list):
+    """
+    Fetches the jobs pending from pulse exchanges and loads them.
+    """
+    JobLoader().process_job_list(job_list)

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -178,7 +178,8 @@ CELERY_QUEUES = (
     Queue('buildapi_4hr', Exchange('default'), routing_key='buildapi_4hr'),
     Queue('cycle_data', Exchange('default'), routing_key='cycle_data'),
     Queue('calculate_eta', Exchange('default'), routing_key='calculate_eta'),
-    Queue('fetch_bugs', Exchange('default'), routing_key='fetch_bugs')
+    Queue('fetch_bugs', Exchange('default'), routing_key='fetch_bugs'),
+    Queue('store_pulse_jobs', Exchange('default'), routing_key='store_pulse_jobs')
 )
 
 CELERY_ACCEPT_CONTENT = ['json']
@@ -338,6 +339,10 @@ PULSE_EXCHANGE_NAMESPACE = None
 # will be updated as new applications come online that Treeherder supports.
 # Can be overridden in local.py to specify fewer or completely different
 # exchanges for testing purposes on local machines.
+# Treeherder will subscribe with routing keys that are all combinations of
+# ``project`` and ``destination`` in the form of:
+#     <project>.<destination>
+# Wildcards such as ``#`` and ``*`` are supported for either field.
 PULSE_DATA_INGESTION_EXCHANGES = env.json(
     "PULSE_DATA_INGESTION_EXCHANGES",
     default=[
@@ -347,23 +352,42 @@ PULSE_DATA_INGESTION_EXCHANGES = env.json(
         #         'mozilla-central',
         #         'mozilla-inbound'
         #         # other repos TC can submit to
+        #     ],
+        #     "destinations": [
+        #         'production'
+        #         'staging'
         #     ]
         # },
         # {
         #     "name": "exchange/treeherder-test/jobs",
         #     "projects": [
         #         'mozilla-inbound'
+        #     ],
+        #     "destinations": [
+        #         'production'
+        #         'staging'
         #     ]
+        #
         # }
         # ... other CI systems
     ])
 
 # Used to specify the PulseGuardian account that will be used to create
 # ingestion queues for the exchanges specified in ``PULSE_DATA_INGESTION_EXCHANGES``.
-# See https://pulse.mozilla.org/whats_pulse for more info
-# Example: "amqp://treeherder-test:thpulsesekrit6@pulse.mozilla.org:5672//"
+# See https://pulse.mozilla.org/whats_pulse for more info.
+# Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/"
 PULSE_DATA_INGESTION_CONFIG = env.url("PULSE_DATA_INGESTION_CONFIG", default="")
-PULSE_QUEUE_USERID = env("PULSE_QUEUE_USERID", default="")
+
+# Whether the Queues created for pulse ingestion are durable or not.
+# For local data ingestion, you probably should set this to False
+PULSE_DATA_INGESTION_QUEUES_DURABLE = env("PULSE_DATA_INGESTION_QUEUES_DURABLE",
+                                          default=True)
+
+# Whether the Queues created for pulse ingestion auto-delete after connections
+# are closed.
+# For local data ingestion, you probably should set this to True
+PULSE_DATA_INGESTION_QUEUES_AUTO_DELETE = env("PULSE_DATA_INGESTION_QUEUES_AUTO_DELETE",
+                                              default=False)
 
 # Note: All the configs below this import will take precedence over what is
 # defined in local.py!


### PR DESCRIPTION
Addresses [Bug 1169320](https://bugzilla.mozilla.org/show_bug.cgi?id=1169320)

This branch enables ingesting jobs from a pulse exchange in the specified YAML format provided here.

Deferred to follow-up PRs:

* Update existing queues based on config changes
* API endpoints to expose the schema


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/940)
<!-- Reviewable:end -->
