### PR TITLE
Bug 1236894 - Add missing trailing slash to python client API URLs

### DIFF
--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -650,7 +650,7 @@ class TreeherderClient(object):
             )
 
     def _get_uri(self, endpoint):
-        uri = '{0}://{1}/api/{2}'.format(
+        uri = '{0}://{1}/api/{2}/'.format(
             self.protocol, self.host, endpoint)
 
         return uri


### PR DESCRIPTION
To avoid 301 redirects during the request. This only affects client functions that are not project-specific (the others use `_get_project_uri()` instead).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1228)
<!-- Reviewable:end -->
