### PR TITLE
Bug 1201852 - Allow E125 and E129 errors in pyflakes.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ exclude = .git,__pycache__,.vagrant,node_modules
 # https://github.com/jcrocholl/pep8/blob/8ca030e2d8f6d377631bae69a18307fb2d051049/pep8.py#L68
 # Our additions...
 # E501: line too long
-ignore = E121,E123,E126,E226,E24,E704,E501
+ignore = E121,E123,E125,E126,E129,E226,E24,E704,E501
 max-line-length = 140
 
 [flake8]
@@ -14,5 +14,5 @@ max-line-length = 140
 exclude = .git,__pycache__,.vagrant,node_modules
 # The ignore list for pep8 above, plus our own PyFlakes addition:
 # F403: 'from module import *' used; unable to detect undefined names
-ignore = E121,E123,E126,E226,E24,E704,E501,F403
+ignore = E121,E123,E125,E126,E129,E226,E24,E704,E501,F403
 max-line-length = 140


### PR DESCRIPTION
These forbid common constructs, notably
if (foo and
    bar):

which has no basis in PEP8 or sanity. In modern pyflakes only E129 would have to be permitted
but Ubuntu 14.04 has an older version which lumps this in with some other cases in E125.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/965)
<!-- Reviewable:end -->
