### PR TITLE
Bug 1205906 - Adds JSON schema YML to validate text_log_summary artifacts

### DIFF
--- a/docs/data_validation.rst
+++ b/docs/data_validation.rst
@@ -1,0 +1,27 @@
+.. _schema_validation:
+
+Schema Validation
+=================
+
+Some data types in Treeherder will have JSON Schema files in the form of YAML.
+You can use these files to validate your data prior to submission to be sure
+it is in the right format.
+
+You can find all our data schemas in the `schemas`_ folder.
+
+To validate your file against a ``yml`` file, you can use something like the
+following example code:
+
+.. code-block:: python
+
+    import yaml
+    import json_schema
+
+    schema = yaml.load("schemas/text-log-summary-artifact.yml")
+    jsonschema.validate(data, schema)
+
+This will give output telling you if your ``data`` element passes validation,
+and, if not, exactly where it is out of compliance.
+
+
+.. _schemas: https://github.com/mozilla/treeherder/tree/master/schemas

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Contents:
    common_tasks
    submitting_data
    retrieving_data
+   data_validation
    troubleshooting
    ui/index
 

--- a/docs/submitting_data.rst
+++ b/docs/submitting_data.rst
@@ -475,6 +475,8 @@ Treeherder will detect what data is submitted in the ``TreeherderCollection``
 and generate the necessary artifacts accordingly.  The outline below describes
 what artifacts *Treeherder* will generate depending on what has been submitted.
 
+See :ref:`schema_validation` for more info on validating some specialized JSON
+data.
 
 JobCollections
 ^^^^^^^^^^^^^^

--- a/schemas/text-log-summary-artifact.yml
+++ b/schemas/text-log-summary-artifact.yml
@@ -1,0 +1,97 @@
+"$schema": http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  blob:
+    type: object
+    properties:
+      step_data:
+        type: object
+        properties:
+          all_errors:
+            type: array
+            items:
+              type: object
+              properties:
+                line:
+                  type: string
+                linenumber:
+                  type: integer
+              additionalProperties: false
+              required:
+              - line
+              - linenumber
+            additionalItems: false
+          steps:
+            type: array
+            items:
+              type: object
+              properties:
+                errors:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      line:
+                        type: string
+                      linenumber:
+                        type: integer
+                    additionalProperties: false
+                  additionalItems: false
+                name:
+                  type: string
+                started:
+                  type: string
+                  format: date-time
+                started_linenumber:
+                  type: integer
+                finished_linenumber:
+                  type: integer
+                finished:
+                  type: string
+                  format: date-time
+                error_count:
+                  type: integer
+                duration:
+                  type: integer
+                order:
+                  type: integer
+                result:
+                  type: string
+                  enum: [busted, testfailed, exception, success, canceled, unknown, retry, skipped]
+              required:
+              - errors
+              - name
+              - started
+              - started_linenumber
+              - finished_linenumber
+              - finished
+              - error_count
+              - duration
+              - order
+              - result
+              additionalProperties: false
+            additionalItems: false
+          errors_truncated:
+            type: boolean
+        additionalProperties: false
+        required:
+        - all_errors
+        - steps
+        - errors_truncated
+      logurl:
+        type: string
+    additionalProperties: false
+    required:
+    - step_data
+    - logurl
+  type:
+    type: string
+  name:
+    type: string
+  job_guid:
+    type: integer
+additionalProperties: false
+required:
+- blob
+- type
+- name


### PR DESCRIPTION
This PR was going to have endpoints to do this validation.  But based on feedback, I'm just including the raw YML file and we can point people to it so they can validate their ``text_log_summary`` artifacts, if they like.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/978)
<!-- Reviewable:end -->
