### PR TITLE
Bug 1153324 - Submit to OrangeFactor's API rather than ES directly

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -7,9 +7,6 @@ TREEHERDER_TEST_PROJECT = "%s_jobs" % DATABASES["default"]["TEST"]["NAME"]
 CELERY_ALWAYS_EAGER = True
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 
-# Don't attempt to submit bug associations to Bugzilla & Elasticsearch.
-MIRROR_CLASSIFICATIONS = False
-
 # Reconfigure pulse to operate on default vhost of rabbitmq
 PULSE_URI = BROKER_URL
 PULSE_EXCHANGE_NAMESPACE = 'test'

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -315,6 +315,10 @@ FAILURE_LINES_CUTOFF = 35
 
 BZ_API_URL = "https://bugzilla.mozilla.org"
 
+ORANGEFACTOR_SUBMISSION_URL = "https://brasstacks.mozilla.com/orangefactor/api/saveclassification"
+ORANGEFACTOR_HAWK_ID = "treeherder"
+ORANGEFACTOR_HAWK_KEY = env("ORANGEFACTOR_HAWK_KEY", default=None)
+
 # this setting allows requests from any host
 CORS_ORIGIN_ALLOW_ALL = True
 
@@ -328,7 +332,6 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Set this to True to submit bug associations to Elasticsearch.
 MIRROR_CLASSIFICATIONS = True
-ES_HOST = "http://of-elasticsearch-zlb.webapp.scl3.mozilla.com:9200"
 
 # Enable integration between autoclassifier and jobs
 AUTOCLASSIFY_JOBS = env.bool("AUTOCLASSIFY_JOBS", default=False)

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -330,9 +330,6 @@ ALLOWED_HOSTS = env.list("TREEHERDER_ALLOWED_HOSTS", default=[".mozilla.org", ".
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
-# Set this to True to submit bug associations to Elasticsearch.
-MIRROR_CLASSIFICATIONS = True
-
 # Enable integration between autoclassifier and jobs
 AUTOCLASSIFY_JOBS = env.bool("AUTOCLASSIFY_JOBS", default=False)
 

--- a/treeherder/config/settings_local.example.py
+++ b/treeherder/config/settings_local.example.py
@@ -1,6 +1,3 @@
 # Applications useful for development, e.g. debug_toolbar, django_extensions.
 # Always empty in production
 LOCAL_APPS = []
-
-# Set this to True to submit bug associations to Elasticsearch.
-MIRROR_CLASSIFICATIONS = False

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -453,7 +453,7 @@ class JobsModel(TreeherderModelBase):
         except IntegrityError as e:
             raise JobDataIntegrityError(e)
 
-        if settings.MIRROR_CLASSIFICATIONS:
+        if settings.ORANGEFACTOR_HAWK_KEY:
             job = self.get_job(job_id)[0]
             if job["state"] == "completed":
                 # importing here to avoid an import loop


### PR DESCRIPTION
* Submit to OrangeFactor's new API rather than ES directly: Since Elasticsearch is protected by VPN (ES doesn't do auth) and setting up access is more hassle than it's worth on Heroku. Instead a new API endpoint is being added by bug 1235097 to OrangeFactor that forwards our classification report on for us. Hawk is used for authentication, the secret key for which will need to be set in the environment of prod before this lands (bug 1238584).
* Remove unused MIRROR_CLASSIFICATIONS setting: Since it's been replaced by the presence (or not) of the OrangeFactor Hawk key instead.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1222)
<!-- Reviewable:end -->
