### PR TITLE
Bug 1259567 - Add a title and UI improvements for the Tier menu

### DIFF
--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -54,8 +54,10 @@ input:focus::-moz-placeholder {
   visibility: hidden;
 }
 
+/* Presently Tier menu, Similar Jobs panel */
 .checkbox {
-  min-height: 20px; /* Override bootstrap 3.3.5 for similar jobs panel */
+  min-height: 20px;
+  padding-left: 4px;
 }
 
 .dropdown-menu > li > a {

--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -22,7 +22,7 @@
 
 .navbar .dropdown-menu {
     max-height: 600px;
-    min-width: 112px;
+    min-width: 80px;
     overflow: auto;
     margin-top: 10px;
     padding-bottom: 8px;

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -18,6 +18,7 @@
         <!--Toggle Tiers filter Button-->
         <span th-checkbox-dropdown-container class="dropdown">
           <span id="tierLabel" role="button"
+                  title="Show/hide job tiers"
                   href="#" data-toggle="dropdown" data-target="#"
                   class="btn btn-view-nav btn-sm nav-menu-btn">Tiers
             <span class="fa fa-angle-down lightgray"></span>
@@ -32,7 +33,7 @@
                          class="dropdown-checkboxk"
                          ng-model="tiers[tier]"
                          ng-change="tierToggled(tier)">
-                  Show Tier {{::tier}}
+                  tier {{::tier}}
                 </label>
               </div>
             </li>


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1259567](https://bugzilla.mozilla.org/show_bug.cgi?id=1259567).

This (maybe?) improves the new Tier menu with a few things:
* a new Title property, consistent with its neighbors
* a menu using lowercase 'tier' visually consistent with our actual job labels
* removing 'Show' which was repeated in the menus
* some minor padding improvements

Current:
![tiermenucurrent](https://cloud.githubusercontent.com/assets/3660661/14030134/6dd2803e-f1dc-11e5-8892-3895768a758b.jpg)

Proposed:
![tiermenuproposed](https://cloud.githubusercontent.com/assets/3660661/14030194/cbdc1d2a-f1dc-11e5-8121-01e42ea597cb.jpg)

We also get a bit better padding on the checkboxes in the Similar Jobs details pane (I've just noted it in pink in the screen grab only).

Everything seems fine on both browsers. I wasn't able to find anywhere else which might be impacted by that extra `4px` padding, Perfherder, etc.

I defer to you guys though on these proposed changes :)

Tested on OSX 10.11.4:
Nightly **47.0a1 (2016-03-03)**
Chrome Latest Release **49.0.2623.87 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1369)
<!-- Reviewable:end -->
