### PR TITLE
Bug 1239428 - Docs: Clarify process for API credential approval

### DIFF
--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -83,12 +83,20 @@ The generated Hawk ``secret`` will be output to the console, which should then
 be passed along with the chosen ``client_id`` to the TreeherderClient constructor.
 For more details see the :doc:`submitting_data` section.
 
-Users can request credentials for the deployed Mozilla Treeherder instances
+Users can generate credentials for the deployed Mozilla Treeherder instances
 (and view/delete existing ones) using the forms here:
 `stage <https://treeherder.allizom.org/credentials/>`__ /
 `production <https://treeherder.mozilla.org/credentials/>`__.
+It is recommended that the same ``client_id`` string be used for both stage
+and production.
 
-Once requested these require approval by a Treeherder administrator, here:
+The credentials must be marked as approved by a Treeherder admin before they can
+be used for submitting to the API. Request this for stage first, by filing a bug in
+`Treeherder: API <https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree%20Management&component=Treeherder%3A%20API>`__.
+Once any submission issues are resolved on stage, file a new bug requesting
+approval for production.
+
+Treeherder administrators can manage credentials here:
 `stage <https://treeherder.allizom.org/admin/credentials/credentials/>`__ /
 `production <https://treeherder.mozilla.org/admin/credentials/credentials/>`__.
 


### PR DESCRIPTION
* Recommend using the same `client_id` for stage/prod.
* Mention the need to file a bug (and where) for requesting approval.
* Explain prod approval needs submission to be working on stage first.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1248)
<!-- Reviewable:end -->
