### PR TITLE
Bug 1234320 - Prepopulate filed perf regression bugs based on a template

### DIFF
--- a/ui/js/controllers/perf/alerts.js
+++ b/ui/js/controllers/perf/alerts.js
@@ -83,15 +83,21 @@ perf.controller(
 
 perf.controller('AlertsCtrl', [
     '$state', '$stateParams', '$scope', '$rootScope', '$http', '$q', '$modal',
+    '$templateRequest', '$interpolate',
     'thUrl', 'ThRepositoryModel', 'ThOptionCollectionModel', 'ThResultSetModel',
     'PhFramework', 'PhSeries', 'PhAlerts', 'phTimeRanges',
-    'phDefaultTimeRangeValue', 'phAlertResolutionMap', 'dateFilter',
-    'thDateFormat',
+    'phDefaultTimeRangeValue', 'phAlertResolutionMap', 'phTalosDocumentationMap',
+    'phTrySyntaxBuildPlatformMap', 'phTrySyntaxTalosModifierMap',
+    'mcTalosConfigUrl', 'dateFilter', 'thDateFormat',
     function AlertsCtrl($state, $stateParams, $scope, $rootScope, $http, $q,
-                        $modal, thUrl, ThRepositoryModel,
+                        $modal, $templateRequest, $interpolate, thUrl,
+                        ThRepositoryModel,
                         ThOptionCollectionModel, ThResultSetModel,
                         PhFramework, PhSeries, PhAlerts, phTimeRanges,
                         phDefaultTimeRangeValue, phAlertResolutionMap,
+                        phTalosDocumentationMap,
+                        phTrySyntaxBuildPlatformMap, phTrySyntaxTalosModifierMap,
+                        mcTalosConfigUrl,
                         dateFilter, thDateFormat) {
         $scope.alertSummaries = [];
         $scope.getMoreAlertSummariesHref = null;
@@ -128,6 +134,28 @@ perf.controller('AlertsCtrl', [
             });
             $scope.numFilteredAlertSummaries = _.filter($scope.alertSummaries, { anyVisible: false }).length;
 
+        }
+
+        function getAlertTitle(alerts) {
+            var title;
+            if (alerts.length > 1) {
+                title = _.min(_.pluck(alerts, 'amount_pct')) + " - " +
+                    _.max(_.pluck(alerts, 'amount_pct')) + "%";
+            } else {
+                title = alerts[0].amount_pct + "%";
+            }
+            // add test info
+            title += " " + _.uniq(
+                _.map(alerts, function(a) {
+                    return PhSeries.getTestName(a.series_signature, { abbreviate:true });
+                })).sort().join(' / ');
+            // add platform info
+            title += "(" + _.uniq(
+                _.map(alerts, function(a) {
+                    return a.series_signature.machine_platform;
+                })).sort().join(', ') + ')';
+
+            return title;
         }
 
         $scope.filtersUpdated = function() {
@@ -171,7 +199,115 @@ perf.controller('AlertsCtrl', [
         };
 
         $scope.fileBug = function(alertSummary) {
-            window.open("https://edmorley.github.io/fileit/");
+            $http.get(mcTalosConfigUrl).then(function(response) {
+                // yes this is ridiculous, but it's (hopefully) less likely
+                // to break than the alternatives, since it should auto-update
+                // whenever someone changes the talos configuration in
+                // mozilla-central
+                var trySuiteMapping = {};
+                _.forEach(
+                    _.filter(Object.keys(response.data.suites),
+                             function(buildbotSuite) {
+                                 // we only want the high level suite names, -
+                                 // and _ denote variants
+                                 return (buildbotSuite.indexOf('-') === -1 &&
+                                         buildbotSuite.indexOf('_') === -1);
+                             }),
+                    function(buildbotSuite) {
+                        _.forEach(
+                            response.data.suites[buildbotSuite].tests, function(test) {
+                                trySuiteMapping[test] = buildbotSuite;
+                            });
+                    });
+                $templateRequest('partials/perf/bugzilla_talos.tmpl').then(
+                    function(template) {
+                        var selectedAlerts = _.filter(alertSummary.alerts,
+                                                      {selected: true});
+                        var testDescriptions = _.uniq(_.map(selectedAlerts, function(alert) {
+                            var suitekey = alert.series_signature.suite;
+                            var testkey = alert.series_signature.suite + '_' +
+                                alert.series_signature.test;
+                            var prefix = 'https://wiki.mozilla.org/Buildbot/Talos/Tests#';
+                            if (phTalosDocumentationMap[suitekey]) {
+                                return prefix + phTalosDocumentationMap[suitekey];
+                            } else if (phTalosDocumentationMap[testkey]) {
+                                return prefix + phTalosDocumentationMap[testkey];
+                            } else {
+                                // assume suitekey or testkey will work otherwise
+                                if (alert.series_signature.test) {
+                                    return prefix + testkey;
+                                }
+                                return prefix + suitekey;
+                            }
+                        }));
+                        var talosSuites = _.uniq(_.map(selectedAlerts, function(alert) {
+                            return alert.series_signature.suite;
+                        }));
+                        var tryBuildPlatforms = _.uniq(_.map(selectedAlerts, function(alert) {
+                            var platform =  alert.series_signature.machine_platform;
+                            var mappedPlatform = phTrySyntaxBuildPlatformMap[platform];
+                            if (mappedPlatform)
+                                return mappedPlatform;
+                            return platform;
+                        }));
+                        var tryTalosModifiers = _.uniq(_.filter(_.map(
+                            selectedAlerts, function(alert) {
+                                var platform =  alert.series_signature.machine_platform;
+                                var mappedPlatform = phTrySyntaxTalosModifierMap[platform];
+                                if (mappedPlatform)
+                                    return mappedPlatform;
+                                return undefined;
+                            })));
+                        if (tryTalosModifiers.length) {
+                            tryTalosModifiers = '[' + tryTalosModifiers.join(',') + ']';
+                        } else {
+                            tryTalosModifiers = "";
+                        }
+                        var trySuites = _.uniq(_.map(selectedAlerts, function(alert) {
+                            var suiteName = trySuiteMapping[alert.series_signature.suite];
+                            if (_.contains(alert.series_signature.test_options, 'e10s')) {
+                                suiteName += '-e10s';
+                            }
+                            return suiteName + tryTalosModifiers;
+                        }));
+                        // they have 3 days from today to respond (if backout day
+                        // would be a Saturday or Sunday, delay until the following
+                        // Monday)
+                        var backoutDate = new Date(Date.now() + 3*86400*1000);
+                        if (backoutDate.getDay() === 6) {
+                            backoutDate.setDate(backoutDate.getDate() + 2);
+                        } else if (backoutDate.getDay() === 0) {
+                            backoutDate.setDate(backoutDate.getDate() + 1);
+                        }
+                        var dayMapping = {
+                            0: 'Sunday', // not used
+                            1: 'Monday',
+                            2: 'Tuesday',
+                            3: 'Wednesday',
+                            4: 'Thursday',
+                            5: 'Friday',
+                            6: 'Saturday' // not used
+                        };
+                        var compiled = $interpolate(template)({
+                            revision: alertSummary.resultSetMetadata.revision,
+                            alertHref: thServiceDomain + '/perf.html#/alerts?id=' +
+                                alertSummary.id,
+                            testDescriptions: testDescriptions.join('\n'),
+                            tryBuildPlatforms: tryBuildPlatforms.join(','),
+                            trySuites: trySuites.join(','),
+                            talosTestListSyntax: talosSuites.join(":"),
+                            backoutDay: dayMapping[backoutDate.getDay()]
+                        });
+                        var pushDate = dateFilter(
+                            alertSummary.resultSetMetadata.push_timestamp*1000,
+                            "EEE MMM d yyyy");
+                        var bugTitle = getAlertTitle(selectedAlerts) +
+                            " regression on push " +
+                            alertSummary.resultSetMetadata.revision + " (" +
+                            pushDate + ")";
+                        window.open("https://bugzilla.mozilla.org/enter_bug.cgi?component=Untriaged&product=Firefox&short_desc=" + encodeURIComponent(bugTitle) + "&comment=" + encodeURIComponent(compiled) + '&keywords=perf%2C%20regression%2C%20&status_whiteboard=%5Btalos_regression%5D');
+                    });
+            });
         };
 
         function modifyAlerts(alertSummary, modifiedStatus) {
@@ -252,20 +388,8 @@ perf.controller('AlertsCtrl', [
                         {includePlatformInName: true});
                 });
 
-                alertSummary.title = alertSummary.repository;
-                if (alertSummary.alerts.length > 1) {
-                    alertSummary.title += " " +
-                        _.min(_.pluck(alertSummary.alerts, 'amount_pct')) + " - " +
-                        _.max(_.pluck(alertSummary.alerts, 'amount_pct')) + "%";
-                } else {
-                    alertSummary.title += " " + alertSummary.alerts[0].amount_pct + "%";
-                }
-                alertSummary.title += " " + _.uniq(
-                    _.map(alertSummary.alerts, function(a) {
-                        return PhSeries.getTestName(a, { abbreviate:true });
-                    })).sort().join(' / ');
-                alertSummary.platforms = _.uniq(_.pluck(alertSummary.alerts,
-                                                        'machine_platform')).sort();
+                alertSummary.title = alertSummary.repository + " " +
+                    getAlertTitle(alertSummary.alerts);
             });
 
             $q.all(_.map(_.keys(resultSetToSummaryMap), function(repo) {

--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -172,6 +172,52 @@ treeherder.value("phAlertResolutionMap", {
     DUPLICATE: 5
 });
 
+treeherder.value("phTalosDocumentationMap", {
+    "a11yr": "a11y",
+    "cart": "TART.2FCART",
+    "damp": "DAMP",
+    "dromaeo_css": "Dromaeo_Tests",
+    "dromaeo_dom": "Dromaeo_Tests",
+    "sessionrestore": "sessionrestore.2Fsessionrestore_no_auto_restore",
+    "sessionrestore_no_auto_restore": "sessionrestore.2Fsessionrestore_no_auto_restore",
+    "tart": "TART.2FCART",
+    "tcanvasmark": "CanvasMark",
+    "tp5n_main_normal_fileio": "xperf",
+    "tp5n_main_normal_netio": "xperf",
+    "tp5n_main_startup_fileio": "xperf",
+    "tp5n_main_startup_netio": "xperf",
+    "tp5n_nonmain_normal_fileio": "xperf",
+    "tp5n_nonmain_normal_netio": "xperf",
+    "tp5n_nonmain_startup_fileio": "xperf",
+    "tp5o": "tp5",
+    "tp5o_% processor time": ".25_CPU",
+    "tp5o_main_rss": "RSS_.28Resident_Set_Size.29",
+    "tp5o_modified page list bytes": "Modified_Page_List_Bytes",
+    "tp5o_private bytes": "Private_Bytes",
+    "tp5o_xres": "Xres_.28X_Resource_Monitoring.29",
+    "tsvgr_opacity": "tsvg-opacity",
+    "v8_7": "V8.2C_version_7",
+});
+
+treeherder.value("phTrySyntaxBuildPlatformMap", {
+    "android-4-0-armv7-api11": "android-api-11",
+    "osx-10-10": "macosx64",
+    "windows7-32": "win32",
+    "windows8-64": "win64",
+    "windowsxp": "win32"
+});
+
+treeherder.value("phTrySyntaxTalosModifierMap", {
+    "android-4-0-armv7-api11": "Android",
+    "osx-10-10": "10.10",
+    "windows7-32": "Windows 7",
+    "windows8-64": "Windows 8",
+    "windowsxp": "Windows XP"
+});
+
+treeherder.value('mcTalosConfigUrl',
+                 'http://hg.mozilla.org/mozilla-central/raw-file/tip/testing/talos/talos.json');
+
 treeherder.value("thJobNavSelectors",
     {
         ALL_JOBS: {

--- a/ui/partials/perf/bugzilla_talos.tmpl
+++ b/ui/partials/perf/bugzilla_talos.tmpl
@@ -1,0 +1,38 @@
+Talos has detected a Firefox performance regression from push {{ revision }}. As author of one of the patches included in that push, we need your help to address this regression.
+
+This is a list of all known regressions and improvements related to the push:
+
+{{ alertHref }}
+
+On the page above you can see an alert for each affected platform as well as a link to a graph showing the history of scores for this test. There is also a link to a treeherder page showing the Talos jobs in a pushlog format.
+
+To learn more about the regressing test(s), please see:
+
+{{ testDescriptions }}
+
+Reproducing and debugging the regression:
+
+If you would like to re-run this Talos test on a potential fix, use try with the following syntax:
+
+try: -b o -p {{ tryBuildPlatforms }} -u none -t {{ trySuites }} --rebuild 5  # add "mozharness: --spsProfile" to generate profile data
+
+(we suggest --rebuild 5 to be more confident in the results)
+
+To run the test locally and do a more in-depth investigation, first set up a local Talos environment:
+
+https://wiki.mozilla.lorg/Buildbot/Talos/Running#Running_locally_-_Source_Code
+
+Then run the following command from the directory where you set up Talos:
+
+talos --develop -e <path>/firefox -a {{ talosTestListSyntax }}
+
+(add --e10s to run tests in e10s mode)
+
+Making a decision:
+
+As the patch author we need your feedback to help us handle this regression.
+*** Please let us know your plans by {{ backoutDay }}, or the offending patch(es) will be backed out! ***
+
+Our wiki page outlines the common responses and expectations:
+
+https://wiki.mozilla.org/Buildbot/Talos/RegressionBugsHandling


### PR DESCRIPTION
This is based on the existing Talos template we're using in AlertManager.
The code is somewhat hacky and will need to be updated for other performance
frameworks like awsy as that comes online, but it's a start!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1244)
<!-- Reviewable:end -->
