### PR TITLE
 	Bug 1226763 - Make talos data ingestion a simple translation layer

### DIFF
--- a/treeherder/etl/perf.py
+++ b/treeherder/etl/perf.py
@@ -202,168 +202,77 @@ def _calculate_test_value(replicates):
 
 
 def load_talos_artifacts(project_name, reference_data, job_data, datum):
-    if 'e10s' in reference_data.get('job_group_symbol', ''):
-        extra_properties = {'test_options': ['e10s']}
-    else:
-        extra_properties = {}
-
-    # transform the reference data so it only contains what we actually
-    # care about (for calculating the signature hash reproducibly), then
-    # get the associated models
-    reference_data = _transform_signature_properties(reference_data)
-    option_collection = OptionCollection.objects.get(
-        option_collection_hash=reference_data['option_collection_hash'])
-    framework = PerformanceFramework.objects.get(name='talos')
-    # there may be multiple machine platforms with the same platform: use
-    # the first
-    platform = MachinePlatform.objects.filter(
-        platform=reference_data['machine_platform'])[0]
-    repository = Repository.objects.get(
-        name=project_name)
-
-    # Get just the talos datazilla structure for treeherder
+    # translate into PERFHERDER_DATA
+    perfherder_data = {
+        'framework': {'name': 'talos'},
+        'suites': []
+    }
     target_datum = json.loads(datum['blob'])
     for talos_datum in target_datum['talos_data']:
         validate(talos_datum, TALOS_SCHEMA)
-        _job_guid = datum["job_guid"]
         _suite = talos_datum["testrun"]["suite"]
-
-        # data for performance series
-        job_id = job_data[_job_guid]['id']
-        result_set_id = job_data[_job_guid]['result_set_id']
-        push_timestamp = datetime.datetime.fromtimestamp(
-            job_data[_job_guid]['push_timestamp'])
-
         # counters will not be part of the summary series
         # counters have a json obj {'stat': val} instead of [val1, val2, ...]
         if 'talos_counters' in talos_datum:
+            counter_tests = []
             for _test in talos_datum["talos_counters"].keys():
-                signature_properties = {
-                    'suite': _suite,
-                    'test': _test
-                }
-                signature_properties.update(reference_data)
-                signature_properties.update(extra_properties)
-                signature_hash = _get_signature_hash(
-                    signature_properties)
-
-                signature, _ = PerformanceSignature.objects.get_or_create(
-                    repository=repository, signature_hash=signature_hash,
-                    defaults={
-                        'test': _test,
-                        'suite': _suite,
-                        'option_collection': option_collection,
-                        'platform': platform,
-                        'framework': framework,
-                        'extra_properties': extra_properties,
-                        'last_updated': push_timestamp
-                    })
-
-                try:
-                    value = float(
-                        talos_datum["talos_counters"][_test]["mean"])
-                except:
-                    logger.warning("Talos counters for job %s, "
-                                   "result_set %s, and counter named %s "
-                                   "have an unexpected value: %s" %
-                                   (job_id, result_set_id, _test,
-                                    talos_datum["talos_counters"][_test]))
-                    continue
-
-                PerformanceDatum.objects.get_or_create(
-                    repository=repository,
-                    result_set_id=result_set_id,
-                    job_id=job_id,
-                    signature=signature,
-                    push_timestamp=push_timestamp,
-                    defaults={'value': value})
-
-        subtest_signatures = []
+                counter_tests.append({
+                    'name': _test,
+                    'value': float(
+                        talos_datum["talos_counters"][_test]["mean"]),
+                    'lowerIsBetter': True
+                })
+            perfherder_data['suites'].append({
+                'name': _suite,
+                'subtests': counter_tests
+            })
 
         # series for all the subtests
+        subtests = []
         for _test in talos_datum["results"].keys():
-
-            signature_properties = {
-                'suite': _suite,
-                'test': _test
-            }
-            signature_properties.update(reference_data)
-
-            signature_hash = _get_signature_hash(
-                signature_properties)
-            subtest_signatures.append(signature_hash)
-
             if "summary" in talos_datum:
                 # most talos results should provide a summary of their
                 # subtest results based on an internal calculation of
                 # the replicates, use that if available
                 testdict = talos_datum["summary"]["subtests"][_test]
-                value = testdict["filtered"]
-                # "lower is better" is a property than can change
-                lower_is_better = testdict.get('lowerIsBetter', True)
+                subtests.append({
+                    'name': _test,
+                    'value': testdict["filtered"],
+                    'lowerIsBetter': testdict.get('lowerIsBetter', True)
+                })
             else:
                 # backwards compatibility for older versions of talos
                 # and android talos which don't provide this summary
-                # (at some point we can remove this)
-                value = _calculate_test_value(
-                    talos_datum["results"][_test])
-                lower_is_better = True
-
-            signature, _ = PerformanceSignature.objects.update_or_create(
-                repository=repository, signature_hash=signature_hash,
-                defaults={
-                    'test': _test,
-                    'suite': _suite,
-                    'option_collection': option_collection,
-                    'platform': platform,
-                    'framework': framework,
-                    'extra_properties': extra_properties,
-                    'lower_is_better': lower_is_better
+                subtests.append({
+                    'name': _test,
+                    'value': _calculate_test_value(
+                        talos_datum["results"][_test]),
+                    'lowerIsBetter': True
                 })
 
-            PerformanceDatum.objects.get_or_create(
-                repository=repository,
-                result_set_id=result_set_id,
-                job_id=job_id,
-                signature=signature,
-                push_timestamp=push_timestamp,
-                defaults={'value': value})
+        suite = {
+            'name': _suite,
+            'subtests': subtests
+        }
 
-        if subtest_signatures and len(subtest_signatures) > 1:
-            # summary series
-            extra_summary_properties = {
-                'subtest_signatures': sorted(subtest_signatures)
-            }
-            extra_summary_properties.update(extra_properties)
-            summary_properties = {'suite': _suite}
-            summary_properties.update(reference_data)
-            summary_properties.update(extra_summary_properties)
-            summary_signature_hash = _get_signature_hash(
-                summary_properties)
-
+        # add a summary value for suite if appropriate (more than one
+        # signature)
+        if len(talos_datum["results"].keys()) > 1:
             if "summary" in talos_datum and "suite" in talos_datum["summary"]:
-                value = talos_datum["summary"]["suite"]
-                lower_is_better = talos_datum["summary"].get("lowerIsBetter",
-                                                             True)
+                suite['value'] = talos_datum["summary"]["suite"]
+                suite['lowerIsBetter'] = talos_datum["summary"].get(
+                    "lowerIsBetter", True)
             else:
-                value = _calculate_summary_value(talos_datum["results"])
-                lower_is_better = True
-            signature, _ = PerformanceSignature.objects.update_or_create(
-                repository=repository, signature_hash=summary_signature_hash,
-                defaults={
-                    'test': '',
-                    'suite': _suite,
-                    'option_collection': option_collection,
-                    'platform': platform,
-                    'framework': framework,
-                    'extra_properties': extra_summary_properties,
-                    'lower_is_better': lower_is_better
-                })
+                suite['value'] = _calculate_summary_value(
+                    talos_datum["results"])
+                suite['lowerIsBetter'] = True
 
-            PerformanceDatum.objects.get_or_create(
-                repository=repository,
-                result_set_id=result_set_id,
-                job_id=job_id,
-                signature=signature,
-                push_timestamp=push_timestamp,
-                defaults={'value': value})
+        # add the suite to the list
+        perfherder_data['suites'].append(suite)
+
+    load_perf_artifacts(project_name, reference_data, job_data, {
+        'job_guid': datum['job_guid'],
+        'blob': json.dumps({
+            'performance_data': perfherder_data
+        })
+    })


### PR DESCRIPTION
Instead of having two completely different paths to inserting data
into the database, we can consolidate into one if we make the (deprecated)
talos data ingestion path simply create a PERFHERDER_DATA blob.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1156)
<!-- Reviewable:end -->
