### PR TITLE
Bug 1224551 - resultset status shouldn't include classified failures

### DIFF
--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -356,7 +356,7 @@ def test_resultset_cancel_all(jm, resultset_with_three_jobs, pulse_action_consum
     user.delete()
 
 
-def test_resultset_status(webapp, eleven_jobs_stored, jm):
+def test_resultset_status(webapp, eleven_jobs_stored, jm, initial_data):
     """
     test retrieving the status of a resultset
     """
@@ -371,3 +371,14 @@ def test_resultset_status(webapp, eleven_jobs_stored, jm):
     assert resp.status_int == 200
     assert isinstance(resp.json, dict)
     assert resp.json == {'success': 1}
+
+    # the first ten resultsets have one job each, so resultset.id == job.id
+    jm.insert_job_note(rs["id"], 2, 'John Doe', 'A random note')
+
+    resp = webapp.get(
+        reverse("resultset-status",
+                kwargs={"project": jm.project, "pk": int(rs["id"])})
+    )
+    assert resp.status_int == 200
+    assert isinstance(resp.json, dict)
+    assert resp.json == {}

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1904,7 +1904,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
     def get_resultset_status(self, resultset_id, exclusion_profile="default"):
         """Retrieve an aggregated job count for the given resultset.
         If an exclusion profile is provided, the job counted will be filtered accordingly"""
-        replace = []
+        replace = [self.refdata_model.get_db_name()]
         placeholders = [resultset_id]
         if exclusion_profile:
             signature_list = self.get_exclusion_profile_signatures(exclusion_profile)

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -731,14 +731,17 @@
         },
         "get_resultset_status":{
             "sql":"SELECT
-                        id,
+                        job.id,
                         state,
                         result,
                         SUM(IF(job_coalesced_to_guid is NULL, 0, 1)) as num_coalesced,
                         count(*) as total
                    FROM job
-                   WHERE result_set_id = ?
-                   REP0
+                   LEFT JOIN REP0.failure_classification fc
+                        ON fc.id = job.failure_classification_id
+                   WHERE result_set_id = ? and (
+                    fc.name = 'not classified' or fc.id IS NULL)
+                   REP1
                    group by state, result
                    ",
             "host_type": "read_host"


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1147)
<!-- Reviewable:end -->
