### PR TITLE
 	Bug 1224740 - Show 14 days of perf data in graphs view by default

### DIFF
--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -161,7 +161,7 @@ treeherder.value("phTimeRanges", [
       { "value":7776000, "text": "Last 90 days" },
       { "value":31536000, "text": "Last year" } ]);
 
-treeherder.value("phDefaultTimeRangeValue", 604800);
+treeherder.value("phDefaultTimeRangeValue", 1209600);
 
 // we are excluding macosx 10.10 by default for now, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1201615
 treeherder.value("phUnreliablePlatforms", [


### PR DESCRIPTION
The extra context is useful.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1150)
<!-- Reviewable:end -->
