### PR TITLE
Bug 1212177 - l10n repacks should be displayed in treeherder properly

### DIFF
--- a/treeherder/etl/buildbot.py
+++ b/treeherder/etl/buildbot.py
@@ -433,7 +433,7 @@ JOB_TYPE_BUILDERNAME = {
         re.compile(r'.+(?<!leak) test .+'),
     ],
     'talos': [re.compile(r'.+ talos .+')],
-    'repack': [re.compile(r'.+ l10n .+')],
+    'repack': [re.compile(r'.+ l10n .+|.+_l10n_.+'))],
 }
 
 # from Data.js ``type`` Config.testNames and Config.buildNames

--- a/treeherder/etl/buildbot.py
+++ b/treeherder/etl/buildbot.py
@@ -433,7 +433,7 @@ JOB_TYPE_BUILDERNAME = {
         re.compile(r'.+(?<!leak) test .+'),
     ],
     'talos': [re.compile(r'.+ talos .+')],
-    'repack': [re.compile(r'.+ l10n .+|.+_l10n_.+'))],
+    'repack': [re.compile(r'(.+ l10n .+|.+_l10n_.+'))],
 }
 
 # from Data.js ``type`` Config.testNames and Config.buildNames


### PR DESCRIPTION
Bug 1212177 - l10n repacks should be displayed in treeherder properly

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1175)
<!-- Reviewable:end -->
