### PR TITLE
Bug 1209555 client hawk new

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -117,7 +117,7 @@ django-environ==0.4.0
 # sha256: QYqTw5en7asj5ViNvAZ6x0pyPts9VBvUk295R252Rdo
 six==1.9.0
 
-# Required by hawkrest
+# Required by hawkrest and requests-hawk
 # sha256: SNZPN8Hy9utro7Xy2LDByQ4offLtH9-Ah0_tDDYJ61I
 mohawk==0.3.0
 
@@ -126,3 +126,6 @@ hawkrest==0.0.8
 
 # sha256: KuY89HXwvQSbci-sIIE9Yq7cFJV91aO_ANEg0rVARGA
 python-dateutil==2.4.2
+
+# sha256: Z1L5dgnjtpS42jP4T96FV4AIil_C-Vqjw5t69hdRcqQ
+ requests-hawk==0.2.0

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -37,13 +37,14 @@ def completed_jobs(sample_data):
 
 @pytest.fixture
 def pending_jobs_stored(
-        jm, pending_jobs, result_set_stored):
+        jm, pending_jobs, result_set_stored, mock_post_json):
     """
     stores a list of buildapi pending jobs into the jobs store
     using BuildApiTreeHerderAdapter
     """
 
     pending_jobs.update(result_set_stored[0])
+    pending_jobs.update({'project': jm.project})
 
     tjc = TreeherderJobCollection()
     tj = tjc.get_job(pending_jobs)
@@ -54,11 +55,12 @@ def pending_jobs_stored(
 
 @pytest.fixture
 def running_jobs_stored(
-        jm, running_jobs, result_set_stored):
+        jm, running_jobs, result_set_stored, mock_post_json):
     """
     stores a list of buildapi running jobs
     """
     running_jobs.update(result_set_stored[0])
+    running_jobs.update({'project': jm.project})
 
     tjc = TreeherderJobCollection()
     tj = tjc.get_job(running_jobs)
@@ -74,6 +76,7 @@ def completed_jobs_stored(
     stores a list of buildapi completed jobs
     """
     completed_jobs['revision_hash'] = result_set_stored[0]['revision_hash']
+    completed_jobs.update({'project': jm.project})
 
     tjc = TreeherderJobCollection()
     tj = tjc.get_job(completed_jobs)

--- a/tests/e2e/test_client_job_ingestion.py
+++ b/tests/e2e/test_client_job_ingestion.py
@@ -3,9 +3,8 @@ import json
 import pytest
 from mock import MagicMock
 
-from treeherder.client.thclient import (TreeherderAuth,
-                                        client)
-from treeherder.etl.oauth_utils import OAuthCredentials
+from tests.test_utils import post_collection
+from treeherder.client.thclient import client
 from treeherder.log_parser.parsers import StepParser
 from treeherder.model import error_summary
 from treeherder.model.derived import (ArtifactsModel,
@@ -29,17 +28,6 @@ def text_log_summary_dict():
         },
         "logurl": "https://queue.taskcluster.net/v1/task/nhxC4hC3RE6LSVWTZT4rag/runs/0/artifacts/public/logs/live_backing.log"
     }
-
-
-def do_post_collection(project, collection):
-    # assume if there were no exceptions we're ok
-    cli = client.TreeherderClient(protocol='http', host='localhost')
-    credentials = OAuthCredentials.get_credentials(project)
-    auth = TreeherderAuth(credentials['consumer_key'],
-                          credentials['consumer_secret'],
-                          project)
-
-    cli.post_collection(project, collection, auth=auth)
 
 
 def check_artifacts(test_project,
@@ -105,7 +93,7 @@ def test_post_job_with_parsed_log(test_project, result_set_stored,
     })
     tjc.add(tj)
 
-    do_post_collection(test_project, tjc)
+    post_collection(test_project, tjc)
 
     check_artifacts(test_project, job_guid, 'parsed', 0)
 
@@ -153,7 +141,7 @@ def test_post_job_with_text_log_summary_artifact_parsed(
     })
     tjc.add(tj)
 
-    do_post_collection(test_project, tjc)
+    post_collection(test_project, tjc)
 
     check_artifacts(test_project, job_guid, 'parsed', 2,
                     {'Bug suggestions', 'text_log_summary'}, mock_error_summary)
@@ -202,7 +190,7 @@ def test_post_job_with_text_log_summary_artifact_parsed_dict_blob(
     })
     tjc.add(tj)
 
-    do_post_collection(test_project, tjc)
+    post_collection(test_project, tjc)
 
     check_artifacts(test_project, job_guid, 'parsed', 2,
                     {'Bug suggestions', 'text_log_summary'}, mock_error_summary)
@@ -253,7 +241,7 @@ def test_post_job_with_text_log_summary_artifact_pending(
 
     tjc.add(tj)
 
-    do_post_collection(test_project, tjc)
+    post_collection(test_project, tjc)
 
     check_artifacts(test_project, job_guid, 'parsed', 2,
                     {'Bug suggestions', 'text_log_summary'}, mock_error_summary)
@@ -315,7 +303,7 @@ def test_post_job_with_text_log_summary_and_bug_suggestions_artifact(
 
     tjc.add(tj)
 
-    do_post_collection(test_project, tjc)
+    post_collection(test_project, tjc)
 
     check_artifacts(test_project, job_guid, 'parsed', 2,
                     {'Bug suggestions', 'text_log_summary'}, error_summary_blob)
@@ -384,7 +372,7 @@ def test_post_job_artifacts_by_add_artifact(
 
     tjc.add(tj)
 
-    do_post_collection(test_project, tjc)
+    post_collection(test_project, tjc)
 
     check_artifacts(test_project, job_guid, 'parsed', 5,
                     {'Bug suggestions', 'text_log_summary', 'Job Info',
@@ -411,7 +399,7 @@ def test_post_job_with_tier(test_project, result_set_stored,
     tj.add_tier(3)
     tjc.add(tj)
 
-    do_post_collection(test_project, tjc)
+    post_collection(test_project, tjc)
 
     with JobsModel(test_project) as jobs_model:
         job = [x for x in jobs_model.get_job_list(0, 20)
@@ -435,7 +423,7 @@ def test_post_job_with_default_tier(test_project, result_set_stored,
     })
     tjc.add(tj)
 
-    do_post_collection(test_project, tjc)
+    post_collection(test_project, tjc)
 
     with JobsModel(test_project) as jobs_model:
         job = [x for x in jobs_model.get_job_list(0, 20)

--- a/tests/e2e/test_perf_ingestion.py
+++ b/tests/e2e/test_perf_ingestion.py
@@ -1,5 +1,5 @@
-from test_client_job_ingestion import do_post_collection
 from tests.sampledata import SampleData
+from tests.test_utils import post_collection
 from treeherder.client.thclient import client
 from treeherder.perf.models import (PerformanceDatum,
                                     PerformanceSignature)
@@ -36,7 +36,7 @@ def test_post_talos_artifact(test_project, test_repository, result_set_stored,
 
     tjc.add(tj)
 
-    do_post_collection(test_project, tjc)
+    post_collection(test_project, tjc)
 
     # we'll just validate that we got the expected number of results for
     # talos (we have validation elsewhere for the actual data adapters)

--- a/tests/webapp/api/test_artifact_api.py
+++ b/tests/webapp/api/test_artifact_api.py
@@ -3,9 +3,7 @@ import json
 import pytest
 from django.core.urlresolvers import reverse
 
-from treeherder.client.thclient import (TreeherderAuth,
-                                        client)
-from treeherder.etl.oauth_utils import OAuthCredentials
+from treeherder.client.thclient import client
 from treeherder.model.derived import (ArtifactsModel,
                                       JobsModel)
 
@@ -92,11 +90,7 @@ def test_artifact_create_text_log_summary(webapp, test_project, eleven_jobs_stor
     })
     tac.add(ta)
 
-    credentials = OAuthCredentials.get_credentials(test_project)
-    auth = TreeherderAuth(credentials['consumer_key'],
-                          credentials['consumer_secret'],
-                          test_project)
-    cli = client.TreeherderClient(protocol='http', host='localhost', auth=auth)
+    cli = client.TreeherderClient(protocol='http', host='localhost')
     cli.post_collection(test_project,  tac)
 
     with ArtifactsModel(test_project) as artifacts_model:
@@ -141,11 +135,7 @@ def test_artifact_create_text_log_summary_and_bug_suggestions(
         'job_guid': job['job_guid']
     }))
 
-    credentials = OAuthCredentials.get_credentials(test_project)
-    auth = TreeherderAuth(credentials['consumer_key'],
-                          credentials['consumer_secret'],
-                          test_project)
-    cli = client.TreeherderClient(protocol='http', host='localhost', auth=auth)
+    cli = client.TreeherderClient(protocol='http', host='localhost')
     cli.post_collection(test_project, tac)
 
     with ArtifactsModel(test_project) as artifacts_model:

--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -216,7 +216,7 @@ def test_result_set_detail_bad_project(webapp, jm):
     assert resp.json == {"detail": "No project with name foo"}
 
 
-def test_resultset_create(sample_resultset, jm, initial_data):
+def test_resultset_create(sample_resultset, jm, initial_data, mock_post_json):
     """
     test posting data to the resultset endpoint via webtest.
     extected result are:
@@ -228,13 +228,11 @@ def test_resultset_create(sample_resultset, jm, initial_data):
     trsc = TreeherderResultSetCollection()
 
     for rs in sample_resultset:
-        rs = trsc.get_resultset(rs)
-        trsc.add(rs)
+        rs.update({'author': 'John Doe'})
+        result_set = trsc.get_resultset(rs)
+        trsc.add(result_set)
 
-    resp = test_utils.post_collection(jm.project, trsc)
-
-    assert resp.status_int == 200
-    assert resp.json['message'] == 'well-formed JSON stored'
+    test_utils.post_collection(jm.project, trsc)
 
     stored_objs = jm.get_dhub().execute(
         proc="jobs_test.selects.resultset_by_rev_hash",
@@ -245,36 +243,6 @@ def test_resultset_create(sample_resultset, jm, initial_data):
     assert stored_objs[0]['revision_hash'] == sample_resultset[0]['revision_hash']
 
     jm.disconnect()
-
-
-def test_resultset_with_bad_secret(sample_resultset, jm, initial_data):
-
-    trsc = TreeherderResultSetCollection()
-    for rs in sample_resultset:
-        rs = trsc.get_resultset(rs)
-        trsc.add(rs)
-
-    resp = test_utils.post_collection(
-        jm.project, trsc, status=403, consumer_secret="horrible secret"
-    )
-
-    assert resp.status_int == 403
-    assert resp.json['detail'] == "Client authentication failed for project {0}".format(jm.project)
-
-
-def test_resultset_with_bad_key(sample_resultset, jm, initial_data):
-
-    trsc = TreeherderResultSetCollection()
-    for rs in sample_resultset:
-        rs = trsc.get_resultset(rs)
-        trsc.add(rs)
-
-    resp = test_utils.post_collection(
-        jm.project, trsc, status=403, consumer_key="horrible-key"
-    )
-
-    assert resp.status_int == 403
-    assert resp.json['detail'] == 'oauth_consumer_key does not match credentials for project {0}'.format(jm.project)
 
 
 def test_resultset_cancel_all(jm, resultset_with_three_jobs, pulse_action_consumer):

--- a/treeherder/client/setup.py
+++ b/treeherder/client/setup.py
@@ -45,5 +45,5 @@ setup(name='treeherder-client',
       license='MPL',
       packages=['thclient'],
       zip_safe=False,
-      install_requires=['oauth2', 'requests']
+      install_requires=['oauth2', 'requests', ' requests-hawk==0.2.0']
       )

--- a/treeherder/client/thclient/auth.py
+++ b/treeherder/client/thclient/auth.py
@@ -13,6 +13,8 @@ class TreeherderAuth(AuthBase):
         self.oauth_key = oauth_key
         self.oauth_secret = oauth_secret
         self.user = user
+        logger.warning('The use of TreeherderAuth is now deprecated.'
+                       'Please use HawkAuth instead')
 
     def __call__(self, r):
         # modify and return the request

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -9,7 +9,7 @@ from requests.exceptions import HTTPError
 # When releasing a new version to PyPI please also file a bug to request
 # that it is uploaded to http://pypi.pub.build.mozilla.org/pub/ too.
 # See bug 1191498 for an example of this.
-__version__ = '1.7.0'
+__version__ = '1.8.0'
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/credentials/management/commands/create_credentials.py
+++ b/treeherder/credentials/management/commands/create_credentials.py
@@ -1,0 +1,25 @@
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+
+from treeherder.credentials.models import Credentials
+
+
+class Command(BaseCommand):
+    help = 'Create a new set of credentials to use with the hawk authentication scheme'
+
+    def add_arguments(self, parser):
+        parser.add_argument('client_id', type=str)
+        parser.add_argument('owner', type=str)
+        parser.add_argument('description', type=str)
+
+    def handle(self, *args, **options):
+        owner = User.objects.get(email=options['owner'])
+        credentials = Credentials.objects.create(
+            client_id=options['client_id'],
+            description=options['description'],
+            owner=owner,
+            authorized=True
+        )
+
+        self.stdout.write('Successfully created credentials for "%s"' % credentials.client_id)
+        self.stdout.write('Secret: %s' % credentials.secret)

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -473,3 +473,6 @@ REST_FRAMEWORK_EXTENSIONS = {
 }
 
 HAWK_CREDENTIALS_LOOKUP = 'treeherder.webapp.api.auth.hawk_lookup'
+
+# This is the client id used by the internal data ingestion service.
+ETL_CLIENT_ID = 'treeherder-etl'

--- a/treeherder/webapp/api/job_log_url.py
+++ b/treeherder/webapp/api/job_log_url.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class JobLogUrlViewSet(viewsets.ViewSet):
+    permission_classes = (permissions.HasHawkOrLegacyOauthPermissionsOrReadOnly,)
 
     """
     A job_log_url object holds a reference to a job log.
@@ -45,8 +46,7 @@ class JobLogUrlViewSet(viewsets.ViewSet):
 
         return Response(job_log_url_list)
 
-    @detail_route(methods=['post'],
-                  permission_classes=(permissions.HasLegacyOauthPermissions,))
+    @detail_route(methods=['post'])
     @with_jobs
     def update_parse_status(self, request, project, jm, pk=None):
         """


### PR DESCRIPTION
I updated the etl code to use HawkAuth instead of TreeherderAuth.
I bumped up the TreeherderClient version to reflect the updated requirements.
I also sneaked in a fix for an error in the job_log_url permission_classes. 
Please note that I kept the last commit separated just for the review. I'll squash it before I merge it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1042)
<!-- Reviewable:end -->
