### PR TITLE
Bug 1232776 - Temporarily increase rate limit on /resultset/ endpoint

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -289,7 +289,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_THROTTLE_RATES': {
         'jobs': '220/minute',
-        'resultset': '220/minute'
+        'resultset': '400/minute'  # temporary increase: https://bugzilla.mozilla.org/show_bug.cgi?id=1232776
     },
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.AcceptHeaderVersioning',
     'DEFAULT_VERSION': '1.0',


### PR DESCRIPTION
For probably not-so-great reasons, we seem to be hitting the limits of
what we can submit in production. Until we've addressed the root causes,
let's temporarily increase things, since the rate limiting is causing
more problems than it's solving.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1208)
<!-- Reviewable:end -->
