### PR TITLE
Bug 1239841 - clicking on the top level 'alerts' link yields no action

### DIFF
--- a/ui/perf.html
+++ b/ui/perf.html
@@ -30,7 +30,7 @@
       </span>
       <a ng-class="{active: $state.includes('graphs')}" class="btn btn-view-nav" ui-sref="graphs">Graphs</a>
       <a ng-class="{active: $state.current.name.indexOf('compare') >= 0}" class="btn btn-view-nav" ui-sref="comparechooser">Compare</a>
-      <a ng-class="{active: $state.current.name.indexOf('alerts') >= 0}" class="btn btn-view-nav" ui-sref="alerts">Alerts</a>
+      <a ng-class="{active: $state.current.name.indexOf('alerts') >= 0}" class="btn btn-view-nav" ui-sref="alerts({id: null})">Alerts</a>
       <div class="nav navbar-nav navbar-right">
         <!-- Help Menu -->
         <span class="dropdown">


### PR DESCRIPTION
This happen when we already are viewing a specific alert id.

The problem is that ui-router merge the parameters from the current url
to determine the new parameters state. So the current is is merged, and
ui-router thinks that there is nothing to do since the states and
parameters are equivalent...

This fixes the issue, but it looks like a hack.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1272)
<!-- Reviewable:end -->
