### PR TITLE
 	Bug 1205412 - Fix highlighting of revisions in perf graphs

### DIFF
--- a/ui/js/graphs.js
+++ b/ui/js/graphs.js
@@ -330,11 +330,7 @@ perf.controller('GraphsCtrl', [
                                         function(resultSets) {
                                             var resultSetId = resultSets[0].id;
                                             var j = series.flotSeries.resultSetData.indexOf(resultSetId);
-                                            var seriesToaddHighlight = _.find(
-                                                $scope.seriesList, function(sr) {
-                                                    return sr.signature == series.signature;
-                                                });
-                                            seriesToaddHighlight.highlightedPoints.push(j);
+                                            series.highlightedPoints.push(j);
                                         });
                             }
                             return null;


### PR DESCRIPTION
When we had two series with the same signature on different branches, we
would incorrectly highlight two points on the same graph instead of
highlighting the relevant revisions on each. This used to work because
we associated a branch with each series signature, so could identify
them uniquely before, but we don't do this any more. Fortunately the fix here
is simple: just use the previously defined series instead of trying to
look it up all over again.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/970)
<!-- Reviewable:end -->
