### PR TITLE
Bug 1229049 - Highlight all points that match the given revision

### DIFF
--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -338,9 +338,10 @@ perf.controller('GraphsCtrl', [
                                 return ThResultSetModel.getResultSetsFromRevision(
                                     series.projectName, rev).then(
                                         function(resultSets) {
-                                            var resultSetId = resultSets[0].id;
-                                            var j = series.flotSeries.resultSetData.indexOf(resultSetId);
-                                            series.highlightedPoints.push(j);
+                                            series.highlightedPoints = _.union(series.highlightedPoints,  _.compact(_.map(
+                                                series.flotSeries.resultSetData, function(resultSetId, index) {
+                                                    return resultSets[0].id == resultSetId ? index : null;
+                                                })));
                                         }, function(reason) {
                                             /* ignore cases where no result set exists
                                                for revision */


### PR DESCRIPTION
<img width="1226" alt="screen shot 2015-12-01 at 10 28 40 am" src="https://cloud.githubusercontent.com/assets/2166227/11490710/5ae56da8-9816-11e5-9834-0ea37c65abfb.png">

Hmm, I think it will become clumsiness in some degree if we highlight all datapoints at once. Maybe we could add a checkout, so user can decide if they need show all datapoints. 
<img width="1266" alt="screen shot 2015-12-01 at 10 39 19 am" src="https://cloud.githubusercontent.com/assets/2166227/11490893/ef40e18e-9817-11e5-846f-0fb45e08e80a.png">

Anyway, I  could address my PR if you guys think it's worth to add or just forget it :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1182)
<!-- Reviewable:end -->
