### PR TITLE
Bug 1182485 - Update datasource to v0.9.1 for the whitespace fix

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -79,8 +79,8 @@ mozlog==3.0
 # sha256: BK-ioGq33MqdgXF7Qgp6FIJgYemyYUpcd90kx1zPl-Q
 futures==3.0.3
 
-# sha256: Vsi_w_4K-L4pRwKWLo2Gcj1RN8ldLbFkQel1BWZF6Xs
-https://github.com/jeads/datasource/archive/v0.9.tar.gz#egg=datasource==0.9
+# sha256: uUuxlcsCM1Ljir_4azpnOtsEnySrg7s16_bE8KItgcY
+https://github.com/jeads/datasource/archive/v0.9.1.tar.gz#egg=datasource==0.9.1
 
 # Required by jsonschema
 # sha256: ajt0IEMrCBfvGSrvNBzXZuGZgBqQyn_jGfnV_KQO3aI


### PR DESCRIPTION
Gives us the fix in:
https://github.com/jeads/datasource/pull/36

https://github.com/jeads/datasource/compare/v0.9...v0.9.1

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1138)
<!-- Reviewable:end -->
