### PR TITLE
Bug 1211893 - Update oauth2 to v1.9.0.post1 and httplib2 to v0.9.2

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -67,8 +67,8 @@ django-cors-headers==1.1.0
 # sha256: -jPrQhcqGbcVrbp6ZJcJEftdj9G2nPjaepXyvH8PMDs
 django-browserid==1.0.0
 
-# sha256: gqOPZ02h-klsD8TfcUy7BYVAvtcqMMUKLjRLDZhMTSE
-oauth2==1.5.211
+# sha256: FbXEIwH0bdYxE_EhSw2BqLFiVPZahtPDKhtSKX8yZuY
+oauth2==1.9.0.post1
 
 # sha256: fn9zpnXFGHErrdeDJ54m0WQUDz_C7XoyECw9CKaipKc
 jsonfield==1.0.3

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -103,8 +103,8 @@ requests==2.7.0
 fancy-tag==0.2.0
 
 # Required by oauth2
-# sha256: vGM5kZpSNbnRqu4BHKVGQYQJjwxHyQmAAfkclxdlg_U
-httplib2==0.9.1
+# sha256: w6uhyVOXEVUfTYPoV7MWtRNKHE3c6YqHW3Anvn3W2Yg
+httplib2==0.9.2
 
 # Required by django.contrib.migrations
 # sha256: Z4xsNspLAUBRd9qLhO7PkuySyfbHYjlsllu10wXyD4E


### PR DESCRIPTION
See individual commits.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1040)
<!-- Reviewable:end -->
