### PR TITLE
Bug 1241144 - Update to pip v8.0.0 on Travis/Vagrant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv ~/venv; fi
         - source ~/venv/bin/activate
+        - pip install -U pip==8.0.0
       install:
         - npm install
         - ./bin/peep.py install --disable-pip-version-check -r requirements/common.txt -r requirements/dev.txt
@@ -62,6 +63,7 @@ matrix:
         # Manually install mysql 5.6 since the default is v5.5.
         - sudo apt-get -qq update
         - sudo apt-get -qq install mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
+        - pip install -U pip==8.0.0
       install:
         # This uses pip rather than peep, since it takes half the time, and unlike the other
         # jobs, this one cannot use caching. The hashes are validated in the linters job.
@@ -83,6 +85,7 @@ matrix:
         # Manually install mysql 5.6 since the default is v5.5.
         - sudo apt-get -qq update
         - sudo apt-get -qq install mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
+        - pip install -U pip==8.0.0
       install:
         # This uses pip rather than peep, since it takes half the time, and unlike the other
         # jobs, this one cannot use caching. The hashes are validated in the linters job.

--- a/bin/peep.py
+++ b/bin/peep.py
@@ -104,7 +104,7 @@ except ImportError:
 
     DownloadProgressBar = DownloadProgressSpinner = NullProgressBar
 
-__version__ = 2, 5, 0
+__version__ = 3, 0, 0
 
 try:
     from pip.index import FormatControl  # noqa
@@ -362,9 +362,11 @@ def package_finder(argv):
     # Carry over PackageFinder kwargs that have [about] the same names as
     # options attr names:
     possible_options = [
-        'find_links', FORMAT_CONTROL_ARG, 'allow_external', 'allow_unverified',
-        'allow_all_external', ('allow_all_prereleases', 'pre'),
-        'process_dependency_links']
+        'find_links',
+        FORMAT_CONTROL_ARG,
+        ('allow_all_prereleases', 'pre'),
+        'process_dependency_links'
+    ]
     kwargs = {}
     for option in possible_options:
         kw, attr = option if isinstance(option, tuple) else (option, option)

--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -23,7 +23,7 @@ class python {
   exec { "install-virtualenv":
     cwd => "/tmp",
     user => "${APP_USER}",
-    command => "sudo pip install virtualenv==13.1.2",
+    command => "sudo pip install virtualenv==14.0.0",
     creates => "/usr/local/bin/virtualenv",
     require => Exec["install-pip"],
   }


### PR DESCRIPTION
* Update to peep v3.0.0 to pick up pip 8.x compatibility fixes.
* Use pip 8.0.0 on Travis.
* Update Vagrant virtualenv to the new release, which bundles pip 8.0.0.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1265)
<!-- Reviewable:end -->
