### PR TITLE
Bug 1209567 - Update 'esc' keyboard shortcut description

### DIFF
--- a/ui/partials/main/thShortcutTable.html
+++ b/ui/partials/main/thShortcutTable.html
@@ -15,7 +15,7 @@
         <td>Display onscreen help</td></tr>
       -->
       <tr><td class="kbd">esc</td>
-        <td>Close all open job or filter panels</td></tr>
+        <td>Close all open panels</td></tr>
       <tr><td class="kbd">f</td>
         <td>Enter a quick filter</td></tr>
       <tr>


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1209567](https://bugzilla.mozilla.org/show_bug.cgi?id=1209567).

This updates the **esc** keyboard shortcut to a more generalized description since the shortcut/overlay panel itself, is now part of what closes on 'esc'.

Tested on OSX 10.10.5:
Release **44.0a1 (2015-09-29)**
Chrome Latest Release **45.0.2454.101 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1015)
<!-- Reviewable:end -->
