### PR TITLE
Bug 1162947 - Refactor & improve buildapi.py's skipping of bad jobs

### DIFF
--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -99,14 +99,6 @@ class Builds4hTransformerMixin(object):
                 if common.should_skip_project(project, valid_projects, project_filter):
                     continue
 
-                prop['revision'] = prop.get('revision',
-                                            prop.get('got_revision',
-                                                     prop.get('sourcestamp', None)))
-
-                if not prop['revision']:
-                    logger.warning("skipping builds-4hr job since no revision found: %s", prop['buildername'])
-                    continue
-
                 prop['short_revision'] = prop['revision'][0:12]
 
                 if prop['short_revision'] == prop.get('l10n_revision', None):
@@ -145,7 +137,7 @@ class Builds4hTransformerMixin(object):
                                                  missing_resultsets,
                                                  logger)
             except KeyError:
-                # skip this job, at least at this point
+                # There was no matching resultset, skip the job.
                 continue
             if revision_filter and revision_filter != resultset['revision']:
                 continue
@@ -315,7 +307,7 @@ class PendingRunningTransformerMixin(object):
                                                      missing_resultsets,
                                                      logger)
                 except KeyError:
-                    # skip this job, at least at this point
+                    # There was no matching resultset, skip the job.
                     continue
 
                 if revision_filter and revision_filter != resultset['revision']:

--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -99,6 +99,9 @@ class Builds4hTransformerMixin(object):
                 if common.should_skip_project(project, valid_projects, project_filter):
                     continue
 
+                if common.should_skip_revision(prop['revision'], revision_filter):
+                    continue
+
                 prop['short_revision'] = prop['revision'][0:12]
 
                 if prop['short_revision'] == prop.get('l10n_revision', None):
@@ -130,6 +133,8 @@ class Builds4hTransformerMixin(object):
                 project = prop['branch']
                 if common.should_skip_project(project, valid_projects, project_filter):
                     continue
+                if common.should_skip_revision(prop['revision'], revision_filter):
+                    continue
                 # todo: Continue using short revisions until Bug 1199364
                 resultset = common.get_resultset(project,
                                                  revisions_lookup,
@@ -138,8 +143,6 @@ class Builds4hTransformerMixin(object):
                                                  logger)
             except KeyError:
                 # There was no matching resultset, skip the job.
-                continue
-            if revision_filter and revision_filter != resultset['revision']:
                 continue
 
             # We record the id here rather than at the start of the loop, since we
@@ -284,6 +287,8 @@ class PendingRunningTransformerMixin(object):
                 continue
 
             for rev, jobs in revisions.items():
+                if common.should_skip_revision(rev, revision_filter):
+                    continue
                 revision_dict[project].append(rev)
 
         # retrieving the revision->resultset lookups
@@ -299,6 +304,8 @@ class PendingRunningTransformerMixin(object):
                 continue
 
             for revision, jobs in revisions.items():
+                if common.should_skip_revision(revision, revision_filter):
+                    continue
 
                 try:
                     resultset = common.get_resultset(project,
@@ -308,9 +315,6 @@ class PendingRunningTransformerMixin(object):
                                                      logger)
                 except KeyError:
                     # There was no matching resultset, skip the job.
-                    continue
-
-                if revision_filter and revision_filter != resultset['revision']:
                     continue
 
                 # using project and revision form the revision lookups

--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import re
 import time
 
 import requests
@@ -7,6 +8,7 @@ import simplejson as json
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
+REVISION_SHA_RE = re.compile(r'^[a-f\d]{12,40}$', re.IGNORECASE)
 
 
 class JobDataError(ValueError):
@@ -104,6 +106,15 @@ def should_skip_project(project, valid_projects, project_filter):
         return True
     if project not in valid_projects:
         logger.info("Skipping unknown branch: %s", project)
+        return True
+    return False
+
+
+def should_skip_revision(revision, revision_filter):
+    if revision_filter and revision != revision_filter:
+        return True
+    if not revision or not REVISION_SHA_RE.match(revision):
+        logger.info("Skipping invalid revision SHA: %s", revision)
         return True
     return False
 

--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -119,6 +119,20 @@ def should_skip_revision(revision, revision_filter):
     return False
 
 
+def is_blacklisted_buildername(buildername):
+    if buildername.endswith(' l10n dep'):
+        # These l10n jobs specify the l10n repo revision under 'revision', rather
+        # than the gecko revision. If we did not skip these, it would result in
+        # fetch_missing_resultsets requests that were guaranteed to 404.
+        # This needs to be fixed upstream in builds-*.js by bug 1125433.
+        # We have to blacklist by buildername rather than comparing the
+        # l10n_revision property, since the latter is not available in
+        # builds-{pending,running}.
+        logger.info("Skipping blacklisted buildername: %s", buildername)
+        return True
+    return False
+
+
 def generate_revision_hash(revisions):
     """Builds the revision hash for a set of revisions"""
 

--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -1,9 +1,12 @@
 import hashlib
+import logging
 import time
 
 import requests
 import simplejson as json
 from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 
 class JobDataError(ValueError):
@@ -94,6 +97,15 @@ def lookup_revisions(revision_dict):
         if lookup_content:
             lookup[project] = lookup_content
     return lookup
+
+
+def should_skip_project(project, valid_projects, project_filter):
+    if project_filter and project != project_filter:
+        return True
+    if project not in valid_projects:
+        logger.info("Skipping unknown branch: %s", project)
+        return True
+    return False
 
 
 def generate_revision_hash(revisions):

--- a/treeherder/etl/management/commands/ingest_push.py
+++ b/treeherder/etl/management/commands/ingest_push.py
@@ -60,15 +60,15 @@ class Command(BaseCommand):
         # or branch name (eg tip). HgPushlogProcess returns the full SHA.
         push_sha = process.run(pushlog_url, project, changeset=changeset)[:12]
 
-        Builds4hJobsProcess().run(filter_to_project=project,
-                                  filter_to_revision=push_sha,
-                                  filter_to_job_group=options['filter_job_group'])
-        PendingJobsProcess().run(filter_to_project=project,
-                                 filter_to_revision=push_sha,
-                                 filter_to_job_group=options['filter_job_group'])
-        RunningJobsProcess().run(filter_to_project=project,
-                                 filter_to_revision=push_sha,
-                                 filter_to_job_group=options['filter_job_group'])
+        Builds4hJobsProcess().run(project_filter=project,
+                                  revision_filter=push_sha,
+                                  job_group_filter=options['filter_job_group'])
+        PendingJobsProcess().run(project_filter=project,
+                                 revision_filter=push_sha,
+                                 job_group_filter=options['filter_job_group'])
+        RunningJobsProcess().run(project_filter=project,
+                                 revision_filter=push_sha,
+                                 job_group_filter=options['filter_job_group'])
 
     def handle(self, *args, **options):
 


### PR DESCRIPTION
Fixes bug 1162947 and bug 1090289 -- but most importantly should help with bug 1232776.
See individual commits for more detail :-)

A lot of the complexity here comes from us having to look up the revisions in advance (since we loop through each dataset twice to improve performance). I wonder if when we move away from the revision hash concept, whether we can avoid that? (Since we'll already know all we need to submit to the /jobs/ endpoint directly).  Anyway topic for another bug :-)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1210)
<!-- Reviewable:end -->
