### PR TITLE
Bug 1184795 - Stop hiding data ingestion exceptions

### DIFF
--- a/tests/etl/test_job_loader.py
+++ b/tests/etl/test_job_loader.py
@@ -52,7 +52,7 @@ def test_ingest_pulse_jobs(pulse_jobs, test_project, jm, result_set_stored,
     """
 
     jl = JobLoader()
-    jl.process_job_list(pulse_jobs, raise_errors=True)
+    jl.process_job_list(pulse_jobs)
 
     jobs = jm.get_job_list(0, 10)
     assert len(jobs) == 4
@@ -106,7 +106,7 @@ def test_transition_pending_retry_fail_stays_retry(first_job, jm, mock_log_parse
 def test_skip_unscheduled(first_job, jm, mock_log_parser):
     jl = JobLoader()
     first_job["state"] = "unscheduled"
-    jl.process_job_list([first_job], raise_errors=True)
+    jl.process_job_list([first_job])
 
     jobs = jm.get_job_list(0, 10)
     assert len(jobs) == 0
@@ -122,7 +122,7 @@ def change_state_result(test_job, job_loader, jm, new_state, new_result, exp_sta
         # support it.
         del job['logs']
 
-    job_loader.process_job_list([job], raise_errors=True)
+    job_loader.process_job_list([job])
 
     jobs = jm.get_job_list(0, 10)
     assert len(jobs) == 1

--- a/treeherder/etl/job_loader.py
+++ b/treeherder/etl/job_loader.py
@@ -29,7 +29,7 @@ class JobLoader:
         "unknown": "unknown"
     }
 
-    def process_job_list(self, all_jobs_list, raise_errors=False):
+    def process_job_list(self, all_jobs_list):
         if not isinstance(all_jobs_list, list):
             all_jobs_list = [all_jobs_list]
 
@@ -51,8 +51,7 @@ class JobLoader:
                             logger.warn("Skipping job due to bad attribute",
                                         exc_info=1)
 
-                jobs_model.store_job_data(storeable_job_list,
-                                          raise_errors=raise_errors)
+                jobs_model.store_job_data(storeable_job_list)
 
     def transform(self, pulse_job, rs_lookup):
         """

--- a/treeherder/webapp/api/resultset.py
+++ b/treeherder/webapp/api/resultset.py
@@ -1,3 +1,4 @@
+import newrelic.agent
 from rest_framework import viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.exceptions import ParseError
@@ -5,7 +6,6 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
-from treeherder.model.derived import DatasetNotFoundError
 from treeherder.model.tasks import publish_resultset_runnable_job_action
 from treeherder.webapp.api import permissions
 from treeherder.webapp.api.utils import (UrlQueryFilter,
@@ -217,16 +217,27 @@ class ResultSetViewSet(viewsets.ViewSet):
         """
         POST method implementation
         """
-        try:
-            jm.store_result_set_data(request.data)
-        except DatasetNotFoundError as e:
-            return Response({"message": str(e)}, status=404)
-        except Exception as e:  # pragma nocover
-            import traceback
-            traceback.print_exc()
-            return Response({"message": str(e)}, status=500)
-        finally:
-            jm.disconnect()
+        username = request.META['hawk.receiver'].parsed_header['id']
+        # check if any revisions are shorter than the expected 40 characters
+        # The volume of resultsets is fairly low, so this loop won't be
+        # onerous.
+        # It could be argued to do this in ``store_result_set_data`` instead,
+        # but doing it here allows us to have access to the hawk user id
+        # so we know the source of the bad data.  This way it will show
+        # up as an error in New Relic, and we can contact the source.
+        for resultset in request.data:
+            for revision in resultset['revisions']:
+                try:
+                    if len(revision['revision']) < 40:
+                        raise ValueError("Revision < 40 characters")
+                except:
+                    params = {
+                        "revision": revision["revision"],
+                        "username": username
+                    }
+                    newrelic.agent.record_exception(params=params)
+
+        jm.store_result_set_data(request.data)
 
         return Response({"message": "well-formed JSON stored"})
 


### PR DESCRIPTION
With this change, if you get an exception during data ingestion in
DEBUG mode, it will simply throw the exception.  If not, it will
post the exception to New Relic with ``record_exception`` and move on
as we did before.  This will make it easier to detect errors in Vagrant
and prevent us from misssing them entirely on production and stage.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1313)
<!-- Reviewable:end -->
