### PR TITLE
Bug 1242038 - Store unique job signatures for buildernames

### DIFF
--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -107,10 +107,10 @@ job_filter_values = [
  (u'option_collection_hash', u'32faaecac742100f7753f0c1d0aa0add01b4046b'),
  (u'platform', u'osx-10-7'),
  (u'reason', u'scheduler'),
- (u'ref_data_name', u'1f2ea1934af0731400c4a5ab831e0c5ec287f0ad'),
+ (u'ref_data_name', u'58cab069cf08211159774de948094dd963fb9d44'),
  (u'result', u'success'),
  (u'result_set_id', 4),
- (u'signature', u'1f2ea1934af0731400c4a5ab831e0c5ec287f0ad'),
+ (u'signature', u'58cab069cf08211159774de948094dd963fb9d44'),
  (u'start_timestamp', 1384356880),
  (u'state', u'completed'),
  (u'submit_timestamp', 1384356854),
@@ -133,7 +133,7 @@ def test_job_list_filter_fields(webapp, eleven_jobs_stored, jm, fieldname, expec
     url = reverse("jobs-list",
                   kwargs={"project": jm.project})
     final_url = url + "?{}={}".format(fieldname, expected)
-    print final_url
+    print(final_url)
     resp = webapp.get(final_url).json
     first = resp['results'][0]
 

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1348,6 +1348,8 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
 
         build_system_type = job.get('build_system_type', 'buildbot')
 
+        reference_data_name = job.get('reference_data_name', None)
+
         sh = sha1()
         sh.update(''.join(
             map(lambda x: str(x),
@@ -1356,12 +1358,12 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                  machine_platform.os_name, machine_platform.platform,
                  machine_platform.architecture,
                  job_group.name, job_group.symbol, job_type.name,
-                 job_type.symbol, option_collection_hash])))
+                 job_type.symbol, option_collection_hash,
+                 reference_data_name])))
         signature_hash = sh.hexdigest()
 
         # Should be the buildername in the case of buildbot (if not provided
         # default to using the signature hash)
-        reference_data_name = job.get('reference_data_name', None)
         if not reference_data_name:
             reference_data_name = signature_hash
 


### PR DESCRIPTION
If our regexes give the same platform values for several different
buildernames, then we may find the wrong signature and buildername for
those jobs.  This means that we will send the wrong buildername when
attempting to backfill or retrigger jobs.

This change ensures that the reference_data_signature is unique for
every buildername we get from buildbot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1372)
<!-- Reviewable:end -->
