### PR TITLE
Bug 1223085 - Sort filted results (further improvment for bug 1223085)

### DIFF
--- a/ui/js/directives/perf/compare.js
+++ b/ui/js/directives/perf/compare.js
@@ -45,6 +45,9 @@ treeherder.directive(
                             scope.filteredResultList[key] = compareResults;
                         }
                     });
+                    scope.filteredResultList = _.map(_.keys(scope.filteredResultList), function(testName) {
+                        return {'testName': testName, 'results': scope.filteredResultList[testName]};
+                    });
                     scope.hasNoResults = _.isEmpty(scope.filteredResultList);
                 }
 

--- a/ui/partials/perf/comparetable.html
+++ b/ui/partials/perf/comparetable.html
@@ -1,8 +1,8 @@
-<table class="table compare-table" style="table-layout: fixed;" ng-repeat="(testName, compareResults) in filteredResultList">
+<table class="table compare-table" style="table-layout: fixed;" ng-repeat="compareResults in filteredResultList | orderBy: 'testName'">
   <tbody>
     <tr class="subtest-header">
       <!-- Manually specify table widths because it's just easier this way -->
-      <th class="test-title"><span style=" word-wrap: break-word;">{{titles[testName]}}</span></th>
+      <th class="test-title"><span style=" word-wrap: break-word;">{{titles[compareResults.testName]}}</span></th>
       <th style="width: 140px;">Base</th>
       <th style="width: 30px;"><!-- less than / greater than --></th>
       <th style="width: 140px;">New</th>
@@ -12,7 +12,7 @@
       <th class="num-runs" style="width: 80px"># Runs</th>
       <th class="test-warning" style="width: 30px"><!-- warning if not enough --></th>
     </tr>
-    <tr ng-class="getCompareClasses(compareResult, 'row')" ng-repeat="compareResult in compareResults | orderBy: 'name'">
+    <tr ng-class="getCompareClasses(compareResult, 'row')" ng-repeat="compareResult in compareResults.results | orderBy: 'name'">
       <td class="test-title">{{compareResult.name}}&nbsp;&nbsp;
         <span class="result-links" ng-if="compareResult.links.length > 0">
           <span ng-repeat="link in compareResult.links">


### PR DESCRIPTION
<img width="1256" alt="screen shot 2015-12-02 at 12 49 20 pm" src="https://cloud.githubusercontent.com/assets/2166227/11522566/270ec974-98f3-11e5-9f95-66b82b2eb12c.png">

Hmm, the orderBy in Angularjs is deal with array or array like object, but our result in here is just a object and we need sort those key for them. So I just add a function to help us sort the result out, and actually I had add same function in last pr (https://github.com/mozilla/treeherder/pull/1160#discussion-diff-45887635R38).
But somehow the results still have same order after I remove this function. Hope it's on the right direction, or I must find another way to fix it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1185)
<!-- Reviewable:end -->
