### PR TITLE
 	Bug 1187000 - Always show e10s data in compare view

### DIFF
--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -113,8 +113,7 @@ perf.controller('CompareResultsCtrl', [
                 $scope.originalProject.name,
                 timeRange,
                 optionCollectionMap,
-                {e10s: $scope.e10s,
-                 excludedPlatforms: $scope.excludedPlatforms }).then(
+                { excludedPlatforms: $scope.excludedPlatforms }).then(
                     function(originalSeriesData) {
                         $scope.platformList = originalSeriesData.platformList;
                         $scope.testList = originalSeriesData.testList;
@@ -137,7 +136,7 @@ perf.controller('CompareResultsCtrl', [
                             $scope.newProject.name,
                             timeRange,
                             optionCollectionMap,
-                            {e10s: $scope.e10s}).then(
+                            { excludedPlatforms: $scope.excludedPlatforms }).then(
                                 function(newSeriesData) {
                                     $scope.platformList = _.union($scope.platformList,
                                                                   newSeriesData.platformList).sort();
@@ -239,7 +238,6 @@ perf.controller('CompareResultsCtrl', [
                 return;
             }
 
-            $scope.e10s = Boolean($stateParams.e10s);
             // we are excluding macosx 10.10 by default for now, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1201615
             $scope.excludedPlatforms = Boolean($stateParams.showExcludedPlatforms) ?
                 [] : [ 'osx-10-10' ];

--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -169,11 +169,8 @@ perf.factory('PhSeries', ['$http', 'thServiceDomain', function($http, thServiceD
 
             return _getAllSeries(projectName, timeRange, optionMap).then(function(lists) {
                 lists.seriesList.forEach(function(seriesSummary) {
-                    // Only keep summary signatures, filter in/out e10s
-
-                    if (!seriesSummary.subtestSignatures ||
-                        (userOptions.e10s && !_.contains(seriesSummary.options, 'e10s')) ||
-                        (!userOptions.e10s && _.contains(seriesSummary.options, 'e10s'))) {
+                    if (!seriesSummary.subtestSignatures) {
+                        // Only keep summary signatures for now
                         return;
                     } else {
                         // We don't generate number for tp5n, this is xperf and we collect counters

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -12,7 +12,7 @@ perf.config(function($compileProvider, $stateProvider, $urlRouterProvider) {
         controller: 'GraphsCtrl'
     }).state('compare', {
         templateUrl: 'partials/perf/comparectrl.html',
-        url: '/compare?originalProject&originalRevision&newProject&newRevision&hideMinorChanges&e10s&showExcludedPlatforms',
+        url: '/compare?originalProject&originalRevision&newProject&newRevision&hideMinorChanges&showExcludedPlatforms',
         controller: 'CompareResultsCtrl'
     }).state('comparesubtest', {
         templateUrl: 'partials/perf/comparesubtestctrl.html',


### PR DESCRIPTION
We can add some kind of a filtering interface later, but until that's
ready it's confusing to just not display it unless people specify
a magic flag (e10s=1).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1074)
<!-- Reviewable:end -->
