### PR TITLE
Bug 1219222 - Update bugherder link to point at bugherder.mozilla.org

### DIFF
--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -10,7 +10,7 @@
   <!-- Menu contents -->
   <ul class="dropdown-menu pull-right">
     <li><a target="_blank" ignore-job-clear-on-click
-           href="https://mozilla-bugherder.herokuapp.com/?cset={{::resultset.revision}}&amp;tree={{::repoName}}"
+           href="https://bugherder.mozilla.org/?cset={{::resultset.revision}}&amp;tree={{::repoName}}"
            title="Use Bugherder to mark the bugs in this push">Mark with Bugherder</a></li>
     <li><a target="_blank" ignore-job-clear-on-click
            href="https://secure.pub.build.mozilla.org/buildapi/self-serve/{{::repoName}}/rev/{{::resultset.revision}}">BuildAPI</a></li>


### PR DESCRIPTION
The new prod domain has now been set up, so we can point directly to that rather than the herokuapp.com domain.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1098)
<!-- Reviewable:end -->
