### PR TITLE
Bug 1201455 - Heroku: Run migrate & other DB tasks after deploy

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "post-release": "./manage.py migrate --noinput && ./manage.py load_initial_data && ./manage.py init_datasources"
+  }
+}


### PR DESCRIPTION
Uses Heroku's new 'Release Phase' beta to run external-resource-touching tasks (that shouldn't be run during the slug compile) in a one-off dyno that runs after the deploy. See:
https://devcenter.heroku.com/articles/release-phase?preview=1

We're using the buildpack to help populate the `.heroku/bin/release` file from the `post-release` key in app.json:
https://github.com/heroku/heroku-buildpack-postrelease/blob/master/README.md
https://github.com/heroku/heroku-buildpack-postrelease/blob/master/bin/compile
(The devcenter release phase docs page instructions haven't yet been updated to cover this buildpack).

The tasks being run are the external-resource ones from `update.py`:
https://github.com/mozilla/treeherder/blob/0ecb647f795c15604b191c5b4010956068b9fb8f/deployment/update/update.py#L79-L88

...minus `clear_cache` (since we want to stop doing it, bug 1223384), and `export_project_credentials` (since Heroku doesn't use oauth any more, and that code is soon to be ripped out).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1136)
<!-- Reviewable:end -->
