### PR TITLE
Bug 1185901 - Convert the bugscache table from MyISAM to InnoDB

### DIFF
--- a/treeherder/model/sql/template_schema/treeherder_reference_1.sql.tmpl
+++ b/treeherder/model/sql/template_schema/treeherder_reference_1.sql.tmpl
@@ -139,7 +139,7 @@ CREATE TABLE `bugscache` (
   FULLTEXT KEY `idx_crash_signature` (`crash_signature`),
   FULLTEXT KEY `idx_keywords` (`keywords`),
   FULLTEXT KEY `idx_all_full_text` (`summary`, `crash_signature`, `keywords`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --


### PR DESCRIPTION
Since MySQL 5.6 supports full text searching, so we no longer need to use MyISAM - and Django doesn't let us mix and match engines, so we need this for bug 1193836.

The bugscache table has already been updated manually on stage/prod and Heroku; this switches it for Travis/the local Vagrant environment.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1089)
<!-- Reviewable:end -->
