### PR TITLE
Bug 1234233 - Disable APPEND_SLASH to prevent usage of API URLs that 301

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -302,6 +302,7 @@ REST_FRAMEWORK = {
 }
 
 SITE_URL = env("SITE_URL", default="http://local.treeherder.mozilla.org")
+APPEND_SLASH = False
 
 BUILDAPI_PENDING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-pending.js"
 BUILDAPI_RUNNING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-running.js"


### PR DESCRIPTION
Rather than play whac-a-mole as and when people use API URLs that are missing the trailing slash, let's just stop redirecting to make the mistake more obvious:
https://docs.djangoproject.com/en/1.8/ref/settings/#append-slash

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1216)
<!-- Reviewable:end -->
