### PR TITLE
Bug 1221079 - make unclassified failures mode show "auto classified"

### DIFF
--- a/treeherder/model/fixtures/failure_classification.json
+++ b/treeherder/model/fixtures/failure_classification.json
@@ -52,5 +52,14 @@
         "description": "",
         "active_status": "active"
     }
+},
+{
+    "pk": 7,
+    "model": "model.failureclassification",
+    "fields": {
+        "name": "auto classified",
+        "description": "",
+        "active_status": "active"
+    }
 }
 ]

--- a/ui/js/controllers/filters.js
+++ b/ui/js/controllers/filters.js
@@ -68,19 +68,6 @@ treeherderApp.controller('FilterPanelCtrl', [
             }
         };
 
-        /**
-         * Toggle the filters to show either unclassified or classified jobs,
-         * neither or both.
-         */
-        $scope.toggleClassifiedFilter = function() {
-            var func = $scope.classifiedFilter? thJobFilters.addFilter: thJobFilters.removeFilter;
-            func(thJobFilters.classifiedState, 'classified');
-        };
-        $scope.toggleUnClassifiedFilter = function() {
-            var func = $scope.unClassifiedFilter? thJobFilters.addFilter: thJobFilters.removeFilter;
-            func(thJobFilters.classifiedState, 'unclassified');
-        };
-
         $scope.createFieldFilter = function() {
             $scope.newFieldFilter = {field: "", value: ""};
         };
@@ -175,14 +162,6 @@ treeherderApp.controller('FilterPanelCtrl', [
                 $scope.resultStatusFilters[opt] = _.contains(
                     thJobFilters.getResultStatusArray(), opt);
             }
-
-            // whether or not to show classified jobs
-            // these are a special case of filtering because we're not checking
-            // for a value, just whether the job has any value set or not.
-            // just a boolean check either way
-            var classifiedState = thJobFilters.getClassifiedStateArray();
-            $scope.classifiedFilter = _.contains(classifiedState, 'classified');
-            $scope.unClassifiedFilter = _.contains(classifiedState, 'unclassified');
 
             // update "all checked" boxes for groups
             _.each($scope.filterGroups, function(group) {

--- a/ui/js/services/classifications.js
+++ b/ui/js/services/classifications.js
@@ -6,6 +6,7 @@ treeherder.factory('thClassificationTypes', [
 
         var classifications = {};
         var classificationOptions = [];
+        var classificationIds = [];
 
         var classificationColors = {
             1: "",                 // not classified
@@ -22,6 +23,7 @@ treeherder.factory('thClassificationTypes', [
                 star: classificationColors[cl.id]
             };
             classificationOptions.push(cl);
+            classificationIds[cl.name] = cl.id;
         };
 
         var load = function() {
@@ -34,6 +36,7 @@ treeherder.factory('thClassificationTypes', [
         return {
             classifications: classifications,
             classificationOptions: classificationOptions,
+            classificationIds: classificationIds,
             load: load
         };
     }]);

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -35,11 +35,9 @@ treeherder.factory('thJobFilters', [
         var PREFIX = "filter-";
 
         // constants for specific types of filters
-        var CLASSIFIED_STATE = "classifiedState";
         var RESULT_STATUS = "resultStatus";
         var SEARCH_STR = "searchStr";
 
-        var QS_CLASSIFIED_STATE = PREFIX + CLASSIFIED_STATE;
         var QS_RESULT_STATUS = PREFIX + RESULT_STATUS;
         var QS_FAILURE_CLASSIFICATION = PREFIX + "failure_classification_id";
         var QS_SEARCH_STR = PREFIX + SEARCH_STR;
@@ -48,9 +46,6 @@ treeherder.factory('thJobFilters', [
         var DEFAULTS = {
             resultStatus: {
                 values: thResultStatusList.defaultFilters()
-            },
-            classifiedState: {
-                values: ['classified', 'unclassified']
             }
         };
 
@@ -116,7 +111,6 @@ treeherder.factory('thJobFilters', [
         // filter caches so that we only collect them when the filter params
         // change in the query string
         var cachedResultStatusFilters = {};
-        var cachedClassifiedStateFilters = {};
         var cachedFieldFilters = {};
         var cachedFilterParams;
 
@@ -148,7 +142,6 @@ treeherder.factory('thJobFilters', [
 
         var _refreshFilterCaches = function() {
             cachedResultStatusFilters = _getFiltersOrDefaults(RESULT_STATUS);
-            cachedClassifiedStateFilters = _getFiltersOrDefaults(CLASSIFIED_STATE);
             cachedFieldFilters = getFieldFiltersObj();
         };
 
@@ -188,25 +181,11 @@ treeherder.factory('thJobFilters', [
          */
         var showJob = function(job) {
 
-            // test against resultStatus, classifiedState and field filters
+            // test against resultStatus and field filters
             if (!_.contains(cachedResultStatusFilters, thResultStatus(job))) {
                 return false;
             }
-            if (!_checkClassifiedStateFilters(job)) {
-                return false;
-            }
             return _checkFieldFilters(job);
-        };
-
-        var _checkClassifiedStateFilters = function(job) {
-            var isClassified = _isJobClassified(job);
-            if (!_.contains(cachedClassifiedStateFilters, 'unclassified') && !isClassified) {
-                return false;
-            }
-            if (!_.contains(cachedClassifiedStateFilters, 'classified') && isClassified) {
-                return false;
-            }
-            return true;
         };
 
         var _checkFieldFilters = function(job) {
@@ -376,14 +355,7 @@ treeherder.factory('thJobFilters', [
         var setOnlyCoalesced = function() {
             var locationSearch = _.clone($location.search());
             locationSearch[QS_RESULT_STATUS] = "coalesced";
-            locationSearch[QS_CLASSIFIED_STATE]= DEFAULTS.classifiedState.values.slice();
             $location.search(locationSearch);
-        };
-
-        var getClassifiedStateArray = function() {
-            var arr = _toArray($location.search()[QS_CLASSIFIED_STATE]) ||
-                DEFAULTS.classifiedState.values;
-            return arr.slice();
         };
 
         /**
@@ -430,7 +402,6 @@ treeherder.factory('thJobFilters', [
         };
 
         var stripFiltersFromQueryString = function(locationSearch) {
-            delete locationSearch[QS_CLASSIFIED_STATE];
             delete locationSearch[QS_RESULT_STATUS];
 
             _stripFieldFilters(locationSearch);
@@ -452,7 +423,7 @@ treeherder.factory('thJobFilters', [
 
         var _isFieldFilter = function(field) {
             return _startsWith(field, PREFIX) &&
-                !_.contains(['resultStatus', 'classifiedState'], _withoutPrefix(field));
+                !_.contains(['resultStatus'], _withoutPrefix(field));
         };
 
         /**
@@ -564,7 +535,6 @@ treeherder.factory('thJobFilters', [
             setOnlyCoalesced: setOnlyCoalesced,
 
             // filter data read-only accessors
-            getClassifiedStateArray: getClassifiedStateArray,
             getFieldFiltersArray: getFieldFiltersArray,
             getFieldFiltersObj: getFieldFiltersObj,
             getResultStatusArray: getResultStatusArray,
@@ -573,7 +543,6 @@ treeherder.factory('thJobFilters', [
             getFieldChoices: getFieldChoices,
 
             // CONSTANTS
-            classifiedState: CLASSIFIED_STATE,
             resultStatus: RESULT_STATUS
         };
         return api;

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -41,6 +41,7 @@ treeherder.factory('thJobFilters', [
 
         var QS_CLASSIFIED_STATE = PREFIX + CLASSIFIED_STATE;
         var QS_RESULT_STATUS = PREFIX + RESULT_STATUS;
+        var QS_FAILURE_CLASSIFICATION = PREFIX + "failure_classification_id";
         var QS_SEARCH_STR = PREFIX + SEARCH_STR;
 
         // default filter values, when a filter is not specified in the query string
@@ -52,6 +53,10 @@ treeherder.factory('thJobFilters', [
                 values: ['classified', 'unclassified']
             }
         };
+
+        // failure classification ids that should be shown in "unclassified" mode
+        var UNCLASSIFIED_IDS = [String(thClassificationTypes.classificationIds["not classified"]),
+                                String(thClassificationTypes.classificationIds["auto classified"])];
 
         // used with field-filters to determine how to match the value against the
         // job field.
@@ -303,10 +308,10 @@ treeherder.factory('thJobFilters', [
          * so the user sees everything.  Doesn't affect the field filters.  This
          * is used to undo the call to ``setOnlyUnclassifiedFailures``.
          */
-        var resetNonFieldFilters = function() {
+        var resetUnclassifiedFilters = function() {
             var locationSearch = _.clone($location.search());
             delete locationSearch[QS_RESULT_STATUS];
-            delete locationSearch[QS_CLASSIFIED_STATE];
+            delete locationSearch[QS_FAILURE_CLASSIFICATION];
             $location.search(locationSearch);
         };
 
@@ -340,7 +345,7 @@ treeherder.factory('thJobFilters', [
         var toggleUnclassifiedFailures = function() {
             $log.debug("toggleUnclassifiedFailures");
             if (_isUnclassifiedFailures()) {
-                resetNonFieldFilters();
+                resetUnclassifiedFilters();
             } else {
                 setOnlyUnclassifiedFailures();
             }
@@ -361,7 +366,7 @@ treeherder.factory('thJobFilters', [
         var setOnlyUnclassifiedFailures = function() {
             var locationSearch = _.clone($location.search());
             locationSearch[QS_RESULT_STATUS] = thFailureResults.slice();
-            locationSearch[QS_CLASSIFIED_STATE] = ['unclassified'];
+            locationSearch[QS_FAILURE_CLASSIFICATION] = UNCLASSIFIED_IDS.slice();
             $location.search(locationSearch);
         };
 
@@ -469,7 +474,8 @@ treeherder.factory('thJobFilters', [
          */
         var _isUnclassifiedFailures = function() {
             return (_.isEqual(_toArray($location.search()[QS_RESULT_STATUS]), thFailureResults) &&
-                    _.isEqual(_toArray($location.search()[QS_CLASSIFIED_STATE]), ['unclassified']));
+                    _.isEqual(_toArray($location.search()[QS_FAILURE_CLASSIFICATION]), UNCLASSIFIED_IDS)
+            );
         };
 
         var _matchesDefaults = function(field, values) {
@@ -550,7 +556,7 @@ treeherder.factory('thJobFilters', [
             removeFilter: removeFilter,
             replaceFilter: replaceFilter,
             removeAllFieldFilters: removeAllFieldFilters,
-            resetNonFieldFilters: resetNonFieldFilters,
+            resetUnclassifiedFilters: resetUnclassifiedFilters,
             toggleFilters: toggleFilters,
             toggleInProgress: toggleInProgress,
             toggleUnclassifiedFailures: toggleUnclassifiedFailures,

--- a/ui/partials/main/thFilterPanel.html
+++ b/ui/partials/main/thFilterPanel.html
@@ -11,7 +11,7 @@
             ng-click="thJobFilters.setOnlyCoalesced()">coalesced only</span>
       <span class="btn btn-default btn-xs"
             title="Reset to default status filters"
-            ng-click="thJobFilters.resetNonFieldFilters()">reset</span>
+            ng-click="thJobFilters.resetUnclassifiedFilters()">reset</span>
     </span>
   </div>
 
@@ -32,25 +32,6 @@
       <span ng-repeat="filterName in group.resultStatuses">
         <th-filter-checkbox></th-filter-checkbox>
       </span>
-    </div>
-  </span>
-
-  <!-- Classified/Unclassified filters -->
-  <span class="panel panel-default th-option-group th-inline-option-group">
-    <div class="panel-heading th-option-heading">classified</div>
-    <div class="panel-body">
-      <label class="checkbox-inline">
-        <input type="checkbox"
-               id="classified"
-               ng-model="classifiedFilter"
-               ng-click="toggleClassifiedFilter()"> classified
-      </label>
-      <label class="checkbox-inline">
-        <input type="checkbox"
-               id="unclassified"
-               ng-model="unClassifiedFilter"
-               ng-click="toggleUnClassifiedFilter()"> un-classified
-      </label>
     </div>
   </span>
 


### PR DESCRIPTION
See individual commit messages for details.

Uses a "field filter" rather than the specialized ``classifiedFilter`` param so that
we can look for two values (id of 1 and id of 7, in this case).  Now, in
unclassified mode, it will show both unclassified and auto classified jobs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1112)
<!-- Reviewable:end -->
