### PR TITLE
Bug 1245760 - Display the failed buildbot step in the log summary pan…

### DIFF
--- a/ui/plugins/failure_summary/main.html
+++ b/ui/plugins/failure_summary/main.html
@@ -63,7 +63,25 @@
 
         </li>
 
-        <li ng-if="!tabs.failureSummary.is_loading && jobLogsAllParsed && bugSuggestionsLoaded && job_log_urls.length && suggestions.length == 0">
+        <li>
+            <span ng-if="errors.length > 0">
+              <div>
+                <span>No Bug Suggestions Available.</span>
+              </div>
+              <span><b>Unsuccessful Execution Steps</b></span>
+              <li ng-repeat="error in errors">
+                  <ul>
+                      <li>{{error.name}} : {{error.result}}.
+                        <a title="Open in Log Viewer"
+                           target="_blank"
+                           href="{{error.lvURL}}">View log</a>
+                      </li>
+                  </ul>
+              </li>
+            </span>
+        </li>
+
+        <li ng-if="!tabs.failureSummary.is_loading && jobLogsAllParsed && bugSuggestionsLoaded && job_log_urls.length && suggestions.length == 0 && errors.length == 0">
             <div class="failure-summary-line-empty">
                 <span>Failure summary is empty</span>
             </div>


### PR DESCRIPTION
…e if nothing else.
@camd, I don't think this is strictly a "log viewer" and hence it doesn't redirect to the correct line number. What would be the correct way to get the URL?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1370)
<!-- Reviewable:end -->
