### PR TITLE
Bug 1165229 - Heroku: Report deployments to New Relic

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -7,4 +7,5 @@ worker_buildapi_4hr: newrelic-admin run-program celery -A treeherder worker -Q b
 worker_default: newrelic-admin run-program celery -A treeherder worker -Q default,cycle_data,calculate_durations,fetch_bugs,fetch_allthethings,generate_perf_alerts,detect_intermittents --maxtasksperchild=50 --concurrency=3
 worker_hp: newrelic-admin run-program celery -A treeherder worker -Q classification_mirroring,publish_to_pulse --maxtasksperchild=50 --concurrency=1
 worker_log_parser: newrelic-admin run-program celery -A treeherder worker -Q log_parser_fail,log_parser,log_parser_hp,log_parser_json,error_summary,store_error_summary,autoclassify --maxtasksperchild=50 --concurrency=5
-release: ./manage.py migrate --noinput && ./manage.py load_initial_data && ./manage.py init_datasources
+
+release: ./bin/pre_deploy

--- a/bin/pre_deploy
+++ b/bin/pre_deploy
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Tasks run after the Heroku buildpack compile, but prior to the deploy.
+# If failures occur, the deploy will not proceed.
+
+set -euo pipefail
+
+echo "-----> PRE-DEPLOY: Running Django migration..."
+./manage.py migrate --noinput
+
+echo "-----> PRE-DEPLOY: Loading initial data..."
+./manage.py load_initial_data
+
+echo "-----> PRE-DEPLOY: Initialising datasources..."
+./manage.py init_datasources
+
+echo "-----> PRE-DEPLOY: Complete!"

--- a/bin/pre_deploy
+++ b/bin/pre_deploy
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 # Tasks run after the Heroku buildpack compile, but prior to the deploy.
-# If failures occur, the deploy will not proceed.
+# Failures will block the deploy unless `IGNORE_PREDEPLOY_ERRORS` is set.
 
-set -euo pipefail
+if [[ -v IGNORE_PREDEPLOY_ERRORS ]]; then
+    echo "-----> PRE-DEPLOY: Warning: Ignoring errors during pre-deploy!"
+else
+    # Make non-zero exit codes & other errors fatal.
+    set -euo pipefail
+fi
 
 echo "-----> PRE-DEPLOY: Running Django migration..."
 ./manage.py migrate --noinput

--- a/bin/pre_deploy
+++ b/bin/pre_deploy
@@ -13,4 +13,23 @@ echo "-----> PRE-DEPLOY: Loading initial data..."
 echo "-----> PRE-DEPLOY: Initialising datasources..."
 ./manage.py init_datasources
 
+echo "-----> PRE-DEPLOY: Reporting deployment to New Relic..."
+# eg: "v750: Deploy 5d6b1f0"
+DESCRIPTION="$HEROKU_RELEASE_VERSION: $HEROKU_SLUG_DESCRIPTION"
+# Use the revision from the live site rather than a local file generated during
+# buildpack compile, so that in the case of deploy failures it's up to date.
+OLD_REVISION="$(curl --silent --show-error --fail --retry 5 --retry-max-time 15 $SITE_URL/revision.txt)"
+CHANGELOG="https://github.com/mozilla/treeherder/compare/$OLD_REVISION...$HEROKU_SLUG_COMMIT"
+# The author of the deploy isn't currently available to us. Have filed:
+# https://help.heroku.com/tickets/343783
+USER="Heroku"
+# Report the deploy to New Relic using their Python agent. In addition to
+# the passed arguments, record-deploy references the environment variables
+# `NEW_RELIC_APP_NAME` and `NEW_RELIC_API_KEY`.
+newrelic-admin record-deploy "$NEW_RELIC_CONFIG_FILE" \
+                             "$DESCRIPTION" \
+                             "$HEROKU_SLUG_COMMIT" \
+                             "$CHANGELOG" \
+                             "$USER"
+
 echo "-----> PRE-DEPLOY: Complete!"


### PR DESCRIPTION
**1)  Move the Heroku deploy tasks to their own script:**
Since the next commit adds reporting deploys to New Relic, which will be too verbose to include in the Procfile. Also adds additional log output (which follows the buildpack compile log formatting convention) to make it easier to find & follow the release tasks on Papertrail. Uses the `set -euo pipefail` recommendation from: http://redsymbol.net/articles/unofficial-bash-strict-mode/

**2) Report Heroku deployments to New Relic:**
Requires that `NEW_RELIC_APP_NAME` and `NEW_RELIC_API_KEY` be set in the environment. NB: `NEW_RELIC_API_KEY` is different from the existing `NEW_RELIC_LICENSE_KEY`. We're also making use of the runtime-dyno-metadata labs feature, which sets the slug/release related environment variables used in this commit: https://devcenter.heroku.com/articles/dyno-metadata

**3) Add option to make pre-deploy errors non-fatal:**
When first setting up a new app on Heroku, things like reporting the deploy to New Relic will fail, since it requires that the app exist on New Relic. However the app will only be created there once the Python agent first reports app metadata, which won't happen until after the deploy (there is no way to create the app via the web interface). 

In addition, there may be cases in the future when stage/prod is broken, and the pre-deploy tasks therefore fail, however we still want the deploy to proceed.

To avoid needing to constantly edit this file, the environment variable `IGNORE_PREDEPLOY_ERRORS` can now be set, in cases where the deploy should continue even if there were errors. (Note this uses the bash 4.2+ `-v` option, see http://stackoverflow.com/a/18448624).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1346)
<!-- Reviewable:end -->
