### PR TITLE
Bug 1201517 - Export a revision.txt containing the Git SHA on Heroku too

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,6 +1,9 @@
 #!/bin/bash -e
 # Tasks run by the Heroku Python buildpack after the compile step.
 
+# Make the current Git revision accessible at <site-root>/revision.txt
+echo $SOURCE_VERSION > dist/revision.txt
+
 # Generate gzipped versions of files that would benefit from compression, that
 # WhiteNoise can then serve in preference to the originals. This is required
 # since WhiteNoise's Django storage backend only gzips assets handled by

--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -39,6 +39,7 @@ def pre_update(ctx, ref=settings.UPDATE_REF):
         # Remove gzipped UI assets in case the uncompressed original no longer exists.
         ctx.local('find dist/ -type f -name "*.gz" -delete')
         ctx.local('git status -s')
+        # Make the current Git revision accessible at <site-root>/revision.txt
         ctx.local('git rev-parse HEAD > dist/revision.txt')
 
 

--- a/ui/partials/main/thHelpMenu.html
+++ b/ui/partials/main/thHelpMenu.html
@@ -24,7 +24,7 @@
     Source</a>
 </li>
 <li>
-  <a href="https://whatsdeployed.paas.allizom.org/?owner=mozilla&repo=treeherder&name[]=Stage&url[]=https://treeherder.allizom.org/revision.txt&name[]=Prod&url[]=https://treeherder.mozilla.org/revision.txt" target="_blank">
+  <a href="https://whatsdeployed.paas.allizom.org/?owner=mozilla&amp;repo=treeherder&amp;name[]=Heroku-prototype&amp;url[]=https://treeherder-heroku.herokuapp.com/revision.txt&amp;name[]=Stage&amp;url[]=https://treeherder.allizom.org/revision.txt&amp;name[]=Prod&amp;url[]=https://treeherder.mozilla.org/revision.txt" target="_blank">
     <span class="fa fa-question midgray"></span>
     What's Deployed?</a>
 </li>

--- a/ui/userguide.html
+++ b/ui/userguide.html
@@ -615,7 +615,7 @@
   </div>
   <div class="col-xs-6">
     <a class="midgray pull-right"
-       href="https://whatsdeployed.paas.allizom.org/?owner=mozilla&repo=treeherder&name[]=Stage&url[]=https://treeherder.allizom.org/revision.txt&name[]=Prod&url[]=https://treeherder.mozilla.org/revision.txt">What's Deployed?</a>
+       href="https://whatsdeployed.paas.allizom.org/?owner=mozilla&amp;repo=treeherder&amp;name[]=Heroku-prototype&amp;url[]=https://treeherder-heroku.herokuapp.com/revision.txt&amp;name[]=Stage&amp;url[]=https://treeherder.allizom.org/revision.txt&amp;name[]=Prod&amp;url[]=https://treeherder.mozilla.org/revision.txt">What's Deployed?</a>
   </div>
 </div>
 


### PR DESCRIPTION
The Git SHA is available in the SOURCE_VERSION environment variable:
https://devcenter.heroku.com/articles/buildpack-api#bin-compile-summary

Also update the What's Deployed links to include Heroku in the comparison alongside stage/prod.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/942)
<!-- Reviewable:end -->
