### PR TITLE
Bug 1197258 - Don't collapse retriggered jobs

### DIFF
--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -279,6 +279,7 @@ treeherder.directive('thCloneJobs', [
 
             var jobList = platformGroup.find(".group-job-list");
             var countList = platformGroup.find(".group-count-list");
+            var typeSymbolCounts = _.countBy(jgObj.jobs, "job_type_symbol");
             jobList.empty();
             countList.empty();
 
@@ -301,7 +302,8 @@ treeherder.directive('thCloneJobs', [
                 //
                 // We don't add it to group counts, because it should not be counted
                 // when filtered out.  Failures don't get included in counts anyway.
-                if (_.contains(failResults, resultStatus)) {
+                if (_.contains(failResults, resultStatus) ||
+                        typeSymbolCounts[job.job_type_symbol] > 1) {
                     // render the job itself, not a count
                     addJobBtnToArray(job, lastJobSelected, jobBtnArray);
                 } else {


### PR DESCRIPTION
If the same job symbol is detected within the same group, don’t collapse
them to counts.  They are almost surely retriggers and will be shown to
make intermittent failures more obvious.

before:
![screenshot 2015-11-10 15 17 53](https://cloud.githubusercontent.com/assets/419924/11079388/e31e83b4-87c0-11e5-9f6c-252f27ca8af8.png)

after:
![screenshot 2015-11-10 15 17 43](https://cloud.githubusercontent.com/assets/419924/11079393/ee3826e2-87c0-11e5-9eb7-08b37fb44419.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1135)
<!-- Reviewable:end -->
