### PR TITLE
Bug 1203255 - Keep sheriff 'Add' buttons well spaced

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -88,8 +88,8 @@ input:focus::-moz-placeholder {
 
 .th-top-nav-options-panel {
     background-color: white;
-    padding: 10px;
-    border: 1px solid black;
+    padding: 10px 10px 0;
+    border-bottom: 1px solid black;
     max-height: 400px;
     overflow-y: auto;
     font-size: 12px;
@@ -166,6 +166,14 @@ input:focus::-moz-placeholder {
 /**
   Sheriff panel
 */
+
+.exclusion-container {
+    padding-bottom: 10px;
+}
+
+.add-new-exclusion {
+    margin-bottom: 10px;
+}
 
 .add-new-exclusion input.ng-invalid.ng-dirty {
     border-color: #B94A48;

--- a/ui/partials/main/thSheriffPanel.html
+++ b/ui/partials/main/thSheriffPanel.html
@@ -12,7 +12,7 @@
 
   <!-- Exclusion profiles -->
   <div ng-if="view == 'exclusion_profile_list'"
-       class="th-inline-option-group add-new-exclusion">
+       class="th-inline-option-group exclusion-container">
     <p ng-if="profiles.length == 0">No profile available</p>
     <table ng-if="profiles.length > 0" class="table table-condensed">
       <tr>
@@ -94,7 +94,7 @@
 
   <!-- Job exclusions -->
   <div ng-if="view == 'job_exclusion_list'"
-       class="th-inline-option-group add-new-exclusion">
+       class="th-inline-option-group exclusion-container">
     <p ng-if="exclusions.length == 0">No exclusion available</p>
     <table ng-if="exclusions.length > 0"
            class="table table-condensed">


### PR DESCRIPTION
This fixes Bugzilla bug [1203255](https://bugzilla.mozilla.org/show_bug.cgi?id=1203255).

This prevents the Add exclusion and Add profile buttons get a bit clipped at the bottom of the Sheriff panel, particularly at narrower browser widths. @camd feel free to let me know if you think there's a better way to do this. I kept thinking it should have been simpler.

I suppose I also could have wrapped this change into [PR949](https://github.com/mozilla/treeherder/pull/949) but I'll rebase this PR on top of that one when it is merged.

Here's before (note the blue 'Add exclusion' button):
![clipped1](https://cloud.githubusercontent.com/assets/3660661/9772583/221e035a-570b-11e5-8a74-ec973325b0ee.jpg)

Proposed (a uniform 10px border bottom for all elements that reach the bottom of the panel):
![proposed](https://cloud.githubusercontent.com/assets/3660661/9772594/309c196c-570b-11e5-8d48-60aa0e0b9fdf.jpg)

This now includes the Add/Update dialogues:
![adddialogue](https://cloud.githubusercontent.com/assets/3660661/9772615/44c73444-570b-11e5-8735-7308fb98cb30.jpg)

Everything seems fine in local testing, web-server (for viewing real exclusion content), and gunicorn (for accessing the Add dialogues).

Tested on OSX 10.10.5:
Release **43.0a1 (2015-09-09)**
Chrome Latest Release **45.0.2454.85 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/954)
<!-- Reviewable:end -->
