### PR TITLE
Bug 1240831 - Loosen revision filtering criteria

### DIFF
--- a/treeherder/etl/management/commands/ingest_push.py
+++ b/treeherder/etl/management/commands/ingest_push.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
         process = HgPushlogProcess()
         # Use the actual push SHA, in case the changeset specified was a tag
         # or branch name (eg tip). HgPushlogProcess returns the full SHA.
-        push_sha = process.run(pushlog_url, project, changeset=changeset)[:12]
+        push_sha = process.run(pushlog_url, project, changeset=changeset)
 
         Builds4hJobsProcess().run(project_filter=project,
                                   revision_filter=push_sha,


### PR DESCRIPTION
In particular, make it so that the revision filter only need to be in
the revision, rather than it be equal. This lets us run ingest_push with
a shortened revision.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1261)
<!-- Reviewable:end -->
