### PR TITLE
Bug 1221064 - improve job list performance

### DIFF
--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -60,11 +60,6 @@ def test_job_list(webapp, eleven_jobs_stored, jm):
     for job in jobs:
         assert set(job.keys()) == set(exp_keys)
 
-    # The jobs should be returned in order of descending order
-    # of their resultset's push_timestamp, so in this case the
-    # first job should have id of 10.
-    assert jobs[0]['id'] == 10
-
 
 def test_job_list_bad_project(webapp, eleven_jobs_stored, jm):
     """

--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -241,3 +241,24 @@ def test_job_error_lines(webapp, eleven_jobs_stored, jm, failure_lines, classifi
     assert set(matches[0].keys()) == set(exp_matches_keys)
 
     jm.disconnect()
+
+
+def test_list_similar_jobs(webapp, eleven_jobs_stored, jm):
+    """
+    test retrieving similar jobs
+    """
+    job = jm.get_job(1)[0]
+
+    resp = webapp.get(
+        reverse("jobs-similar-jobs",
+                kwargs={"project": jm.project, "pk": job["id"]})
+    )
+    assert resp.status_int == 200
+
+    similar_jobs = resp.json
+
+    assert 'results' in similar_jobs
+
+    assert isinstance(similar_jobs['results'], list)
+
+    assert len(similar_jobs['results']) == 3

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -208,6 +208,21 @@ class JobsModel(TreeherderModelBase):
         )
         return data
 
+    def get_job_list_sorted(self, offset, limit, conditions=None):
+        replace_str, placeholders = self._process_conditions(
+            conditions, self.INDEXED_COLUMNS['job']
+        )
+        repl = [self.refdata_model.get_db_name(), replace_str]
+        data = self.execute(
+            proc="jobs.selects.get_job_list_sorted",
+            replace=repl,
+            placeholders=placeholders,
+            limit=limit,
+            offset=offset,
+            debug_show=self.DEBUG,
+        )
+        return data
+
     def set_state(self, job_id, state):
         """Update the state of an existing job"""
         self.execute(

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -495,6 +495,67 @@
 
             "host_type":"read_host"
         },
+        "get_job_list_sorted":{
+            "sql":"SELECT
+                    j.id,
+                    j.`job_guid`,
+                    j.`signature`,
+                    j.`job_coalesced_to_guid`,
+                    j.`build_platform_id`,
+                    j.`option_collection_hash`,
+                    j.failure_classification_id,
+                    m.`name` as machine_name,
+                    mp.`platform` as platform,
+                    mp.`os_name` as machine_platform_os,
+                    mp.`architecture` as machine_platform_architecture,
+                    bp.`platform` as build_platform,
+                    bp.`os_name` as build_os,
+                    bp.`architecture` as build_architecture,
+                    j.`job_type_id` as job_type_id,
+                    jt.`name` as job_type_name,
+                    jt.`symbol` as job_type_symbol,
+                    jt.`description` as job_type_description,
+					jg.`name` as job_group_name,
+                    jt.`job_group_id` as job_group_id,
+                    jg.`symbol` as job_group_symbol,
+                    jg.`description` as job_group_description,
+                    j.`who`,
+                    j.`result_set_id`,
+                    j.`result`,
+                    j.`state`,
+                    j.`reason`,
+                    j.`start_timestamp`,
+                    j.`end_timestamp`,
+                    j.`submit_timestamp`,
+                    j.`running_eta`,
+                    j.`last_modified`,
+                    j.`tier`,
+                    rds.`name` as ref_data_name,
+                    rds.`build_system_type` as build_system_type
+                  FROM `job` as j
+                  LEFT JOIN `REP0`.`machine` as m
+                    ON j.`machine_id` = m.id
+                  LEFT JOIN `REP0`.`machine_platform` as mp
+                    ON j.`machine_platform_id` = mp.id
+                  LEFT JOIN `REP0`.`build_platform` as bp
+                    ON j.`build_platform_id` = bp.id
+                  LEFT JOIN `REP0`.`job_type` as jt
+                    ON j.`job_type_id` = jt.id
+				  LEFT JOIN `REP0`.`job_group` as jg
+                    ON jt.`job_group_id` = jg.id
+                  LEFT JOIN `REP0`.reference_data_signatures rds
+                    ON j.signature = rds.signature
+                  LEFT JOIN result_set rs
+                    ON rs.id = j.result_set_id
+                  WHERE 1
+                  REP1
+                  GROUP BY j.id
+                  ORDER BY
+                    rs.push_timestamp DESC
+                  ",
+
+            "host_type":"read_host"
+        },
         "get_log_references":{
             "sql":"SELECT `name`, `url`
                    FROM `job_log_url`

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -482,15 +482,11 @@
                     ON j.`job_type_id` = jt.id
 				  LEFT JOIN `REP0`.`job_group` as jg
                     ON jt.`job_group_id` = jg.id
-                  LEFT JOIN result_set rs
-                    ON rs.id = j.result_set_id
                   LEFT JOIN `REP0`.reference_data_signatures rds
                     ON j.signature = rds.signature
                   WHERE 1
                   REP1
                   GROUP BY j.id
-                  ORDER BY
-                    rs.push_timestamp DESC
                   ",
 
             "host_type":"read_host"

--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -30,8 +30,12 @@ treeherder.factory('ThJobModel', [
             config = config || {};
             var timeout = config.timeout || null;
             var fetch_all = config.fetch_all || false;
+            // The `uri` config allows to fetch a list of jobs from an arbitrary
+            // endpoint e.g. the similar jobs endpoint. It defaults to the job
+            // list endpoint.
+            var uri = config.uri || ThJobModel.get_uri(repoName);
 
-            return $http.get(ThJobModel.get_uri(repoName),{
+            return $http.get(uri,{
                 params: options,
                 timeout: timeout
             }).
@@ -77,6 +81,14 @@ treeherder.factory('ThJobModel', [
                 .then(function(response) {
                     return new ThJobModel(response.data);
                 });
+        };
+
+        ThJobModel.get_similar_jobs = function(repoName, pk, options, config){
+            config = config || {};
+            // The similar jobs endpoints returns the same type of objects as
+            // the job list endpoint, so let's reuse the get_list method logic.
+            config.uri = ThJobModel.get_uri(repoName)+pk+"/similar_jobs/";
+            return ThJobModel.get_list(repoName, options, config);
         };
 
         ThJobModel.retrigger = function(repoName, job_id_list, config) {

--- a/ui/plugins/similar_jobs/controller.js
+++ b/ui/plugins/similar_jobs/controller.js
@@ -27,7 +27,7 @@ treeherder.controller('SimilarJobsPluginCtrl', [
                     options[key] = $scope.job[key];
                 }
             });
-            ThJobModel.get_list($scope.repoName, options)
+            ThJobModel.get_similar_jobs($scope.repoName, $scope.job.id, options)
                 .then(function(data){
                     if(data.length > 0){
                         if(data.length > $scope.page_size){
@@ -90,7 +90,6 @@ treeherder.controller('SimilarJobsPluginCtrl', [
 
         $scope.similar_jobs_filters = {
             "machine_id": false,
-            "job_type_id": true,
             "build_platform_id": true,
             "option_collection_hash": true
         };
@@ -143,5 +142,3 @@ treeherder.controller('SimilarJobsPluginCtrl', [
                 });
         };
 }]);
-
-

--- a/ui/plugins/similar_jobs/main.html
+++ b/ui/plugins/similar_jobs/main.html
@@ -39,11 +39,6 @@
             <div class="right_panel">
                 <form role="form" class="form form-inline">
                     <div class="checkbox">
-                            <input ng-change="update_similar_jobs()" type="checkbox" ng-model="similar_jobs_filters.job_type_id"/>
-                            <small>Same job type</small>
-
-                    </div>
-                    <div class="checkbox">
                             <input ng-change="update_similar_jobs()" type="checkbox" ng-model="similar_jobs_filters.build_platform_id"/>
                             <small>Same platform</small>
 
@@ -126,4 +121,3 @@
         </div>
     </div>
 </div>
-


### PR DESCRIPTION
The job list endpoint was joining the job table and the resultset table
with the only purpose of sorting the results by push_timestamp. Sorting
by result_set_id seems to be a good enough solution and at the same time
it avoids running a poor performing join between job and resultset.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1111)
<!-- Reviewable:end -->
