### PR TITLE
 	Bug 1207237 - Fix cursor when hovering over non-selectable job group

### DIFF
--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -4,6 +4,7 @@
 
 .job-group {
   margin: 0 -3px 0 3px;
+  cursor: default;
 }
 
 .job-btn {
@@ -42,7 +43,6 @@
 
 .group-content {
   margin-left: -3px;
-  cursor: pointer;
 }
 
 .group-content::before {


### PR DESCRIPTION
We were applying the "pointer" style, which implied you could select
something when you couldn't before. We should only use that style when
hovering over the job buttons themselves.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/993)
<!-- Reviewable:end -->
