### PR TITLE
Bug 1220445 - hide automatic classification

### DIFF
--- a/ui/js/models/bug_job_map.js
+++ b/ui/js/models/bug_job_map.js
@@ -21,6 +21,10 @@ treeherder.factory('ThBugJobMapModel', [
                 item_list.push(new ThBugJobMapModel(elem));
             });
             return item_list;
+        }).then(function(bugJobMapList){
+            return _.filter(bugJobMapList, function(bugJobMap){
+                return bugJobMap.type !== 'autoclassification';
+            });
         });
     };
 

--- a/ui/js/models/classification.js
+++ b/ui/js/models/classification.js
@@ -24,6 +24,10 @@ treeherder.factory('ThJobClassificationModel', [
                         item_list.push(new ThJobClassificationModel(elem));
                     });
                     return item_list;
+                }).then(function(classificationList){
+                    return _.filter(classificationList, function(jobClassification){
+                        return jobClassification.failure_classification_id !== 7;
+                    });
                 });
         };
 

--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -64,6 +64,13 @@ treeherder.factory('ThJobModel', [
                     return $q.when(next_pages_jobs).then(function(maybe_job_list){
                         return  item_list.concat(maybe_job_list);
                     });
+                }).then(function(job_list){
+                    return _.map(job_list, function(job){
+                        if (job.failure_classification_id === 7) {
+                            job.failure_classification_id = 1;
+                        }
+                        return job;
+                    });
                 });
         };
 


### PR DESCRIPTION
We want to find a better ui for the integration between manual and
automatic classification.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1107)
<!-- Reviewable:end -->
