### PR TITLE
Bug 1212951 - Set 'verbose-name-plural' for models that need it

### DIFF
--- a/treeherder/credentials/models.py
+++ b/treeherder/credentials/models.py
@@ -16,3 +16,4 @@ class Credentials(models.Model):
 
     class Meta:
         db_table = 'credentials'
+        verbose_name_plural = 'credentials'

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -99,6 +99,7 @@ class Repository(models.Model):
 
     class Meta:
         db_table = 'repository'
+        verbose_name_plural = 'repositories'
 
     def __str__(self):
         return "{0} {1}".format(
@@ -134,6 +135,7 @@ class Bugscache(models.Model):
 
     class Meta:
         db_table = 'bugscache'
+        verbose_name_plural = 'bugscache'
 
     def __str__(self):
         return "{0}".format(self.id)
@@ -497,6 +499,8 @@ class ReferenceDataSignatures(models.Model):
     A collection of all the possible combinations of reference data,
     populated on data ingestion. signature is a hash of the data it refers to
     build_system_type is buildbot by default
+
+    TODO: Rename to 'ReferenceDataSignature'.
     """
     name = models.CharField(max_length=255L)
     signature = models.CharField(max_length=50L, db_index=True)
@@ -520,6 +524,8 @@ class ReferenceDataSignatures(models.Model):
 
     class Meta:
         db_table = 'reference_data_signatures'
+        # Remove if/when the model is renamed to 'ReferenceDataSignature'.
+        verbose_name_plural = 'reference data signatures'
 
 
 class FailureLineManager(models.Manager):
@@ -667,6 +673,7 @@ class FailureMatch(models.Model):
 
     class Meta:
         db_table = 'failure_match'
+        verbose_name_plural = 'failure matches'
         unique_together = (
             ('failure_line', 'classified_failure', 'matcher')
         )


### PR DESCRIPTION
By default Django appends an 's' onto the singular model name (in addition to munging CamelCase) when generating the plural form that is used in the admin panel/elsewhere. For example:

Device -> "devices"
RepositoryGroup -> "repository groups"

For some of our model names this doesn't make sense and results in items in the admin panel like "Credentialss", "Bugscaches" or "Repositorys", so we use verbose-name-plural to explicitly set the name that should be used:
https://docs.djangoproject.com/en/1.8/ref/models/options/#verbose-name-plural

"Credentials" is valid for the singular (ie: model name), according to:
http://english.stackexchange.com/questions/252073/which-is-correct-credential-or-credentials

"ReferenceDataSignatures" should really be renamed to the singular, but for now I've just left a TODO and set verbose-name-plural so it looks less awkward in the admin panel.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1049)
<!-- Reviewable:end -->
