### PR TITLE
Bug 1202476 - Move remaining userguide css, naming and indent

### DIFF
--- a/ui/css/treeherder-userguide.css
+++ b/ui/css/treeherder-userguide.css
@@ -1,4 +1,21 @@
-.help-btn-sm tr > th > button {
+#userguide {
+    padding: 10px 10px 0px;
+    overflow: auto;
+}
+
+#userguide.dt, #userguide.dd {
+    text-align: center;
+}
+
+#userguide.panel {
+    padding: 5px;
+}
+
+/*
+ * Job notation table
+ */
+
+.ug-btn-sm tr > th > button {
     font-size: 13px;
     padding: 0px 2px;
     margin-top: 1px;
@@ -9,54 +26,66 @@
     background: #fff;
 }
 
-.help-btn-sm tr > th > button:focus {
+.ug-btn-sm tr > th > button:focus {
     outline: 0;
 }
 
-.help-btn-desc tr > td {
+.ug-btn-desc tr > td {
     vertical-align: bottom;
 }
 
-.help-btn {
+.ug-btn {
     margin: 2px;
     border: 2px solid;
 }
 
-.help-btn-comment {
+.ug-btn-comment {
     border: none;
     background-color: #fff;
 }
 
-.help-btn-orange {
+.ug-btn-orange {
     border-color: #dd6602;
 }
 
-.help-btn-purple {
+.ug-btn-purple {
     border-color: #6f0296;
 }
 
-.help-btn-red {
+.ug-btn-red {
     border-color: #a1020e;
 }
 
-.help-btn-yellow {
+.ug-btn-yellow {
     border-color: #fbd890;
 }
 
-.help-btn-bg {
+.ug-btn-bg {
     background-color: #fff;
 }
 
-#help-job-name {
+/*
+ * Copy values on hover
+ */
+
+#ug-job-name {
     color: #428bca;
 }
 
-#help-raw-log-icon {
+#ug-raw-log-icon {
     font-size: 14px;
     color: #666;
 }
 
-#help-logviewer-icon {
+#ug-logviewer-icon {
     vertical-align: text-bottom;
     width: 15px;
+}
+
+/*
+ * Footer
+ */
+
+.ug-footer {
+    overflow: auto;
 }

--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -1710,23 +1710,6 @@ fieldset[disabled] .btn-repo.active {
     color: gray;
 }
 
-#userguide {
-    padding: 10px 10px 0px;
-    overflow: auto;
-}
-
-#userguide.dt, #userguide.dd {
-    text-align: center;
-}
-
-#userguide.panel {
-    padding: 5px;
-}
-
-.userguide-footer {
-    overflow: auto;
-}
-
 /* Used in Help but for general use */
 .kbd {
     display: inline-block;

--- a/ui/userguide.html
+++ b/ui/userguide.html
@@ -1,212 +1,227 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="utf-8">
-    <title>Treeherder User Guide</title>
-    <!-- build:css css/userguide.min.css -->
-    <link href="vendor/css/bootstrap.css" rel="stylesheet" media="screen">
-    <link href="css/treeherder.css" rel="stylesheet" media="screen">
-    <link href="css/treeherder-userguide.css" rel="stylesheet" media="screen">
-    <link href="vendor/css/font-awesome.css" rel="stylesheet" media="screen">
-    <!-- endbuild -->
-    <link id="favicon" type="image/png" rel="shortcut icon" href="img/tree_open.png">
+  <meta charset="utf-8">
+  <title>Treeherder User Guide</title>
+  <!-- build:css css/userguide.min.css -->
+  <link href="vendor/css/bootstrap.css" rel="stylesheet" media="screen">
+  <link href="css/treeherder.css" rel="stylesheet" media="screen">
+  <link href="css/treeherder-userguide.css" rel="stylesheet" media="screen">
+  <link href="vendor/css/font-awesome.css" rel="stylesheet" media="screen">
+  <!-- endbuild -->
+  <link id="favicon" type="image/png" rel="shortcut icon" href="img/tree_open.png">
 </head>
-<body id="userguide">
-<div class="panel panel-default">
-<div class="panel-heading">
-    <h1>Treeherder User Guide</h1>
 
-    <h5>
-      Want to contribute?
-      <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&amp;component=Treeherder">File a bug</a> /
-      <a href="https://github.com/mozilla/treeherder">Source</a> /
-      <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder#Contributing">Contributing</a>
-    </h5>
-    For anything else visit our
-    <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder">Project Wiki</a>
-    or ask us on IRC in
-    <a href="irc://irc.mozilla.org/treeherder">#treeherder</a>
-</div>
-<div class="panel-body">
-<div class="row">
-    <div class="col-xs-6">
-        <div class="panel panel-default">
+<body id="userguide">
+  <!-- Content panel -->
+  <div class="panel panel-default">
+    <!-- Header -->
+    <div class="panel-heading">
+      <h1>Treeherder User Guide</h1>
+      <h5>Want to contribute?
+        <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&amp;component=Treeherder">
+          File a bug</a> /
+        <a href="https://github.com/mozilla/treeherder">
+          Source</a> /
+        <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder#Contributing">
+          Contributing</a>
+      </h5>
+      For anything else visit our
+      <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder">
+        Project Wiki</a>
+      or ask us on IRC in
+      <a href="irc://irc.mozilla.org/treeherder">#treeherder</a>
+    </div>
+
+    <!-- Start of interior panels -->
+    <div class="panel-body">
+      <div class="row">
+        <!-- Job Notation table -->
+        <div class="col-xs-6">
+          <div class="panel panel-default">
             <div class="panel-heading">
-                <h3>Job notation</h3>
+              <h3>Job notation</h3>
             </div>
             <div class="panel-body">
-                <table id="legend-other">
-                  <tr>
-                    <th>
-                      <button class="btn btn-green help-btn help-btn-comment">+n</button>
-                    </th>
-                    <td>Collapsed job count</td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <button class="btn btn-dkgray help-btn help-btn-comment">Th( )</button>
-                    </th>
-                    <td>Wrapped job group</td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <button class="btn btn-orange-classified help-btn help-btn-comment">Th</button>
-                    </th>
-                    <td>Asterisk, classified</td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <button class="btn btn-ltgray help-btn help-btn-bg">Th</button>
-                    </th>
-                    <td>Light gray, pending</td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <button class="btn btn-dkgray help-btn help-btn-bg">Th</button>
-                    </th>
-                    <td>Gray, running</td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <button class="btn btn-green help-btn help-btn-bg">Th</button>
-                    </th>
-                    <td>Green, success</td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <button class="btn btn-orange help-btn help-btn-orange">Th</button>
-                    </th>
-                    <td>Orange, tests failed</td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <button class="btn btn-purple help-btn help-btn-purple">Th</button>
-                    </th>
-                    <td>Purple, infrastructure exception</td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <button class="btn btn-red help-btn help-btn-red">Th</button>
-                    </th>
-                    <td>Red, build error</td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <button class="btn btn-dkblue help-btn help-btn-bg">Th</button>
-                    </th>
-                    <td>Dark blue, build restarted</td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <button class="btn btn-pink help-btn help-btn-bg">Th</button>
-                    </th>
-                    <td>Pink, build cancelled</td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <button class="btn btn-yellow help-btn help-btn-yellow">Th</button>
-                    </th>
-                    <td>Yellow, unknown</td>
-                  </tr>
-                  <tr>
-                    <th class="coalesced">
-                      <button class="btn btn-ltblue help-btn help-btn-bg">Th</button>
-                    </th>
-                    <td>Light blue, coalesced</td>
-                  </tr>
-                </table>
+              <table id="legend-other">
+                <tr>
+                  <th>
+                    <button class="btn btn-green ug-btn ug-btn-comment">+n</button>
+                  </th>
+                  <td>Collapsed job count</td>
+                </tr>
+                <tr>
+                  <th>
+                    <button class="btn btn-dkgray ug-btn ug-btn-comment">Th( )</button>
+                  </th>
+                  <td>Wrapped job group</td>
+                </tr>
+                <tr>
+                  <th>
+                    <button class="btn btn-orange-classified ug-btn ug-btn-comment">Th</button>
+                  </th>
+                  <td>Asterisk, classified</td>
+                </tr>
+                <tr>
+                  <th>
+                    <button class="btn btn-ltgray ug-btn ug-btn-bg">Th</button>
+                  </th>
+                  <td>Light gray, pending</td>
+                </tr>
+                <tr>
+                  <th>
+                    <button class="btn btn-dkgray ug-btn ug-btn-bg">Th</button>
+                  </th>
+                  <td>Gray, running</td>
+                </tr>
+                <tr>
+                  <th>
+                    <button class="btn btn-green ug-btn ug-btn-bg">Th</button>
+                  </th>
+                  <td>Green, success</td>
+                </tr>
+                <tr>
+                  <th>
+                    <button class="btn btn-orange ug-btn ug-btn-orange">Th</button>
+                  </th>
+                  <td>Orange, tests failed</td>
+                </tr>
+                <tr>
+                  <th>
+                    <button class="btn btn-purple ug-btn ug-btn-purple">Th</button>
+                  </th>
+                  <td>Purple, infrastructure exception</td>
+                </tr>
+                <tr>
+                  <th>
+                    <button class="btn btn-red ug-btn ug-btn-red">Th</button>
+                  </th>
+                  <td>Red, build error</td>
+                </tr>
+                <tr>
+                  <th>
+                    <button class="btn btn-dkblue ug-btn ug-btn-bg">Th</button>
+                  </th>
+                  <td>Dark blue, build restarted</td>
+                </tr>
+                <tr>
+                  <th>
+                    <button class="btn btn-pink ug-btn ug-btn-bg">Th</button>
+                  </th>
+                  <td>Pink, build cancelled</td>
+                </tr>
+                <tr>
+                  <th>
+                    <button class="btn btn-yellow ug-btn ug-btn-yellow">Th</button>
+                  </th>
+                  <td>Yellow, unknown</td>
+                </tr>
+                <tr>
+                  <th class="coalesced">
+                    <button class="btn btn-ltblue ug-btn ug-btn-bg">Th</button>
+                  </th>
+                  <td>Light blue, coalesced</td>
+                </tr>
+              </table>
             </div>
+          </div>
         </div>
 
-
-    </div>
-    <div class="col-xs-6">
-        <div class="panel panel-default">
-            <div class="panel-heading"><h3>Keyboard shortcuts</h3></div>
+        <!-- Shortcuts table -->
+        <div class="col-xs-6">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h3>Keyboard shortcuts</h3></div>
             <div class="panel-body panel-spacing">
-                <table id="shortcuts">
-                    <tr><td class="kbd">esc</td>
-                    <td>Close all open job or filter panels</td></tr>
-                    <tr><td class="kbd">f</td>
-                    <td>Enter a quick filter</td></tr>
-                    <tr>
-                      <td><span class="kbd">ctrl</span><span class="kbd">shift
-                        </span><span class="kbd">f</span></td>
-                      <td>Clear the quick filter</td>
-                    </tr>
-                    <tr><td class="kbd">&larr;</td>
-                    <td>Select previous job</td></tr>
-                    <tr><td class="kbd">&rarr;</span></td>
-                    <td>Select next job</td></tr>
-                    <tr><td><span class="kbd">k</span> or <span class="kbd">p</span></td>
-                    <td>Select previous unclassified failure</td></tr>
-                    <tr><td><span class="kbd">j</span> or <span class="kbd">n</span></td>
-                    <td>Select next unclassified failure</td></tr>
-                    <tr><td class="kbd">l</td>
-                    <td>Open the logviewer for the selected job</td></tr>
-                    <tr><td><span class="kbd">ctrl</span> or <span class="kbd">cmd</span></td>
-                    <td>Add job to the pinboard during click selection</td></tr>
-                    <tr><td class="kbd">spacebar</td>
-                    <td>Add a selected job to the pinboard</td></tr>
-                    <tr><td class="kbd">b</td>
-                    <td>Add a selected job to the pinboard + enter related bug</td></tr>
-                    <tr><td class="kbd">c</td>
-                    <td>Add a selected job to the pinboard + enter classification</td></tr>
-                    <tr><td><span class="kbd">ctrl</span><span class="kbd">enter</span></td>
-                    <td>Save pinboard classification and related bugs</td></tr>
-                    <tr>
-                      <td><span class="kbd">ctrl</span><span class="kbd">shift
-                        </span><span class="kbd">u</span></td>
-                      <td>Clear the pinboard</td>
-                    </tr>
-                    <tr><td class="kbd">r</span></td>
-                    <td>Retrigger selected job</td></tr>
-                    <tr><td><span class="kbd">ctrl</span><span class="kbd">backspace</span></td>
-                    <td>Delete job classification and related bugs</td></tr>
-                    <tr><td class="kbd">i</td>
-                    <td>Toggle in-progress (running/pending) jobs</td></tr>
-                    <tr><td class="kbd">u</td>
-                    <td>Show only unclassified failures</td></tr>
-                </table>
+              <table id="shortcuts">
+                <tr><td class="kbd">esc</td>
+                  <td>Close all open job or filter panels</td></tr>
+                <tr><td class="kbd">f</td>
+                  <td>Enter a quick filter</td></tr>
+                <tr>
+                  <td><span class="kbd">ctrl</span><span class="kbd">shift
+                    </span><span class="kbd">f</span></td>
+                  <td>Clear the quick filter</td>
+                </tr>
+                <tr><td class="kbd">&larr;</td>
+                  <td>Select previous job</td></tr>
+                <tr><td class="kbd">&rarr;</span></td>
+                  <td>Select next job</td></tr>
+                <tr><td><span class="kbd">k</span> or <span class="kbd">p</span></td>
+                  <td>Select previous unclassified failure</td></tr>
+                <tr><td><span class="kbd">j</span> or <span class="kbd">n</span></td>
+                  <td>Select next unclassified failure</td></tr>
+                <tr><td class="kbd">l</td>
+                  <td>Open the logviewer for the selected job</td></tr>
+                <tr><td><span class="kbd">ctrl</span> or <span class="kbd">cmd</span></td>
+                  <td>Add job to the pinboard during click selection</td></tr>
+                <tr><td class="kbd">spacebar</td>
+                  <td>Add a selected job to the pinboard</td></tr>
+                <tr><td class="kbd">b</td>
+                  <td>Add a selected job to the pinboard + enter related bug</td></tr>
+                <tr><td class="kbd">c</td>
+                  <td>Add a selected job to the pinboard + enter classification</td></tr>
+                <tr><td><span class="kbd">ctrl</span><span class="kbd">enter</span></td>
+                  <td>Save pinboard classification and related bugs</td></tr>
+                <tr>
+                  <td><span class="kbd">ctrl</span><span class="kbd">shift
+                    </span><span class="kbd">u</span></td>
+                  <td>Clear the pinboard</td>
+                </tr>
+                <tr><td class="kbd">r</span></td>
+                  <td>Retrigger selected job</td></tr>
+                <tr><td><span class="kbd">ctrl</span><span class="kbd">backspace</span></td>
+                  <td>Delete job classification and related bugs</td></tr>
+                <tr><td class="kbd">i</td>
+                  <td>Toggle in-progress (running/pending) jobs</td></tr>
+                <tr><td class="kbd">u</td>
+                  <td>Show only unclassified failures</td></tr>
+              </table>
             </div>
+
+            <!-- Copy values on hover table -->
             <div class="panel-heading"><h3>Copy values on hover</h3></div>
             <div class="panel-body panel-spacing">
-                <table id="shortcuts">
-                    <tr>
-                      <td><span class="kbd">ctrl/cmd</span>+<span class="kbd">c</td>
-                      <td>Copy job details
-                        <img src="./img/logviewerIconHelp.svg" id="help-logviewer-icon">
-                        </span> logviewer url on hover</td>
-                    </tr>
-                    <tr>
-                      <td><span class="kbd">ctrl/cmd</span>+<span class="kbd">c</td>
-                      <td>Copy job details
-                        <span id="help-raw-log-icon" class="fa fa-file-text-o">
-                        </span> raw log url on hover</td>
-                    </tr>
-                    <tr>
-                      <td><span class="kbd">ctrl/cmd</span>+<span class="kbd">c</td>
-                      <td>Copy job details <span class="small"><label>Job:</label>
-                        <span id="help-job-name">name</span></span> as raw text on hover
-                      </td>
-                    </tr>
-                </table>
+              <table id="shortcuts">
+                <tr>
+                  <td><span class="kbd">ctrl/cmd</span>+<span class="kbd">c</td>
+                  <td>Copy job details
+                    <img src="./img/logviewerIconHelp.svg" id="ug-logviewer-icon">
+                    </span> logviewer url on hover</td>
+                </tr>
+                <tr>
+                  <td><span class="kbd">ctrl/cmd</span>+<span class="kbd">c</td>
+                  <td>Copy job details
+                    <span id="ug-raw-log-icon" class="fa fa-file-text-o">
+                    </span> raw log url on hover</td>
+                </tr>
+                <tr>
+                  <td><span class="kbd">ctrl/cmd</span>+<span class="kbd">c</td>
+                  <td>Copy job details <span class="small"><label>Job:</label>
+                    <span id="ug-job-name">name</span></span> as raw text on hover
+                  </td>
+                </tr>
+              </table>
             </div>
+          </div>
         </div>
-    </div>
-</div>
+      </div>
 
-<div class="col-xs-6">
-    <div class="panel panel-default">
-        <div class="panel-heading"><h3>Builds</h3></div>
-        <div class="panel-body panel-spacing">
-            <table id="legend-builds" class="help-btn-sm help-btn-desc">
+      <div class="row">
+        <!-- Builds table -->
+        <div class="col-xs-6">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h3>Builds</h3>
+            </div>
+            <div class="panel-body panel-spacing">
+              <table id="legend-builds" class="ug-btn-sm ug-btn-desc">
                 <tr><th><button>B</button></th>
-                <td>Build</td></tr>
+                  <td>Build</td></tr>
                 <tr><th><button>Bn</button></th>
-                <td>Non-Unified Build</td></tr>
+                  <td>Non-Unified Build</td></tr>
                 <tr><th><button>S</button></th>
-                <td>Static Checking Build</td></tr>
+                  <td>Static Checking Build</td></tr>
                 <tr><th><button>SM</button></th>
                   <td>
                     <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
@@ -268,9 +283,9 @@
                   </td>
                 </tr>
                 <tr><th><button>N</button></th>
-                <td>Nightly</td></tr>
+                  <td>Nightly</td></tr>
                 <tr><th><button>Dxr</button></th>
-                <td>DXR Index Build</td></tr>
+                  <td>DXR Index Build</td></tr>
                 <tr><th><button>H</button></th>
                   <td>
                     <a href="https://wiki.mozilla.org/Javascript:Hazard_Builds">
@@ -278,347 +293,360 @@
                   </td>
                 </tr>
                 <tr><th><button>V</button></th>
-                <td>Valgrind Build</td></tr>
+                  <td>Valgrind Build</td></tr>
                 <tr><th><button>Xr</button></th>
-                <td>XULRunner Nightly</td></tr>
+                  <td>XULRunner Nightly</td></tr>
                 <tr><th><button>Bo</button></th>
-                <td>AddressSanitizer Opt Build</td></tr>
+                  <td>AddressSanitizer Opt Build</td></tr>
                 <tr><th><button>Bd</button></th>
-                <td>AddressSanitizer Debug Build</td></tr>
+                  <td>AddressSanitizer Debug Build</td></tr>
                 <tr><th><button>No</button></th>
-                <td>AddressSanitizer Opt Nightly</td></tr>
+                  <td>AddressSanitizer Opt Nightly</td></tr>
                 <tr><th><button>Nd</button></th>
-                <td>AddressSanitizer Debug Nightly</td></tr>
+                  <td>AddressSanitizer Debug Nightly</td></tr>
                 <tr><th><button>N</button></th>
-                <td>L10n Nightly</td></tr>
+                  <td>L10n Nightly</td></tr>
                 <tr><th><button>L10n</button></th>
-                <td>L10n Repack</td></tr>
+                  <td>L10n Repack</td></tr>
                 <tr><th><button>B</button></th>
-                <td>B2G Emulator Image Build</td></tr>
+                  <td>B2G Emulator Image Build</td></tr>
                 <tr><th><button>Bn</button></th>
-                <td>B2G Emulator Image Non-Unified Build</td></tr>
+                  <td>B2G Emulator Image Non-Unified Build</td></tr>
                 <tr><th><button>N</button></th>
-                <td>B2G Emulator Image Nightly</td></tr>
+                  <td>B2G Emulator Image Nightly</td></tr>
                 <tr><th><button>Dolphin</button></th>
-                <td>Dolphin Device Image</td></tr>
+                  <td>Dolphin Device Image</td></tr>
                 <tr><th><button>B</button></th>
-                <td>Dolphin Device Image Build</td></tr>
+                  <td>Dolphin Device Image Build</td></tr>
                 <tr><th><button>Be</button></th>
-                <td>Dolphin Device Image Build (Engineering)</td></tr>
+                  <td>Dolphin Device Image Build (Engineering)</td></tr>
                 <tr><th><button>N</button></th>
-                <td>Dolphin Device Image Nightly</td></tr>
+                  <td>Dolphin Device Image Nightly</td></tr>
                 <tr><th><button>Ne</button></th>
-                <td>Dolphin Device Image Nightly (Engineering)</td></tr>
+                  <td>Dolphin Device Image Nightly (Engineering)</td></tr>
                 <tr><th><button>Flame</button></th>
-                <td>Flame Device Image</td></tr>
+                  <td>Flame Device Image</td></tr>
                 <tr><th><button>B</button></th>
-                <td>Flame Device Image Build</td></tr>
+                  <td>Flame Device Image Build</td></tr>
                 <tr><th><button>Be</button></th>
-                <td>Flame Device Image Build (Engineering)</td></tr>
+                  <td>Flame Device Image Build (Engineering)</td></tr>
                 <tr><th><button>N</button></th>
-                <td>Flame Device Image Nightly</td></tr>
+                  <td>Flame Device Image Nightly</td></tr>
                 <tr><th><button>Ne</button></th>
-                <td>Flame Device Image Nightly (Engineering)</td></tr>
+                  <td>Flame Device Image Nightly (Engineering)</td></tr>
                 <tr><th><button>Flame-KK</button></th>
-                <td>Flame KitKat Device Image</td></tr>
+                  <td>Flame KitKat Device Image</td></tr>
                 <tr><th><button>B</button></th>
-                <td>Flame KitKat Device Image Build</td></tr>
+                  <td>Flame KitKat Device Image Build</td></tr>
                 <tr><th><button>Be</button></th>
-                <td>Flame KitKat Device Image Build (Engineering)</td></tr>
+                  <td>Flame KitKat Device Image Build (Engineering)</td></tr>
                 <tr><th><button>N</button></th>
-                <td>Flame KitKat Device Image Nightly</td></tr>
+                  <td>Flame KitKat Device Image Nightly</td></tr>
                 <tr><th><button>Ne</button></th>
-                <td>Flame KitKat Device Image Nightly (Engineering)</td></tr>
+                  <td>Flame KitKat Device Image Nightly (Engineering)</td></tr>
                 <tr><th><button>Buri/Hamachi</button></th>
-                <td>Buri/Hamachi Device Image</td></tr>
+                  <td>Buri/Hamachi Device Image</td></tr>
                 <tr><th><button>B</button></th>
-                <td>Hamachi Device Image Build</td></tr>
+                  <td>Hamachi Device Image Build</td></tr>
                 <tr><th><button>Be</button></th>
-                <td>Hamachi Device Image Build (Engineering)</td></tr>
+                  <td>Hamachi Device Image Build (Engineering)</td></tr>
                 <tr><th><button>N</button></th>
-                <td>Hamachi Device Image Nightly</td></tr>
+                  <td>Hamachi Device Image Nightly</td></tr>
                 <tr><th><button>Ne</button></th>
-                <td>Hamachi Device Image Nightly (Engineering)</td></tr>
+                  <td>Hamachi Device Image Nightly (Engineering)</td></tr>
                 <tr><th><button>Helix</button></th>
-                <td>Helix Device Image</td></tr>
+                  <td>Helix Device Image</td></tr>
                 <tr><th><button>B</button></th>
-                <td>Helix Device Image Build</td></tr>
+                  <td>Helix Device Image Build</td></tr>
                 <tr><th><button>Be</button></th>
-                <td>Helix Device Image Build (Engineering)</td></tr>
+                  <td>Helix Device Image Build (Engineering)</td></tr>
                 <tr><th><button>N</button></th>
-                <td>Helix Device Image Nightly</td></tr>
+                  <td>Helix Device Image Nightly</td></tr>
                 <tr><th><button>Ne</button></th>
-                <td>Helix Device Image Nightly (Engineering)</td></tr>
+                  <td>Helix Device Image Nightly (Engineering)</td></tr>
                 <tr><th><button>Inari</button></th>
-                <td>Inari Device Image</td></tr>
+                  <td>Inari Device Image</td></tr>
                 <tr><th><button>B</button></th>
-                <td>Inari Device Image Build</td></tr>
+                  <td>Inari Device Image Build</td></tr>
                 <tr><th><button>Be</button></th>
-                <td>Inari Device Image Build (Engineering)</td></tr>
+                  <td>Inari Device Image Build (Engineering)</td></tr>
                 <tr><th><button>N</button></th>
-                <td>Inari Device Image Nightly</td></tr>
+                  <td>Inari Device Image Nightly</td></tr>
                 <tr><th><button>Ne</button></th>
-                <td>Inari Device Image Nightly (Engineering)</td></tr>
+                  <td>Inari Device Image Nightly (Engineering)</td></tr>
                 <tr><th><button>Leo</button></th>
-                <td>Leo Device Image</td></tr>
+                  <td>Leo Device Image</td></tr>
                 <tr><th><button>B</button></th>
-                <td>Leo Device Image Build</td></tr>
+                  <td>Leo Device Image Build</td></tr>
                 <tr><th><button>Be</button></th>
-                <td>Leo Device Image Build (Engineering)</td></tr>
+                  <td>Leo Device Image Build (Engineering)</td></tr>
                 <tr><th><button>N</button></th>
-                <td>Leo Device Image Nightly</td></tr>
+                  <td>Leo Device Image Nightly</td></tr>
                 <tr><th><button>Ne</button></th>
-                <td>Leo Device Image Nightly (Engineering)</td></tr>
+                  <td>Leo Device Image Nightly (Engineering)</td></tr>
                 <tr><th><button>Nexus 4</button></th>
-                <td>Nexus 4 Device Image</td></tr>
+                  <td>Nexus 4 Device Image</td></tr>
                 <tr><th><button>B</button></th>
-                <td>Nexus 4 Device Image Build</td></tr>
+                  <td>Nexus 4 Device Image Build</td></tr>
                 <tr><th><button>Be</button></th>
-                <td>Nexus 4 Device Image Build (Engineering)</td></tr>
+                  <td>Nexus 4 Device Image Build (Engineering)</td></tr>
                 <tr><th><button>N</button></th>
-                <td>Nexus 4 Device Image Nightly</td></tr>
+                  <td>Nexus 4 Device Image Nightly</td></tr>
                 <tr><th><button>Ne</button></th>
-                <td>Nexus 4 Device Image Nightly (Engineering)</td></tr>
+                  <td>Nexus 4 Device Image Nightly (Engineering)</td></tr>
                 <tr><th><button>Tarako</button></th>
-                <td>Tarako Device Image</td></tr>
+                  <td>Tarako Device Image</td></tr>
                 <tr><th><button>B</button></th>
-                <td>Tarako Device Image Build</td></tr>
+                  <td>Tarako Device Image Build</td></tr>
                 <tr><th><button>Be</button></th>
-                <td>Tarako Device Image Build (Engineering)</td></tr>
+                  <td>Tarako Device Image Build (Engineering)</td></tr>
                 <tr><th><button>N</button></th>
-                <td>Tarako Device Image Nightly</td></tr>
+                  <td>Tarako Device Image Nightly</td></tr>
                 <tr><th><button>Ne</button></th>
-                <td>Tarako Device Image Nightly (Engineering)</td></tr>
+                  <td>Tarako Device Image Nightly (Engineering)</td></tr>
                 <tr><th><button>Unagi</button></th>
-                <td>Unagi Device Image</td></tr>
+                  <td>Unagi Device Image</td></tr>
                 <tr><th><button>B</button></th>
-                <td>Unagi Device Image Build</td></tr>
+                  <td>Unagi Device Image Build</td></tr>
                 <tr><th><button>Be</button></th>
-                <td>Unagi Device Image Build (Engineering)</td></tr>
+                  <td>Unagi Device Image Build (Engineering)</td></tr>
                 <tr><th><button>N</button></th>
-                <td>Unagi Device Image Nightly</td></tr>
+                  <td>Unagi Device Image Nightly</td></tr>
                 <tr><th><button>Ne</button></th>
-                <td>Unagi Device Image Nightly (Engineering)</td></tr>
+                  <td>Unagi Device Image Nightly (Engineering)</td></tr>
                 <tr><th><button>Wasabi</button></th>
-                <td>Wasabi Device Image</td></tr>
+                  <td>Wasabi Device Image</td></tr>
                 <tr><th><button>B</button></th>
-                <td>Wasabi Device Image Build</td></tr>
+                  <td>Wasabi Device Image Build</td></tr>
                 <tr><th><button>N</button></th>
-                <td>Wasabi Device Image Nightly</td></tr>
+                  <td>Wasabi Device Image Nightly</td></tr>
                 <tr><th><button>Unknown</button></th>
-                <td>Unknown Device Image</td></tr>
+                  <td>Unknown Device Image</td></tr>
                 <tr><th><button>B</button></th>
-                <td>Unknown B2G Device Image Build</td></tr>
+                  <td>Unknown B2G Device Image Build</td></tr>
                 <tr><th><button>Be</button></th>
-                <td>Unknown B2G Device Image Build (Engineering)</td></tr>
+                  <td>Unknown B2G Device Image Build (Engineering)</td></tr>
                 <tr><th><button>N</button></th>
-                <td>Unknown B2G Device Image Nightly</td></tr>
+                  <td>Unknown B2G Device Image Nightly</td></tr>
                 <tr><th><button>Ne</button></th>
-                <td>Unknown B2G Device Image Nightly (Engineering)</td></tr>
-            </table>
-        </div>
-    </div>
-
-
-</div>
-<div class="col-xs-6">
-    <div class="panel panel-default">
-        <div class="panel-heading"><h3>Tests</h3></div>
-        <div class="panel-body panel-spacing">
-            <table id="legend-tests" class="help-btn-sm help-btn-desc">
-                <tr><th><button>Mb</button></th>
-                <td>Mozbase Unit Tests</td></tr>
-                <tr><th><button>M</button></th>
-                <td>Mochitest</td></tr>
-                <tr><th><button>bc</button></th>
-                <td>Mochitest Browser Chrome</td></tr>
-                <tr><th><button>dt</button></th>
-                <td>Mochitest DevTools Browser Chrome</td></tr>
-                <tr><th><button>gl</button></th>
-                <td>Mochitest WebGL</td></tr>
-                <tr><th><button>JP</button></th>
-                <td>Mochitest Jetpack</td></tr>
-                <tr><th><button>mc</button></th>
-                <td>Mochitest Metro Browser Chrome</td></tr>
-                <tr><th><button>oth</button></th>
-                <td>Mochitest Other</td></tr>
-                <tr><th><button>M-e10s</button></th>
-                <td>Mochitest e10s</td></tr>
-                <tr><th><button>M-csb</button></th>
-                <td>Mochitest csb</td></tr>
-                <tr><th><button>M-oop</button></th>
-                <td>Mochitest OOP</td></tr>
-                <tr><th><button>rc</button></th>
-                <td>Robocop</td></tr>
-                <tr><th><button>w</button></th>
-                <td>Webapprt Content</td></tr>
-                <tr><th><button>wc</button></th>
-                <td>Webapprt Chrome</td></tr>
-                <tr><th><button>C</button></th>
-                <td>Crashtest</td></tr>
-                <tr><th><button>Cipc</button></th>
-                <td>Crashtest IPC</td></tr>
-                <tr><th><button>J</button></th>
-                <td>JSReftest</td></tr>
-                <tr><th><button>R</button></th>
-                <td>Reftest</td></tr>
-                <tr><th><button>R-e10s</button></th>
-                <td>Reftest e10s</td></tr>
-                <tr><th><button>Rs-oop</button></th>
-                <td>Reftest Sanity OOP</td></tr>
-                <tr><th><button>Ripc</button></th>
-                <td>Reftest IPC</td></tr>
-                <tr><th><button>Ro</button></th>
-                <td>Reftest OMTC</td></tr>
-                <tr><th><button>Rs</button></th>
-                <td>Reftest Sanity</td></tr>
-                <tr><th><button>Ru</button></th>
-                <td>Reftest Unaccelerated</td></tr>
-                <tr><th><button>W</button></th>
-                <td>W3C Web Platform Tests</td></tr>
-                <tr><th><button>Wr</button></th>
-                <td>W3C Web Platform Reftests</td></tr>
-                <tr><th><button>I</button></th>
-                <td>Android Instrumentation Tests</td></tr>
-                <tr><th><button>Ba</button></th>
-                <td>Android Instrumentation Background</td></tr>
-                <tr><th><button>Br</button></th>
-                <td>Android Instrumentation Browser</td></tr>
-                <tr><th><button>Cpp</button></th>
-                <td>CPP Unit Tests</td></tr>
-                <tr><th><button>Jit</button></th>
-                <td>JIT Tests</td></tr>
-                <tr><th><button>JP</button></th>
-                <td>Jetpack SDK Test</td></tr>
-                <tr><th><button>Gb</button></th>
-                <td>Gaia Build Test</td></tr>
-                <tr><th><button>Gbu</button></th>
-                <td>Gaia Build Unit Test</td></tr>
-                <tr><th><button>Gij</button></th>
-                <td>Gaia JS Integration Test</td></tr>
-                <tr><th><button>Gij-oop</button></th>
-                <td>Gaia JS Integration Test OOP</td></tr>
-                <tr><th><button>Gip</button></th>
-                <td>Gaia Python Integration Tests</td></tr>
-                <tr><th><button>a</button></th>
-                <td>Gaia Python Accessibility Integration Tests</td></tr>
-                <tr><th><button>f</button></th>
-                <td>Gaia Python Functional Integration Tests</td></tr>
-                <tr><th><button>u</button></th>
-                <td>Gaia Python Integration Unit Tests</td></tr>
-                <tr><th><button>Gip-oop</button></th>
-                <td>Gaia Python Integration Tests OOP</td></tr>
-                <tr><th><button>Gu</button></th>
-                <td>Gaia Unit Test</td></tr>
-                <tr><th><button>Gu-oop</button></th>
-                <td>Gaia Unit Test OOP</td></tr>
-                <tr><th><button>Li</button></th>
-                <td>Linter Test</td></tr>
-                <tr><th><button>Mn</button></th>
-                <td>Marionette Framework Unit Tests</td></tr>
-                <tr><th><button>Mnw</button></th>
-                <td>Marionette WebAPI Tests</td></tr>
-                <tr><th><button>S</button></th>
-                <td>Android x86 Test Set</td></tr>
-                <tr><th><button>Sets</button></th>
-                <td>Android x86 Test Combos</td></tr>
-                <tr><th><button>X</button></th>
-                <td>XPCShell</td></tr>
-                <tr><th><button>Z</button></th>
-                <td>Mozmill</td></tr>
-                <tr><th><button>T</button></th>
-                <td>Talos Performance</td></tr>
-                <tr><th><button>T-e10s</button></th>
-                <td>Talos Performance e10s</td></tr>
-                <tr><th><button>cm</button></th>
-                <td>Talos canvasmark</td></tr>
-                <tr><th><button>c</button></th>
-                <td>Talos chrome</td></tr>
-                <tr><th><button>d</button></th>
-                <td>Talos dromaeojs</td></tr>
-                <tr><th><button>g1</button></th>
-                <td>Talos g1</td></tr>
-                <tr><th><button>o</button></th>
-                <td>Talos other</td></tr>
-                <tr><th><button>p</button></th>
-                <td>Talos paint</td></tr>
-                <tr><th><button>rck2</button></th>
-                <td>Talos robocheck2</td></tr>
-                <tr><th><button>rp</button></th>
-                <td>Talos robopan</td></tr>
-                <tr><th><button>rpr</button></th>
-                <td>Talos roboprovider</td></tr>
-                <tr><th><button>s</button></th>
-                <td>Talos svg</td></tr>
-                <tr><th><button>tp</button></th>
-                <td>Talos tp</td></tr>
-                <tr><th><button>tpn</button></th>
-                <td>Talos tp nochrome</td></tr>
-                <tr><th><button>ts</button></th>
-                <td>Talos ts</td></tr>
-                <tr><th><button>tsp</button></th>
-                <td>Talos tspaint</td></tr>
-                <tr><th><button>x</button></th>
-                <td>Talos xperf</td></tr>
-                <tr><th><button>U</button></th>
-                <td>Unknown Unit Test</td></tr>
-                <tr><th><button>?</button></th>
-                <td>Unknown</td></tr>
-            </table>
-        </div>
-    </div>
-</div>
-<div class="col-xs-12">
-    <div class="panel panel-default">
-            <div class="panel-heading"><h3>URL Query String Parameters</h3></div>
-            <div class="panel-body panel-spacing">
-                <table id="queryparams">
-                    <tr>
-                      <td><span class="queryparam">nojobs</span></td>
-                      <td>Load result sets and revisions without loading any job results.</td>
-                      <td><span class="queryparam">&nojobs</span></td>
-                    </tr>
-                    <tr>
-                      <td><span class="queryparam">fromchange</span></td>
-                      <td>Specify the earliest revision hash in the resultset range.</td>
-                      <td><span class="queryparam">&fromchange=a12ca6c8b89b</span></td>
-                    </tr>
-                    <tr>
-                      <td><span class="queryparam">tochange</span></td>
-                      <td>Specify the latest revision hash in the resultset range.</td>
-                      <td><span class="queryparam">&tochange=3215c7fc090b</span></td>
-                    </tr>
-                    <tr>
-                      <td><span class="queryparam">startdate</span></td>
-                      <td>Specify the earliest date in the resultset range.</td>
-                      <td><span class="queryparam">&startdate=2015-02-18</span></td>
-                    </tr>
-                    <tr>
-                      <td><span class="queryparam">enddate</span></td>
-                      <td>Specify the latest date in the resultset range.</td>
-                      <td><span class="queryparam">&enddate=2015-02-21</span></td>
-                    </tr>
-                </table>
+                  <td>Unknown B2G Device Image Nightly (Engineering)</td></tr>
+              </table>
             </div>
-    </div>
-</div>
-</div>
+          </div>
+        </div>
 
-<div class="panel-footer userguide-footer">
-  <div class="col-xs-6">
-    <div>Some icons by
-      <a href="http://www.freepik.com" title="Freepik">Freepik</a> from
-      <a href="http://www.flaticon.com" title="Flaticon">www.flaticon.com</a> licensed under
-      <a href="http://creativecommons.org/licenses/by/3.0/"
-         title="Creative Commons BY 3.0">CC BY 3.0</a>
-    </div>
-  </div>
-  <div class="col-xs-6">
-    <a class="midgray pull-right"
-       href="https://whatsdeployed.paas.allizom.org/?owner=mozilla&amp;repo=treeherder&amp;name[]=Heroku-prototype&amp;url[]=https://treeherder-heroku.herokuapp.com/revision.txt&amp;name[]=Stage&amp;url[]=https://treeherder.allizom.org/revision.txt&amp;name[]=Prod&amp;url[]=https://treeherder.mozilla.org/revision.txt">What's Deployed?</a>
-  </div>
-</div>
+        <!-- Tests table -->
+        <div class="col-xs-6">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h3>Tests</h3>
+            </div>
+            <div class="panel-body panel-spacing">
+              <table id="legend-tests" class="ug-btn-sm ug-btn-desc">
+                <tr><th><button>Mb</button></th>
+                  <td>Mozbase Unit Tests</td></tr>
+                <tr><th><button>M</button></th>
+                  <td>Mochitest</td></tr>
+                <tr><th><button>bc</button></th>
+                  <td>Mochitest Browser Chrome</td></tr>
+                <tr><th><button>dt</button></th>
+                  <td>Mochitest DevTools Browser Chrome</td></tr>
+                <tr><th><button>gl</button></th>
+                  <td>Mochitest WebGL</td></tr>
+                <tr><th><button>JP</button></th>
+                  <td>Mochitest Jetpack</td></tr>
+                <tr><th><button>mc</button></th>
+                 <td>Mochitest Metro Browser Chrome</td></tr>
+                <tr><th><button>oth</button></th>
+                  <td>Mochitest Other</td></tr>
+                <tr><th><button>M-e10s</button></th>
+                  <td>Mochitest e10s</td></tr>
+                <tr><th><button>M-csb</button></th>
+                  <td>Mochitest csb</td></tr>
+                <tr><th><button>M-oop</button></th>
+                  <td>Mochitest OOP</td></tr>
+                <tr><th><button>rc</button></th>
+                  <td>Robocop</td></tr>
+                <tr><th><button>w</button></th>
+                  <td>Webapprt Content</td></tr>
+                <tr><th><button>wc</button></th>
+                  <td>Webapprt Chrome</td></tr>
+                <tr><th><button>C</button></th>
+                  <td>Crashtest</td></tr>
+                <tr><th><button>Cipc</button></th>
+                  <td>Crashtest IPC</td></tr>
+                <tr><th><button>J</button></th>
+                  <td>JSReftest</td></tr>
+                <tr><th><button>R</button></th>
+                  <td>Reftest</td></tr>
+                <tr><th><button>R-e10s</button></th>
+                  <td>Reftest e10s</td></tr>
+                <tr><th><button>Rs-oop</button></th>
+                  <td>Reftest Sanity OOP</td></tr>
+                <tr><th><button>Ripc</button></th>
+                  <td>Reftest IPC</td></tr>
+                <tr><th><button>Ro</button></th>
+                  <td>Reftest OMTC</td></tr>
+                <tr><th><button>Rs</button></th>
+                  <td>Reftest Sanity</td></tr>
+                <tr><th><button>Ru</button></th>
+                  <td>Reftest Unaccelerated</td></tr>
+                <tr><th><button>W</button></th>
+                  <td>W3C Web Platform Tests</td></tr>
+                <tr><th><button>Wr</button></th>
+                  <td>W3C Web Platform Reftests</td></tr>
+                <tr><th><button>I</button></th>
+                  <td>Android Instrumentation Tests</td></tr>
+                <tr><th><button>Ba</button></th>
+                  <td>Android Instrumentation Background</td></tr>
+                <tr><th><button>Br</button></th>
+                  <td>Android Instrumentation Browser</td></tr>
+                <tr><th><button>Cpp</button></th>
+                  <td>CPP Unit Tests</td></tr>
+                <tr><th><button>Jit</button></th>
+                  <td>JIT Tests</td></tr>
+                <tr><th><button>JP</button></th>
+                  <td>Jetpack SDK Test</td></tr>
+                <tr><th><button>Gb</button></th>
+                  <td>Gaia Build Test</td></tr>
+                <tr><th><button>Gbu</button></th>
+                  <td>Gaia Build Unit Test</td></tr>
+                <tr><th><button>Gij</button></th>
+                  <td>Gaia JS Integration Test</td></tr>
+                <tr><th><button>Gij-oop</button></th>
+                  <td>Gaia JS Integration Test OOP</td></tr>
+                <tr><th><button>Gip</button></th>
+                  <td>Gaia Python Integration Tests</td></tr>
+                <tr><th><button>a</button></th>
+                  <td>Gaia Python Accessibility Integration Tests</td></tr>
+                <tr><th><button>f</button></th>
+                  <td>Gaia Python Functional Integration Tests</td></tr>
+                <tr><th><button>u</button></th>
+                  <td>Gaia Python Integration Unit Tests</td></tr>
+                <tr><th><button>Gip-oop</button></th>
+                  <td>Gaia Python Integration Tests OOP</td></tr>
+                <tr><th><button>Gu</button></th>
+                  <td>Gaia Unit Test</td></tr>
+                <tr><th><button>Gu-oop</button></th>
+                  <td>Gaia Unit Test OOP</td></tr>
+                <tr><th><button>Li</button></th>
+                  <td>Linter Test</td></tr>
+                <tr><th><button>Mn</button></th>
+                  <td>Marionette Framework Unit Tests</td></tr>
+                <tr><th><button>Mnw</button></th>
+                  <td>Marionette WebAPI Tests</td></tr>
+                <tr><th><button>S</button></th>
+                  <td>Android x86 Test Set</td></tr>
+                <tr><th><button>Sets</button></th>
+                  <td>Android x86 Test Combos</td></tr>
+                <tr><th><button>X</button></th>
+                  <td>XPCShell</td></tr>
+                <tr><th><button>Z</button></th>
+                  <td>Mozmill</td></tr>
+                <tr><th><button>T</button></th>
+                  <td>Talos Performance</td></tr>
+                <tr><th><button>T-e10s</button></th>
+                  <td>Talos Performance e10s</td></tr>
+                <tr><th><button>cm</button></th>
+                  <td>Talos canvasmark</td></tr>
+                <tr><th><button>c</button></th>
+                  <td>Talos chrome</td></tr>
+                <tr><th><button>d</button></th>
+                  <td>Talos dromaeojs</td></tr>
+                <tr><th><button>g1</button></th>
+                  <td>Talos g1</td></tr>
+                <tr><th><button>o</button></th>
+                  <td>Talos other</td></tr>
+                <tr><th><button>p</button></th>
+                  <td>Talos paint</td></tr>
+                <tr><th><button>rck2</button></th>
+                  <td>Talos robocheck2</td></tr>
+                <tr><th><button>rp</button></th>
+                  <td>Talos robopan</td></tr>
+                <tr><th><button>rpr</button></th>
+                  <td>Talos roboprovider</td></tr>
+                <tr><th><button>s</button></th>
+                  <td>Talos svg</td></tr>
+                <tr><th><button>tp</button></th>
+                  <td>Talos tp</td></tr>
+                <tr><th><button>tpn</button></th>
+                  <td>Talos tp nochrome</td></tr>
+                <tr><th><button>ts</button></th>
+                  <td>Talos ts</td></tr>
+                <tr><th><button>tsp</button></th>
+                  <td>Talos tspaint</td></tr>
+                <tr><th><button>x</button></th>
+                  <td>Talos xperf</td></tr>
+                <tr><th><button>U</button></th>
+                  <td>Unknown Unit Test</td></tr>
+                <tr><th><button>?</button></th>
+                  <td>Unknown</td></tr>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
 
-</div>
+      <!-- Query string params -->
+      <div class="row">
+        <div class="col-xs-12">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h3>URL Query String Parameters</h3>
+            </div>
+            <div class="panel-body panel-spacing">
+              <table id="queryparams">
+                <tr>
+                  <td><span class="queryparam">nojobs</span></td>
+                  <td>Load result sets and revisions without loading any job results.</td>
+                  <td><span class="queryparam">&nojobs</span></td>
+                </tr>
+                <tr>
+                  <td><span class="queryparam">fromchange</span></td>
+                    <td>Specify the earliest revision hash in the resultset range.</td>
+                  <td><span class="queryparam">&fromchange=a12ca6c8b89b</span></td>
+                </tr>
+                <tr>
+                  <td><span class="queryparam">tochange</span></td>
+                  <td>Specify the latest revision hash in the resultset range.</td>
+                  <td><span class="queryparam">&tochange=3215c7fc090b</span></td>
+                </tr>
+                <tr>
+                  <td><span class="queryparam">startdate</span></td>
+                  <td>Specify the earliest date in the resultset range.</td>
+                  <td><span class="queryparam">&startdate=2015-02-18</span></td>
+                </tr>
+                <tr>
+                  <td><span class="queryparam">enddate</span></td>
+                  <td>Specify the latest date in the resultset range.</td>
+                  <td><span class="queryparam">&enddate=2015-02-21</span></td>
+                </tr>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    <!-- End of interior panels -->
+    </div>
+
+    <!-- Credits and Whats Deployed -->
+    <div class="panel-footer ug-footer">
+      <div class="col-xs-6">
+        <div>Some icons by
+          <a href="http://www.freepik.com" title="Freepik">Freepik</a> from
+          <a href="http://www.flaticon.com" title="Flaticon">www.flaticon.com</a> licensed under
+            <a href="http://creativecommons.org/licenses/by/3.0/"
+             title="Creative Commons BY 3.0">CC BY 3.0</a>
+        </div>
+      </div>
+      <div class="col-xs-6">
+        <a class="midgray pull-right"
+           href="https://whatsdeployed.paas.allizom.org/?owner=mozilla&amp;repo=treeherder&amp;name[]=Heroku-prototype&amp;url[]=https://treeherder-heroku.herokuapp.com/revision.txt&amp;name[]=Stage&amp;url[]=https://treeherder.allizom.org/revision.txt&amp;name[]=Prod&amp;url[]=https://treeherder.mozilla.org/revision.txt">What's Deployed?</a>
+      </div>
+    </div>
+
+  <!-- End of content panel -->
+  </div>
 </body>
 </html>


### PR DESCRIPTION
This fixes Bugzilla bug [1202476](https://bugzilla.mozilla.org/show_bug.cgi?id=1202476).

This moves remaining help aka. userguide css from treeherder.css to userguide.css, consolidates the naming of `.help-` to `.ug-`, converts all of userguide.html to 2-space indent, and makes a few small fixes along the way.

Post change we have the same layout as before except the lower two Builds and Tests panels are correct children of the the main panel body div, so they are now as wide as they should be (like the Notation and Shortcuts panels).

Proposed (unchanged):
![proposed](https://cloud.githubusercontent.com/assets/3660661/9738131/1a7a8c70-5618-11e5-85f4-2d0e375de364.jpg)

And yes, we still have open bug [1053203](https://bugzilla.mozilla.org/show_bug.cgi?id=1053203) for dealing with the lengthy Builds/Tests tables and moving them to some more appropriate place, eg. readthedocs, or elsewhere.

Tested on OSX 10.10.5:
Release **43.0a1 (2015-09-07)**
Chrome Latest Release **45.0.2454.85 (64-bit)**

Everything seems fine in local testing.

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/946)
<!-- Reviewable:end -->
