### PR TITLE
Bug 1176489 - Use Django's GZip middleware

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -72,6 +72,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 )
 
 MIDDLEWARE_CLASSES = [
+    'django.middleware.gzip.GZipMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
The Heroku router doesn't support gzipping content itself, so we have to do so in the application. WhiteNoise handles serving gzipped static content already, but this change means that content served by Django will now be compressed by Django's gzip middleware:
https://docs.djangoproject.com/en/1.8/ref/middleware/#module-django.middleware.gzip

[~/src/treeherder]$ curl -i --compress http://local.treeherder.mozilla.org/api/
HTTP/1.1 200 OK
Server: WSGIServer/0.1 Python/2.7.11
Vary: Accept, Cookie, Accept-Encoding
Content-Length: 268
Content-Type: application/json
Allow: GET, HEAD, OPTIONS
Content-Encoding: gzip
Accept-Ranges: bytes
Date: Mon, 11 Jan 2016 17:32:28 GMT
X-Varnish: 173196109
Age: 0
Via: 1.1 varnish
Connection: keep-alive

...

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1240)
<!-- Reviewable:end -->
