### PR TITLE
Bug 1229203 - Remove etag caching from frontend views

### DIFF
--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -25,8 +25,6 @@ from .fields import (BigAutoField,
 
 # the cache key is specific to the database name we're pulling the data from
 SOURCES_CACHE_KEY = "treeherder-datasources"
-REPOSITORY_LIST_CACHE_KEY = 'treeherder-repositories'
-FAILURE_CLASSIFICAION_LIST_CACHE_KEY = 'treeherder-failure-classifications'
 
 SQL_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'sql')
 
@@ -181,7 +179,6 @@ class Datasource(models.Model):
     @classmethod
     def reset_cache(cls):
         cache.delete(SOURCES_CACHE_KEY)
-        cache.delete(REPOSITORY_LIST_CACHE_KEY)
         cls.objects.cached()
 
     @property

--- a/treeherder/webapp/api/refdata.py
+++ b/treeherder/webapp/api/refdata.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.models import User
 from rest_framework import viewsets
 from rest_framework.response import Response
-from rest_framework_extensions.mixins import CacheResponseAndETAGMixin
 
 from treeherder.model import models
 from treeherder.model.derived import (JobsModel,
@@ -37,15 +36,11 @@ class JobGroupViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = th_serializers.JobGroupSerializer
 
 
-class RepositoryViewSet(CacheResponseAndETAGMixin,
-                        viewsets.ReadOnlyModelViewSet):
+class RepositoryViewSet(viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata Repository model"""
     queryset = models.Repository.objects.filter(active_status='active')
     serializer_class = th_serializers.RepositorySerializer
-
-    def list_cache_key_func(self, **kwargs):
-        return models.REPOSITORY_LIST_CACHE_KEY
 
     """
     Overrides the retrieve method to get the extra information from the Jobs model
@@ -115,15 +110,11 @@ class JobTypeViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = th_serializers.JobTypeSerializer
 
 
-class FailureClassificationViewSet(CacheResponseAndETAGMixin,
-                                   viewsets.ReadOnlyModelViewSet):
+class FailureClassificationViewSet(viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata FailureClassification model"""
     queryset = models.FailureClassification.objects.all()
     serializer_class = th_serializers.FailureClassificationSerializer
-
-    def list_cache_key_func(self, **kwargs):
-        return models.FAILURE_CLASSIFICAION_LIST_CACHE_KEY
 
 #############################
 # User and exclusion profiles


### PR DESCRIPTION
It doesn't handle cache invalidation/updates properly. Since the
savings are almost certainly negligible, let's just get rid of it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1184)
<!-- Reviewable:end -->
