### PR TITLE
 	Bug 1222540 - Remove cleanup at beginning of perfherder tests

### DIFF
--- a/tests/e2e/test_perf_ingestion.py
+++ b/tests/e2e/test_perf_ingestion.py
@@ -10,12 +10,6 @@ def test_post_talos_artifact(test_project, test_repository, result_set_stored,
                              mock_post_json):
     test_repository.save()
 
-    # delete any previously-created perf objects until bug 1133273 is fixed
-    # https://bugzilla.mozilla.org/show_bug.cgi?id=1133273 (this can be really
-    # slow if the local database has a lot of objects in it)
-    PerformanceSignature.objects.all().delete()
-    PerformanceDatum.objects.all().delete()
-
     tjc = client.TreeherderJobCollection()
     job_guid = 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
     tj = client.TreeherderJob({
@@ -48,11 +42,6 @@ def test_post_talos_artifact(test_project, test_repository, result_set_stored,
 def test_post_perf_artifact(test_project, test_repository, result_set_stored,
                             mock_post_json):
     test_repository.save()
-
-    PerformanceSignature.objects.all().delete()
-    PerformanceDatum.objects.all().delete()
-    PerformanceFramework.objects.all().delete()
-
     PerformanceFramework.objects.get_or_create(name='cheezburger')
 
     tjc = client.TreeherderJobCollection()

--- a/tests/etl/test_perf_data_adapters.py
+++ b/tests/etl/test_perf_data_adapters.py
@@ -88,10 +88,6 @@ class PerfDataAdapterTest(TestCase):
 
     def test_load_generic_data(self):
         framework_name = "cheezburger"
-
-        PerformanceDatum.objects.all().delete()
-        PerformanceSignature.objects.all().delete()
-        PerformanceFramework.objects.all().delete()
         PerformanceFramework.objects.get_or_create(name=framework_name)
 
         (job_data, reference_data) = self._get_job_and_reference_data()
@@ -165,15 +161,6 @@ class PerfDataAdapterTest(TestCase):
 
         talos_perf_data = SampleData.get_talos_perf_data()
         for talos_datum in talos_perf_data:
-            # delete any previously-created perf objects
-            # FIXME: because of https://bugzilla.mozilla.org/show_bug.cgi?id=1133273
-            # this can be really slow if we have a dev database with lots of
-            # performance data in it (if the test succeeds, the transaction
-            # will be rolled back so at least it won't pollute the production
-            # database)
-            PerformanceSignature.objects.all().delete()
-            PerformanceDatum.objects.all().delete()
-
             (job_data, reference_data) = self._get_job_and_reference_data()
 
             datum = {
@@ -244,3 +231,7 @@ class PerfDataAdapterTest(TestCase):
             self.assertEqual(datum.push_timestamp,
                              datetime.datetime.fromtimestamp(
                                  self.PUSH_TIMESTAMP))
+
+            # delete perf objects for next iteration
+            PerformanceSignature.objects.all().delete()
+            PerformanceDatum.objects.all().delete()


### PR DESCRIPTION
Now that bug 1193836 is fixed, this is no longer necessary.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1127)
<!-- Reviewable:end -->
