### PR TITLE
Bug 1233653 - Fix the UI display of job durations & time remaining

### DIFF
--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -12,9 +12,9 @@ treeherder.factory('ThJobModel', [
         };
 
         ThJobModel.prototype.running_time_remaining = function(){
-            var timestampSeconds = new Date().getTime()/1000;
-            return Math.round( ( timestampSeconds - (
-                parseInt(this.submit_timestamp) + parseInt(this.running_eta) ) )/60 );
+            var timestampNow = new Date().getTime()/1000;
+            var current_duration = timestampNow - parseInt(this.start_timestamp);
+            return Math.round( (parseInt(this.running_eta) - current_duration) / 60);
         };
 
         ThJobModel.prototype.get_average_duration = function(){

--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -17,7 +17,7 @@ treeherder.factory('ThJobModel', [
                 parseInt(this.submit_timestamp) + parseInt(this.running_eta) ) )/60 );
         };
 
-        ThJobModel.prototype.get_typical_eta = function(){
+        ThJobModel.prototype.get_average_duration = function(){
             return Math.round(
                 parseInt(this.running_eta) /60
             );

--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -11,7 +11,7 @@ treeherder.factory('ThJobModel', [
             angular.extend(this, data);
         };
 
-        ThJobModel.prototype.get_current_eta = function(){
+        ThJobModel.prototype.running_time_remaining = function(){
             var timestampSeconds = new Date().getTime()/1000;
             return Math.round( ( timestampSeconds - (
                 parseInt(this.submit_timestamp) + parseInt(this.running_eta) ) )/60 );

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -302,12 +302,14 @@ treeherder.controller('PluginCtrl', [
             var starttime = $scope.job.start_timestamp || $scope.job.submit_timestamp;
             duration = numberFilter((endtime-starttime)/60, 0) + " minute(s)";
 
-            $scope.visibleTimeFields.duration = duration;
-
             if ($scope.job.start_timestamp) {
                 $scope.visibleTimeFields.startTime = dateFilter(
                     $scope.job.start_timestamp*1000, thDateFormat);
+                $scope.visibleTimeFields.duration = duration;
+            } else {
+                $scope.visibleTimeFields.duration = "Not started (queued for " + duration + ")";
             }
+
             if ($scope.job.end_timestamp) {
                 $scope.visibleTimeFields.endTime = dateFilter(
                     $scope.job.end_timestamp*1000, thDateFormat);

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -135,8 +135,10 @@ treeherder.controller('PluginCtrl', [
                 ]).then(function(results){
                     //the first result comes from the job detail promise
                     $scope.job = results[0];
-                    $scope.eta = $scope.job.running_time_remaining();
-                    $scope.eta_abs = Math.abs($scope.eta);
+                    if ($scope.job.state =='running') {
+                        $scope.eta = $scope.job.running_time_remaining();
+                        $scope.eta_abs = Math.abs($scope.eta);
+                    }
                     $scope.average_duration = $scope.job.get_average_duration();
                     $scope.jobRevision = ThResultSetStore.getSelectedJob($scope.repoName).job.revision;
                     $scope.jobIds = results[4];

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -135,8 +135,8 @@ treeherder.controller('PluginCtrl', [
                 ]).then(function(results){
                     //the first result comes from the job detail promise
                     $scope.job = results[0];
-                    $scope.eta = $scope.job.get_current_eta();
-                    $scope.eta_abs = Math.abs($scope.job.get_current_eta());
+                    $scope.eta = $scope.job.running_time_remaining();
+                    $scope.eta_abs = Math.abs($scope.eta);
                     $scope.average_duration = $scope.job.get_average_duration();
                     $scope.jobRevision = ThResultSetStore.getSelectedJob($scope.repoName).job.revision;
                     $scope.jobIds = results[4];

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -137,7 +137,7 @@ treeherder.controller('PluginCtrl', [
                     $scope.job = results[0];
                     $scope.eta = $scope.job.get_current_eta();
                     $scope.eta_abs = Math.abs($scope.job.get_current_eta());
-                    $scope.typical_eta = $scope.job.get_typical_eta();
+                    $scope.average_duration = $scope.job.get_average_duration();
                     $scope.jobRevision = ThResultSetStore.getSelectedJob($scope.repoName).job.revision;
                     $scope.jobIds = results[4];
 

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -142,11 +142,11 @@
           </div>
           <div ng-if="job.state =='running'">
             <span ng-if="eta < 0">ETA to completed: ~ {{eta_abs}} minutes</span>
-            <span ng-if="eta > 0">{{eta}} mins overdue, typically takes ~ {{typical_eta}} mins</span>
-            <span ng-if="eta == 0">ETA any minute now, typically takes ~ {{typical_eta}} mins</span>
+            <span ng-if="eta > 0">{{eta}} mins overdue, typically takes ~ {{average_duration}} mins</span>
+            <span ng-if="eta == 0">ETA any minute now, typically takes ~ {{average_duration}} mins</span>
           </div>
           <div ng-if="job.state =='pending'">
-            <span>Typically takes ~ {{typical_eta}} mins once started</span>
+            <span>Typically takes ~ {{average_duration}} mins once started</span>
           </div>
         </li>
       </ul>

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -141,12 +141,12 @@
             <span>{{ job.state }}</span>
           </div>
           <div ng-if="job.state =='running'">
-            <span ng-if="eta > 0">ETA to completed: ~ {{eta}} minutes</span>
-            <span ng-if="eta < 0">{{eta_abs}} mins overdue, typically takes ~ {{average_duration}} mins</span>
-            <span ng-if="eta == 0">ETA any minute now, typically takes ~ {{average_duration}} mins</span>
+            <span ng-if="eta > 0">Time remaining: ~{{eta}} minutes</span>
+            <span ng-if="eta < 0">{{eta_abs}} mins overdue, typically takes ~{{average_duration}} mins</span>
+            <span ng-if="eta == 0">Due any minute now, typically takes ~{{average_duration}} mins</span>
           </div>
           <div ng-if="job.state =='pending'">
-            <span>Typically takes ~ {{average_duration}} mins once started</span>
+            <span>Typically takes ~{{average_duration}} mins once started</span>
           </div>
         </li>
       </ul>

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -141,8 +141,8 @@
             <span>{{ job.state }}</span>
           </div>
           <div ng-if="job.state =='running'">
-            <span ng-if="eta < 0">ETA to completed: ~ {{eta_abs}} minutes</span>
-            <span ng-if="eta > 0">{{eta}} mins overdue, typically takes ~ {{average_duration}} mins</span>
+            <span ng-if="eta > 0">ETA to completed: ~ {{eta}} minutes</span>
+            <span ng-if="eta < 0">{{eta_abs}} mins overdue, typically takes ~ {{average_duration}} mins</span>
             <span ng-if="eta == 0">ETA any minute now, typically takes ~ {{average_duration}} mins</span>
           </div>
           <div ng-if="job.state =='pending'">


### PR DESCRIPTION
Previously the "ETA" incorrectly used the submit time rather than the start time to calculate the time remaining.

This PR fixes that, clarifies what's shown for "duration" when the job hasn't started yet, and also cleans up a few other issues.

See individual commits for more details :-)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1260)
<!-- Reviewable:end -->
