### PR TITLE
Bug 1244325 - adjust the pulse job YAML schema to accommodate task TC needs

### DIFF
--- a/schemas/pulse-job.yml
+++ b/schemas/pulse-job.yml
@@ -6,15 +6,32 @@ description: |
 id: "jobDefinition"
 type: "object"
 properties:
-  jobGuid:
-    title: "jobGuid"
+  taskId:
+    title: "taskId"
+    descriptio: |
+      This could just be what was formerly submitted as a job_guid in the
+      REST API.
     type: "string"
     pattern: "^[A-Za-z0-9_/+-]+$"
     minLength: 1
     maxLength: 50
+  retryId:
+    title: "retryId"
+    description: |
+      The infrastructure retry iteration on this job.  The number of times this
+      job has been retried by the infrastructure.
+      If it's the 1st time running, then it should be 0. If this is the first
+      retry, it will be 1, etc.
+    type: "integer"
+    default: 0
+    minimum: 0
+
+  isRetried:
+    description: True indicates this job has been retried.
+    type: "boolean"
 
   origin:
-    anyOf:
+    oneOf:
       - type: "object"
         properties:
           kind:
@@ -39,7 +56,15 @@ properties:
           kind:
             type: "string"
             enum: ['github.com']
-          project:
+          owner:
+            description: |
+              This could be the organization or the individual git username
+              depending on who owns the repo.
+            type: "string"
+            pattern: "^[0-9a-f]+$"
+            minLength: 1
+            maxLength: 50
+          projectName:
             type: "string"
             pattern: "^[0-9a-f]+$"
             minLength: 1
@@ -60,8 +85,16 @@ properties:
         type: "string"
         # spaces and "?" are not valid for job symbols
         pattern: "^[A-Za-z0-9._-]+$"
-        minLength: 1
+        minLength: 0
         maxLength: 25
+      chunkId:
+        title: "chunkId"
+        type: "integer"
+        minimum: 1
+      chunkCount:
+        title: "chunkCount"
+        type: "integer"
+        minimum: 1
       groupSymbol:
         title: "group symbol"
         type: "string"
@@ -82,7 +115,6 @@ properties:
         minLength: 1
         maxLength: 100
     required:
-      - jobSymbol
       - groupSymbol
 
 
@@ -116,19 +148,18 @@ properties:
       - unknown
   jobKind:
     type: "string"
+    default: "other"
     enum:
       - build
       - test
+      - other
   tier:
     type: "integer"
     minimum: 1
     maximum: 3
 
-  isRetried:
-    description: True indicates this job has been retried.
-    type: "boolean"
-
   coalesced:
+    description: The job guids that were coalesced to this job.
     title: "coalesced"
     type: "array"
     items:
@@ -150,14 +181,18 @@ properties:
     type: "string"
     format: "date-time"
 
-  optionCollection:
-    title: "option collection"
+  labels:
+    title: "labels"
     description: |
-      Options are a dimension of a platform.  The values here can vary wildly,
-      so most strings are valid for this.  The list of options that are used
+      Labels are a dimension of a platform.  The values here can vary wildly,
+      so most strings are valid for this.  The list of labels that are used
       is maleable going forward.
 
-      Some examples of options that have been used:
+      These were formerly known as "Options" within "Option Collections" but
+      calling labels now so they can be understood to be just strings that
+      denotes a characteristic of the job.
+
+      Some examples of labels that have been used:
         opt    Optimize Compiler GCC optimize flags
         debug  Debug flags passed in
         pgo    Profile Guided Optimization - Like opt, but runs with profiling, then builds again using that profiling
@@ -170,9 +205,10 @@ properties:
       maxLength: 50
       pattern: "^[A-Za-z0-9_-]+$"
 
-  who:
-    title: "who"
-    format: "email"
+  owner:
+    description: |
+      Description of who submitted the job: gaia | scheduler name | username | email
+    title: "owner"
     type: "string"
     minLength: 1
     maxLength: 50
@@ -204,28 +240,44 @@ properties:
   runMachine:
     $ref: "#/definitions/machine"
 
-  artifacts:
-    type: "array"
-    items:
-      type: "object"
-      properties:
-        type:
-          type: "string"
-          enum: ["json", "text"]
-        name:
+  jobInfo:
+    description: |
+      Definition of the Job Info for a job.  These are extra data
+      fields that go along with a job that will be displayed in
+      the details panel within Treeherder.
+    id: "jobInfo"
+    type: object
+    properties:
+      summary:
+        type: string
+        description: |
+          Plain text description of the job and its state.  Submitted with
+          the final message about a task.
+      links:
+        type: array
+        items:
+        - type: object
           description: |
-            The artifact name can be anything.  But when the name ``text_log_summary`` is used
-            then treeherder uses that as the summary file for the Log Viewer in the UI.
-          type: "string"
-          minLength: 1
-          maxLength: 50
-        blob:
-          type: "string"
-          minLength: 1
-      required:
-        - type
-        - name
-        - blob
+            List of URLs shown as key/value pairs.  Shown as:
+            "<label>: <linkText>" where linkText will be a link to the url.
+          properties:
+            url:
+              type: string
+              format: url
+            linkText:
+              type: string
+              minLength: 1
+              maxLength: 50
+            label:
+              type: string
+              minLength: 1
+              maxLength: 50
+          additionalProperties: false
+          required:
+          - url
+          - linkText
+          - label
+    additionalProperties: false
 
   logs:
     type: "array"
@@ -241,11 +293,76 @@ properties:
           type: "string"
           minLength: 1
           maxLength: 50
+        steps:
+          type: array
+          description: |
+            This object defines what is seen in the Treeherder Log Viewer.
+            These values can be submitted here, or they will be generated
+            by Treeherder's internal log parsing process from the
+            submitted log.  If this value is submitted, Treeherder will
+            consider the log already parsed and skip parsing.
+          items:
+            type: object
+            properties:
+              errors:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    line:
+                      type: string
+                      minLength: 1
+                      maxLength: 255
+                    linenumber:
+                      type: integer
+                      minimum: 0
+                  additionalProperties: false
+              name:
+                type: string
+                minLength: 1
+                maxLength: 255
+              timeStarted:
+                type: string
+                format: date-time
+              timeFinished:
+                type: string
+                format: date-time
+              lineStarted:
+                type: integer
+                minimum: 0
+              lineFinished:
+                type: integer
+                minimum: 0
+              result:
+                type: string
+                enum:
+                  - success
+                  - fail
+                  - exception
+                  - canceled
+                  - unknown
+            required:
+            - name
+            - timeStarted
+            - lineStarted
+            - lineFinished
+            - timeFinished
+            - result
+        errorsTruncated:
+          type: boolean
+          description: |
+            If true, indicates that the number of errors in the log was too
+            large and not all of those lines are indicated here.
+      additionalProperties: false
       required: [url, name]
+
+  extra:
+    type: "object"
+    description: Extra information that Treeherder reads on a best-effort basis
 
 additionalProperties: false
 required:
-  - jobGuid
+  - taskId
   - origin
   - display
   - state

--- a/tests/etl/test_job_loader.py
+++ b/tests/etl/test_job_loader.py
@@ -15,30 +15,56 @@ def first_job(sample_data, test_project, result_set_stored):
     return job
 
 
-def test_ingest_pulse_job(sample_data, test_project, jm, result_set_stored):
+@pytest.fixture
+def pulse_jobs(sample_data, test_project, result_set_stored):
+    revision = result_set_stored[0]["revisions"][0]["revision"]
+    jobs = copy.deepcopy(sample_data.pulse_jobs)
+    for job in jobs:
+        job["origin"]["project"] = test_project
+        job["origin"]["revision"] = revision
+    return jobs
+
+
+@pytest.fixture
+def transformed_pulse_jobs(sample_data, test_project):
+    jobs = copy.deepcopy(sample_data.transformed_pulse_jobs)
+    return jobs
+
+
+def test_job_transformation(pulse_jobs, transformed_pulse_jobs, result_set_stored):
+    revision = result_set_stored[0]["revisions"][0]["revision"][:12]
+    rs_lookup = {revision: {"revision_hash": "123"}}
+    jl = JobLoader()
+    validated_jobs = jl._get_validated_jobs_by_project(pulse_jobs)
+    import json
+    import pprint
+    for (idx, job) in enumerate(validated_jobs["test_treeherder_jobs"]):
+        xformed = jl.transform(job, rs_lookup)
+        pprint.pprint(xformed)
+        # assert transformed_pulse_jobs[idx] == jl.transform(job, rs_lookup)
+        assert transformed_pulse_jobs[idx] == json.loads(json.dumps(jl.transform(job, rs_lookup)))
+
+
+def test_ingest_pulse_jobs(pulse_jobs, test_project, jm, result_set_stored,
+                           mock_log_parser):
     """
     Ingest a job through the JSON Schema validated JobLoader used by Pulse
     """
-    revision = result_set_stored[0]["revisions"][0]["revision"]
-    sample_jobs = sample_data.pulse_jobs
-    for job in sample_jobs:
-        job["origin"]["project"] = test_project
-        job["origin"]["revision"] = revision
 
     jl = JobLoader()
-    jl.process_job_list(sample_jobs, raise_errors=True)
+    jl.process_job_list(pulse_jobs, raise_errors=True)
 
     jobs = jm.get_job_list(0, 10)
-    assert len(jobs) == 3
+    assert len(jobs) == 4
 
     logs = jm.get_job_log_url_list([jobs[0]["id"]])
     assert len(logs) == 1
     with ArtifactsModel(test_project) as am:
         artifacts = am.get_job_artifact_list(0, 10)
-        assert len(artifacts) == 2
+        assert len(artifacts) == 4
 
 
-def test_transition_pending_running_complete(first_job, jm):
+def test_transition_pending_running_complete(first_job, jm, mock_log_parser):
     jl = JobLoader()
 
     change_state_result(first_job, jl, jm, "pending", "unknown", "pending", "unknown")
@@ -46,28 +72,28 @@ def test_transition_pending_running_complete(first_job, jm):
     change_state_result(first_job, jl, jm, "completed", "fail", "completed", "testfailed")
 
 
-def test_transition_complete_pending_stays_complete(first_job, jm):
+def test_transition_complete_pending_stays_complete(first_job, jm, mock_log_parser):
     jl = JobLoader()
 
     change_state_result(first_job, jl, jm, "completed", "fail", "completed", "testfailed")
     change_state_result(first_job, jl, jm, "pending", "unknown", "completed", "testfailed")
 
 
-def test_transition_complete_running_stays_complete(first_job, jm):
+def test_transition_complete_running_stays_complete(first_job, jm, mock_log_parser):
     jl = JobLoader()
 
     change_state_result(first_job, jl, jm, "completed", "fail", "completed", "testfailed")
     change_state_result(first_job, jl, jm, "running", "unknown", "completed", "testfailed")
 
 
-def test_transition_running_pending_stays_running(first_job, jm):
+def test_transition_running_pending_stays_running(first_job, jm, mock_log_parser):
     jl = JobLoader()
 
     change_state_result(first_job, jl, jm, "running", "unknown", "running", "unknown")
     change_state_result(first_job, jl, jm, "pending", "unknown", "running", "unknown")
 
 
-def test_transition_pending_retry_fail_stays_retry(first_job, jm):
+def test_transition_pending_retry_fail_stays_retry(first_job, jm, mock_log_parser):
     jl = JobLoader()
 
     change_state_result(first_job, jl, jm, "pending", "unknown", "pending", "unknown")
@@ -77,7 +103,7 @@ def test_transition_pending_retry_fail_stays_retry(first_job, jm):
     change_state_result(first_job, jl, jm, "completed", "fail", "completed", "retry")
 
 
-def test_skip_unscheduled(first_job, jm):
+def test_skip_unscheduled(first_job, jm, mock_log_parser):
     jl = JobLoader()
     first_job["state"] = "unscheduled"
     jl.process_job_list([first_job], raise_errors=True)
@@ -86,9 +112,9 @@ def test_skip_unscheduled(first_job, jm):
     assert len(jobs) == 0
 
 
-def change_state_result(job, job_loader, jm, new_state, new_result, exp_state, exp_result):
+def change_state_result(test_job, job_loader, jm, new_state, new_result, exp_state, exp_result):
     # make a copy so we can modify it and not affect other tests
-    job = copy.deepcopy(job)
+    job = copy.deepcopy(test_job)
     job["state"] = new_state
     job["result"] = new_result
     if new_state == 'pending':

--- a/tests/etl/test_job_schema.py
+++ b/tests/etl/test_job_schema.py
@@ -15,6 +15,7 @@ def test_group_symbols(sample_data, group_symbol):
     """
     job = sample_data.pulse_jobs[0]
     job["origin"]["project"] = "proj"
+    job["origin"]["revision"] = "1234567890123456789012345678901234567890"
     job["display"]["groupSymbol"] = group_symbol
     jsonschema.validate(job, job_json_schema)
 
@@ -26,5 +27,6 @@ def test_job_symbols(sample_data, job_symbol):
     """
     job = sample_data.pulse_jobs[0]
     job["origin"]["project"] = "proj"
+    job["origin"]["revision"] = "1234567890123456789012345678901234567890"
     job["display"]["jobSymbol"] = job_symbol
     jsonschema.validate(job, job_json_schema)

--- a/tests/sample_data/pulse_consumer/job_data.json
+++ b/tests/sample_data/pulse_consumer/job_data.json
@@ -1,14 +1,14 @@
 [
   {
-    "jobGuid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33",
+    "taskId": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33",
     "origin": {
       "kind": "hg.mozilla.org",
       "project": "set by test",
-      "revision": "set by test"
+      "revision": "1234567890123456789012345678901234567890"
     },
 
     "display": {
-      "jobSymbol": "P1",
+      "jobSymbol": "P",
       "jobName": "Pulse Ingestion Test",
       "groupSymbol": "PI",
       "groupName": "PulseIngestion"
@@ -31,7 +31,7 @@
       "architecture": "x86_64"
     },
 
-    "who": "thedude@lebowski.com",
+    "owner": "thedude@lebowski.com",
     "reason": "scheduler",
     "productName": "Oscillation Overthruster",
 
@@ -39,39 +39,47 @@
     "timeStarted": "2014-12-19T17:39:57-08:00",
     "timeCompleted": "2014-12-19T18:39:57-08:00",
 
+    "labels": ["debug"],
+
     "logs": [
       {
         "url": "http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/tinderbox-builds/mozilla-inbound-linux64/mozilla-inbound_linux64_spidermonkey-warnaserr-bm57-build1-build352.txt.gz",
-        "parseStatus": "parsed",
         "name": "builds-4h"
       }
     ],
-    "artifacts": [
-      {
-        "type": "json",
-        "name": "Artie Fact",
-        "blob": "{\"some\": \"value\"}"
-      }
-    ]
+    "jobInfo": {
+      "links": [
+        {
+          "url": "http://mozilla-releng-blobs.s3.amazonaws.com/blobs/Mozilla-Inbound-Non-PGO/sha512/05c7f57df6583c6351c6b49e439e2678e0f43c2e5b66695ea7d096a7519e1805f441448b5ffd4cc3b80b8b2c74b244288fda644f55ed0e226ef4e25ba02ca466",
+          "linkText": "svgr-e10s_errorsummary.log",
+          "label": "artifact uploaded"
+        },
+        {
+          "url": "http://mozilla-releng-blobs.s3.amazonaws.com/blobs/Mozilla-Inbound-Non-PGO/sha512/a6b13038a5ea71b0975580904e35e08c9d965949c07eb8a12f75eb33f1ec9af1da6f4197c424d850deadebf631aa71da3c0d57a59ec9d82a419aa8c4644a2905",
+          "linkText": "svgr-e10s_raw.log",
+          "label": "artifact uploaded"
+        }
+      ]
+    }
   },
+
   {
-    "jobGuid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf34",
+    "taskId": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf34",
+    "retryId": 0,
     "origin": {
       "kind": "hg.mozilla.org",
       "project": "set by test",
-      "revision": "set by test"
+      "revision": "1234567890123456789012345678901234567890"
     },
-
     "display": {
-      "jobSymbol": "P2",
+      "jobSymbol": "P",
+      "chunkId": 2,
       "jobName": "Pulse Ingestion Test",
       "groupSymbol": "?",
       "groupName": "unknown"
     },
-
     "state": "running",
     "jobKind": "test",
-
     "runMachine": {
       "name": "bld-linux64-ec2-104",
       "platform": "linux64",
@@ -84,25 +92,30 @@
       "os": "linux",
       "architecture": "x86_64"
     },
-
-    "who": "thedude@lebowski.com",
+    "owner": "thedude@lebowski.com",
     "reason": "scheduler",
     "productName": "Oscillation Overthruster",
-
     "timeScheduled": "2014-12-19T16:39:57-08:00",
     "timeStarted": "2014-12-19T17:39:57-08:00",
-    "timeCompleted": "2014-12-19T18:39:57-08:00"
+    "timeCompleted": "2014-12-19T18:39:57-08:00",
+    "labels": [
+      "debug",
+      "opt"
+    ]
   },
+
   {
-    "jobGuid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35",
+    "taskId": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35",
+    "retryId": 0,
+    "isRetried": true,
     "origin": {
       "kind": "hg.mozilla.org",
       "project": "set by test",
-      "revision": "set by test"
+      "revision": "1234567890123456789012345678901234567890"
     },
 
     "display": {
-      "jobSymbol": "P3",
+      "chunkId": 3,
       "jobName": "Pulse Ingestion Test",
       "groupSymbol": "PI",
       "groupName": "PulseIngestion"
@@ -125,7 +138,7 @@
       "architecture": "x86_64"
     },
 
-    "who": "thedude@lebowski.com",
+    "owner": "thedude@lebowski.com",
     "reason": "scheduler",
 
     "timeScheduled": "2014-12-19T16:39:57-08:00",
@@ -135,16 +148,109 @@
     "logs": [
       {
         "url": "http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/tinderbox-builds/mozilla-inbound-linux64/mozilla-inbound_linux64_spidermonkey-warnaserr-bm57-build1-build352.txt.gz",
-        "parseStatus": "parsed",
+        "name": "builds-4h",
+        "steps": [
+          {
+            "name": "downloading to oauth.txt",
+            "timeStarted": "2016-02-02T14:20:05-08:00",
+            "lineStarted": 231,
+            "lineFinished": 232,
+            "timeFinished": "2016-02-02T14:27:05-08:00",
+            "result": "success"
+          },
+          {
+            "errors": [
+              {
+                "line": "14:38:05     INFO -  PROCESS | 16672 | [Child 17361] ###!!! ABORT: Aborting on channel error.: file /builds/slave/m-in-l64-000000000000000000000/build/src/ipc/glue/MessageChannel.cpp, line 1823",
+                "linenumber": 3211
+              },
+              {
+                "line": "14:38:05     INFO -  TEST-UNEXPECTED-ERROR | tart | TIMEOUT: TART",
+                "linenumber": 3212
+              },
+              {
+                "line": "14:38:05    ERROR -  Traceback (most recent call last):",
+                "linenumber": 3213
+              }
+            ],
+            "name": "'/tools/buildbot/bin/python scripts/scripts/talos_script.py ...' failed",
+            "timeStarted": "2016-02-02T14:27:05-07:00",
+            "lineStarted": 234,
+            "lineFinished": 3269,
+            "timeFinished": "2016-02-02T14:38:09-08:00",
+            "result": "fail"
+          }
+        ],
+        "errorsTruncated": false
+      }
+    ],
+    "extra": {
+      "artifacts": [
+        {
+          "blob": {"fee": "foo"},
+          "type": "json",
+          "name": "Bug suggestions"
+        }
+      ]
+    }
+
+  },
+  {
+    "taskId": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35",
+    "retryId": 3,
+    "origin": {
+      "kind": "hg.mozilla.org",
+      "project": "set by test",
+      "revision": "1234567890123456789012345678901234567890"
+    },
+
+    "display": {
+      "chunkId": 3,
+      "jobName": "Pulse Ingestion Test",
+      "groupSymbol": "PI",
+      "groupName": "PulseIngestion"
+    },
+
+    "state": "completed",
+    "result": "fail",
+    "jobKind": "test",
+
+    "runMachine": {
+      "name": "bld-linux64-ec2-104",
+      "platform": "linux64",
+      "os": "linux",
+      "architecture": "x86_64"
+    },
+    "buildMachine": {
+      "name": "bld-linux64-ec2-104",
+      "platform": "linux64",
+      "os": "linux",
+      "architecture": "x86_64"
+    },
+
+    "owner": "thedude@lebowski.com",
+    "reason": "scheduler",
+
+    "timeScheduled": "2014-12-19T16:39:57-08:00",
+    "timeStarted": "2014-12-19T17:39:57-08:00",
+    "timeCompleted": "2014-12-19T18:39:57-08:00",
+
+    "logs": [
+      {
+        "url": "http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/tinderbox-builds/mozilla-inbound-linux64/mozilla-inbound_linux64_spidermonkey-warnaserr-bm57-build1-build352.txt.gz",
         "name": "builds-4h"
       }
     ],
-    "artifacts": [
-      {
-        "type": "json",
-        "name": "Artie Fact",
-        "blob": "{\"some\": \"value\"}"
-      }
-    ]
+    "extra": {
+      "artifacts": [
+        {
+          "blob": {"fee": "foo"},
+          "type": "json",
+          "name": "quagmire"
+        }
+      ]
+    }
+
   }
+
 ]

--- a/tests/sample_data/pulse_consumer/transformed_job_data.json
+++ b/tests/sample_data/pulse_consumer/transformed_job_data.json
@@ -1,0 +1,265 @@
+[
+  {
+    "job": {
+      "build_platform": {
+        "platform": "linux64",
+        "os_name": "linux",
+        "architecture": "x86_64"
+      },
+      "submit_timestamp": 1419035997.0,
+      "start_timestamp": 1419039597.0,
+      "name": "Pulse Ingestion Test",
+      "option_collection": {
+        "debug": true
+      },
+      "artifacts": [
+        {
+          "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33",
+          "type": "json",
+          "blob": {
+            "job_details": [
+              {
+                "url": "http://mozilla-releng-blobs.s3.amazonaws.com/blobs/Mozilla-Inbound-Non-PGO/sha512/05c7f57df6583c6351c6b49e439e2678e0f43c2e5b66695ea7d096a7519e1805f441448b5ffd4cc3b80b8b2c74b244288fda644f55ed0e226ef4e25ba02ca466",
+                "content_type": "link",
+                "value": "svgr-e10s_errorsummary.log",
+                "title": "artifact uploaded"
+              },
+              {
+                "url": "http://mozilla-releng-blobs.s3.amazonaws.com/blobs/Mozilla-Inbound-Non-PGO/sha512/a6b13038a5ea71b0975580904e35e08c9d965949c07eb8a12f75eb33f1ec9af1da6f4197c424d850deadebf631aa71da3c0d57a59ec9d82a419aa8c4644a2905",
+                "content_type": "link",
+                "value": "svgr-e10s_raw.log",
+                "title": "artifact uploaded"
+              }
+            ]
+          },
+          "name": "Job Info"
+        }
+      ],
+      "machine_platform": {
+        "platform": "linux64",
+        "os_name": "linux",
+        "architecture": "x86_64"
+      },
+      "who": "thedude@lebowski.com",
+      "group_symbol": "PI",
+      "reason": "scheduler",
+      "group_name": "PulseIngestion",
+      "machine": "bld-linux64-ec2-104",
+      "state": "completed",
+      "result": "success",
+      "log_references": [
+        {
+          "url": "http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/tinderbox-builds/mozilla-inbound-linux64/mozilla-inbound_linux64_spidermonkey-warnaserr-bm57-build1-build352.txt.gz",
+          "parse_status": "pending",
+          "name": "builds-4h"
+        }
+      ],
+      "tier": 1,
+      "job_symbol": "P",
+      "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33",
+      "product_name": "Oscillation Overthruster",
+      "end_timestamp": 1419043197.0
+    },
+    "revision_hash": "123",
+    "coalesced": []
+  },
+  {
+    "job": {
+      "build_platform": {
+        "platform": "linux64",
+        "os_name": "linux",
+        "architecture": "x86_64"
+      },
+      "submit_timestamp": 1419035997.0,
+      "start_timestamp": 1419039597.0,
+      "name": "Pulse Ingestion Test",
+      "option_collection": {
+        "debug": true,
+        "opt": true
+      },
+      "artifacts": [],
+      "machine_platform": {
+        "platform": "linux64",
+        "os_name": "linux",
+        "architecture": "x86_64"
+      },
+      "who": "thedude@lebowski.com",
+      "group_symbol": "?",
+      "reason": "scheduler",
+      "group_name": "unknown",
+      "machine": "bld-linux64-ec2-104",
+      "state": "running",
+      "result": "unknown",
+      "log_references": [],
+      "tier": 1,
+      "job_symbol": "P2",
+      "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf34",
+      "product_name": "Oscillation Overthruster",
+      "end_timestamp": 1419043197.0
+    },
+    "revision_hash": "123",
+    "coalesced": []
+  },
+  {
+    "job": {
+      "build_platform": {
+        "platform": "linux64",
+        "os_name": "linux",
+        "architecture": "x86_64"
+      },
+      "submit_timestamp": 1419035997.0,
+      "start_timestamp": 1419039597.0,
+      "name": "Pulse Ingestion Test",
+      "option_collection": {
+        "opt": true
+      },
+      "artifacts": [
+        {
+          "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35",
+          "type": "json",
+          "blob": {
+            "step_data": {
+              "all_errors": [
+                {
+                  "line": "14:38:05     INFO -  PROCESS | 16672 | [Child 17361] ###!!! ABORT: Aborting on channel error.: file /builds/slave/m-in-l64-000000000000000000000/build/src/ipc/glue/MessageChannel.cpp, line 1823",
+                  "linenumber": 3211
+                },
+                {
+                  "line": "14:38:05     INFO -  TEST-UNEXPECTED-ERROR | tart | TIMEOUT: TART",
+                  "linenumber": 3212
+                },
+                {
+                  "line": "14:38:05    ERROR -  Traceback (most recent call last):",
+                  "linenumber": 3213
+                }
+              ],
+              "steps": [
+                {
+                  "errors": [],
+                  "name": "downloading to oauth.txt",
+                  "started": 1454451605.0,
+                  "started_linenumber": 231,
+                  "finished_linenumber": 232,
+                  "finished": 1454452025.0,
+                  "error_count": 0,
+                  "duration": 420.0,
+                  "order": 0,
+                  "result": "success"
+                },
+                {
+                  "errors": [
+                    {
+                      "line": "14:38:05     INFO -  PROCESS | 16672 | [Child 17361] ###!!! ABORT: Aborting on channel error.: file /builds/slave/m-in-l64-000000000000000000000/build/src/ipc/glue/MessageChannel.cpp, line 1823",
+                      "linenumber": 3211
+                    },
+                    {
+                      "line": "14:38:05     INFO -  TEST-UNEXPECTED-ERROR | tart | TIMEOUT: TART",
+                      "linenumber": 3212
+                    },
+                    {
+                      "line": "14:38:05    ERROR -  Traceback (most recent call last):",
+                      "linenumber": 3213
+                    }
+                  ],
+                  "name": "'/tools/buildbot/bin/python scripts/scripts/talos_script.py ...' failed",
+                  "started": 1454452025.0,
+                  "started_linenumber": 234,
+                  "finished_linenumber": 3269,
+                  "finished": 1454452689.0,
+                  "error_count": 3,
+                  "duration": 664.0,
+                  "order": 1,
+                  "result": "testfailed"
+                }
+              ],
+              "errors_truncated": false
+            },
+            "logurl": "http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/tinderbox-builds/mozilla-inbound-linux64/mozilla-inbound_linux64_spidermonkey-warnaserr-bm57-build1-build352.txt.gz"
+          },
+          "name": "text_log_summary"
+        },
+        {
+          "type": "json",
+          "blob": {"fee": "foo"},
+          "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35",
+          "name": "Bug suggestions"
+        }
+      ],
+      "machine_platform": {
+        "platform": "linux64",
+        "os_name": "linux",
+        "architecture": "x86_64"
+      },
+      "who": "thedude@lebowski.com",
+      "group_symbol": "PI",
+      "reason": "scheduler",
+      "group_name": "PulseIngestion",
+      "machine": "bld-linux64-ec2-104",
+      "state": "completed",
+      "result": "retry",
+      "log_references": [
+        {
+          "url": "http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/tinderbox-builds/mozilla-inbound-linux64/mozilla-inbound_linux64_spidermonkey-warnaserr-bm57-build1-build352.txt.gz",
+          "parse_status": "parsed",
+          "name": "builds-4h"
+        }
+      ],
+      "tier": 1,
+      "job_symbol": "3",
+      "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35",
+      "product_name": "unknown",
+      "end_timestamp": 1419043197.0
+    },
+    "revision_hash": "123",
+    "coalesced": []
+  },
+  {
+    "job": {
+      "build_platform": {
+        "platform": "linux64",
+        "os_name": "linux",
+        "architecture": "x86_64"
+      },
+      "submit_timestamp": 1419035997.0,
+      "start_timestamp": 1419039597.0,
+      "name": "Pulse Ingestion Test",
+      "option_collection": {
+        "opt": true
+      },
+      "artifacts": [
+        {
+          "blob": {"fee": "foo"},
+          "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35/3",
+          "name": "quagmire",
+          "type": "json"
+        }
+      ],
+      "machine_platform": {
+        "platform": "linux64",
+        "os_name": "linux",
+        "architecture": "x86_64"
+      },
+      "who": "thedude@lebowski.com",
+      "group_symbol": "PI",
+      "reason": "scheduler",
+      "group_name": "PulseIngestion",
+      "machine": "bld-linux64-ec2-104",
+      "state": "completed",
+      "result": "testfailed",
+      "log_references": [
+        {
+          "url": "http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/tinderbox-builds/mozilla-inbound-linux64/mozilla-inbound_linux64_spidermonkey-warnaserr-bm57-build1-build352.txt.gz",
+          "parse_status": "pending",
+          "name": "builds-4h"
+        }
+      ],
+      "tier": 1,
+      "job_symbol": "3",
+      "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35/3",
+      "product_name": "unknown",
+      "end_timestamp": 1419043197.0
+    },
+    "revision_hash": "123",
+    "coalesced": []
+  }
+]

--- a/tests/sampledata.py
+++ b/tests/sampledata.py
@@ -53,6 +53,10 @@ class SampleData(object):
                   os.path.dirname(__file__))) as f:
             self.pulse_jobs = json.load(f)
 
+        with open("{0}/sample_data/pulse_consumer/transformed_job_data.json".format(
+                  os.path.dirname(__file__))) as f:
+            self.transformed_pulse_jobs = json.load(f)
+
         self.job_data = []
         self.resultset_data = []
 

--- a/treeherder/etl/job_loader.py
+++ b/treeherder/etl/job_loader.py
@@ -63,20 +63,21 @@ class JobLoader:
         We can rely on the structure of ``pulse_job`` because it will
         already have been validated against the JSON Schema at this point.
         """
-        return {
+        job_guid = self._get_job_guid(pulse_job)
+        x = {
             # todo: Continue using short revisions until Bug 1199364
             "revision_hash": rs_lookup[pulse_job["origin"]["revision"][:12]]["revision_hash"],
             "job": {
-                "job_guid": pulse_job["jobGuid"],
+                "job_guid": job_guid,
                 "name": pulse_job["display"].get("jobName", "unknown"),
-                "job_symbol": pulse_job["display"].get("jobSymbol"),
+                "job_symbol": self._get_job_symbol(pulse_job),
                 "group_name": pulse_job["display"].get("groupName", "unknown"),
                 "group_symbol": pulse_job["display"].get("groupSymbol"),
                 "product_name": pulse_job.get("productName", "unknown"),
                 "state": pulse_job["state"],
                 "result": self._get_result(pulse_job),
                 "reason": pulse_job.get("reason", "unknown"),
-                "who": pulse_job.get("who", "unknown"),
+                "who": pulse_job.get("owner", "unknown"),
                 "tier": pulse_job.get("tier", 1),
                 "submit_timestamp": self._to_timestamp(pulse_job["timeScheduled"]),
                 "start_timestamp": self._to_timestamp(pulse_job["timeStarted"]),
@@ -86,16 +87,123 @@ class JobLoader:
                 "machine_platform": self._get_platform(pulse_job.get("runMachine", None)),
                 "option_collection": self._get_option_collection(pulse_job),
                 "log_references": self._get_log_references(pulse_job),
-                "artifacts": self._get_artifacts(pulse_job),
+                "artifacts": self._get_artifacts(pulse_job, job_guid),
             },
             "coalesced": pulse_job.get("coalesced", [])
         }
+        return x
 
-    def _get_artifacts(self, job):
-        pulse_artifacts = job.get("artifacts", [])
-        for artifact in pulse_artifacts:
-            artifact["job_guid"] = job["jobGuid"]
+    def _get_job_guid(self, job):
+        guid_parts = [job["taskId"]]
+        retry_id = job.get("retryId", 0)
+        if retry_id > 0:
+            guid_parts.append(str(retry_id))
+        return "/".join(guid_parts)
+
+    def _get_job_symbol(self, job):
+        return "{}{}".format(
+            job["display"].get("jobSymbol", ""),
+            job["display"].get("chunkId", "")
+        )
+
+    def _get_artifacts(self, job, job_guid):
+        artifact_funcs = [self._get_job_info_artifact,
+                          self._get_text_log_summary_artifact]
+        pulse_artifacts = []
+        for artifact_func in artifact_funcs:
+            artifact = artifact_func(job, job_guid)
+            if artifact:
+                pulse_artifacts.append(artifact)
+
+        # add in any arbitrary artifacts included in the "extra" section
+        pulse_artifacts.extend(self._get_extra_artifacts(job, job_guid))
         return pulse_artifacts
+
+    def _get_job_info_artifact(self, job, job_guid):
+        if "jobInfo" in job:
+
+            ji = job["jobInfo"]
+            job_details = []
+            if "summary" in ji:
+                job_details.append({
+                    "content_type": "raw_html",
+                    "value": ji["summary"]["text"],
+                    "title": ji["summary"]["label"]
+                })
+            if "links" in ji:
+                for link in ji["links"]:
+                    job_details.append({
+                        "url": link["url"],
+                        "content_type": "link",
+                        "value": link["linkText"],
+                        "title": link["label"]
+                    })
+
+            artifact = {
+                "blob": {
+                    "job_details": job_details
+                },
+                "type": "json",
+                "name": "Job Info",
+                "job_guid": job_guid
+            }
+            return artifact
+
+    def _get_text_log_summary_artifact(self, job, job_guid):
+        # We can only have one text_log_summary artifact,
+        # so pick the first log with steps to create it.
+
+        if "logs" in job:
+            for log in job["logs"]:
+                if "steps" in log:
+                    all_errors = []
+                    old_steps = log["steps"]
+                    new_steps = []
+
+                    for idx, step in enumerate(old_steps):
+                        errors = step.get("errors", [])
+                        error_count = len(errors)
+                        if error_count:
+                            all_errors.extend(errors)
+
+                        started = self._to_timestamp(step["timeStarted"])
+                        finished = self._to_timestamp(step["timeFinished"])
+                        new_steps.append({
+                            "name": step["name"],
+                            "result": self._get_step_result(job, step["result"]),
+                            "started": started,
+                            "finished": finished,
+                            "started_linenumber": step["lineStarted"],
+                            "finished_linenumber": step["lineFinished"],
+                            "errors": errors,
+                            "error_count": error_count,
+                            "duration": finished - started,
+                            "order": idx
+                        })
+
+                    return {
+                        "blob": {
+                            "step_data": {
+                                "all_errors": all_errors,
+                                "steps": new_steps,
+                                "errors_truncated": log.get("errorsTruncated")
+                            },
+                            "logurl": log["url"]
+                        },
+                        "type": "json",
+                        "name": "text_log_summary",
+                        "job_guid": job_guid
+                    }
+
+    def _get_extra_artifacts(self, job, job_guid):
+        artifacts = []
+        if "extra" in job and "artifacts" in job["extra"]:
+            for extra_artifact in job["extra"]["artifacts"]:
+                artifact = extra_artifact
+                artifact["job_guid"] = job_guid
+                artifacts.append(artifact)
+
+        return artifacts
 
     def _get_log_references(self, job):
         log_references = []
@@ -103,15 +211,15 @@ class JobLoader:
             log_references.append({
                 "name": logref["name"],
                 "url": logref["url"],
-                "parse_status": logref.get("parseStatus", "pending")
+                "parse_status": "parsed" if "steps" in logref else "pending"
             })
         return log_references
 
     def _get_option_collection(self, job):
         option_collection = {"opt": True}
-        if "optionCollection" in job:
+        if "labels" in job:
             option_collection = {}
-            for option in job["optionCollection"]:
+            for option in job["labels"]:
                 option_collection[option] = True
         return option_collection
 
@@ -135,13 +243,17 @@ class JobLoader:
 
     def _get_result(self, job):
         if job["state"] == "completed":
-            resmap = self.BUILD_RESULT_MAP if job["jobKind"] == "build" else self.TEST_RESULT_MAP
+            resmap = self.TEST_RESULT_MAP if job["jobKind"] == "test" else self.BUILD_RESULT_MAP
             result = job.get("result", "unknown")
             if job.get("isRetried", False):
                 return "retry"
             else:
                 return resmap[result]
         return "unknown"
+
+    def _get_step_result(self, job, result):
+        resmap = self.TEST_RESULT_MAP if job["jobKind"] == "test" else self.BUILD_RESULT_MAP
+        return resmap[result]
 
     def _get_validated_jobs_by_project(self, jobs_list):
         validated_jobs = defaultdict(list)


### PR DESCRIPTION
These changes reflect updates to the ``pulse-job.yml`` file.  Some of these changes are based on the discussion here: https://public.etherpad-mozilla.org/p/jonasfj-teach-TH-retries-chunking

Summary of changes:

1. ``job_guid`` has been changed to a combination of ``taskId`` and ``retryId`` where the ``taskId`` *can* simply be the same as the old ``job_guid`` but the ``retryId`` will indicate how many times this job has been retried.  The values will be concatenated to <taskId>/<retryId> to form the ``job_guid`` value currently in the TH schema.

2. ``jobSymbol`` and ``chunkId`` will be concatenated to create the ``job_type_symbol`` internally.  But this allows us flexibility in the schema to separate the two in the future.

3. ``labels`` are being used in place of ``optionCollection`` to indicate more clearly that these are really just arbitrary strings that indicate attributes of the platform.  As we move forward to a wider matrix of platform configurations, the hope is that the term ``label`` is less confusing.  ``tag`` could have been used here, too.  But ``tag`` could possibly be confused with a tag in a version control system.  These values are, however, still translated to the ``option_collection`` internally to match the existing schema.

4. ``owner`` is used in place of ``who``.  Still maps to ``who`` internally for jobs.  But, again, the hope is that this term is a little clearer.

5. The general ``artifacts`` field has been removed and several ``artifacts`` are now top-level fields.  ``text_log_summary``, ``Bug suggestions``, and ``Job Info`` are not mere artifacts.  These are used heavily by the TH UI and should really become 1st class citizens if we continue to use them.  In this way, their format is now strictly defined.

6. An ``extra`` section has been added.  If the field of ``extra.artifacts`` is present, we will do our best to add those as arbitrary artifacts.  Anything else in the ``extra`` section is not yet used, but is flexible enough to be put to use later.


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1286)
<!-- Reviewable:end -->
