### PR TITLE
 	Bug 1207816 - Bump default vagrant memory to 2G from 1G

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder ".", "/home/vagrant/treeherder", type: "nfs"
 
   config.vm.provider "virtualbox" do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "1024"]
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
   end
 
   config.vm.define "default", primary: true


### PR DESCRIPTION
It seems like 1G is too little for mysql as it is currently configured,
bumping the default memory on the Vagrant instance is an easy way of
addressing this.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1003)
<!-- Reviewable:end -->
