### PR TITLE
Bug 1205758 - Run `npm install --production` during stage/prod deploy

### DIFF
--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -72,6 +72,8 @@ def update(ctx):
         # collectstatic should be performed on one of the stage/prod specific
         # nodes at the end of the deploy, rather than on the admin node.
 
+        # Install nodejs non-dev packages, needed for the grunt build.
+        ctx.local("npm install --production")
         # Generate gzipped versions of files that would benefit from compression, that
         # WhiteNoise can then serve in preference to the originals. This is required
         # since WhiteNoise's Django storage backend only gzips assets handled by


### PR DESCRIPTION
Install the non-development packages listed under `dependencies` in package.json, in preparation for running grunt build during the deploy.

I've split this out of the other PR in bug 1205758, so we can at least check the dependencies all install ok, before fully switching over to running `grunt build` during the deploy.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1092)
<!-- Reviewable:end -->
