### PR TITLE
Bug 1244367 - Link to perfherder compare shouldn't always be against treeherder prod

### DIFF
--- a/ui/plugins/talos/main.html
+++ b/ui/plugins/talos/main.html
@@ -25,7 +25,7 @@
          target="_blank">Open {{line.value}} in Cleopatra</a>
     </li>
     <li>
-      <a href="https://treeherder.mozilla.org/perf.html#/comparechooser?newProject={{repoName}}&newRevision={{jobRevision}}">
+      <a href="perf.html#/comparechooser?newProject={{repoName}}&newRevision={{jobRevision}}">
          Compare result against another revision</a>
     </li>
   </ul>


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1287)
<!-- Reviewable:end -->
