### PR TITLE
Bug 1141569 - Display onscreen keyboard shortcuts

### DIFF
--- a/tests/ui/config/karma.conf.js
+++ b/tests/ui/config/karma.conf.js
@@ -23,6 +23,7 @@ module.exports = function (config) {
             'ui/js/providers.js',
             'ui/js/values.js',
             'ui/js/logviewer.js',
+            'ui/js/userguide.js',
             'ui/js/treeherder_app.js',
             'ui/js/controllers/*.js',
             'ui/js/directives/treeherder/**/*.js',

--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -357,6 +357,24 @@ input:focus::-moz-placeholder {
 }
 
 /*
+ * Onscreen help
+ */
+
+#onscreen-overlay {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    z-index: 10000; /* 1 more than .overlay wait spinners */
+    background: rgba(0, 0, 0, 0.4);
+}
+
+#onscreen-shortcuts {
+    position: relative;
+    top: 130px;
+    left: 16.5%;
+}
+
+/*
  * Clipboard
  *
  * This facilitates copy on hover for

--- a/ui/index.html
+++ b/ui/index.html
@@ -24,8 +24,17 @@
     </head>
     <body ng-controller="MainCtrl" ng-keydown="processKeyboardInput($event)">
         <div id="global-container">
+            <div id="onscreen-overlay" ng-if="onscreenOverlayShowing">
+               <div id="onscreen-shortcuts" ng-if="onscreenShortcutsShowing">
+                 <div class="col-xs-8">
+                    <ng-include src="'partials/main/thShortcutTable.html'"></ng-include>
+                 </div>
+               </div>
+            </div>
             <div id="global-navbar-container">
-                <ng-include id="th-global-top-nav-panel" src="'partials/main/thGlobalTopNavPanel.html'"></ng-include>
+                <ng-include id="th-global-top-nav-panel"
+                            src="'partials/main/thGlobalTopNavPanel.html'">
+                </ng-include>
             </div>
             <div id="th-global-content" class="th-global-content"
                  ng-click="clearJobOnClick($event)">

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -59,7 +59,8 @@ treeherderApp.controller('MainCtrl', [
             'b',     // Pin selected job and add related bug
             'c',     // Pin selected job and add classification
             'f',     // Enter a quick filter
-            'l'      // Open the logviewer for the selected job
+            'l',     // Open the logviewer for the selected job
+            '?'      // Display onscreen keyboard shortcuts
         ];
 
         // Make the single key exclusions available
@@ -216,6 +217,7 @@ treeherderApp.controller('MainCtrl', [
                 $scope.$evalAsync($scope.setSettingsPanelShowing(false));
                 $scope.$evalAsync($scope.setSheriffPanelShowing(false));
                 $scope.$evalAsync($scope.closeJob());
+                $scope.$evalAsync($scope.setOnscreenShortcutsShowing(false));
             });
 
             // Shortcut: clear the pinboard
@@ -240,6 +242,11 @@ treeherderApp.controller('MainCtrl', [
                 if ($scope.selectedJob) {
                     $scope.$evalAsync($rootScope.$emit(thEvents.deleteClassification));
                 }
+            });
+
+            // Shortcut: display onscreen keyboard shortcuts
+            Mousetrap.bind('?', function() {
+                $scope.$evalAsync($scope.setOnscreenShortcutsShowing(true));
             });
 
         };
@@ -388,6 +395,14 @@ treeherderApp.controller('MainCtrl', [
         $scope.clearFilterBox = function() {
             thJobFilters.removeFilter("searchStr");
             $("#quick-filter").val("").focus();
+        };
+
+        $scope.onscreenOverlayShowing = false;
+
+        $scope.onscreenShortcutsShowing = false;
+        $scope.setOnscreenShortcutsShowing = function(tf) {
+            $scope.onscreenShortcutsShowing = tf;
+            $scope.onscreenOverlayShowing = tf;
         };
 
         $scope.isFilterPanelShowing = false;

--- a/ui/js/controllers/userguide.js
+++ b/ui/js/controllers/userguide.js
@@ -1,0 +1,6 @@
+"use strict";
+
+userguideApp.controller('UserguideCtrl', [
+    '$scope', '$log', function ($scope, $log) {
+    }
+]);

--- a/ui/js/userguide.js
+++ b/ui/js/userguide.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var userguideApp = angular.module('userguide.app', []);
+
+userguideApp.config(function ($compileProvider) {
+    // Disable debug data, as recommended by https://docs.angularjs.org/guide/production
+    $compileProvider.debugInfoEnabled(false);
+});

--- a/ui/partials/main/thShortcutTable.html
+++ b/ui/partials/main/thShortcutTable.html
@@ -1,0 +1,61 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3>Keyboard shortcuts
+      <a ng-show="onscreenShortcutsShowing"
+         ng-click="setOnscreenShortcutsShowing(false)"
+         class="pull-right" href="" title="Close this help">
+        <span class="fa fa-times lightgray"</span>
+      </a>
+    </h3>
+  </div>
+  <div class="panel-body panel-spacing">
+    <table id="shortcuts">
+      <!-- Expose when onscreen help is complete - bug 1141569
+      <tr><td class="kbd">F1</td>
+        <td>Display onscreen help</td></tr>
+      -->
+      <tr><td class="kbd">esc</td>
+        <td>Close all open job or filter panels</td></tr>
+      <tr><td class="kbd">f</td>
+        <td>Enter a quick filter</td></tr>
+      <tr>
+        <td><span class="kbd">ctrl</span><span class="kbd">shift
+          </span><span class="kbd">f</span></td>
+        <td>Clear the quick filter</td>
+      </tr>
+      <tr><td class="kbd">&larr;</td>
+        <td>Select previous job</td></tr>
+      <tr><td class="kbd">&rarr;</span></td>
+        <td>Select next job</td></tr>
+      <tr><td><span class="kbd">k</span> or <span class="kbd">p</span></td>
+        <td>Select previous unclassified failure</td></tr>
+      <tr><td><span class="kbd">j</span> or <span class="kbd">n</span></td>
+        <td>Select next unclassified failure</td></tr>
+      <tr><td class="kbd">l</td>
+        <td>Open the logviewer for the selected job</td></tr>
+      <tr><td><span class="kbd">ctrl</span> or <span class="kbd">cmd</span></td>
+        <td>Add job to the pinboard during click selection</td></tr>
+      <tr><td class="kbd">spacebar</td>
+        <td>Add a selected job to the pinboard</td></tr>
+      <tr><td class="kbd">b</td>
+        <td>Add a selected job to the pinboard + enter related bug</td></tr>
+      <tr><td class="kbd">c</td>
+        <td>Add a selected job to the pinboard + enter classification</td></tr>
+      <tr><td><span class="kbd">ctrl</span><span class="kbd">enter</span></td>
+        <td>Save pinboard classification and related bugs</td></tr>
+      <tr>
+        <td><span class="kbd">ctrl</span><span class="kbd">shift
+          </span><span class="kbd">u</span></td>
+        <td>Clear the pinboard</td>
+      </tr>
+      <tr><td class="kbd">r</span></td>
+        <td>Retrigger selected job</td></tr>
+      <tr><td><span class="kbd">ctrl</span><span class="kbd">backspace</span></td>
+        <td>Delete job classification and related bugs</td></tr>
+      <tr><td class="kbd">u</td>
+        <td>Show only unclassified failures</td></tr>
+      <tr ng-if="!onscreenShortcutsShowing"><td class="kbd">?</td>
+        <td>Display onscreen keyboard shortcuts</td></tr>
+    </table>
+  </div>
+</div>

--- a/ui/userguide.html
+++ b/ui/userguide.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html ng-app="userguide.app">
 <head>
   <meta charset="utf-8">
   <title>Treeherder User Guide</title>
@@ -13,7 +13,11 @@
   <link id="favicon" type="image/png" rel="shortcut icon" href="img/tree_open.png">
 </head>
 
-<body id="userguide">
+<body ng-controller="UserguideCtrl" id="userguide">
+  <script src="vendor/angular/angular.js"></script>
+  <script src="js/userguide.js"></script>
+  <script src="js/controllers/userguide.js"></script>
+
   <!-- Content panel -->
   <div class="panel panel-default">
     <!-- Header -->
@@ -130,57 +134,13 @@
 
         <!-- Shortcuts table -->
         <div class="col-xs-6">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <h3>Keyboard shortcuts</h3></div>
-            <div class="panel-body panel-spacing">
-              <table id="shortcuts">
-                <tr><td class="kbd">esc</td>
-                  <td>Close all open job or filter panels</td></tr>
-                <tr><td class="kbd">f</td>
-                  <td>Enter a quick filter</td></tr>
-                <tr>
-                  <td><span class="kbd">ctrl</span><span class="kbd">shift
-                    </span><span class="kbd">f</span></td>
-                  <td>Clear the quick filter</td>
-                </tr>
-                <tr><td class="kbd">&larr;</td>
-                  <td>Select previous job</td></tr>
-                <tr><td class="kbd">&rarr;</span></td>
-                  <td>Select next job</td></tr>
-                <tr><td><span class="kbd">k</span> or <span class="kbd">p</span></td>
-                  <td>Select previous unclassified failure</td></tr>
-                <tr><td><span class="kbd">j</span> or <span class="kbd">n</span></td>
-                  <td>Select next unclassified failure</td></tr>
-                <tr><td class="kbd">l</td>
-                  <td>Open the logviewer for the selected job</td></tr>
-                <tr><td><span class="kbd">ctrl</span> or <span class="kbd">cmd</span></td>
-                  <td>Add job to the pinboard during click selection</td></tr>
-                <tr><td class="kbd">spacebar</td>
-                  <td>Add a selected job to the pinboard</td></tr>
-                <tr><td class="kbd">b</td>
-                  <td>Add a selected job to the pinboard + enter related bug</td></tr>
-                <tr><td class="kbd">c</td>
-                  <td>Add a selected job to the pinboard + enter classification</td></tr>
-                <tr><td><span class="kbd">ctrl</span><span class="kbd">enter</span></td>
-                  <td>Save pinboard classification and related bugs</td></tr>
-                <tr>
-                  <td><span class="kbd">ctrl</span><span class="kbd">shift
-                    </span><span class="kbd">u</span></td>
-                  <td>Clear the pinboard</td>
-                </tr>
-                <tr><td class="kbd">r</span></td>
-                  <td>Retrigger selected job</td></tr>
-                <tr><td><span class="kbd">ctrl</span><span class="kbd">backspace</span></td>
-                  <td>Delete job classification and related bugs</td></tr>
-                <tr><td class="kbd">i</td>
-                  <td>Toggle in-progress (running/pending) jobs</td></tr>
-                <tr><td class="kbd">u</td>
-                  <td>Show only unclassified failures</td></tr>
-              </table>
-            </div>
+          <ng-include id="th-shortcut-table"
+                      src="'partials/main/thShortcutTable.html'"></ng-include>
+        </div>
 
             <!-- Copy values on hover table -->
+        <div class="col-xs-6">
+          <div class="panel panel-default">
             <div class="panel-heading"><h3>Copy values on hover</h3></div>
             <div class="panel-body panel-spacing">
               <table id="shortcuts">
@@ -206,6 +166,8 @@
             </div>
           </div>
         </div>
+
+      <!-- End of row -->
       </div>
 
       <div class="row">


### PR DESCRIPTION
This work fixes part1 of Bugzilla bug [1141569](https://bugzilla.mozilla.org/show_bug.cgi?id=1141569).

This provides an onscreen help for keyboard shortcuts.

**Note**: I anticipate we'd ultimately add this F1 entry below to the shortcut list, once we have part2 of the bug (an inline Help for all UI elements) done, and perhaps emphasize it with `btn-primary` in the onscreen version, versus the UserGuide version:

![onscreenhelplater](https://cloud.githubusercontent.com/assets/3660661/10079721/b60e750e-62b9-11e5-965c-66dcd127cbe2.jpg)

But that's for later, for now we'll just display the existing shortcuts. So here's the current PR.

Proposed ('?' key depressed, click [x] to close like Github):

![onscreenhelpshortcuts](https://cloud.githubusercontent.com/assets/3660661/10079790/14eb72e8-62ba-11e5-97e3-fb605f9277e9.jpg)

I decided to keep the two shortcut tables (here, and UserGuide.html) separate since they get different stylings, and I want to add the shortcut `?` to the UserGuide, but it isn't necessary in the onscreen version. I don't think it's a big deal to maintain two locations.

The only other notable point, is unlike Github we set two properties on `head, body` [here](https://github.com/mozilla/treeherder/blob/b0b5460441fa146e99179be62d92717b08141a88/ui/css/treeherder.css#L2-L3) and once we get to the point where we are displaying inline Help for all UI elements, we'll need to ng-class override these when `onscreenOverlayShowing = true`. Otherwise the user can't access the scroll bar to navigate down the page.

But the shortcuts overlay is just momentary display, it is compact, and we don't need to see other bits of the UI. So I think it's fine we overlay the scroll bar here, and we can revisit that behavior later, I think.

I tested this at various sizes on Nightly and Chrome, and everything seems reasonable.

Tested on OSX 10.10.5:
Release **44.0a1 (2015-09-24)**
Chrome Latest Release **45.0.2454.99 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1005)
<!-- Reviewable:end -->
