### PR TITLE
Bug 1247376 - Improve alert summary status options

### DIFF
--- a/treeherder/perf/migrations/0010_add_alertsummary_backed_out.py
+++ b/treeherder/perf/migrations/0010_add_alertsummary_backed_out.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('perf', '0009_refactor_perfalerts'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='performancealertsummary',
+            name='status',
+            field=models.IntegerField(default=0, choices=[(0, b'Untriaged'), (1, b'Downstream'), (3, b'Invalid'), (4, b'Improvement'), (5, b'Investigating'), (6, b"Won't fix"), (7, b'Fixed'), (8, b'Backed out')]),
+        ),
+    ]

--- a/treeherder/perf/models.py
+++ b/treeherder/perf/models.py
@@ -114,7 +114,8 @@ class PerformanceAlertSummary(models.Model):
     IMPROVEMENT = 4
     INVESTIGATING = 5
     WONTFIX = 6
-    RESOLVED = 7
+    FIXED = 7
+    BACKED_OUT = 8
 
     STATUSES = ((UNTRIAGED, 'Untriaged'),
                 (DOWNSTREAM, 'Downstream'),
@@ -122,7 +123,8 @@ class PerformanceAlertSummary(models.Model):
                 (IMPROVEMENT, 'Improvement'),
                 (INVESTIGATING, 'Investigating'),
                 (WONTFIX, 'Won\'t fix'),
-                (RESOLVED, 'Resolved'))
+                (FIXED, 'Fixed'),
+                (BACKED_OUT, 'Backed out'))
 
     status = models.IntegerField(choices=STATUSES, default=UNTRIAGED)
 
@@ -163,7 +165,8 @@ class PerformanceAlertSummary(models.Model):
             elif self.status not in (PerformanceAlertSummary.IMPROVEMENT,
                                      PerformanceAlertSummary.INVESTIGATING,
                                      PerformanceAlertSummary.WONTFIX,
-                                     PerformanceAlertSummary.RESOLVED):
+                                     PerformanceAlertSummary.FIXED,
+                                     PerformanceAlertSummary.BACKED_OUT):
                 return PerformanceAlertSummary.INVESTIGATING
             # keep status if one of the investigating ones
             return self.status

--- a/ui/js/controllers/perf/alerts.js
+++ b/ui/js/controllers/perf/alerts.js
@@ -157,7 +157,13 @@ perf.factory('PhAlerts', [
             AlertSummary.prototype['is' + _.capitalize(status.text)] = function() {
                 return this.status === status.id;
             };
+            AlertSummary.prototype['mark' + _.capitalize(status.text)] = function() {
+                this.updateStatus(status);
+            };
         });
+        AlertSummary.prototype.isResolved = function() {
+            return this.isFixed() || this.isWontfix() || this.isBackedout();
+        };
         AlertSummary.prototype._initializeAlerts = function(optionCollectionMap) {
             // this function converts the representation returned by the perfherder
             // api into a representation more suited for display in the UI
@@ -225,9 +231,8 @@ perf.factory('PhAlerts', [
 
             return $q.all(_.where(this.alerts, {'selected': true}).map(
                 function(selectedAlert) {
-                    return selectedAlert.modify(modification).then(function() {
-                        selectedAlert.selected = false;
-                    });
+                    selectedAlert.selected = false;
+                    return selectedAlert.modify(modification);
                 }));
         };
         AlertSummary.prototype.getStatusText = function() {
@@ -536,15 +541,6 @@ perf.controller('AlertsCtrl', [
             alertSummary.assignBug(null).then(function() {
                 updateAlertVisibility();
             });
-        };
-        $scope.markWontfix = function(alertSummary) {
-            alertSummary.updateStatus(phAlertSummaryStatusMap.WONTFIX);
-        };
-        $scope.markResolved = function(alertSummary) {
-            alertSummary.updateStatus(phAlertSummaryStatusMap.RESOLVED);
-        };
-        $scope.markInvestigating = function(alertSummary) {
-            alertSummary.updateStatus(phAlertSummaryStatusMap.INVESTIGATING);
         };
         $scope.markAlertsDownstream = function(alertSummary) {
             $modal.open({

--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -185,7 +185,8 @@ treeherder.value("phAlertSummaryStatusMap", {
     IMPROVEMENT: { id: 4, text: "improvement" },
     INVESTIGATING: { id: 5, text: "investigating" },
     WONTFIX: { id: 6, text: "wontfix" },
-    RESOLVED: { id: 7, text: "resolved" }
+    FIXED: { id: 7, text: "fixed" },
+    BACKEDOUT: { id: 8, text: "backedout" }
 });
 
 treeherder.value("phAlertStatusMap", {

--- a/ui/partials/perf/alertsctrl.html
+++ b/ui/partials/perf/alertsctrl.html
@@ -83,20 +83,20 @@
             <li role="menuitem" ng-show="alertSummary.bug_number">
               <a ng-click="unlinkBug(alertSummary)">Unlink from bug</a>
             </li>
-            <li role="menuitem"
-                ng-if="alertSummary.bug_number && (alertSummary.isResolved() || alertSummary.isWontfix())">
-              <a ng-click="markInvestigating(alertSummary)">Mark as investigating</a>
+            <li role="menuitem" ng-if="alertSummary.isResolved()">
+              <a ng-click="alertSummary.markInvestigating()">Re-open</a>
             </li>
             <li role="menuitem"
-                ng-if="alertSummary.bug_number && (alertSummary.isInvestigating() || alertSummary.isResolved())">
-              <a ng-click="markWontfix(alertSummary)">Mark as "won't fix"</a>
+                ng-if="alertSummary.isInvestigating() || (alertSummary.isResolved() && !alertSummary.isWontfix())">
+              <a ng-click="alertSummary.markWontfix()">Mark as "won't fix"</a>
             </li>
             <li role="menuitem"
-                ng-if="alertSummary.bug_number && (alertSummary.isInvestigating() || alertSummary.isWontfix())">
-              <a ng-click="markResolved(alertSummary)">Mark as resolved</a>
+                ng-if="alertSummary.isInvestigating() || (alertSummary.isResolved() && !alertSummary.isBackedout())">
+              <a ng-click="alertSummary.markBackedout()">Mark as backed out</a>
             </li>
-            <li role="menuitem" ng-if="alertSummary.isClosed()">
-              <a ng-if="!alertSummary.is_open" ng-click="changeAlertSummaryStatus(alertSummary, true)">Reopen</a>
+            <li role="menuitem"
+                ng-if="alertSummary.isInvestigating() || (alertSummary.isResolved() && !alertSummary.isFixed())">
+              <a ng-click="alertSummary.markFixed()">Mark as fixed</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
* Rename 'resolved' -> 'fixed'
* Don't require a bug # for setting resolution status
* Some other related code cleanup

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1300)
<!-- Reviewable:end -->
