### PR TITLE
 	Bug 1214860 - Reduce amount of data loaded in perfherder compare view

### DIFF
--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -119,7 +119,6 @@ perf.controller('CompareResultsCtrl', [
                         $scope.testList = originalSeriesData.testList;
                         return PhCompare.getResultsMap($scope.originalProject.name,
                                                        originalSeriesData.seriesList,
-                                                       timeRange,
                                                        resultSetIds);
                     }).then(function(resultMaps) {
                         var originalResultsMap = resultMaps[$scope.originalResultSet.id];
@@ -144,7 +143,6 @@ perf.controller('CompareResultsCtrl', [
                                                               newSeriesData.testList).sort();
                                     return PhCompare.getResultsMap($scope.newProject.name,
                                                                    newSeriesData.seriesList,
-                                                                   timeRange,
                                                                    [$scope.newResultSet.id]);
                                 }).then(function(resultMaps) {
                                     var newResultsMap = resultMaps[$scope.newResultSet.id];
@@ -395,7 +393,6 @@ perf.controller('CompareSubtestResultsCtrl', [
                                     $scope.platformList = originalSeriesData.platformList;
                                     return PhCompare.getResultsMap($scope.originalProject.name,
                                                                    originalSeriesData.seriesList,
-                                                                   timeRange,
                                                                    resultSetIds);
                                 }).then(function(seriesMaps) {
                                     var originalSeriesMap = seriesMaps[$scope.originalResultSet.id];
@@ -431,7 +428,6 @@ perf.controller('CompareSubtestResultsCtrl', [
 
                                                 return PhCompare.getResultsMap($scope.newProject.name,
                                                                                newSeriesData.seriesList,
-                                                                               timeRange,
                                                                                [$scope.newResultSet.id]);
                                             }).then(function(newSeriesMaps) {
                                                 var newSeriesMap = newSeriesMaps[$scope.newResultSet.id];

--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -429,18 +429,20 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                         return errors;
                                     },
 
-                                    getResultsMap: function(projectName, seriesList, timeRange, resultSetIds) {
-                                        var baseURL = thServiceDomain + '/api/project/' +
+                                    getResultsMap: function(projectName, seriesList, resultSetIds) {
+                                        var url = thServiceDomain + '/api/project/' +
                                             projectName + '/performance/' +
-                                            'data/?interval=' + timeRange;
-
+                                            'data/?';
+                                        url += _.map(resultSetIds, function(resultSetId) {
+                                            return 'result_set_id=' + resultSetId;
+                                        }).join('&');
                                         var resultsMap = {};
                                         return $q.all(_.chunk(seriesList, 20).map(function(seriesChunk) {
                                             var signatures = "";
                                             seriesChunk.forEach(function(series) {
                                                 signatures += "&signatures=" + series.signature;
                                             });
-                                            return $http.get(baseURL + signatures).then(
+                                            return $http.get(url + signatures).then(
                                                 function(response) {
                                                     resultSetIds.forEach(function(resultSetId) {
                                                         if (resultsMap[resultSetId] === undefined) {
@@ -455,14 +457,14 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                                             _.where(data, { result_set_id: resultSetId }).forEach(function(pdata) {
                                                                 values.push(pdata.value);
                                                             });
-
-                                                            var seriesData = _.find(seriesChunk, {'signature': signature});
-
-                                                            resultsMap[resultSetId][signature] = {
-                                                                platform: seriesData.platform,
-                                                                name: seriesData.name,
-                                                                values: values
-                                                            };
+                                                            var seriesData = _.find(seriesList, {'signature': signature});
+                                                            if (seriesData) {
+                                                                resultsMap[resultSetId][signature] = {
+                                                                    platform: seriesData.platform,
+                                                                    name: seriesData.name,
+                                                                    values: values
+                                                                };
+                                                            }
                                                         });
                                                     });
                                                 });


### PR DESCRIPTION
We only need the data associated with the result sets we are comparing,
instead of a large time interval covering it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1076)
<!-- Reviewable:end -->
