### PR TITLE
Bug 1202626 - Stop storing each revision's commit_timestamp

### DIFF
--- a/tests/jobs_test.json
+++ b/tests/jobs_test.json
@@ -34,8 +34,7 @@
             "host_type": "master_host"
         },
         "job_source": {
-            "sql": "SELECT rev.commit_timestamp,
-                           res.push_timestamp,
+            "sql": "SELECT res.push_timestamp,
                            rev.comments,
                            rev.repository_id,
                            rev.revision

--- a/tests/model/derived/conftest.py
+++ b/tests/model/derived/conftest.py
@@ -5,7 +5,6 @@ import pytest
 def revision_params():
     return {
         "author": u"Mauro Doglio - <mdoglio@mozilla.com>",
-        "commit_timestamp": 1365732271,  # this is nullable
         "comments": u"Bug 854583 - Use _pointer_ instead of...",
         "repository": u"mozilla-aurora",
         "revision": u"c91ee0e8a980",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -305,7 +305,6 @@ def unicode_keys(d):
 
 def clean_source_blob_dict(src):
     """Fix a few fields so they're easier to compare"""
-    src["commit_timestamp"] = long(src["commit_timestamp"])
     src["push_timestamp"] = long(src["push_timestamp"])
     return src
 

--- a/tests/ui/mock/resultset_list.json
+++ b/tests/ui/mock/resultset_list.json
@@ -19,7 +19,6 @@
       "revisions": [
         {
           "repository_id": 2,
-          "commit_timestamp": null,
           "author": "john@doe.com",
           "comments": "Back out bug 1071880 for causing bug 1083952.",
           "revision": "acf46fe8b054"
@@ -39,7 +38,6 @@
       "revisions": [
         {
           "repository_id": 2,
-          "commit_timestamp": null,
           "author": "john@doe.com",
           "comments": "Bug 1133254 - Dehandlify shape-updating object methods, allow setting multiple flags on an object at once, r=terrence.",
           "revision": "b1cc2dd3e35c"

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -868,7 +868,6 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                     'author': detail['author'],
                     'repository_id': detail['repository_id'],
                     'comments': detail['comments'],
-                    'commit_timestamp': detail['commit_timestamp']
                 })
 
         return aggregate_details
@@ -1744,11 +1743,6 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                     )
                     repository_id_lookup[rev_datum['repository']] = repository_id
 
-                # We may not have a commit timestamp in the push data
-                commit_timestamp = rev_datum.get(
-                    'commit_timestamp', None
-                )
-
                 # We may not have a comment in the push data
                 comment = rev_datum.get(
                     'comment', None
@@ -1759,7 +1753,6 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                     [rev_datum['revision'],
                      rev_datum['author'],
                      comment,
-                     commit_timestamp,
                      repository_id,
                      rev_datum['revision'],
                      repository_id]

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -116,10 +116,9 @@
                     `revision`,
                     `author`,
                     `comments`,
-                    `commit_timestamp`,
                     `repository_id`
                     )
-                SELECT ?,?,?,?,?
+                SELECT ?,?,?,?
                 FROM DUAL
                 WHERE NOT EXISTS (
                     SELECT `revision`
@@ -648,8 +647,7 @@
                     r.repository_id,
                     r.revision,
                     r.author,
-                    r.comments,
-                    r.commit_timestamp
+                    r.comments
                    FROM revision_map AS rm
                    LEFT JOIN revision AS r ON rm.revision_id = r.id
                    WHERE r.active_status = 'active' AND rm.result_set_id IN (REP0)

--- a/treeherder/model/sql/template_schema/project.sql.tmpl
+++ b/treeherder/model/sql/template_schema/project.sql.tmpl
@@ -377,20 +377,17 @@ DROP TABLE IF EXISTS `revision`;
  *  revision - The revision string associated with the repository
  *  author - The author associated with the revision
  *  comments - The comments associated with the revision
- *  commit_timestamp - Timestamp associated with the commit
  **************************/
 CREATE TABLE `revision` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `revision` varchar(50) COLLATE utf8_bin NOT NULL,
   `author` varchar(150) COLLATE utf8_bin NOT NULL,
   `comments` text DEFAULT NULL,
-  `commit_timestamp` int(11) unsigned default NULL,
   `repository_id` int(11) unsigned NOT NULL,
   `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_revision` (`revision`, `repository_id`),
   KEY `idx_author` (`author`),
-  KEY `idx_commit_timestamp` (`commit_timestamp`),
   KEY `idx_repository_id` (`repository_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION
It's unused in the UI and doesn't add any value, since we're normally much more interested in the push_timestamp.

This can land without causing errors, since the field is DEFAULT NULL, so can be dropped at our leisure later.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/992)
<!-- Reviewable:end -->
