### PR TITLE
Bug 1157149 - The unclassified failure count should respect selected tiers of jobs

### DIFF
--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -184,6 +184,10 @@ treeherder.provider('thEvents', function() {
             // fired when a global filter has changed
             globalFilterChanged: "status-filter-changed-EVT",
 
+            // after something happened that requires the number
+            // of unclassified jobs by tier to be recalculated
+            recalculateUnclassified: "recalc-unclassified-EVT",
+
             groupStateChanged: "group-state-changed-EVT",
 
             toggleRevisions: "toggle-revisions-EVT",

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -12,7 +12,7 @@
                          'btn-view-nav': getUnclassifiedFailureCount(repoName)===0}"
               ng-click="toggleUnclassifiedFailures()">
           <span id="unclassified-failure-count">
-            {{getUnclassifiedFailureCount(repoName)}}</span> unclassified
+            {{ getUnclassifiedFailureCount(repoName) }}</span> unclassified
         </span>
 
         <!--Toggle Tiers filter Button-->


### PR DESCRIPTION
Keep track of the count of unclassified jobs currently loaded that match the selected Tier settings.

When an event takes place that could change that value (new jobs loaded, classified or unclassified) then update that count again.  This uses the unclassified map like we did before, but re-evaluates it as needed.

This same technique can be leveraged (in the future) to get a count of unclassified for the current filter set as well.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1281)
<!-- Reviewable:end -->
