### PR TITLE
Bug 1200025 - selected Title Case for supplementary menus

### DIFF
--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -17,14 +17,14 @@
     <li><a target="_blank" ignore-job-clear-on-click
            href="" prevent-default-on-left-click
            ng-show="user.is_staff"
-           ng-click="triggerMissingJobs(resultset.revision)">Trigger Missing Jobs</a></li>
+           ng-click="triggerMissingJobs(resultset.revision)">Trigger Missing jobs</a></li>
     <li><a target="_blank" ignore-job-clear-on-click
            href="" prevent-default-on-left-click
            ng-show="user.is_staff"
-           ng-click="triggerAllTalosJobs(resultset.revision)">Trigger All Talos Jobs</a></li>
+           ng-click="triggerAllTalosJobs(resultset.revision)">Trigger All Talos jobs</a></li>
     <li><a target="_blank" ignore-job-clear-on-click
            href="" prevent-default-on-left-click
-           ng-click="openRevisionListWindow()">Revision URL List</a></li>
+           ng-click="openRevisionListWindow()">Revision URL list</a></li>
     <li><a target="_blank" ignore-job-clear-on-click
            href="" prevent-default-on-left-click
            ng-click="setLocationSearchParam('tochange', resultset.revision)">Set as top of range</a></li>

--- a/ui/partials/main/thPinboardPanel.html
+++ b/ui/partials/main/thPinboardPanel.html
@@ -81,7 +81,7 @@
     <ul class="dropdown-menu pull-right" role="menu">
       <li><a ng-click="saveClassificationOnly()">Save classification only</a></li>
       <li><a ng-click="saveBugsOnly()">Save bugs only</a></li>
-      <li><a ng-click="retriggerAllPinnedJobs()">Retrigger All</a></li>
+      <li><a ng-click="retriggerAllPinnedJobs()">Retrigger all</a></li>
       <li><a ng-click="unPinAll()">Clear all</a></li>
     </ul>
   </div>

--- a/ui/partials/main/thWatchedRepoInfoDropDown.html
+++ b/ui/partials/main/thWatchedRepoInfoDropDown.html
@@ -9,13 +9,13 @@
   <li class="divider" ng-show="reason || message_of_the_day"></li>
   <li class="watched-repo-dropdown-item">
     <a href="https://treestatus.mozilla.org/{{::treeStatus}}"
-       target="_blank">tree status</a>
+       target="_blank">Tree Status</a>
   </li>
   <li class="watched-repo-dropdown-item">
-    <a href="{{::pushlog}}" target="_blank">pushlog</a>
+    <a href="{{::pushlog}}" target="_blank">Pushlog</a>
   </li>
   <li class="watched-repo-dropdown-item">
     <a href="https://api.pub.build.mozilla.org/clobberer/?branch={{::name}}"
-       target="_blank">clobberer</a>
+       target="_blank">Clobberer</a>
   </li>
 </ul>


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1200025](https://bugzilla.mozilla.org/show_bug.cgi?id=1200025).

This makes some minor tweaks for our current menu presentation logic:

* Title Case for the main navbar menus
* Modified title Case or Sentence case, for small supplementary menus as applicable

Here's the changes and their new appearance:

Main navbar - Tree Status, Pushlog, Clobberer:

![treestatusmenu](https://cloud.githubusercontent.com/assets/3660661/9881653/ef375f66-5b9e-11e5-9425-d892700fa4d8.jpg)
Supplementary menu - Pinboard - Save menu

![pinboardmenu](https://cloud.githubusercontent.com/assets/3660661/9881679/0d61d610-5b9f-11e5-8c61-f7b991f4bb60.jpg)

Supplementary menu - Resultset bar - Revision URL list
![resultsetmenu](https://cloud.githubusercontent.com/assets/3660661/9881705/332bdcb0-5b9f-11e5-9923-cbe111d605a5.jpg)

I had tried full Title Case for the pinboard Save menu, and to be honest it did seem a bit overwhelming graphically. If folks feel strongly I can make it full Title Case though.

Revision URL list - is also going to disappear soon anyway, with @KWierso's open PR https://github.com/mozilla/treeherder/pull/677 to retire it.

Tested on OSX 10.10.5:
Release **43.0a1 (2015-09-15)**
Chrome Latest Release **45.0.2454.85 (64-bit)**

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/964)
<!-- Reviewable:end -->
