### PR TITLE
Bug 1209922 - Display sheriff menu for all users

### DIFF
--- a/ui/partials/main/thGlobalTopNavPanel.html
+++ b/ui/partials/main/thGlobalTopNavPanel.html
@@ -15,17 +15,15 @@
 
     <span class="navbar-right">
       <!-- Sheriffing Button -->
-      <span ng-show="user.loggedin">
-        <span class="btn btn-view-nav btn-right-navbar nav-menu-btn"
-             ng-class="{'active': (isSheriffPanelShowing)}"
-             ng-click="setSheriffPanelShowing(!isSheriffPanelShowing)"
-             tabindex="0"
-             role="button"><span>Sheriffing</span>
-          <i class="fa fa-angle-down lightgray"
-             ng-hide="isSheriffPanelShowing"></i>
-          <i class="fa fa-angle-up lightgray"
-             ng-show="isSheriffPanelShowing"></i>
-        </span>
+      <span class="btn btn-view-nav btn-right-navbar nav-menu-btn"
+            ng-class="{'active': (isSheriffPanelShowing)}"
+            ng-click="setSheriffPanelShowing(!isSheriffPanelShowing)"
+            tabindex="0"
+            role="button"><span>Sheriffing</span>
+        <i class="fa fa-angle-down lightgray"
+           ng-hide="isSheriffPanelShowing"></i>
+        <i class="fa fa-angle-up lightgray"
+           ng-show="isSheriffPanelShowing"></i>
       </span>
 
       <!-- Infra Menu -->

--- a/ui/partials/main/thSheriffPanel.html
+++ b/ui/partials/main/thSheriffPanel.html
@@ -67,7 +67,7 @@
     </table>
     <button ng-click="init_profile_add()" type="button"
             ng-disabled="!user.is_staff"
-            ng-attr-title="{{!user.is_staff ? 'Staff permissions required' : ''}}"
+            ng-attr-title="{{!user.is_staff ? 'Sheriff permissions required' : ''}}"
             class="btn btn-sm btn-primary">Add profile</button>
   </div>
 
@@ -151,7 +151,7 @@
     </table>
     <button ng-click="init_exclusion_add()" type="button"
             ng-disabled="!user.is_staff"
-            ng-attr-title="{{!user.is_staff ? 'Staff permissions required' : ''}}"
+            ng-attr-title="{{!user.is_staff ? 'Sheriff permissions required' : ''}}"
             class="btn btn-sm btn-primary">Add exclusion</button>
   </div>
 


### PR DESCRIPTION
This fixes Bugzilla bug [1209922](https://bugzilla.mozilla.org/show_bug.cgi?id=1209922).

This exposes the read-only Sheriff menu/panel to anyone on the web, not just users who are logged in.

Current:
![currentnavbar](https://cloud.githubusercontent.com/assets/3660661/10195763/433b3c08-675d-11e5-8b68-4d5bf4f0c22c.jpg)

Proposed (Sheriff menu available):
![proposednavbar](https://cloud.githubusercontent.com/assets/3660661/10195779/584e8672-675d-11e5-9ae5-1a49c12e3ef8.jpg)

Proposed (Sheriff panel open):
![proposedsheriffpanelopen](https://cloud.githubusercontent.com/assets/3660661/10195783/64be176a-675d-11e5-89fd-685aef5c11f9.jpg)

Everything seems fine in local testing and we don't need the extra span for any child element css targeting, so it was removed. I also checked it under vagrant logging in and logging out with a django `is_staff=true` and the panel presents itself as read/write, as expected.

Tested on OSX 10.10.5:
Release **44.0a1 (2015-09-30)**
Chrome Latest Release **45.0.2454.101 (64-bit)**

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1019)
<!-- Reviewable:end -->
