### PR TITLE
Bug 1220105 - Remove unused fancy_tag package dependency

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -98,10 +98,6 @@ PyYAML==3.11
 # sha256: IPl2zc4CpCtpzoDp4DiXpRgUs21EizcohUYIbrxHMUY
 requests==2.7.0
 
-# Required by django-browserid
-# sha256: akF58qKszaKyc7_Ybeb3AkzuIDBDzJp8BA_nswa74SA
-fancy-tag==0.2.0
-
 # Required by oauth2
 # sha256: w6uhyVOXEVUfTYPoV7MWtRNKHE3c6YqHW3Anvn3W2Yg
 httplib2==0.9.2


### PR DESCRIPTION
As of django-browserid v1.0.0, it no longer uses fancy_tag:
https://github.com/mozilla/django-browserid/pull/281

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1104)
<!-- Reviewable:end -->
