### PR TITLE
Bug 1224069 - Remove Talos entry from job details

### DIFF
--- a/ui/plugins/job_details/main.html
+++ b/ui/plugins/job_details/main.html
@@ -1,12 +1,11 @@
 <div class="job-tabs-content">
   <ul class="list-unstyled">
     <li ng-repeat="line in job_details | orderBy:'title'" class="small">
-      <label>{{line.title}}:</label>
-      <span ng-switch on="line.content_type">
+      <label ng-if="line.content_type != 'TalosResult'">{{line.title}}:</label>
+      <span ng-if="line.content_type != 'TalosResult'" ng-switch on="line.content_type">
         <a ng-switch-when="link" title="{{line.value}}"
            href="{{line.url}}" target="_blank">{{line.value}}</a>
         <span ng-switch-when="raw_html" ng-bind-html="line.value"></span>
-        <span ng-switch-when="TalosResult">See talos panel</span>
         <span title="{{line.value}}" ng-switch-when="object">{{line.value}}</span>
         <span title="{{line.value}}" ng-switch-default>{{line.value}}</span>
       </span>


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1224069](https://bugzilla.mozilla.org/show_bug.cgi?id=1224069).

This removes the **TalosResult:** entry from the Job Details pane, without altering the job_details blob. This is case we use it / want to use it elsewhere in this scope, and to keep it consistent with the logviewer blob of the same name. So instead we just suppress it from the array in the markup.

Current:
![current](https://cloud.githubusercontent.com/assets/3660661/12244841/8a9c5714-b873-11e5-9262-03465700047f.jpg)

Proposed:
![proposed](https://cloud.githubusercontent.com/assets/3660661/12244867/9e0f774a-b873-11e5-976a-19b3228bc6ec.jpg)

Everything seems fine locally with both Talos jobs and non-Talos jobs.

Tested on OSX 10.10.5:
Nightly **46.0a1 (2016-01-11)**
Chrome Latest Release **47.0.2526.106** (64-bit)

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1242)
<!-- Reviewable:end -->
