### PR TITLE
Bug 1210546 - Run `grunt build` on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
 script:
   - npm test
   - py.test tests/$* --runslow
+  - ./node_modules/.bin/grunt build --production
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
To ensure build script/parsing breakage is detected early.

It only adds 18s to the travis job, so seems like a no-brainer :-)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1027)
<!-- Reviewable:end -->
