### PR TITLE
Bug 1230601 - Remove unused GitPushlogProcess/GitPushlogTransformerMixin

### DIFF
--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -8,8 +8,7 @@ from treeherder.client import TreeherderResultSetCollection
 from treeherder.etl.common import (generate_revision_hash,
                                    get_not_found_onhold_push)
 
-from .mixins import (JsonExtractorMixin,
-                     OAuthLoaderMixin)
+from .mixins import OAuthLoaderMixin
 
 logger = logging.getLogger(__name__)
 
@@ -203,19 +202,3 @@ class MissingHgPushlogProcess(HgPushlogTransformerMixin,
                 source_url
             ))
             raise
-
-
-class GitPushlogTransformerMixin(object):
-
-    def transform(self, source_url):
-        # TODO: implement git sources.xml transformation logic
-        pass
-
-
-class GitPushlogProcess(JsonExtractorMixin,
-                        GitPushlogTransformerMixin,
-                        OAuthLoaderMixin):
-
-    def run(self, source_url, project):
-        # TODO: implement the whole sources.xml ingestion process
-        pass


### PR DESCRIPTION
We don't ingest from Git ourselves at the moment and may never do so.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1191)
<!-- Reviewable:end -->
