### PR TITLE
Bug 1192407 - Make bug suggestion tooltips show for the whole link

### DIFF
--- a/ui/plugins/failure_summary/main.html
+++ b/ui/plugins/failure_summary/main.html
@@ -17,8 +17,8 @@
                     </a>
                     <a href="{{:: getBugUrl(bug.id) }}"
                        target="_blank">{{::bug.id}}
-                        <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search"
-                              title="{{::bug.summary}}">{{::bug.summary}}
+                        <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search">
+                            {{::bug.summary}}
                         </span>
                     </a>
                 </li>
@@ -42,16 +42,16 @@
                     <a ng-if="bug.resolution === ''"
                        href="{{:: getBugUrl(bug.id) }}"
                        target="_blank">{{::bug.id}}
-                        <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search"
-                              title="{{::bug.summary}}">{{::bug.summary}}
+                        <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search">
+                            {{::bug.summary}}
                         </span>
                     </a>
                     <a ng-if="bug.resolution !== ''"
                        href="{{:: getBugUrl(bug.id) }}"
+                       title="{{::bug.resolution}}"
                        target="_blank"
                        class="deleted">{{::bug.id}}
                         <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search"
-                              title="{{::bug.resolution}} - {{::bug.summary}}"
                               class="deleted">{{::bug.summary}}
                         </span>
                     </a>


### PR DESCRIPTION
Rather than just the summary text. Also removes the redundant bug summary from the title (since it matches the link text) - which means that there is no tooltip to show for bug suggestions unless the bugs are resolved.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/994)
<!-- Reviewable:end -->
