### PR TITLE
Bug 1254961 - Update to pip 8.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv ~/venv; fi
         - source ~/venv/bin/activate
-        - pip install -U pip==8.0.2
+        - pip install -U pip==8.1.0
       install:
         - npm install
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
@@ -63,7 +63,7 @@ matrix:
         # Manually install mysql 5.6 since the default is v5.5.
         - sudo apt-get -qq update
         - sudo apt-get -qq install mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
-        - pip install -U pip==8.0.2
+        - pip install -U pip==8.1.0
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
       script:
@@ -83,7 +83,7 @@ matrix:
         # Manually install mysql 5.6 since the default is v5.5.
         - sudo apt-get -qq update
         - sudo apt-get -qq install mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
-        - pip install -U pip==8.0.2
+        - pip install -U pip==8.1.0
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
       script:

--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -25,7 +25,7 @@ class python {
   exec { "install-virtualenv":
     cwd => "/tmp",
     user => "${APP_USER}",
-    command => "sudo pip install virtualenv==14.0.1",
+    command => "sudo pip install virtualenv==15.0.0",
     creates => "/usr/local/bin/virtualenv",
     require => Exec["install-pip"],
   }


### PR DESCRIPTION
To pick up require-hashes improvements, amongst other things:
https://pip.pypa.io/en/stable/news/
https://github.com/pypa/pip/compare/8.0.2...8.1.0

The Vagrant environment's virtualenv has been updated to 15.0.0, since that includes pip 8.1.0:
https://virtualenv.pypa.io/en/latest/changes.html
https://github.com/pypa/virtualenv/compare/14.0.1...15.0.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1341)
<!-- Reviewable:end -->
