### PR TITLE
Bug 1207403 - don't replace existing local.py on vagrant

### DIFF
--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -46,6 +46,7 @@ file {"/var/log/treeherder/":
 }
 
 file {"${PROJ_DIR}/treeherder/settings/local.py":
+     replace => "no",
      content => template("${PROJ_DIR}/puppet/files/treeherder/local.vagrant.py"),
 }
 


### PR DESCRIPTION
Without this line, ``local.py`` will get overwritten every time ``vagrant provision`` is executed. But some folks mike LIKE their ``local.py`` file.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/998)
<!-- Reviewable:end -->
