### PR TITLE
Bug 1199364 - Add revision fields

### DIFF
--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -318,6 +318,6 @@ def _do_missing_resultset_test(jm, etl_process):
     assert len(revisions_stored) == 20
     was_stored = False
     for rs in revisions_stored:
-        if str(rs['revision']) == new_revision:
+        if str(rs['short_revision']) == new_revision:
             was_stored = True
     assert was_stored

--- a/tests/jobs_test.json
+++ b/tests/jobs_test.json
@@ -31,7 +31,7 @@
             "sql": "SELECT res.push_timestamp,
                            rev.comments,
                            rev.repository_id,
-                           rev.revision
+                           rev.short_revision
                 FROM `revision` as rev
                 LEFT JOIN `revision_map` as revmap
                     ON rev.id = revmap.revision_id
@@ -52,7 +52,7 @@
             "host_type": "master_host"
         },
         "revision_ids": {
-            "sql": "SELECT `id`, `revision` FROM `revision`",
+            "sql": "SELECT `id`, `short_revision` FROM `revision`",
             "host_type": "master_host"
         },
         "revision_map": {

--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -363,7 +363,7 @@ def test_store_result_set_data(jm, initial_data, sample_resultset):
     )
     revision_ids = jm.get_dhub().execute(
         proc="jobs_test.selects.revision_ids",
-        key_column='revision',
+        key_column='short_revision',
         return_type='dict'
     )
 

--- a/treeherder/etl/classification_mirroring.py
+++ b/treeherder/etl/classification_mirroring.py
@@ -56,7 +56,7 @@ class ElasticsearchDocRequest(object):
             # with TBPL's legacy output format.
             "starttime": str(job_data["start_timestamp"]),
             "tree": self.project,
-            "rev": revision_list[0]["revision"],
+            "rev": revision_list[0]["short_revision"],
             "bug": str(self.bug_id),
             "who": self.who,
             "timestamp": str(self.classification_timestamp),

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -740,7 +740,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             debug_show=self.DEBUG,
             replace=[replacement],
             return_type="dict",
-            key_column="revision"
+            key_column="short_revision"
         )
         return lookups
 
@@ -798,7 +798,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
 
             aggregate_details[detail['result_set_id']].append(
                 {
-                    'revision': detail['revision'],
+                    'revision': detail['short_revision'],
                     'author': detail['author'],
                     'repository_id': detail['repository_id'],
                     'comments': detail['comments'],
@@ -1642,7 +1642,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                     result['push_timestamp'],
                     result.get('active_status', 'active'),
                     result['revision_hash'],
-                    top_revision['revision'],
+                    top_revision,
                     short_top_revision
 
                 ]
@@ -1675,6 +1675,8 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                      rev_datum['author'],
                      comment,
                      repository_id,
+                     rev_datum['revision'],
+                     short_revision,
                      short_revision,
                      repository_id]
                 )
@@ -1748,7 +1750,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             proc='jobs.selects.get_revisions',
             placeholders=all_revisions,
             replace=[rev_where_in_clause],
-            key_column='revision',
+            key_column='short_revision',
             return_type='dict',
             debug_show=self.DEBUG
         )

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1641,7 +1641,10 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                     short_top_revision,
                     result['push_timestamp'],
                     result.get('active_status', 'active'),
-                    result['revision_hash']
+                    result['revision_hash'],
+                    top_revision['revision'],
+                    short_top_revision
+
                 ]
             )
             where_in_list.append('%s')
@@ -1662,6 +1665,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                     'comment', None
                 )
 
+                # todo: camd store revision with short_revision and long_revision
                 repository_id = repository_id_lookup[rev_datum['repository']]
                 short_revision = rev_datum['revision'][:12]
                 revision_placeholders.append(

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -94,7 +94,7 @@
                 WHERE NOT EXISTS (
                     SELECT `revision`
                     FROM `revision`
-                    WHERE (`long_revision` = ? OR `short_revision` = ? `revision` = ?) AND `repository_id` = ?
+                    WHERE (`long_revision` = ? OR `short_revision` = ? OR `revision` = ?) AND `repository_id` = ?
                 )",
 
             "host_type":"master_host"

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -74,7 +74,7 @@
                 WHERE NOT EXISTS (
                     SELECT `revision_hash`, `push_timestamp`
                     FROM `result_set`
-                    WHERE `revision_hash` = ?
+                    WHERE `revision_hash` = ? or `long_revision` = ? or `short_revision` = ?
                 )",
 
             "host_type":"master_host"
@@ -94,7 +94,7 @@
                 WHERE NOT EXISTS (
                     SELECT `revision`
                     FROM `revision`
-                    WHERE `revision` = ? AND `repository_id` = ?
+                    WHERE (`long_revision` = ? OR `short_revision` = ? `revision` = ?) AND `repository_id` = ?
                 )",
 
             "host_type":"master_host"
@@ -575,8 +575,8 @@
             "host_type": "read_host"
         },
         "get_revisions":{
-            "sql":"SELECT `id`, `revision` FROM `revision`
-                   WHERE `active_status` = 'active' AND `revision` IN (REP0)",
+            "sql":"SELECT `id`, `short_revision` FROM `revision`
+                   WHERE `active_status` = 'active' AND `short_revision` IN (REP0)",
 
             "host_type": "master_host"
         },
@@ -615,7 +615,7 @@
                       rs.push_timestamp,
                       rs.active_status,
                       revision.id as revision_id,
-                      revision.revision
+                      revision.short_revision
                    FROM result_set AS rs
                    INNER JOIN revision_map
                       ON rs.id = revision_map.result_set_id
@@ -632,7 +632,7 @@
             "sql":"SELECT
                     rm.result_set_id,
                     r.repository_id,
-                    r.revision,
+                    r.short_revision,
                     r.author,
                     r.comments
                    FROM revision_map AS rm


### PR DESCRIPTION
DO NOT MERGE - WIP

* still support and use ``short_revision`` internally for lookups and ingestion dup checking.  
* begin storing the ``long_revision``
* require ``long_revision`` for pulse jobs
* support both short and long revisions for UI, but default to long
* support both short and long for resultset submissions via API.  But communicate with submitters to transition to long.
NEED 
* tests for submitting short and long resultset revisions
* tests for jobs with short and long revisions
* try using short and long revisions from UI.  should just truncate.  FAILING NOW


later PRs:
* switch to using ``long_revision`` rather than ``revision_hash``
* remove ``revision_hash`` field

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1053)
<!-- Reviewable:end -->
