### PR TITLE
Bug 1223739 - Travis: Put etl tests in the 2nd chunk to balance runtimes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,9 @@ matrix:
         # jobs, this one cannot use caching. The hashes are validated in the linters job.
         - pip install --disable-pip-version-check -r requirements/common.txt -r requirements/dev.txt
       script:
-        - py.test tests/ --runslow --ignore=tests/e2e/ --ignore=tests/log_parser/
-    - env: python-tests-e2e-and-logparser
+        - py.test tests/ --runslow --ignore=tests/e2e/ --ignore=tests/etl/ --ignore=tests/log_parser/
+
+    - env: python-tests-e2e-etl-and-logparser
       # Once mysql 5.6 is available on the container infra, we should switch back
       # to it, by setting `sudo: false`, so we can use caching for this job.
       sudo: required
@@ -86,7 +87,7 @@ matrix:
         # jobs, this one cannot use caching. The hashes are validated in the linters job.
         - pip install --disable-pip-version-check -r requirements/common.txt -r requirements/dev.txt
       script:
-        - py.test tests/e2e/ tests/log_parser/ --runslow
+        - py.test tests/e2e/ tests/etl/ tests/log_parser/ --runslow
 
 notifications:
   email:


### PR DESCRIPTION
Previously the python chunks were approx 3m55s and 2m55s respectively, since we couldn't move one of the largest running directories (etl) to the second chunk, since the tests would fail due to bug 1219922.

After this change the python chunk run times are 3m15s and 3m25s.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1139)
<!-- Reviewable:end -->
