### PR TITLE
Bug 1210158 - Clear onscreen help overlay on click

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -24,8 +24,10 @@
     </head>
     <body ng-controller="MainCtrl" ng-keydown="processKeyboardInput($event)">
         <div id="global-container">
-            <div id="onscreen-overlay" ng-if="onscreenOverlayShowing">
-               <div id="onscreen-shortcuts" ng-if="onscreenShortcutsShowing">
+            <div id="onscreen-overlay" ng-if="onscreenOverlayShowing"
+                 ng-click="setOnscreenShortcutsShowing(false)">
+               <div id="onscreen-shortcuts" ng-if="onscreenShortcutsShowing"
+                    stop-propagation-on-left-click>
                  <div class="col-xs-8">
                     <ng-include src="'partials/main/thShortcutTable.html'"></ng-include>
                  </div>

--- a/ui/js/directives/treeherder/main.js
+++ b/ui/js/directives/treeherder/main.js
@@ -90,13 +90,28 @@ treeherder.directive('copyValue', [
 // on left click but default href type functionality on
 // middle or right mouse click.
 treeherder.directive('preventDefaultOnLeftClick', [
-    function(){
+    function() {
         return {
             restrict: 'A',
             link: function(scope, element, attrs){
-                element.on('click', function(event){
-                    if(event.which === 1){
+                element.on('click', function(event) {
+                    if (event.which === 1) {
                         event.preventDefault();
+                    }
+                });
+            }
+        };
+    }
+]);
+
+treeherder.directive('stopPropagationOnLeftClick', [
+    function() {
+        return {
+            restrict: 'A',
+            link: function(scope, element) {
+                element.on('click', function(event) {
+                    if (event.which === 1) {
+                        event.stopPropagation();
                     }
                 });
             }


### PR DESCRIPTION
This fixes Bugzilla bug [1210158](https://bugzilla.mozilla.org/show_bug.cgi?id=1210158).

This dismisses the keyboard shortcut overlay if the user clicks on the dimmed perimeter area. Previously only hitting `esc` or clicking on the [x] icon dismissed the panel.

Current (overlay visible via `?`, then click in the dimmed/grey surround region):
![dismissoverlayproposed](https://cloud.githubusercontent.com/assets/3660661/10527156/fd723ce2-735c-11e5-8566-e4f52d42b633.jpg)

Proposed (overlay and shortcuts are dismissed):
![dismissoverlayproposed2](https://cloud.githubusercontent.com/assets/3660661/10527188/21166740-735d-11e5-8270-83c495a2d1d0.jpg)

Shortcut table selection, still allowed:
![dismissoverlayproposed3](https://cloud.githubusercontent.com/assets/3660661/10527213/436acf48-735d-11e5-840e-e27a9226ee74.jpg)

We add a new stop propagation directive to support the above. This allows the user to click and select the shortcut table itself without the event bubbling up and closing the panel.

Eventually, if a full onscreen/inline-help UI is built, we'd tweak it further and wrap the close action(s) eg. `setOnscreenShortcutsShowing()` in a parent function. For now it seems to be fine as is since we only have this content at the moment.

I did some minor linting on the prevent default directive at the same time, since they are adjacent to each other in main.js.

Tested on OSX 10.10.5:
Release **44.0a1 (2015-10-14)**
Chrome Latest Release **46.0.2490.71 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1069)
<!-- Reviewable:end -->
