### PR TITLE
Bug 1258700 - Update to WhiteNoise 3.0 and switch to its middleware-based approach

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -12,7 +12,7 @@ echo $SOURCE_VERSION > dist/revision.txt
 # WhiteNoise can then serve in preference to the originals. This is required
 # since WhiteNoise's Django storage backend only gzips assets handled by
 # collectstatic, and so does not affect files in the `dist/` directory.
-python -m whitenoise.gzip dist
+python -m whitenoise.compress dist
 
 # The post_compile script is run in a sub-shell, so we need to source the
 # buildpack's utils script again, so we can use set-env/set-default-env:

--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -69,7 +69,7 @@ def update(ctx):
         # WhiteNoise can then serve in preference to the originals. This is required
         # since WhiteNoise's Django storage backend only gzips assets handled by
         # collectstatic, and so does not affect files in the `dist/` directory.
-        ctx.local("python2.7 -m whitenoise.gzip dist")
+        ctx.local("python2.7 -m whitenoise.compress dist")
         # Collect the static files (eg for the Persona or Django admin UI)
         run_local_with_env(ctx, "python2.7 manage.py collectstatic --noinput")
         # Update the database schema, if necessary.

--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -7,6 +7,8 @@ class python {
            "python-dev",
            # Required by pylibmc.
            "libmemcached-dev",
+           # Required by Brotli.
+           "g++",
            # To improve the UX of the Vagrant environment.
            "git"]:
     ensure => "latest",

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -2,8 +2,6 @@
 
 gunicorn==19.4.5 --hash=sha256:c57f1b005a4b90933303c8deed9bedeb509331aa6a0a990023a5796e52bd8988
 
-wsgi-sslify==1.0.1 --hash=sha256:cde368fda0fb9958dd58bc2cb955d0bf3df1b79c132d97cee90be5fda34a5089
-
 whitenoise==3.0 --hash=sha256:2537cf2b0c12e1c8beaa23605076344a89d08b686592abffddb6ba13b284a8c6
 
 # Used by the Whitenoise CLI tool to provide Brotli-compressed versions of static files.
@@ -21,9 +19,6 @@ kombu==3.0.33 --hash=sha256:6741a5d7e8b8f53151aabd47fd3df1195aed540b169b2d7684b9
 simplejson==3.8.2 --hash=sha256:d58439c548433adcda98e695be53e526ba940a4b9c44fb9a05d92cd495cdd47f
 
 newrelic==2.60.0.46 --hash=sha256:17d598fccca0845c0337e5276d40d65f951afea6adf9bd9172cff3a87f2ef294
-
-# Required by wsgi-sslify
-Werkzeug==0.11.4 --hash=sha256:7db3cb2d4725be0680abf64a45b18229186f03ad8b9989abbe053f9357b17b37
 
 # Required by datasource
 MySQL-python==1.2.5 --hash=sha256:811040b647e5d5686f84db415efd697e6250008b112b6909ba77ac059e140c74

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -6,6 +6,12 @@ wsgi-sslify==1.0.1 --hash=sha256:cde368fda0fb9958dd58bc2cb955d0bf3df1b79c132d97c
 
 whitenoise==3.0 --hash=sha256:2537cf2b0c12e1c8beaa23605076344a89d08b686592abffddb6ba13b284a8c6
 
+# Used by the Whitenoise CLI tool to provide Brotli-compressed versions of static files.
+# There is not yet an official package on PyPI:
+# https://github.com/google/brotli/issues/72
+https://github.com/google/brotli/archive/v0.3.0.zip#egg=Brotli==0.3.0 \
+    --hash=sha256:0e1e88c74b5a4c9c39123fe8adfdce6262c80524398367420475716389d70791
+
 Django==1.8.10 --hash=sha256:471b41cb53d675138475b488c429424ed143e57ad755a2c8ab1206ac30490284
 
 celery==3.1.20 --hash=sha256:3071b71ef8c43178ace8435002b11f2ff06db7690f07d960540eab7f4183ddf7

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -4,7 +4,7 @@ gunicorn==19.4.5 --hash=sha256:c57f1b005a4b90933303c8deed9bedeb509331aa6a0a99002
 
 wsgi-sslify==1.0.1 --hash=sha256:cde368fda0fb9958dd58bc2cb955d0bf3df1b79c132d97cee90be5fda34a5089
 
-whitenoise==2.0.6 --hash=sha256:826ffe5d608c9dc8daebef1b0b43d01f7958f17c2fce36e75c80e26160172c4f
+whitenoise==3.0 --hash=sha256:2537cf2b0c12e1c8beaa23605076344a89d08b686592abffddb6ba13b284a8c6
 
 Django==1.8.10 --hash=sha256:471b41cb53d675138475b488c429424ed143e57ad755a2c8ab1206ac30490284
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,6 +12,9 @@ responses==0.5.1 --hash=sha256:3a907f7aae2fd2286d06cfdf238957786c38bbcadc451adce
 
 django-extensions==1.6.1 --hash=sha256:f98f991d2b039033ac5faa638c0d1afb2720abf4d9d781573c3592d6899480a1
 
+# Required by django-extension's runserver_plus command.
+Werkzeug==0.11.4 --hash=sha256:7db3cb2d4725be0680abf64a45b18229186f03ad8b9989abbe053f9357b17b37
+
 #for celery auto-reloading
 pyinotify==0.9.6 --hash=sha256:9c998a5d7606ca835065cdabc013ae6c66eb9ea76a00a1e3bc6e0cfe2b4f71f4
 

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -66,6 +66,8 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 )
 
 MIDDLEWARE_CLASSES = [
+    # Redirect to HTTPS/set HSTS and other security headers.
+    'django.middleware.security.SecurityMiddleware',
     # Allows both Django static files and those specified via `WHITENOISE_ROOT`
     # to be served by WhiteNoise, avoiding the need for Apache/nginx on Heroku.
     'treeherder.config.whitenoise_custom.CustomWhiteNoise',
@@ -335,6 +337,10 @@ ALLOWED_HOSTS = env.list("TREEHERDER_ALLOWED_HOSTS", default=[".mozilla.org", ".
 
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+if env.bool('IS_HEROKU', default=False):
+    SECURE_SSL_REDIRECT = True
+    SECURE_HSTS_SECONDS = timedelta(days=365)
 
 # Enable integration between autoclassifier and jobs
 AUTOCLASSIFY_JOBS = env.bool("AUTOCLASSIFY_JOBS", default=False)

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -106,6 +106,9 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.messages',
+    # Disable Django's own staticfiles handling in favour of WhiteNoise, for
+    # greater consistency between gunicorn and `./manage.py runserver`.
+    'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
     'django.contrib.admin',
     # 3rd party apps

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -48,7 +48,7 @@ PERFHERDER_ALERTS_MAX_AGE = timedelta(weeks=2)
 
 # Create hashed+gzipped versions of assets during collectstatic,
 # which will then be served by WhiteNoise with a suitable max-age.
-STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 TEMPLATE_LOADERS = [
     "django.template.loaders.filesystem.Loader",

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -338,7 +338,7 @@ ALLOWED_HOSTS = env.list("TREEHERDER_ALLOWED_HOSTS", default=[".mozilla.org", ".
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
-if env.bool('IS_HEROKU', default=False):
+if SITE_URL.startswith('https://'):
     SECURE_SSL_REDIRECT = True
     SECURE_HSTS_SECONDS = timedelta(days=365)
 

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -31,6 +31,7 @@ USE_I18N = False
 USE_L10N = True
 
 SERVE_MINIFIED_UI = env.bool("SERVE_MINIFIED_UI", default=False)
+# Files in this directory will be served by WhiteNoise at the site root.
 WHITENOISE_ROOT = path("..", "dist" if SERVE_MINIFIED_UI else "ui")
 
 STATIC_ROOT = path("static")
@@ -65,6 +66,9 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 )
 
 MIDDLEWARE_CLASSES = [
+    # Allows both Django static files and those specified via `WHITENOISE_ROOT`
+    # to be served by WhiteNoise, avoiding the need for Apache/nginx on Heroku.
+    'treeherder.config.whitenoise_custom.CustomWhiteNoise',
     'django.middleware.gzip.GZipMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/treeherder/config/whitenoise_custom.py
+++ b/treeherder/config/whitenoise_custom.py
@@ -4,12 +4,20 @@ from whitenoise.middleware import WhiteNoiseMiddleware
 
 
 class CustomWhiteNoise(WhiteNoiseMiddleware):
+    """
+    Adds two additional features to WhiteNoise:
 
-    # Matches grunt-cache-busting's style of hash filenames.
+    1) Serving index pages for directory paths (such as the site root).
+    2) Setting long max-age headers for files created by grunt-cache-busting.
+    """
+
+    # Matches grunt-cache-busting's style of hash filenames. eg:
+    #   index.min-feae259e2c205af67b0e91306f9363fa.js
     IMMUTABLE_FILE_RE = re.compile(r'\.min-[a-f0-9]{32}\.(js|css)$')
     INDEX_NAME = 'index.html'
 
     def update_files_dictionary(self, *args):
+        """Add support for serving index pages for directory paths."""
         super(CustomWhiteNoise, self).update_files_dictionary(*args)
         index_page_suffix = "/" + self.INDEX_NAME
         index_name_length = len(self.INDEX_NAME)
@@ -21,6 +29,7 @@ class CustomWhiteNoise(WhiteNoiseMiddleware):
         self.files.update(index_files)
 
     def find_file(self, url):
+        """Add support for serving index pages for directory paths when in DEBUG mode."""
         # In debug mode, find_file() is used to serve files directly from the filesystem
         # instead of using the list in `self.files`, so we append the index filename so
         # that will be served if present.
@@ -29,8 +38,7 @@ class CustomWhiteNoise(WhiteNoiseMiddleware):
         return super(CustomWhiteNoise, self).find_file(url)
 
     def is_immutable_file(self, path, url):
-        # Support grunt-cache-busting's style of hash filenames. eg:
-        #   index.min-feae259e2c205af67b0e91306f9363fa.js
+        """Support grunt-cache-busting style filenames when setting long max-age headers."""
         if self.IMMUTABLE_FILE_RE.search(url):
             return True
         # Otherwise fall back to the default method, so we catch filenames in the

--- a/treeherder/config/whitenoise_custom.py
+++ b/treeherder/config/whitenoise_custom.py
@@ -1,9 +1,9 @@
 import re
 
-from whitenoise.django import DjangoWhiteNoise
+from whitenoise.middleware import WhiteNoiseMiddleware
 
 
-class CustomWhiteNoise(DjangoWhiteNoise):
+class CustomWhiteNoise(WhiteNoiseMiddleware):
 
     # Matches grunt-cache-busting's style of hash filenames.
     IMMUTABLE_FILE_RE = re.compile(r'\.min-[a-f0-9]{32}\.(js|css)$')

--- a/treeherder/config/whitenoise_custom.py
+++ b/treeherder/config/whitenoise_custom.py
@@ -9,8 +9,8 @@ class CustomWhiteNoise(DjangoWhiteNoise):
     IMMUTABLE_FILE_RE = re.compile(r'\.min-[a-f0-9]{32}\.(js|css)$')
     INDEX_NAME = 'index.html'
 
-    def add_files(self, *args, **kwargs):
-        super(CustomWhiteNoise, self).add_files(*args, **kwargs)
+    def update_files_dictionary(self, *args):
+        super(CustomWhiteNoise, self).update_files_dictionary(*args)
         index_page_suffix = "/" + self.INDEX_NAME
         index_name_length = len(self.INDEX_NAME)
         index_files = {}

--- a/treeherder/config/wsgi.py
+++ b/treeherder/config/wsgi.py
@@ -19,15 +19,9 @@ from django.core.cache.backends.memcached import BaseMemcachedCache
 from django.core.wsgi import get_wsgi_application as django_app
 from wsgi_sslify import sslify
 
-from treeherder.config.whitenoise_custom import CustomWhiteNoise
-
 env = environ.Env()
 
-# Wrap the Django WSGI app with WhiteNoise so the UI can be served by gunicorn
-# in production, avoiding the need for Apache/nginx on Heroku. WhiteNoise will
-# serve the Django static files at /static/ and also those in the directory
-# referenced by WHITENOISE_ROOT at the site root.
-application = CustomWhiteNoise(django_app())
+application = django_app()
 
 if env.bool('IS_HEROKU', default=False):
     # Redirect HTTP requests to HTTPS and set an HSTS header.

--- a/treeherder/config/wsgi.py
+++ b/treeherder/config/wsgi.py
@@ -14,20 +14,11 @@ import os
 # os.environ["DJANGO_SETTINGS_MODULE"] = "treeherder.config.settings"
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "treeherder.config.settings")
 
-import environ
 from django.core.cache.backends.memcached import BaseMemcachedCache
-from django.core.wsgi import get_wsgi_application as django_app
-from wsgi_sslify import sslify
+from django.core.wsgi import get_wsgi_application
 
-env = environ.Env()
 
-application = django_app()
-
-if env.bool('IS_HEROKU', default=False):
-    # Redirect HTTP requests to HTTPS and set an HSTS header.
-    # Required since the equivalent Django features will not be
-    # able to alter requests that were served by WhiteNoise.
-    application = sslify(application)
+application = get_wsgi_application()
 
 # Fix django closing connection to MemCachier after every request:
 # https://code.djangoproject.com/ticket/11331


### PR DESCRIPTION
WhiteNoise 3.0 now uses a Django middleware-based approach of integrating with Django, which means:
* simpler integration
* the ability to still use [Django's security middleware](https://docs.djangoproject.com/en/1.8/ref/middleware/#django.middleware.security.SecurityMiddleware) for things like HTTPS redirection, avoiding the need for yet another package (wsgi-sslify)
* Brotli compression support
* improved mimetype handling
* more consistent behaviour between development and production environments

For more info, see the [WhiteNoise changelog](http://whitenoise.evans.io/en/latest/changelog.html).

David Evans asked if I could give it a spin before he produced the final release, and from my testing locally it works really well.

See individual commit diffs & messages for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1362)
<!-- Reviewable:end -->
