### PR TITLE
Bug 1207197 - Add a cursor property for the Retrigger dropdown

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -90,6 +90,11 @@ div#info-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
   flex-flow: row;
 }
 
+#info-panel-content .dropdown-menu > li > a {
+    /* Explicit addition for our Info-panel menus eg. Retrigger */
+    cursor: pointer;
+}
+
 #job-details-panel, #job-tabs-panel {
   background-color: #fff;
   display: -webkit-flex;


### PR DESCRIPTION
This fixes Bugzilla bug [1207197](https://bugzilla.mozilla.org/show_bug.cgi?id=1207197).

This adds a pointer cursor for any existing or future dropdowns that will exist in the info-panel. I chose not to brute force apply it everywhere, since the main navbar (Infra, Repo, Help) is already inheriting its pointer property correctly via some other bootstrap mojo.

So retrigger/backfill is the only info-panel dropdown at present that receives the change.

![pointercursorretrigger](https://cloud.githubusercontent.com/assets/3660661/10024002/0ad5055a-6123-11e5-9352-738d638dcdd9.jpg)

Tested on OSX 10.10.5:
Release **43.0a1 (2015-09-21)**
Chrome Latest Release **45.0.2454.99 (64-bit)**

Everything seems fine in local testing.

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/991)
<!-- Reviewable:end -->
