### PR TITLE
Bug 1196764 - Rewrite handling of estimated job durations

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -4,6 +4,6 @@ worker_pushlog: newrelic-admin run-program celery -A treeherder worker -Q pushlo
 worker_buildapi_pending: newrelic-admin run-program celery -A treeherder worker -Q buildapi_pending --maxtasksperchild=20 --concurrency=5
 worker_buildapi_running: newrelic-admin run-program celery -A treeherder worker -Q buildapi_running --maxtasksperchild=20 --concurrency=5
 worker_buildapi_4hr: newrelic-admin run-program celery -A treeherder worker -Q buildapi_4hr --maxtasksperchild=20 --concurrency=1
-worker_default: newrelic-admin run-program celery -A treeherder worker -Q default,cycle_data,calculate_eta,fetch_bugs,fetch_allthethings --maxtasksperchild=50 --concurrency=3
+worker_default: newrelic-admin run-program celery -A treeherder worker -Q default,cycle_data,calculate_durations,fetch_bugs,fetch_allthethings --maxtasksperchild=50 --concurrency=3
 worker_hp: newrelic-admin run-program celery -A treeherder worker -Q classification_mirroring,publish_to_pulse --maxtasksperchild=50 --concurrency=1
 worker_log_parser: newrelic-admin run-program celery -A treeherder worker -Q log_parser_fail,log_parser,log_parser_hp,log_parser_json --maxtasksperchild=50 --concurrency=5

--- a/bin/run_celery_worker
+++ b/bin/run_celery_worker
@@ -19,6 +19,6 @@ if [ ! -f $LOGFILE ]; then
 fi
 
 exec $NEWRELIC_ADMIN celery -A treeherder worker -c 3 \
-     -Q default,cycle_data,calculate_eta,fetch_bugs,autoclassify,detect_intermittents,fetch_allthethings \
+     -Q default,cycle_data,calculate_durations,fetch_bugs,autoclassify,detect_intermittents,fetch_allthethings \
      -E --maxtasksperchild=500 \
      --logfile=$LOGFILE -l INFO -n default.%h

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,7 +160,7 @@ def mock_log_parser(monkeypatch):
 
 
 @pytest.fixture
-def result_set_stored(jm, initial_data, sample_resultset):
+def result_set_stored(jm, initial_data, sample_resultset, test_repository):
 
     jm.store_result_set_data(sample_resultset)
 
@@ -215,7 +215,7 @@ def mock_message_broker(monkeypatch):
 
 
 @pytest.fixture
-def resultset_with_three_jobs(jm, sample_data, sample_resultset):
+def resultset_with_three_jobs(jm, sample_data, sample_resultset, test_repository):
     """
     Stores a number of jobs in the same resultset.
     """
@@ -246,7 +246,7 @@ def resultset_with_three_jobs(jm, sample_data, sample_resultset):
 
 
 @pytest.fixture
-def eleven_jobs_stored(jm, sample_data, sample_resultset, mock_log_parser):
+def eleven_jobs_stored(jm, sample_data, sample_resultset, test_repository, mock_log_parser):
     """stores a list of 11 job samples"""
 
     jm.store_result_set_data(sample_resultset)

--- a/tests/log_parser/test_tasks.py
+++ b/tests/log_parser/test_tasks.py
@@ -58,7 +58,7 @@ def mock_mozlog_get_log_handler(monkeypatch):
 
 
 def test_parse_log(jm, initial_data, jobs_with_local_log, sample_resultset,
-                   mock_post_json, mock_get_remote_content):
+                   test_repository, mock_post_json, mock_get_remote_content):
     """
     check that at least 3 job_artifacts get inserted when running
     a parse_log task for a successful job
@@ -96,7 +96,7 @@ def test_parse_log(jm, initial_data, jobs_with_local_log, sample_resultset,
 # json-log parsing is disabled due to bug 1152681.
 @pytest.mark.xfail
 def test_parse_mozlog_log(jm, initial_data, jobs_with_local_mozlog_log,
-                          sample_resultset, mock_post_json,
+                          sample_resultset, test_repository, mock_post_json,
                           mock_get_remote_content,
                           mock_mozlog_get_log_handler
                           ):
@@ -139,7 +139,7 @@ def test_parse_mozlog_log(jm, initial_data, jobs_with_local_mozlog_log,
 
 
 def test_bug_suggestions_artifact(jm, initial_data, jobs_with_local_log,
-                                  sample_resultset, mock_post_json,
+                                  sample_resultset, test_repository, mock_post_json,
                                   mock_get_remote_content
                                   ):
     """

--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -31,7 +31,7 @@ def test_disconnect(jm):
 
 
 def test_ingest_single_sample_job(jm, refdata, sample_data, initial_data,
-                                  mock_log_parser, sample_resultset):
+                                  sample_resultset, test_repository, mock_log_parser):
     """Process a single job structure in the job_data.txt file"""
     job_data = sample_data.job_data[:1]
     test_utils.do_job_ingestion(jm, refdata, job_data, sample_resultset)
@@ -40,7 +40,8 @@ def test_ingest_single_sample_job(jm, refdata, sample_data, initial_data,
     refdata.disconnect()
 
 
-def test_ingest_all_sample_jobs(jm, refdata, sample_data, initial_data, sample_resultset, mock_log_parser):
+def test_ingest_all_sample_jobs(jm, refdata, sample_data, initial_data,
+                                sample_resultset, test_repository, mock_log_parser):
     """
     @@@ - Re-enable when our job_data.txt has been re-created with
           correct data.
@@ -81,7 +82,7 @@ def test_get_inserted_row_ids(jm, sample_resultset, test_repository):
 
 
 def test_ingest_running_to_retry_sample_job(jm, refdata, sample_data, initial_data,
-                                            mock_log_parser, sample_resultset):
+                                            sample_resultset, test_repository, mock_log_parser):
     """Process a single job structure in the job_data.txt file"""
     job_data = copy.deepcopy(sample_data.job_data[:1])
     job = job_data[0]['job']
@@ -117,7 +118,7 @@ def test_ingest_running_to_retry_sample_job(jm, refdata, sample_data, initial_da
 
 
 def test_ingest_running_to_retry_to_success_sample_job(jm, refdata, sample_data, initial_data,
-                                                       mock_log_parser, sample_resultset):
+                                                       sample_resultset, test_repository, mock_log_parser):
     """Process a single job structure in the job_data.txt file"""
     job_data = copy.deepcopy(sample_data.job_data[:1])
     job = job_data[0]['job']
@@ -161,7 +162,7 @@ def test_ingest_running_to_retry_to_success_sample_job(jm, refdata, sample_data,
 
 
 def test_ingest_retry_sample_job_no_running(jm, refdata, sample_data, initial_data,
-                                            mock_log_parser, sample_resultset):
+                                            sample_resultset, test_repository, mock_log_parser):
     """Process a single job structure in the job_data.txt file"""
     job_data = copy.deepcopy(sample_data.job_data[:1])
     job = job_data[0]['job']
@@ -187,7 +188,7 @@ def test_ingest_retry_sample_job_no_running(jm, refdata, sample_data, initial_da
 
 
 def test_cycle_all_data(jm, refdata, sample_data, initial_data,
-                        sample_resultset, mock_log_parser):
+                        sample_resultset, test_repository, mock_log_parser):
     """
     Test cycling the sample data
     """
@@ -220,7 +221,7 @@ def test_cycle_all_data(jm, refdata, sample_data, initial_data,
 
 
 def test_cycle_one_job(jm, refdata, sample_data, initial_data,
-                       sample_resultset, mock_log_parser):
+                       sample_resultset, test_repository, mock_log_parser):
     """
     Test cycling one job in a group of jobs to confirm there are no
     unexpected deletions
@@ -266,7 +267,7 @@ def test_cycle_one_job(jm, refdata, sample_data, initial_data,
 
 
 def test_cycle_all_data_in_chunks(jm, refdata, sample_data, initial_data,
-                                  sample_resultset, mock_log_parser):
+                                  sample_resultset, test_repository, mock_log_parser):
     """
     Test cycling the sample data in chunks.
     """
@@ -299,7 +300,7 @@ def test_cycle_all_data_in_chunks(jm, refdata, sample_data, initial_data,
     assert len(jobs_after) == 0
 
 
-def test_bad_date_value_ingestion(jm, initial_data, mock_log_parser):
+def test_bad_date_value_ingestion(jm, initial_data, test_repository, mock_log_parser):
     """
     Test ingesting an blob with bad date value
 
@@ -365,7 +366,7 @@ def test_store_result_set_revisions(jm, initial_data, sample_resultset):
 
 
 def test_get_job_data(jm, test_project, refdata, sample_data, initial_data,
-                      mock_log_parser, sample_resultset):
+                      sample_resultset, test_repository, mock_log_parser):
 
     target_len = 10
     job_data = sample_data.job_data[:target_len]
@@ -378,7 +379,7 @@ def test_get_job_data(jm, test_project, refdata, sample_data, initial_data,
 
 
 def test_remove_existing_jobs_single_existing(jm, sample_data, initial_data, refdata,
-                                              mock_log_parser, sample_resultset):
+                                              sample_resultset, test_repository, mock_log_parser):
     """Remove single existing job prior to loading"""
 
     job_data = sample_data.job_data[:1]
@@ -393,7 +394,7 @@ def test_remove_existing_jobs_single_existing(jm, sample_data, initial_data, ref
 
 
 def test_remove_existing_jobs_one_existing_one_new(jm, sample_data, initial_data, refdata,
-                                                   mock_log_parser, sample_resultset):
+                                                   sample_resultset, test_repository, mock_log_parser):
     """Remove single existing job prior to loading"""
 
     job_data = sample_data.job_data[:1]
@@ -405,7 +406,7 @@ def test_remove_existing_jobs_one_existing_one_new(jm, sample_data, initial_data
 
 
 def test_ingesting_skip_existing(jm, sample_data, initial_data, refdata,
-                                 mock_log_parser, sample_resultset):
+                                 sample_resultset, test_repository, mock_log_parser):
     """Remove single existing job prior to loading"""
 
     job_data = sample_data.job_data[:1]

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -188,7 +188,7 @@ CELERY_QUEUES = (
     Queue('buildapi_4hr', Exchange('default'), routing_key='buildapi_4hr'),
     Queue('fetch_allthethings', Exchange('default'), routing_key='fetch_allthethings'),
     Queue('cycle_data', Exchange('default'), routing_key='cycle_data'),
-    Queue('calculate_eta', Exchange('default'), routing_key='calculate_eta'),
+    Queue('calculate_durations', Exchange('default'), routing_key='calculate_durations'),
     Queue('fetch_bugs', Exchange('default'), routing_key='fetch_bugs'),
     Queue('store_pulse_jobs', Exchange('default'), routing_key='store_pulse_jobs')
 )
@@ -251,12 +251,12 @@ CELERYBEAT_SCHEDULE = {
             'queue': 'cycle_data'
         }
     },
-    'calculate-eta-every-6-hours': {
-        'task': 'calculate-eta',
+    'calculate-durations-every-6-hours': {
+        'task': 'calculate-durations',
         'schedule': timedelta(hours=6),
         'relative': True,
         'options': {
-            'queue': 'calculate_eta'
+            'queue': 'calculate_durations'
         }
     },
     'fetch-bugs-every-hour': {

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -492,23 +492,11 @@ class JobsModel(TreeherderModelBase):
             submit_timestamp = int(time.time())
             for signature in eta_groups:
 
-                running_samples = map(
-                    lambda x: int(x or 0),
-                    eta_groups[signature]['running_samples'].split(','))
-
-                running_median = self.get_median_from_sorted_list(
-                    sorted(running_samples))
-
                 placeholders.append(
                     [
                         signature,
                         'running',
                         eta_groups[signature]['running_avg_sec'],
-                        running_median,
-                        eta_groups[signature]['running_min_sec'],
-                        eta_groups[signature]['running_max_sec'],
-                        eta_groups[signature]['running_std'],
-                        len(running_samples),
                         submit_timestamp
                     ])
 
@@ -518,25 +506,6 @@ class JobsModel(TreeherderModelBase):
                 executemany=True,
                 debug_show=self.DEBUG
             )
-
-    def get_median_from_sorted_list(self, sorted_list):
-
-        length = len(sorted_list)
-
-        if length == 0:
-            return 0
-
-        # Cannot take the median with only on sample,
-        # return it
-        elif length == 1:
-            return sorted_list[0]
-
-        elif not length % 2:
-            return round(
-                (sorted_list[length / 2] + sorted_list[length / 2 - 1]) / 2, 0
-            )
-
-        return round(sorted_list[length / 2], 0)
 
     def cycle_data(self, cycle_interval, chunk_size, sleep_time):
         """Delete data older than cycle_interval, splitting the target data

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -467,7 +467,7 @@ class JobsModel(TreeherderModelBase):
             debug_show=self.DEBUG
         )
 
-    def calculate_eta(self, sample_window_seconds, debug):
+    def calculate_durations(self, sample_window_seconds, debug):
         # Get the most recent timestamp from jobs
         max_start_timestamp = self.execute(
             proc='jobs.selects.get_max_job_start_timestamp',

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -468,17 +468,16 @@ class JobsModel(TreeherderModelBase):
         )
 
     def calculate_eta(self, sample_window_seconds, debug):
-
         # Get the most recent timestamp from jobs
-        max_timestamp = self.execute(
-            proc='jobs.selects.get_max_job_submit_timestamp',
+        max_start_timestamp = self.execute(
+            proc='jobs.selects.get_max_job_start_timestamp',
             return_type='iter',
             debug_show=self.DEBUG
-        ).get_column_data('submit_timestamp')
+        ).get_column_data('start_timestamp')
 
-        if max_timestamp:
+        if max_start_timestamp:
 
-            time_window = int(max_timestamp) - sample_window_seconds
+            time_window = int(max_start_timestamp) - sample_window_seconds
 
             eta_groups = self.execute(
                 proc='jobs.selects.get_eta_groups',

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -956,7 +956,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
         # Store all reference data and retrieve associated ids
         id_lookups = self.refdata_model.set_all_reference_data()
 
-        job_eta_times = self.get_job_eta_times(
+        average_job_durations = self.get_average_job_durations(
             id_lookups['reference_data_signatures']
         )
 
@@ -979,7 +979,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 job_guid_list,
                 job_update_placeholders,
                 result_set_ids,
-                job_eta_times,
+                average_job_durations,
                 push_timestamps
             )
 
@@ -1243,7 +1243,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             self.get_number(job.get('submit_timestamp')),
             self.get_number(job.get('start_timestamp')),
             self.get_number(job.get('end_timestamp')),
-            0,                      # idx:17, replace with running_avg_sec
+            0,                      # idx:17, replace with average job duration
             tier,
             job_guid,
             get_guid_root(job_guid)  # will be the same except for ``retry`` jobs
@@ -1306,7 +1306,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
     def _set_data_ids(
         self, index, job_placeholders, id_lookups,
         job_guid_list, job_update_placeholders,
-        result_set_ids, job_eta_times, push_timestamps
+        result_set_ids, average_job_durations, push_timestamps
     ):
         """
         Supplant ref data with ids and create update placeholders
@@ -1385,7 +1385,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             job_guid_list.append(job_guid_root)
 
         reference_data_signature = job_placeholders[index][1]
-        average_duration = job_eta_times.get(reference_data_signature, 0)
+        average_duration = average_job_durations.get(reference_data_signature, 0)
 
         job_placeholders[index][self.JOB_PH_RUNNING_AVG] = average_duration
 
@@ -1424,8 +1424,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
 
         return self.get_job_ids_by_guid(job_guid_list)
 
-    def get_job_eta_times(self, reference_data_signatures):
-
+    def get_average_job_durations(self, reference_data_signatures):
         eta_lookup = {}
 
         if len(reference_data_signatures) == 0:

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -478,24 +478,21 @@ class JobsModel(TreeherderModelBase):
         if max_start_timestamp:
 
             time_window = int(max_start_timestamp) - sample_window_seconds
-
-            eta_groups = self.execute(
-                proc='jobs.selects.get_eta_groups',
+            average_durations = self.execute(
+                proc='jobs.selects.get_average_job_durations',
                 placeholders=[time_window],
-                key_column='signature',
-                return_type='dict',
+                return_type='tuple',
                 debug_show=self.DEBUG
             )
 
             placeholders = []
             submit_timestamp = int(time.time())
-            for signature in eta_groups:
-
+            for job in average_durations:
                 placeholders.append(
                     [
-                        signature,
+                        job['signature'],
                         'running',
-                        eta_groups[signature]['running_avg_sec'],
+                        job['average_duration'],
                         submit_timestamp
                     ])
 

--- a/treeherder/model/management/commands/calculate_durations.py
+++ b/treeherder/model/management/commands/calculate_durations.py
@@ -2,11 +2,11 @@ from optparse import make_option
 
 from django.core.management.base import BaseCommand
 
-from treeherder.model.tasks import calculate_eta
+from treeherder.model.tasks import calculate_durations
 
 
 class Command(BaseCommand):
-    help = """Cycle data that exceeds the time constraint limit"""
+    help = """Populate the job_duration table with average durations for recent jobs"""
 
     option_list = BaseCommand.option_list + (
 
@@ -30,4 +30,4 @@ class Command(BaseCommand):
 
         sample_window_seconds = 60 * 60 * sample_window_size
 
-        calculate_eta(sample_window_seconds, debug)
+        calculate_durations(sample_window_seconds, debug)

--- a/treeherder/model/migrations/0005_add_job_duration_table.py
+++ b/treeherder/model/migrations/0005_add_job_duration_table.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0004_add_runnable_job_table'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='JobDuration',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('signature', models.CharField(max_length=50L)),
+                ('average_duration', models.PositiveIntegerField()),
+                ('repository', models.ForeignKey(to='model.Repository')),
+            ],
+            options={
+                'db_table': 'job_duration',
+            },
+        ),
+        migrations.AlterUniqueTogether(
+            name='jobduration',
+            unique_together=set([('signature', 'repository')]),
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -525,6 +525,21 @@ class ReferenceDataSignatures(models.Model):
         unique_together = ('name', 'signature', 'build_system_type', 'repository')
 
 
+class JobDuration(models.Model):
+    """
+    Average job duration for each repository/job signature combination.
+
+    These are updated periodically by the calculate_durations task.
+    """
+    signature = models.CharField(max_length=50L)
+    repository = models.ForeignKey(Repository)
+    average_duration = models.PositiveIntegerField()
+
+    class Meta:
+        db_table = 'job_duration'
+        unique_together = ('signature', 'repository')
+
+
 class FailureLineManager(models.Manager):
     def unmatched_for_job(self, repository, job_guid):
         return FailureLine.objects.filter(

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -66,16 +66,6 @@
 
             "host_type":"master_host"
         },
-        "set_job_eta":{
-            "sql":"INSERT INTO `job_eta` (
-                    `signature`,
-                    `state`,
-                    `avg_sec`,
-                    `submit_timestamp`)
-                   VALUES (?,?,?,?)",
-
-            "host_type":"master_host"
-        },
         "set_result_set":{
 
             "sql":"INSERT INTO `result_set` (`author`, `revision_hash`,`long_revision`,`short_revision`,`push_timestamp`, `active_status`)

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -291,17 +291,6 @@
             "host_type":"master_host"
 
         },
-        "get_last_eta_by_signatures":{
-            "sql":"SELECT signature,
-                          state,
-                          avg_sec,
-                          MAX(submit_timestamp)
-                    FROM job_eta
-                    WHERE signature IN (REP0)
-                    GROUP BY signature, state
-                    ORDER BY submit_timestamp DESC",
-            "host_type":"read_host"
-        },
         "get_revision_ids_to_cycle":{
             "sql":"SELECT revision_id FROM revision_map WHERE result_set_id IN (REP0)",
             "host_type":"master_host"

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -271,12 +271,9 @@
         }
     },
     "selects":{
-        "get_max_job_submit_timestamp":{
-
-            "sql": "SELECT MAX(`submit_timestamp`) AS 'submit_timestamp' FROM `job`",
-
+        "get_max_job_start_timestamp":{
+            "sql": "SELECT MAX(`start_timestamp`) AS 'start_timestamp' FROM `job`",
             "host_type":"master_host"
-
         },
         "get_eta_groups":{
 
@@ -285,14 +282,11 @@
                             ROUND( AVG(end_timestamp - start_timestamp) )
                             AS UNSIGNED) AS 'running_avg_sec'
                    FROM job
-                   WHERE submit_timestamp >= ? AND
-                         start_timestamp >= submit_timestamp AND
+                   WHERE start_timestamp >= ? AND
                          end_timestamp >= start_timestamp AND
-                         start_timestamp > 0 AND end_timestamp > 0
+                         end_timestamp is NOT NULL
                    GROUP BY signature",
-
             "host_type":"read_host"
-
         },
         "get_signature_list_from_job_ids":{
 

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -275,12 +275,11 @@
             "sql": "SELECT MAX(`start_timestamp`) AS 'start_timestamp' FROM `job`",
             "host_type":"master_host"
         },
-        "get_eta_groups":{
-
+        "get_average_job_durations":{
             "sql":"SELECT signature,
                           CAST(
                             ROUND( AVG(end_timestamp - start_timestamp) )
-                            AS UNSIGNED) AS 'running_avg_sec'
+                            AS UNSIGNED) AS 'average_duration'
                    FROM job
                    WHERE start_timestamp >= ? AND
                          end_timestamp >= start_timestamp AND

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -71,13 +71,8 @@
                     `signature`,
                     `state`,
                     `avg_sec`,
-                    `median_sec`,
-                    `min_sec`,
-                    `max_sec`,
-                    `std`,
-                    `sample_count`,
                     `submit_timestamp`)
-                   VALUES (?,?,?,?,?,?,?,?,?)",
+                   VALUES (?,?,?,?)",
 
             "host_type":"master_host"
         },
@@ -288,17 +283,7 @@
             "sql":"SELECT signature,
                           CAST(
                             ROUND( AVG(end_timestamp - start_timestamp) )
-                            AS UNSIGNED) AS 'running_avg_sec',
-
-                          MIN(end_timestamp - start_timestamp) AS 'running_min_sec',
-                          MAX(end_timestamp - start_timestamp) AS 'running_max_sec',
-
-                          CAST(
-                            ROUND( STD(end_timestamp - start_timestamp) )
-                            AS SIGNED) AS 'running_std',
-
-                          GROUP_CONCAT(end_timestamp - start_timestamp SEPARATOR ',')
-                            AS 'running_samples'
+                            AS UNSIGNED) AS 'running_avg_sec'
                    FROM job
                    WHERE submit_timestamp >= ? AND
                          start_timestamp >= submit_timestamp AND
@@ -327,11 +312,6 @@
             "sql":"SELECT signature,
                           state,
                           avg_sec,
-                          median_sec,
-                          min_sec,
-                          max_sec,
-                          std,
-                          sample_count,
                           MAX(submit_timestamp)
                     FROM job_eta
                     WHERE signature IN (REP0)

--- a/treeherder/model/sql/template_schema/project.sql.tmpl
+++ b/treeherder/model/sql/template_schema/project.sql.tmpl
@@ -166,11 +166,6 @@ DROP TABLE IF EXISTS `job_eta`;
  *  signature - References treeherder_reference_1.buildbot_buildernames.signature
  *  state - pending | running
  *  avg_sec - A rolling average over a 12 hr window in seconds
- *  median_sec - The median of the sample range
- *  min_sec - The minimum value of the sample range
- *  max_sec - The minimum value of the sample range
- *  std - Of the of avg_sec
- *  sample_count - The number of samples used in the rolling average
  *  submit_timestamp - The timestamp the eta data was computed and entered
  *************************/
 CREATE TABLE `job_eta` (
@@ -178,17 +173,10 @@ CREATE TABLE `job_eta` (
   `signature` varchar(50) DEFAULT NULL,
   `state` varchar(25) COLLATE utf8_bin NOT NULL,
   `avg_sec` int(10) unsigned NOT NULL,
-  `median_sec` int(10) unsigned NOT NULL,
-  `min_sec` int(10) unsigned NOT NULL,
-  `max_sec` int(10) unsigned NOT NULL,
-  `std` int(10) unsigned NOT NULL,
-  `sample_count` int(10) unsigned NOT NULL,
   `submit_timestamp` int(10) unsigned NOT NULL,
   PRIMARY KEY (`id`),
   KEY `idx_state` (`state`),
   KEY `idx_avg_sec` (`avg_sec`),
-  KEY `idx_median_sec` (`median_sec`),
-  KEY `idx_sample_count` (`sample_count`),
   KEY `idx_submit_timestamp` (`submit_timestamp`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/treeherder/model/sql/template_schema/project.sql.tmpl
+++ b/treeherder/model/sql/template_schema/project.sql.tmpl
@@ -95,7 +95,7 @@ DROP TABLE IF EXISTS `job`;
  *  start_timestamp - Time the job was started.
  *  end_timestamp - Time the job completed.
  *  last_modified - The last time the job was modified
- *  running_eta - ETA to a completed state. A rolling average over a 6 hr window of end_timestamp - start_timestamp, recomputed every 30 min.
+ *  running_eta - The estimated job duration as recorded in the job_duration table at time of submission.
  **************************/
 CREATE TABLE `job` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,

--- a/treeherder/model/sql/template_schema/project.sql.tmpl
+++ b/treeherder/model/sql/template_schema/project.sql.tmpl
@@ -148,39 +148,6 @@ CREATE TABLE `job` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
-DROP TABLE IF EXISTS `job_eta`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
---
--- Table structure for table `job_eta`
---
-/*************************
- * Table: job_eta
- *
- * This table holds a timeline of eta trends for pending and running jobs
- *
- * Population Method: dynamic from incoming data
- *
- * Example Data:
- *
- *  signature - References treeherder_reference_1.buildbot_buildernames.signature
- *  state - pending | running
- *  avg_sec - A rolling average over a 12 hr window in seconds
- *  submit_timestamp - The timestamp the eta data was computed and entered
- *************************/
-CREATE TABLE `job_eta` (
-  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-  `signature` varchar(50) DEFAULT NULL,
-  `state` varchar(25) COLLATE utf8_bin NOT NULL,
-  `avg_sec` int(10) unsigned NOT NULL,
-  `submit_timestamp` int(10) unsigned NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `idx_state` (`state`),
-  KEY `idx_avg_sec` (`avg_sec`),
-  KEY `idx_submit_timestamp` (`submit_timestamp`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
 --
 -- Table structure for table `job_artifact`
 --

--- a/treeherder/model/tasks.py
+++ b/treeherder/model/tasks.py
@@ -46,8 +46,8 @@ def cycle_data():
     call_command('cycle_data')
 
 
-@task(name='calculate-eta', rate_limit='1/h')
-def calculate_eta(sample_window_seconds=21600, debug=False):
+@task(name='calculate-durations', rate_limit='1/h')
+def calculate_durations(sample_window_seconds=21600, debug=False):
     from treeherder.model.derived.jobs import JobsModel
 
     projects = Repository.objects.filter(active_status='active').values_list('name', flat=True)
@@ -55,7 +55,7 @@ def calculate_eta(sample_window_seconds=21600, debug=False):
     for project in projects:
 
         with JobsModel(project) as jm:
-            jm.calculate_eta(sample_window_seconds, debug)
+            jm.calculate_durations(sample_window_seconds, debug)
 
 
 @task(name='publish-job-action')


### PR DESCRIPTION
In order that the UI can show ETAs for running jobs, we have to generate average job durations based on historic data. This currently happens via a periodically run `calculate_eta` task, which:
1. Looks at the last X hours of jobs for each repo and generates averages/min/max/median/... for each job signature.
2. Stores those stats in a `job_eta` table (one for each repository) using Datasource, by appending new rows every time it runs.
...then when jobs are ingested:
3. The `job_eta` table for that repository is queried for matching signatures.
4. The results are used to populate the `running_eta` field for each job inserted into the `job` table.

There are a few problems with this:
* We're appending rather than updating existing rows, such that there are now ~3-4 million rows in `mozilla-inbound.job_eta` for example, when only the most recent few thousand are actually needed. (The original design believed we would have a use for historic data, but this has not proven to be the case).
* The job_eta table is unfortunately missing an index on `signature`, so the queries during [3] are very slow, particularly given there are millions of unnecessary rows (they are taking up 80% of the job creation time). Adding a signature and/or deleting old rows will be time consuming in production and may require a downtime.
* The calculate_eta task generates a bunch of stats that we have no need for, such as min/max/median duration.

(Also ideally `running_eta` on the jobs table wouldn't exist and instead we'd join with the table that stored generated durations, however that's out of scope here - I'll file a separate bug.)

To solve these, and given that we're not bothered about historic data, it will be easiest to start with a fresh table in the main `treeherder` database - avoiding the need for deletes/slow index adding.

As an added bonus this also means:
* We can use the ORM for these queries and now have one less table using Datasource.
* We can pick a more accurate table name (since 'eta' means an absolute time, not a relative duration).

When we first land this, ingested jobs will have a `running_eta` of zero until the new `calculate_durations` task runs for the first time. If we felt that was an issue, we could land the last three commits separately - which would mean job ingestion would use the old table temporarily, whilst we ran the task to populate the new table. However I don't think this is necessary, since we can run the task manually immediately after deploying and previously unseen job types regularly have a `running_eta` of zero anyway.

Tests have been added since there was previously zero coverage.

For more details, see the individual commit messages :-)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1178)
<!-- Reviewable:end -->
