### PR TITLE
Bug 1209079 - Make all dropdowns use a pointer cursor

### DIFF
--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -58,6 +58,10 @@ input:focus::-moz-placeholder {
   min-height: 20px; /* Override bootstrap 3.3.5 for similar jobs panel */
 }
 
+.dropdown-menu > li > a {
+  cursor: pointer;
+}
+
 /* Spacing for menus with adjacent checkboxes */
 .checkbox-dropdown-menu {
   padding-left: 8px;

--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -90,11 +90,6 @@ div#info-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
   flex-flow: row;
 }
 
-#info-panel-content .dropdown-menu > li > a {
-    /* Explicit addition for our Info-panel menus eg. Retrigger */
-    cursor: pointer;
-}
-
 #job-details-panel, #job-tabs-panel {
   background-color: #fff;
   display: -webkit-flex;


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1209079](https://bugzilla.mozilla.org/show_bug.cgi?id=1209079).

This makes all dropdowns present with a pointer cursor, even if they don't contain an `href` in the markup. I don't think we want to stick empty hrefs into the menus to fix them, since you'd get context menus to "Open this link in a new window" which don't go anywhere.

So instead we add a global property to `treeherder-global.css` which provides `pointer` for:

* Navbar > Logout
* Pinboard > Save ^
* Info Panel > Retrigger ^

Everything seems fine in local testing. Other dropdowns which *do* have an href do their own thing, and present with a pointer anyway (Treeherder > Logo menu, Logviewer > Logo menu).

Tested on OSX 10.10.5:
Release **44.0a1 (2015-09-29)**
Chrome Latest Release **45.0.2454.101 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1016)
<!-- Reviewable:end -->
