### PR TITLE
Bug 1213263 - Replace leftover references to "App ID" with "Client ID"

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -475,5 +475,5 @@ REST_FRAMEWORK_EXTENSIONS = {
 
 HAWK_CREDENTIALS_LOOKUP = 'treeherder.webapp.api.auth.hawk_lookup'
 
-# This is the client id used by the internal data ingestion service.
+# This is the client ID used by the internal data ingestion service.
 ETL_CLIENT_ID = 'treeherder-etl'

--- a/treeherder/credentials/models.py
+++ b/treeherder/credentials/models.py
@@ -6,7 +6,7 @@ from django.db import models
 
 class Credentials(models.Model):
     """A list of treeherder api credentials"""
-    client_id = models.SlugField(max_length=32, unique=True)
+    client_id = models.SlugField("client ID", max_length=32, unique=True)
     secret = models.UUIDField(default=uuid.uuid4, editable=False)
     description = models.TextField()
     owner = models.ForeignKey(User)

--- a/treeherder/credentials/templates/credentials/base.html
+++ b/treeherder/credentials/templates/credentials/base.html
@@ -4,7 +4,7 @@
 <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Treeherder Credentials management</title>
+        <title>Treeherder credentials management</title>
         <link rel="stylesheet" href="{% static "webapp/css/bootstrap.min.css" %}">
         {% browserid_css %}
     </head>
@@ -15,7 +15,7 @@
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <h3 class="panel-title">
-                        {% block header %}Treeherder Credentials management{% endblock %}
+                        {% block header %}Treeherder credentials management{% endblock %}
                     </h3>
                 </div>
                 <div class="panel-body">

--- a/treeherder/credentials/templates/credentials/credentials_confirm_delete.html
+++ b/treeherder/credentials/templates/credentials/credentials_confirm_delete.html
@@ -6,7 +6,7 @@
         Are you sure you want to delete the following credentials?
     </div>
     <dl class="dl-horizontal">
-        <dt>App ID</dt><dd>{{ object.client_id }}</dd>
+        <dt>Client ID</dt><dd>{{ object.client_id }}</dd>
         <dt>Secret</dt><dd>{{ object.secret }}</dd>
         <dt>Authorization</dt>
         <dd>

--- a/treeherder/credentials/templates/credentials/credentials_detail.html
+++ b/treeherder/credentials/templates/credentials/credentials_detail.html
@@ -3,7 +3,7 @@
 {% block content %}
     <h2>Credentials detail</h2>
     <dl class="dl-horizontal">
-        <dt>App ID</dt><dd>{{ object.client_id }}</dd>
+        <dt>Client ID</dt><dd>{{ object.client_id }}</dd>
         <dt>Secret</dt><dd><code>{{ object.secret }}</code></dd>
         <dt>Authorization</dt>
         <dd>

--- a/treeherder/credentials/templates/credentials/credentials_list.html
+++ b/treeherder/credentials/templates/credentials/credentials_list.html
@@ -6,7 +6,7 @@
         <thead>
             <tr>
                 <th>
-                    App ID
+                    Client ID
                 </th>
                 <th>
                     Authorized


### PR DESCRIPTION
* Replace leftover references to "App ID" with "Client ID". So it's clearer to users of the credentials management pages, since "Client ID" is used everywhere else.
* Make capitalisation on credentials pages consistent.
Sets a verbose name for client_id so "ID" always appears capitalised:
https://docs.djangoproject.com/en/1.8/topics/db/models/#verbose-field-names
Also tweaks the mixed capitalisation for the page title/heading.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1055)
<!-- Reviewable:end -->
