### PR TITLE
Bug 1182425 - Add a config file for the New Relic Python agent

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -1,0 +1,9 @@
+# Options that can be set via the New Relic website (which is most of them)
+# override any listed here, so this file should only be used for settings
+# that are not available on the website to avoid confusion. See:
+# https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/python-agent-configuration
+# The NEW_RELIC_CONFIG_FILE environment variable must point at this file,
+# and both NEW_RELIC_APP_NAME + NEW_RELIC_LICENSE_KEY be set appropriately.
+
+[newrelic]
+log_file = stdout


### PR DESCRIPTION
The settings for the New Relic Python agent are defined via the following methods (later items override the earlier ones):
1. Agent defaults
2. Environment variables
3. Local agent configuration file (iff `NEW_RELIC_CONFIG_FILE` set)
4. Server-side configuration (ie via the New Relic website)
5. Per-request configuration

Some settings can only be controlled by a subset of these methods, eg the more security-sensitive ones (like whether request parameters should be recorded) must be set via [3].

In addition, once [4] is activated, *all* settings that can be set via their website will override those from 1-3, even if they are set to the empty string. As such, it's recommended to *only* use the local agent config file for settings that are unavailable on the website.

Stage/prod do currently have their own config file (managed via puppet, forked from the standard IT config), however it turns out it's unused since `NEW_RELIC_CONFIG_FILE` isn't defined. This explains why bug 1141036 didn't actually make any difference.

To change New Relic settings (that can't be set via the website) on Heroku, we're going to need to commit a config file to the repo anyway, so we might as well use that same file for stage/prod too, so we can modify the config there without requiring puppet changes. I've not copied the unused stage/prod config file from puppet, since it's crufty and mostly contains defaults.

This commit is a no-op until `NEW_RELIC_CONFIG_FILE` is defined in each environment. The `log_file` setting within will make the NEW_RELIC_LOG environment variable redundant. That variable is currently set to 'stderr' for stage/prod and 'stdout' for Heroku, so I've settled on 'stdout'.

In later bugs (eg for bug 1223496) more useful options will be added, but we'll at least be able to start pointing at the config file using `NEW_RELIC_CONFIG_FILE` in the meantime.

For the agent defaults and more info, see:
https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/python-agent-configuration

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1152)
<!-- Reviewable:end -->
