### PR TITLE
Bug 1182043 - Use pylibmc instead of python-memcached

### DIFF
--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -5,6 +5,8 @@ class python {
            "python2.7",
            # Required by MySQLdb.
            "python-dev",
+           # Required by pylibmc.
+           "libmemcached-dev",
            # To improve the UX of the Vagrant environment.
            "git"]:
     ensure => "latest",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,4 @@
 
 -r requirements/common.txt
 
-# Pylibmc must be in this file so that heroku knows it has to install
-# libmemcached when bootstrapping the containers.
-# More info here: https://devcenter.heroku.com/articles/memcachier#python
-pylibmc==1.5.0
-
-django-pylibmc==0.6.1
 django-heroku-memcacheify==1.0.0

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -48,11 +48,6 @@ anyjson==0.3.3
 # sha256: 7cVxMGHxCWYEi_a0DZpRSzgeC6hJxk4DTE72wYR9MAc
 blessings==1.6
 
-# python-memcached v1.54 has a performance regression, don't update until
-# https://github.com/linsomniac/python-memcached/issues/71 is fixed.
-# sha256: vPcTcdmXu0ajFop7Y6rma1bMyswCWvkxDbQxVoHviGg
-python-memcached==1.53
-
 # sha256: ceezvPn8pAi8tlu2CJLzddOr3S5PKW7uuP4Lu_zeWY4
 jsonschema==2.5.1
 
@@ -125,3 +120,9 @@ requests-hawk==1.0.0
 
 # sha256: AMxHk1r7vYMmD90oOwqnkOZY0qcZIgSfbkZ9yooSRTc
 django-filter==0.11.0
+
+# sha256: FiVVlWFqbXjNeGpVzGQx2lt6zPRlEt-FRxKgzbs6z6o
+pylibmc==1.5.0
+
+# sha256: nP_e5wOq-evAKdnb3uir3QcjVkuV5LKsWeSmaLjlj5M
+django-pylibmc==0.6.1

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -435,7 +435,7 @@ MEMCACHED_LOCATION = TREEHERDER_MEMCACHED.strip(',').split(',')
 
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+        "BACKEND": "django_pylibmc.memcached.PyLibMCCache",
         "LOCATION": MEMCACHED_LOCATION,
         # Cache forever
         "TIMEOUT": None,


### PR DESCRIPTION
We're already using pylibmc on Heroku, since we need its SASL authentication support. However we were still using python-memcached on Vagrant, Travis, stage & prod.

To reduce the number of simultaneous changes when we migrate to Heroku, and to ensure at that point we're testing what we ship, this switches us to pylibmc pre-emptively for all environments.

Django does have a native pylibmc backend [1], however it doesn't support SASL authentication, so we have to use the custom django-pylibmc backend instead [2], which we choose to use everywhere (even though only Heroku's memcache instances require auth) for consistency.

Installing pylibmc requires libmemcached-dev, which is installed by default on Travis, has just been installed on stage/prod (bug 1243767), and as of this change, is now installed in the Vagrant environment too.

The comment mentioning that pylibmc must be present in the root requirements.txt file no longer applies, since the Python buildpack now uses pip-grep (rather than regex) to determine whether it is in the requirements files [3], and so handles included requirements files too. Example:
https://emorley.pastebin.mozilla.org/8858007

I'll be checking for any changes in performance when this is deployed, however if anything I expect it to be faster since it's not pure Python.

[1] https://github.com/django/django/blob/1.8.7/django/core/cache/backends/memcached.py#L171
[2] https://github.com/django-pylibmc/django-pylibmc/blob/master/django_pylibmc/memcached.py
[3] https://github.com/heroku/heroku-buildpack-python/blob/v75/bin/steps/pylibmc#L22

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1291)
<!-- Reviewable:end -->
