### PR TITLE
Bug 1255406 - "Retrigger all" on a >10 pinned jobs only retriggers 10

### DIFF
--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -368,7 +368,10 @@ treeherder.controller('PluginCtrl', [
                 // to the self serve api (which does not listen over pulse!).
                 ThJobModel.retrigger($scope.repoName, job_id_list).then(function() {
                     // XXX: Remove this after 1134929 is resolved.
-                    return ThJobArtifactModel.get_list({"name": "buildapi", "type": "json", "job_id__in": job_id_list.join(',')})
+                    return ThJobArtifactModel.get_list({"name": "buildapi",
+                                                        "type": "json",
+                                                        "count": job_id_list.length,
+                                                        "job_id__in": job_id_list.join(',')})
                         .then(function(data) {
                             var request_id_list = _.pluck(_.pluck(data, 'blob'), 'request_id');
                             _.each(request_id_list, function(request_id) {


### PR DESCRIPTION
The /artifacts endpoint defaults to only returning the first 10 items
unless a count is passed in.  We weren’t passing in that param, so we’d
only get back the first 10 (we need them for the buildbot request_ids).

This fixes it by passing in a “count” param equal to the number of jobs
we want to retrigger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1373)
<!-- Reviewable:end -->
