### PR TITLE
Bug 1219922 - Stop using the refdata test fixture

### DIFF
--- a/tests/etl/test_bugzilla.py
+++ b/tests/etl/test_bugzilla.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 from treeherder.etl.bugzilla import BzApiBugProcess
+from treeherder.model.models import Bugscache
 
 
 @pytest.fixture
@@ -27,20 +28,14 @@ def mock_extract(monkeypatch):
                         extract)
 
 
-def test_bz_api_process(mock_extract, refdata):
+@pytest.mark.django_db(transaction=True)
+def test_bz_api_process(mock_extract):
     process = BzApiBugProcess()
     process.run()
 
-    row_data = refdata.dhub.execute(
-        proc='refdata_test.selects.test_bugscache',
-        return_type='tuple'
-    )
-
-    refdata.disconnect()
-
     # the number of rows inserted should equal to the number of bugs
-    assert len(row_data) == 15
+    assert Bugscache.objects.count() == 15
 
     # test that a second ingestion of the same bugs doesn't insert new rows
     process.run()
-    assert len(row_data) == 15
+    assert Bugscache.objects.count() == 15


### PR DESCRIPTION
I haven't found the exact reason why the tests were failing but it must
be a test isolation problem because they were passing individually.
I debugged this issue disabling the tests backwards starting from the
first failure and I found out that test_bz_api_process was the offender.
The test itself is not doing anything wrong but the refdata fixture
used to setup the test seems to be the root cause..
I replaced the two method calls with their orm counterpart and the
problem disappeared.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1105)
<!-- Reviewable:end -->
