### PR TITLE
Bug 1225351 - Don't enter job selection mode when list of runnable jo…

### DIFF
--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -283,6 +283,7 @@ treeherder.factory('ThResultSetStore', [
                 });
 
                 if (jobList.length === 0) {
+                    resultSet.isRunnableVisible = false;
                     thNotify.send("No new jobs available");
                 }
 


### PR DESCRIPTION
…bs is empty. r=adusca.

Hi @adusca , @jgraham , I'm sorry I couldn't really test this fix. I tried though and encountered some errors.
I managed to run my treeherder successfully using `vagrant up` and `vagrant ssh` followed by the `./bin/run_gunicorn`. I encountered problems while ingesting tasks. Firstly, I wasn't too sure about the revision under ` ./manage.py ingest_push mozilla-inbound 63f8a47cfdf5` so I used the `revision` field under http://builddata.pub.build.mozilla.org/buildjson/builds-4hr.js.gz
Got the following stack trace :- https://pastebin.mozilla.org/8854571