### PR TITLE
Bug 1256485 - Don't load initial data in unit tests

### DIFF
--- a/tests/autoclassify/test_classify_failures.py
+++ b/tests/autoclassify/test_classify_failures.py
@@ -10,7 +10,7 @@ from .utils import (create_failure_lines,
 
 
 @pytest.mark.skipif(True, reason="Awaiting landing of Bug 1177519")
-def test_classify_test_failure(activate_responses, jm, eleven_jobs_stored, initial_data,
+def test_classify_test_failure(activate_responses, jm, eleven_jobs_stored,
                                failure_lines, classified_failures):
 
     repository = Repository.objects.get(name=jm.project)

--- a/tests/autoclassify/test_detect_intermittents.py
+++ b/tests/autoclassify/test_detect_intermittents.py
@@ -12,7 +12,7 @@ from .utils import (create_failure_lines,
 
 
 @pytest.mark.skipif(True, reason="Awaiting landing of Bug 1177519")
-def test_detect_intermittents(activate_responses, jm, eleven_jobs_stored, initial_data,
+def test_detect_intermittents(activate_responses, jm, eleven_jobs_stored,
                               failure_lines, classified_failures, retriggers):
 
     repository = Repository.objects.get(name=jm.project)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ import kombu
 import pytest
 import responses
 from django.conf import settings
-from django.core.management import call_command
 from requests import Request
 from requests_hawk import HawkAuth
 from webtest.app import TestApp
@@ -51,11 +50,6 @@ def increment_cache_key_prefix():
     cache.key_prefix = "t{0}".format(key_prefix_counter)
 
 
-@pytest.fixture()
-def initial_data(transactional_db):
-    call_command('load_initial_data')
-
-
 @pytest.fixture
 def jobs_ds(request, transactional_db):
     from treeherder.model.models import Datasource
@@ -69,7 +63,7 @@ def jobs_ds(request, transactional_db):
 
 
 @pytest.fixture
-def jm(request, jobs_ds):
+def jm(request, test_repository, jobs_ds):
     """ Give a test access to a JobsModel instance. """
     model = JobsModel(jobs_ds.project)
 
@@ -124,7 +118,7 @@ def test_project(jm):
 
 
 @pytest.fixture
-def test_repository(jm, transactional_db):
+def test_repository(transactional_db):
     from treeherder.model.models import Repository, RepositoryGroup
 
     RepositoryGroup.objects.create(
@@ -133,15 +127,16 @@ def test_repository(jm, transactional_db):
         description=""
     )
 
-    return Repository.objects.create(
+    r = Repository.objects.create(
         dvcs_type="hg",
-        name=jm.project,
+        name=settings.TREEHERDER_TEST_PROJECT,
         url="https://hg.mozilla.org/mozilla-central",
         active_status="active",
         codebase="gecko",
         repository_group_id=1,
         description=""
     )
+    return r
 
 
 @pytest.fixture
@@ -159,8 +154,7 @@ def mock_log_parser(monkeypatch):
 
 
 @pytest.fixture
-def result_set_stored(jm, initial_data, sample_resultset, test_repository):
-
+def result_set_stored(jm, sample_resultset):
     jm.store_result_set_data(sample_resultset)
 
     return sample_resultset
@@ -374,7 +368,7 @@ def mock_error_summary(monkeypatch):
 
 
 @pytest.fixture
-def failure_lines(jm, eleven_jobs_stored, initial_data, test_repository):
+def failure_lines(jm, eleven_jobs_stored, test_repository):
     from tests.autoclassify.utils import test_line, create_failure_lines
 
     job = jm.get_job(1)[0]
@@ -386,7 +380,7 @@ def failure_lines(jm, eleven_jobs_stored, initial_data, test_repository):
 
 
 @pytest.fixture
-def classified_failures(request, jm, eleven_jobs_stored, initial_data, failure_lines):
+def classified_failures(request, jm, eleven_jobs_stored, failure_lines):
     from treeherder.model.models import ClassifiedFailure, FailureMatch, Matcher
     from treeherder.autoclassify import detectors
 

--- a/tests/e2e/test_jobs_loaded.py
+++ b/tests/e2e/test_jobs_loaded.py
@@ -4,7 +4,7 @@ from webtest import TestApp
 from treeherder.config.wsgi import application
 
 
-def test_pending_job_available(jm, initial_data, pending_jobs_stored):
+def test_pending_job_available(jm, pending_jobs_stored):
     webapp = TestApp(application)
     resp = webapp.get(
         reverse("jobs-list", kwargs={"project": jm.project})
@@ -16,7 +16,7 @@ def test_pending_job_available(jm, initial_data, pending_jobs_stored):
     assert jobs['results'][0]['state'] == 'pending'
 
 
-def test_running_job_available(jm, initial_data, running_jobs_stored):
+def test_running_job_available(jm, running_jobs_stored):
     webapp = TestApp(application)
     resp = webapp.get(
         reverse("jobs-list", kwargs={"project": jm.project})
@@ -28,7 +28,7 @@ def test_running_job_available(jm, initial_data, running_jobs_stored):
     assert jobs['results'][0]['state'] == 'running'
 
 
-def test_completed_job_available(jm, initial_data, completed_jobs_stored):
+def test_completed_job_available(jm, completed_jobs_stored):
     webapp = TestApp(application)
     resp = webapp.get(
         reverse("jobs-list", kwargs={"project": jm.project})
@@ -39,7 +39,7 @@ def test_completed_job_available(jm, initial_data, completed_jobs_stored):
     assert jobs['results'][0]['state'] == 'completed'
 
 
-def test_pending_stored_to_running_loaded(jm, initial_data, pending_jobs_stored, running_jobs_stored):
+def test_pending_stored_to_running_loaded(jm, pending_jobs_stored, running_jobs_stored):
     """
     tests a job transition from pending to running
     given a loaded pending job, if I store and load the same job with status running,
@@ -55,7 +55,7 @@ def test_pending_stored_to_running_loaded(jm, initial_data, pending_jobs_stored,
     assert jobs['results'][0]['state'] == 'running'
 
 
-def test_finished_job_to_running(jm, initial_data, completed_jobs_stored, running_jobs_stored):
+def test_finished_job_to_running(jm, completed_jobs_stored, running_jobs_stored):
     """
     tests that a job finished cannot change state
     """
@@ -69,7 +69,7 @@ def test_finished_job_to_running(jm, initial_data, completed_jobs_stored, runnin
     assert jobs['results'][0]['state'] == 'completed'
 
 
-def test_running_job_to_pending(jm, initial_data, running_jobs_stored, pending_jobs_stored):
+def test_running_job_to_pending(jm, running_jobs_stored, pending_jobs_stored):
     """
     tests that a job transition from pending to running
     cannot happen

--- a/tests/e2e/test_perf_ingestion.py
+++ b/tests/e2e/test_perf_ingestion.py
@@ -8,9 +8,9 @@ from treeherder.perf.models import (PerformanceDatum,
                                     PerformanceSignature)
 
 
-def test_post_talos_artifact(test_project, test_repository, result_set_stored,
+def test_post_talos_artifact(jobs_ds, test_repository, result_set_stored,
                              mock_post_json):
-    test_repository.save()
+    PerformanceFramework.objects.get_or_create(name='talos')
 
     tjc = client.TreeherderJobCollection()
     job_guid = 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
@@ -33,7 +33,7 @@ def test_post_talos_artifact(test_project, test_repository, result_set_stored,
 
     tjc.add(tj)
 
-    post_collection(test_project, tjc)
+    post_collection(test_repository.name, tjc)
 
     # we'll just validate that we got the expected number of results for
     # talos (we have validation elsewhere for the actual data adapters)
@@ -41,9 +41,8 @@ def test_post_talos_artifact(test_project, test_repository, result_set_stored,
     assert PerformanceDatum.objects.count() == 1
 
 
-def test_post_perf_artifact(test_project, test_repository, result_set_stored,
+def test_post_perf_artifact(jobs_ds, test_repository, result_set_stored,
                             mock_post_json):
-    test_repository.save()
     PerformanceFramework.objects.get_or_create(name='cheezburger')
 
     tjc = client.TreeherderJobCollection()
@@ -79,7 +78,7 @@ def test_post_perf_artifact(test_project, test_repository, result_set_stored,
 
     tjc.add(tj)
 
-    post_collection(test_project, tjc)
+    post_collection(test_repository.name, tjc)
 
     # we'll just validate that we got the expected number of results for
     # talos (we have validation elsewhere for the actual data adapters)
@@ -87,9 +86,8 @@ def test_post_perf_artifact(test_project, test_repository, result_set_stored,
     assert PerformanceDatum.objects.all().count() == 3
 
 
-def test_post_perf_artifact_multiple(test_project, test_repository,
+def test_post_perf_artifact_multiple(jobs_ds, test_repository,
                                      result_set_stored, mock_post_json):
-    test_repository.save()
     PerformanceFramework.objects.get_or_create(name='cheezburger')
     perfobj = {
         "framework": {"name": "cheezburger"},
@@ -127,7 +125,7 @@ def test_post_perf_artifact_multiple(test_project, test_repository,
 
     tjc.add(tj)
 
-    post_collection(test_project, tjc)
+    post_collection(test_repository.name, tjc)
 
     # we'll just validate that we got the expected number of results for
     # talos (we have validation elsewhere for the actual data adapters)

--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -103,7 +103,7 @@ def mock_buildapi_builds4h_missing_branch_url(monkeypatch):
                         "file://{0}".format(path))
 
 
-def test_ingest_pending_jobs(jm, initial_data,
+def test_ingest_pending_jobs(jm,
                              mock_buildapi_pending_url,
                              mock_post_json,
                              mock_log_parser,
@@ -126,7 +126,7 @@ def test_ingest_pending_jobs(jm, initial_data,
     assert len(stored_obj) == 1
 
 
-def test_ingest_running_jobs(jm, initial_data,
+def test_ingest_running_jobs(jm,
                              mock_buildapi_running_url,
                              mock_post_json,
                              mock_log_parser,
@@ -149,7 +149,7 @@ def test_ingest_running_jobs(jm, initial_data,
     assert len(stored_obj) == 1
 
 
-def test_ingest_builds4h_jobs(jm, initial_data,
+def test_ingest_builds4h_jobs(jm,
                               mock_buildapi_builds4h_url,
                               mock_post_json,
                               mock_log_parser,
@@ -172,7 +172,7 @@ def test_ingest_builds4h_jobs(jm, initial_data,
     assert len(stored_obj) == 32
 
 
-def test_ingest_running_to_complete_job(jm, initial_data,
+def test_ingest_running_to_complete_job(jm,
                                         mock_buildapi_running_url,
                                         mock_buildapi_builds4h_url,
                                         mock_post_json,
@@ -206,7 +206,7 @@ def test_ingest_running_to_complete_job(jm, initial_data,
         assert job['state'] == 'completed'
 
 
-def test_ingest_running_job_fields(jm, initial_data,
+def test_ingest_running_job_fields(jm,
                                    mock_buildapi_running_url,
                                    mock_post_json,
                                    mock_log_parser,
@@ -229,9 +229,9 @@ def test_ingest_running_job_fields(jm, initial_data,
 #####################
 
 
-def test_ingest_pending_jobs_1_missing_resultset(jm, initial_data,
-                                                 sample_resultset, test_repository, mock_buildapi_pending_missing1_url,
-                                                 mock_post_json, mock_get_resultset, mock_fetch_json,
+def test_ingest_pending_jobs_1_missing_resultset(jm,
+                                                 sample_resultset, mock_buildapi_pending_missing1_url,
+                                                 mock_post_json, mock_get_resultset,
                                                  activate_responses):
     """
     Ensure the pending job with the missing resultset is queued for refetching
@@ -240,9 +240,9 @@ def test_ingest_pending_jobs_1_missing_resultset(jm, initial_data,
     _do_missing_resultset_test(jm, etl_process)
 
 
-def test_ingest_running_jobs_1_missing_resultset(jm, initial_data,
-                                                 sample_resultset, test_repository, mock_buildapi_running_missing1_url,
-                                                 mock_post_json, mock_get_resultset, mock_fetch_json,
+def test_ingest_running_jobs_1_missing_resultset(jm,
+                                                 sample_resultset, mock_buildapi_running_missing1_url,
+                                                 mock_post_json, mock_get_resultset,
                                                  activate_responses):
     """
     Ensure the running job with the missing resultset is queued for refetching
@@ -251,8 +251,8 @@ def test_ingest_running_jobs_1_missing_resultset(jm, initial_data,
     _do_missing_resultset_test(jm, etl_process)
 
 
-def test_ingest_builds4h_jobs_1_missing_resultset(jm, initial_data,
-                                                  sample_resultset, test_repository, mock_buildapi_builds4h_missing1_url,
+def test_ingest_builds4h_jobs_1_missing_resultset(jm,
+                                                  sample_resultset, mock_buildapi_builds4h_missing1_url,
                                                   mock_post_json, mock_log_parser, mock_get_resultset,
                                                   mock_fetch_json, activate_responses):
     """
@@ -262,8 +262,8 @@ def test_ingest_builds4h_jobs_1_missing_resultset(jm, initial_data,
     _do_missing_resultset_test(jm, etl_process)
 
 
-def test_ingest_builds4h_jobs_missing_branch(jm, initial_data,
-                                             sample_resultset, test_repository, mock_buildapi_builds4h_missing_branch_url,
+def test_ingest_builds4h_jobs_missing_branch(jm,
+                                             sample_resultset, mock_buildapi_builds4h_missing_branch_url,
                                              mock_post_json, mock_log_parser, mock_get_resultset,
                                              mock_fetch_json):
     """

--- a/tests/etl/test_common.py
+++ b/tests/etl/test_common.py
@@ -1,8 +1,7 @@
 from treeherder.etl import common
 
 
-def test_get_revision_hash(initial_data,
-                           result_set_stored, mock_fetch_json):
+def test_get_revision_hash(result_set_stored, mock_fetch_json):
     """That the correct revision_hash is retrieved if the revision exists"""
     project = result_set_stored[0]['revisions'][0]['repository']
     # todo: Continue using short revisions until Bug 1199364
@@ -12,7 +11,7 @@ def test_get_revision_hash(initial_data,
 
 
 def test_get_revision_hash_none(mock_fetch_json, test_project,
-                                initial_data, result_set_stored):
+                                result_set_stored):
     """Test that none is returned if the revision doesn't exist"""
     project = test_project
     revision = "fakerevision"

--- a/tests/etl/test_pushlog.py
+++ b/tests/etl/test_pushlog.py
@@ -9,7 +9,7 @@ from treeherder.etl.pushlog import (HgPushlogProcess,
                                     MissingHgPushlogProcess)
 
 
-def test_ingest_hg_pushlog(jm, initial_data, test_base_dir,
+def test_ingest_hg_pushlog(jm, test_base_dir,
                            test_repository, mock_post_json,
                            activate_responses):
     """ingesting a number of pushes should populate result set and revisions"""
@@ -42,7 +42,7 @@ def test_ingest_hg_pushlog(jm, initial_data, test_base_dir,
     assert len(revisions_stored) == 15
 
 
-def test_ingest_hg_pushlog_already_stored(jm, initial_data, test_base_dir,
+def test_ingest_hg_pushlog_already_stored(jm, test_base_dir,
                                           test_repository, mock_post_json, activate_responses):
     """test that trying to ingest a push already stored doesn't doesn't affect
     all the pushes in the request,
@@ -98,7 +98,7 @@ def test_ingest_hg_pushlog_already_stored(jm, initial_data, test_base_dir,
     assert len(pushes_stored) == 2
 
 
-def test_ingest_hg_pushlog_not_found_in_json_pushes(jm, initial_data, test_base_dir,
+def test_ingest_hg_pushlog_not_found_in_json_pushes(jm, test_base_dir,
                                                     test_repository, mock_post_json,
                                                     activate_responses):
     """
@@ -132,7 +132,7 @@ def test_ingest_hg_pushlog_not_found_in_json_pushes(jm, initial_data, test_base_
     assert len(revisions_stored) == 1
 
 
-def test_ingest_hg_pushlog_cache_last_push(jm, initial_data, test_repository,
+def test_ingest_hg_pushlog_cache_last_push(jm, test_repository,
                                            test_base_dir, mock_post_json,
                                            activate_responses):
     """
@@ -158,7 +158,7 @@ def test_ingest_hg_pushlog_cache_last_push(jm, initial_data, test_repository,
     assert cache.get(cache_key) == max_push_id
 
 
-def test_empty_json_pushes(jm, initial_data, test_base_dir,
+def test_empty_json_pushes(jm, test_base_dir,
                            test_repository, mock_post_json,
                            activate_responses):
     """

--- a/tests/log_parser/test_job_artifact_builder.py
+++ b/tests/log_parser/test_job_artifact_builder.py
@@ -39,48 +39,48 @@ def do_test(log):
     # assert act == exp#, json.dumps(act, indent=4)
 
 
-def test_crashtest_passing(initial_data):
+def test_crashtest_passing():
     """Process a job with a single log reference."""
 
     do_test("mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50")
 
 
-def test_opt_test_failing(initial_data):
+def test_opt_test_failing():
     """Process log with printlines and errors"""
     do_test("mozilla-central_mountainlion_test-mochitest-2-bm80-tests1-macosx-build138")
 
 
-def test_build_failing(initial_data):
+def test_build_failing():
     """Process a job with a single log reference."""
 
     do_test("mozilla-central-macosx64-debug-bm65-build1-build15")
 
 
-def test_mochitest_debug_passing(initial_data):
+def test_mochitest_debug_passing():
     """Process a job with a single log reference."""
 
     do_test("mozilla-central_mountainlion-debug_test-mochitest-2-bm80-tests1-macosx-build93")
 
 
-def test_mochitest_pass(initial_data):
+def test_mochitest_pass():
     """Process a job with a single log reference."""
 
     do_test("mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141")
 
 
-def test_mochitest_fail(initial_data):
+def test_mochitest_fail():
     """Process a job with a single log reference."""
 
     do_test("mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12")
 
 
-def test_mochitest_process_crash(initial_data):
+def test_mochitest_process_crash():
     """Test a mochitest log that has PROCESS-CRASH """
 
     do_test("mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122")
 
 
-def test_jetpack_fail(initial_data):
+def test_jetpack_fail():
     """Process a job with a single log reference."""
 
     do_test("ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16")

--- a/tests/log_parser/test_log_view_artifact_builder.py
+++ b/tests/log_parser/test_log_view_artifact_builder.py
@@ -48,7 +48,7 @@ def do_test(log):
     # assert act == exp, json.dumps(act, indent=4)
 
 
-def test_crashtest_passing(initial_data):
+def test_crashtest_passing():
     """Process a job with a single log reference."""
 
     do_test(
@@ -56,7 +56,7 @@ def test_crashtest_passing(initial_data):
     )
 
 
-def test_mochitest_pass(initial_data):
+def test_mochitest_pass():
     """Process a job with a single log reference."""
 
     do_test(
@@ -64,14 +64,14 @@ def test_mochitest_pass(initial_data):
     )
 
 
-def test_duration_gt_1hr(initial_data):
+def test_duration_gt_1hr():
     do_test(
         "mozilla-central-win32-pgo-bm85-build1-build111"
     )
 
 
 @slow
-def test_mochitest_fail(initial_data):
+def test_mochitest_fail():
     """Process a job with a single log reference."""
 
     do_test(
@@ -79,7 +79,7 @@ def test_mochitest_fail(initial_data):
     )
 
 
-def test_mochitest_process_crash(initial_data):
+def test_mochitest_process_crash():
     """Test a mochitest log that has PROCESS-CRASH """
 
     do_test(
@@ -88,7 +88,7 @@ def test_mochitest_process_crash(initial_data):
 
 
 @slow
-def test_jetpack_fail(initial_data):
+def test_jetpack_fail():
     """Process a job with a single log reference."""
 
     do_test(
@@ -97,7 +97,7 @@ def test_jetpack_fail(initial_data):
 
 
 @slow
-def test_crash_1(initial_data):
+def test_crash_1():
     """Test from old log parser"""
     do_test(
         "crash-1"
@@ -105,7 +105,7 @@ def test_crash_1(initial_data):
 
 
 @slow
-def test_crash_2(initial_data):
+def test_crash_2():
     """Test from old log parser"""
     do_test(
         "crash-2"
@@ -113,7 +113,7 @@ def test_crash_2(initial_data):
 
 
 @slow
-def test_crash_mac_1(initial_data):
+def test_crash_mac_1():
     """Test from old log parser"""
     do_test(
         "crash-mac-1"
@@ -121,7 +121,7 @@ def test_crash_mac_1(initial_data):
 
 
 @slow
-def test_crashtest_timeout(initial_data):
+def test_crashtest_timeout():
     """Test from old log parser"""
     do_test(
         "crashtest-timeout"
@@ -129,7 +129,7 @@ def test_crashtest_timeout(initial_data):
 
 
 @slow
-def test_jsreftest_fail(initial_data):
+def test_jsreftest_fail():
     """Test from old log parser"""
     do_test(
         "jsreftest-fail"
@@ -137,7 +137,7 @@ def test_jsreftest_fail(initial_data):
 
 
 @slow
-def test_jsreftest_timeout_crash(initial_data):
+def test_jsreftest_timeout_crash():
     """Test from old log parser"""
     do_test(
         "jsreftest-timeout-crash"
@@ -145,7 +145,7 @@ def test_jsreftest_timeout_crash(initial_data):
 
 
 @slow
-def test_leaks_1(initial_data):
+def test_leaks_1():
     """Test from old log parser"""
     do_test(
         "leaks-1"
@@ -153,7 +153,7 @@ def test_leaks_1(initial_data):
 
 
 @slow
-def test_mochitest_test_end(initial_data):
+def test_mochitest_test_end():
     """Test from old log parser"""
     do_test(
         "mochitest-test-end"
@@ -161,7 +161,7 @@ def test_mochitest_test_end(initial_data):
 
 
 @slow
-def test_multiple_timeouts(initial_data):
+def test_multiple_timeouts():
     """Test from old log parser"""
     do_test(
         "multiple-timeouts"
@@ -169,7 +169,7 @@ def test_multiple_timeouts(initial_data):
 
 
 @slow
-def test_opt_objc_exception(initial_data):
+def test_opt_objc_exception():
     """Test from old log parser"""
     do_test(
         "opt-objc-exception"
@@ -177,7 +177,7 @@ def test_opt_objc_exception(initial_data):
 
 
 @slow
-def test_reftest_fail_crash(initial_data):
+def test_reftest_fail_crash():
     """Test from old log parser"""
     do_test(
         "reftest-fail-crash"
@@ -185,7 +185,7 @@ def test_reftest_fail_crash(initial_data):
 
 
 @slow
-def test_reftest_jserror(initial_data):
+def test_reftest_jserror():
     """Test from old log parser"""
     do_test(
         "reftest-jserror"
@@ -193,7 +193,7 @@ def test_reftest_jserror(initial_data):
 
 
 @slow
-def test_reftest_opt_fail(initial_data):
+def test_reftest_opt_fail():
     """Test from old log parser"""
     do_test(
         "reftest-opt-fail"
@@ -201,7 +201,7 @@ def test_reftest_opt_fail(initial_data):
 
 
 @slow
-def test_reftest_timeout(initial_data):
+def test_reftest_timeout():
     """Test from old log parser"""
     do_test(
         "reftest-timeout"
@@ -209,49 +209,49 @@ def test_reftest_timeout(initial_data):
 
 
 @slow
-def test_tinderbox_exception(initial_data):
+def test_tinderbox_exception():
     """Test from old log parser"""
     do_test(
         "tinderbox-exception"
     )
 
 
-def test_xpcshell_crash(initial_data):
+def test_xpcshell_crash():
     """Test from old log parser"""
     do_test(
         "xpcshell-crash"
     )
 
 
-def test_xpcshell_multiple(initial_data):
+def test_xpcshell_multiple():
     """Test from old log parser"""
     do_test(
         "xpcshell-multiple"
     )
 
 
-def test_xpcshell_timeout(initial_data):
+def test_xpcshell_timeout():
     """Test from old log parser"""
     do_test(
         "xpcshell-timeout"
     )
 
 
-def test_extreme_log_line_length_truncation(initial_data):
+def test_extreme_log_line_length_truncation():
     """This log has lines that are huge.  Ensure we truncate the lines to 100"""
     do_test(
         "mozilla-central_ubuntu64_hw_test-androidx86-set-4-bm103-tests1-linux-build369"
     )
 
 
-def test_too_many_error_lines_truncation(initial_data):
+def test_too_many_error_lines_truncation():
     """This log has a large number of lines that match the error regex. Ensure we truncate to 100 lines."""
     do_test(
         "large-number-of-error-lines"
     )
 
 
-def test_taskcluster_missing_finish_marker(initial_data):
+def test_taskcluster_missing_finish_marker():
     """
     A log from a Taskcluster job, where there was an infrastructure problem,
     and so the final step finish marker is missing. There is also log content

--- a/tests/log_parser/test_store_error_summary.py
+++ b/tests/log_parser/test_store_error_summary.py
@@ -2,14 +2,13 @@ import responses
 from django.conf import settings
 from django.core.management import call_command
 
-from treeherder.model.models import (FailureLine,
-                                     Repository,
-                                     RepositoryGroup)
+from treeherder.model.models import FailureLine
 
 from ..sampledata import SampleData
 
 
-def test_store_error_summary(activate_responses, jm, eleven_jobs_stored, initial_data):
+def test_store_error_summary(activate_responses, test_repository, jm,
+                             eleven_jobs_stored):
     log_path = SampleData().get_log_path("plain-chunked_errorsummary.log")
     log_url = 'http://my-log.mozilla.org'
 
@@ -18,9 +17,6 @@ def test_store_error_summary(activate_responses, jm, eleven_jobs_stored, initial
                       body=log_handler.read(), status=200)
 
     job = jm.get_job(1)[0]
-    repository_group = RepositoryGroup.objects.create(name="repo_group")
-    repository = Repository.objects.create(name=jm.project,
-                                           repository_group=repository_group)
 
     call_command('store_error_summary', log_url, job['job_guid'], jm.project)
 
@@ -30,11 +26,11 @@ def test_store_error_summary(activate_responses, jm, eleven_jobs_stored, initial
 
     assert failure.job_guid == job['job_guid']
 
-    assert failure.repository == repository
+    assert failure.repository == test_repository
 
 
-def test_store_error_summary_truncated(activate_responses, jm, eleven_jobs_stored,
-                                       initial_data, monkeypatch):
+def test_store_error_summary_truncated(activate_responses, test_repository,
+                                       jm, eleven_jobs_stored, monkeypatch):
     log_path = SampleData().get_log_path("plain-chunked_errorsummary_10_lines.log")
     log_url = 'http://my-log.mozilla.org'
 
@@ -45,9 +41,6 @@ def test_store_error_summary_truncated(activate_responses, jm, eleven_jobs_store
                       body=log_handler.read(), status=200)
 
     job = jm.get_job(1)[0]
-    repository_group = RepositoryGroup.objects.create(name="repo_group")
-    repository = Repository.objects.create(name=jm.project,
-                                           repository_group=repository_group)
 
     call_command('store_error_summary', log_url, job['job_guid'], jm.project)
 
@@ -57,4 +50,4 @@ def test_store_error_summary_truncated(activate_responses, jm, eleven_jobs_store
 
     assert failure.job_guid == job['job_guid']
 
-    assert failure.repository == repository
+    assert failure.repository == test_repository

--- a/tests/log_parser/test_tasks.py
+++ b/tests/log_parser/test_tasks.py
@@ -11,7 +11,7 @@ from ..sampledata import SampleData
 
 
 @pytest.fixture
-def jobs_with_local_log(initial_data):
+def jobs_with_local_log():
     log = ("mozilla-inbound_ubuntu64_vm-debug_test-"
            "mochitest-other-bm53-tests1-linux-build122")
     sample_data = SampleData()
@@ -26,7 +26,7 @@ def jobs_with_local_log(initial_data):
 
 
 @pytest.fixture
-def jobs_with_local_mozlog_log(initial_data):
+def jobs_with_local_mozlog_log():
     log = ("plain-chunked_raw.log")
     sample_data = SampleData()
     url = "file://{0}".format(
@@ -57,8 +57,8 @@ def mock_mozlog_get_log_handler(monkeypatch):
                         'get_log_handle', _get_log_handle)
 
 
-def test_parse_log(jm, initial_data, jobs_with_local_log, sample_resultset,
-                   test_repository, mock_post_json, mock_fetch_json):
+def test_parse_log(jm, jobs_with_local_log, sample_resultset,
+                   mock_post_json, mock_fetch_json):
     """
     check that at least 3 job_artifacts get inserted when running
     a parse_log task for a successful job
@@ -95,8 +95,8 @@ def test_parse_log(jm, initial_data, jobs_with_local_log, sample_resultset,
 
 # json-log parsing is disabled due to bug 1152681.
 @pytest.mark.xfail
-def test_parse_mozlog_log(jm, initial_data, jobs_with_local_mozlog_log,
-                          sample_resultset, test_repository, mock_post_json,
+def test_parse_mozlog_log(jm, jobs_with_local_mozlog_log,
+                          sample_resultset, mock_post_json,
                           mock_fetch_json,
                           mock_mozlog_get_log_handler
                           ):
@@ -138,8 +138,8 @@ def test_parse_mozlog_log(jm, initial_data, jobs_with_local_mozlog_log,
     assert len(fails) == 3
 
 
-def test_bug_suggestions_artifact(jm, initial_data, jobs_with_local_log,
-                                  sample_resultset, test_repository, mock_post_json,
+def test_bug_suggestions_artifact(jm, jobs_with_local_log,
+                                  sample_resultset, mock_post_json,
                                   mock_fetch_json
                                   ):
     """

--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -35,7 +35,7 @@ def test_disconnect(jm):
     assert not jm.get_dhub().connection["master_host"]["con_obj"].open
 
 
-def test_ingest_single_sample_job(jm, refdata, sample_data, initial_data,
+def test_ingest_single_sample_job(jm, refdata, sample_data,
                                   sample_resultset, test_repository, mock_log_parser):
     """Process a single job structure in the job_data.txt file"""
     job_data = sample_data.job_data[:1]
@@ -45,7 +45,7 @@ def test_ingest_single_sample_job(jm, refdata, sample_data, initial_data,
     refdata.disconnect()
 
 
-def test_ingest_all_sample_jobs(jm, refdata, sample_data, initial_data,
+def test_ingest_all_sample_jobs(jm, refdata, sample_data,
                                 sample_resultset, test_repository, mock_log_parser):
     """
     @@@ - Re-enable when our job_data.txt has been re-created with
@@ -86,7 +86,7 @@ def test_get_inserted_row_ids(jm, sample_resultset, test_repository):
         len(sample_resultset) - slice_limit
 
 
-def test_ingest_running_to_retry_sample_job(jm, refdata, sample_data, initial_data,
+def test_ingest_running_to_retry_sample_job(jm, refdata, sample_data,
                                             sample_resultset, test_repository, mock_log_parser):
     """Process a single job structure in the job_data.txt file"""
     job_data = copy.deepcopy(sample_data.job_data[:1])
@@ -122,7 +122,7 @@ def test_ingest_running_to_retry_sample_job(jm, refdata, sample_data, initial_da
     assert jl[0]['id'] == initial_job_id
 
 
-def test_ingest_running_to_retry_to_success_sample_job(jm, refdata, sample_data, initial_data,
+def test_ingest_running_to_retry_to_success_sample_job(jm, refdata, sample_data,
                                                        sample_resultset, test_repository, mock_log_parser):
     """Process a single job structure in the job_data.txt file"""
     job_data = copy.deepcopy(sample_data.job_data[:1])
@@ -166,7 +166,7 @@ def test_ingest_running_to_retry_to_success_sample_job(jm, refdata, sample_data,
     assert jl[1]['result'] == 'success'
 
 
-def test_ingest_retry_sample_job_no_running(jm, refdata, sample_data, initial_data,
+def test_ingest_retry_sample_job_no_running(jm, refdata, sample_data,
                                             sample_resultset, test_repository, mock_log_parser):
     """Process a single job structure in the job_data.txt file"""
     job_data = copy.deepcopy(sample_data.job_data[:1])
@@ -229,7 +229,7 @@ def test_calculate_durations(jm, test_repository, mock_log_parser):
     assert durations[0].average_duration == expected_duration
 
 
-def test_cycle_all_data(jm, refdata, sample_data, initial_data,
+def test_cycle_all_data(jm, refdata, sample_data,
                         sample_resultset, test_repository, mock_log_parser,
                         failure_lines):
     """
@@ -264,7 +264,7 @@ def test_cycle_all_data(jm, refdata, sample_data, initial_data,
     assert FailureLine.objects.count() == 0
 
 
-def test_cycle_one_job(jm, refdata, sample_data, initial_data,
+def test_cycle_one_job(jm, refdata, sample_data,
                        sample_resultset, test_repository, mock_log_parser,
                        failure_lines):
     """
@@ -321,7 +321,7 @@ def test_cycle_one_job(jm, refdata, sample_data, initial_data,
             set(item.id for item in failure_lines_remaining))
 
 
-def test_cycle_all_data_in_chunks(jm, refdata, sample_data, initial_data,
+def test_cycle_all_data_in_chunks(jm, refdata, sample_data,
                                   sample_resultset, test_repository, mock_log_parser):
     """
     Test cycling the sample data in chunks.
@@ -361,7 +361,7 @@ def test_cycle_all_data_in_chunks(jm, refdata, sample_data, initial_data,
     assert len(FailureLine.objects.all()) == 0
 
 
-def test_bad_date_value_ingestion(jm, initial_data, test_repository, mock_log_parser):
+def test_bad_date_value_ingestion(jm, test_repository, mock_log_parser):
     """
     Test ingesting an blob with bad date value
 
@@ -375,7 +375,7 @@ def test_bad_date_value_ingestion(jm, initial_data, test_repository, mock_log_pa
     # if no exception, we are good.
 
 
-def test_store_result_set_data(jm, initial_data, sample_resultset):
+def test_store_result_set_data(jm, sample_resultset):
 
     data = jm.store_result_set_data(sample_resultset)
 
@@ -417,7 +417,7 @@ def test_store_result_set_data(jm, initial_data, sample_resultset):
     assert data['revision_ids'] == revision_ids
 
 
-def test_store_result_set_revisions(jm, initial_data, sample_resultset):
+def test_store_result_set_revisions(jm, sample_resultset):
     """Test that the ``top`` revision stored for resultset is correct"""
     resultsets = sample_resultset[8:9]
     jm.store_result_set_data(resultsets)
@@ -426,7 +426,7 @@ def test_store_result_set_revisions(jm, initial_data, sample_resultset):
     assert stored["short_revision"] == "997b28cb8737"
 
 
-def test_get_job_data(jm, test_project, refdata, sample_data, initial_data,
+def test_get_job_data(jm, test_project, refdata, sample_data,
                       sample_resultset, test_repository, mock_log_parser):
 
     target_len = 10
@@ -439,8 +439,8 @@ def test_get_job_data(jm, test_project, refdata, sample_data, initial_data,
     assert len(job_data) is target_len
 
 
-def test_remove_existing_jobs_single_existing(jm, sample_data, initial_data, refdata,
-                                              sample_resultset, test_repository, mock_log_parser):
+def test_remove_existing_jobs_single_existing(jm, sample_data, refdata,
+                                              sample_resultset, mock_log_parser):
     """Remove single existing job prior to loading"""
 
     job_data = sample_data.job_data[:1]
@@ -454,8 +454,8 @@ def test_remove_existing_jobs_single_existing(jm, sample_data, initial_data, ref
     assert len(jl) == 1
 
 
-def test_remove_existing_jobs_one_existing_one_new(jm, sample_data, initial_data, refdata,
-                                                   sample_resultset, test_repository, mock_log_parser):
+def test_remove_existing_jobs_one_existing_one_new(jm, sample_data, refdata,
+                                                   sample_resultset, mock_log_parser):
     """Remove single existing job prior to loading"""
 
     job_data = sample_data.job_data[:1]
@@ -466,8 +466,8 @@ def test_remove_existing_jobs_one_existing_one_new(jm, sample_data, initial_data
     assert len(data) == 1
 
 
-def test_ingesting_skip_existing(jm, sample_data, initial_data, refdata,
-                                 sample_resultset, test_repository, mock_log_parser):
+def test_ingesting_skip_existing(jm, sample_data, refdata,
+                                 sample_resultset, mock_log_parser):
     """Remove single existing job prior to loading"""
 
     job_data = sample_data.job_data[:1]
@@ -516,7 +516,7 @@ def test_ingest_job_with_updated_job_group(jm, sample_data, mock_log_parser,
         JobGroup.objects.get(name="second group name")
 
 
-def test_retry_on_operational_failure(jm, initial_data, monkeypatch):
+def test_retry_on_operational_failure(jm, monkeypatch):
     """Test that we retry 20 times on operational failures"""
     from _mysql_exceptions import OperationalError
     from treeherder.model import utils

--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -6,6 +6,7 @@ from rest_framework.test import APIClient
 
 from tests import test_utils
 from treeherder.client import TreeherderResultSetCollection
+from treeherder.model.models import FailureClassification
 from treeherder.webapp.api import utils
 
 
@@ -61,7 +62,7 @@ def test_resultset_list_bad_project(webapp, jm):
     assert resp.json == {"detail": "No project with name foo"}
 
 
-def test_resultset_list_empty_rs_still_show(webapp, initial_data,
+def test_resultset_list_empty_rs_still_show(webapp, test_repository,
                                             sample_resultset, jm):
     """
     test retrieving a resultset list, when the resultset has no jobs.
@@ -126,7 +127,9 @@ def test_resultset_list_single_long_revision(webapp, eleven_jobs_stored, jm, tes
     )
 
 
-def test_resultset_list_single_long_revision_stored_long(webapp, sample_resultset, jm, test_project):
+def test_resultset_list_single_long_revision_stored_long(webapp, test_repository,
+                                                         sample_resultset, jm,
+                                                         test_project):
     """
     test retrieving a resultset list with store long revision, filtered by a single long revision
     """
@@ -183,7 +186,7 @@ def test_resultset_list_filter_by_revision(webapp, eleven_jobs_stored, jm, test_
     )
 
 
-def test_resultset_list_filter_by_date(webapp, initial_data,
+def test_resultset_list_filter_by_date(webapp, test_repository,
                                        sample_resultset, jm, test_project):
     """
     test retrieving a resultset list, filtered by a date range
@@ -221,7 +224,7 @@ def test_resultset_list_filter_by_date(webapp, initial_data,
     jm.disconnect()
 
 
-def test_resultset_list_without_jobs(webapp, initial_data,
+def test_resultset_list_without_jobs(webapp, test_repository,
                                      sample_resultset, jm, test_project):
     """
     test retrieving a resultset list without jobs
@@ -293,7 +296,7 @@ def test_result_set_detail_bad_project(webapp, jm):
     assert resp.json == {"detail": "No project with name foo"}
 
 
-def test_resultset_create(jm, initial_data, test_repository, sample_resultset,
+def test_resultset_create(jm, test_repository, sample_resultset,
                           mock_post_json):
     """
     test posting data to the resultset endpoint via webtest.
@@ -365,10 +368,12 @@ def test_resultset_cancel_all(jm, resultset_with_three_jobs, pulse_action_consum
     user.delete()
 
 
-def test_resultset_status(webapp, eleven_jobs_stored, jm, initial_data):
+def test_resultset_status(jm, webapp, eleven_jobs_stored):
     """
     test retrieving the status of a resultset
     """
+    # create a failure classification corresponding to "not successful"
+    FailureClassification.objects.create(id=2, name="fixed by commit")
 
     rs_list = jm.get_result_set_list(0, 10)
     rs = rs_list[0]


### PR DESCRIPTION
It's almost entirely unnecessary (the few times we need base data
we can generate it ourselves) and can overwrite other test data
if we're not careful. Better just to remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1350)
<!-- Reviewable:end -->
