### PR TITLE
Bug 1117583 - Add UI to treeherder to use the new bug filing API

### DIFF
--- a/treeherder/config/settings_local.example.py
+++ b/treeherder/config/settings_local.example.py
@@ -1,5 +1,5 @@
 # Switch to using a different bugzilla instance
-BZ_API_URL = "http://bugzilla-dev.allizom.org/"
+BZ_API_URL = "https://bugzilla-dev.allizom.org"
 
 # Applications useful for development, e.g. debug_toolbar, django_extensions.
 # Always empty in production

--- a/ui/css/treeherder-bugfiler.css
+++ b/ui/css/treeherder-bugfiler.css
@@ -1,0 +1,59 @@
+/*
+ * Intermittent Bug Filer
+ */
+#modalForm {
+    padding: 20px;
+}
+
+#modalSummarylabel {
+  margin-top: -5px;
+}
+
+#modalSummary {
+    width:80%;
+}
+
+#modalComment {
+    width:80%;
+    height:150px;
+}
+
+#modalForm > div:not(#modalLogLinkCheckboxes) > label, #productFinderButton {
+    float:left;
+    padding: 5px;
+}
+
+#modalLogLinkCheckboxes {
+    padding-left:15px;
+    padding-bottom:5px;
+    color: #337AB7;
+}
+
+#modalLogLinkCheckboxes a {
+    color:inherit;
+}
+
+#modalForm > div:after {
+    content: ".";
+    display: block;
+    height: 0;
+    clear: both;
+    visibility: hidden;
+}
+
+#modalBottomDiv {
+    padding:5px;
+    width:650px;
+}
+
+#modalBottomDiv button {
+    /* float:right; */
+}
+
+#modalFailureList {
+  width: 80%;
+  padding: 5px;
+  max-height: 250px;
+  overflow: auto;
+  clear:both;
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -18,6 +18,7 @@
         <link href="css/treeherder-job-buttons.css" rel="stylesheet" media="screen">
         <link href="css/treeherder-resultsets.css" rel="stylesheet" media="screen">
         <link href="css/treeherder-pinboard.css" rel="stylesheet" media="screen">
+        <link href="css/treeherder-bugfiler.css" rel="stylesheet" media="screen">
         <link href="vendor/css/persona-buttons.css" rel="stylesheet" media="screen">
         <!-- endbuild -->
 
@@ -121,6 +122,7 @@
         <script src="js/controllers/repository.js"></script>
         <script src="js/controllers/filters.js"></script>
         <script src="js/controllers/jobs.js"></script>
+        <script src="js/controllers/bugfiler.js"></script>
         <!-- Plugins -->
         <script src="plugins/tabs.js"></script>
         <script src="plugins/controller.js"></script>

--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -1,0 +1,226 @@
+"use strict";
+
+treeherder.controller('BugFilerCtrl', [
+    '$scope', '$rootScope', '$uibModalInstance', '$http', 'summary', 'thBugzillaProductObject',
+    'thPinboard', 'thEvents', 'fullLog', 'parsedLog', 'reftest', 'selectedJob', 'allFailures',
+    'thNotify', 'ThLog',
+    function BugFilerCtrl(
+        $scope, $rootScope, $uibModalInstance, $http, summary, thBugzillaProductObject,
+        thPinboard, thEvents, fullLog, parsedLog, reftest, selectedJob, allFailures,
+        thNotify, ThLog) {
+
+        var $log = new ThLog("BugFilerCtrl");
+
+        $scope.omittedLeads = ["TEST-UNEXPECTED-FAIL", "PROCESS-CRASH", "TEST-UNEXPECTED-ERROR", "TEST-UNEXPECTED-TIMEOUT"];
+
+        /**
+         *  'enter' from the product search input should initiate the search
+         */
+        $scope.productSearchEnter = function(ev) {
+            if (ev.keyCode === 13) {
+                $scope.findProduct();
+            }
+        };
+
+        /*
+         **
+         */
+        $scope.isReftest = function() {
+            return reftest !== "";
+        };
+
+        $scope.parsedLog = parsedLog;
+        $scope.fullLog = fullLog;
+        if ($scope.isReftest()) {
+            $scope.reftest = reftest;
+        }
+
+        /**
+         *  Pre-fill the form with information/metadata from the failure
+         */
+        $scope.initiate = function() {
+            var thisFailure = "";
+            for(var i = 0; i < allFailures.length; i++) {
+                for(var j=0; j < $scope.omittedLeads.length; j++) {
+                    if(allFailures[i][0].search($scope.omittedLeads[j]) >= 0) {
+                        allFailures[i].shift();
+                    }
+                }
+                if(i !== 0) {
+                    thisFailure += "\n";
+                }
+                thisFailure += allFailures[i].join(" | ");
+            }
+            $scope.thisFailure = thisFailure;
+
+            $scope.findProduct();
+        };
+
+        $uibModalInstance.parsedSummary = "";
+        $uibModalInstance.initiate = $scope.initiate;
+        $uibModalInstance.possibleFilename = "";
+
+        /*
+         *  Remove extraneous junk from the start of the summary line
+         *  and try to find the failing test name from what's left
+         */
+        $uibModalInstance.parseSummary = function(summary) {
+            summary = summary.split(" | ");
+
+            for(var i=0; i < $scope.omittedLeads.length; i++) {
+                if(summary[0].search($scope.omittedLeads[i]) >= 0) {
+                    summary.shift();
+                }
+            }
+
+            $uibModalInstance.possibleFilename = summary[0].split("/").pop();
+
+            return [summary, $uibModalInstance.possibleFilename];
+        };
+
+        $uibModalInstance.parsedSummary = $uibModalInstance.parseSummary(summary);
+        $scope.modalSummary = "Intermittent " + $uibModalInstance.parsedSummary[0].join(" | ");
+
+        $scope.toggleFilerSummaryVisibility = function() {
+            $scope.isFilerSummaryVisible = !$scope.isFilerSummaryVisible;
+        };
+
+        $scope.isFilerSummaryVisible = false;
+
+        /*
+         *  Attempt to find a good product/component for this failure
+         */
+        $scope.findProduct = function() {
+            $scope.suggestedProducts = [];
+            var failurePath = $uibModalInstance.parsedSummary[0][0];
+            var failurePathRoot = failurePath.split("/")[0];
+
+            // Look up the product via the root of the failure's file path
+            if(thBugzillaProductObject[failurePathRoot]) {
+                $scope.suggestedProducts.push(thBugzillaProductObject[failurePathRoot][0]);
+                $scope.selectedProduct = $scope.suggestedProducts[0];
+            }
+
+            // Look up product suggestions via Bugzilla's api
+            var productSearch = $scope.productSearch;
+
+            if(productSearch) {
+                $http.get("https://bugzilla.mozilla.org/rest/prod_comp_search/" + productSearch + "?limit=5").then(function(request) {
+                    var data = request.data;
+                    // We can't file unless product and component are provided, this api can return just product. Cut those out.
+                    for(var i = data.products.length - 1; i >= 0; i--) {
+                        if(!data.products[i].component) {
+                            data.products.splice(i, 1);
+                        }
+                    }
+                    $scope.suggestedProducts = [];
+                    $scope.suggestedProducts = _.map(data.products, function(prod) {
+                        if(prod.product && prod.component) {
+                            return prod.product + " :: " + prod.component;
+                        } else {
+                            return prod.product;
+                        }
+                    });
+                    $scope.selectedProduct = $scope.suggestedProducts[0];
+                });
+            }
+        };
+
+        /*
+         *  Same as clicking outside of the modal, but with a nice button-clicking feel...
+         */
+        $scope.cancelFiler = function() {
+            $uibModalInstance.dismiss('cancel');
+        };
+
+        $scope.checkedLogLinks = {
+            parsedLog: $scope.parsedLog,
+            fullLog: $scope.fullLog,
+            reftest: $scope.reftest
+        };
+
+        /*
+         *  Actually send the gathered information to bugzilla.
+         */
+        $scope.submitFiler = function() {
+            var summarystring = $scope.modalSummary;
+            var productString = "";
+            var componentString = "";
+
+            $scope.toggleForm(true);
+            if($scope.selectedProduct) {
+                var prodParts = $scope.selectedProduct.split(" :: ");
+                productString += prodParts[0];
+                componentString += prodParts[1];
+            } else {
+                thNotify.send("Please select (or search and select) a product/component pair to continue", "danger");
+                $scope.toggleForm(false);
+                return;
+            }
+
+            var descriptionStrings = _.reduce($scope.checkedLogLinks, function(result, link) {
+                if(link) {
+                    result = result + link + "\n\n";
+                }
+                return result;
+            }, "");
+            if($scope.modalComment) {
+                descriptionStrings += $scope.modalComment;
+            }
+
+            // Fetch product information from bugzilla to get version numbers, then submit the new bug
+            // Only request the versions because some products take quite a long time to fetch the full object
+            $.ajax("https://bugzilla.mozilla.org/rest/product/" + productString + "?include_fields=versions").done(function(productJSON) {
+                var productObject = productJSON.products[0];
+                $http({
+                    url: "api/bugzilla/create_bug/",
+                    method: "POST",
+                    data: {
+                        "product": productString,
+                        "component": componentString,
+                        "summary": summarystring,
+                        "keywords": "intermittent-failure",
+                        // XXX This takes the last version returned from the product query, probably should be smarter about this in the future...
+                        "version": productObject.versions[productObject.versions.length-1].name,
+                        "description": descriptionStrings,
+                        "comment_tags": "treeherder"
+                    }
+                }).then(function successCallback(json) {
+                    if(json.data.failure) {
+                        var errorString = "";
+                        for (var i = 0; i < json.data.failure.length; i++) {
+                            errorString += json.data.failure[i];
+                        }
+                        errorString = JSON.parse(errorString);
+                        thNotify.send("Bugzilla error: " + errorString.message, "danger", true);
+                        $scope.toggleForm(false);
+                    } else {
+                        // Auto-classify this failure now that the bug has been filed and we have a bug number
+                        thPinboard.pinJob($rootScope.selectedJob);
+                        thPinboard.addBug({id:json.data.success});
+                        $rootScope.$evalAsync($rootScope.$emit(thEvents.saveClassification));
+
+                        // Open the newly filed bug in a new tab or window for further editing
+                        window.open("https://bugzilla.mozilla.org/show_bug.cgi?id=" + json.data.success);
+                        $scope.cancelFiler();
+                    }
+                }, function errorCallback(response) {
+                    var failureString = "Bug Filer API returned status " + response.status + " (" + response.statusText + ")";
+                    if(response.data && response.data.failure) {
+                        failureString += "\n\n" + response.data.failure;
+                    }
+                    thNotify.send(failureString, "danger");
+                    $scope.toggleForm(false);
+                });
+            });
+        };
+
+        /*
+         *  Disable or enable form elements as needed at various points in the submission process
+         */
+        $scope.toggleForm = function(disabled) {
+            $(':input','#modalForm').attr("disabled", disabled);
+        };
+    }
+]);
+

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -2,13 +2,13 @@
 
 treeherderApp.controller('MainCtrl', [
     '$scope', '$rootScope', '$routeParams', '$location', 'ThLog',
-    'ThRepositoryModel', 'thPinboard', 'thNotify', 'thTabs',
+    'ThRepositoryModel', 'thPinboard', 'thTabs',
     'thClassificationTypes', 'thEvents', '$interval', '$window',
     'ThExclusionProfileModel', 'thJobFilters', 'ThResultSetStore',
     'thDefaultRepo', 'thJobNavSelectors', 'thTitleSuffixLimit', 'ThResultSetModel',
     function MainController(
         $scope, $rootScope, $routeParams, $location, ThLog,
-        ThRepositoryModel, thPinboard, thNotify, thTabs,
+        ThRepositoryModel, thPinboard, thTabs,
         thClassificationTypes, thEvents, $interval, $window,
         ThExclusionProfileModel, thJobFilters, ThResultSetStore,
         thDefaultRepo, thJobNavSelectors, thTitleSuffixLimit, ThResultSetModel) {
@@ -561,6 +561,7 @@ treeherderApp.controller('MainCtrl', [
         $scope.pinboardCount = thPinboard.count;
         $scope.pinnedJobs = thPinboard.pinnedJobs;
         $scope.jobFilters = thJobFilters;
+
     }
 ]);
 

--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -269,3 +269,90 @@ treeherder.value("thJobNavSelectors",
 treeherder.value("thPerformanceBranches", [
     "mozilla-inbound", "mozilla-central", "fx-team"
 ]);
+
+treeherder.value("thBugzillaProductObject", {
+    "accessible":
+        ["Core :: Disability Access APIs","Firefox :: Disability Access"],
+    "addon-sdk":
+        ["Add-on SDK :: General"],
+    "b2g":
+        ["Firefox OS :: General"],
+    "browser":
+        ["Firefox :: General"],
+    "build":
+        ["Core :: Build Config"],
+    "caps":
+        ["Core :: Security: CAPS"],
+    "config":
+        ["Firefox :: Build Config","Core :: Build Config","Firefox for Android :: Build Config & IDE Support"],
+    "db":
+        ["Toolkit :: Storage"],
+    "devtools":
+        ["Firefox :: Developer Tools"],
+    "docshell":
+        ["Core :: Document Navigation"],
+    "dom":
+        ["Core :: DOM"],
+    "editor":
+        ["Core :: Editor"],
+    "embedding":
+        ["Core :: Embedding: APIs"],
+    "gfx":
+        ["Core :: Graphics","Core :: Graphics: Layers","Core :: Graphics: Text"],
+    "gradle":
+        ["Core :: Build Config"],
+    "hal":
+        ["Core :: Hardware Abstraction Layer (HAL)"],
+    "image":
+        ["Core :: ImageLib"],
+    "intl":
+        ["Core :: Internationalization"],
+    "ipc":
+        ["Core :: IPC","Core :: DOM: Content Processes"],
+    "js":
+        ["Core :: Javascript Engine","Core :: Javascript Engine: Jit","Core :: Javascript Engine: GC","Core :: Javascript Engine: Internationalization API","Core :: Javascript Engine: Standard Library"],
+    "layout":
+        ["Core :: Layout"],
+    "media":
+        ["Core :: Audio/Video"],
+    "memory":
+        ["Core :: Memory Allocator"],
+    "mfbt":
+        ["Core :: MFBT"],
+    "mobile":
+        ["Firefox for Android :: General"],
+    "mozglue":
+        ["Core :: mozglue"],
+    "netwerk":
+        ["Core :: Networking"],
+    "nsprpub":
+        ["NSPR :: NSPR"],
+    "parser":
+        ["Core :: HTML: Parser"],
+    "rdf":
+        ["Core :: RDF"],
+    "security":
+        ["Core :: Security","Firefox :: Security"],
+    "services":
+        ["Core :: Web Services"],
+    "startupcache":
+        ["Core :: XPCOM"],
+    "storage":
+        ["Toolkit :: Storage"],
+    "testing":
+        ["Testing :: General"],
+    "toolkit":
+        ["Toolkit :: General"],
+    "view":
+        ["Core :: Layout"],
+    "webapprt":
+        ["Firefox :: Webapp Runtime"],
+    "widget":
+        ["Core :: Widget"],
+    "xpcom":
+        ["Core :: XPCOM"],
+    "xpfe":
+        ["Core :: XUL"],
+    "xulrunner":
+        ["Toolkit :: XULRunner"]
+});

--- a/ui/partials/main/intermittent.html
+++ b/ui/partials/main/intermittent.html
@@ -1,0 +1,64 @@
+<form id="modalForm">
+  <h2> Intermittent Bug Filer </h2>
+
+  <input name="modalProductFinderSearch" id="modalProductFinderSearch" ng-keydown="productSearchEnter($event)"
+         ng-model="productSearch" type="text" placeholder="Firefox" uib-tooltip="Manually search for a product" />
+  <button name="modalProductFinderButton" id="modalProductFinderButton"
+          type="button" ng-click="findProduct()" prevent-default-on-left-click>Find Product</button>
+  <div>
+    <fieldset id="suggestedProducts">
+      <div ng-repeat="product in suggestedProducts">
+        <input type="radio" value="{{product}}"
+               ng-model="selectedProduct"
+               name="productGroup" id="modalProductSuggestion{{$id}}"/>
+        <label for="modalProductSuggestion{{$id}}">{{product}}</label>
+      </div>
+    </fieldset>
+  </div>
+
+  <br/><br/>
+
+  <div id="failureSummaryGroup" class="collapsed">
+    <label id="modalSummarylabel" for="modalSummary">Summary:</label>
+    <input id="modalSummary" type="text" placeholder="Intermittent..." maxlength="255" ng-model="modalSummary" />
+    <a ng-class="{'filersummary-open-btn': isFilerSummaryVisible}" prevent-default-on-left-click>
+      <i ng-click="toggleFilerSummaryVisibility()" ng-hide="isFilerSummaryVisible" class="fa fa-chevron-right" uib-tooltip="Show all failure lines for this job"></i>
+      <span ng-show="isFilerSummaryVisible">
+        <i ng-click="toggleFilerSummaryVisibility()" class="fa fa-chevron-down" uib-tooltip="Hide all failure lines for this job"></i>
+        <textarea id="modalFailureList">{{thisFailure}}</textarea>
+      </span>
+    </a>
+  </div>
+
+  <div id="modalLogLinkCheckboxes">
+    <label>
+      <input id="modalParsedLog" type="checkbox"
+             ng-model="checkedLogLinks.parsedLog"
+             ng-true-value="'{{parsedLog}}'"/>
+      <a target="_blank" href="{{ parsedLog }}">Include Parsed Log Link</a>
+    </label><br/>
+    <label>
+      <input id="modalFullLog" type="checkbox"
+             ng-model="checkedLogLinks.fullLog"
+             ng-true-value="'{{fullLog}}'"/>
+      <a target="_blank"  href="{{ fullLog }}">Include Full Log Link</a>
+    </label><br/>
+    <label id="modalReftestLogLabel" ng-if="isReftest()">
+      <input id="modalReftestLog" type="checkbox"
+             ng-model="checkedLogLinks.reftest"
+             ng-true-value="'{{reftest}}'"/>
+      <a target="_blank" href="{{ reftest }}">Include Reftest Viewer Link</a>
+    </label>
+  </div>
+
+  <div id="modalCommentDiv">
+    <label id="modalCommentlabel" for="modalComment">Comment:</label>
+    <textarea ng-model="modalComment" id="modalComment" type="textarea" placeholder=""></textarea>
+  </div>
+
+  <div id="modalBottomDiv">
+    <button name="modalCancelButton" id="modalCancelButton" type="button" ng-click="cancelFiler()"> Cancel </button>
+    <button name="modalSubmitButton" id="modalSubmitButton" type="button" ng-click="submitFiler()"> Submit Bug </button>
+  </div>
+</form>
+

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -22,6 +22,8 @@ treeherder.controller('PluginCtrl', [
         $scope.job = {};
         $scope.artifacts = {};
 
+        var reftestUrlRoot = "https://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl=";
+
         var getJobSearchStrHref = function(jobSearchStr){
             var absUrl = $location.absUrl();
 
@@ -205,6 +207,7 @@ treeherder.controller('PluginCtrl', [
 
                     $scope.lvUrl = thUrl.getLogViewerUrl($scope.job.id);
                     $scope.lvFullUrl = location.origin + "/" + $scope.lvUrl;
+                    $scope.reftestUrl = reftestUrlRoot + $scope.job_log_urls[0].url + "&only_show_unexpected=1";
                     $scope.resultStatusShading = "result-status-shading-" + thResultStatus($scope.job);
 
                     var performanceData = results[4];

--- a/ui/plugins/failure_summary/main.html
+++ b/ui/plugins/failure_summary/main.html
@@ -3,6 +3,13 @@
 
         <li ng-repeat="suggestion in suggestions">
             <div class="job-tabs-content">
+                <a class="btn btn-xs btn-default"
+                   prevent-default-on-left-click
+                   ng-show="user.loggedin && filerInAddress"
+                   ng-click="fileBug($index)"
+                   title="file a bug for this failure">
+                  <i class="fa fa-bug"></i>
+                </a>
                 <span>{{::suggestion.search}}</span>
             </div>
             <!--Open recent bugs-->

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -99,7 +99,7 @@
           <li ng-if="isReftest()" ng-repeat="job_log_url in job_log_urls">
             <a title="Launch the Reftest Analyser in a new window"
                target="_blank"
-               href="http://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl={{::job_log_url.url}}&only_show_unexpected=1">
+               href="{{::reftestUrl}}">
               <span class="fa fa-bar-chart-o"></span>
             </a>
           </li>


### PR DESCRIPTION
This is now rebased onto the now-landed server-side component to this.

This adds buttons to lines in the failure summary panel when a failed job is selected in the UI. When you click that line, a modal dialog pops up with the new bug filer form. 

At the top of the form, you can select a product/component pair for the bug. An attempt is first made to select the product/component based on the filename of the failure, but that's imperfect, so there's a product finder tool that searches bugzilla for the product/component pair for the soon-to-be-filed bug. 

The form pre-fills the summary line from the line that was clicked in the failure summary panel, stripping out extraneous things like "TEST-UNEXPECTED-FAIL". Off to the right of the Summary field is a '>' button, which shows the other lines from the failure summary so they can be added to the Summary field.

Below that are a few checkboxes. Each checkbox controls whether the URL for a test log is included in the bug description (comment 0). Every failure includes checkboxes for the parsed log and for the full unparsed log, and reftest failures also include a checkbox for the reftest viewer log.

Below the checkboxes is a freeform textbox for adding any additional information to be included in the bug's comment 0.

After all of the information has been verified, click "submit bug" to send the information from the Treeherder UI back to Treeherder's API. Once there, the information is sent on to Bugzilla's REST API, along with the Treeherder Bugzilla API key.

Assuming everything is correct, Bugzilla will send back to the Treeherder server a bug number for the newly filed bug, and the server then passes bug number back to the UI. The failed job is then pinned to the pinboard and the bug number is added to the classification (but the classification is not submitted automatically). Additionally, the new bug is opened in a new tab/window for further changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1374)
<!-- Reviewable:end -->
