### PR TITLE
Fix bug in display of perf subtest comparison results

### DIFF
--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -434,9 +434,9 @@ perf.controller('CompareSubtestResultsCtrl', [
                                                 return PhCompare.getResultsMap($scope.newProject.name,
                                                                                newSeriesData.seriesList,
                                                                                timeRange,
-                                                                               [$scope.newResultSetID]);
+                                                                               [$scope.newResultSet.id]);
                                             }).then(function(newSeriesMaps) {
-                                                var newSeriesMap = newSeriesMaps[$scope.newResultSetID];
+                                                var newSeriesMap = newSeriesMaps[$scope.newResultSet.id];
                                                 // There is a chance that we haven't received data for the given signature/resultSet yet
                                                 if (newSeriesMap) {
                                                     Object.keys(newSeriesMap).forEach(function(series) {


### PR DESCRIPTION
When original repository was not the same as the new repository, we wouldn't
show new results. This commit fixes that.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1021)
<!-- Reviewable:end -->
