### PR TITLE
Bug 1240574 - Animate job group expansion/deletion only on click

### DIFF
--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -96,14 +96,8 @@
   transform: scale(1.7, 1.7);
 }
 
-@keyframes fadein {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
 .filter-shown {
   display: inline-block;
-  animation: fadein 0.5s;
 }
 
 /*

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -197,12 +197,20 @@ treeherder.directive('thCloneJobs', [
                     });
                     if (isGroupExpanded(gi.jgObj)) {
                         gi.jgObj.groupState = "collapsed";
-                        addGroupJobsAndCounts(gi.jgObj, gi.platformGroupEl);
+                        // fade out to hidden, then show again
+                        gi.grpJobList.fadeOut("fast", function() {
+                            gi.grpJobList.show();
+                            addGroupJobsAndCounts(gi.jgObj, gi.platformGroupEl);
+                        });
                     } else {
                         gi.grpCountList.empty();
                         gi.jgObj.groupState = "expanded";
-                        gi.grpJobList.empty();
-                        gi.grpJobList.append(renderJobBtnEls(gi.jgObj));
+                        // render as hidden initially, then fade in
+                        gi.grpJobList.hide();
+                        gi.grpJobList.html(renderJobBtnEls(gi.jgObj));
+                        gi.grpJobList.fadeIn("fast", function() {
+                            gi.grpJobList.css("opacity", "");
+                        });
                     }
                 }
             }


### PR DESCRIPTION
We were animating all transitions for the job elements before, which
could be extremely expensive.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1317)
<!-- Reviewable:end -->
