### PR TITLE
Bug 1169696 - Use librabbitmq with Celery/Kombu for improved performance

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -44,6 +44,10 @@ amqp==1.4.8
 # sha256: N4Ethjya0-NcBzTELgvwMgzow77YLNIK1UyzTRWBV7o
 anyjson==0.3.3
 
+# Celery/Kombu optional extra for improved performance over amqp.
+# sha256: YEoia5_j-eQ5NTcCpzHyo5z3cYguaLygIMsiTZuZDEk
+librabbitmq==1.6.1
+
 # Required by mozlog
 # sha256: 7cVxMGHxCWYEi_a0DZpRSzgeC6hJxk4DTE72wYR9MAc
 blessings==1.6

--- a/tests/etl/test_pushlog.py
+++ b/tests/etl/test_pushlog.py
@@ -42,7 +42,7 @@ def test_ingest_hg_pushlog(jm, initial_data, test_base_dir,
     # Ensure for each push we sent a pulse notification...
     for _ in range(0, push_num):
         message = pulse_resultset_consumer.get(block=True, timeout=2)
-        content = json.loads(message.body)
+        content = message.payload
         assert content['revision'] in rev_to_push
         # Ensure we don't match the same revision twice...
         rev_to_push.remove(content['revision'])

--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -1,5 +1,3 @@
-import json
-
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from rest_framework.test import APIClient
@@ -145,7 +143,7 @@ def test_job_retrigger_authorized(webapp, eleven_jobs_stored, jm,
     client.post(url, {"job_id_list": job_id_list}, format='json')
 
     message = pulse_action_consumer.get(block=True, timeout=2)
-    content = json.loads(message.body)
+    content = message.payload
 
     assert content['project'] == jm.project
     assert content['action'] == 'retrigger'
@@ -170,7 +168,7 @@ def test_job_cancel_authorized(webapp, eleven_jobs_stored, jm,
     client.post(url)
 
     message = pulse_action_consumer.get(block=True, timeout=2)
-    content = json.loads(message.body)
+    content = message.payload
 
     assert content['project'] == jm.project
     assert content['action'] == 'cancel'

--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -1,5 +1,4 @@
 import copy
-import json
 
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
@@ -348,7 +347,7 @@ def test_resultset_cancel_all(jm, resultset_with_three_jobs, pulse_action_consum
 
     for _ in range(0, 3):
         message = pulse_action_consumer.get(block=True, timeout=2)
-        content = json.loads(message.body)
+        content = message.payload
 
         assert content['action'] == 'cancel'
         assert content['project'] == jm.project


### PR DESCRIPTION
For rabbitmq transports specified using `amqp://`, Celery/Kombu will use librabbitmq automatically if it's available, otherwise will fall back to the pure Python (and therefore slower) amqp:
http://celery.readthedocs.org/en/latest/userguide/optimizing.html#librabbitmq

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1225)
<!-- Reviewable:end -->
