### PR TITLE
Bug 1187469 - Provide alternate tooltip content when (pushlog, compare) isn't available

### DIFF
--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -107,7 +107,8 @@ perf.controller('GraphsCtrl', [
                     deltaValue: dv.toFixed(1),
                     deltaPercentValue: (100 * dvp).toFixed(1),
                     date: $.plot.formatDate(new Date(t), '%a %b %d, %H:%M:%S'),
-                    retriggers: (retriggerNum['retrigger'] - 1)
+                    retriggers: (retriggerNum['retrigger'] - 1),
+                    revisionInfoAvailable: true
                 };
 
                 // Get revision information for both this datapoint and the previous
@@ -129,6 +130,7 @@ perf.controller('GraphsCtrl', [
                                            });
                                        }
                                    }, function(error) {
+                                       $scope.tooltipContent.revisionInfoAvailable = false;
                                        console.log("Failed to get revision: " + error.reason);
                                    });
                        });

--- a/ui/partials/perf/graphsctrl.html
+++ b/ui/partials/perf/graphsctrl.html
@@ -64,7 +64,10 @@
             <a ng-href="#/comparesubtest?originalProject={{tooltipContent.project.name}}&newProject={{tooltipContent.project.name}}&originalRevision={{tooltipContent.prevRevision}}&newRevision={{tooltipContent.revision}}&originalSignature={{selectedDataPoint.signature}}&newSignature={{selectedDataPoint.signature}}" target="_blank">compare</a>)
           </span>
         </p>
-        <p ng-hide="tooltipContent.revision">Loading revision...</p>
+        <p ng-hide="tooltipContent.revision">
+          <span ng-hide="tooltipContent.revisionInfoAvailable">Revision info unavailable</span>
+          <span ng-show="tooltipContent.revisionInfoAvailable">Loading revision...</span>
+        </p>
         <p id="tt-t" class="small" ng-bind="tooltipContent.date"></p>
         <p id="tt-v" class="small" ng-show="tooltipContent.retriggers > 0">Retriggers: {{tooltipContent.retriggers}}</p>
       </div>


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1246)
<!-- Reviewable:end -->
