### PR TITLE
Bug 1212177 - l10n repacks should be displayed in treeherder properly

### DIFF
--- a/tests/etl/test_buildbot.py
+++ b/tests/etl/test_buildbot.py
@@ -1556,6 +1556,16 @@ buildernames = [
       'platform': {'arch': 'x86_64',
                    'os': 'win',
                    'os_platform': 'windows8-64'}}),
+    ('release-mozilla-beta_firefox_macosx64_l10n_repack',
+     {'build_type': 'opt',
+      'job_type': 'repack',
+      'name': {'group_name': 'L10n Repack',
+               'group_symbol': 'L10n',
+               'name': 'L10n Repack',
+               'job_symbol': 'L10n'},
+      'platform': {'arch': 'x86_64',
+                   'os': 'mac',
+                   'os_platform': 'osx-10-10'}}),
 ]
 
 

--- a/treeherder/etl/buildbot.py
+++ b/treeherder/etl/buildbot.py
@@ -457,7 +457,10 @@ JOB_TYPE_BUILDERNAME = {
         re.compile(r'.+(?<!leak) test .+'),
     ],
     'talos': [re.compile(r'.+ talos .+')],
-    'repack': [re.compile(r'.+ l10n .+')],
+    'repack': [
+        re.compile(r'.+ l10n .+'),
+        re.compile(r'.+_l10n_repack'),
+    ],
 }
 
 # from Data.js ``type`` Config.testNames and Config.buildNames
@@ -638,6 +641,7 @@ JOB_NAME_BUILDERNAME = [
     {"regex": re.compile(r'valgrind'), "name": "Valgrind Build"},
     {"regex": re.compile(r'dxr'), "name": "DXR Index Build"},
     {"regex": re.compile(r'(build|dep|periodic)$'), "name": "Build"},
+    {"regex": re.compile(r'_l10n_'), "name": "L10n Repack"},
 ]
 
 # map test names to group names as "<testname>": "<groupname>"
@@ -699,6 +703,7 @@ GROUP_NAMES = {
     "Unknown B2G Device Image Nightly": "Unknown Device Image",
     "Unknown B2G Device Image Nightly (Engineering)": "Unknown Device Image",
     "L10n Nightly": "L10n Repack",
+    "L10n Repack": "L10n Repack",
     "Android x86 Test Set": "Android x86 Test Combos",
     "Mochitest": "Mochitest",
     "Mochitest Push": "Mochitest",


### PR DESCRIPTION
This supercedes PR 1361 and is rebased onto master and has my test fixes squashed into @kmoir's patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1391)
<!-- Reviewable:end -->
