### PR TITLE
Bug 1249353 - Update deprecated angular directives to uib

### DIFF
--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -1,5 +1,5 @@
-<span class="btn-group" dropdown>
-  <button dropdown-toggle
+<span class="btn-group" uib-dropdown>
+  <button uib-dropdown-toggle
           class="btn btn-sm btn-resultset dropdown-toggle"
           type="button"
           title="Action menu"


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1249353](https://bugzilla.mozilla.org/show_bug.cgi?id=1249353).

This updates our calls to native angular directives to `uib-[directive]` and suppresses the recent diagnostic warnings in the console.

Before:
![before](https://cloud.githubusercontent.com/assets/3660661/13198338/3828c4f6-d7d4-11e5-88fa-0d5ba7829452.jpg)

After:
![after](https://cloud.githubusercontent.com/assets/3660661/13198340/45aaf22a-d7d4-11e5-8212-e7c8fe20f29c.jpg)

Everything seems fine locally on Nightly and Chrome.

Tested on OSX 10.10.5:
Nightly **47.0a1 (2016-02-12)**
Chrome Latest Release **48.0.2564.116 (64-bit)**

Adding @wlach for review.