### PR TITLE
Bug 1212886 - Fail early if stage/prod grunt build forgotten

### DIFF
--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -35,6 +35,11 @@ def pre_update(ctx, ref=settings.UPDATE_REF):
     with ctx.lcd(th_service_src):
         ctx.local('git fetch --quiet origin %s' % ref)
         ctx.local('git reset --hard FETCH_HEAD')
+        # Fail early if we've forgotten to run grunt build before deploy.
+        # This is easier to do (and more necessary) - now that dist/ is not
+        # present on master, and only created on the stage/production branches.
+        if not os.path.isfile(os.path.join(th_service_src, 'dist', 'index.html')):
+            raise Exception("Grunt build hasn't been run and committed to the repo!")
         ctx.local('find . -type f -name "*.pyc" -delete')
         # Remove gzipped UI assets in case the uncompressed original no longer exists.
         ctx.local('find dist/ -type f -name "*.gz" -delete')


### PR DESCRIPTION
This prevents 404s on the UI if the output from `grunt build` hasn't been committed to the repo prior to deploying to stage/prod.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1047)
<!-- Reviewable:end -->
