### PR TITLE
Bug 1244199 - Support a Tier-3 exclusion profile for jobs

### DIFF
--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -124,6 +124,8 @@ class JobsModel(TreeherderModelBase):
         "jobs.deletes.cycle_job",
     ]
 
+    LOWER_TIERS = [2, 3]
+
     @classmethod
     def create(cls, project):
         """
@@ -885,21 +887,28 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
 
         async_error_summary_list = []
 
-        # get the tier-2 data signatures for this project.
+        # get the lower tier data signatures for this project.
         # if there are none, then just return an empty list
-        tier_2_signatures = []
-        try:
-            tier_2 = ExclusionProfile.objects.get(name="Tier-2")
-            # tier_2_blob = json.loads(tier_2['flat_exclusion'])
-            tier_2_signatures = set(tier_2.flat_exclusion[self.project])
-        except KeyError:
-            # may be no tier 2 jobs for the current project
-            # and that's ok.
-            pass
-        except ObjectDoesNotExist:
-            # if this profile doesn't exist, then no second tier jobs
-            # and that's ok.
-            pass
+        # this keeps track of them order (2, then 3) so that the latest
+        # will have precedence.  If a job signature is in both Tier-2 and
+        # Tier-3, then it will end up in Tier-3.
+        lower_tier_signatures = []
+        for tier_num in self.LOWER_TIERS:
+            tier_info = {"tier": tier_num}
+            try:
+                lower_tier = ExclusionProfile.objects.get(
+                    name="Tier-{}".format(tier_num))
+                signatures = set(lower_tier.flat_exclusion[self.project])
+                tier_info["signatures"] = signatures
+                lower_tier_signatures.append(tier_info)
+            except KeyError:
+                # may be no jobs of this tier for the current project
+                # and that's ok.
+                pass
+            except ObjectDoesNotExist:
+                # if this profile doesn't exist, then no jobs of this tier
+                # and that's ok.
+                pass
 
         for datum in data:
             # Make sure we can deserialize the json object
@@ -936,7 +945,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                     log_placeholders,
                     artifact_placeholders,
                     retry_job_guids,
-                    tier_2_signatures,
+                    lower_tier_signatures,
                     async_error_summary_list
                 )
 
@@ -1123,7 +1132,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
         self, job, revision_hash, revision_hash_lookup,
         unique_revision_hashes, rh_where_in, job_placeholders,
         log_placeholders, artifact_placeholders, retry_job_guids,
-        tier_2_signatures, async_artifact_list
+        lower_tier_signatures, async_artifact_list
     ):
         """
         Take the raw job object after etl and convert it to job_placeholders.
@@ -1217,9 +1226,17 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
              option_collection_hash]
         )
 
-        job_tier = job.get('tier') or 1
+        tier = job.get('tier') or 1
         # job tier signatures override the setting from the job structure
-        tier = 2 if signature in tier_2_signatures else job_tier
+        # Check the signatures list for any supported LOWER_TIERS that have
+        # an active exclusion profile.
+
+        # As stated elsewhere, a job will end up in the lowest tier where its
+        # signature belongs.  So if a signature is in Tier-2 and Tier-3, it
+        # will end up in 3.
+        for tier_info in lower_tier_signatures:
+            if signature in tier_info["signatures"]:
+                tier = tier_info["tier"]
 
         job_placeholders.append([
             job_guid,


### PR DESCRIPTION
This works just like for Tier-2 jobs.  We create an exclusion profile
called "Tier-3" and any job signature added to that will get assigned
a tier value of 3.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1285)
<!-- Reviewable:end -->
