### PR TITLE
Bug 1217374 - Improve logging for "Hawk authentication failed" errors on stage/prod

### DIFF
--- a/puppet/files/treeherder/local.vagrant.py
+++ b/puppet/files/treeherder/local.vagrant.py
@@ -27,6 +27,10 @@ LOGGING = {
             'level': 'INFO',
             'propagate': True,
         },
+        'hawkrest': {
+            'handlers': ['console'],
+            'level': 'WARNING',
+        },
         'treeherder': {
             'handlers': ['console', 'logfile'],
             'level': 'DEBUG',

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -148,7 +148,7 @@ LOGGING = {
     'loggers': {
         'django.request': {
             'handlers': ['console'],
-            'level': 'ERROR',
+            'level': 'WARNING',
             'propagate': True,
         },
         'hawkrest': {

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -141,7 +141,6 @@ LOGGING = {
     },
     'handlers': {
         'console': {
-            'level': 'ERROR',
             'class': 'logging.StreamHandler',
             'formatter': 'standard'
         },
@@ -152,8 +151,13 @@ LOGGING = {
             'level': 'ERROR',
             'propagate': True,
         },
+        'hawkrest': {
+            'handlers': ['console'],
+            'level': 'WARNING',
+        },
         'treeherder': {
-            'handlers': ['console']
+            'handlers': ['console'],
+            'level': 'ERROR',
         }
     }
 }


### PR DESCRIPTION
See individual commit messages.

After these commits, and with the typical Vagrant local settings file removed (so we can see the default settings that get used on stage/prod) [logging_tree](http://rhodesmill.org/brandon/2012/logging_tree/) shows the logging hierarchy as:
```
<--""
   Level WARNING
   |
   o<--[/home/vagrant/venv/local/lib/python2]
   |   |
   |   o<--[/home/vagrant/venv/local/lib/python2.7/site-packages/environ/environ]
   |       |
   |       o<--"/home/vagrant/venv/local/lib/python2.7/site-packages/environ/environ.pyc"
   |           Level NOTSET so inherits level WARNING
   |
   o<--"amqp"
   |   Level NOTSET so inherits level WARNING
   |
   o<--"celery"
   |   Level NOTSET so inherits level WARNING
   |   Handler <kombu.log.NullHandler object at 0xb6b6922c>
   |   |
   |   o<--[celery.app]
   |   |   |
   |   |   o<--"celery.app.builtins"
   |   |       Level NOTSET so inherits level WARNING
   |   |       Handler <kombu.log.NullHandler object at 0xb6b3014c>
   |   |
   |   o<--"celery.task"
   |   |   Level NOTSET so inherits level WARNING
   |   |   Handler <kombu.log.NullHandler object at 0xb6b6932c>
   |   |
   |   o<--"celery.worker"
   |       Level NOTSET so inherits level WARNING
   |       Handler <kombu.log.NullHandler object at 0xb6b6938c>
   |
   o<--"django"
   |   Level NOTSET so inherits level WARNING
   |   Handler Stream <open file '<stderr>', mode 'w' at 0xb74b70d0>
   |     Level INFO
   |     Filter <django.utils.log.RequireDebugTrue object at 0xb569ac2c>
   |   |
   |   o<--[django.db]
   |   |   |
   |   |   o<--"django.db.backends"
   |   |       Level NOTSET so inherits level WARNING
   |   |       |
   |   |       o<--"django.db.backends.schema"
   |   |           Level NOTSET so inherits level WARNING
   |   |
   |   o<--"django.request"
   |   |   Level WARNING
   |   |   Handler Stream <open file '<stderr>', mode 'w' at 0xb74b70d0>
   |   |     Formatter fmt='[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s' datefmt=None
   |   |
   |   o   "django.security"
   |       Level ERROR
   |       Propagate OFF
   |       Handler <django.utils.log.AdminEmailHandler object at 0xb569ac4c>
   |         Level ERROR
   |         Filter <django.utils.log.RequireDebugFalse object at 0xb562decc>
   |
   o<--[django_browserid]
   |   |
   |   o<--"django_browserid.auth"
   |   |   Level NOTSET so inherits level WARNING
   |   |
   |   o<--"django_browserid.base"
   |       Level NOTSET so inherits level WARNING
   |
   o<--"hawkrest"
   |   Level WARNING
   |   Handler Stream <open file '<stderr>', mode 'w' at 0xb74b70d0>
   |     Formatter fmt='[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s' datefmt=None
   |
   o<--[kombu]
   |   |
   |   o<--"kombu.common"
   |   |   Level NOTSET so inherits level WARNING
   |   |   Handler <kombu.log.NullHandler object at 0xb6b7f62c>
   |   |
   |   o<--"kombu.connection"
   |       Level NOTSET so inherits level WARNING
   |       Handler <kombu.log.NullHandler object at 0xb6cb616c>
   |
   o<--[mohawk]
   |   |
   |   o<--"mohawk.base"
   |   |   Level NOTSET so inherits level WARNING
   |   |
   |   o<--"mohawk.receiver"
   |   |   Level NOTSET so inherits level WARNING
   |   |
   |   o<--"mohawk.sender"
   |   |   Level NOTSET so inherits level WARNING
   |   |
   |   o<--"mohawk.util"
   |       Level NOTSET so inherits level WARNING
   |
   o<--"multiprocessing"
   |   Level NOTSET so inherits level WARNING
   |   Handler <kombu.log.NullHandler object at 0xb6b6928c>
   |
   o<--[py]
   |   |
   |   o<--"py.warnings"
   |       Level NOTSET so inherits level WARNING
   |       Handler Stream <open file '<stderr>', mode 'w' at 0xb74b70d0>
   |         Level INFO
   |         Filter <django.utils.log.RequireDebugTrue object at 0xb569ac2c>
   |
   o<--"pyinotify"
   |   Level INFO
   |   Handler Stream <open file '<stderr>', mode 'w' at 0xb74b70d0>
   |     Formatter fmt='[%(asctime)s %(name)s %(levelname)s] %(message)s' datefmt=None
   |
   o<--"requests"
   |   Level NOTSET so inherits level WARNING
   |   Handler <logging.NullHandler object at 0xb60e3cec>
   |   |
   |   o<--[requests.packages]
   |       |
   |       o<--"requests.packages.urllib3"
   |           Level NOTSET so inherits level WARNING
   |           Handler <logging.NullHandler object at 0xb60e3c8c>
   |           |
   |           o<--"requests.packages.urllib3.connectionpool"
   |           |   Level NOTSET so inherits level WARNING
   |           |
   |           o<--"requests.packages.urllib3.poolmanager"
   |           |   Level NOTSET so inherits level WARNING
   |           |
   |           o<--[requests.packages.urllib3.util]
   |               |
   |               o<--"requests.packages.urllib3.util.retry"
   |                   Level NOTSET so inherits level WARNING
   |
   o<--"treeherder"
       Level ERROR
       Handler Stream <open file '<stderr>', mode 'w' at 0xb74b70d0>
         Formatter fmt='[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s' datefmt=None
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1083)
<!-- Reviewable:end -->
