### PR TITLE
Bug 1205871 - Add support to transition completed jobs to retry

### DIFF
--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1153,11 +1153,22 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             try:
                 job = datum['job']
 
-                job_guid = str(job['job_guid'])
-                states[str(job['state'])].append(job_guid)
+                # Retry is a special case here (isn't it everywhere?).  A retry
+                # could come in after a job is complete.  For Buildbot, we
+                # don't usually get that.  It changes from running to retry
+                # almost instantly.  But in order to be idempotent from other
+                # sources that won't have the special retry guid like
+                # ``sha_timestamp``, we need to handle that a job can come
+                # in complete/failed then get updated to complete/retry and
+                # it will be updated.  If we remove the job from the list of
+                # updates here because we detect it is already completed,
+                # then it will never get updated to retry.
+                if job['result'] != "retry":
+                    job_guid = str(job['job_guid'])
+                    states[str(job['state'])].append(job_guid)
 
-                # index this place in the ``data`` object
-                data_idx.append(job_guid)
+                    # index this place in the ``data`` object
+                    data_idx.append(job_guid)
 
             except Exception:
                 data_idx.append("skipped")
@@ -1194,6 +1205,11 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             for i, guid in enumerate(data_idx):
                 if guid not in existing_guids:
                     new_data.append(data[i])
+        else:
+            # if we had a list of jobs that were, say, all retry, then we would
+            # have no placeholders and new_data would be empty when it should
+            # be the unchanged data.
+            new_data = data
 
         return new_data
 
@@ -1489,6 +1505,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 job_state,
                 start_timestamp,
                 end_timestamp,
+                result,
                 job_state,
                 get_guid_root(job_guid)
             ])

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -248,7 +248,7 @@
                 `start_timestamp` = ?,
                 `end_timestamp` = ?
                 WHERE
-                    `state` != 'completed'
+                    (`state` != 'completed' OR ? = 'retry')
                 AND ? <> 'pending'
                 AND `id` = ?",
 


### PR DESCRIPTION
In buildbot, a job transitions directly from ``running`` to ``retry`` in the
cases where it will be retried automatically.  But for upcoming Buildbot
Bridge and Task Cluster jobs that we will ingest, we need to be able to make
the transition from ``completed`` to ``retry``.

This change involves special case handling that patches an already ugly
ingestion scenario.  When we no longer ingest from Buildbot directly, we
can refactor ``jobs.py`` to remove these work-arounds.  A bit part of that
is that there is no unique job id for a Buildbot job to know when it has
transitioned.  Each time a job is retried, it has the same request_id and
request_time.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/972)
<!-- Reviewable:end -->
