### PR TITLE
Bug 1226651 - Add missing unique_together model constraints

### DIFF
--- a/treeherder/model/migrations/0001_initial.py
+++ b/treeherder/model/migrations/0001_initial.py
@@ -313,6 +313,14 @@ class Migration(migrations.Migration):
             name='repository_group',
             field=models.ForeignKey(to='model.RepositoryGroup'),
         ),
+        migrations.AlterUniqueTogether(
+            name='referencedatasignatures',
+            unique_together=set([('name', 'signature', 'build_system_type', 'repository')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='jobgroup',
+            unique_together=set([('name', 'symbol')]),
+        ),
         migrations.AddField(
             model_name='failurematch',
             name='matcher',
@@ -332,6 +340,10 @@ class Migration(migrations.Migration):
             model_name='classifiedfailure',
             name='failure_lines',
             field=models.ManyToManyField(related_name='intermittent_failures', through='model.FailureMatch', to='model.FailureLine'),
+        ),
+        migrations.AlterUniqueTogether(
+            name='userexclusionprofile',
+            unique_together=set([('user', 'exclusion_profile')]),
         ),
         migrations.AlterUniqueTogether(
             name='optioncollection',

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -330,6 +330,7 @@ class JobGroup(models.Model):
 
     class Meta:
         db_table = 'job_group'
+        unique_together = ('name', 'symbol')
 
     def __str__(self):
         return "{0} ({1})".format(
@@ -486,6 +487,7 @@ class UserExclusionProfile(models.Model):
 
     class Meta:
         db_table = 'user_exclusion_profile'
+        unique_together = ('user', 'exclusion_profile')
 
 
 class ReferenceDataSignatures(models.Model):
@@ -520,6 +522,7 @@ class ReferenceDataSignatures(models.Model):
         db_table = 'reference_data_signatures'
         # Remove if/when the model is renamed to 'ReferenceDataSignature'.
         verbose_name_plural = 'reference data signatures'
+        unique_together = ('name', 'signature', 'build_system_type', 'repository')
 
 
 class FailureLineManager(models.Manager):


### PR DESCRIPTION
These were present in the raw SQL used prior to bug 1193836, so should already exist on stage/prod/heroku. As such, I've added these to the initial migration to avoid errors during migrate/having to use `--fake`.

Please do double check I've transposed correctly from https://github.com/mozilla/treeherder/commit/0f3788036290146d99df76dea73edbebaa2b1aab#diff-8fb6f09f253240c1fed214aec80c1896 :-)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1169)
<!-- Reviewable:end -->
