### PR TITLE
Bug 1201523 - Run grunt build during the Heroku deploy

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,3 +1,4 @@
+/dist/
 /docker/
 /docs/
 /puppet/

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,6 +1,13 @@
 #!/bin/bash -e
 # Tasks run by the Heroku Python buildpack after the compile step.
 
+# Work around https://github.com/heroku/heroku-buildpack-python/issues/223
+export PATH=/app/.heroku/node/bin:$PATH
+
+# Create a `dist/` directory containing built/minified versions of the `ui/` assets.
+# Uses the node binaries/packages installed by the nodejs buildpack previously.
+./node_modules/.bin/grunt build --production
+
 # Make the current Git revision accessible at <site-root>/revision.txt
 echo $SOURCE_VERSION > dist/revision.txt
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "grunt": "0.4.5",
     "grunt-angular-templates": "0.5.7",
     "grunt-cache-busting": "0.0.11",
+    "grunt-cli": "0.1.13",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-concat": "0.5.1",
     "grunt-contrib-copy": "0.8.1",


### PR DESCRIPTION
1) Add grunt-cli to local dependencies list
2) Run grunt build during the Heroku deploy

See individual commit messages for more details.

Example successful Heroku build log:
https://dashboard.heroku.com/apps/treeherder-heroku/activity/builds/01fad156-3378-41a3-9e7c-e3c7567ab049

And Heroku has this branch deployed currently, which can be confirmed by testing one of the recent UI features that is not in `dist/` on master (eg pressing "?" to open the keyboard shortcuts list), on:
https://treeherder-heroku.herokuapp.com/

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1022)
<!-- Reviewable:end -->
