### PR TITLE
Bug 1214039 - Handle either 12 or 40 char revision hashes in resultset API

### DIFF
--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -78,9 +78,57 @@ def test_resultset_list_empty_rs_still_show(webapp, initial_data,
     jm.disconnect()
 
 
+def test_resultset_list_single_short_revision(webapp, eleven_jobs_stored, jm):
+    """
+    test retrieving a resultset list, filtered by single short revision
+    """
+
+    resp = webapp.get(
+        reverse("resultset-list", kwargs={"project": jm.project}),
+        {"revision": "21fb3eed1b5f"}
+    )
+    assert resp.status_int == 200
+    results = resp.json['results']
+    meta = resp.json['meta']
+    assert len(results) == 1
+    assert set([rs["revision"] for rs in results]) == {"21fb3eed1b5f"}
+    assert(meta == {
+        u'count': 1,
+        u'revision': u'21fb3eed1b5f',
+        u'filter_params': {
+            u'revision': "21fb3eed1b5f"
+        },
+        u'repository': u'test_treeherder'}
+    )
+
+
+def test_resultset_list_single_long_revision(webapp, eleven_jobs_stored, jm):
+    """
+    test retrieving a resultset list, filtered by a single long revision
+    """
+
+    resp = webapp.get(
+        reverse("resultset-list", kwargs={"project": jm.project}),
+        {"revision": "21fb3eed1b5f3456789012345678901234567890"}
+    )
+    assert resp.status_int == 200
+    results = resp.json['results']
+    meta = resp.json['meta']
+    assert len(results) == 1
+    assert set([rs["revision"] for rs in results]) == {"21fb3eed1b5f"}
+    assert(meta == {
+        u'count': 1,
+        u'revision': u'21fb3eed1b5f3456789012345678901234567890',
+        u'filter_params': {
+            u'revision': "21fb3eed1b5f"
+        },
+        u'repository': u'test_treeherder'}
+    )
+
+
 def test_resultset_list_filter_by_revision(webapp, eleven_jobs_stored, jm):
     """
-    test retrieving a resultset list, filtered by a date range
+    test retrieving a resultset list, filtered by a revision range
     """
 
     resp = webapp.get(

--- a/treeherder/webapp/api/resultset.py
+++ b/treeherder/webapp/api/resultset.py
@@ -35,7 +35,7 @@ class ResultSetViewSet(viewsets.ViewSet):
         meta = {}
 
         # support ranges for date as well as revisions(changes) like old tbpl
-        for param in ["fromchange", "tochange", "startdate", "enddate"]:
+        for param in ["fromchange", "tochange", "startdate", "enddate", "revision"]:
             v = filter_params.get(param, None)
             if v:
                 del(filter_params[param])
@@ -60,6 +60,13 @@ class ResultSetViewSet(viewsets.ViewSet):
             # we're doing ``less than``, rather than ``less than or equal to``.
             filter_params.update({
                 "push_timestamp__lt": to_timestamp(meta['enddate']) + 86400
+            })
+        if 'revision' in meta:
+            filter_params.update({
+                # TODO: modify to use ``short_revision`` or ``long_revision``
+                # when addressing Bug 1079796
+                # Truncate to short revision for now
+                "revision": meta['revision'][:12]
             })
 
         meta['filter_params'] = filter_params


### PR DESCRIPTION
This will simply truncate the revision down to 12 chars, so it will work with our existing data.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1059)
<!-- Reviewable:end -->
