### PR TITLE
Bug 1215324 - Scroll job-details-pane to the top on job selection

### DIFF
--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -310,6 +310,10 @@ treeherder.controller('PluginCtrl', [
                 $scope.visibleTimeFields.endTime = dateFilter(
                     $scope.job.end_timestamp*1000, thDateFormat);
             }
+
+            // Scroll the job details pane to the top during job selection
+            var jobDetailsPane = document.getElementById('job-details-pane');
+            jobDetailsPane.scrollTop = 0;
         };
 
         $scope.getCountPinnedJobs = function() {


### PR DESCRIPTION
A little holiday stocking-stuffer :) This hopefully fixes Bugzilla bug [1215324](https://bugzilla.mozilla.org/show_bug.cgi?id=1215324).

This ensures we scroll to the top in the job details pane during job selection. For example, the user had scrolled down to the bottom of the details pane on one job, then selected another job.

Scenario - viewing a build, then selecting a unit test:

![preselection](https://cloud.githubusercontent.com/assets/3660661/11773221/b9b5764c-a1f4-11e5-8a9a-bb5f18b7aea4.jpg)

Selecting the unit test - current behavior:

![current](https://cloud.githubusercontent.com/assets/3660661/11773227/d0d71844-a1f4-11e5-933b-700ac58e3966.jpg)

Selecting the unit test - proposed:

![proposed](https://cloud.githubusercontent.com/assets/3660661/11773231/d9fcc2de-a1f4-11e5-8606-45528d03b084.jpg)

I checked the Failure Summary tab, and in similar conditions it appears to be doing the right thing already.

Tested on OSX 10.10.5:
Release **45.0a1 (2015-12-11)**
Chrome Latest Release **47.0.2526.80 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1202)
<!-- Reviewable:end -->
