### PR TITLE
Bug 1208102 - Submit the job start time date as UTC to ElasticSearch

### DIFF
--- a/treeherder/etl/classification_mirroring.py
+++ b/treeherder/etl/classification_mirroring.py
@@ -45,8 +45,7 @@ class ElasticsearchDocRequest(object):
             "os": job_data["platform"],
             # I'm using the request time date here, as start time is not
             # available for pending jobs
-            "date": datetime.fromtimestamp(
-                int(job_data["submit_timestamp"])).strftime("%Y-%m-%d"),
+            "date": datetime.utcfromtimestamp(job_data["submit_timestamp"]).strftime("%Y-%m-%d"),
             "type": job_data["job_type_name"],
             "buildtype": option_collection[
                 job_data["option_collection_hash"]


### PR DESCRIPTION
Since `.fromtimestamp()` is being overridden by Django's TIME_ZONE and so uses Pacific Time, even though rabbitmq's server time is UTC.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1013)
<!-- Reviewable:end -->
