### PR TITLE
Bug 1246208 - Heroku: Remove manual collectstatic workaround

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -14,11 +14,6 @@ echo $SOURCE_VERSION > dist/revision.txt
 # collectstatic, and so does not affect files in the `dist/` directory.
 python -m whitenoise.gzip dist
 
-# The Python buildpack automatic collectstatic has been disabled using
-# DISABLE_COLLECTSTATIC, since it's slower than us running it here.
-# See: https://github.com/heroku/heroku-buildpack-python/issues/252
-./manage.py collectstatic --noinput
-
 # The post_compile script is run in a sub-shell, so we need to source the
 # buildpack's utils script again, so we can use set-env/set-default-env:
 # https://github.com/heroku/heroku-buildpack-python/blob/master/bin/utils


### PR DESCRIPTION
The Python buildpack has now rewritten the automatic collectstatic feature, such that it no longer does an unnecessary (and time-consuming) dry-run every time. As such, we can switch back to the buildpack's automatic collectstatic:
https://github.com/heroku/heroku-buildpack-python/blob/master/bin/steps/collectstatic

Prior to this landing, I'll update us to the latest version of the buildpack (using the `heroku buildpacks:set -i X ...` command) and remove the `DISABLE_COLLECTSTATIC` environment variable.

[ci skip]

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1292)
<!-- Reviewable:end -->
