### PR TITLE
Bug 1213847 - Deprecate passing the auth object to the client's methods

### DIFF
--- a/docs/submitting_data.rst
+++ b/docs/submitting_data.rst
@@ -566,18 +566,10 @@ To create a TreeherderAuth instance you have to provide your oauth key, secret a
 
     auth = TreeherderAuth('my-key', 'my-secret', 'mozilla-central')
 
-You can either pass the auth instance directly to the client if you want to use them globally:
+This auth instance should then be passed to the TreeherderClient constructor, like so:
 
 .. code-block:: python
 
     auth = TreeherderAuth('my-key', 'my-secret', 'mozilla-central')
     client = TreeherderClient(protocol='https', host='treeherder.mozilla.org', auth=auth)
     client.post_collection('mozilla-central', tac)
-
-or to the post_collection method if you want to use the same client to submit data to different repositories:
-
-.. code-block:: python
-
-    auth = TreeherderAuth('my-key', 'my-secret', 'mozilla-central')
-    client = TreeherderClient(protocol='https', host='treeherder.mozilla.org')
-    client.post_collection('mozilla-central', tac, auth=auth)

--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -434,13 +434,14 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
         for job in self.job_data:
             tjc.add(tjc.get_job(job))
 
+        auth = TreeherderAuth('key', 'secret', 'project')
         client = TreeherderClient(
             protocol='http',
             host='host',
+            auth=auth,
             )
 
-        auth = TreeherderAuth('key', 'secret', 'project')
-        client.post_collection('project', tjc, auth=auth)
+        client.post_collection('project', tjc)
 
         path, resp = mock_post.call_args
 
@@ -460,13 +461,14 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
         for resultset in self.resultset_data:
             trc.add(trc.get_resultset(resultset))
 
+        auth = TreeherderAuth('key', 'secret', 'project')
         client = TreeherderClient(
             protocol='http',
             host='host',
+            auth=auth,
             )
 
-        auth = TreeherderAuth('key', 'secret', 'project')
-        client.post_collection('project', trc, auth=auth)
+        client.post_collection('project', trc)
 
         path, resp = mock_post.call_args
 
@@ -486,13 +488,14 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
         for artifact in self.artifact_data:
             tac.add(tac.get_artifact(artifact))
 
+        auth = TreeherderAuth('key', 'secret', 'project')
         client = TreeherderClient(
             protocol='http',
             host='host',
+            auth=auth,
             )
 
-        auth = TreeherderAuth('key', 'secret', 'project')
-        client.post_collection('project', tac, auth=auth)
+        client.post_collection('project', tac)
 
         path, resp = mock_post.call_args
 

--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -384,7 +384,6 @@ class TreeherderJobTest(DataSetup, unittest.TestCase):
     def test_sample_data_validation(self):
 
         for job in self.job_data:
-
             tj = TreeherderJob(job)
             tj.validate()
 
@@ -433,7 +432,6 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
         tjc = TreeherderJobCollection()
 
         for job in self.job_data:
-
             tjc.add(tjc.get_job(job))
 
         client = TreeherderClient(
@@ -460,7 +458,6 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
         trc = TreeherderResultSetCollection()
 
         for resultset in self.resultset_data:
-
             trc.add(trc.get_resultset(resultset))
 
         client = TreeherderClient(
@@ -487,7 +484,6 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
         tac = TreeherderArtifactCollection()
 
         for artifact in self.artifact_data:
-
             tac.add(tac.get_artifact(artifact))
 
         client = TreeherderClient(

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -625,7 +625,7 @@ class TreeherderClient(object):
         :param protocol: protocol to use (http or https)
         :param host: treeherder host to post to
         :param timeout: maximum time it can take for a request to complete
-        :param auth: an instance of TreeherderAuth holding the auth credentials
+        :param auth: an instance of HawkAuth/TreeherderAuth holding the auth credentials
         """
         self.host = host
 
@@ -903,9 +903,14 @@ class TreeherderClient(object):
         :param project: project to submit data for
         :param collection_inst: a TreeherderCollection instance
         :param timeout: custom timeout in seconds (defaults to class timeout)
-        :param auth: an instance of TreeherderAuth holding the auth credentials
+        :param auth: an instance of HawkAuth/TreeherderAuth (deprecated)
         """
-        auth = auth or self.auth
+        if auth:
+            logger.warning('Passing `auth` to post_collection() is deprecated, '
+                           'pass it to the TreeherderClient constructor instead.')
+        else:
+            auth = self.auth
+
         if not isinstance(collection_inst, TreeherderCollection):
             msg = '{0} should be an instance of TreeherderCollection'.format(
                 type(collection_inst))
@@ -936,9 +941,14 @@ class TreeherderClient(object):
         :param parse_status: string representing parse status of a treeherder
                              job
         :param timeout: custom timeout in seconds (defaults to class timeout)
-        :param auth: an instance of TreeherderAuth holding the auth credentials
+        :param auth: an instance of HawkAuth/TreeherderAuth (deprecated)
         """
-        auth = auth or self.auth
+        if auth:
+            logger.warning('Passing `auth` to update_parse_status() is deprecated, '
+                           'pass it to the TreeherderClient constructor instead.')
+        else:
+            auth = self.auth
+
         self._post_json(project, self.UPDATE_ENDPOINT.format(job_log_url_id),
                         {'parse_status': parse_status},
                         timeout, auth)

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -907,24 +907,18 @@ class TreeherderClient(object):
         """
         auth = auth or self.auth
         if not isinstance(collection_inst, TreeherderCollection):
-
             msg = '{0} should be an instance of TreeherderCollection'.format(
                 type(collection_inst))
-
             raise TreeherderClientError(msg, [])
 
         if not collection_inst.endpoint_base:
-
             msg = "{0}: collection endpoint_base property not defined".format(
                 self.__class__.__name__)
-
             raise TreeherderClientError(msg, [])
 
         if not collection_inst.data:
-
             msg = "{0}: collection data property not defined".format(
                 self.__class__.__name__)
-
             raise TreeherderClientError(msg, [])
 
         collection_inst.validate()


### PR DESCRIPTION
Since with the new per-user Hawk credentials, the same auth object can be used for the whole session, so should just be passed when instantiating TreeherderClient.

The tests in test_treeherder_client.py need updating to use HawkAuth, but that's unrelated for now, so I'll do that in another bug/PR.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1056)
<!-- Reviewable:end -->
