### PR TITLE
Bug 1228324 - Use the new style urlpatterns syntax

### DIFF
--- a/treeherder/embed/urls.py
+++ b/treeherder/embed/urls.py
@@ -1,10 +1,8 @@
-from django.conf.urls import (patterns,
-                              url)
+from django.conf.urls import url
 
 from .views import ResultsetStatusView
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^resultset-status/(?P<repository>[\w-]{0,50})/(?P<revision>\w+)/$',
         ResultsetStatusView.as_view(), name="resultset_status"),
-)
+]

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import (include,
-                              patterns,
                               url)
 from rest_framework import routers
 
@@ -104,10 +103,9 @@ default_router.register(r'performance/alertsummary',
                         performance_data.PerformanceAlertSummaryViewSet,
                         base_name='performance-alert-summaries')
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^project/(?P<project>[\w-]{0,50})/',
         include(project_bound_router.urls)),
     url(r'^',
         include(default_router.urls)),
-)
+]


### PR DESCRIPTION
Since the `patterns()` syntax is now deprecated:
https://docs.djangoproject.com/en/1.8/releases/1.8/#django-conf-urls-patterns

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1173)
<!-- Reviewable:end -->
