### PR TITLE
Bug 1260901 - enable eqeqeq eslint directive for JavaScript

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
         "accessor-pairs": 2,
         "comma-style": 2,
         "eol-last": 2,
+        "eqeqeq": 2,
         "guard-for-in": 2,
         "indent": [2, 4, {"SwitchCase": 1}],
         "linebreak-style": 2,

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -266,7 +266,7 @@ logViewerApp.controller('LogviewerCtrl', [
                         // also need to test for the 0th element for outlier jobs.
                         if ($scope.step_data.steps[0]) {
 
-                            if ($scope.step_data.all_errors.length == 0) {
+                            if ($scope.step_data.all_errors.length === 0) {
                                 angular.element(document).ready(function () {
                                     if (isNaN($scope.selectedBegin)) {
                                         $scope.displayLog($scope.step_data.steps[0], 'initialLoad');

--- a/ui/js/controllers/perf/alerts.js
+++ b/ui/js/controllers/perf/alerts.js
@@ -246,7 +246,7 @@ perf.controller('AlertsCtrl', [
         $scope.getMoreAlertSummariesHref = null;
         $scope.getCappedMagnitude = function(percent) {
             // arbitrary scale from 0-20% multiplied by 5, capped
-            // at 100 (so 20% regression == 100% bad)
+            // at 100 (so 20% regression === 100% bad)
             return Math.min(Math.abs(percent)*5, 100);
         };
 
@@ -492,7 +492,7 @@ perf.controller('AlertsCtrl', [
                                           function(summary) {
                                               if (summary.result_set_id === resultSet.id) {
                                                   summary.resultSetMetadata = resultSet;
-                                              } else if (summary.prev_result_set_id == resultSet.id) {
+                                              } else if (summary.prev_result_set_id === resultSet.id) {
                                                   summary.prevResultSetMetadata = resultSet;
                                               }
                                           });

--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -64,7 +64,7 @@ perf.controller('CompareChooserCtrl', [
                 $scope.proposedRevision = $scope.newRevisionError = null;
 
                 // only check for a full revision
-                if ($scope.newRevision.length != 12) return;
+                if ($scope.newRevision.length !== 12) return;
 
                 $scope.proposedRevisionLoading = true;
 
@@ -229,10 +229,10 @@ perf.controller('CompareResultsCtrl', [
                 $scope.titles[testName] = testName.replace('summary ', '');
                 $scope.platformList.forEach(function(platform) {
                     var oldSig = _.find(Object.keys(rawResultsMap), function(sig) {
-                        return rawResultsMap[sig].name == testName && rawResultsMap[sig].platform == platform;
+                        return rawResultsMap[sig].name === testName && rawResultsMap[sig].platform === platform;
                     });
                     var newSig = _.find(Object.keys(newRawResultsMap), function(sig) {
-                        return newRawResultsMap[sig].name == testName && newRawResultsMap[sig].platform == platform;
+                        return newRawResultsMap[sig].name === testName && newRawResultsMap[sig].platform === platform;
                     });
 
                     var cmap = PhCompare.getCounterMap(testName, rawResultsMap[oldSig], newRawResultsMap[newSig]);
@@ -288,7 +288,7 @@ perf.controller('CompareResultsCtrl', [
                 function(resultSets) {
                     var resultSet = resultSets[0];
                     //TODO: this is a bit hacky to pass in 'original' as a text string
-                    if (rsid == 'original') {
+                    if (rsid === 'original') {
                         $scope.originalResultSet = resultSet;
                     } else {
                         $scope.newResultSet = resultSet;
@@ -381,7 +381,7 @@ perf.controller('CompareSubtestResultsCtrl', [
                 function(resultSets) {
                     var resultSet = resultSets[0];
                     //TODO: this is a bit hacky to pass in 'original' as a text string
-                    if (rsid == 'original') {
+                    if (rsid === 'original') {
                         $scope.originalResultSet = resultSet;
                     } else {
                         $scope.newResultSet = resultSet;
@@ -436,7 +436,7 @@ perf.controller('CompareSubtestResultsCtrl', [
                         // If no data for a given platform, or test, display N/A in table
                         if (resultsMap) {
                             var tempsig = _.find(Object.keys(resultsMap), function (sig) {
-                                return resultsMap[sig].name == page;
+                                return resultsMap[sig].name === page;
                             });
                         } else {
                             var tempsig = 'undefined';
@@ -449,10 +449,10 @@ perf.controller('CompareSubtestResultsCtrl', [
                     var newSig = mapsigs[1];
 
                     var cmap = PhCompare.getCounterMap(testName, rawResultsMap[oldSig], newRawResultsMap[newSig]);
-                    if (oldSig == $scope.originalSignature ||
-                        oldSig == $scope.newSignature ||
-                        newSig == $scope.originalSignature ||
-                        newSig == $scope.newSignature) {
+                    if (oldSig === $scope.originalSignature ||
+                        oldSig === $scope.newSignature ||
+                        newSig === $scope.originalSignature ||
+                        newSig === $scope.newSignature) {
                         cmap.highlightedTest = true;
                     }
 
@@ -512,7 +512,7 @@ perf.controller('CompareSubtestResultsCtrl', [
                     var resultSetIds = [$scope.originalResultSet.id];
 
                     // Optimization - if old/new branches are the same collect data in one pass
-                    if ($scope.originalProject == $scope.newProject) {
+                    if ($scope.originalProject === $scope.newProject) {
                         resultSetIds = [$scope.originalResultSet.id, $scope.newResultSet.id];
                     }
 

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -63,8 +63,8 @@ perf.controller('GraphsCtrl', [
                 var phSeriesIndex = _.findIndex(
                     $scope.seriesList,
                     function(s) {
-                        return s.projectName == dataPoint.projectName &&
-                            s.signature == dataPoint.signature;
+                        return s.projectName === dataPoint.projectName &&
+                            s.signature === dataPoint.signature;
                     });
                 var phSeries = $scope.seriesList[phSeriesIndex];
 
@@ -78,8 +78,8 @@ perf.controller('GraphsCtrl', [
                 }
                 var flotData = {
                     series: _.find($scope.plot.getData(), function(fs) {
-                        return fs.thSeries.projectName == dataPoint.projectName &&
-                            fs.thSeries.signature == dataPoint.signature;
+                        return fs.thSeries.projectName === dataPoint.projectName &&
+                            fs.thSeries.signature === dataPoint.signature;
                     }),
                     pointIndex: index ? index : phSeries.flotSeries.resultSetData.indexOf(dataPoint.resultSetId)
                 };
@@ -167,7 +167,7 @@ perf.controller('GraphsCtrl', [
 
                     // get new tip position after transform
                     var tipPosition = getTipPosition(tip, x, y, 10);
-                    if (tip.css('visibility') == 'hidden') {
+                    if (tip.css('visibility') === 'hidden') {
                         tip.css({ opacity: 0, visibility: 'visible', left: tipPosition.left,
                                   top: tipPosition.top + 10 });
                         tip.animate({ opacity: 1, left: tipPosition.left,
@@ -185,7 +185,7 @@ perf.controller('GraphsCtrl', [
                 window.clearTimeout($scope.showToolTipTimeout);
             }
 
-            if (!$scope.ttHideTimer && tip.css('visibility') == 'visible') {
+            if (!$scope.ttHideTimer && tip.css('visibility') === 'visible') {
                 $scope.ttHideTimer = setTimeout(function() {
                     $scope.ttHideTimer = null;
                     tip.animate({ opacity: 0, top: '+=10' },
@@ -219,8 +219,8 @@ perf.controller('GraphsCtrl', [
                 var selectedSeriesIndex = _.findIndex(
                     $scope.seriesList,
                     function(s) {
-                        return s.projectName == $scope.selectedDataPoint.projectName &&
-                            s.signature == $scope.selectedDataPoint.signature;
+                        return s.projectName === $scope.selectedDataPoint.projectName &&
+                            s.signature === $scope.selectedDataPoint.signature;
                     });
                 var selectedSeries = $scope.seriesList[selectedSeriesIndex];
                 var flotDataPoint = selectedSeries.flotSeries.jobIdData.indexOf(
@@ -379,7 +379,7 @@ perf.controller('GraphsCtrl', [
             // highlight each explicitly highlighted revision on visible serii
             var highlightPromises = [];
             _.each($scope.highlightedRevisions, function(rev) {
-                if (rev && rev.length == 12) {
+                if (rev && rev.length === 12) {
                     highlightPromises = _.union(
                         highlightPromises, $scope.seriesList.map(function(series) {
                             if (series.visible) {
@@ -450,8 +450,8 @@ perf.controller('GraphsCtrl', [
                     $('#graph').css({ cursor: item ? 'pointer' : '' });
 
                     if (item && item.series.thSeries) {
-                        if (item.seriesIndex != $scope.prevSeriesIndex ||
-                            item.dataIndex != $scope.prevDataIndex) {
+                        if (item.seriesIndex !== $scope.prevSeriesIndex ||
+                            item.dataIndex !== $scope.prevDataIndex) {
                             var seriesDataPoint = getSeriesDataPoint(item);
 
                             showTooltip(seriesDataPoint);
@@ -509,18 +509,18 @@ perf.controller('GraphsCtrl', [
                         series.signature + "," + (series.visible ? 1 : 0) +
                         "]";
                 }),
-                timerange: ($scope.myTimerange.value != phDefaultTimeRangeValue) ?
+                timerange: ($scope.myTimerange.value !== phDefaultTimeRangeValue) ?
                     $scope.myTimerange.value : undefined,
                 highlightedRevisions: _.filter($scope.highlightedRevisions,
                                                function(highlight) {
                                                    return (highlight &&
-                                                           highlight.length == 12);
+                                                           highlight.length === 12);
                                                }),
                 highlightAlerts: !$scope.highlightAlerts ? 0 : undefined,
                 zoom: (function() {
-                    if ((typeof $scope.zoom.x != "undefined")
-                        && (typeof $scope.zoom.y != "undefined")
-                        && ($scope.zoom.x != 0 && $scope.zoom.y != 0)) {
+                    if ((typeof $scope.zoom.x !== "undefined")
+                        && (typeof $scope.zoom.y !== "undefined")
+                        && ($scope.zoom.x !== 0 && $scope.zoom.y !== 0)) {
                         var modifiedZoom = ("[" + ($scope.zoom['x'].toString()
                                                    + ',' + $scope.zoom['y'].toString()) + "]").replace(/[\[\{\}\]"]+/g, '');
                         return modifiedZoom;
@@ -638,7 +638,7 @@ perf.controller('GraphsCtrl', [
             });
             $scope.seriesList = newSeriesList;
 
-            if ($scope.seriesList.length == 0) {
+            if ($scope.seriesList.length === 0) {
                 $scope.resetHighlight();
                 $scope.zoom = {};
             }
@@ -720,7 +720,7 @@ perf.controller('GraphsCtrl', [
                     var partialSeriesObject = {
                         "project":  partialSeriesArray[0],
                         "signature":  partialSeriesArray[1],
-                        "visible": (partialSeriesArray[2] == 0) ? false : true
+                        "visible": (partialSeriesArray[2] === 0) ? false : true
                     };
                     return partialSeriesObject;
                 });
@@ -836,7 +836,7 @@ perf.controller('TestChooserCtrl', function($scope, $uibModalInstance, $http,
     $scope.addTestData = function () {
         if (($scope.testsToAdd.length + testsDisplayed.length) > 6) {
             var a = window.confirm('WARNING: Displaying more than 6 graphs at the same time is not supported in the UI. Do it anyway?');
-            if (a == true) {
+            if (a === true) {
                 addTestToGraph();
             }
         } else {
@@ -871,7 +871,7 @@ perf.controller('TestChooserCtrl', function($scope, $uibModalInstance, $http,
             // add test back to unselected test list if we're browsing for
             // the current project/platform, otherwise just discard it
             if (test.projectName === $scope.selectedProject.name &&
-                test.platform == $scope.selectedPlatform) {
+                test.platform === $scope.selectedPlatform) {
                 $scope.unselectedTestList.push(test);
             }
 

--- a/ui/js/directives/treeherder/main.js
+++ b/ui/js/directives/treeherder/main.js
@@ -18,7 +18,7 @@ treeherder.directive('ngRightClick', [
 treeherder.directive('focusThis', ['$timeout', function($timeout) {
     return function(scope, elem, attr) {
         scope.$on('focus-this', function(event, id) {
-            if (attr.id == id) {
+            if (attr.id === id) {
                 $timeout(function() {
                     elem[0].focus();
                 }, 0);
@@ -31,7 +31,7 @@ treeherder.directive('focusThis', ['$timeout', function($timeout) {
 treeherder.directive('blurThis', ['$timeout', function($timeout) {
     return function(scope, elem, attr) {
         scope.$on('blur-this', function(event, id) {
-            if (attr.id == id) {
+            if (attr.id === id) {
                 $timeout(function() {
                     elem[0].blur();
                 }, 0);
@@ -174,9 +174,9 @@ treeherder.directive('numbersOnly', function(){
                 // this next is necessary for when using ng-required on your input.
                 // In such cases, when a letter is typed first, this parser will be called
                 // again, and the 2nd time, the value will be undefined
-                if (inputValue == undefined) return '';
+                if (inputValue === undefined) return '';
                 var transformedInput = inputValue.replace(/[^0-9]/g, '');
-                if (transformedInput!=inputValue) {
+                if (transformedInput!==inputValue) {
                     modelCtrl.$setViewValue(transformedInput);
                     modelCtrl.$render();
                 }

--- a/ui/js/models/perf/alerts.js
+++ b/ui/js/models/perf/alerts.js
@@ -99,7 +99,7 @@ treeherder.factory('PhAlerts', [
             var alertSummary = this;
             var alertsInSummary = _.filter(this.alerts, function(alert) {
                 return (alert.status !== phAlertStatusMap.DOWNSTREAM.id ||
-                        alert.summary_id == alertSummary.id);
+                        alert.summary_id === alertSummary.id);
             });
 
             // figure out if there are any regressions -- if there are,

--- a/ui/js/models/repository.js
+++ b/ui/js/models/repository.js
@@ -94,10 +94,10 @@ treeherder.factory('ThRepositoryModel', [
                 return get_list().
                     success(function(data) {
                         // FIXME: only supporting github + hg for now for pushlog
-                        // + revision info (we also assume dvcs_type git==github)
+                        // + revision info (we also assume dvcs_type git===github)
                         function Repo(props) {
                             _.assign(this, props);
-                            if (this.dvcs_type == 'git') {
+                            if (this.dvcs_type === 'git') {
                                 // FIXME: assuming master branch, which may not
                                 // always be right -- unfortunately fixing this
                                 // requires backend changes as we're not storing
@@ -109,13 +109,13 @@ treeherder.factory('ThRepositoryModel', [
                         }
                         Repo.prototype = {
                             getRevisionHref: function(revision) {
-                                if (this.dvcs_type == 'git') {
+                                if (this.dvcs_type === 'git') {
                                     return this.url + '/commit/' + revision;
                                 }
                                 return this.url + '/rev/' + revision;
                             },
                             getPushLogHref: function(arg) {
-                                if (this.dvcs_type == 'git') {
+                                if (this.dvcs_type === 'git') {
                                     // if git, assume github
                                     if (typeof(arg) === 'string') {
                                         return this.getRevisionHref(arg);
@@ -287,7 +287,7 @@ treeherder.factory('ThRepositoryModel', [
                         updateStatusesIfDone();
                     },
                     function(data) {
-                        if (data.data != null) {
+                        if (data.data !== null) {
                             newStatuses[repo] = getUnsupportedTreeStatus(repo);
                         } else {
                             newStatuses[repo] = getErrorTreeStatus(repo);

--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -13,7 +13,7 @@ treeherder.factory('PhSeries', ['$http', 'thServiceDomain', 'ThOptionCollectionM
             testName = testName || "summary";
         }
 
-        return suiteName == testName ? suiteName : suiteName + " " + testName;
+        return suiteName === testName ? suiteName : suiteName + " " + testName;
     };
 
     var _getSeriesOptions = function(signatureProps, optionCollectionMap) {
@@ -139,11 +139,11 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                 return {
                                     getCompareClasses: function(cr, type) {
                                         if (cr.isEmpty) return 'subtest-empty';
-                                        if (type == 'row' && cr.highlightedTest) return 'active subtest-highlighted';
-                                        if (type == 'row') return '';
-                                        if (type == 'bar' && cr.isRegression) return 'bar-regression';
-                                        if (type == 'bar' && cr.isImprovement) return 'bar-improvement';
-                                        if (type == 'bar') return '';
+                                        if (type === 'row' && cr.highlightedTest) return 'active subtest-highlighted';
+                                        if (type === 'row') return '';
+                                        if (type === 'bar' && cr.isRegression) return 'bar-regression';
+                                        if (type === 'bar' && cr.isImprovement) return 'bar-improvement';
+                                        if (type === 'bar') return '';
                                         return cr.className;
                                     },
 
@@ -253,7 +253,7 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                         // delta percentage (for display)
                                         cmap.deltaPercentage = math.percentOf(cmap.delta, cmap.originalValue);
                                         // arbitrary scale from 0-20% multiplied by 5, capped
-                                        // at 100 (so 20% regression == 100% bad)
+                                        // at 100 (so 20% regression === 100% bad)
                                         cmap.magnitude = Math.min(Math.abs(cmap.deltaPercentage)*5, 100);
 
                                         var abs_t_value = Math.abs(math.t_test(originalData.values, newData.values, STDDEV_DEFAULT_FACTOR));
@@ -270,8 +270,8 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                             cmap.confidenceText = "high";
                                             cmap.confidenceTextLong += "A value of 'high' indicates more confidence that there is a significant change, however you should check the historical record for the test by looking at the graph to be more sure (some noisy tests can provide inconsistent results).";
                                         }
-                                        cmap.isRegression = (cmap.className == 'compare-regression');
-                                        cmap.isImprovement = (cmap.className == 'compare-improvement');
+                                        cmap.isRegression = (cmap.className === 'compare-regression');
+                                        cmap.isImprovement = (cmap.className === 'compare-improvement');
                                         if (!_.isUndefined(blockerCriteria) &&
                                             !_.isUndefined(blockerCriteria[testName]) &&
                                             cmap.isRegression &&
@@ -280,7 +280,7 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                         } else {
                                             cmap.isBlocker = false;
                                         }
-                                        cmap.isMeaningful = (cmap.className != "");
+                                        cmap.isMeaningful = (cmap.className !== "");
                                         cmap.isComplete = (cmap.originalRuns.length &&
                                                            cmap.newRuns.length);
                                         cmap.isConfident = ((cmap.originalRuns.length > 1 &&
@@ -461,9 +461,9 @@ perf.factory('math', [ function() {
         // If one of the sets has only a single sample, assume its stddev is
         // the same as that of the other set (in percentage). If both sets
         // have only one sample, both will use stddev_default_factor.
-        if (lenC == 1) {
+        if (lenC === 1) {
             stddevC = valuesC[0] * stddevT / avgT;
-        } else if (lenT == 1) {
+        } else if (lenT === 1) {
             stddevT = valuesT[0] * stddevC / avgC;
         }
 

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -141,7 +141,7 @@ treeherder.controller('PluginCtrl', [
 
                     //the first result comes from the job detail promise
                     $scope.job = results[0];
-                    if ($scope.job.state =='running') {
+                    if ($scope.job.state === 'running') {
                         $scope.eta = $scope.job.running_time_remaining();
                         $scope.eta_abs = Math.abs($scope.eta);
                     }


### PR DESCRIPTION
Requires “===“  and “!==“ instead of just “==“ and “!=“ for equality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1380)
<!-- Reviewable:end -->
