### PR TITLE
Bug 1231361 - fixes for skipping onhold repos

### DIFF
--- a/treeherder/etl/management/commands/ingest_push.py
+++ b/treeherder/etl/management/commands/ingest_push.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
         (project, changeset) = args
 
         # get reference to repo
-        repo = Repository.objects.get(name=project)
+        repo = Repository.objects.get(name=project, active_status='active')
 
         # make sure all tasks are run synchronously / immediately
         settings.CELERY_ALWAYS_EAGER = True

--- a/treeherder/etl/tasks/buildapi_tasks.py
+++ b/treeherder/etl/tasks/buildapi_tasks.py
@@ -48,7 +48,8 @@ def fetch_push_logs():
     """
     Run several fetch_hg_push_log subtasks, one per repository
     """
-    for repo in Repository.objects.all(dvcs_type='hg'):
+    for repo in Repository.objects.filter(dvcs_type='hg',
+                                          active_status="active"):
         fetch_hg_push_log.apply_async(
             args=(repo.name, repo.url),
             routing_key='pushlog'

--- a/treeherder/etl/tasks/cleanup_tasks.py
+++ b/treeherder/etl/tasks/cleanup_tasks.py
@@ -14,7 +14,8 @@ def fetch_missing_push_logs(missing_pushlogs):
     """
     Run several fetch_hg_push_log subtasks, one per repository
     """
-    for repo in Repository.objects.filter(dvcs_type='hg'):
+    for repo in Repository.objects.filter(dvcs_type='hg',
+                                          active_status='active'):
         if repo.name in missing_pushlogs:
             # we must get them one at a time, because if ANY are missing
             # from json-pushes, it'll return a 404 for the group.


### PR DESCRIPTION
need to add a check for ``active_status`` in a few places, because our fixtures have some "onhold" repos, which mess things up on ingestion loops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1389)
<!-- Reviewable:end -->
