### PR TITLE
Bug 1215450 - single resultset view stuck when using long revision

### DIFF
--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -120,7 +120,36 @@ def test_resultset_list_single_long_revision(webapp, eleven_jobs_stored, jm):
         u'count': 1,
         u'revision': u'21fb3eed1b5f3456789012345678901234567890',
         u'filter_params': {
-            u'revision': "21fb3eed1b5f"
+            u'revision__in': u'21fb3eed1b5f3456789012345678901234567890,21fb3eed1b5f'
+        },
+        u'repository': u'test_treeherder'}
+    )
+
+
+def test_resultset_list_single_long_revision_stored_long(webapp, sample_resultset, jm):
+    """
+    test retrieving a resultset list with store long revision, filtered by a single long revision
+    """
+
+    # store a resultset with long revision
+    resultset = sample_resultset[0]
+    resultset["revisions"][0]["revision"] = "21fb3eed1b5f3456789012345678901234567890"
+    jm.store_result_set_data([resultset])
+
+    resp = webapp.get(
+        reverse("resultset-list", kwargs={"project": jm.project}),
+        {"revision": "21fb3eed1b5f3456789012345678901234567890"}
+    )
+    assert resp.status_int == 200
+    results = resp.json['results']
+    meta = resp.json['meta']
+    assert len(results) == 1
+    assert set([rs["revision"] for rs in results]) == {"21fb3eed1b5f3456789012345678901234567890"}
+    assert(meta == {
+        u'count': 1,
+        u'revision': u'21fb3eed1b5f3456789012345678901234567890',
+        u'filter_params': {
+            u'revision__in': u'21fb3eed1b5f3456789012345678901234567890,21fb3eed1b5f'
         },
         u'repository': u'test_treeherder'}
     )

--- a/treeherder/webapp/api/resultset.py
+++ b/treeherder/webapp/api/resultset.py
@@ -62,12 +62,18 @@ class ResultSetViewSet(viewsets.ViewSet):
                 "push_timestamp__lt": to_timestamp(meta['enddate']) + 86400
             })
         if 'revision' in meta:
-            filter_params.update({
-                # TODO: modify to use ``short_revision`` or ``long_revision``
-                # when addressing Bug 1079796
-                # Truncate to short revision for now
-                "revision": meta['revision'][:12]
-            })
+            # TODO: modify to use ``short_revision`` or ``long_revision`` fields
+            # when addressing Bug 1079796
+            # It ends up that we store sometimes long, sometimes short
+            # revisions in the ``revision`` field, depending on the repo/source.
+            # (gaia, for instance).  So we must search
+            # for EITHER the short or long, when long is passed in.
+            if len(meta['revision']) > 12:
+                filter_params.update(
+                    {"revision__in": "{},{}".format(meta['revision'], meta['revision'][:12])}
+                )
+            else:
+                filter_params.update({"revision": meta['revision']})
 
         meta['filter_params'] = filter_params
 


### PR DESCRIPTION
Some repos have been storing 40 char revisions, though most only store
12.
But a recent change to search by only 12 chars, even if 40 passed in
broke
the ability to search when the stored length was 40.  This change will
search for both length revisions, if the 40 char is passed in.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1075)
<!-- Reviewable:end -->
