### PR TITLE
 	Bug 1217461 - Handle missing job group info in import_reference_data

### DIFF
--- a/treeherder/model/management/commands/import_reference_data.py
+++ b/treeherder/model/management/commands/import_reference_data.py
@@ -75,8 +75,9 @@ class Command(BaseCommand):
 
         # job type
         for job_type in c.get_job_types():
-            jgroup = JobGroup.objects.get(id=job_type['job_group'])
-            JobType.objects.get_or_create(
+            try:
+                jgroup = JobGroup.objects.get(id=job_type['job_group'])
+                JobType.objects.get_or_create(
                     id=job_type['id'],
                     symbol=job_type['symbol'],
                     name=job_type['name'],
@@ -85,6 +86,12 @@ class Command(BaseCommand):
                         'description': job_type['description'],
                         'active_status': job_type['active_status']
                     })
+            except JobGroup.DoesNotExist:
+                # ignore job types whose job group does not exist
+                self.stderr.write("WARNING: Job type '{}' ({}) references a "
+                                  "job group ({}) which does not have an "
+                                  "id".format(job_type['symbol'], job_type['name'],
+                                              job_type['job_group']))
 
         # product
         for product in c.get_products():


### PR DESCRIPTION
This shouldn't happen, but it does if there's something wrong with the
database (as is currently the case). So just print a warning instead of
throwing an exception.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1085)
<!-- Reviewable:end -->
