### PR TITLE
Bug 1230616 - Show MacOS X 10.10 by default in perf compare view

### DIFF
--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -244,8 +244,7 @@ perf.controller('CompareResultsCtrl', [
             $state.transitionTo('compare', {
                 filter: $scope.filterOptions.filter,
                 showOnlyImportant: Boolean($scope.filterOptions.showOnlyImportant) ? undefined : 0,
-                showOnlyConfident: Boolean($scope.filterOptions.showOnlyConfident) ? 1 : undefined,
-                showUnreliablePlatforms: Boolean($scope.filterOptions.showUnreliablePlatforms) ? 1 : undefined
+                showOnlyConfident: Boolean($scope.filterOptions.showOnlyConfident) ? 1 : undefined
             }, {
                 location: true,
                 inherit: true,
@@ -275,8 +274,7 @@ perf.controller('CompareResultsCtrl', [
                 showOnlyImportant: $stateParams.showOnlyImportant === undefined ||
                     parseInt($stateParams.showOnlyImportant),
                 showOnlyConfident: $stateParams.showOnlyConfident !== undefined ||
-                    parseInt($stateParams.showOnlyConfident),
-                showUnreliablePlatforms: Boolean(parseInt($stateParams.showUnreliablePlatforms))
+                    parseInt($stateParams.showOnlyConfident)
             };
 
             $scope.originalProject = ThRepositoryModel.getRepo(

--- a/ui/js/directives/perf/compare.js
+++ b/ui/js/directives/perf/compare.js
@@ -2,7 +2,7 @@
 
 treeherder.directive(
     'phCompareTable',
-    ['PhCompare', 'phUnreliablePlatforms', function(PhCompare, phUnreliablePlatforms) {
+    ['PhCompare', function(PhCompare) {
         return {
             templateUrl: 'partials/perf/comparetable.html',
             scope: {
@@ -11,8 +11,7 @@ treeherder.directive(
                 testList: '=',
                 filter: '=',
                 showOnlyImportant: '=',
-                showOnlyConfident: '=',
-                showUnreliablePlatforms: '='
+                showOnlyConfident: '='
             },
             link: function(scope, element, attrs) {
                 scope.getCompareClasses = PhCompare.getCompareClasses;
@@ -21,9 +20,7 @@ treeherder.directive(
                 }
                 function shouldBeHidden(result) {
                     return (!scope.showOnlyImportant || result.isMeaningful)
-                        && (!scope.showOnlyConfident || result.isConfident)
-                        && (scope.showUnreliablePlatforms || !_.contains(
-                            phUnreliablePlatforms, result.name));
+                        && (!scope.showOnlyConfident || result.isConfident);
                 }
                 function filterResult (results, key) {
                     if (scope.filter === undefined) {
@@ -51,10 +48,10 @@ treeherder.directive(
                     scope.hasNoResults = _.isEmpty(scope.filteredResultList);
                 }
 
-                scope.$watchGroup(['filter', 'showOnlyImportant', 'showOnlyConfident',
-                                   'showUnreliablePlatforms'], function() {
-                    updateFilteredTestList();
-                });
+                scope.$watchGroup(['filter', 'showOnlyImportant', 'showOnlyConfident'],
+                                  function() {
+                                      updateFilteredTestList();
+                                  });
                 updateFilteredTestList();
             }
         };

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -21,7 +21,7 @@ perf.config(function($compileProvider, $httpProvider, $stateProvider, $urlRouter
         controller: 'GraphsCtrl'
     }).state('compare', {
         templateUrl: 'partials/perf/comparectrl.html',
-        url: '/compare?originalProject&originalRevision&newProject&newRevision&hideMinorChanges&showExcludedPlatforms&filter&showOnlyImportant&showOnlyConfident&showUnreliablePlatforms',
+        url: '/compare?originalProject&originalRevision&newProject&newRevision&hideMinorChanges&showExcludedPlatforms&filter&showOnlyImportant&showOnlyConfident',
         controller: 'CompareResultsCtrl'
     }).state('comparesubtest', {
         templateUrl: 'partials/perf/comparesubtestctrl.html',

--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -163,11 +163,6 @@ treeherder.value("phTimeRanges", [
 
 treeherder.value("phDefaultTimeRangeValue", 1209600);
 
-// we are excluding macosx 10.10 by default for now, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1201615
-treeherder.value("phUnreliablePlatforms", [
-    'osx-10-10'
-]);
-
 treeherder.value("thJobNavSelectors",
     {
         ALL_JOBS: {

--- a/ui/partials/perf/comparectrl.html
+++ b/ui/partials/perf/comparectrl.html
@@ -32,12 +32,6 @@
             Hide uncertain results
           </label>
         </div>
-        <div class="checkbox" tooltip="Platforms which don't produce consistent / reliable data -- beware!">
-          <label>
-            <input type="checkbox" ng-model="filterOptions.showUnreliablePlatforms" ng-change="updateFilters()"/>
-            Show unreliable platforms
-          </label>
-        </div>
       </form>
       <hr/>
       <ph-compare-table
@@ -46,8 +40,7 @@
          compare-results="compareResults"
          filter="filterOptions.filter"
          show-only-important="filterOptions.showOnlyImportant"
-         show-only-confident="filterOptions.showOnlyConfident"
-         show-unreliable-platforms="filterOptions.showUnreliablePlatforms">
+         show-only-confident="filterOptions.showOnlyConfident">
       </ph-compare-table>
     </div>
   </div>

--- a/ui/partials/perf/comparesubtestctrl.html
+++ b/ui/partials/perf/comparesubtestctrl.html
@@ -17,8 +17,7 @@
        compare-results="compareResults"
        filter=""
        show-only-important="0"
-       show-only-confident="0"
-       show-unreliable-platforms="1">
+       show-only-confident="0">
     </ph-compare-table>
   </div>
 </div>


### PR DESCRIPTION
Also remove the "unreliable platforms" option, since it's no longer required.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1192)
<!-- Reviewable:end -->
