### PR TITLE
Bug 1219889 - Speed up the Travis run by splitting it up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,3 @@
-# This doesn't do anything on the non-container infra. See:
-#   https://github.com/travis-ci/travis-ci/issues/4997
-# cache:
-#   directories:
-#     - $HOME/virtualenv/python2.7.9
-#     - node_modules
 env:
   global:
     - DATABASE_URL='mysql://root@localhost/test_treeherder'
@@ -13,8 +7,30 @@ matrix:
   include:
     # Each entry here creates another sub-job.
 
+    - env: linters
+      sudo: false
+      language: python
+      python: "2.7"
+      cache:
+        directories:
+          - ~/venv
+          - node_modules
+      before_install:
+        # Create a clean virtualenv rather than using the one given to us,
+        # to work around: https://github.com/travis-ci/travis-ci/issues/4873
+        - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv ~/venv; fi
+        - source ~/venv/bin/activate
+      install:
+        - npm install
+        - ./bin/peep.py install --disable-pip-version-check -r requirements/common.txt -r requirements/dev.txt
+      script:
+        - grunt checkjs
+        - flake8 --show-source
+        - isort --check-only --diff --quiet
+
     - env: main-test-run
-      # Once mysql 5.6 is available on the container infra, this can be removed.
+      # Once mysql 5.6 is available on the container infra, we should switch back
+      # to it, by setting `sudo: false`, so we can use caching for this job.
       sudo: required
       dist: trusty
       python: "2.7"
@@ -34,9 +50,6 @@ matrix:
         # calls pip once per package, which results in duplicate checks (plus log spam).
         - ./bin/peep.py install --user -r requirements/common.txt -r requirements/dev.txt --disable-pip-version-check
       before_script:
-        - flake8 --show-source
-        - isort --check-only --diff --quiet
-        - grunt checkjs
         # Required for Karma tests (http://docs.travis-ci.com/user/gui-and-headless-browsers/)
         - export DISPLAY=:99.0
         - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,26 @@ matrix:
         - flake8 --show-source
         - isort --check-only --diff --quiet
 
-    - env: main-test-run
+    - env: ui-tests
+      sudo: false
+      language: node_js
+      node_js: "4.2.1"
+      cache:
+        # Note: This won't re-use the same cache as the linters job,
+        # since caches are tied to the language/version combination.
+        directories:
+          - node_modules
+      install:
+        - npm install
+      before_script:
+        # Required for Karma tests (http://docs.travis-ci.com/user/gui-and-headless-browsers/)
+        - export DISPLAY=:99.0
+        - sh -e /etc/init.d/xvfb start
+      script:
+        - npm test
+        - ./node_modules/.bin/grunt build --production
+
+    - env: python-tests
       # Once mysql 5.6 is available on the container infra, we should switch back
       # to it, by setting `sudo: false`, so we can use caching for this job.
       sudo: required
@@ -42,21 +61,14 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install -qq mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
       install:
-        - npm install
         # We use `--user` with pip install since the non-container infra doesn't set up
         # a virtualenv, and we cannot use sudo due to:
         #   https://github.com/travis-ci/travis-ci/issues/4989
         # Disabling the pip version check speeds up the install considerably, since peep
         # calls pip once per package, which results in duplicate checks (plus log spam).
         - ./bin/peep.py install --user -r requirements/common.txt -r requirements/dev.txt --disable-pip-version-check
-      before_script:
-        # Required for Karma tests (http://docs.travis-ci.com/user/gui-and-headless-browsers/)
-        - export DISPLAY=:99.0
-        - sh -e /etc/init.d/xvfb start
       script:
-        - npm test
         - py.test tests/$* --runslow
-        - ./node_modules/.bin/grunt build --production
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,14 +59,14 @@ matrix:
         - memcached
       before_install:
         # Manually install mysql 5.6 since the default is v5.5.
-        - sudo apt-get update -qq
-        - sudo apt-get install -qq mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
+        - sudo apt-get -qq update
+        - sudo apt-get -qq install mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
       install:
         # This uses pip rather than peep, since it takes half the time, and unlike the other
         # jobs, this one cannot use caching. The hashes are validated in the linters job.
         - pip install --disable-pip-version-check -r requirements/common.txt -r requirements/dev.txt
       script:
-        - py.test tests/$* --runslow
+        - py.test tests/ --runslow
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-# Once mysql 5.6 is available on the container infra, this can be removed.
-sudo: required
-dist: trusty
-python:
-  - "2.7"
 # This doesn't do anything on the non-container infra. See:
 #   https://github.com/travis-ci/travis-ci/issues/4997
 # cache:
@@ -14,32 +9,42 @@ env:
     - DATABASE_URL='mysql://root@localhost/test_treeherder'
     - DATABASE_URL_RO='mysql://root@localhost/test_treeherder'
     - TREEHERDER_DJANGO_SECRET_KEY='secretkey-1234'
-services:
-  - rabbitmq
-  - memcached
-before_install:
-  # Manually install mysql 5.6 since the default is v5.5.
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
-install:
-  - npm install
-  # We use `--user` with pip install since the non-container infra doesn't set up
-  # a virtualenv, and we cannot use sudo due to:
-  #   https://github.com/travis-ci/travis-ci/issues/4989
-  # Disabling the pip version check speeds up the install considerably, since peep
-  # calls pip once per package, which results in duplicate checks (plus log spam).
-  - ./bin/peep.py install --user -r requirements/common.txt -r requirements/dev.txt --disable-pip-version-check
-before_script:
-  - flake8 --show-source
-  - isort --check-only --diff --quiet
-  - grunt checkjs
-  # Required for Karma tests (http://docs.travis-ci.com/user/gui-and-headless-browsers/)
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-script:
-  - npm test
-  - py.test tests/$* --runslow
-  - ./node_modules/.bin/grunt build --production
+matrix:
+  include:
+    # Each entry here creates another sub-job.
+
+    - env: main-test-run
+      # Once mysql 5.6 is available on the container infra, this can be removed.
+      sudo: required
+      dist: trusty
+      python: "2.7"
+      services:
+        - rabbitmq
+        - memcached
+      before_install:
+        # Manually install mysql 5.6 since the default is v5.5.
+        - sudo apt-get update -qq
+        - sudo apt-get install -qq mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
+      install:
+        - npm install
+        # We use `--user` with pip install since the non-container infra doesn't set up
+        # a virtualenv, and we cannot use sudo due to:
+        #   https://github.com/travis-ci/travis-ci/issues/4989
+        # Disabling the pip version check speeds up the install considerably, since peep
+        # calls pip once per package, which results in duplicate checks (plus log spam).
+        - ./bin/peep.py install --user -r requirements/common.txt -r requirements/dev.txt --disable-pip-version-check
+      before_script:
+        - flake8 --show-source
+        - isort --check-only --diff --quiet
+        - grunt checkjs
+        # Required for Karma tests (http://docs.travis-ci.com/user/gui-and-headless-browsers/)
+        - export DISPLAY=:99.0
+        - sh -e /etc/init.d/xvfb start
+      script:
+        - npm test
+        - py.test tests/$* --runslow
+        - ./node_modules/.bin/grunt build --production
+
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
         - npm test
         - ./node_modules/.bin/grunt build --production
 
-    - env: python-tests
+    - env: python-tests-main
       # Once mysql 5.6 is available on the container infra, we should switch back
       # to it, by setting `sudo: false`, so we can use caching for this job.
       sudo: required
@@ -66,7 +66,27 @@ matrix:
         # jobs, this one cannot use caching. The hashes are validated in the linters job.
         - pip install --disable-pip-version-check -r requirements/common.txt -r requirements/dev.txt
       script:
-        - py.test tests/ --runslow
+        - py.test tests/ --runslow --ignore=tests/e2e/ --ignore=tests/log_parser/
+    - env: python-tests-e2e-and-logparser
+      # Once mysql 5.6 is available on the container infra, we should switch back
+      # to it, by setting `sudo: false`, so we can use caching for this job.
+      sudo: required
+      dist: trusty
+      language: python
+      python: "2.7"
+      services:
+        - rabbitmq
+        - memcached
+      before_install:
+        # Manually install mysql 5.6 since the default is v5.5.
+        - sudo apt-get -qq update
+        - sudo apt-get -qq install mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
+      install:
+        # This uses pip rather than peep, since it takes half the time, and unlike the other
+        # jobs, this one cannot use caching. The hashes are validated in the linters job.
+        - pip install --disable-pip-version-check -r requirements/common.txt -r requirements/dev.txt
+      script:
+        - py.test tests/e2e/ tests/log_parser/ --runslow
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ matrix:
       # to it, by setting `sudo: false`, so we can use caching for this job.
       sudo: required
       dist: trusty
+      language: python
       python: "2.7"
       services:
         - rabbitmq
@@ -61,12 +62,9 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install -qq mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
       install:
-        # We use `--user` with pip install since the non-container infra doesn't set up
-        # a virtualenv, and we cannot use sudo due to:
-        #   https://github.com/travis-ci/travis-ci/issues/4989
-        # Disabling the pip version check speeds up the install considerably, since peep
-        # calls pip once per package, which results in duplicate checks (plus log spam).
-        - ./bin/peep.py install --user -r requirements/common.txt -r requirements/dev.txt --disable-pip-version-check
+        # This uses pip rather than peep, since it takes half the time, and unlike the other
+        # jobs, this one cannot use caching. The hashes are validated in the linters job.
+        - pip install --disable-pip-version-check -r requirements/common.txt -r requirements/dev.txt
       script:
         - py.test tests/$* --runslow
 


### PR DESCRIPTION
See individual commits.

Time until result... (includes "hidden" non-container boot time)

Before:
* linters/JS tests: ~3.5 mins
* python tests: ~7.5 mins
* grunt build: ~8 mins

After:
* linters: 24s
* JS tests/grunt build: 55s
* python tests (main): ~4.75 mins
* python tests (e2e + log parser): ~3.5 mins

As an added bonus, failing the linters tests will now not stop all of the other tests from running.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1101)
<!-- Reviewable:end -->
