### PR TITLE
Bug 1207398 - Disable the backfill button on try repos

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -47,7 +47,8 @@ div#info-panel .navbar-nav > li > a#logviewer-btn {
   line-height: 18px;
 }
 
-div#info-panel .navbar-nav > li > a.disabled {
+div#info-panel .navbar-nav > li > a.disabled,
+ul.actionbar-menu > li.disabled {
   cursor: not-allowed;
   text-decoration: none;
 }

--- a/ui/partials/main/thJobDetailsRetriggerMenu.html
+++ b/ui/partials/main/thJobDetailsRetriggerMenu.html
@@ -2,6 +2,6 @@
   <a ng-click="retriggerJob([selectedJob])" title="Repeat the selected job">Retrigger job</a>
 </li>
 <li ng-class="canBackfill() ? '' : 'disabled'"
-    ng-attr-title="{{canBackfill() ? 'Trigger jobs of this type on prior pushes, to fill in gaps where the job was not run' : 'Backfilling not available in this repository'}}">
+    ng-attr-title="{{canBackfill() ? backfillEnabledString : backfillDisabledString}}">
   <a ng-disabled="!canBackfill()" ng-click="backfillJob()">Backfill job</a>
 </li>

--- a/ui/partials/main/thJobDetailsRetriggerMenu.html
+++ b/ui/partials/main/thJobDetailsRetriggerMenu.html
@@ -1,6 +1,7 @@
 <li>
   <a ng-click="retriggerJob([selectedJob])" title="Repeat the selected job">Retrigger job</a>
 </li>
-<li>
-  <a ng-click="backfillJob()" title="Trigger jobs of this type on prior pushes, to fill in gaps where the job was not run">Backfill job</a>
+<li ng-class="canBackfill() ? '' : 'disabled'"
+    ng-attr-title="{{canBackfill() ? 'Trigger jobs of this type on prior pushes, to fill in gaps where the job was not run' : 'Backfilling not available in this repository'}}">
+  <a ng-disabled="!canBackfill()" ng-click="backfillJob()">Backfill job</a>
 </li>

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -416,6 +416,10 @@ treeherder.controller('PluginCtrl', [
             return $scope.currentRepo && $scope.currentRepo.repository_group.name !== 'try';
         };
 
+        $scope.backfillEnabledString = "Trigger jobs of this type on prior pushes, " +
+                                       "to fill in gaps where the job was not run";
+        $scope.backfillDisabledString = "Backfilling not available in this repository";
+
         $scope.cancelJob = function() {
             if ($scope.user.loggedin) {
                 // See note in retrigger logic.

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -390,23 +390,30 @@ treeherder.controller('PluginCtrl', [
         };
 
         $scope.backfillJob = function() {
-            if ($scope.user.loggedin) {
-                // Only backfill if we have a valid loaded job, if the user
-                // tries to backfill eg. via shortcut before the load we warn them
-                if ($scope.job.id) {
-                    ThJobModel.backfill($scope.repoName, $scope.job.id).then(function() {
-                        thNotify.send("Request sent to backfill jobs", 'success');
-                    }, function(e) {
-                        // Generic error eg. the user doesn't have LDAP access
-                        thNotify.send(
-                            ThModelErrors.format(e, "Unable to send backfill"), 'danger');
-                    });
+            if ($scope.canBackfill()) {
+                if ($scope.user.loggedin) {
+                    // Only backfill if we have a valid loaded job, if the user
+                    // tries to backfill eg. via shortcut before the load we warn them
+                    if ($scope.job.id) {
+                        ThJobModel.backfill($scope.repoName, $scope.job.id).then(function() {
+                            thNotify.send("Request sent to backfill jobs", 'success');
+                        }, function(e) {
+                            // Generic error eg. the user doesn't have LDAP access
+                            thNotify.send(
+                                ThModelErrors.format(e, "Unable to send backfill"), 'danger');
+                        });
+                    } else {
+                        thNotify.send("Job not yet loaded for backfill", 'warning');
+                    }
                 } else {
-                    thNotify.send("Job not yet loaded for backfill", 'warning');
+                    thNotify.send("Must be logged in to backfill a job", 'danger');
                 }
-            } else {
-                thNotify.send("Must be logged in to backfill a job", 'danger');
             }
+        };
+
+        // Can we backfill? At the moment, this only ensures we're not in a 'try' repo.
+        $scope.canBackfill = function() {
+            return $scope.currentRepo && $scope.currentRepo.repository_group.name !== 'try';
         };
 
         $scope.cancelJob = function() {


### PR DESCRIPTION
This is the easiest option I saw for this. It does mean the menu's tooltip is not completely correct (since it will still mention backfilling, even if that option is not present.

I guess the other options would be:
1) Also fix the tooltip for try repos.
2) On try, hide the entire menu and only show the old retrigger button.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1102)
<!-- Reviewable:end -->
