### PR TITLE
Bug 1193836 - use `--noinput` on migrate

### DIFF
--- a/puppet/manifests/classes/dev.pp
+++ b/puppet/manifests/classes/dev.pp
@@ -8,7 +8,7 @@ class dev{
 
   exec{"migrate":
     cwd => "${PROJ_DIR}",
-    command => "bash -c 'source /etc/profile.d/treeherder.sh; ${VENV_DIR}/bin/python manage.py migrate'",
+    command => "bash -c 'source /etc/profile.d/treeherder.sh; ${VENV_DIR}/bin/python manage.py migrate --noinput'",
     user => "${APP_USER}",
   }
 


### PR DESCRIPTION
This is a followup of 829cf22bc482937406a22f1511db7a0db53a0648

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1095)
<!-- Reviewable:end -->
