### PR TITLE
Bug 1223384 - Stop running clear_cache on stage/prod deploy

### DIFF
--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -84,8 +84,6 @@ def update(ctx):
         run_local_with_env(ctx, "python2.7 manage.py init_datasources")
         # Update oauth credentials.
         run_local_with_env(ctx, "python2.7 manage.py export_project_credentials")
-        # Clear the cache.
-        run_local_with_env(ctx, "python2.7 manage.py clear_cache")
 
 
 @task


### PR DESCRIPTION
Since it should be unnecessary, and causes additional load until the cache is re-populated, since:
* the builds-{4hr,running,pending} tasks have to ingest all jobs, including those previously seen
* the pushlog task defaults back to "the last 10 pushes", which in the case of inactive repos, means extra busy work, and for active repos means we might actually miss commits (particularly if the prod push was to fix an issue that has say broken ingestion for the last X mins)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1140)
<!-- Reviewable:end -->
