### PR TITLE
Bug 1237237 - Log parser: Handle malformed step marker dates gracefully

### DIFF
--- a/tests/log_parser/test_step_parser.py
+++ b/tests/log_parser/test_step_parser.py
@@ -15,3 +15,11 @@ def test_date_without_milliseconds():
     parser = StepParser()
     dt = parser.parsetime('2015-01-20 16:42:33')
     assert dt == datetime(2015, 1, 20, 16, 42, 33)
+
+
+def test_date_with_invalid_month():
+    """Gracefully handle a date whose month is invalid."""
+    parser = StepParser()
+    parser.start_step(1, timestamp='2016-00-04 19:44:35.838000')
+    parser.end_step(2, timestamp='2016-00-04 19:47:12.880000')
+    assert parser.current_step['duration'] is None

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -218,7 +218,7 @@ class StepParser(ParserBase):
             "errors": step_errors,
             "error_count": step_error_count
         })
-        self.set_duration()
+        self.current_step["duration"] = self.calculate_duration()
         # Append errors from current step to "all_errors" field
         self.artifact["all_errors"].extend(step_errors)
         # reset the sub_parser for the next step
@@ -243,28 +243,26 @@ class StepParser(ParserBase):
             match = "{0}.0".format(match)
         return datetime.datetime.strptime(match, self.DATE_FORMAT)
 
-    def set_duration(self):
+    def calculate_duration(self):
         """Sets duration for the step in seconds."""
         started_string = self.current_step["started"]
         finished_string = self.current_step["finished"]
         if not (started_string and finished_string):
             # Handle the dummy steps (created to hold Taskcluster log content that
             # is between step markers), which have no recorded start/finish time.
-            self.current_step["duration"] = None
-            return
+            return None
         try:
             start_time = self.parsetime(started_string)
             finish_time = self.parsetime(finished_string)
         except ValueError:
             # Gracefully fail if the dates were malformed in the log,
             # otherwise we won't get an error summary at all.
-            self.current_step["duration"] = None
-            return
+            return None
         td = finish_time - start_time
         secs = (
             td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6
         ) / 10.0**6
-        self.current_step["duration"] = int(round(secs))
+        return int(round(secs))
 
     @property
     def steps(self):

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -252,8 +252,14 @@ class StepParser(ParserBase):
             # is between step markers), which have no recorded start/finish time.
             self.current_step["duration"] = None
             return
-        start_time = self.parsetime(started_string)
-        finish_time = self.parsetime(finished_string)
+        try:
+            start_time = self.parsetime(started_string)
+            finish_time = self.parsetime(finished_string)
+        except ValueError:
+            # Gracefully fail if the dates were malformed in the log,
+            # otherwise we won't get an error summary at all.
+            self.current_step["duration"] = None
+            return
         td = finish_time - start_time
         secs = (
             td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6


### PR DESCRIPTION
This avoids breaking the whole log parsing task (including error summary generation) if the dates are invalid (eg like in bug 1236655). Instead the UI will just display 'unknown duration'.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1233)
<!-- Reviewable:end -->
