### PR TITLE
Bug 1245472 - Heroku: Update to the new release-phase implementation

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -7,3 +7,4 @@ worker_buildapi_4hr: newrelic-admin run-program celery -A treeherder worker -Q b
 worker_default: newrelic-admin run-program celery -A treeherder worker -Q default,cycle_data,calculate_durations,fetch_bugs,fetch_allthethings,generate_perf_alerts --maxtasksperchild=50 --concurrency=3
 worker_hp: newrelic-admin run-program celery -A treeherder worker -Q classification_mirroring,publish_to_pulse --maxtasksperchild=50 --concurrency=1
 worker_log_parser: newrelic-admin run-program celery -A treeherder worker -Q log_parser_fail,log_parser,log_parser_hp,log_parser_json,error_summary,store_error_summary --maxtasksperchild=50 --concurrency=5
+release: ./manage.py migrate --noinput && ./manage.py load_initial_data && ./manage.py init_datasources

--- a/app.json
+++ b/app.json
@@ -1,5 +1,0 @@
-{
-  "scripts": {
-    "post-release": "./manage.py migrate --noinput && ./manage.py load_initial_data && ./manage.py init_datasources"
-  }
-}


### PR DESCRIPTION
The beta release-phase feature is making a backwards incompatible change today - moving from an app.json (and corresponding buildpack) approach to specifying a `release` Procfile entry that blocks the app deploy.

For more info, see:
https://devcenter.heroku.com/articles/release-phase?preview=1

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1290)
<!-- Reviewable:end -->
