### PR TITLE
Bug 1207771 - Disable Cancel job button when not logged in

### DIFF
--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -84,8 +84,9 @@
             </ul>
           </li>
           <li ng-show="canCancel()">
-            <a title="Cancel this job"
-               class="hover-warning"
+            <a ng-attr-title="{{user.loggedin ? 'Cancel this job' :
+                              'Must be logged in to cancel a job'}}"
+               ng-class="user.loggedin ? 'hover-warning' : 'disabled'"
                href="" prevent-default-on-left-click
                target="_blank"
                ng-click="cancelJob()">


### PR DESCRIPTION
This fixes Bugzilla bug [1207771](https://bugzilla.mozilla.org/show_bug.cgi?id=1207771).

This disables the info-panel Cancel button unless the user is logged in.

I had disabled the ng-click also via `ng-click="!user.loggedin || cancelJob()"` but decided to allow it and continue to put up the identical pink thNotify *"Must be logged in to cancel a job"* message in that condition.

We still want that thNotify message in the code also, in the event we adopt a shortcut or other means of cancelling.

Proposed:

![canceldisabledloggedout](https://cloud.githubusercontent.com/assets/3660661/10058005/198d4adc-6211-11e5-8dab-a7d8dc719ad7.jpg)

Tested on OSX 10.10.5:
Release **44.0a1 (2015-09-24)**
Chrome Latest Release **45.0.2454.99 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1006)
<!-- Reviewable:end -->
