### PR TITLE
Bug 1219222 - Update bugherder link to point at the new Heroku instance

### DIFF
--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -10,7 +10,7 @@
   <!-- Menu contents -->
   <ul class="dropdown-menu pull-right">
     <li><a target="_blank" ignore-job-clear-on-click
-           href="https://mcmerge.paas.allizom.org/?cset={{::resultset.revision}}&amp;tree={{::repoName}}"
+           href="https://mozilla-bugherder.herokuapp.com/?cset={{::resultset.revision}}&amp;tree={{::repoName}}"
            title="Use Bugherder to mark the bugs in this push">Mark with Bugherder</a></li>
     <li><a target="_blank" ignore-job-clear-on-click
            href="https://secure.pub.build.mozilla.org/buildapi/self-serve/{{::repoName}}/rev/{{::resultset.revision}}">BuildAPI</a></li>


### PR DESCRIPTION
The old Stackato PaaS link 404s, so point at the Heroku instance's herokuapp.com domain whilst we wait for the certificate/DNS to be set up for it at bugherder.mozilla.org.

Merging without review since the updated link works locally and I'd like this to catch today's deploy, given the current link 404s.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1097)
<!-- Reviewable:end -->
