### PR TITLE
Bug 1259570 - Throw exception if adding an artifact to a job without a guid

### DIFF
--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -342,6 +342,17 @@ class TreeherderJobTest(DataSetup, unittest.TestCase):
             tj_dict = TreeherderJob(job)
             self.compare_structs(tj.data, tj_dict.data)
 
+    def test_error_add_artifact_no_guid(self):
+
+        tj = TreeherderJob()
+        job_data = self.job_data[0]
+
+        with self.assertRaises(TreeherderClientError):
+            tj.add_artifact(
+                job_data['job']['artifacts'][0]['name'],
+                job_data['job']['artifacts'][0]['type'],
+                job_data['job']['artifacts'][0]['blob'])
+
     def test_job_guid_validation(self):
 
         tj = TreeherderJob(self.job_data[0])

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -247,6 +247,10 @@ class TreeherderJob(TreeherderData, ValidatorMixin):
                 )
 
     def add_artifact(self, name, artifact_type, blob):
+
+        if not self.data['job']['job_guid']:
+            raise TreeherderClientError('job guid must be set before adding '
+                                        'artifact', [])
         if blob:
             self.data['job']['artifacts'].append({
                 'name': name,


### PR DESCRIPTION
This will create artifacts that get ignored by treeherder, which we don't
want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1368)
<!-- Reviewable:end -->
