### PR TITLE
Bug 1181153: use the new treestatus in RelengAPI

### DIFF
--- a/tests/ui/unit/controllers/jobs.tests.js
+++ b/tests/ui/unit/controllers/jobs.tests.js
@@ -30,12 +30,14 @@ describe('JobsCtrl', function(){
             getJSONFixture('job_list/job_2.json')
         );
 
-        $httpBackend.whenGET('https://treestatus.mozilla.org/mozilla-central?format=json').respond(
+        $httpBackend.whenGET('https://api.pub.build.mozilla.org/treestatus/trees/mozilla-central').respond(
             {
-                "status": "closed",
-                "message_of_the_day": "See the <a href=\"https://wiki.mozilla.org/Tree_Rules/Inbound\">Inbound tree rules</a> before pushing. <a href=\"https://sheriffs.etherpad.mozilla.org/sheriffing-notes\">Sheriff notes/current issues</a>.",
-                "tree": "mozilla-central",
-                "reason": "Bustage"
+                "result": {
+                    "status": "closed",
+                    "message_of_the_day": "See the <a href=\"https://wiki.mozilla.org/Tree_Rules/Inbound\">Inbound tree rules</a> before pushing. <a href=\"https://sheriffs.etherpad.mozilla.org/sheriffing-notes\">Sheriff notes/current issues</a>.",
+                    "tree": "mozilla-central",
+                    "reason": "Bustage"
+                }
             }
         );
 

--- a/tests/ui/unit/models/resultsets.tests.js
+++ b/tests/ui/unit/models/resultsets.tests.js
@@ -20,13 +20,16 @@ describe('ThResultSetStore', function(){
 
 
 
-        $httpBackend.whenGET('https://treestatus.mozilla.org/mozilla-central?format=json').respond(
+        $httpBackend.whenGET('https://api.pub.build.mozilla.org/treestatus/trees/mozilla-central').respond(
             {
-                "status": "approval required",
-                "message_of_the_day": "I before E",
-                "tree": "mozilla-central",
-                "reason": ""
+                "result": {
+                    "status": "approval required",
+                    "message_of_the_day": "I before E",
+                    "tree": "mozilla-central",
+                    "reason": ""
+                }
             }
+
         );
 
         $httpBackend.whenGET(foregroundPrefix + '/jobs/0/unclassified_failure_count/').respond(

--- a/ui/js/models/repository.js
+++ b/ui/js/models/repository.js
@@ -220,7 +220,7 @@ treeherder.factory('ThRepositoryModel', [
             return {
                 status: "unsupported",
                 message_of_the_day: repoName +
-                    ' is not supported in <a href="https://treestatus.mozilla.org">treestatus.mozilla.org</a>',
+                    ' is not supported in <a href="https://api.pub.build.mozilla.org/treestatus">api.pub.build.mozilla.org/treestatus</a>',
                 reason: "",
                 tree: repoName
             };
@@ -233,8 +233,8 @@ treeherder.factory('ThRepositoryModel', [
         var getErrorTreeStatus = function(repoName) {
             return {
                 status: "error",
-                message_of_the_day: 'Error reaching <a href="https://treestatus.mozilla.org">treestatus.mozilla.org</a>',
-                reason: 'Error reaching <a href="https://treestatus.mozilla.org">treestatus.mozilla.org</a>',
+                message_of_the_day: 'Error reaching <a href="https://api.pub.build.mozilla.org/treestatus">api.pub.build.mozilla.org/treestatus</a>',
+                reason: 'Error reaching <a href="https://api.pub.build.mozilla.org/treestatus">api.pub.build.mozilla.org/treestatus</a>',
                 tree: repoName
             };
         };
@@ -265,7 +265,7 @@ treeherder.factory('ThRepositoryModel', [
                 $log.debug("updateTreeStatus", "getStatus", "updating", repo);
                 treeStatus.get(repo).then(
                     function(data) {
-                        newStatuses[repo] = data.data;
+                        newStatuses[repo] = data.data.result;
                         updateStatusesIfDone();
                     }, function(data) {
                         if (data.data != null) {

--- a/ui/js/services/treestatus.js
+++ b/ui/js/services/treestatus.js
@@ -3,10 +3,10 @@
 treeherder.factory('treeStatus', [
     '$http', '$q',
     function($http, $q) {
-        var urlBase = "https://treestatus.mozilla.org/";
+        var urlBase = "https://api.pub.build.mozilla.org/treestatus/trees/";
 
         var getTreeStatusName = function(name) {
-            // the thunderbird names in treestatus.mozilla.org don't match what
+            // the thunderbird names in api.pub.build.mozilla.org/treestatus don't match what
             // we use, so translate them.  pretty hacky, yes...
             // TODO: Move these to the repository fixture in the service.
             if (name.indexOf("comm-") >= 0 && name !== "try-comm-central") {
@@ -24,7 +24,7 @@ treeherder.factory('treeStatus', [
         var get = function(repoName) {
             var url = urlBase + getTreeStatusName(repoName);
 
-            return $http.get(url, {params: {format: "json"}});
+            return $http.get(url);
         };
 
         return {

--- a/ui/partials/main/thInfraMenu.html
+++ b/ui/partials/main/thInfraMenu.html
@@ -30,7 +30,7 @@
 <li role="presentation" class="divider"></li>
 <li role="presentation" class="dropdown-header">Other</li>
 <li>
-  <a href="https://treestatus.mozilla.org/"
+  <a href="https://api.pub.build.mozilla.org/treestatus/"
      target="_blank">TreeStatus</a>
 </li>
 <li>

--- a/ui/partials/main/thWatchedRepoInfoDropDown.html
+++ b/ui/partials/main/thWatchedRepoInfoDropDown.html
@@ -8,7 +8,7 @@
   </li>
   <li class="divider" ng-show="reason || message_of_the_day"></li>
   <li class="watched-repo-dropdown-item">
-    <a href="https://treestatus.mozilla.org/{{::treeStatus}}"
+    <a href="https://api.pub.build.mozilla.org/treestatus/details/{{::treeStatus}}"
        target="_blank">Tree Status</a>
   </li>
   <li class="watched-repo-dropdown-item">


### PR DESCRIPTION
This updates treeherder to work against the new relengapi-based treestatus.  However, that new treestatus is not yet live, so please review but don't merge!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/995)
<!-- Reviewable:end -->
