### PR TITLE
Bug 1212447 - Rename DATA_CYCLE_INTERVAL and make it an int

### DIFF
--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -209,7 +209,7 @@ def test_cycle_all_data(jm, refdata, sample_data, initial_data,
 
     jobs_before = jm.execute(proc="jobs_test.selects.jobs")
 
-    call_command('cycle_data', sleep_time=0, cycle_interval=1)
+    call_command('cycle_data', sleep_time=0, days=1)
 
     jobs_after = jm.execute(proc="jobs_test.selects.jobs")
 
@@ -249,7 +249,7 @@ def test_cycle_one_job(jm, refdata, sample_data, initial_data,
 
     jobs_before = jm.execute(proc="jobs_test.selects.jobs")
 
-    call_command('cycle_data', sleep_time=0, cycle_interval=1, debug=True)
+    call_command('cycle_data', sleep_time=0, days=1, debug=True)
 
     jobs_after = jm.execute(proc="jobs_test.selects.jobs")
 
@@ -289,7 +289,7 @@ def test_cycle_all_data_in_chunks(jm, refdata, sample_data, initial_data,
 
     jobs_before = jm.execute(proc="jobs_test.selects.jobs")
 
-    call_command('cycle_data', sleep_time=0, cycle_interval=1, chunk_size=3)
+    call_command('cycle_data', sleep_time=0, days=1, chunk_size=3)
 
     jobs_after = jm.execute(proc="jobs_test.selects.jobs")
 

--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -21,10 +21,10 @@ class Command(BaseCommand):
             help='Write debug messages to stdout'),
 
         make_option(
-            '--cycle-interval',
+            '--days',
             action='store',
-            dest='cycle_interval',
-            default=0,
+            dest='days',
+            default=settings.DATA_CYCLE_DAYS,
             type='int',
             help='Data cycle interval expressed in days'),
 
@@ -49,12 +49,9 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.is_debug = options['debug']
 
-        if options['cycle_interval']:
-            cycle_interval = datetime.timedelta(days=options['cycle_interval'])
-        else:
-            cycle_interval = settings.DATA_CYCLE_INTERVAL
+        cycle_interval = datetime.timedelta(days=options['days'])
 
-        self.debug("cycle interval... jobs: {}".format(cycle_interval))
+        self.debug("cycle interval... {}".format(cycle_interval))
 
         projects = Datasource.objects.values_list('project', flat=True)
         for project in projects:

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -20,7 +20,8 @@ DEBUG = os.environ.get("TREEHERDER_DEBUG", False)
 TREEHERDER_REQUEST_PROTOCOL = os.environ.get("TREEHERDER_REQUEST_PROTOCOL", "http")
 TREEHERDER_REQUEST_HOST = os.environ.get("TREEHERDER_REQUEST_HOST", "local.treeherder.mozilla.org")
 
-DATA_CYCLE_INTERVAL = timedelta(days=30 * 4)
+# Default to retaining data for ~4 months.
+DATA_CYCLE_DAYS = env.int("DATA_CYCLE_DAYS", default=120)
 
 RABBITMQ_USER = os.environ.get("TREEHERDER_RABBITMQ_USER", "guest")
 RABBITMQ_PASSWORD = os.environ.get("TREEHERDER_RABBITMQ_PASSWORD", "guest")


### PR DESCRIPTION
Since we'll then we able to set it via the environment, avoiding the need for local.py. Prior to this landing, stage will need `DATA_CYCLE_DAYS` to be added to the environment (in bug 1212461).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1043)
<!-- Reviewable:end -->
