### PR TITLE
Bug 1228013 - Add a test for missing Django migrations

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -3,6 +3,7 @@ import pytest
 from celery import current_app
 from django.conf import settings
 from django.core.cache import cache
+from django.core.management import call_command
 
 
 @pytest.fixture
@@ -14,6 +15,16 @@ def db_conn():
         passwd=settings.DATABASES['default'].get('PASSWORD') or '',
         **db_options
     )
+
+
+def test_no_missing_migrations():
+    """Check no model changes have been made since the last `./manage.py makemigrations`."""
+    with pytest.raises(SystemExit) as e:
+        # Replace with `check_changes=True` once we're using a Django version that includes:
+        # https://code.djangoproject.com/ticket/25604
+        # https://github.com/django/django/pull/5453
+        call_command('makemigrations', interactive=False, dry_run=True, exit_code=True)
+    assert str(e.value) == '1'
 
 
 def test_datasource_db_created(jobs_ds, db_conn):


### PR DESCRIPTION
This test checks that `./manage.py makemigrations` was run, and the resultant migrations file committed to the repo, since the last time the Django models were updated.

Django 1.8 only supports an `exit_code` option, which unhelpfully makes the command `sys.exit(1)` if there are *no* missing migrations, when we're more interested in the opposite. As such, we have to confirm that it does exit 1 (which causes a `SystemExit` exception).

On Django master they've replaced `exit_code` with `check_changes` that inverts the check, which we should switch to once we're using a version of Django that includes that fix.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1172)
<!-- Reviewable:end -->
