### PR TITLE
Bug 1210367 - Heroku: Run collectstatic manually to speed up deploy

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -17,6 +17,11 @@ echo $SOURCE_VERSION > dist/revision.txt
 # collectstatic, and so does not affect files in the `dist/` directory.
 python -m whitenoise.gzip dist
 
+# The Python buildpack automatic collectstatic has been disabled using
+# DISABLE_COLLECTSTATIC, since it's slower than us running it here.
+# See: https://github.com/heroku/heroku-buildpack-python/issues/252
+./manage.py collectstatic --noinput
+
 # The post_compile script is run in a sub-shell, so we need to source the
 # buildpack's utils script again, so we can use set-env/set-default-env:
 # https://github.com/heroku/heroku-buildpack-python/blob/master/bin/utils


### PR DESCRIPTION
The Python buildpack's automatic collectstatic is slower, since it does a `--dry-run` first. To avoid the time penalty of this, we disable it by setting `DISABLE_COLLECTSTATIC` in the Heroku environment, and run collectstatic manually in `bin/post_compile`. See:
https://github.com/heroku/heroku-buildpack-python/issues/252

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1050)
<!-- Reviewable:end -->
