### PR TITLE
Bug 1232654 - Update requests-hawk from v0.2.0 to v1.0.0

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -120,8 +120,8 @@ hawkrest==0.0.8
 # sha256: KuY89HXwvQSbci-sIIE9Yq7cFJV91aO_ANEg0rVARGA
 python-dateutil==2.4.2
 
-# sha256: Z1L5dgnjtpS42jP4T96FV4AIil_C-Vqjw5t69hdRcqQ
-requests-hawk==0.2.0
+# sha256: wmJqsx6-8Mgbl3gcRMInW_zG2OhSD8TO1JXw84b4_iY
+requests-hawk==1.0.0
 
 # sha256: AMxHk1r7vYMmD90oOwqnkOZY0qcZIgSfbkZ9yooSRTc
 django-filter==0.11.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,11 +288,8 @@ def mock_post_json(monkeypatch, client_credentials):
 
         auth = auth or th_client.auth
         if not auth:
-            auth = HawkAuth(credentials={
-                'id': client_credentials.client_id,
-                'key': str(client_credentials.secret),
-                'algorithm': 'sha256'
-            })
+            auth = HawkAuth(id=client_credentials.client_id,
+                            key=str(client_credentials.secret))
         app = TestApp(application)
         uri = th_client._get_project_uri(project, endpoint)
         req = Request('POST', uri, json=data, auth=auth)

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -644,11 +644,7 @@ class TreeherderClient(object):
                            'as `client_id` and `secret` instead (see bug 1212936).')
             self.auth = auth
         elif client_id and secret:
-            self.auth = HawkAuth(credentials={
-                'id': client_id,
-                'key': secret,
-                'algorithm': 'sha256'
-            })
+            self.auth = HawkAuth(id=client_id, key=secret)
         else:
             self.auth = None
 


### PR DESCRIPTION
v1.0.0 has a simplified API for passing the id and key, see:
https://github.com/mozilla-services/requests-hawk#great-how-can-i-use-it

https://github.com/mozilla-services/requests-hawk/blob/master/CHANGES.txt
https://github.com/mozilla-services/requests-hawk/compare/0.2.0...1.0.0

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1206)
<!-- Reviewable:end -->
