### PR TITLE
Bug 1221095 - Adds autoclassification options (bugs) to failure lines endpoint

### DIFF
--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -231,9 +231,16 @@ def test_job_error_lines(webapp, eleven_jobs_stored, jm, failure_lines, classifi
     matches = failures[0]["matches"]
     assert isinstance(matches, list)
 
-    exp_matches_keys = ["id", "matcher", "score", "is_best"]
+    exp_matches_keys = ["id", "matcher", "score", "is_best", "classified_failure"]
 
     assert set(matches[0].keys()) == set(exp_matches_keys)
+
+    classified = matches[0]["classified_failure"]
+    assert isinstance(classified, dict)
+
+    exp_classified_keys = ["id", "bug_number"]
+
+    assert set(classified.keys()) == set(exp_classified_keys)
 
     jm.disconnect()
 

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -128,12 +128,19 @@ class MatcherSerializer(serializers.ModelSerializer):
         model = models.Matcher
 
 
+class ClassifiedFailureSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = models.ClassifiedFailure
+        exclude = ['failure_lines', 'created', 'modified']
+
+
 class FailureMatchSerializer(serializers.ModelSerializer):
+    classified_failure = ClassifiedFailureSerializer()
 
     class Meta:
         model = models.FailureMatch
-        exclude = ['classified_failure',
-                   'failure_line']
+        exclude = ['failure_line']
 
 
 class FailureLineNoStackSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
This adds the matched bugs to the failure_lines endpoint for a job so that the user will be able to choose the "right" one.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1120)
<!-- Reviewable:end -->
