### PR TITLE
Bug 1117556 - Add read only sheriff panel for non-staff

### DIFF
--- a/ui/css/treeherder-navbar-panels.css
+++ b/ui/css/treeherder-navbar-panels.css
@@ -110,16 +110,43 @@
   color: #bababa;
 }
 
+.sheriff-panel-btn {
+  padding-left: 0;
+  padding-right: 0;
+  border: none;
+  background: #fff;
+}
+
+.sheriff-panel-text-btn {
+  color: #337ab7;
+}
+
+.sheriff-panel-text-btn-disabled {
+  color: initial;
+}
+
 .sheriff-panel-excluded-job {
   margin-right: 20px;
 }
 
 .sheriff-panel-exclusion-profiles-row td:first-child {
-  /* Aligns second column nicely under Job exclusion tab */
+  /* Aligns second column nicely under Exclusion profile tab
+   * if no profile is longer than the default container */
   width: 119px;
 }
 
+.sheriff-panel-exclusion-profiles-row td:first-child > button {
+  /* Handle long profile names within the button */
+  white-space: nowrap;
+}
+
 .sheriff-panel-job-exclusions-row td:first-child {
-  /* Aligns second column nicely under Job exclusion tab */
+  /* Aligns second column nicely under Job exclusion tab
+   * if no exclusion is longer than the default container */
   width: 138px;
+}
+
+.sheriff-panel-job-exclusions-row td:first-child > button {
+  /* Handle long exclusion names within the button */
+  white-space: nowrap;
 }

--- a/ui/partials/main/thGlobalTopNavPanel.html
+++ b/ui/partials/main/thGlobalTopNavPanel.html
@@ -15,7 +15,7 @@
 
     <span class="navbar-right">
       <!-- Sheriffing Button -->
-      <span ng-show="user.is_staff">
+      <span ng-show="user.loggedin">
         <span class="btn btn-view-nav btn-right-navbar nav-menu-btn"
              ng-class="{'active': (isSheriffPanelShowing)}"
              ng-click="setSheriffPanelShowing(!isSheriffPanelShowing)"

--- a/ui/partials/main/thSheriffPanel.html
+++ b/ui/partials/main/thSheriffPanel.html
@@ -21,38 +21,53 @@
       <tr ng-repeat="profile in profiles"
           class="sheriff-panel-exclusion-profiles-row">
         <td>
-          <a ng-click="init_profile_update(profile)"
-             class="pointable"
-             title="Change the members in this profile">
+          <!-- Profile name button -->
+          <button ng-click="init_profile_update(profile)"
+                  ng-disabled="!user.is_staff"
+                  class="sheriff-panel-btn pointable"
+                  ng-class="!user.is_staff ? 'sheriff-panel-text-btn-disabled' :
+                           'sheriff-panel-text-btn'"
+                  ng-attr-title="{{!user.is_staff ? '' : 'Change the members in this profile'}}">
             {{::profile.name}}
-          </a>
+          </button>
         </td>
         <td class="text-center">
-          <span ng-click="set_default_profile(profile)"
-                ng-class="profile.is_default ? 'fa-check-circle text-success' :
-                          'fa-circle-o xlightgray'"
-                class="fa pointable"
-                title="{{profile.is_default ? 'Default profile' :
-                       'Set this as the default profile'}}">
-          </span>
+          <!-- Default profile button -->
+          <button ng-click="set_default_profile(profile)"
+                  ng-disabled="!user.is_staff"
+                  ng-hide="!profile.is_default && !user.is_staff"
+                  ng-class="profile.is_default ? 'fa-check-circle text-success' :
+                           'fa-circle-o xlightgray'"
+                  class="fa sheriff-panel-btn pointable"
+                  ng-attr-title="{{profile.is_default ? 'Default profile' :
+                                 'Set this as the default profile'}}">
+          </button>
         </td>
         <td>
-          <a ng-click="init_exclusion_update(exclusions_map[exclusion])"
-             ng-repeat="exclusion in profile.exclusions"
-             class="th-inline-option-group sheriff-panel-excluded-job pointable"
-             title="Modify this exclusion">
-            &#8226; {{::exclusions_map[exclusion].name}}</a>
+          <!-- Exclusion names buttons -->
+          <button ng-click="init_exclusion_update(exclusions_map[exclusion])"
+                  ng-repeat="exclusion in profile.exclusions"
+                  ng-disabled="!user.is_staff"
+                  class="th-inline-option-group sheriff-panel-btn sheriff-panel-excluded-job pointable"
+                  ng-class="!user.is_staff ? 'sheriff-panel-text-btn-disabled' :
+                           'sheriff-panel-text-btn'"
+                  ng-attr-title="{{!user.is_staff ? '' : 'Modify this exclusion'}}">
+            &#8226; {{::exclusions_map[exclusion].name}}</button>
         </td>
         <td>
-          <span ng-click="delete_profile(profile)"
-                class="sheriff-panel-delete-icon hover-warning pointable"
-                title="Delete this profile">
+          <!-- Delete profile button -->
+          <button ng-click="delete_profile(profile)"
+                  ng-if="user.is_staff"
+                  class="sheriff-panel-btn sheriff-panel-delete-icon hover-warning pointable"
+                  title="Delete this profile">
             <i class="fa fa-times-circle"></i>
-          </span>
+          </button>
         </td>
       </tr>
     </table>
     <button ng-click="init_profile_add()" type="button"
+            ng-disabled="!user.is_staff"
+            ng-attr-title="{{!user.is_staff ? 'Staff permissions required' : ''}}"
             class="btn btn-sm btn-primary">Add profile</button>
   </div>
 
@@ -109,11 +124,15 @@
       <tr ng-repeat="exclusion in exclusions"
           class="sheriff-panel-job-exclusions-row">
         <td>
-          <a ng-click="init_exclusion_update(exclusion)"
-             class="pointable"
-             title="Modify this exclusion">
+          <!-- Exclusion name button -->
+          <button ng-click="init_exclusion_update(exclusion)"
+                  ng-disabled="!user.is_staff"
+                  class="sheriff-panel-btn pointable"
+                  ng-class="!user.is_staff ? 'sheriff-panel-text-btn-disabled' :
+                           'sheriff-panel-text-btn'"
+                  ng-attr-title="{{!user.is_staff ? '' : 'Modify this exclusion'}}">
             {{::exclusion.name}}
-          </a>
+          </button>
         </td>
         <td>{{::exclusion.description}}</td>
         <td><th-truncated-list numvisible="2" elements="exclusion.info.repos" /></td>
@@ -122,6 +141,7 @@
         <td><th-truncated-list numvisible="2" elements="exclusion.info.job_types" /></td>
         <td>
           <span ng-click="delete_exclusion(exclusion)"
+                ng-if="user.is_staff"
                 class="sheriff-panel-delete-icon hover-warning pointable"
                 title="Delete this exclusion">
             <i class="fa fa-times-circle"></i>
@@ -130,6 +150,8 @@
       </tr>
     </table>
     <button ng-click="init_exclusion_add()" type="button"
+            ng-disabled="!user.is_staff"
+            ng-attr-title="{{!user.is_staff ? 'Staff permissions required' : ''}}"
             class="btn btn-sm btn-primary">Add exclusion</button>
   </div>
 


### PR DESCRIPTION
This work fixes Bugzilla bug [1117556](https://bugzilla.mozilla.org/show_bug.cgi?id=1117556).

This provides a read-only version of the Sheriff panel for non-staff users. A few points:

* navbar menu access is now `.loggedin` as the UX seems to make sense
* so you get a staged menu experience
* suppressed when not logged in, visible read-only when logged in, editable when staff
* all former spans and anchors have been switched to buttons to facilitate `ng-disable`
* those buttons are styled so the UI will appear unchanged
* we do lose underlining on clickable names during hover, but we plan to hover `fa-pencil` later
* Add/Update panels remain unchanged since their access is prevented via the disabled Add buttons

PR Testing:
If you have the ability to push a branch to stage and modify your own `.is_staff` on stage back end for testing purposes, that might be the best way to test the two states? During the work I was changing .is_staff in the markup to t/f or sometimes .loggedin as needed, and ran under ./web-server pointing at stage. That way it read all the real profiles, where under vagrant you just have your own.

Here's the changes:

Exclusion profiles (non-staff, read-only, default profile checkbox only, no delete ability)
![nonstaffreadonly](https://cloud.githubusercontent.com/assets/3660661/9911057/44912c60-5c6e-11e5-8cf1-52a7bd411c06.jpg)

Add buttons (non-staff, read-only, disabled and tooltip to cue the user)

![nonstaffreadonlyaddbuttons](https://cloud.githubusercontent.com/assets/3660661/9911155/c17fc272-5c6e-11e5-89e3-f9a09b2a244a.jpg)

Exclusion profiles (staff, unchanged, full access)
![staffeditable](https://cloud.githubusercontent.com/assets/3660661/9912205/4a9ac5c0-5c74-11e5-9eb4-37e945550e59.jpg)

Job exclusions (non-staff, read-only, names not editable, ***(n) others*** data tooltips accessible)
![nonstaffreadonlyexclusions](https://cloud.githubusercontent.com/assets/3660661/9911179/dd9f9e6e-5c6e-11e5-9cbb-16de1354f355.jpg)

Everything seems fine in local testing, but this could use some double-checking of the exclusion lists in both staff conditions.

Tested on OSX 10.10.5:
Release **43.0a1 (2015-09-15)**
Chrome Latest Release **45.0.2454.93 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/969)
<!-- Reviewable:end -->
