### PR TITLE
Bug 1199291 - Create result set on the fly for jobs ingested where the resultset is missing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import json
 import os
@@ -109,7 +110,7 @@ def test_base_dir():
 
 @pytest.fixture
 def sample_resultset(sample_data):
-    return sample_data.resultset_data
+    return copy.deepcopy(sample_data.resultset_data)
 
 
 @pytest.fixture

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -733,6 +733,28 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
 
         return lookup
 
+    def _create_missing_resultsets(self, resultset_lookup, all_revisions):
+        """Create any missing resultsets and update the revision_lookup"""
+
+        # revision_lookup here will have both short and long revisions,
+        # so this list will filter properly, whether entries in all_revisions
+        # are long or short.
+        missing_revisions = [r for r in all_revisions if r not in resultset_lookup]
+
+        if missing_revisions:
+            result_sets = []
+            for new_rev in missing_revisions:
+                result_sets.append({
+                    "revision": new_rev,
+                    "push_timestamp": 0,
+                    "author": "pending...",
+                    "revisions": []
+                })
+            self.store_result_set_data(result_sets)
+
+            new_lookup = self.get_resultset_top_revision_lookup(missing_revisions)
+            resultset_lookup.update(new_lookup)
+
     def get_result_set_list_by_ids(self, result_set_ids):
         """Given a list of result_set_ids, fetch the matching resultsets."""
 
@@ -1039,14 +1061,20 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                     logger.exception(e)
                     raise e
                 else:
+                    # make more fields visible in new relic for the job
+                    # where we encountered the error
+                    datum.update(datum.get("job", {}))
                     newrelic.agent.record_exception(params=datum)
 
                 # skip any jobs that hit errors in these stages.
                 continue
 
-        result_set_ids = self.get_resultset_all_revision_lookup(
-            unique_revisions
-        )
+        rs_lookup = self.get_resultset_all_revision_lookup(unique_revisions)
+        self._create_missing_resultsets(rs_lookup, unique_revisions)
+        # this will be keyed ONLY by long_revision, at this point.
+        # Add the resultsets keyed by short_revision in case the job came in
+        # with a short revision.
+        self._add_short_revision_lookups(rs_lookup)
 
         average_job_durations = self.get_average_job_durations(
             reference_data_signatures
@@ -1064,7 +1092,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 job_placeholders,
                 job_guid_list,
                 job_update_placeholders,
-                result_set_ids,
+                rs_lookup,
                 average_job_durations,
                 push_timestamps
             )
@@ -1230,9 +1258,8 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             debug_show=self.DEBUG,
         )
         if not len(rh):
-            raise ValueError("Revision hash not found: {}".format(
+            raise JobDataError("Revision hash not found: {}".format(
                 revision_hash))
-            # allow the next line to except out and be handled later.
         return rh[0]["long_revision"]
 
     def _load_ref_and_job_data_structs(
@@ -1709,6 +1736,9 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
         Build single queries to add new result_sets, revisions, and
         revision_map for a list of result_sets.
 
+        Determine which ones we already have, which ones we need and
+        which ones we need to update.
+
         result_sets = [
             {
              "revision": "8afdb7debc82a8b6e0d56449dfdf916c77a7bf80",
@@ -1735,13 +1765,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
         if not result_sets:
             return {}
 
-        # result_set data structures
-        result_set_placeholders = []
-        unique_rs_revisions = []
-        where_in_list = []
-
         # revision data structures
-        repository_id_lookup = dict()
         revision_placeholders = []
         all_revisions = []
         rev_where_in_list = []
@@ -1749,18 +1773,141 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
         # revision_map structures
         revision_to_rs_revision_lookup = dict()
 
-        # TODO: Confirm whether we need to do a lookup in this loop in the
-        #   memcache to reduce query overhead
-        for result in result_sets:
-            if "revision" in result:
-                top_revision = result["revision"]
+        unique_rs_revisions = self._get_unique_revisions(result_sets)
+
+        # Retrieve a list of revisions that have already been stored
+        # in the list of unique_revisions. Use it to determine the new
+        # result_sets.  Key this off of both long and short revisions since
+        # we can get either
+        resultsets_before = self.get_resultset_top_revision_lookup(
+            unique_rs_revisions)
+        self._add_short_revision_lookups(resultsets_before)
+        resultset_revisions_before = resultsets_before.keys()
+
+        # UPDATE any resultsets that are incomplete
+        #
+        resultset_updates = self._get_resultset_updates(
+            result_sets, resultsets_before)
+        self._modify_resultsets(resultset_updates,
+                                "jobs.updates.update_result_set",
+                                revision_placeholders,
+                                all_revisions, rev_where_in_list,
+                                revision_to_rs_revision_lookup)
+
+        # INSERT any resultsets we don't already have
+        #
+        resultset_inserts = self._get_resultset_inserts(
+            result_sets, resultset_revisions_before, unique_rs_revisions)
+
+        self._modify_resultsets(resultset_inserts,
+                                "jobs.inserts.set_result_set",
+                                revision_placeholders,
+                                all_revisions, rev_where_in_list,
+                                revision_to_rs_revision_lookup)
+
+        last_row_id = self.get_dhub().connection['master_host']['cursor'].lastrowid
+
+        # Retrieve new, updated and already existing result sets that
+        # match all the revisions sent in during this request
+        result_set_id_lookup = self.get_resultset_top_revision_lookup(
+            unique_rs_revisions)
+        self._add_short_revision_lookups(result_set_id_lookup)
+
+        # identify the newly inserted result sets
+        result_set_ids_after = set(result_set_id_lookup.keys())
+        inserted_result_sets = result_set_ids_after.difference(
+            resultset_revisions_before
+        )
+
+        inserted_result_set_ids = []
+
+        # If cursor.lastrowid is > 0 rows were inserted on this
+        # cursor. When new rows are inserted, determine the new
+        # result_set ids and submit publish to pulse tasks.
+        if inserted_result_sets and last_row_id > 0:
+
+            for revision in inserted_result_sets:
+                inserted_result_set_ids.append(
+                    result_set_id_lookup[revision]['id']
+                )
+
+        # Revisions don't get updated, if we have conflicts here, they
+        # are just skipped.  This will insert revisions for both new
+        # resultsets and resultset skeletons that were just updated.
+        # Resultset skeletons don't get revisions till we insert them here.
+        revision_id_lookup = self._insert_revisions(
+            revision_placeholders, all_revisions, rev_where_in_list,
+            revision_to_rs_revision_lookup, result_set_id_lookup)
+
+        return {
+            'result_set_ids': result_set_id_lookup,
+            'revision_ids': revision_id_lookup,
+            'inserted_result_set_ids': inserted_result_set_ids
+        }
+
+    def _get_resultset_updates(self, result_sets,
+                               resultsets_before):
+        # find the existing resultsets that meet the requirements of needing
+        # to be updated.
+        rs_need_update = set()
+        for rev, resultset in resultsets_before.iteritems():
+            if resultset["push_timestamp"] == 0:
+                rs_need_update.add(rev)
+
+        # collect the new values for the resultsets that needed updating
+        # The revision ingested earlier that needs update could be either
+        # 40 or 12 character.  And the new one coming in could be either as
+        # well.  The rs_need_update will be keyed by both, but we must
+        # check for both 12 and 40.
+        resultset_updates = [x for x in result_sets
+                             if x["revision"] in rs_need_update or
+                             x["revision"][:12] in rs_need_update]
+        return resultset_updates
+
+    def _get_resultset_inserts(self, result_sets,
+                               resultset_revisions_before,
+                               unique_rs_revisions):
+        # find the revisions that we don't have resultsets for yet
+        revisions_need_insert = unique_rs_revisions.difference(
+            resultset_revisions_before)
+
+        # collect the new resultset values that need inserting
+        resultset_inserts = [r for r in result_sets
+                             if r["revision"] in revisions_need_insert]
+        return resultset_inserts
+
+    def _get_unique_revisions(self, result_sets):
+        unique_rs_revisions = set()
+        for result_set in result_sets:
+            if "revision" in result_set:
+                unique_rs_revisions.add(result_set["revision"])
+                unique_rs_revisions.add(result_set["revision"][:12])
             else:
-                top_revision = result['revisions'][-1]['revision']
+                top_revision = result_set['revisions'][-1]['revision']
+                result_set["revision"] = top_revision
+                unique_rs_revisions.add(top_revision)
+                unique_rs_revisions.add(top_revision[:12])
                 newrelic.agent.record_exception(
                     exc=ValueError(
                         "New resultset submitted without ``revision`` value"),
                     params={"revision": top_revision}
                 )
+        return unique_rs_revisions
+
+    def _modify_resultsets(self, result_sets, procedure, revision_placeholders,
+                           all_revisions, rev_where_in_list,
+                           revision_to_rs_revision_lookup):
+        """
+        Either insert or update resultsets, based on the ``procedure``.
+        """
+        # result_set data structures
+        result_set_placeholders = []
+        unique_rs_revisions = set()
+        where_in_list = []
+        repository_id_lookup = dict()
+
+        for result in result_sets:
+            top_revision = result["revision"]
             revision_hash = result.get("revision_hash", top_revision)
             short_top_revision = top_revision[:12]
             result_set_placeholders.append(
@@ -1771,11 +1918,12 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                     short_top_revision,
                     result['push_timestamp'],
                     result.get('active_status', 'active'),
-                    top_revision
+                    top_revision,
+                    short_top_revision
                 ]
             )
             where_in_list.append('%s')
-            unique_rs_revisions.append(top_revision)
+            unique_rs_revisions.add(top_revision)
 
             for rev_datum in result['revisions']:
 
@@ -1810,42 +1958,17 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 rev_where_in_list.append('%s')
                 revision_to_rs_revision_lookup[long_revision] = top_revision
 
-        # Retrieve a list of revisions that have already been stored
-        # in the list of unique_revisions. Use it to determine the new
-        # result_sets
-        result_set_ids_before = self.get_resultset_top_revision_lookup(unique_rs_revisions).keys()
-
-        # Insert new result sets
         self.execute(
-            proc='jobs.inserts.set_result_set',
+            proc=procedure,
             placeholders=result_set_placeholders,
             executemany=True,
             debug_show=self.DEBUG
         )
 
-        lastrowid = self.get_dhub().connection['master_host']['cursor'].lastrowid
-
-        # Retrieve new and already existing result set ids
-        result_set_id_lookup = self.get_resultset_top_revision_lookup(unique_rs_revisions)
-
-        # identify the newly inserted result sets
-        result_set_ids_after = set(result_set_id_lookup.keys())
-        inserted_result_sets = result_set_ids_after.difference(
-            result_set_ids_before
-        )
-
-        inserted_result_set_ids = []
-
-        # If cursor.lastrowid is > 0 rows were inserted on this
-        # cursor. When new rows are inserted, determine the new
-        # result_set ids and submit publish to pulse tasks.
-        if inserted_result_sets and lastrowid > 0:
-
-            for revision in inserted_result_sets:
-                inserted_result_set_ids.append(
-                    result_set_id_lookup[revision]['id']
-                )
-
+    def _insert_revisions(self, revision_placeholders,
+                          all_revisions, rev_where_in_list,
+                          revision_to_rs_revision_lookup,
+                          result_set_id_lookup):
         if all_revisions:
             # Insert new revisions
             self.execute(
@@ -1890,12 +2013,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             )
         else:
             revision_id_lookup = []
-
-        return {
-            'result_set_ids': result_set_id_lookup,
-            'revision_ids': revision_id_lookup,
-            'inserted_result_set_ids': inserted_result_set_ids
-        }
+        return revision_id_lookup
 
     def get_exclusion_profile_signatures(self, exclusion_profile):
         """Retrieve the reference data signatures associates to an exclusion profile"""

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -75,6 +75,7 @@
                     SELECT `long_revision`, `push_timestamp`
                     FROM `result_set`
                     WHERE `long_revision` = ?
+                    OR `short_revision` = ?
                 )",
 
             "host_type":"master_host"
@@ -257,6 +258,21 @@
                 SET    `parse_status` = ?
                 WHERE  `id` = ?
                 AND `active_status` = 'active'",
+            "host_type":"master_host"
+        },
+        "update_result_set":{
+
+            "sql":"UPDATE `result_set`
+                   SET
+                   `author` = ?,
+                   `revision_hash` = ?,
+                   `long_revision` = ?,
+                   `short_revision` = ?,
+                   `push_timestamp` = ?,
+                   `active_status` = ?
+                WHERE long_revision = ?
+                  OR short_revision = ?",
+
             "host_type":"master_host"
         }
     },


### PR DESCRIPTION
This will look for the ``revision`` field in a job during ingestion.  If a resultset for that job can not be found, it will create a "skeleton" of one based on the ``revision``.  The skeleton resultset will look like:

    {
        "revision": <new_revision>,
        "push_timestamp": 0,
        "author": "pending...",
        "revisions": []
    }

Having no revisions, the resultset will not be visible in the UI until its data has been filled.  The data for the resultset will be filled by our periodic call to ``json-pushes``.

The BuildBot mechanism won't change in that we will wait to ingest jobs till we have the resultset created already.  This is for users of the ``Client`` (and the Pulse Job Ingestion, when Task Cluster starts using that).

The Client has been updated to require submitting the ``revision`` for a job and no longer requires the ``revision_hash``.  This should be a lot easier on folks submitting data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1356)
<!-- Reviewable:end -->
