### PR TITLE
Bug 1209523 - Fix grunt build of userguide.html

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,6 +82,12 @@ module.exports = function(grunt) {
                 file: 'dist/js/perf.min.js',
                 cleanup: true
             },
+            userguidejs: {
+                replace: ['dist/**/*.html'],
+                replacement: 'userguide.min.js',
+                file: 'dist/js/userguide.min.js',
+                cleanup: true
+            },
             indexcss: {
                 replace: ['dist/**/*.html'],
                 replacement: 'index.min.css',
@@ -212,6 +218,27 @@ module.exports = function(grunt) {
                 dest: 'dist/js/perf.min.js',
                 options: {
                     usemin: 'dist/js/perf.min.js',
+                    append: true,
+                    htmlmin: {
+                        collapseBooleanAttributes:      true,
+                        collapseWhitespace:             true,
+                        conservativeCollapse:           true,
+                        removeAttributeQuotes:          true,
+                        removeComments:                 true,
+                        removeEmptyAttributes:          true,
+                        removeRedundantAttributes:      true,
+                        removeScriptTypeAttributes:     true,
+                        removeStyleLinkTypeAttributes:  true,
+                        keepClosingSlash: true
+                    }
+                }
+            },
+            userguide: {
+                cwd: 'ui',
+                src: 'partials/main/thShortcutTable.html',
+                dest: 'dist/js/userguide.min.js',
+                options: {
+                    usemin: 'dist/js/userguide.min.js',
                     append: true,
                     htmlmin: {
                         collapseBooleanAttributes:      true,

--- a/ui/js/userguide.js
+++ b/ui/js/userguide.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var userguideApp = angular.module('userguide.app', []);
+var userguideApp = angular.module('userguide', []);
 
 userguideApp.config(function ($compileProvider) {
     // Disable debug data, as recommended by https://docs.angularjs.org/guide/production

--- a/ui/partials/main/thShortcutTable.html
+++ b/ui/partials/main/thShortcutTable.html
@@ -4,7 +4,7 @@
       <a ng-show="onscreenShortcutsShowing"
          ng-click="setOnscreenShortcutsShowing(false)"
          class="pull-right" href="" title="Close this help">
-        <span class="fa fa-times lightgray"</span>
+        <span class="fa fa-times lightgray"></span>
       </a>
     </h3>
   </div>

--- a/ui/userguide.html
+++ b/ui/userguide.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="userguide.app">
+<html ng-app="userguide">
 <head>
   <meta charset="utf-8">
   <title>Treeherder User Guide</title>
@@ -14,10 +14,6 @@
 </head>
 
 <body ng-controller="UserguideCtrl" id="userguide">
-  <script src="vendor/angular/angular.js"></script>
-  <script src="js/userguide.js"></script>
-  <script src="js/controllers/userguide.js"></script>
-
   <!-- Content panel -->
   <div class="panel panel-default">
     <!-- Header -->
@@ -614,5 +610,11 @@
 
   <!-- End of content panel -->
   </div>
+
+  <!-- build:js js/userguide.min.js -->
+  <script src="vendor/angular/angular.js"></script>
+  <script src="js/userguide.js"></script>
+  <script src="js/controllers/userguide.js"></script>
+  <!-- endbuild -->
 </body>
 </html>


### PR DESCRIPTION
1) Fix parse error during grunt build …
2) Fix grunt build minification of userguide.html …
Also the s/userguide.app/userguide/ was to fix:
> Error: [$injector:nomod] Module 'userguide' is not available!

As part of my work to get grunt build running automatically on deploy, I'm going to run it on Travis to make sure we catch things like this before deploy :-)
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1014)
<!-- Reviewable:end -->
