### PR TITLE
Bug 1221536 - Docs: Emphasise starting the worker before ingest_push

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -100,9 +100,10 @@ talos jobs for a particular push, try:
 
      (venv)vagrant@local:~/treeherder$ ./manage.py ingest_push --filter-job-group T mozilla-inbound 63f8a47cfdf
 
-Note that some types of data (e.g. performance) are not processed immediately, and you
-will thus need to start a celery worker to handle them. You don't need
-to enable the beat service for this though, so you can omit the "-B":
+Note that some types of data (e.g. performance, log error summaries) are not processed
+immediately, and you will thus need to start a celery worker *before* running `ingest_push`
+to handle them. You don't need to enable the beat service for this though, so you can
+omit the `-B`:
 
   .. code-block:: bash
 


### PR DESCRIPTION
If the worker is not running, any `apply_async()` calls are silently thrown away, due to `ingest_push`'s use of `CELERY_ALWAYS_EAGER` and:
https://github.com/celery/celery/issues/2910

As such, running the worker after ingest_push doesn't help (since the rabbitmq queues are empty) and so if people are interested in perf/log data, then they must start the worker first instead.

James hit this today and it took several of us a while to figure out what was happening.

Ideally ingest_push would run the log parser tasks and things as well, but that's more involved (and the list of tasks is likely going to get out of date as we add things like autoclassification).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1119)
<!-- Reviewable:end -->
