### PR TITLE
Bug 1201086 - new relic should track exceptions

### DIFF
--- a/treeherder/webapp/api/exceptions.py
+++ b/treeherder/webapp/api/exceptions.py
@@ -1,8 +1,6 @@
 import logging
 
-from django.conf import settings
 from rest_framework import exceptions
-from rest_framework.response import Response
 from rest_framework.views import exception_handler as drf_exc_handler
 
 from treeherder.model.derived import (DatasetNotFoundError,
@@ -35,10 +33,4 @@ Mostly a conversion of treeherders ORM exceptions to drf APIExceptions
             "{0} object not found using: {1}".format(
                 exc.table, unicode(exc.extra_info)))
 
-    response = drf_exc_handler(exc, context)
-    if response is None:
-        msg = {"detail": unicode(exc)}
-        if settings.DEBUG:
-            msg["traceback"] = full_message
-        response = Response(msg, status=500)
-    return response
+    return drf_exc_handler(exc, context)


### PR DESCRIPTION
The treeherder custom api exception handler always converts unexpected
errors into ApiExceptions. In order to keep track of those errors in
newrelic we shouldn't do the conversion and let the default exception
handler decide what to do instead.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1123)
<!-- Reviewable:end -->
