### PR TITLE
Bug 1198978 - Fix keyboard input after job classification

### DIFF
--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -72,6 +72,11 @@ treeherder.controller('PinboardCtrl', [
                 $scope.completeClassification();
                 $scope.classification = thPinboard.createNewClassification();
 
+                // HACK: it looks like Firefox on Linux and Windows doesn't
+                // want to accept keyboard input after this change for some
+                // reason which I don't understand. Chrome (any platform)
+                // or Firefox on Mac works fine though.
+                document.activeElement.blur();
             } else {
                 thNotify.send("Must be logged in to save job classifications", "danger");
             }


### PR DESCRIPTION
For some reason changing the span to a button broke keyboard input
after job classification on Firefox on Linux/Windows (not Mac,
any flavor of Chrome also works fine). Blurring the input element
seems to fix this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1376)
<!-- Reviewable:end -->
