### PR TITLE
Bug 1253029 - Use case-insensitive matching in performance test selector

### DIFF
--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -841,7 +841,7 @@ perf.filter('testNameContainsWords', function() {
         var filters = textFilter.split(/\s+/);
         return _.filter(tests, function(test) {
             return _.every(filters, function(filter) {
-                return test.name.indexOf(filter) !== -1;
+                return test.name.toLowerCase().indexOf(filter) !== -1;
             });
         });
     };


### PR DESCRIPTION
Request to merge code for Bug 1253029

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1386)
<!-- Reviewable:end -->
