### PR TITLE
Bug 1203165 - Remove settings that are identical to the Django defaults

### DIFF
--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -38,18 +38,13 @@ RABBITMQ_PORT = os.environ.get("TREEHERDER_RABBITMQ_PORT", "5672")
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = os.environ.get("TREEHERDER_DJANGO_SECRET_KEY")
 
-ADMINS = []  # TBD
-MANAGERS = ADMINS
-
 SITE_ID = 1
 ROOT_URLCONF = "treeherder.webapp.urls"
 WSGI_APPLICATION = 'treeherder.webapp.wsgi.application'
 
 TIME_ZONE = "America/Los_Angeles"
-LANGUAGE_CODE = "en-us"
 USE_I18N = False
 USE_L10N = True
-USE_TZ = False
 
 SERVE_MINIFIED_UI = os.environ.get("SERVE_MINIFIED_UI") == "True"
 WHITENOISE_ROOT = path("..", "dist" if SERVE_MINIFIED_UI else "ui")
@@ -59,14 +54,6 @@ STATIC_URL = "/static/"
 
 MEDIA_ROOT = path("media")
 MEDIA_URL = "/media/"
-
-# Additional locations of static files
-STATICFILES_DIRS = []
-STATICFILES_FINDERS = [
-    "django.contrib.staticfiles.finders.FileSystemFinder",
-    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
-    # "django.contrib.staticfiles.finders.DefaultStorageFinder",
-]
 
 # Create hashed+gzipped versions of assets during collectstatic,
 # which will then be served by WhiteNoise with a suitable max-age.
@@ -172,8 +159,6 @@ LOGGING = {
         }
     }
 }
-
-TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 CELERY_QUEUES = (
     Queue('default', Exchange('default'), routing_key='default'),


### PR DESCRIPTION
Removes settings that are identical to the Django 1.8 defaults:

https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-ADMINS
https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-MANAGERS
https://docs.djangoproject.com/en/1.8/ref/settings/#language-code
https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-USE_TZ
https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-STATICFILES_DIRS
https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-STATICFILES_FINDERS
https://docs.djangoproject.com/en/1.8/ref/settings/#test-runner

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/952)
<!-- Reviewable:end -->
