### PR TITLE
Bug 1205049 - make FailureLine bulk creation atomic

### DIFF
--- a/treeherder/log_parser/management/commands/store_error_summary.py
+++ b/treeherder/log_parser/management/commands/store_error_summary.py
@@ -2,6 +2,7 @@ from cStringIO import StringIO
 from itertools import islice
 
 import requests
+from django.db import transaction
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 from mozlog import reader
@@ -44,7 +45,8 @@ class Command(BaseCommand):
                 if not job_id:
                     raise CommandError('No job found with guid %s in the %s repository' % (args[1], args[2]))
 
-            FailureLine.objects.bulk_create(
-                [FailureLine(repository=repository, job_guid=args[1], **failure_line)
-                 for failure_line in log_iter]
-            )
+            with transaction.atomic():
+                FailureLine.objects.bulk_create(
+                    [FailureLine(repository=repository, job_guid=args[1], **failure_line)
+                     for failure_line in log_iter]
+                )


### PR DESCRIPTION
This should prevent occurences of IntegrityError happening when something goes wrong
on first insertion and the task is retried.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/966)
<!-- Reviewable:end -->
