### PR TITLE
Bug 1207304 - Dynamically set the min-width for job-tabs-panel

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -211,7 +211,12 @@ div#info-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
   -webkit-flex: 1 6;
   flex: 1 6;
   padding: 0px;
-  min-width: 625px;
+  min-width: 565px;
+}
+
+.talos-job-selected {
+  /* Override to optimize all other jobs above at 565px */
+  min-width: 625px !important;
 }
 
 #job-tabs-pane {

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -222,7 +222,8 @@
       </div>
     </div>
   </div>
-  <div id="job-tabs-panel">
+  <div id="job-tabs-panel"
+       ng-class="{'talos-job-selected': tabService.tabs.talos.enabled}">
     <div id="job-tabs-navbar">
       <nav class="navbar navbar-dark">
         <ul class="nav navbar-nav tab-headers">


### PR DESCRIPTION
This fixes Bugzilla bug [1207304](https://bugzilla.mozilla.org/show_bug.cgi?id=1207304).

This adjusts the button wrap-preventing `min-width` of the job-tabs-panel, so that we optimize for Talos and non-Talos jobs. If you select a non-Talos, you can reduce the size of the browser further, while still having view of the Pinboard^ and [x] close icon.

What we'd like to optimize for (non-Talos job, see lower right):

![optimizemaster](https://cloud.githubusercontent.com/assets/3660661/10054550/9a763aa8-61ff-11e5-8880-971ad5db6b9e.jpg)

Proposed (non-Talos job):

![nontalosjob](https://cloud.githubusercontent.com/assets/3660661/10054302/6a237132-61fe-11e5-8c57-bdf4b290733f.jpg)

And Talos job selection is unchanged from master (wider, 625px):

![talosjob](https://cloud.githubusercontent.com/assets/3660661/10054272/48a284ee-61fe-11e5-934e-b4d9436c2047.jpg)

Tested on OSX 10.10.5:
Release **44.0a1 (2015-09-22)**
Chrome Latest Release **45.0.2454.99 (64-bit)**

Everything seems fine in local testing.

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1002)
<!-- Reviewable:end -->
