### PR TITLE
Bug 1231774 - Exlude Tier3 jobs from being displayed by default

### DIFF
--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -22,6 +22,7 @@
 
 .navbar .dropdown-menu {
     max-height: 600px;
+    min-width: 112px;
     overflow: auto;
     margin-top: 10px;
     padding-bottom: 8px;

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -308,7 +308,6 @@ treeherderApp.controller('MainCtrl', [
         };
 
         $scope.toggleUnclassifiedFailures = thJobFilters.toggleUnclassifiedFailures;
-        $scope.toggleTier1Only = thJobFilters.toggleTier1Only;
 
         $scope.toggleInProgress = function() {
             thJobFilters.toggleInProgress();
@@ -342,6 +341,14 @@ treeherderApp.controller('MainCtrl', [
         $scope.toggleGroupState = function() {
             var newGroupState = $scope.groupState === "collapsed" ? "expanded" : null;
             $location.search("group_state", newGroupState);
+        };
+
+        $scope.isTierShowing = function(tier) {
+            return thJobFilters.isFilterSetToShow("tier", tier);
+        };
+
+        $scope.toggleTier = function(tier) {
+            thJobFilters.toggleFilters('tier', [tier], !$scope.isTierShowing(tier));
         };
 
         var getNewReloadTriggerParams = function() {
@@ -438,6 +445,6 @@ treeherderApp.controller('MainCtrl', [
 
         $scope.pinboardCount = thPinboard.count;
         $scope.pinnedJobs = thPinboard.pinnedJobs;
-
+        $scope.jobFilters = thJobFilters;
     }
 ]);

--- a/ui/js/directives/treeherder/top_nav_bar.js
+++ b/ui/js/directives/treeherder/top_nav_bar.js
@@ -111,11 +111,11 @@ treeherder.directive('thWatchedRepoInfoDropDown', [
     }]);
 
 
-treeherder.directive('thRepoDropdownContainer', [
+treeherder.directive('thCheckboxDropdownContainer', [
     'ThLog', '$rootScope', 'thEvents',
     function (ThLog, $rootScope, thEvents) {
 
-        var $log = new ThLog("thRepoDropdownContainer");
+        var $log = new ThLog("thCheckboxDropdownContainer");
 
         return {
             restrict: "A",
@@ -131,16 +131,12 @@ treeherder.directive('thRepoDropdownContainer', [
                     }
                 });
 
-                $('.repo-dropdown-menu').on({
+                $('.checkbox-dropdown-menu').on({
                     "click": function(ev) {
-                        if ($(ev.target).hasClass(".repo-link") || $(ev.target).hasClass(".repo-checkbox")) {
+                        if ($(ev.target).hasClass("dropdown-link")) {
                             scope.closeable = false;
                         }
-                        $log.debug("repo menu dropdown", "click", scope.closeable, ev.target.className);
-                    },
-                    "mouseup": function(ev) {
-                        scope.closeable = false;
-                        $log.debug("repo menu dropdown", "mouseup", scope.closeable, ev.target.className);
+                        $log.debug("menu dropdown", "click", scope.closeable, ev.target.className);
                     }
                 });
 
@@ -159,9 +155,9 @@ treeherder.directive('thRepoMenuItem', [
             replace: true,
             link: function(scope, element, attrs) {
                 var elem = $(element);
-                elem.find('.repo-link').prop('href', scope.urlBasePath + "?repo=" + scope.repo.name);
+                elem.find('.dropdown-link').prop('href', scope.urlBasePath + "?repo=" + scope.repo.name);
                 if (scope.repo.name === scope.repoName) {
-                    elem.find('.repo-checkbox').prop('disabled', 'disabled');
+                    elem.find('.dropdown-checkbox').prop('disabled', 'disabled');
                 }
 
             },

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -50,11 +50,16 @@ treeherder.factory('thJobFilters', [
             },
             classifiedState: {
                 values: ['classified', 'unclassified']
+            },
+            tier: {
+                values: ["1", "2"]
             }
         };
 
         // failure classification ids that should be shown in "unclassified" mode
         var UNCLASSIFIED_IDS = [1, 7];
+
+        var TIERS = ["1", "2", "3"];
 
         // used with field-filters to determine how to match the value against the
         // job field.
@@ -160,7 +165,7 @@ treeherder.factory('thJobFilters', [
                         fieldFilters[_withoutPrefix(field)] = decodeURIComponent(values).replace(/ +(?= )/g, ' ').toLowerCase().split(' ');
                     } else {
                         var lowerVals = _.map(_toArray(values),
-                                              function(v) {return v.toLowerCase();});
+                                              function(v) {return String(v).toLowerCase();});
                         fieldFilters[_withoutPrefix(field)] = lowerVals;
                     }
                 }
@@ -352,13 +357,8 @@ treeherder.factory('thJobFilters', [
             }
         };
 
-        var toggleTier1Only = function() {
-            $log.debug("toggleTier1Only");
-            if (_.contains(_getFiltersOrDefaults('tier'), '1')) {
-                removeFilter('tier', '1');
-            } else {
-                addFilter('tier', '1');
-            }
+        var isFilterSetToShow = function(field, value) {
+            return _.contains(_getFiltersOrDefaults(field), String(value));
         };
 
         /**
@@ -561,7 +561,6 @@ treeherder.factory('thJobFilters', [
             toggleResultStatuses: toggleResultStatuses,
             toggleInProgress: toggleInProgress,
             toggleUnclassifiedFailures: toggleUnclassifiedFailures,
-            toggleTier1Only: toggleTier1Only,
             setOnlyCoalesced: setOnlyCoalesced,
 
             // filter data read-only accessors
@@ -570,12 +569,14 @@ treeherder.factory('thJobFilters', [
             getFieldFiltersObj: getFieldFiltersObj,
             getResultStatusArray: getResultStatusArray,
             isJobUnclassifiedFailure: isJobUnclassifiedFailure,
+            isFilterSetToShow: isFilterSetToShow,
             stripFiltersFromQueryString: stripFiltersFromQueryString,
             getFieldChoices: getFieldChoices,
 
             // CONSTANTS
             classifiedState: CLASSIFIED_STATE,
-            resultStatus: RESULT_STATUS
+            resultStatus: RESULT_STATUS,
+            tiers: TIERS
         };
         return api;
     }]);

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -90,7 +90,6 @@
               <td ng-if="property.label == 'Revision'" class="break-word">
                 <a href="{{::property.value | getRevisionUrl:repoName}}"
                    title="Open resultset"
-                   class="repo-link"
                    ng-cloak>{{property.value}}</a>
               </td>
               <td ng-if="property.label != 'Revision'"

--- a/ui/partials/main/thGlobalTopNavPanel.html
+++ b/ui/partials/main/thGlobalTopNavPanel.html
@@ -40,7 +40,7 @@
 
       <!-- Repos Menu -->
       <span ng-controller="RepositoryMenuCtrl" >
-        <span th-repo-dropdown-container class="dropdown">
+        <span th-checkbox-dropdown-container class="dropdown">
           <button id="repoLabel" title="Watch a repo" role="button"
                   href="#" data-toggle="dropdown" data-target="#"
                   class="btn btn-view-nav btn-right-navbar nav-menu-btn">Repos

--- a/ui/partials/main/thRepoMenuItem.html
+++ b/ui/partials/main/thRepoMenuItem.html
@@ -1,8 +1,8 @@
 <li>
   <input type="checkbox"
-         class="repo-checkbox"
+         class="dropdown-checkbox"
          ng-checked="repoModel.watchedRepos[repo.name]"
          ng-click="repoModel.toggleWatched(repo.name)"
          title="toggle watching this repo">
-  <a title="Open repo" class="repo-link">{{::repo.name}}</a>
+  <a title="Open repo" class="dropdown-link">{{::repo.name}}</a>
 </li>

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -15,11 +15,23 @@
             {{getUnclassifiedFailureCount(repoName)}}</span> unclassified
         </span>
 
-        <!--Toggle Tier-1 jobs only Button-->
-        <span class="btn btn-view-nav btn-sm"
-              title="Toggle Tier-1 jobs only mode"
-              tabindex="0" role="button"
-              ng-click="toggleTier1Only()">1</span>
+        <!--Toggle Tiers filter Button-->
+        <span th-checkbox-dropdown-container class="dropdown">
+          <button id="tierLabel" role="button"
+                  href="#" data-toggle="dropdown" data-target="#"
+                  class="btn btn-view-nav btn-sm nav-menu-btn">Tiers
+            <span class="fa fa-angle-down lightgray"></span>
+          </button>
+          <ul class="dropdown-menu checkbox-dropdown-menu"
+              role="menu">
+              <li ng-repeat="tier in jobFilters.tiers">
+                <input type="checkbox"
+                       class="dropdown-checkbox"
+                       ng-checked="isTierShowing(tier)"
+                       ng-click="toggleTier(tier)"> Show Tier {{::tier}}
+              </li>
+          </ul>
+        </span>
 
         <!--Hidden Jobs Button-->
         <span class="btn btn-view-nav btn-sm btn-right-navbar"


### PR DESCRIPTION
This changes the navbar button titled "1" to be "Tiers"  It is now a dropdown that lets you choose which tiers to show.  

The default is now to show all Tier 1 and 2 jobs and filter away Tier 3 jobs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1213)
<!-- Reviewable:end -->
