### PR TITLE
Bug 1230188 - Only generate alerts for recent performance data

### DIFF
--- a/tests/etl/test_perf_data_adapters.py
+++ b/tests/etl/test_perf_data_adapters.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import json
+import time
 
 import pytest
 
@@ -65,12 +66,13 @@ def _generate_perf_data_range(test_project, test_repository,
     framework_name = "cheezburger"
     PerformanceFramework.objects.create(name=framework_name)
 
+    now = int(time.time())
     for (i, value) in zip(range(30), [1]*15 + [2]*15):
         perf_job_data = {
             'fake_job_guid': {
                 'id': i,
                 'result_set_id': i,
-                'push_timestamp': i
+                'push_timestamp': now + i
             }
         }
         datum = {

--- a/tests/perfalert/test_create_alerts.py
+++ b/tests/perfalert/test_create_alerts.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 
 import pytest
 
@@ -58,6 +59,7 @@ def test_detect_alerts_in_series(test_project, test_repository,
                                  test_perf_signature):
 
     INTERVAL = 30
+    now = time.time()
     for (t, v) in zip([i for i in range(INTERVAL)],
                       ([0.5 for i in range(INTERVAL/2)] +
                        [1.0 for i in range(INTERVAL/2)])):
@@ -66,7 +68,7 @@ def test_detect_alerts_in_series(test_project, test_repository,
             result_set_id=t,
             job_id=t,
             signature=test_perf_signature,
-            push_timestamp=datetime.datetime.fromtimestamp(t),
+            push_timestamp=datetime.datetime.fromtimestamp(now + t),
             value=v)
 
     generate_new_alerts_in_series(test_perf_signature)
@@ -91,7 +93,7 @@ def test_detect_alerts_in_series(test_project, test_repository,
             result_set_id=t,
             job_id=0,
             signature=test_perf_signature,
-            push_timestamp=datetime.datetime.fromtimestamp(t),
+            push_timestamp=datetime.datetime.fromtimestamp(now + t),
             value=v)
 
     generate_new_alerts_in_series(test_perf_signature)
@@ -110,7 +112,8 @@ def test_detect_alerts_in_series_with_retriggers(
     # gracefully by generating a sequence where the regression
     # "appears" in the middle of a series with the same resultset
     # to make sure things are calculated correctly
-    for (r, j, v) in zip(
+    now = time.time()
+    for (t, j, v) in zip(
             ([1 for i in range(30)] +
              [2 for i in range(60)]),
             [i for i in range(90)],
@@ -119,10 +122,30 @@ def test_detect_alerts_in_series_with_retriggers(
     ):
         PerformanceDatum.objects.create(
             repository=test_repository,
-            result_set_id=r,
+            result_set_id=t,
             job_id=j,
             signature=test_perf_signature,
-            push_timestamp=datetime.datetime.fromtimestamp(r),
+            push_timestamp=datetime.datetime.fromtimestamp(now + t),
             value=v)
     generate_new_alerts_in_series(test_perf_signature)
     _verify_alert(1, 2, 1, test_perf_signature, 0.5, 1.0, True)
+
+
+def test_no_alerts_with_old_data(
+        test_project, test_repository, test_perf_signature):
+    INTERVAL = 30
+    for (t, v) in zip([i for i in range(INTERVAL)],
+                      ([0.5 for i in range(INTERVAL/2)] +
+                       [1.0 for i in range(INTERVAL/2)])):
+        PerformanceDatum.objects.create(
+            repository=test_repository,
+            result_set_id=t,
+            job_id=t,
+            signature=test_perf_signature,
+            push_timestamp=datetime.datetime.fromtimestamp(t),
+            value=v)
+
+    generate_new_alerts_in_series(test_perf_signature)
+
+    assert PerformanceAlert.objects.count() == 0
+    assert PerformanceAlertSummary.objects.count() == 0

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -50,6 +50,9 @@ MEDIA_URL = "/media/"
 # e.g. the build size tests will alert on every commit)
 PERFHERDER_REGRESSION_THRESHOLD = 2
 
+# Only generate alerts for data newer than this time in seconds in perfherder
+PERFHERDER_ALERTS_MAX_AGE = timedelta(weeks=2)
+
 # Create hashed+gzipped versions of assets during collectstatic,
 # which will then be served by WhiteNoise with a suitable max-age.
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'

--- a/treeherder/perf/alerts.py
+++ b/treeherder/perf/alerts.py
@@ -11,9 +11,14 @@ from treeherder.perfalert import Analyzer
 
 
 def generate_new_alerts_in_series(signature):
-    series = PerformanceDatum.objects.filter(
-        signature=signature).order_by(
-            'push_timestamp')
+    # get series data starting from either:
+    # (1) the last alert, if there is one
+    # (2) the alerts max age
+    # (use whichever is newer)
+    max_alert_age = (datetime.datetime.now() -
+                     settings.PERFHERDER_ALERTS_MAX_AGE)
+    series = PerformanceDatum.objects.filter(signature=signature).filter(
+        push_timestamp__gte=max_alert_age).order_by('push_timestamp')
     existing_alerts = PerformanceAlert.objects.filter(
         series_signature=signature).select_related(
             'summary').order_by('-summary__result_set_id')[:1]


### PR DESCRIPTION
Generating data for old alerts is pointless in a production environment is
pointless and resource intensive.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1189)
<!-- Reviewable:end -->
