### PR TITLE
Bug 1250574 - Animate job group expansion/deletion only on click

### DIFF
--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -96,14 +96,8 @@
   transform: scale(1.7, 1.7);
 }
 
-@keyframes fadein {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
 .filter-shown {
   display: inline-block;
-  animation: fadein 0.5s;
 }
 
 /*

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -195,15 +195,18 @@ treeherder.directive('thCloneJobs', [
                         job.searchStr = thJobSearchStr(job) + ' ' + job.ref_data_name  + ' ' + job.signature;
                         job.visible = filterWithRunnable(job);
                     });
+                    gi.grpCountList.hide();
+                    gi.grpJobList.hide();
                     if (isGroupExpanded(gi.jgObj)) {
                         gi.jgObj.groupState = "collapsed";
                         addGroupJobsAndCounts(gi.jgObj, gi.platformGroupEl);
                     } else {
-                        gi.grpCountList.empty();
                         gi.jgObj.groupState = "expanded";
-                        gi.grpJobList.empty();
-                        gi.grpJobList.append(renderJobBtnEls(gi.jgObj));
+                        gi.grpCountList.empty();
+                        gi.grpJobList.html(renderJobBtnEls(gi.jgObj));
                     }
+                    gi.grpJobList.fadeIn();
+                    gi.grpCountList.fadeIn();
                 }
             }
         };


### PR DESCRIPTION
We were animating all transitions for the job elements before, which
could be extremely expensive.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1318)
<!-- Reviewable:end -->
