### PR TITLE
Bug 1206108 - Split up devDependencies packages into those for testing vs `grunt build`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,13 @@
 
 module.exports = function(grunt) {
 
-    require('load-grunt-tasks')(grunt);
+    if (grunt.option('production')) {
+        // Only load tasks from packages listed under `dependencies`.
+        require('load-grunt-tasks')(grunt, {scope: 'dependencies'});
+    } else {
+        // Load tasks from all packages listed in package.json.
+        require('load-grunt-tasks')(grunt);
+    }
 
     grunt.initConfig({
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -232,16 +232,6 @@ module.exports = function(grunt) {
         }
     });
 
-    grunt.loadNpmTasks('grunt-contrib-clean');
-    grunt.loadNpmTasks('grunt-contrib-copy');
-    grunt.loadNpmTasks('grunt-contrib-concat');
-    grunt.loadNpmTasks('grunt-contrib-cssmin');
-    grunt.loadNpmTasks('grunt-contrib-uglify');
-    grunt.loadNpmTasks('grunt-usemin');
-    grunt.loadNpmTasks('grunt-cache-busting');
-    grunt.loadNpmTasks('grunt-angular-templates');
-    grunt.loadNpmTasks('grunt-html-angular-validate');
-
     // Default tasks
     grunt.registerTask('build', [
         'clean:dist',

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "grunt-contrib-cssmin": "0.12.3",
     "grunt-contrib-uglify": "0.9.1",
     "grunt-usemin": "3.0.0",
-    "load-grunt-tasks": "^3.2.0"
+    "load-grunt-tasks": "3.2.0"
   },
   "devDependencies": {
     "grunt-eslint": "16.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/mozilla/treeherder.git"
   },
-  "devDependencies": {
+  "dependencies": {
     "grunt": "0.4.5",
     "grunt-angular-templates": "0.5.7",
     "grunt-cache-busting": "0.0.11",
@@ -14,17 +14,19 @@
     "grunt-contrib-copy": "0.8.0",
     "grunt-contrib-cssmin": "0.12.3",
     "grunt-contrib-uglify": "0.9.1",
+    "grunt-usemin": "3.0.0",
+    "load-grunt-tasks": "^3.2.0"
+  },
+  "devDependencies": {
     "grunt-eslint": "16.0.0",
     "grunt-html-angular-validate": "0.4.1",
-    "grunt-usemin": "3.0.0",
     "karma": "~0.12.0",
     "karma-cli": "0.0.4",
     "karma-coverage": ">=0.2.0",
     "karma-firefox-launcher": ">=0.1.3",
     "karma-jasmine": "0.1.0",
     "karma-junit-reporter": ">=0.2.1",
-    "karma-ng-scenario": ">=0.1.0",
-    "load-grunt-tasks": "^3.2.0"
+    "karma-ng-scenario": ">=0.1.0"
   },
   "scripts": {
     "test": "karma start tests/ui/config/karma.conf.js --single-run --browsers Firefox"


### PR DESCRIPTION
**1) Separate grunt build npm packages from those for testing**

To run grunt build as part of deploy, we're going to need to npm install the dependencies required for it. However we do not need to install the testing related packages, so by splitting the two between `dependencies` and `devDependencies` we'll have more control. eg: `npm install --production` will only install those under `dependencies`.

See:
https://docs.npmjs.com/files/package.json#dependencies
https://docs.npmjs.com/files/package.json#devdependencies
https://docs.npmjs.com/misc/config#production

**2) Remove unnecessary loadNpmTasks() calls**

Since they're duplicating what the `require('load-grunt-tasks')(grunt)` call is already doing. See:
https://github.com/sindresorhus/load-grunt-tasks/blob/master/readme.md

**3) Add grunt option to skip loading devDependencies tasks**

In production we plan to only install the packages listed under `dependencies` in package.json. However by default load-grunt-tasks loads tasks from packages from `devDependencies` too, which results in warnings if those packages are not installed locally.

To ensure that the local development grunt tasks are still loaded, but that warnings are not shown for missing packages on production, a new option is added to select which packages are loaded. eg:
`grunt build --production`

See:
http://gruntjs.com/api/grunt.option
https://github.com/sindresorhus/load-grunt-tasks/blob/master/readme.md#only-load-from-devdependencies

**4) Pin load-grunt-tasks to v3.2.0**

The previous value of "^3.2.0" is equivalent to "4 > version >= 3.2.0". We should pin to a specific version to stop deployments breaking if a new release doesn't behave as expected. See:
https://nodesource.com/blog/semver-tilde-and-caret

We should also do the same for devDependencies, but let's do that in another bug, since it won't affect production.

--

See individual commits for clearer diffs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/979)
<!-- Reviewable:end -->
