### PR TITLE
Bug 1227552: Don't force a new job_group on fetch_allthethings

### DIFF
--- a/treeherder/etl/allthethings.py
+++ b/treeherder/etl/allthethings.py
@@ -81,7 +81,7 @@ class RunnableJobsProcess(JsonExtractorMixin,
                 job_type, _ = JobType.objects.get_or_create(
                     name=datum['job_type_name'],
                     symbol=datum['job_type_symbol'],
-                    job_group=job_group
+                    defaults={'job_group': job_group}
                 )
 
                 option_collection_hash = self.get_option_collection_hash(


### PR DESCRIPTION
Since "W3C Web Platform Reftests" is being grouped as "W" instead
of "Wr" on production, we are getting a duplicate symbol error.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1163)
<!-- Reviewable:end -->
