### PR TITLE
Bug 1203597 - Heroku: Redirect HTTP to HTTPS and set an HSTS header

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -3,6 +3,9 @@
 # sha256: 3dAwKuysU9C1QJCe_vUdNyVFe1e_mNbuSdpKLFApzYo
 gunicorn==19.4.3
 
+# sha256: zeNo_aD7mVjdWLwsuVXQvz3xt5wTLZfO6Qvl_aNKUIk
+wsgi-sslify==1.0.1
+
 # sha256: gm_-XWCMncja6-8bC0PQH3lY8XwvzjbnXIDiYWAXLE8
 whitenoise==2.0.6
 
@@ -20,6 +23,10 @@ simplejson==3.8.1
 
 # sha256: F9WY_MyghFwDN-UnbUDWX5Ua_qat-b2Rcs_zqH8u8pQ
 newrelic==2.60.0.46
+
+# Required by wsgi-sslify
+# sha256: aUkbUwUVfDxuDwSnAZhNaud_1yn8HJrNJQd_HfOFMms
+werkzeug==0.11.3
 
 # Required by datasource
 # sha256: gRBAtkfl1WhvhNtBXv1pfmJQAIsRK2kJunesBZ4UDHQ


### PR DESCRIPTION
Since Heroku doesn't use nginx/Apache we must perform this via wsgi middleware. We cannot use Django's HTTPS/HSTS features since they won't help with requests that were served by WhiteNoise directly (eg the site homepage).

Instead we use wsgi-sslify, as recommended by:
https://github.com/evansd/whitenoise/issues/53#issuecomment-166972824

We only enable it when IS_HEROKU is set, since stage/prod is handled by Apache, and for local development we have to use HTTP.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1221)
<!-- Reviewable:end -->
