### PR TITLE
Bug 1223496 - Make New Relic capture request parameters too

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -7,3 +7,5 @@
 
 [newrelic]
 log_file = stdout
+# Turn on the capturing of request parameters.
+attributes.include = request.parameters.*

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -21,8 +21,8 @@ kombu==3.0.26
 # sha256: Y9f3sUog8p90Mlpp5ttFkl6vbjoAPqtGwCNP0FCoyT8
 simplejson==3.7.3
 
-# sha256: tYAUqlZA40Vup9vzPxUaHEud9HKJdocwwKAwYaRxOGU
-newrelic==2.56.0.42
+# sha256: KXli8j9mkLQbdp9g67m0Oy3k8jGLnFCLkqAvCrPth4s
+newrelic==2.58.1.44
 
 # Required by datasource
 # sha256: gRBAtkfl1WhvhNtBXv1pfmJQAIsRK2kJunesBZ4UDHQ


### PR DESCRIPTION
See:
https://docs.newrelic.com/docs/agents/python-agent/attributes/python-agent-attributes#requestParameters
https://docs.newrelic.com/docs/agents/python-agent/attributes/python-attribute-examples#ex_req_params

There's also a commit to update to the newest New Relic Python agent:
https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-258043
https://github.com/edmorley/newrelic-python-agent/commit/d0317a260172e081a28d3851af61983655253227

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1153)
<!-- Reviewable:end -->
