### PR TITLE
Bug 1249674 - Remove addon-sdk repository

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -149,7 +149,7 @@
         "dvcs_type": "hg",
         "name": "addon-sdk",
         "url": "https://hg.mozilla.org/projects/addon-sdk",
-        "active_status": "active",
+        "active_status": "onhold",
         "codebase": "jetpack",
         "repository_group": 1,
         "description": ""


### PR DESCRIPTION
Since it's EOL.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1315)
<!-- Reviewable:end -->
