### PR TITLE
Bug 1240129 - compare vew filter misses many characters due to filter…

### DIFF
--- a/ui/partials/perf/comparectrl.html
+++ b/ui/partials/perf/comparectrl.html
@@ -22,7 +22,7 @@
         </div>
         &nbsp;
         <div class="form-group">
-            <input id="filter" type="text" class="form-control" ng-model="filterOptions.filter" placeholder="filter text e.g. linux tp5o" ng-change="updateFilters()"/>
+            <input id="filter" type="text" class="form-control" ng-model="filterOptions.filter" placeholder="filter text e.g. linux tp5o" ng-change="updateFilters()" ng-model-options="{debounce: 250}"/>
         </div>
         <div class="checkbox" uib-tooltip="Non-trivial changes (2%+)">
           <label>


### PR DESCRIPTION
…ing on each keypress

Not a perfect solution, but debounce help in this case. I picked the
same value as for the test selection: 250 ms.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1273)
<!-- Reviewable:end -->
