### PR TITLE
Bug 1221157 - Update hash for django-browserid now it has a wheel

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -64,7 +64,7 @@ drf-extensions==0.2.8
 # sha256: _NluK-R8ju80xlDgB6bVRuGefuYQQbie27u-dhmqOYc
 django-cors-headers==1.1.0
 
-# sha256: -jPrQhcqGbcVrbp6ZJcJEftdj9G2nPjaepXyvH8PMDs
+# sha256: 56MxTtRt0kOTkYZwt6EVbkuvODGJ9kSz5hIbocv7wvk
 django-browserid==1.0.0
 
 # sha256: FbXEIwH0bdYxE_EhSw2BqLFiVPZahtPDKhtSKX8yZuY


### PR DESCRIPTION
The wheel archive is preferred over the standard one, so we need to update the hash associated with django-browserid.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1113)
<!-- Reviewable:end -->
