### PR TITLE
Bug 1213857 - Allow passing Hawk client_id/secret directly to the client

### DIFF
--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -6,6 +6,7 @@ import unittest
 
 import requests
 from mock import patch
+from requests_hawk import HawkAuth
 
 from treeherder.client import (TreeherderArtifact,
                                TreeherderArtifactCollection,
@@ -531,6 +532,21 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
                                                "oauth_token=&"
                                                "user=project&"
                                                "oauth_signature=kxmsE%2BCqRDtV%2Bqk9GYeA7n4F%2FCI%3D"))
+
+    def test_hawkauth_setup(self):
+        """Test that HawkAuth is correctly set up from the `client_id` and `secret` params."""
+        client = TreeherderClient(
+            client_id='client-abc',
+            secret='secret123',
+            )
+        auth = client.auth
+        assert isinstance(auth, HawkAuth)
+        expected_credentials = {
+            'id': 'client-abc',
+            'key': 'secret123',
+            'algorithm': 'sha256'
+        }
+        self.assertEqual(auth.credentials, expected_credentials)
 
     @patch("treeherder.client.client.requests.get")
     def test_get_job(self, mock_get):

--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -435,11 +435,11 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
         for job in self.job_data:
             tjc.add(tjc.get_job(job))
 
-        auth = TreeherderAuth('key', 'secret', 'project')
         client = TreeherderClient(
             protocol='http',
             host='host',
-            auth=auth,
+            client_id='client-abc',
+            secret='secret123',
             )
 
         client.post_collection('project', tjc)
@@ -462,11 +462,11 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
         for resultset in self.resultset_data:
             trc.add(trc.get_resultset(resultset))
 
-        auth = TreeherderAuth('key', 'secret', 'project')
         client = TreeherderClient(
             protocol='http',
             host='host',
-            auth=auth,
+            client_id='client-abc',
+            secret='secret123',
             )
 
         client.post_collection('project', trc)
@@ -489,11 +489,11 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
         for artifact in self.artifact_data:
             tac.add(tac.get_artifact(artifact))
 
-        auth = TreeherderAuth('key', 'secret', 'project')
         client = TreeherderClient(
             protocol='http',
             host='host',
-            auth=auth,
+            client_id='client-abc',
+            secret='secret123',
             )
 
         client.post_collection('project', tac)

--- a/treeherder/client/setup.py
+++ b/treeherder/client/setup.py
@@ -45,5 +45,5 @@ setup(name='treeherder-client',
       license='MPL',
       packages=['thclient'],
       zip_safe=False,
-      install_requires=['oauth2', 'requests', ' requests-hawk==0.2.0']
+      install_requires=['oauth2', 'requests>=2.4.3', 'requests-hawk']
       )

--- a/treeherder/client/thclient/auth.py
+++ b/treeherder/client/thclient/auth.py
@@ -13,8 +13,8 @@ class TreeherderAuth(AuthBase):
         self.oauth_key = oauth_key
         self.oauth_secret = oauth_secret
         self.user = user
-        logger.warning('The use of TreeherderAuth is now deprecated.'
-                       'Please use HawkAuth instead')
+        logger.warning('The use of TreeherderAuth is now deprecated. Please switch to using '
+                       'Hawk credentials, which are passed directly to TreeherderClient.')
 
     def __call__(self, r):
         # modify and return the request

--- a/treeherder/etl/th_publisher.py
+++ b/treeherder/etl/th_publisher.py
@@ -3,7 +3,6 @@ import traceback
 
 from django.conf import settings
 from django.utils.encoding import python_2_unicode_compatible
-from requests_hawk import HawkAuth
 
 from treeherder.client import TreeherderClient
 from treeherder.credentials.models import Credentials
@@ -15,16 +14,12 @@ def post_treeherder_collections(th_collections, chunk_size=1):
 
     errors = []
     credentials = Credentials.objects.get(client_id=settings.ETL_CLIENT_ID)
-    auth = HawkAuth(credentials={
-        'id': credentials.client_id,
-        'key': str(credentials.secret),
-        'algorithm': 'sha256'
-    })
 
     cli = TreeherderClient(
         protocol=settings.TREEHERDER_REQUEST_PROTOCOL,
         host=settings.TREEHERDER_REQUEST_HOST,
-        auth=auth
+        client_id=credentials.client_id,
+        secret=str(credentials.secret),
     )
 
     for project in th_collections:

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -3,7 +3,6 @@ import urllib2
 
 import simplejson as json
 from django.conf import settings
-from requests_hawk import HawkAuth
 
 from treeherder import celery_app
 from treeherder.client import (TreeherderArtifactCollection,
@@ -83,15 +82,11 @@ def post_log_artifacts(project,
     logger.debug("Downloading/parsing log for %s", log_description)
 
     credentials = Credentials.objects.get(client_id=settings.ETL_CLIENT_ID)
-    auth = HawkAuth(credentials={
-        'id': credentials.client_id,
-        'key': str(credentials.secret),
-        'algorithm': 'sha256'
-    })
     client = TreeherderClient(
         protocol=settings.TREEHERDER_REQUEST_PROTOCOL,
         host=settings.TREEHERDER_REQUEST_HOST,
-        auth=auth
+        client_id=credentials.client_id,
+        secret=str(credentials.secret),
     )
 
     try:


### PR DESCRIPTION
See individual commits.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1065)
<!-- Reviewable:end -->
