### PR TITLE
Bug 1246962 - Accept lines containing TEST-VALGRIND-ERROR as an error…

### DIFF
--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -377,6 +377,7 @@ class ErrorParser(ParserBase):
         "Automation Error:",
         "command timed out:",
         "wget: unable ",
+        "TEST-VALGRIND-ERROR",
     )
 
     RE_ERR_MATCH = re.compile((


### PR DESCRIPTION
… line

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1296)
<!-- Reviewable:end -->
