### PR TITLE
 	Bug 1215297 - Fix various usability issues/bugs in the graphs view

### DIFF
--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -894,30 +894,37 @@ perf.controller('TestChooserCtrl', function($scope, $modalInstance, $http,
             $scope.timeRange).then(function(platformList) {
                 $scope.platformList = platformList.platformList;
                 $scope.platformList.sort();
-                $scope.selectedPlatform = $scope.platformList[0];
+                if (_.contains($scope.platformList, defaultPlatform)) {
+                    $scope.selectedPlatform = defaultPlatform;
+                } else {
+                    $scope.selectedPlatform = $scope.platformList[0];
+                }
                 $scope.loadingPlatformList = false;
                 $scope.updateTestSelector();
             });
 
         $scope.updateTestSelector = function() {
             $scope.loadingTestData = true;
+            if ($scope.selectedPlatform) {
+                defaultPlatform = $scope.selectedPlatform;
+            }
             PhSeries.getSeriesByPlatform($scope.selectedProject.name,
                 $scope.timeRange, $scope.selectedPlatform, optionCollectionMap).then(
                 function(seriesData) {
                     $scope.unselectedTestList = _.sortBy(
                         _.filter(seriesData.seriesList,
-                            { platform: $scope.selectedPlatform }), 'name');
+                                 { platform: $scope.selectedPlatform }), 'name');
+                    // filter out tests which are already displayed or are
+                    // already selected
+                    _.forEach(_.union(testsDisplayed, $scope.testsToAdd),
+                              function(test) {
+                                  _.remove($scope.unselectedTestList, {
+                                      projectName: test.projectName,
+                                      signature: test.signature });
+                              });
+                    $scope.loadingTestData = false;
                 }
             );
-            // filter out tests which are already displayed or are
-            // already selected
-            _.forEach(_.union(testsDisplayed, $scope.testsToAdd),
-                function(test) {
-                    _.remove($scope.unselectedTestList, {
-                        projectName: test.projectName,
-                        signature: test.signature });
-                });
-            $scope.loadingTestData = false;
         };
 
     };

--- a/ui/partials/perf/testdatachooser.html
+++ b/ui/partials/perf/testdatachooser.html
@@ -20,7 +20,7 @@
     </div>
     <div id="choose-test-list" class="form-group">
       <p class="blink" ng-show="loadingTestData">Loading series data...</p>
-      <select multiple class="form-control" ng-model="selectedTestSignatures" ng-hide="loadingTestData">
+      <select ng-hide="loadingPlatformList || loadingTestData" multiple class="form-control" ng-model="selectedTestSignatures" ng-hide="loadingTestData">
         <option value="{{::testElem.signature}}" ng-repeat="testElem in unselectedTestList| filter: testFilter track by testElem.signature">
             {{::testElem.name}}
         </option>


### PR DESCRIPTION
* Preserve selected platform when switching between branches
* Automatically pick the platform of the last series when bringing up test selector
* Give an indicator that we are reloading test data when switching platforms
* Fix filtering out of selected tests

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1070)
<!-- Reviewable:end -->
