### PR TITLE
Bug 1245080 - Remove failure lines with corresponding jobs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -374,17 +374,12 @@ def mock_error_summary(monkeypatch):
 
 
 @pytest.fixture
-def failure_lines(jm, eleven_jobs_stored, initial_data):
-    from treeherder.model.models import RepositoryGroup, Repository
+def failure_lines(jm, eleven_jobs_stored, initial_data, test_repository):
     from tests.autoclassify.utils import test_line, create_failure_lines
 
     job = jm.get_job(1)[0]
 
-    repository_group = RepositoryGroup.objects.create(name="repo_group")
-    repository = Repository.objects.create(name=jm.project,
-                                           repository_group=repository_group)
-
-    return create_failure_lines(repository,
+    return create_failure_lines(test_repository,
                                 job["job_guid"],
                                 [(test_line, {}),
                                  (test_line, {"subtest": "subtest2"})])

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -15,6 +15,7 @@ from treeherder.model import (error_summary,
 from treeherder.model.models import (BuildPlatform,
                                      Datasource,
                                      ExclusionProfile,
+                                     FailureLine,
                                      JobDuration,
                                      JobGroup,
                                      JobType,
@@ -540,6 +541,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
 
         for jobs_chunk in jobs_chunk_list:
             job_id_list = [d['id'] for d in jobs_chunk]
+            job_guid_list = [d['job_guid'] for d in jobs_chunk]
             job_where_in_clause = [','.join(['%s'] * len(job_id_list))]
 
             # Associate placeholders and replace data with sql
@@ -553,6 +555,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
 
             # remove data from specified jobs tables that is older than max_timestamp
             self._execute_table_deletes(jobs_targets, 'jobs', sleep_time)
+            self._execute_orm_deletes(job_guid_list, chunk_size, sleep_time)
 
         return len(jobs_to_cycle)
 
@@ -580,6 +583,18 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             self.execute(
                 proc='generic.db_control.enable_foreign_key_checks',
                 debug_show=self.DEBUG)
+
+            if sleep_time:
+                # Allow some time for other queries to get through
+                time.sleep(sleep_time)
+
+    def _execute_orm_deletes(self, job_guids, chunk_size, sleep_time):
+        failure_line_ids = [item['id'] for item in
+                            FailureLine.objects.filter(job_guid__in=job_guids).values('id')]
+
+        for lower_bound in xrange(0, len(failure_line_ids), chunk_size):
+            FailureLine.objects.filter(
+                id__in=failure_line_ids[lower_bound:lower_bound+chunk_size]).delete()
 
             if sleep_time:
                 # Allow some time for other queries to get through

--- a/treeherder/model/migrations/0011_auto_20160316_1023.py
+++ b/treeherder/model/migrations/0011_auto_20160316_1023.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+import django.db.models.deletion
+import treeherder.model.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0010_machine_name_unique'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='failureline',
+            name='best_classification',
+            field=treeherder.model.fields.FlexibleForeignKey(related_name='best_for_lines', on_delete=django.db.models.deletion.SET_NULL, to='model.ClassifiedFailure', null=True),
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -579,7 +579,10 @@ class FailureLine(models.Model):
     # for future autoclassifications.
     best_classification = FlexibleForeignKey("ClassifiedFailure",
                                              related_name="best_for_lines",
-                                             null=True)
+                                             null=True,
+                                             db_index=True,
+                                             on_delete=models.SET_NULL)
+
     best_is_verified = models.BooleanField(default=False)
 
     created = models.DateTimeField(auto_now_add=True)
@@ -770,8 +773,12 @@ class Matcher(models.Model):
 
 class FailureMatch(models.Model):
     id = BigAutoField(primary_key=True)
-    failure_line = FlexibleForeignKey(FailureLine, related_name="matches")
-    classified_failure = FlexibleForeignKey(ClassifiedFailure, related_name="matches")
+    failure_line = FlexibleForeignKey(FailureLine,
+                                      related_name="matches",
+                                      on_delete=models.CASCADE)
+    classified_failure = FlexibleForeignKey(ClassifiedFailure,
+                                            related_name="matches",
+                                            on_delete=models.CASCADE)
 
     matcher = models.ForeignKey(Matcher)
     score = models.DecimalField(max_digits=3, decimal_places=2, blank=True, null=True)

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -297,7 +297,7 @@
         },
 
         "get_jobs_to_cycle":{
-            "sql":"SELECT id FROM job WHERE submit_timestamp < ?",
+            "sql":"SELECT id, job_guid FROM job WHERE submit_timestamp < ?",
             "host_type":"master_host"
         },
 


### PR DESCRIPTION
When jobs are cycled, also remove the failure_line rows for
those jobs, to limit data consumption of the failure_line
table.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1333)
<!-- Reviewable:end -->
