### PR TITLE
 	Bug 1223077 - Don't zoom out on click to main graph

### DIFF
--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -432,9 +432,6 @@ perf.controller('GraphsCtrl', [
                     highlightDataPoints();
                 });
 
-                // This part of code is simply copy from overview-plot
-                $('#graph').bind("plotunselected", plotUnselected);
-
                 $('#graph').bind("plotselected", function(event, ranges) {
                     $scope.plot.clearSelection();
                     plotSelected(event, ranges);


### PR DESCRIPTION
This can cause unexpected behaviour if the user is clicking to select
a datapoint.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1131)
<!-- Reviewable:end -->
