### PR TITLE
Bug 1187394 - Move backfill ui to Job details actionbar

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -252,7 +252,9 @@ input:focus::-moz-placeholder {
     color: #68aae2;
 }
 
-.icon-green:hover {
+.icon-green:hover,
+.icon-green:focus,
+.icon-green:active {
     color: #0de00d !important;
 }
 
@@ -330,7 +332,6 @@ div#info-panel .navbar {
     font-size:12px;
     min-height: 33px;
     min-width: initial;
-    overflow: hidden;
     z-index: 100;
 }
 
@@ -412,7 +413,18 @@ div#info-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
 
 #job-details-actionbar, #job-tabs-navbar {
     min-height: 33px;
-    overflow-y: auto;
+}
+
+.actionbar-nav > li:not(:first-child) {
+    /* Preserve left side padding on our first icon but keep others compact */
+    padding: 0 !important;
+}
+
+.actionbar-menu {
+    /* We have to override non-responsive bootstrap for correct styling */
+    margin-top: 1px !important;
+    margin-left: 6px;
+    border-radius: 4px !important;
 }
 
 .pinned-job-count {
@@ -420,7 +432,8 @@ div#info-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
 }
 
 #job-details-panel {
-    width: 260px;
+    width: 250px;
+    min-width: 250px;
 }
 
 #job-details-pane > ul {
@@ -461,7 +474,7 @@ div#info-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
     -webkit-flex: 1 6;
     flex: 1 6;
     padding:0px;
-    min-width: 500px;
+    min-width: 565px;
 }
 
 #info-panel nav.navbar.navbar-sub {

--- a/ui/partials/main/thJobDetailsRetriggerMenu.html
+++ b/ui/partials/main/thJobDetailsRetriggerMenu.html
@@ -1,0 +1,6 @@
+<li>
+  <a ng-click="retriggerJob([selectedJob])">Retrigger job</a>
+</li>
+<li>
+  <a ng-click="backfillJob()">Backfill job</a>
+</li>

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -12,7 +12,7 @@
   <div id="job-details-panel">
     <div id="job-details-actionbar">
       <nav class="navbar navbar-dark">
-        <ul class="nav navbar-nav">
+        <ul class="nav navbar-nav actionbar-nav">
 
           <li ng-repeat="job_log_url in job_log_urls">
             <a ng-if="job_log_url.parse_status == 'parsed'"
@@ -92,14 +92,17 @@
               <span class="fa fa-times-circle cancel-job-icon"></span>
             </a>
           </li>
-          <li>
-            <a title="Retrigger this job"
-               class="icon-green"
-               href="" prevent-default-on-left-click
-               target="_blank"
-               ng-click="retriggerJob([selectedJob])">
-              <span class="fa fa-repeat"></span>
+          <li class="dropdown">
+            <a id="retriggerLabel"
+               ng-attr-title="{{user.loggedin ? 'Retrigger or backfill this job' :
+                              'Must be logged in to retrigger a job'}}"
+               ng-class="user.loggedin ? 'icon-green' : 'disabled'" href="" data-toggle="dropdown">
+              <span class="fa fa-repeat"></span>&nbsp
+              <span class="fa fa-angle-down lightgray"></span>
             </a>
+            <ul class="dropdown-menu actionbar-menu" role="menu" aria-labelledby="retriggerLabel"
+                ng-include src="'partials/main/thJobDetailsRetriggerMenu.html'">
+            </ul>
           </li>
           <li ng-if="isReftest()" ng-repeat="job_log_url in job_log_urls">
             <a title="Launch the Reftest Analyser in a new window"
@@ -209,13 +212,6 @@
         <li class="small" ng-repeat="line in job_details" ng-if="line.value == 'Inspect Task'">
           <label>Taskcluster:</label>
           <span><a href="{{line.url}}" target="_blank">{{line.value}}</a></span>
-        </li>
-        <li class="small" ng-click="backfillJob()" ng-show="user.is_staff">
-          <label>
-            <a title="Trigger this jobtype on previous pushes.">
-                Backfill this job
-            </a>
-          </label>
         </li>
       </ul>
 


### PR DESCRIPTION
This work fixes Bugzilla bug [1187394](https://bugzilla.mozilla.org/show_bug.cgi?id=1187394)

This moves the blue "**Backfill this job**" text link in the bottom of the job details pane, into a unified menu in the job details actionbar.

Current (see bottom left):
![current](https://cloud.githubusercontent.com/assets/3660661/9818013/3231efa8-5874-11e5-8629-b0adb5e25328.jpg)

Proposed (see retrigger icon in the actionbar, with added dropdown menu arrow):
![backfilljobproposed1a](https://cloud.githubusercontent.com/assets/3660661/9818024/43b0fcc4-5874-11e5-9562-2cf1a65ef67a.jpg)

Proposed (posted menu):
![backfilljobproposed1](https://cloud.githubusercontent.com/assets/3660661/9818049/6882827a-5874-11e5-8645-1f1db9ea51e6.jpg)

To facilitate this we needed to remove two overflow hidden properties, so the bootstrap menu could post below the actionbar and not be obscured underneath the job details pane container. The net of this, is we have a fixed minimum size for the job details pane and the job tabs containers, and they don't collapse down as they did prior. That being said, as super narrow widths it's questionable how useful that was anyway. @KWierso has given preliminary thumbs up on this approach. Since at super narrow widths even with the prior implementation, the action bar icons would be covered up and the Pinboard^ collapse expand button would disappear anyway.

So here's the new minimum size where everything is visible. If you go narrower, the browser just progressively covers up the [x] and Pinboard^ buttons, which seems fine.

![backfilljobproposedminsize](https://cloud.githubusercontent.com/assets/3660661/9818178/25403c4a-5875-11e5-8a4d-3fa5ad3e6ddd.jpg)

I've also added a disabled class to the retrigger icon when the user isn't logged in, and we suppress the menus. We provide a suitable tooltip in this condition, telling the user they need to log in. In contrast on production we allow the user to click the button, *then* thNotify them they can't retrigger because they weren't logged in. So it seems to make sense to save them the experience.

I've yet to figure out a way to override the blue menu treatment on the new menu, as the parent nav element assigns it bootstrap-non-responsive properties that seem resistant to change :) There is also a brief flash where the icon turns grey when exiting the menu, but it may be related.

Tested on OSX 10.10.5:
Release **43.0a1 (2015-09-10)**
Chrome Latest Release **45.0.2454.85 (64-bit)**

Adding @camd for review and @KWierso and @vaibhavmagarwal for visibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/958)
<!-- Reviewable:end -->
