### PR TITLE
Bug 1237244 - Update to karma v0.13.19 to support new socket.io API

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "grunt-eslint": "17.3.1",
     "grunt-html-angular-validate": "0.5.2",
     "jasmine-core": "2.3.4",
-    "karma": "0.13.10",
+    "karma": "0.13.19",
     "karma-coverage": "0.5.2",
     "karma-firefox-launcher": "0.1.6",
     "karma-jasmine": "0.3.6",


### PR DESCRIPTION
socket.io released backwards incompatible API changes in a minor version update, causing failures during our ui-tests travis run. See:
https://github.com/socketio/socket.io/issues/2368

However the latest version of Karma has added support for it:
https://github.com/karma-runner/karma/issues/1782

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1232)
<!-- Reviewable:end -->
