### PR TITLE
Bug 1210738 - Declare the license type in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "type": "git",
     "url": "https://github.com/mozilla/treeherder.git"
   },
+  "license" : "MPL-2.0",
   "dependencies": {
     "grunt": "0.4.5",
     "grunt-angular-templates": "0.5.7",


### PR DESCRIPTION
To suppress the warning shown when using `npm install`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1038)
<!-- Reviewable:end -->
