### PR TITLE
Bug 1058531 - Don't enable pytest coverage checker in runtests.sh

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -8,4 +8,4 @@ isort --check-only --diff --quiet \
  || { echo "isort errors found! Run 'isort' with no options to fix."; exit 1; }
 
 echo "Running Python tests"
-py.test tests/$* --cov-report html --cov treeherder
+py.test tests/


### PR DESCRIPTION
It shouldn't be enabled by default IMO. For better overall visibility, we should be using something like coveralls or codeclimate.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1066)
<!-- Reviewable:end -->
