### PR TITLE
Bug 1223085 - Only use one search box to filter in perfherder compare

### DIFF
--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -242,8 +242,7 @@ perf.controller('CompareResultsCtrl', [
         $scope.updateFilters = function() {
 
             $state.transitionTo('compare', {
-                filterTest: $scope.filterOptions.testFilter,
-                filterPlatform: $scope.filterOptions.platformFilter,
+                filter: $scope.filterOptions.filter,
                 showOnlyImportant: Boolean($scope.filterOptions.showOnlyImportant) ? undefined : 0,
                 showOnlyConfident: Boolean($scope.filterOptions.showOnlyConfident) ? 1 : undefined,
                 showUnreliablePlatforms: Boolean($scope.filterOptions.showUnreliablePlatforms) ? 1 : undefined
@@ -272,8 +271,7 @@ perf.controller('CompareResultsCtrl', [
                 return;
             }
             $scope.filterOptions = {
-                testFilter: $stateParams.filterTest || "",
-                platformFilter: $stateParams.filterPlatform || "",
+                filter: $stateParams.filter || "",
                 showOnlyImportant: $stateParams.showOnlyImportant === undefined ||
                     parseInt($stateParams.showOnlyImportant),
                 showOnlyConfident: $stateParams.showOnlyConfident !== undefined ||

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -17,7 +17,7 @@ perf.config(function($compileProvider, $stateProvider, $urlRouterProvider) {
         controller: 'GraphsCtrl'
     }).state('compare', {
         templateUrl: 'partials/perf/comparectrl.html',
-        url: '/compare?originalProject&originalRevision&newProject&newRevision&hideMinorChanges&showExcludedPlatforms&filterTest&filterPlatform&showOnlyImportant&showOnlyConfident&showUnreliablePlatforms',
+        url: '/compare?originalProject&originalRevision&newProject&newRevision&hideMinorChanges&showExcludedPlatforms&filter&showOnlyImportant&showOnlyConfident&showUnreliablePlatforms',
         controller: 'CompareResultsCtrl'
     }).state('comparesubtest', {
         templateUrl: 'partials/perf/comparesubtestctrl.html',

--- a/ui/partials/perf/comparectrl.html
+++ b/ui/partials/perf/comparectrl.html
@@ -17,12 +17,8 @@
       <h4>Filters</h4>
       <form class="form-inline">
         <div class="form-group">
-          <label for="filter-test">Test</label>
-            <input id="filter-test" type="text" class="form-control" ng-model="filterOptions.testFilter" placeholder="e.g. tp5o opt" ng-change="updateFilters()"/>
-        </div>
-        <div class="form-group">
-          <label for="filter-platform">Platform</label>
-            <input id="filter-platform" type="text" class="form-control" ng-model="filterOptions.platformFilter" placeholder="e.g. linux64" ng-change="updateFilters()"/>
+          <label for="filter">Filter</label>
+            <input id="filter" type="text" class="form-control" ng-model="filterOptions.filter" placeholder="e.g. linux tp5o" ng-change="updateFilters()"/>
         </div>
         <div class="checkbox" tooltip="Non-trivial changes (1.5%+)">
           <label>
@@ -48,8 +44,7 @@
          titles="titles"
          test-list="testList"
          compare-results="compareResults"
-         test-filter="filterOptions.testFilter"
-         platform-filter="filterOptions.platformFilter"
+         filter="filterOptions.filter"
          show-only-important="filterOptions.showOnlyImportant"
          show-only-confident="filterOptions.showOnlyConfident"
          show-unreliable-platforms="filterOptions.showUnreliablePlatforms">

--- a/ui/partials/perf/comparesubtestctrl.html
+++ b/ui/partials/perf/comparesubtestctrl.html
@@ -15,8 +15,7 @@
        titles="titles"
        test-list="testList"
        compare-results="compareResults"
-       test-filter=""
-       platform-filter=""
+       filter=""
        show-only-important="0"
        show-only-confident="0"
        show-unreliable-platforms="1">

--- a/ui/partials/perf/comparetable.html
+++ b/ui/partials/perf/comparetable.html
@@ -1,4 +1,4 @@
-<table class="table compare-table" style="table-layout: fixed;" ng-repeat="testName in filteredTestList">
+<table class="table compare-table" style="table-layout: fixed;" ng-repeat="(testName, compareResults) in filteredResultList">
   <tbody>
     <tr class="subtest-header">
       <!-- Manually specify table widths because it's just easier this way -->
@@ -12,7 +12,7 @@
       <th class="num-runs" style="width: 80px"># Runs</th>
       <th class="test-warning" style="width: 30px"><!-- warning if not enough --></th>
     </tr>
-    <tr ng-class="getCompareClasses(compareResult, 'row')" ng-repeat="compareResult in compareResults[testName] | orderBy: 'name'" ng-show="filterPlatform(compareResult)">
+    <tr ng-class="getCompareClasses(compareResult, 'row')" ng-repeat="compareResult in compareResults | orderBy: 'name'">
       <td class="test-title">{{compareResult.name}}&nbsp;&nbsp;
         <span class="result-links" ng-if="compareResult.links.length > 0">
           <span ng-repeat="link in compareResult.links">
@@ -97,7 +97,7 @@
     </tr>
   </tbody>
 </table>
-<p class="lead text-center" ng-show="!filteredTestList.length">
+<p class="lead text-center" ng-show="hasNoResults">
   No results to show for these two revisions.
   <span ng-show="testList.length">
     Try changing your filter settings?


### PR DESCRIPTION
Hi Will,
So we can filter platform and filter result by option like "show only important changes"
<img width="1239" alt="screen shot 2015-11-24 at 11 58 22 am" src="https://cloud.githubusercontent.com/assets/2166227/11357511/ed7cea7a-92a2-11e5-94e4-6c97a774f8d2.png">
<img width="1221" alt="screen shot 2015-11-24 at 12 00 26 pm" src="https://cloud.githubusercontent.com/assets/2166227/11357526/0a0b0492-92a3-11e5-9882-4a808344bcd2.png">

But it went wrong as long as I use it to filter test
<img width="1253" alt="screen shot 2015-11-24 at 12 01 49 pm" src="https://cloud.githubusercontent.com/assets/2166227/11357542/2c07f79e-92a3-11e5-9335-0efddf5103b5.png">
 
Actually, I can get the right filteredTestList data by console.log() it out in compare.js, but it display incorrect on html :(

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1160)
<!-- Reviewable:end -->
