### PR TITLE
Bug 1227682 - Enable the ESLint no-extra-semi rule & fix infringements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,6 @@
         // Remove a line to enable the rule.
         "comma-dangle": 0,
         "no-console": 0,
-        "no-extra-semi": 0,
         "no-redeclare": 0,
         "no-undef": 0,
         "no-unused-vars": 0,

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -580,7 +580,7 @@ perf.controller('GraphsCtrl', [
                              // a hint on what the problem is
                              alert("Error loading performance data\n\n" + error);
                          });
-        };
+        }
 
         $scope.removeSeries = function(projectName, signature) {
             var newSeriesList = [];

--- a/ui/js/models/repository.js
+++ b/ui/js/models/repository.js
@@ -106,7 +106,7 @@ treeherder.factory('ThRepositoryModel', [
                             } else {
                                 this.pushlogURL = this.url + "/pushloghtml";
                             }
-                        };
+                        }
                         Repo.prototype = {
                             getRevisionHref: function(revision) {
                                 if (this.dvcs_type == 'git') {

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -284,7 +284,7 @@ treeherder.factory('ThResultSetStore', [
 
                 if (jobList.length === 0) {
                     thNotify.send("No new jobs available");
-                };
+                }
 
                 mapResultSetJobs(repoName, jobList);
             });

--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -16,7 +16,7 @@ treeherder.factory('PhSeries', ['$http', 'thServiceDomain', function($http, thSe
         return signatureProps.suite + " " + testName;
     };
 
-    function _getSeriesOptions(signatureProps, optionCollectionMap) {
+    var _getSeriesOptions = function(signatureProps, optionCollectionMap) {
         var options = [ optionCollectionMap[signatureProps.option_collection_hash] ];
         if (signatureProps.test_options) {
             options = options.concat(signatureProps.test_options);


### PR DESCRIPTION
Disallows unnecessary semicolons:
http://eslint.org/docs/rules/no-extra-semi

I converted `_getSeriesOptions()` to a variable, to match the others in that file - let me know if you'd instead prefer to just remove the trailing semi-colon from the function instead (it appears to be unused either way).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1166)
<!-- Reviewable:end -->
