### PR TITLE
Bug 1221806 - Change the stage/prod Gunicorn timeout from 120s to 30s

### DIFF
--- a/bin/run_gunicorn
+++ b/bin/run_gunicorn
@@ -34,4 +34,4 @@ exec $NEWRELIC_ADMIN gunicorn -w $NUM_WORKERS \
     --error-logfile=$ERROR_LOGFILE treeherder.config.wsgi:application \
     --keep-alive=3 \
     --log-level error \
-    --timeout=120
+    --timeout=30

--- a/docker/gunicorn.sh
+++ b/docker/gunicorn.sh
@@ -3,9 +3,9 @@
 source /etc/profile.d/treeherder.sh
 ./docker/generate_test_credentials.py
 
-# Use exec so pid 1 is now gunicon instead of bash...
+# Use exec so pid 1 is now gunicorn instead of bash...
 exec gunicorn \
   -w 5 \
   -b 0.0.0.0:8000 \
-  --timeout 120 \
+  --timeout 30 \
   treeherder.config.wsgi:application


### PR DESCRIPTION
To help prevent excessively demanding queries from having a detrimental effect on the API/DBs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1121)
<!-- Reviewable:end -->
