### PR TITLE
 	Bug 1206118 - Fix document title when navigating away from perfherder graphs

### DIFF
--- a/ui/js/graphs.js
+++ b/ui/js/graphs.js
@@ -439,6 +439,19 @@ perf.controller('GraphsCtrl', [
 
         $scope.repoName = $stateParams.projectId;
 
+        function updateDocumentTitle() {
+            if ($scope.seriesList.length) {
+                window.document.title = ($scope.seriesList[0].name + " " +
+                                         $scope.seriesList[0].platform +
+                                         " (" + $scope.seriesList[0].projectName +
+                                         ")");
+                if ($scope.seriesList.length > 1)
+                    window.document.title += " and others";
+            } else {
+                window.document.title = $state.current.title;
+            }
+        }
+
         function updateDocument() {
             $state.transitionTo('graphs', {
                 timerange: $scope.myTimerange.value,
@@ -466,16 +479,8 @@ perf.controller('GraphsCtrl', [
             }, {location: true, inherit: true,
                 relative: $state.$current,
                 notify: false});
-            if ($scope.seriesList.length) {
-                window.document.title = ($scope.seriesList[0].name + " " +
-                                         $scope.seriesList[0].platform +
-                                         " (" + $scope.seriesList[0].projectName +
-                                         ")");
-                if ($scope.seriesList.length > 1)
-                    window.document.title += " and others";
-            } else {
-                window.document.title = "Perfherder Graphs";
-            }
+
+            updateDocumentTitle();
         }
 
         function getSeriesData(series) {
@@ -536,6 +541,8 @@ perf.controller('GraphsCtrl', [
                     });
                     $q.all($scope.seriesList.map(getSeriesData)).then(function() {
                         plotGraph();
+                        updateDocumentTitle();
+
                         if ($scope.selectedDataPoint) {
                             showTooltip($scope.selectedDataPoint);
                         }

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -6,6 +6,7 @@ perf.config(function($compileProvider, $stateProvider, $urlRouterProvider) {
     $compileProvider.debugInfoEnabled(false);
 
     $stateProvider.state('graphs', {
+        title: 'Perfherder Graphs',
         templateUrl: 'partials/perf/graphsctrl.html',
         url: '/graphs?timerange&series&highlightedRevisions&zoom',
         controller: 'GraphsCtrl'
@@ -18,6 +19,7 @@ perf.config(function($compileProvider, $stateProvider, $urlRouterProvider) {
         url: '/comparesubtest?originalProject&originalRevision&newProject&newRevision&originalSignature&newSignature&hideMinorChanges',
         controller: 'CompareSubtestResultsCtrl'
     }).state('comparechooser', {
+        title: 'Perfherder Compare',
         templateUrl: 'partials/perf/comparechooserctrl.html',
         url: '/comparechooser?originalProject&originalRevision&newProject&newRevision',
         controller: 'CompareChooserCtrl'
@@ -25,7 +27,13 @@ perf.config(function($compileProvider, $stateProvider, $urlRouterProvider) {
 
     $urlRouterProvider.otherwise('/graphs?timerange&series&highlightedRevisions&zoom');
 }).run(['$rootScope', '$state', '$stateParams',
-        function ($rootScope,   $state,   $stateParams) {
+        function ($rootScope, $state, $stateParams) {
             $rootScope.$state = $state;
             $rootScope.$stateParams = $stateParams;
+
+            $rootScope.$on('$stateChangeSuccess', function() {
+                if ($state.current.title) {
+                    window.document.title = $state.current.title;
+                }
+            });
         }]);


### PR DESCRIPTION
… graphs

Before we would persist the name of the series when navigating to (e.g.)
compare. Let's fix this in a robust way.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/976)
<!-- Reviewable:end -->
