### PR TITLE
Bug 1232654 - Update common.txt Python packages: Part 2

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -12,8 +12,8 @@ Django==1.8.7
 # sha256: 2_WWGNWp7_Fy0lAh82YUvlrwUB5FJ5dcpQS5WGPxT-0
 celery==3.1.18
 
-# sha256: _qhlOuS4en6wmWWUCfCeaANqe4PwoVoLxq7629mKUdw
-kombu==3.0.26
+# sha256: _ss07fSFIGTzhdv1OWkEeyI1PTYIpXZJfdBfcblD-uY
+kombu==3.0.30
 
 # sha256: QorI8yGcePsEzgWJXV3_m9gTwFqaeSLFPch5zTKhJJM
 simplejson==3.8.1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -9,8 +9,8 @@ whitenoise==2.0.6
 # sha256: j7aT7P5M1v-a4xNv8KHqpKyuAa8ie7geZG3CutMpXM8
 Django==1.8.7
 
-# sha256: 2_WWGNWp7_Fy0lAh82YUvlrwUB5FJ5dcpQS5WGPxT-0
-celery==3.1.18
+# sha256: Q0tOYjCEKLDoP7zRzruIU76yMCN7GyNIQGP88f9hC24
+celery==3.1.19
 
 # sha256: _ss07fSFIGTzhdv1OWkEeyI1PTYIpXZJfdBfcblD-uY
 kombu==3.0.30

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -26,8 +26,8 @@ newrelic==2.58.1.44
 MySQL-python==1.2.5
 
 # Required by celery
-# sha256: aI-UZrHDrhQQY4Hm29MoEV51xSYMVC60jmxGkx9pKMw
-billiard==3.3.0.20
+# sha256: 0hYYE4cxf4aWxtHICiSRJY0DdJPB8MbrWJkqVJSB534
+billiard==3.3.0.22
 # sha256: Pt5HDT0XujwHY436DRBFK8G25a0yYSemW6d-aq6xG-w
 pytz==2015.7
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -32,8 +32,8 @@ billiard==3.3.0.22
 pytz==2015.7
 
 # Required by kombu
-# sha256: 406XZaYSD0ZkwSD0GYp4bDmg-35KWb0ZotbjqIS2OIk
-amqp==1.4.6
+# sha256: lNKmgifnmEvUD19xxoOXMGIq_4pGM_Ke3h_90NJAeV4
+amqp==1.4.8
 # sha256: N4Ethjya0-NcBzTELgvwMgzow77YLNIK1UyzTRWBV7o
 anyjson==0.3.3
 


### PR DESCRIPTION
The kombu update is needed for compatibility with Python 2.7.11.
The newer celery/kombu require newer billiard and amqp.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1209)
<!-- Reviewable:end -->
