### PR TITLE
Bug 1240385 - Remove taskcluster-integration, try-taskcluster & qa-try

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -552,7 +552,7 @@
         "dvcs_type": "git",
         "name": "taskcluster-integration",
         "url": "https://github.com/taskcluster/github-graph-example",
-        "active_status": "active",
+        "active_status": "onhold",
         "codebase": "taskcluster",
         "repository_group": 4,
         "description": "taskcluster integration test dumping ground."
@@ -591,7 +591,7 @@
         "dvcs_type": "git",
         "name": "try-taskcluster",
         "url": "https://github.com/mozilla",
-        "active_status": "active",
+        "active_status": "onhold",
         "codebase": "gecko",
         "repository_group": 4,
         "description": ""
@@ -630,7 +630,7 @@
         "dvcs_type": "git",
         "name": "qa-try",
         "url": "https://github.com/mozilla",
-        "active_status": "active",
+        "active_status": "onhold",
         "codebase": "gecko",
         "repository_group": 5,
         "description": ""


### PR DESCRIPTION
Since they are unused.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1271)
<!-- Reviewable:end -->
