### PR TITLE
Bug 1207163 - Increase min-width to accommodate Talos tab

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -206,7 +206,7 @@ div#info-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
   -webkit-flex: 1 6;
   flex: 1 6;
   padding: 0px;
-  min-width: 565px;
+  min-width: 625px;
 }
 
 #job-tabs-pane {


### PR DESCRIPTION
This fixes Bugzilla bug [1207163](https://bugzilla.mozilla.org/show_bug.cgi?id=1207163).

This increases the min-width of our `job-tabs-panel` to support the 5th *Talos* tab when present and prevent wrapping of the Pinboard^ and Talos content at narrow browser sizes.

Nightly/Release wanted 622, Chrome wanted 623, so we'll play it safe and go with 625 in case someone adds a vertical somewhere.

If the user narrows it further, it just progressively obscures the [x] and Pinboard^ buttons, the same as current master in a 4 tab non-Talos job. But as a side effect it means for non-Talos jobs we aren't as narrow as we could be.

Before:
![before](https://cloud.githubusercontent.com/assets/3660661/10022038/d5beaf7e-6118-11e5-8967-1aeaaae8ba28.jpg)

After:
![after](https://cloud.githubusercontent.com/assets/3660661/10022043/e28fa924-6118-11e5-82e2-1823e15eeb1b.jpg)

Tested on OSX 10.10.5:
Release **43.0a1 (2015-09-21)**
Chrome Latest Release **45.0.2454.99 (64-bit)**

Everything seems fine in local testing.

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/989)
<!-- Reviewable:end -->
