### PR TITLE
Bug 1220200 - Autoclassify read-only ui

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -42,6 +42,11 @@ div#info-panel .navbar-nav > li > a {
   line-height: 19px;
 }
 
+/* Use a loaded image, rather than an icon, so it needs to be slightly shorter */
+div#info-panel .navbar-nav > li > a#logviewer-btn {
+  line-height: 18px;
+}
+
 div#info-panel .navbar-nav > li > a.disabled {
   cursor: not-allowed;
   text-decoration: none;
@@ -53,28 +58,47 @@ div#info-panel .navbar-nav > li.active a:focus {
   outline: 0;
 }
 
-div#info-panel .navbar > ul.tab-headers > li {
+div#info-panel .info-panel-navbar > ul.tab-headers > li {
   border-right: 1px solid #42484F;
 }
 
-.navbar.navbar-dark {
+.info-panel-navbar {
   background-color: #252C33;
+  border: 1px solid transparent;
   color: #CED3D9;
+  display: flex;
+  z-index: 100;
 }
 
-.navbar.navbar-dark .navbar-nav > li > a {
+.info-panel-navbar-tabs {
+  justify-content: space-between;
+}
+
+.info-panel-navbar-controls {
+  flex-wrap: nowrap;
+}
+
+.info-panel-navbar .navbar-nav {
+  display: flex;
+}
+
+.info-panel-navbar .navbar-nav > li {
+  white-space: nowrap;
+}
+
+.info-panel-navbar .navbar-nav > li > a {
   color: #9FA3A5;
 }
 
-.navbar.navbar-dark .navbar-nav > li > a:hover,
-.navbar.navbar-dark .navbar-nav > li > a:focus {
+.info-panel-navbar .navbar-nav > li > a:hover,
+.info-panel-navbar .navbar-nav > li > a:focus {
   background-color: #1E252B;
   color: #D3D8DA;
 }
 
-div#info-panel .navbar.navbar-dark .navbar-nav > li.active a,
-div#info-panel .navbar.navbar-dark .navbar-nav > li.active a:hover,
-div#info-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
+div#info-panel .info-panel-navbar .navbar-nav > li.active a,
+div#info-panel .info-panel-navbar .navbar-nav > li.active a:hover,
+div#info-panel .info-panel-navbar .navbar-nav > li.active a:focus {
   background-color: #1A4666;
   color: #EEF0F2;
 }
@@ -215,11 +239,6 @@ div#info-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
   flex: 1 6;
   padding: 0px;
   min-width: 565px;
-}
-
-.talos-job-selected {
-  /* Override to optimize all other jobs above at 565px */
-  min-width: 625px !important;
 }
 
 #job-tabs-pane {
@@ -437,4 +456,44 @@ div.similar_jobs .left_panel table tr {
 
 div.talos-panel {
   display: block !important;
+}
+
+/*
+ * Error Classification
+ */
+
+.failure-line {
+  padding: 2px 4px 0;
+}
+
+.classified-line {
+  background: #ccfaff;
+}
+
+.failure-line-message {
+  display: flex;
+}
+
+.failure-line-message-toggle {
+  cursor: pointer;
+  width: 10px;
+  flex-basis: auto;
+  padding: 2px 4px;
+}
+
+.failure-line-message-collapsed {
+  max-height: 14px;
+  height: 14px;
+  overflow: hidden;
+  padding-left: 5px;
+  color: darkgray;
+}
+
+.failure-line-message-expanded {
+  margin-left: 5px;
+  margin-bottom: 10px;
+  color: #747474;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -106,6 +106,7 @@
         <script src="js/models/option_collection.js"></script>
         <script src="js/models/user.js"></script>
         <script src="js/models/error.js"></script>
+        <script src="js/models/failure_lines.js"></script>
         <script src="js/perf.js"></script>
         <!-- Controllers -->
         <script src="js/controllers/main.js"></script>
@@ -121,6 +122,7 @@
         <script src="plugins/annotations/controller.js"></script>
         <script src="plugins/failure_summary/controller.js"></script>
         <script src="plugins/similar_jobs/controller.js"></script>
+        <script src="plugins/auto_classification/controller.js"></script>
 
         <script src="js/filters.js"></script>
         <!-- endbuild -->

--- a/ui/js/filters.js
+++ b/ui/js/filters.js
@@ -126,3 +126,9 @@ treeherder.filter('getRevisionUrl', ['thServiceDomain', function(thServiceDomain
         return '';
     };
 }]);
+
+treeherder.filter('classified', function() {
+    return function(matches){
+        return matches.some(function(x) {return x.is_best;}) ? "CLASSIFIED" : "UNCLASSIFIED";
+    };
+});

--- a/ui/js/filters.js
+++ b/ui/js/filters.js
@@ -5,7 +5,7 @@
 treeherder.filter('showOrHide', function() {
     // determine whether this is a label for a job group (like mochitest)
     return function(input, isCollapsed) {
-        if (isCollapsed == true) {
+        if (isCollapsed === true) {
             return "show" + input;
         } else {
             return "hide" + input;

--- a/ui/js/models/failure_lines.js
+++ b/ui/js/models/failure_lines.js
@@ -1,0 +1,34 @@
+'use strict';
+
+treeherder.factory('ThFailureLinesModel', [
+    '$http', 'ThLog', 'thUrl',
+    function($http, ThLog, thUrl) {
+
+        var ThFailureLinesModel = function(data) {
+            angular.extend(this, data);
+        };
+
+        ThFailureLinesModel.get_url = function(job_id) {
+            return thUrl.getProjectJobUrl("/failure_lines/", job_id);
+        };
+
+        ThFailureLinesModel.get_list = function(job_id, config) {
+            // a static method to retrieve a list of ThFailureLinesModel
+            // the timeout configuration parameter is a promise that can be used to abort
+            // the ajax request
+            config = config || {};
+            var timeout = config.timeout || null;
+            return $http.get(ThFailureLinesModel.get_url(job_id), {
+                timeout: timeout
+            })
+            .then(function(response) {
+                var item_list = [];
+                angular.forEach(response.data, function(elem){
+                    item_list.push(new ThFailureLinesModel(elem));
+                });
+                return item_list;
+            });
+        };
+
+        return ThFailureLinesModel;
+    }]);

--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -15,6 +15,10 @@ treeherder.factory('thUrl', [
                 }
                 return thServiceDomain + "/api/project/" + repoName + uri;
             },
+            getProjectJobUrl: function(url, jobId, repoName) {
+                var uri = "/jobs/" + jobId + url;
+                return thUrl.getProjectUrl(uri, repoName);
+            },
             getLogViewerUrl: function(job_id) {
                 return "logviewer.html#?job_id=" + job_id + "&repo=" + $rootScope.repoName;
             },

--- a/ui/plugins/auto_classification/controller.js
+++ b/ui/plugins/auto_classification/controller.js
@@ -1,0 +1,42 @@
+"use strict";
+
+treeherder.controller('ClassificationPluginCtrl', [
+    '$scope', 'ThLog', 'ThFailureLinesModel','$q', 'thTabs', '$timeout',
+    function ClassificationPluginCtrl(
+        $scope, ThLog, ThFailureLinesModel, $q, thTabs, $timeout) {
+        var $log = new ThLog(this.constructor.name);
+
+        $log.debug("error classification plugin initialized");
+
+        var timeoutPromise = null;
+        var requestPromise = null;
+
+        thTabs.tabs.autoClassification.update = function() {
+            var jobId = thTabs.tabs.autoClassification.contentId;
+            // if there's an ongoing timeout, cancel it
+            if (timeoutPromise !== null) {
+                $timeout.cancel(timeoutPromise);
+            }
+            // if there's a ongoing request, abort it
+            if (requestPromise !== null) {
+                requestPromise.resolve();
+            }
+
+            requestPromise = $q.defer();
+
+            thTabs.tabs.autoClassification.is_loading = true;
+            ThFailureLinesModel.get_list(jobId,
+                                         {timeout: requestPromise})
+            .then(function(failureLines) {
+                $scope.failureLines = failureLines;
+                $scope.failureLinesLoaded = failureLines.length > 0;
+                if (!$scope.failureLinesLoaded) {
+                    timeoutPromise = $timeout(thTabs.tabs.autoClassification.update, 5000);
+                }
+            })
+            .finally(function() {
+                thTabs.tabs.autoClassification.is_loading = false;
+            });
+        };
+    }
+]);

--- a/ui/plugins/auto_classification/main.html
+++ b/ui/plugins/auto_classification/main.html
@@ -1,0 +1,46 @@
+<div ng-controller="ClassificationPluginCtrl"
+     class="error-classification-content">
+  <ul class="list-unstyled">
+
+    <li ng-repeat="line in failureLines"
+        class="failure-line"
+        ng-class="{'classified-line': line.matches.length }">
+      <span><strong>{{line.matches | classified}}</strong></span>
+      <span ng-if="line.matches.length">
+          <span ng-repeat="match in line.matches">
+              <a href="{{:: getBugUrl(match.classified_failure.bug_number) }}"
+                 target="_blank">{{::match.classified_failure.bug_number}}</a>
+          </span>
+      </span>
+      <span ng-if="line.action === 'test_result'">
+        <span>{{line.test}} {{line.subtest}}
+          Expected: {{line.expected}}, got: <span class="label label-default">{{line.status}}</span>
+        </span>
+        <div ng-if="line.message"
+             ng-init="messageExpanded=false"
+             class="failure-line-message">
+             <span class="failure-line-message-toggle fa fa-fw fa-lg"
+                     ng-class="{'fa-caret-down': messageExpanded, 'fa-caret-right': !messageExpanded}"
+                     ng-click="messageExpanded = !messageExpanded"></span>
+             <span ng-if="!messageExpanded"
+                   class="failure-line-message-collapsed">{{ line.message }}</span>
+             <span ng-if="messageExpanded"
+                   class="failure-line-message-expanded">{{ line.message }}</span>
+        </div>
+      </span>
+      <span ng-if="line.action === 'log'">
+        LOG {{line.level}} | {{line.message}}
+      </span>
+      <span ng-if="line.action === 'crash'">
+        CRASH | {{line.signature}}
+      </span>
+      <span ng-if="line.action === ''">
+        CRASH | {{line.signature}}
+      </span>
+    </li>
+
+    <li ng-if="!tabs.autoClassification.is_loading &&  !failureLines.length">
+      <span>No classifiable errors for this job.</span>
+    </li>
+  </ul>
+</div>

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -7,7 +7,7 @@ treeherder.controller('PluginCtrl', [
     'ThResultSetModel', 'ThLog', '$q', 'thPinboard', 'ThJobArtifactModel',
     'thBuildApi', 'thNotify', 'ThJobLogUrlModel', 'ThModelErrors', 'thTabs',
     '$timeout', 'thJobSearchStr', 'thReftestStatus', 'ThResultSetStore',
-    'PhSeries', 'thServiceDomain',
+    'PhSeries', 'thServiceDomain', 'ThFailureLinesModel',
     function PluginCtrl(
         $scope, $rootScope, $location, $http, thUrl, ThJobClassificationModel,
         thClassificationTypes, ThJobModel, thEvents, dateFilter, thDateFormat,
@@ -15,7 +15,7 @@ treeherder.controller('PluginCtrl', [
         ThResultSetModel, ThLog, $q, thPinboard, ThJobArtifactModel,
         thBuildApi, thNotify, ThJobLogUrlModel, ThModelErrors, thTabs,
         $timeout, thJobSearchStr, thReftestStatus, ThResultSetStore, PhSeries,
-        thServiceDomain) {
+        thServiceDomain, ThFailureLinesModel) {
 
         var $log = new ThLog("PluginCtrl");
 
@@ -41,12 +41,25 @@ treeherder.controller('PluginCtrl', [
             thJobFilters.replaceFilter('searchStr', jobSearchStr || null);
         };
 
+        // if the ``autoclassify`` param is set on the query sting, then
+        // show the ``autoClassification`` tab.  Otherwise, hide it.
+        // NOTE: This is a temporary param used during the evaluation/experimentation
+        // phase of this feature.
+        var showAutoClassifyTab = function() {
+            thTabs.tabs.autoClassification.enabled = ($location.search().autoclassify === true);
+        };
+        showAutoClassifyTab();
+        $rootScope.$on('$locationChangeSuccess', function() {
+            showAutoClassifyTab();
+        });
+
         /**
          * Set the tab options and selections based on the selected job.
          * The default selected tab will be based on whether the job was a
          * success or failure.
          *
          * Some tabs will be shown/hidden based on the job (such as Talos)
+         * and some based on query string params (such as autoClassification).
          *
          */
         var initializeTabs = function(job) {
@@ -58,6 +71,11 @@ treeherder.controller('PluginCtrl', [
             $scope.tabService.tabs.talos.enabled = (job.job_group_name.indexOf('Talos') !== -1);
             if ($scope.tabService.tabs.talos.enabled) {
                 successTab = "talos";
+            }
+
+            // Error Classification/autoclassify special handling
+            if ($scope.tabService.tabs.autoClassification.enabled) {
+                failTab = "autoClassification";
             }
 
             // set the selected tab

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -41,6 +41,33 @@ treeherder.controller('PluginCtrl', [
             thJobFilters.replaceFilter('searchStr', jobSearchStr || null);
         };
 
+        /**
+         * Set the tab options and selections based on the selected job.
+         * The default selected tab will be based on whether the job was a
+         * success or failure.
+         *
+         * Some tabs will be shown/hidden based on the job (such as Talos)
+         *
+         */
+        var initializeTabs = function(job) {
+            var successTab = "jobDetails";
+            var failTab = "failureSummary";
+
+            // show/hide Talos panel if this is a Talos job and default to
+            // Talos if the job was a ``success``
+            $scope.tabService.tabs.talos.enabled = (job.job_group_name.indexOf('Talos') !== -1);
+            if ($scope.tabService.tabs.talos.enabled) {
+                successTab = "talos";
+            }
+
+            // set the selected tab
+            if (thResultStatus(job) === 'success') {
+                $scope.tabService.selectedTab = successTab;
+            } else {
+                $scope.tabService.selectedTab = failTab;
+            }
+        };
+
         // this promise will void all the ajax requests
         // triggered by selectJob once resolved
         var selectJobPromise = null;
@@ -96,24 +123,8 @@ treeherder.controller('PluginCtrl', [
                     $scope.jobRevision = ThResultSetStore.getSelectedJob($scope.repoName).job.revision;
                     $scope.jobIds = results[4];
 
-                    // we handle which tab gets presented in the job details panel
-                    // and a special set of rules for talos
-                    if ($scope.job.job_group_name.indexOf('Talos') !== -1) {
-                        $scope.tabService.tabs.talos.enabled = true;
-                        if (thResultStatus($scope.job) === 'success') {
-                            $scope.tabService.selectedTab = 'talos';
-                        } else {
-                            $scope.tabService.selectedTab = 'failureSummary';
-                        }
-                    } else {
-                        // tab presentation for any other (non-talos) job
-                        $scope.tabService.tabs.talos.enabled = false;
-                        if (thResultStatus($scope.job) === 'success') {
-                            $scope.tabService.selectedTab = 'jobDetails';
-                        } else {
-                            $scope.tabService.selectedTab = 'failureSummary';
-                        }
-                    }
+                    // set the tab options and selections based on the selected job
+                    initializeTabs($scope.job);
 
                     // the second result come from the buildapi artifact promise
                     var buildapi_artifact = results[1];

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -223,45 +223,17 @@
       </div>
     </div>
   </div>
-  <div id="job-tabs-panel"
-       ng-class="{'talos-job-selected': tabService.tabs.talos.enabled}">
+  <div id="job-tabs-panel">
     <div id="job-tabs-navbar">
       <nav class="navbar navbar-dark">
         <ul class="nav navbar-nav tab-headers">
-          <li ng-class="{'active': tabService.selectedTab == 'jobDetails'}">
-            <a title="Show additional job information"
+          <li ng-repeat="tabName in tabService.tabOrder"
+              ng-if="tabService.tabs[tabName].enabled"
+              ng-class="{'active': tabService.selectedTab == tabName}">
+            <a title="Show {{ tabService.tabs[tabName].description }}"
                href="" prevent-default-on-left-click
-               ng-click="tabService.showTab('jobDetails', job.id)">
-              Job details
-            </a>
-          <li ng-class="{'active': tabService.selectedTab == 'failureSummary'}">
-            <a title="Show failure summary"
-               href="" prevent-default-on-left-click
-               ng-click="tabService.showTab('failureSummary', job.id)">
-              Failure summary
-            </a>
-          </li>
-          <li ng-class="{'active': tabService.selectedTab == 'annotations'}">
-            <a title="Show annotations"
-               href="" prevent-default-on-left-click
-               ng-click="tabService.showTab('annotations', job.id)">
-              Annotations
-            </a>
-          </li>
-          </li>
-          <li ng-class="{'active': tabService.selectedTab == 'similarJobs'}">
-            <a title="Show similar jobs"
-               href="" prevent-default-on-left-click
-               ng-click="tabService.showTab('similarJobs', job.id)">
-              Similar jobs
-            </a>
-          </li>
-          <li ng-if="tabService.tabs.talos.enabled"
-              ng-class="{'active': tabService.selectedTab == 'talos'}">
-            <a title="Show Talos job details"
-               href="" prevent-default-on-left-click
-               ng-click="tabService.showTab('talos', job.id)">
-              Talos
+               ng-click="tabService.showTab(tabName, job.id)">
+              {{ tabService.tabs[tabName].title }}
             </a>
           </li>
         </ul>

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -11,7 +11,7 @@
 <div id="info-panel-content">
   <div id="job-details-panel">
     <div id="job-details-actionbar">
-      <nav class="navbar navbar-dark">
+      <nav class="navbar info-panel-navbar">
         <ul class="nav navbar-nav actionbar-nav">
 
           <li ng-repeat="job_log_url in job_log_urls">
@@ -225,7 +225,7 @@
   </div>
   <div id="job-tabs-panel">
     <div id="job-tabs-navbar">
-      <nav class="navbar navbar-dark">
+      <nav class="info-panel-navbar info-panel-navbar-tabs">
         <ul class="nav navbar-nav tab-headers">
           <li ng-repeat="tabName in tabService.tabOrder"
               ng-if="tabService.tabs[tabName].enabled"
@@ -238,7 +238,7 @@
           </li>
         </ul>
 
-        <ul class="nav navbar-nav pull-right">
+        <ul class="nav navbar-nav info-panel-navbar-controls">
           <li>
             <a href="#" prevent-default-on-left-click ng-click="togglePinboardVisibility()"
                ng-class="{'pinboard-open-btn': isPinboardVisible}">

--- a/ui/plugins/tabs.js
+++ b/ui/plugins/tabs.js
@@ -16,6 +16,12 @@ treeherder.factory('thTabs', [
                     content: "plugins/failure_summary/main.html",
                     enabled: true
                 },
+                "autoClassification": {
+                    title: "Autoclassification",
+                    description: "Auto classification list",
+                    content: "plugins/auto_classification/main.html",
+                    enabled: false
+                },
                 "annotations": {
                     title: "Annotations",
                     description: "annotations",
@@ -38,6 +44,7 @@ treeherder.factory('thTabs', [
             "tabOrder": [
                 "jobDetails",
                 "failureSummary",
+                "autoClassification",
                 "annotations",
                 "similarJobs",
                 "talos"

--- a/ui/plugins/tabs.js
+++ b/ui/plugins/tabs.js
@@ -6,30 +6,42 @@ treeherder.factory('thTabs', [
             "tabs": {
                 "jobDetails": {
                     title: "Job details",
+                    description: "additional job information",
                     content: "plugins/job_details/main.html",
                     enabled: true
                 },
                 "failureSummary": {
                     title: "Failure summary",
+                    description: "failure summary",
                     content: "plugins/failure_summary/main.html",
                     enabled: true
                 },
                 "annotations": {
                     title: "Annotations",
+                    description: "annotations",
                     content: "plugins/annotations/main.html",
                     enabled: true
                 },
                 "similarJobs": {
                     title: "Similar jobs",
+                    description: "similar jobs",
                     content: "plugins/similar_jobs/main.html",
                     enabled: true
                 },
                 "talos": {
-                    title: "Job Info",
+                    title: "Talos",
+                    description: "Talos job details",
                     content: "plugins/talos/main.html",
                     enabled: false
                 }
             },
+            "tabOrder": [
+                "jobDetails",
+                "failureSummary",
+                "annotations",
+                "similarJobs",
+                "talos"
+            ],
             "selectedTab": "jobDetails",
             "showTab" : function(tab, contentId){
                 thTabs.selectedTab = tab;


### PR DESCRIPTION
Read-Only (prototype) UI for the Auto Classify panel.  This does not have any actions, just formats the data in a read-able way.

The panel tab only shows if the query string param of ``autoclassify`` is included.

An example can be seen here:
http://camd.github.io/treeherder/ui/#/jobs?repo=mozilla-inbound&revision=f968c82a1b15&autoclassify&filter-searchStr=ba74f7346fafb5d77d937cc9f8435107e67c348c

With Classified and Unclassified lines:
![screenshot 2015-10-30 14 41 09](https://cloud.githubusercontent.com/assets/419924/10858730/626b7998-7f14-11e5-9e74-ca493c55d2bc.png)

Expanded stack trace:
![screenshot 2015-10-30 14 42 58](https://cloud.githubusercontent.com/assets/419924/10858755/89cc9918-7f14-11e5-9334-f277a398e465.png)


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1096)
<!-- Reviewable:end -->
