### PR TITLE
Bug 1201989 - Reduce space consumption in Sheriff/Filter panels

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -92,6 +92,7 @@ input:focus::-moz-placeholder {
     border: 1px solid black;
     max-height: 400px;
     overflow-y: auto;
+    font-size: 12px;
 }
 
 .th-top-nav-options-panel .th-option-heading {
@@ -131,6 +132,15 @@ input:focus::-moz-placeholder {
 
 #jobFilterField {
     width: 200px;
+}
+
+/* Will remove these when we redo the Filter panel layout in bug 1202003 */
+#filter .th-option-heading input {
+    margin: 0;
+}
+
+#filter .checkbox-inline input {
+    margin: 1px 0 0 -16px;
 }
 
 .field-filter-form {
@@ -181,11 +191,11 @@ input:focus::-moz-placeholder {
 }
 
 .sheriff-panel-exclusion-profiles-row td:first-child {
-  width: 133px;
+  width: 119px;
 }
 
 .sheriff-panel-job-exclusions-row td:first-child {
-  width: 155px;
+  width: 138px;
 }
 
 /**

--- a/ui/partials/main/thFilterPanel.html
+++ b/ui/partials/main/thFilterPanel.html
@@ -70,13 +70,13 @@
         <a ng-click="createFieldFilter()"
            title="Create new field filter">new</a> to filter by a specific job field
       </span>
-      <h4>
+      <h5>
         <div class="label label-default field-filter"
              ng-repeat="filter in fieldFilters">{{::fieldChoices[filter.field].name}}: "{{::getFilterValue(filter.field, filter.value)}}"
           <a ng-click="removeFilter($index)"
              title="Delete this filter"><i class="glyphicon glyphicon-remove"></i></a>
         </div>
-      </h4>
+      </h5>
     </div>
     <div class="field-filter-form" ng-show="newFieldFilter">
       <form novalidate class="form-inline" role="form">


### PR DESCRIPTION
This fixes Bugzilla bug [1201989](https://bugzilla.mozilla.org/show_bug.cgi?id=1201989)

This reduces the font sizes (14px to 12px) in the Sheriff and Filter panels. Some minor tweaks to improve the alignment checkboxes, although I anticipating those tweaks being replaced in [1202003](https://bugzilla.mozilla.org/show_bug.cgi?id=1202003).

Current (Sheriff):
![sheriffpanelcurrent](https://cloud.githubusercontent.com/assets/3660661/9743217/3000aadc-5633-11e5-9761-4703d1273628.jpg)

Proposed:
![sheriffpanelproposed](https://cloud.githubusercontent.com/assets/3660661/9743227/3c2853d2-5633-11e5-8629-595a8b291b4a.jpg)

Current (Filter):
![filterpanelcurrent](https://cloud.githubusercontent.com/assets/3660661/9743274/6cf670a2-5633-11e5-8ec5-19f27aa5711f.jpg)

Proposed:
![filterpanelproposed](https://cloud.githubusercontent.com/assets/3660661/9743308/98c43426-5633-11e5-9102-58665b541566.jpg)

At some browser widths like above, it will also delay initial container flow.

Tested on OSX 10.10.5:
Release **43.0a1 (2015-09-07)**
Chrome Latest Release **45.0.2454.85 (64-bit)**

Everything seems fine in local testing.

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/949)
<!-- Reviewable:end -->
