### PR TITLE
Bug 1192957 - Add isort to the Travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - ./bin/peep.py install -r requirements/common.txt -r requirements/dev.txt
 before_script:
   - flake8 --show-source
+  - isort --check-only --diff --quiet
   - grunt checkjs
   # Required for Karma tests (http://docs.travis-ci.com/user/gui-and-headless-browsers/)
   - export DISPLAY=:99.0

--- a/docs/code_style.rst
+++ b/docs/code_style.rst
@@ -1,0 +1,31 @@
+Code Style
+==========
+
+.. _python-import-style:
+
+Python imports
+--------------
+
+`isort <https://github.com/timothycrosley/isort>`_ enforces the following Python global import order:
+
+* ``from __future__ import ...``
+* Python standard library
+* Third party modules
+* Local project imports (absolutely specified)
+* Local project imports (relative path, eg: ``from .models import Credentials``)
+
+In addition:
+
+* Each group should be separated by a blank line.
+* Within each group, all ``import ...`` statements should be before ``from ... import ...``.
+* After that, sort alphabetically by module name.
+* When importing multiple items from one module, use this style:
+
+  .. code-block:: python
+
+     from treeherder.client import (TreeherderAuth,
+                                    TreeherderClient)
+
+The quickest way to correct import style locally is to let isort make the changes for you - see :ref:`running the tests <running-tests>`.
+
+Note: It's not possible to disable isort wrapping style checking, so for now we've chosen the most deterministic `wrapping mode <https://github.com/timothycrosley/isort#multi-line-output-modes>`_ to reduce the line length guess-work when adding imports, even though it's not the most concise.

--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -17,13 +17,15 @@ In order to make the various services aware of a change in the code you need to 
 Running the tests
 -----------------
 
-* You can run flake8 and the py.test suite inside the Vagrant VM, using
+You can run flake8, isort and the py.test suite inside the Vagrant VM, using:
 
   .. code-block:: bash
 
      (venv)vagrant@local:~/treeherder$ ./runtests.sh
 
-* Or for more control, run py.test directly
+Or for more control, run each tool individually:
+
+* `py.test <http://pytest.org/>`_:
 
   .. code-block:: bash
 
@@ -31,19 +33,37 @@ Running the tests
      (venv)vagrant@local:~/treeherder$ py.test tests/log_parser/test_utils.py
      (venv)vagrant@local:~/treeherder$ py.test tests/etl/test_buildapi.py -k test_ingest_builds4h_jobs
 
-* To run all tests, including slow tests that are normally skipped, use
+  To run all tests, including slow tests that are normally skipped, use:
 
   .. code-block:: bash
 
      (venv)vagrant@local:~/treeherder$ py.test --runslow tests/
 
-* For more options, see ``py.test --help`` or http://pytest.org/latest/usage.html
+  For more options, see ``py.test --help`` or http://pytest.org/latest/usage.html
 
-* To run flake8 on its own, use
+* `flake8 <https://flake8.readthedocs.org/>`_:
 
   .. code-block:: bash
 
      (venv)vagrant@local:~/treeherder$ flake8
+
+  NB: If running flake8 from outside of the VM, ensure you are using the same version as used on Travis (see ``requirements/dev.txt``).
+
+* `isort <https://github.com/timothycrosley/isort>`_ (checks the :ref:`Python import style <python-import-style>`):
+
+  To run interactively:
+
+  .. code-block:: bash
+
+     (venv)vagrant@local:~/treeherder$ isort
+
+  Or to apply all changes without confirmation:
+
+  .. code-block:: bash
+
+     (venv)vagrant@local:~/treeherder$ isort --apply
+
+  NB: isort must be run from inside the VM, since a populated (and up to date) virtualenv is required so that isort can correctly categorise the imports.
 
 
 Look up credentials for a project

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ Contents:
    submitting_data
    retrieving_data
    data_validation
+   code_style
    troubleshooting
    ui/index
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,6 +26,9 @@ pyinotify==0.9.6
 # sha256: j8ToZaKfPG7K5AGn3OGCR_ir0EbSTjkOFq-Zdsyceqg
 flake8==2.4.1
 
+# sha256: OtJDrXOLL5pYAFrESxOjwpewIBMn7a7DLCRbW8ZtJ-4
+isort==4.2.2
+
 # Required by pytest
 # sha256: B-IKuQpVC9PCGJHg2IfwkxtAmPFIrsleKbUYjxYbsHU
 py==1.4.30

--- a/runtests.sh
+++ b/runtests.sh
@@ -3,5 +3,9 @@
 echo "Running flake8"
 flake8 || { echo "flake8 errors found!"; exit 1; }
 
+echo "Running isort"
+isort --check-only --diff --quiet \
+ || { echo "isort errors found! Run 'isort' with no options to fix."; exit 1; }
+
 echo "Running Python tests"
 py.test tests/$* --cov-report html --cov treeherder

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,11 @@ exclude = .git,__pycache__,.vagrant,node_modules
 # F403: 'from module import *' used; unable to detect undefined names
 ignore = E121,E123,E125,E126,E129,E226,E24,E704,E501,F403
 max-line-length = 140
+
+[isort]
+skip = .git,__pycache__,.vagrant,node_modules,migrations,peep.py,update.py,wsgi.py
+multi_line_output = 1
+force_grid_wrap = true
+line_length = 140
+# Remove when https://github.com/timothycrosley/isort/issues/297 fixed.
+known_first_party = tests

--- a/tests/autoclassify/test_classify_failures.py
+++ b/tests/autoclassify/test_classify_failures.py
@@ -1,8 +1,11 @@
 from django.core.management import call_command
 
-from treeherder.model.models import Matcher, Repository
 from treeherder.autoclassify.matchers import PreciseTestMatcher
-from .utils import test_line, create_failure_lines
+from treeherder.model.models import (Matcher,
+                                     Repository)
+
+from .utils import (create_failure_lines,
+                    test_line)
 
 
 def test_classify_test_failure(activate_responses, jm, eleven_jobs_stored, initial_data,

--- a/tests/autoclassify/test_detect_intermittents.py
+++ b/tests/autoclassify/test_detect_intermittents.py
@@ -1,9 +1,13 @@
 from django.core.management import call_command
 
-from treeherder.model.models import Matcher, Repository, ClassifiedFailure
-from treeherder.autoclassify.matchers import PreciseTestMatcher
 from treeherder.autoclassify.detectors import TestFailureDetector
-from .utils import test_line, create_failure_lines
+from treeherder.autoclassify.matchers import PreciseTestMatcher
+from treeherder.model.models import (ClassifiedFailure,
+                                     Matcher,
+                                     Repository)
+
+from .utils import (create_failure_lines,
+                    test_line)
 
 
 def test_detect_intermittents(activate_responses, jm, eleven_jobs_stored, initial_data,

--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -8,9 +8,12 @@ import requests
 from mock import patch
 
 from treeherder.client import (TreeherderArtifact,
-                               TreeherderArtifactCollection, TreeherderAuth,
-                               TreeherderClient, TreeherderClientError,
-                               TreeherderJob, TreeherderJobCollection,
+                               TreeherderArtifactCollection,
+                               TreeherderAuth,
+                               TreeherderClient,
+                               TreeherderClientError,
+                               TreeherderJob,
+                               TreeherderJobCollection,
                                TreeherderResultSet,
                                TreeherderResultSetCollection,
                                TreeherderRevision)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,7 +2,8 @@ import os
 
 import pytest
 import simplejson as json
-from django.template import Context, Template
+from django.template import (Context,
+                             Template)
 
 from tests import test_utils
 from treeherder.client import TreeherderJobCollection

--- a/tests/e2e/test_client_job_ingestion.py
+++ b/tests/e2e/test_client_job_ingestion.py
@@ -3,11 +3,13 @@ import json
 import pytest
 from mock import MagicMock
 
-from treeherder.client.thclient import TreeherderAuth, client
+from treeherder.client.thclient import (TreeherderAuth,
+                                        client)
 from treeherder.etl.oauth_utils import OAuthCredentials
 from treeherder.log_parser.parsers import StepParser
 from treeherder.model import error_summary
-from treeherder.model.derived import ArtifactsModel, JobsModel
+from treeherder.model.derived import (ArtifactsModel,
+                                      JobsModel)
 
 
 @pytest.fixture

--- a/tests/e2e/test_perf_ingestion.py
+++ b/tests/e2e/test_perf_ingestion.py
@@ -1,8 +1,8 @@
+from test_client_job_ingestion import do_post_collection
 from tests.sampledata import SampleData
 from treeherder.client.thclient import client
-from treeherder.perf.models import (PerformanceSignature, PerformanceDatum)
-
-from test_client_job_ingestion import do_post_collection
+from treeherder.perf.models import (PerformanceDatum,
+                                    PerformanceSignature)
 
 
 def test_post_talos_artifact(test_project, test_repository, result_set_stored,

--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -6,8 +6,10 @@ import responses
 from django.conf import settings
 from django.core.cache import cache
 
-from treeherder.etl.buildapi import (CACHE_KEYS, Builds4hJobsProcess,
-                                     PendingJobsProcess, RunningJobsProcess)
+from treeherder.etl.buildapi import (CACHE_KEYS,
+                                     Builds4hJobsProcess,
+                                     PendingJobsProcess,
+                                     RunningJobsProcess)
 
 
 @pytest.fixture

--- a/tests/etl/test_classification_mirroring.py
+++ b/tests/etl/test_classification_mirroring.py
@@ -2,6 +2,7 @@ import json
 from time import time
 
 from datadiff import diff
+
 from treeherder.etl.classification_mirroring import ElasticsearchDocRequest
 from treeherder.model.derived import ArtifactsModel
 

--- a/tests/etl/test_job_loader.py
+++ b/tests/etl/test_job_loader.py
@@ -1,4 +1,5 @@
 import copy
+
 import pytest
 
 from treeherder.etl.job_loader import JobLoader

--- a/tests/etl/test_job_schema.py
+++ b/tests/etl/test_job_schema.py
@@ -1,7 +1,8 @@
-import pytest
 import jsonschema
+import pytest
 
 from treeherder.etl.schema import job_json_schema
+
 
 # The test data in this file are a representative sample-set from
 # production Treeherder

--- a/tests/etl/test_perf_data_adapters.py
+++ b/tests/etl/test_perf_data_adapters.py
@@ -4,10 +4,13 @@ from django.test import TestCase
 
 from tests.sampledata import SampleData
 from treeherder.etl.perf_data_adapters import TalosDataAdapter
-from treeherder.model.models import (MachinePlatform, Option,
-                                     OptionCollection, Repository,
+from treeherder.model.models import (MachinePlatform,
+                                     Option,
+                                     OptionCollection,
+                                     Repository,
                                      RepositoryGroup)
-from treeherder.perf.models import PerformanceSignature, PerformanceDatum
+from treeherder.perf.models import (PerformanceDatum,
+                                    PerformanceSignature)
 
 
 class TalosDataAdapterTest(TestCase):

--- a/tests/etl/test_pushlog.py
+++ b/tests/etl/test_pushlog.py
@@ -4,7 +4,8 @@ import os
 import responses
 from django.core.cache import cache
 
-from treeherder.etl.pushlog import HgPushlogProcess, MissingHgPushlogProcess
+from treeherder.etl.pushlog import (HgPushlogProcess,
+                                    MissingHgPushlogProcess)
 
 
 def test_ingest_hg_pushlog(jm, initial_data, test_base_dir,

--- a/tests/log_parser/test_store_error_summary.py
+++ b/tests/log_parser/test_store_error_summary.py
@@ -1,8 +1,11 @@
 import responses
-from django.core.management import call_command
 from django.conf import settings
+from django.core.management import call_command
 
-from treeherder.model.models import FailureLine, Repository, RepositoryGroup
+from treeherder.model.models import (FailureLine,
+                                     Repository,
+                                     RepositoryGroup)
+
 from ..sampledata import SampleData
 
 

--- a/tests/model/commands/test_init_datasource.py
+++ b/tests/model/commands/test_init_datasource.py
@@ -1,7 +1,9 @@
 import pytest
 from django.core.management import call_command
 
-from treeherder.model.models import Datasource, Repository, RepositoryGroup
+from treeherder.model.models import (Datasource,
+                                     Repository,
+                                     RepositoryGroup)
 
 
 @pytest.fixture

--- a/tests/model/derived/test_artifacts_model.py
+++ b/tests/model/derived/test_artifacts_model.py
@@ -2,7 +2,8 @@ import json
 
 import pytest
 
-from treeherder.model.derived import ArtifactsModel, JobsModel
+from treeherder.model.derived import (ArtifactsModel,
+                                      JobsModel)
 
 xfail = pytest.mark.xfail
 

--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -5,7 +5,8 @@ import pytest
 from django.core.management import call_command
 
 from tests import test_utils
-from tests.sample_data_generator import job_data, result_set
+from tests.sample_data_generator import (job_data,
+                                         result_set)
 from treeherder.model.derived import ArtifactsModel
 
 slow = pytest.mark.slow

--- a/tests/model/derived/test_refdata.py
+++ b/tests/model/derived/test_refdata.py
@@ -1,11 +1,13 @@
 import json
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import (datetime,
+                      timedelta)
 
 import pytest
 
-from treeherder.model.models import Repository, RepositoryGroup
+from treeherder.model.models import (Repository,
+                                     RepositoryGroup)
 
 
 @pytest.fixture

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,8 @@ from requests import Request
 from webtest.app import TestApp
 
 from tests.sampledata import SampleData
-from treeherder.client import TreeherderAuth, TreeherderClient
+from treeherder.client import (TreeherderAuth,
+                               TreeherderClient)
 from treeherder.etl.oauth_utils import OAuthCredentials
 from treeherder.model.derived.refdata import RefDataManager
 from treeherder.webapp.wsgi import application

--- a/tests/webapp/api/test_artifact_api.py
+++ b/tests/webapp/api/test_artifact_api.py
@@ -3,9 +3,11 @@ import json
 import pytest
 from django.core.urlresolvers import reverse
 
-from treeherder.client.thclient import TreeherderAuth, client
+from treeherder.client.thclient import (TreeherderAuth,
+                                        client)
 from treeherder.etl.oauth_utils import OAuthCredentials
-from treeherder.model.derived import ArtifactsModel, JobsModel
+from treeherder.model.derived import (ArtifactsModel,
+                                      JobsModel)
 
 xfail = pytest.mark.xfail
 

--- a/tests/webapp/api/test_auth.py
+++ b/tests/webapp/api/test_auth.py
@@ -1,11 +1,13 @@
 import oauth2 as oauth
-from django.contrib.auth.models import User
-from django.core.urlresolvers import resolve, reverse
-from mohawk import Sender
 import pytest
+from django.contrib.auth.models import User
+from django.core.urlresolvers import (resolve,
+                                      reverse)
+from mohawk import Sender
 from rest_framework.decorators import APIView
 from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory
+
 from treeherder.credentials.models import Credentials
 from treeherder.etl.oauth_utils import OAuthCredentials
 from treeherder.webapp.api import permissions

--- a/tests/webapp/api/test_throttling.py
+++ b/tests/webapp/api/test_throttling.py
@@ -1,7 +1,8 @@
+from hawkrest import HawkAuthentication
 from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory
 from rest_framework.views import APIView
-from hawkrest import HawkAuthentication
+
 from treeherder.webapp.api import throttling
 
 

--- a/treeherder/autoclassify/detectors.py
+++ b/treeherder/autoclassify/detectors.py
@@ -1,5 +1,7 @@
 import logging
-from abc import ABCMeta, abstractmethod
+from abc import (ABCMeta,
+                 abstractmethod)
+
 from treeherder.model import models
 
 logger = logging.getLogger(__name__)

--- a/treeherder/autoclassify/management/commands/autoclassify.py
+++ b/treeherder/autoclassify/management/commands/autoclassify.py
@@ -1,10 +1,13 @@
 import logging
 from collections import defaultdict
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import (BaseCommand,
+                                         CommandError)
 
 from treeherder.autoclassify import matchers
-from treeherder.model.models import FailureLine, Matcher, FailureMatch
+from treeherder.model.models import (FailureLine,
+                                     FailureMatch,
+                                     Matcher)
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/autoclassify/management/commands/detect_intermittents.py
+++ b/treeherder/autoclassify/management/commands/detect_intermittents.py
@@ -1,10 +1,13 @@
 import logging
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import (BaseCommand,
+                                         CommandError)
 
 from treeherder.autoclassify import detectors
 from treeherder.model.derived import JobsModel
-from treeherder.model.models import FailureLine, Matcher
+from treeherder.model.models import (FailureLine,
+                                     Matcher)
+
 from .autoclassify import match_errors
 
 logger = logging.getLogger(__name__)

--- a/treeherder/autoclassify/management/commands/matchers.py
+++ b/treeherder/autoclassify/management/commands/matchers.py
@@ -1,4 +1,5 @@
-from django.core.management.base import BaseCommand, make_option
+from django.core.management.base import (BaseCommand,
+                                         make_option)
 
 from treeherder.model.models import Matcher
 

--- a/treeherder/autoclassify/matchers.py
+++ b/treeherder/autoclassify/matchers.py
@@ -1,5 +1,6 @@
 import logging
-from abc import ABCMeta, abstractmethod
+from abc import (ABCMeta,
+                 abstractmethod)
 from collections import namedtuple
 
 from treeherder.model import models

--- a/treeherder/autoclassify/tasks.py
+++ b/treeherder/autoclassify/tasks.py
@@ -2,6 +2,7 @@ import logging
 
 from celery import task
 from django.core.management import call_command
+
 from treeherder import celery_app
 
 logger = logging.getLogger(__name__)

--- a/treeherder/credentials/forms.py
+++ b/treeherder/credentials/forms.py
@@ -1,4 +1,6 @@
-from django.forms import ModelForm, Textarea, TextInput
+from django.forms import (ModelForm,
+                          Textarea,
+                          TextInput)
 
 from .models import Credentials
 

--- a/treeherder/credentials/views.py
+++ b/treeherder/credentials/views.py
@@ -1,8 +1,10 @@
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse_lazy
 from django.utils.decorators import method_decorator
-from django.views.generic.edit import CreateView, DeleteView
-from django.views.generic import DetailView, ListView
+from django.views.generic import (DetailView,
+                                  ListView)
+from django.views.generic.edit import (CreateView,
+                                       DeleteView)
 
 from .forms import CredentialsForm
 from .models import Credentials

--- a/treeherder/embed/urls.py
+++ b/treeherder/embed/urls.py
@@ -1,4 +1,5 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import (patterns,
+                              url)
 
 from .views import ResultsetStatusView
 

--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -6,8 +6,10 @@ from django.conf import settings
 from django.core.cache import cache
 
 from treeherder.client import TreeherderJobCollection
-from treeherder.etl import buildbot, common
-from treeherder.etl.mixins import JsonExtractorMixin, OAuthLoaderMixin
+from treeherder.etl import (buildbot,
+                            common)
+from treeherder.etl.mixins import (JsonExtractorMixin,
+                                   OAuthLoaderMixin)
 from treeherder.model.models import Datasource
 
 logger = logging.getLogger(__name__)

--- a/treeherder/etl/classification_mirroring.py
+++ b/treeherder/etl/classification_mirroring.py
@@ -5,7 +5,8 @@ import requests
 import simplejson as json
 from django.conf import settings
 
-from treeherder.model.derived import ArtifactsModel, JobsModel
+from treeherder.model.derived import (ArtifactsModel,
+                                      JobsModel)
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/etl/job_loader.py
+++ b/treeherder/etl/job_loader.py
@@ -1,11 +1,12 @@
 import logging
-import jsonschema
 import time
-from dateutil import parser
 from collections import defaultdict
 
-from treeherder.model.derived.jobs import JobsModel
+import jsonschema
+from dateutil import parser
+
 from treeherder.etl.schema import job_json_schema
+from treeherder.model.derived.jobs import JobsModel
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/etl/management/commands/import_project_credentials.py
+++ b/treeherder/etl/management/commands/import_project_credentials.py
@@ -1,7 +1,8 @@
 import os
 
 import simplejson as json
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import (BaseCommand,
+                                         CommandError)
 
 from treeherder.model.models import Datasource
 

--- a/treeherder/etl/management/commands/ingest_from_pulse.py
+++ b/treeherder/etl/management/commands/ingest_from_pulse.py
@@ -1,9 +1,10 @@
 import logging
 from urlparse import urlparse
-from kombu import Connection, Exchange
 
-from django.core.management.base import BaseCommand
 from django.conf import settings
+from django.core.management.base import BaseCommand
+from kombu import (Connection,
+                   Exchange)
 
 from treeherder.etl.pulse_consumer import JobConsumer
 

--- a/treeherder/etl/management/commands/ingest_push.py
+++ b/treeherder/etl/management/commands/ingest_push.py
@@ -2,9 +2,11 @@ from cProfile import Profile
 from optparse import make_option
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import (BaseCommand,
+                                         CommandError)
 
-from treeherder.etl.buildapi import (Builds4hJobsProcess, PendingJobsProcess,
+from treeherder.etl.buildapi import (Builds4hJobsProcess,
+                                     PendingJobsProcess,
                                      RunningJobsProcess)
 from treeherder.etl.pushlog import HgPushlogProcess
 from treeherder.model.derived import RefDataManager

--- a/treeherder/etl/management/commands/publish_to_pulse.py
+++ b/treeherder/etl/management/commands/publish_to_pulse.py
@@ -1,10 +1,10 @@
 import logging
-
-from kombu.messaging import Producer
-from kombu import Connection, Exchange
 from urlparse import urlparse
 
 from django.core.management.base import BaseCommand
+from kombu import (Connection,
+                   Exchange)
+from kombu.messaging import Producer
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/etl/perf_data_adapters.py
+++ b/treeherder/etl/perf_data_adapters.py
@@ -10,10 +10,9 @@ from simplejson import encoder
 from treeherder.model.models import (MachinePlatform,
                                      OptionCollection,
                                      Repository)
-from treeherder.perf.models import (PerformanceFramework,
-                                    PerformanceSignature,
-                                    PerformanceDatum)
-
+from treeherder.perf.models import (PerformanceDatum,
+                                    PerformanceFramework,
+                                    PerformanceSignature)
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/etl/pulse_consumer.py
+++ b/treeherder/etl/pulse_consumer.py
@@ -1,11 +1,10 @@
-import logging
 import json
+import logging
 
 from kombu import Queue
 from kombu.mixins import ConsumerMixin
 
 from treeherder.etl.tasks.pulse_tasks import store_pulse_jobs
-
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -5,9 +5,11 @@ from django.conf import settings
 from django.core.cache import cache
 
 from treeherder.client import TreeherderResultSetCollection
-from treeherder.etl.common import generate_revision_hash, get_not_found_onhold_push
+from treeherder.etl.common import (generate_revision_hash,
+                                   get_not_found_onhold_push)
 
-from .mixins import JsonExtractorMixin, OAuthLoaderMixin
+from .mixins import (JsonExtractorMixin,
+                     OAuthLoaderMixin)
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/etl/schema.py
+++ b/treeherder/etl/schema.py
@@ -1,4 +1,5 @@
 import os
+
 import yaml
 
 

--- a/treeherder/etl/tasks/buildapi_tasks.py
+++ b/treeherder/etl/tasks/buildapi_tasks.py
@@ -3,7 +3,8 @@ This module contains
 """
 from celery import task
 
-from treeherder.etl.buildapi import (Builds4hJobsProcess, PendingJobsProcess,
+from treeherder.etl.buildapi import (Builds4hJobsProcess,
+                                     PendingJobsProcess,
                                      RunningJobsProcess)
 from treeherder.etl.pushlog import HgPushlogProcess
 from treeherder.model.derived import RefDataManager

--- a/treeherder/etl/th_publisher.py
+++ b/treeherder/etl/th_publisher.py
@@ -4,7 +4,8 @@ import traceback
 from django.conf import settings
 from django.utils.encoding import python_2_unicode_compatible
 
-from treeherder.client import TreeherderAuth, TreeherderClient
+from treeherder.client import (TreeherderAuth,
+                               TreeherderClient)
 from treeherder.etl.oauth_utils import OAuthCredentials
 
 logger = logging.getLogger(__name__)

--- a/treeherder/events/publisher.py
+++ b/treeherder/events/publisher.py
@@ -1,6 +1,8 @@
 import logging
 
-from kombu import Connection, Exchange, Producer
+from kombu import (Connection,
+                   Exchange,
+                   Producer)
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/log_parser/artifactbuilders.py
+++ b/treeherder/log_parser/artifactbuilders.py
@@ -6,7 +6,9 @@ from django.conf import settings
 from django.utils.six import BytesIO
 from mozlog.structured import reader
 
-from .parsers import StepParser, TalosParser, TinderboxPrintParser
+from .parsers import (StepParser,
+                      TalosParser,
+                      TinderboxPrintParser)
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/log_parser/management/commands/store_error_summary.py
+++ b/treeherder/log_parser/management/commands/store_error_summary.py
@@ -2,13 +2,15 @@ from cStringIO import StringIO
 from itertools import islice
 
 import requests
-from django.db import transaction
-from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
+from django.core.management.base import (BaseCommand,
+                                         CommandError)
+from django.db import transaction
 from mozlog import reader
 
 from treeherder.model.derived import JobsModel
-from treeherder.model.models import FailureLine, Repository
+from treeherder.model.models import (FailureLine,
+                                     Repository)
 
 
 class Command(BaseCommand):

--- a/treeherder/log_parser/management/commands/test_parse_log.py
+++ b/treeherder/log_parser/management/commands/test_parse_log.py
@@ -2,10 +2,10 @@ import time
 from optparse import make_option
 
 import simplejson as json
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import (BaseCommand,
+                                         CommandError)
 
-from treeherder.log_parser.artifactbuildercollection import \
-    ArtifactBuilderCollection
+from treeherder.log_parser.artifactbuildercollection import ArtifactBuilderCollection
 
 
 class Command(BaseCommand):

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -5,7 +5,8 @@ from django.core.management import call_command
 
 from treeherder import celery_app
 from treeherder.log_parser.utils import (extract_json_log_artifacts,
-                                         extract_text_log_artifacts, is_parsed,
+                                         extract_text_log_artifacts,
+                                         is_parsed,
                                          post_log_artifacts)
 
 logger = logging.getLogger(__name__)

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -5,11 +5,11 @@ import simplejson as json
 from django.conf import settings
 
 from treeherder import celery_app
-from treeherder.client import (TreeherderArtifactCollection, TreeherderAuth,
+from treeherder.client import (TreeherderArtifactCollection,
+                               TreeherderAuth,
                                TreeherderClient)
 from treeherder.etl.oauth_utils import OAuthCredentials
-from treeherder.log_parser.artifactbuildercollection import \
-    ArtifactBuilderCollection
+from treeherder.log_parser.artifactbuildercollection import ArtifactBuilderCollection
 from treeherder.log_parser.artifactbuilders import MozlogArtifactBuilder
 from treeherder.model.error_summary import get_error_summary_artifacts
 

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -9,14 +9,18 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from treeherder.etl.common import get_guid_root
 from treeherder.events.publisher import JobStatusPublisher
-from treeherder.model import error_summary, utils
-from treeherder.model.models import Datasource, ExclusionProfile
-from treeherder.model.tasks import (populate_error_summary, publish_job_action,
+from treeherder.model import (error_summary,
+                              utils)
+from treeherder.model.models import (Datasource,
+                                     ExclusionProfile)
+from treeherder.model.tasks import (populate_error_summary,
+                                    publish_job_action,
                                     publish_resultset,
                                     publish_resultset_action)
 
 from .artifacts import ArtifactsModel
-from .base import ObjectNotFoundException, TreeherderModelBase
+from .base import (ObjectNotFoundException,
+                   TreeherderModelBase)
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/model/derived/refdata.py
+++ b/treeherder/model/derived/refdata.py
@@ -1,7 +1,8 @@
 import logging
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import (datetime,
+                      timedelta)
 from hashlib import sha1
 
 from datasource.bases.BaseHub import BaseHub

--- a/treeherder/model/exchanges.py
+++ b/treeherder/model/exchanges.py
@@ -1,4 +1,6 @@
-from treeherder.model.pulse_publisher import Exchange, Key, PulsePublisher
+from treeherder.model.pulse_publisher import (Exchange,
+                                              Key,
+                                              PulsePublisher)
 
 
 class TreeherderPublisher(PulsePublisher):

--- a/treeherder/model/management/commands/import_reference_data.py
+++ b/treeherder/model/management/commands/import_reference_data.py
@@ -4,8 +4,17 @@ from urlparse import urlparse
 from django.core.management.base import BaseCommand
 
 from treeherder.client import TreeherderClient
-from treeherder.model.models import Option, OptionCollection, MachinePlatform, Machine, JobGroup, Product
-from treeherder.model.models import FailureClassification, BuildPlatform, JobType, Repository, RepositoryGroup
+from treeherder.model.models import (BuildPlatform,
+                                     FailureClassification,
+                                     JobGroup,
+                                     JobType,
+                                     Machine,
+                                     MachinePlatform,
+                                     Option,
+                                     OptionCollection,
+                                     Product,
+                                     Repository,
+                                     RepositoryGroup)
 
 
 class Command(BaseCommand):

--- a/treeherder/model/management/commands/init_datasources.py
+++ b/treeherder/model/management/commands/init_datasources.py
@@ -3,7 +3,8 @@ from optparse import make_option
 from django.core.management.base import BaseCommand
 from django.utils.six.moves import input
 
-from treeherder.model.models import Datasource, Repository
+from treeherder.model.models import (Datasource,
+                                     Repository)
 
 
 class Command(BaseCommand):

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -2,22 +2,26 @@ from __future__ import unicode_literals
 
 import os
 import uuid
-from collections import defaultdict, OrderedDict
-from warnings import filterwarnings, resetwarnings
+from collections import (OrderedDict,
+                         defaultdict)
+from warnings import (filterwarnings,
+                      resetwarnings)
 
 from datasource.bases.BaseHub import BaseHub
 from datasource.hubs.MySQL import MySQL
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.db import connection, models
+from django.db import (connection,
+                       models)
 from django.db.models import Q
 from django.utils.encoding import python_2_unicode_compatible
 from jsonfield import JSONField
 
 from treeherder import path
 
-from .fields import BigAutoField, FlexibleForeignKey
+from .fields import (BigAutoField,
+                     FlexibleForeignKey)
 
 # the cache key is specific to the database name we're pulling the data from
 SOURCES_CACHE_KEY = "treeherder-datasources"

--- a/treeherder/perf/management/commands/add_perf_framework.py
+++ b/treeherder/perf/management/commands/add_perf_framework.py
@@ -1,4 +1,5 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import (BaseCommand,
+                                         CommandError)
 
 from treeherder.perf.models import PerformanceFramework
 

--- a/treeherder/perf/management/commands/import_perf_data.py
+++ b/treeherder/perf/management/commands/import_perf_data.py
@@ -3,15 +3,18 @@ from optparse import make_option
 from urlparse import urlparse
 
 import concurrent.futures
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import (BaseCommand,
+                                         CommandError)
 from django.db import transaction
 
-from treeherder.client import PerfherderClient, PerformanceTimeInterval
-from treeherder.model.models import (MachinePlatform, OptionCollection,
+from treeherder.client import (PerfherderClient,
+                               PerformanceTimeInterval)
+from treeherder.model.models import (MachinePlatform,
+                                     OptionCollection,
                                      Repository)
-from treeherder.perf.models import (PerformanceFramework,
-                                    PerformanceSignature,
-                                    PerformanceDatum)
+from treeherder.perf.models import (PerformanceDatum,
+                                    PerformanceFramework,
+                                    PerformanceSignature)
 
 
 def _add_series(pc, project_name, signature_hash, signature_props, verbosity):

--- a/treeherder/perf/management/commands/test_analyze_perf.py
+++ b/treeherder/perf/management/commands/test_analyze_perf.py
@@ -2,10 +2,13 @@ from optparse import make_option
 from urlparse import urlparse
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import (BaseCommand,
+                                         CommandError)
 
-from treeherder.client import PerfherderClient, PerformanceTimeInterval
-from treeherder.perfalert import PerfDatum, TalosAnalyzer
+from treeherder.client import (PerfherderClient,
+                               PerformanceTimeInterval)
+from treeherder.perfalert import (PerfDatum,
+                                  TalosAnalyzer)
 
 
 class Command(BaseCommand):

--- a/treeherder/perf/models.py
+++ b/treeherder/perf/models.py
@@ -3,7 +3,9 @@ from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from jsonfield import JSONField
 
-from treeherder.model.models import MachinePlatform, OptionCollection, Repository
+from treeherder.model.models import (MachinePlatform,
+                                     OptionCollection,
+                                     Repository)
 
 SIGNATURE_HASH_LENGTH = 40L
 

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -2,9 +2,10 @@
 import os
 from datetime import timedelta
 
-import environ
 import dj_database_url
-from kombu import Exchange, Queue
+import environ
+from kombu import (Exchange,
+                   Queue)
 
 from treeherder import path
 

--- a/treeherder/webapp/api/artifact.py
+++ b/treeherder/webapp/api/artifact.py
@@ -1,7 +1,8 @@
 from rest_framework import viewsets
 from rest_framework.response import Response
 
-from treeherder.model.derived import ArtifactsModel, JobsModel
+from treeherder.model.derived import (ArtifactsModel,
+                                      JobsModel)
 from treeherder.model.error_summary import get_artifacts_that_need_bug_suggestions
 from treeherder.model.tasks import populate_error_summary
 from treeherder.webapp.api import permissions

--- a/treeherder/webapp/api/bug.py
+++ b/treeherder/webapp/api/bug.py
@@ -5,7 +5,8 @@ from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 
 from treeherder.model.derived.jobs import JobDataIntegrityError
-from treeherder.webapp.api.utils import UrlQueryFilter, with_jobs
+from treeherder.webapp.api.utils import (UrlQueryFilter,
+                                         with_jobs)
 
 
 class BugJobMapViewSet(viewsets.ViewSet):

--- a/treeherder/webapp/api/exceptions.py
+++ b/treeherder/webapp/api/exceptions.py
@@ -5,7 +5,8 @@ from rest_framework import exceptions
 from rest_framework.response import Response
 from rest_framework.views import exception_handler as drf_exc_handler
 
-from treeherder.model.derived import DatasetNotFoundError, ObjectNotFoundException
+from treeherder.model.derived import (DatasetNotFoundError,
+                                      ObjectNotFoundException)
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -1,15 +1,18 @@
 from rest_framework import viewsets
-from rest_framework.decorators import detail_route, list_route
+from rest_framework.decorators import (detail_route,
+                                       list_route)
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
 from treeherder.model.derived import ArtifactsModel
 from treeherder.model.models import FailureLine
-from treeherder.webapp.api import serializers
-from treeherder.webapp.api import permissions
+from treeherder.webapp.api import (permissions,
+                                   serializers)
 from treeherder.webapp.api.permissions import IsStaffOrReadOnly
-from treeherder.webapp.api.utils import UrlQueryFilter, get_option, with_jobs
+from treeherder.webapp.api.utils import (UrlQueryFilter,
+                                         get_option,
+                                         with_jobs)
 
 
 class JobsViewSet(viewsets.ViewSet):

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -1,14 +1,15 @@
 import datetime
 import json
 import time
-
 from collections import defaultdict
-from rest_framework import exceptions
-from rest_framework import viewsets
+
+from rest_framework import (exceptions,
+                            viewsets)
 from rest_framework.response import Response
 
 from treeherder.model import models
-from treeherder.perf.models import (PerformanceSignature, PerformanceDatum)
+from treeherder.perf.models import (PerformanceDatum,
+                                    PerformanceSignature)
 
 
 class PerformanceSignatureViewSet(viewsets.ViewSet):

--- a/treeherder/webapp/api/refdata.py
+++ b/treeherder/webapp/api/refdata.py
@@ -4,10 +4,12 @@ from rest_framework.response import Response
 from rest_framework_extensions.mixins import CacheResponseAndETAGMixin
 
 from treeherder.model import models
-from treeherder.model.derived import RefDataManager, JobsModel
+from treeherder.model.derived import (JobsModel,
+                                      RefDataManager)
 from treeherder.webapp.api import serializers as th_serializers
 from treeherder.webapp.api.permissions import (IsOwnerOrReadOnly,
                                                IsStaffOrReadOnly)
+
 
 #####################
 # Refdata ViewSets

--- a/treeherder/webapp/api/resultset.py
+++ b/treeherder/webapp/api/resultset.py
@@ -7,7 +7,9 @@ from rest_framework.reverse import reverse
 
 from treeherder.model.derived import DatasetNotFoundError
 from treeherder.webapp.api import permissions
-from treeherder.webapp.api.utils import UrlQueryFilter, to_timestamp, with_jobs
+from treeherder.webapp.api.utils import (UrlQueryFilter,
+                                         to_timestamp,
+                                         with_jobs)
 
 
 class ResultSetViewSet(viewsets.ViewSet):

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -1,10 +1,17 @@
-from django.conf.urls import include, patterns, url
+from django.conf.urls import (include,
+                              patterns,
+                              url)
 from rest_framework import routers
 
-from treeherder.webapp.api import (artifact, bug, job_log_url, jobs, logslice,
-                                   note, performance_data, refdata,
+from treeherder.webapp.api import (artifact,
+                                   bug,
+                                   job_log_url,
+                                   jobs,
+                                   logslice,
+                                   note,
+                                   performance_data,
+                                   refdata,
                                    resultset)
-
 
 # router for views that are bound to a project
 # i.e. all those views that don't involve reference data

--- a/treeherder/webapp/urls.py
+++ b/treeherder/webapp/urls.py
@@ -1,9 +1,10 @@
-from django.conf.urls import include, url
+from django.conf.urls import (include,
+                              url)
 from django.contrib import admin
 from django_browserid.admin import site as browserid_admin
 
-from treeherder.embed import urls as embed_urls
 from treeherder.credentials.urls import urlpatterns as credentials_patterns
+from treeherder.embed import urls as embed_urls
 
 from .api import urls as api_urls
 from .views import LoginView


### PR DESCRIPTION
Most of the changes in this PR are just updating the current imports to use the enforced style, by running isort against the repo - see individual commits/messages :-)

For an example Travis failure if someone deviates from the style, see:
https://travis-ci.org/mozilla/treeherder/builds/82941768

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1018)
<!-- Reviewable:end -->
