### PR TITLE
 	Bug 1208086 - Hide links to whatsdeployed

### DIFF
--- a/ui/partials/main/thHelpMenu.html
+++ b/ui/partials/main/thHelpMenu.html
@@ -23,8 +23,11 @@
     <span class="fa fa-github midgray"></span>
     Source</a>
 </li>
+<!-- Disabling whatsdeployed for now -- https://bugzilla.mozilla.org/show_bug.cgi?id=1208086 -->
+<!--
 <li>
   <a href="https://whatsdeployed.paas.allizom.org/?owner=mozilla&amp;repo=treeherder&amp;name[]=Heroku-prototype&amp;url[]=https://treeherder-heroku.herokuapp.com/revision.txt&amp;name[]=Stage&amp;url[]=https://treeherder.allizom.org/revision.txt&amp;name[]=Prod&amp;url[]=https://treeherder.mozilla.org/revision.txt" target="_blank">
     <span class="fa fa-question midgray"></span>
     What's Deployed?</a>
 </li>
+-->

--- a/ui/userguide.html
+++ b/ui/userguide.html
@@ -641,10 +641,13 @@
              title="Creative Commons BY 3.0">CC BY 3.0</a>
         </div>
       </div>
+      <!-- Disabling whatsdeployed for now -- https://bugzilla.mozilla.org/show_bug.cgi?id=1208086 -->
+      <!--
       <div class="col-xs-6">
         <a class="midgray pull-right"
            href="https://whatsdeployed.paas.allizom.org/?owner=mozilla&amp;repo=treeherder&amp;name[]=Heroku-prototype&amp;url[]=https://treeherder-heroku.herokuapp.com/revision.txt&amp;name[]=Stage&amp;url[]=https://treeherder.allizom.org/revision.txt&amp;name[]=Prod&amp;url[]=https://treeherder.mozilla.org/revision.txt">What's Deployed?</a>
       </div>
+      -->
     </div>
 
   <!-- End of content panel -->


### PR DESCRIPTION
It currently doesn't do anything useful. Commenting it out instead of eliminating
it just in case someone wants to bring it back.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1004)
<!-- Reviewable:end -->
