### PR TITLE
Bug 1205316 - Travis: Use the beta Trusty infra & update to mysql 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
-sudo: false
-language: python
+# Once mysql 5.6 is available on the container infra, this can be removed.
+sudo: required
+dist: trusty
 python:
   - "2.7"
-cache:
-  directories:
-    - $HOME/virtualenv/python2.7.9
-    - node_modules
+# This doesn't do anything on the non-container infra. See:
+#   https://github.com/travis-ci/travis-ci/issues/4997
+# cache:
+#   directories:
+#     - $HOME/virtualenv/python2.7.9
+#     - node_modules
 env:
   global:
     - DATABASE_URL='mysql://root@localhost/treeherder'
@@ -14,9 +17,18 @@ env:
 services:
   - rabbitmq
   - memcached
+before_install:
+  # Manually install mysql 5.6 since the default is v5.5.
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
 install:
   - npm install
-  - ./bin/peep.py install -r requirements/common.txt -r requirements/dev.txt
+  # We use `--user` with pip install since the non-container infra doesn't set up
+  # a virtualenv, and we cannot use sudo due to:
+  #   https://github.com/travis-ci/travis-ci/issues/4989
+  # Disabling the pip version check speeds up the install considerably, since peep
+  # calls pip once per package, which results in duplicate checks (plus log spam).
+  - ./bin/peep.py install --user -r requirements/common.txt -r requirements/dev.txt --disable-pip-version-check
 before_script:
   - flake8 --show-source
   - isort --check-only --diff --quiet
@@ -24,7 +36,7 @@ before_script:
   # Required for Karma tests (http://docs.travis-ci.com/user/gui-and-headless-browsers/)
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - mysql -e 'create database treeherder;'
+  - mysql -u root -e 'create database treeherder;'
 script:
   - npm test
   - py.test tests/$* --runslow


### PR DESCRIPTION
Stage/production/Vagrant/Heroku's RDS all use mysql 5.6, however Travis is currently running v5.5. Installing mysql 5.6 manually on the Travis container infra is currently broken:
https://github.com/travis-ci/apt-package-whitelist/issues/1206#issuecomment-149884653

To use sudo (for apt-get) we either have to fall back to the legacy non-container infra, or else use the new Trusty beta infra:
http://blog.travis-ci.com/2015-10-14-opening-up-ubuntu-trusty-beta/
http://docs.travis-ci.com/user/trusty-ci-environment/#Runtimes

The Trusty beta infra is also non-container, but at least isn't EOL. Unfortunately similar to the legacy non-container infra, it doesn't offer caching, so incurs a setup time penalty of approx 3 minutes (including the mysql 5.6 install, npm install and peep install).

If/when the container infra uses mysql 5.6 by default, or the bug preventing installing it using the apt travis.yml option is fixed, we should switch back to the container infra, to speed up the Travis run.

In this commit, we use `--user` with the peep install, since the non-container infra doesn't set up a virtualenv, and we cannot use sudo due to:
https://github.com/travis-ci/travis-ci/issues/4989

In addition, the current user ("travis") now doesn't have permissions to create the Treeherder DB, so we have to use `-u root` (the password is blank).

The new infra is running Python 2.7.10 (rather than the v2.7.9 of the container infra) which now matches what runs in the Vagrant environment. In future bugs we should update stage/prod and Heroku to 2.7.10 too.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1080)
<!-- Reviewable:end -->
