### PR TITLE
Bug 1225597 - Docs: Make local hawk credentials section easier to find

### DIFF
--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -65,6 +65,7 @@ Or for more control, run each tool individually:
 
   NB: isort must be run from inside the VM, since a populated (and up to date) virtualenv is required so that isort can correctly categorise the imports.
 
+.. _managing-api-credentials:
 
 Managing API credentials
 ------------------------

--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -85,12 +85,12 @@ For more details see the :doc:`submitting_data` section.
 
 Users can request credentials for the deployed Mozilla Treeherder instances
 (and view/delete existing ones) using the forms here:
-`stage <https://treeherder.allizom.org/credentials/>`_,
-`production <https://treeherder.mozilla.org/credentials/>`_.
+`stage <https://treeherder.allizom.org/credentials/>`__ /
+`production <https://treeherder.mozilla.org/credentials/>`__.
 
 Once requested these require approval by a Treeherder administrator, here:
-`stage <https://treeherder.allizom.org/admin/credentials/credentials/>`_,
-`production <https://treeherder.mozilla.org/admin/credentials/credentials/>`_.
+`stage <https://treeherder.allizom.org/admin/credentials/credentials/>`__ /
+`production <https://treeherder.mozilla.org/admin/credentials/credentials/>`__.
 
 
 Add a new repository

--- a/docs/submitting_data.rst
+++ b/docs/submitting_data.rst
@@ -558,13 +558,10 @@ Authentication
 --------------
 
 A treeherder client instance should identify itself to the server
-via the `Hawk authentication mechanism`_. You can apply for
-credentials by going to:
+via the `Hawk authentication mechanism`_. To apply for credentials or
+create some for local testing, see :ref:`managing-api-credentials`.
 
-https://treeherder.mozilla.org/credentials/create/
-
-Once they have been approved by a Treeherder administrator, you can
-pass the credentials for this mechanism via the `client_id` and
+Once your credentials are set up, pass them via the `client_id` and
 `secret` parameters to TreeherderClient's constructor:
 
 .. code-block:: python


### PR DESCRIPTION
Also:
* Remove the duplication between the two pages, by having the submitting data section not mention requesting credentials at all, and leave that to the common tasks page instead.
* Use anonymous links to avoid build warnings

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1171)
<!-- Reviewable:end -->
