### PR TITLE
Bug 1198978 - Pressing "Save" when no jobs are selected on the pinboard…

### DIFF
--- a/ui/partials/main/thPinboardPanel.html
+++ b/ui/partials/main/thPinboardPanel.html
@@ -67,11 +67,11 @@
 <div id="pinboard-controls" class="btn-group-vertical"
      title="{{!hasPinnedJobs() ? 'No jobs pinned' : ''}}">
   <div class="btn-group">
-    <span class="btn btn-default btn-xs save-btn"
-          title="Save all classification data"
+    <button class="btn btn-default btn-xs save-btn"
+          title="{{ !hasPinnedJobs() ? 'No job selected' : 'Save all classification data' }}"
           ng-click="save()"
           ng-disabled="!hasPinnedJobs()">save
-    </span>
+    </button>
     <span class="btn btn-default btn-xs dropdown-toggle save-btn-dropdown"
           title="Additional pinboard functions"
           ng-disabled="!hasPinnedJobs() && !hasRelatedBugs()"


### PR DESCRIPTION
… clears the classification/comment

added condition to ng-click to prevent save() from being called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1366)
<!-- Reviewable:end -->
