### PR TITLE
Bug 1208486 - Lint and tidy up logviewer directives

### DIFF
--- a/ui/js/directives/treeherder/log_viewer_infinite_scroll.js
+++ b/ui/js/directives/treeherder/log_viewer_infinite_scroll.js
@@ -9,7 +9,7 @@ treeherder.directive('lvInfiniteScroll', ['$timeout', '$parse', function ($timeo
             if (raw.scrollTop <= 100) {
                 scope.loadMore({top: true}, raw).then(function(haltScrollTop) {
                     if (!haltScrollTop) {
-                        $timeout(function() {
+                        $timeout(function () {
                             raw.scrollTop = raw.scrollHeight - sh;
                         });
                     }

--- a/ui/js/directives/treeherder/log_viewer_lines.js
+++ b/ui/js/directives/treeherder/log_viewer_lines.js
@@ -14,16 +14,18 @@ treeherder.directive('lvLogLines', ['$timeout', '$parse', function ($timeout) {
         var lines = $('.lv-log-line');
         var scrollTop = $('.lv-log-container').scrollTop();
 
-        for (var i = 0, l = lines.length; i < l; i++) {
+        for (var i = 0, ll = lines.length; i < ll; i++) {
             if (lines[i].offsetTop > scrollTop) {
                 var steps = $scope.artifact.step_data.steps;
                 var lineNumber = +$(lines[i]).attr('line');
 
-                for (var j = 0, ll = steps.length; j < ll; j++) {
+                for (var j = 0, sl = steps.length; j < sl; j++) {
                     if (lineNumber > (steps[j].started_linenumber - 1) &&
                         lineNumber < (steps[j].finished_linenumber + 1)) {
                         // make sure we aren't updating when its already correct
-                        if ($scope.displayedStep.order === steps[j].order) return;
+                        if ($scope.displayedStep.order === steps[j].order) {
+                            return;
+                        }
 
                         $scope.displayedStep = steps[j];
 
@@ -31,7 +33,9 @@ treeherder.directive('lvLogLines', ['$timeout', '$parse', function ($timeout) {
                         var scrollTop = getOffsetOfStep(steps[j].order);
                         $('.steps-data').scrollTop(scrollTop);
 
-                        if(!$scope.$$phase) {$scope.$apply();}
+                        if (!$scope.$$phase) {
+                            $scope.$apply();
+                        }
 
                         return;
                     }

--- a/ui/js/directives/treeherder/log_viewer_steps.js
+++ b/ui/js/directives/treeherder/log_viewer_steps.js
@@ -36,10 +36,10 @@ treeherder.directive('lvLogSteps', ['$timeout', '$q', function ($timeout, $q) {
                 }
             };
 
-            scope.toggleSuccessfulSteps = function() {
+            scope.toggleSuccessfulSteps = function () {
                 scope.showSuccessful = !scope.showSuccessful;
 
-                var firstError = scope.artifact.step_data.steps.filter(function(step){
+                var firstError = scope.artifact.step_data.steps.filter(function (step) {
                     return step.result && step.result !== "success";
                 })[0];
 
@@ -50,12 +50,11 @@ treeherder.directive('lvLogSteps', ['$timeout', '$q', function ($timeout, $q) {
                 // scroll to the first error
                 $timeout(function () {
                     var scrollTop = getOffsetOfStep(firstError.order);
-
                     $('.steps-data').scrollTop( scrollTop );
                 });
             };
 
-            scope.displayLog = function(step, state) {
+            scope.displayLog = function (step, state) {
                 scope.displayedStep = step;
                 scope.currentLineNumber = step.started_linenumber;
 


### PR DESCRIPTION
These tweaks fix Bugzilla bug [1208486](https://bugzilla.mozilla.org/show_bug.cgi?id=1208486).

Nothing exciting just some very minor tidying up of the logviewer directives. There's no functionality change or other bug fixes, just readability and linting.

I don't have an opinion on `function(param)` vs `function (param)` but we have a mix in the codebase, and old/new jslint emphatically claims it should be `function ()`.

Everything seems fine in local testing, as expected.

Tested on OSX 10.10.5:
Release **44.0a1 (2015-09-29)**
Chrome Latest Release **45.0.2454.101 (64-bit)**

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1017)
<!-- Reviewable:end -->
