### PR TITLE
Bug 1246398 - Automatically offer to set base revision when preloading perf compare chooser

### DIFF
--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -142,6 +142,12 @@ perf.controller('CompareChooserCtrl', [
                     }
                 );
             };
+
+            // if we have a try push prepopulated, automatically offer a new revision
+            if ($scope.newRevision.length === 12) {
+                $scope.updateNewRevisionTips();
+                $scope.getPreviousRevision();
+            }
         });
     }]);
 


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1305)
<!-- Reviewable:end -->
