### PR TITLE
Bug 1249383 - Remove b2g-inbound as a performance branch

### DIFF
--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -260,5 +260,5 @@ treeherder.value("thJobNavSelectors",
 );
 
 treeherder.value("thPerformanceBranches", [
-    "mozilla-inbound", "mozilla-central", "fx-team", "b2g-inbound"
+    "mozilla-inbound", "mozilla-central", "fx-team"
 ]);


### PR DESCRIPTION
This means that perfherder won't try to get performance series related to
this repository when getting related branch information.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1306)
<!-- Reviewable:end -->
