### PR TITLE
 	Bug 1206160 - Add some fast transitions for basic treeherder actions

### DIFF
--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -12,6 +12,7 @@
   vertical-align: 0;
   line-height: 1.32;
   display: none;
+  transition: transform 0.1s;
 }
 
 .group-btn {
@@ -73,8 +74,14 @@
   transform: scale(1.7, 1.7);
 }
 
+@keyframes fadein {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
 .filter-shown {
   display: inline-block;
+  animation: fadein 0.5s;
 }
 
 /*


### PR DESCRIPTION
* Selecting a job (scale up from standard size)
* Expanding a job group (fade in)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/980)
<!-- Reviewable:end -->
