### PR TITLE
Bug 1206825 - Remove obsolete comment for div.talos-panel

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -428,6 +428,5 @@ div.similar_jobs .left_panel table tr {
  */
 
 div.talos-panel {
-  /* The !important can be removed if/when bug 1094466 is fixed */
   display: block !important;
 }


### PR DESCRIPTION
This fixes Bugzilla bug [1206825](https://bugzilla.mozilla.org/show_bug.cgi?id=1206825).

This `!important` rule is still required after the commented bug was fixed, so we're removing the referencing comment here.

Tested on OSX 10.10.5:
Release **44.0a1 (2015-09-22)**
Chrome Latest Release **45.0.2454.99 (64-bit)**

Everything seems fine in local testing.

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/999)
<!-- Reviewable:end -->
