### PR TITLE
Bug 1227249 - filter perfherder tests with words

### DIFF
--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -776,6 +776,25 @@ perf.controller('GraphsCtrl', [
             });
     }]);
 
+perf.filter('testNameContainsWords', function() {
+    /**
+     Filter a list of test by ensuring that every word in the textFilter is
+     present in the test name.
+     **/
+    return function(tests, textFilter) {
+        if (!textFilter) {
+            return tests;
+        }
+
+        var filters = textFilter.split(/\s+/);
+        return _.filter(tests, function(test) {
+            return _.every(filters, function(filter) {
+                return test.name.indexOf(filter) !== -1;
+            });
+        });
+    };
+});
+
 perf.controller('TestChooserCtrl', function($scope, $modalInstance, $http,
                                             projects, optionCollectionMap,
                                             timeRange, thServiceDomain,

--- a/ui/partials/perf/testdatachooser.html
+++ b/ui/partials/perf/testdatachooser.html
@@ -16,12 +16,12 @@
     </select>
     <h4>Tests</h4>
     <div class="form-group">
-      <input class="form-control input-sm" type="text" ng-model="testFilter" placeholder="Filter tests"/>
+      <input class="form-control input-sm" type="text" ng-model="testFilter" placeholder="Filter tests" ng-model-options="{debounce: 250}"/>
     </div>
     <div id="choose-test-list" class="form-group">
       <p class="blink" ng-show="loadingTestData">Loading series data...</p>
       <select ng-hide="loadingPlatformList || loadingTestData" multiple class="form-control" ng-model="selectedTestSignatures" ng-hide="loadingTestData">
-        <option value="{{::testElem.signature}}" ng-repeat="testElem in unselectedTestList| filter: testFilter track by testElem.signature">
+        <option value="{{::testElem.signature}}" ng-repeat="testElem in unselectedTestList| testNameContainsWords: testFilter track by testElem.signature">
             {{::testElem.name}}
         </option>
       </select>


### PR DESCRIPTION
Now the test selection filter filters every test that do not contain
every word in its name.

The 'ng-model-options="{debounce: 500}' makes the ui a bit more reactive
on large test lists.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1200)
<!-- Reviewable:end -->
