### PR TITLE
Bug 1240612 - Tweak thresholds and algorithms for perfherder compare view

### DIFF
--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -265,9 +265,9 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                 // Should be rare case and it's unreliable, but at least have something.
                                 var STDDEV_DEFAULT_FACTOR = 0.15;
 
-                                var RATIO_CARE_MIN = 1.015; // We don't care about less than ~1.5% diff
-                                var T_VALUE_CARE_MIN = 0.5; // Observations
-                                var T_VALUE_CONFIDENT = 1; // Observations. Weirdly nice that ended up as 0.5 and 1...
+                                var RATIO_CARE_MIN = 1.02; // We don't care about less than ~2% diff
+                                var T_VALUE_CARE_MIN = 3; // Anything below this is "low" in confidence
+                                var T_VALUE_CONFIDENT = 5; // Anything above this is "high" in confidence
 
                                 function getClassName(newIsBetter, oldVal, newVal, abs_t_value) {
                                     // NOTE: we care about general ratio rather than how much is new compared
@@ -436,9 +436,10 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                                            cmap.newRuns.length);
                                         cmap.isConfident = ((cmap.originalRuns.length > 1 &&
                                                              cmap.newRuns.length > 1 &&
-                                                             cmap.confidenceText === 'high') ||
+                                                             abs_t_value >= T_VALUE_CONFIDENT) ||
                                                             (cmap.originalRuns.length >= 6 &&
-                                                             cmap.newRuns.length >= 6));
+                                                             cmap.newRuns.length >= 6 &&
+                                                             abs_t_value >= T_VALUE_CARE_MIN));
 
                                         return cmap;
                                     },

--- a/ui/partials/perf/comparectrl.html
+++ b/ui/partials/perf/comparectrl.html
@@ -24,7 +24,7 @@
         <div class="form-group">
             <input id="filter" type="text" class="form-control" ng-model="filterOptions.filter" placeholder="filter text e.g. linux tp5o" ng-change="updateFilters()"/>
         </div>
-        <div class="checkbox" uib-tooltip="Non-trivial changes (1.5%+)">
+        <div class="checkbox" uib-tooltip="Non-trivial changes (2%+)">
           <label>
             <input type="checkbox" ng-model="filterOptions.showOnlyImportant" ng-change="updateFilters()"/>
             Show only important changes


### PR DESCRIPTION
* Only results with at least "med" confidence considered to be worth
  showing by default
* Minimum t value for "high" confidence bumped to 5
* Minimum difference for regression/improvement bumped from 1.5 to 2

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1259)
<!-- Reviewable:end -->
