### PR TITLE
Bug 1262202 - More fixes related to revision length for perfherder

### DIFF
--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -514,7 +514,7 @@ perf.controller('GraphsCtrl', [
                 highlightedRevisions: _.filter($scope.highlightedRevisions,
                                                function(highlight) {
                                                    return (highlight &&
-                                                           highlight.length === 12);
+                                                           highlight.length >= 12);
                                                }),
                 highlightAlerts: !$scope.highlightAlerts ? 0 : undefined,
                 zoom: (function() {

--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -389,7 +389,7 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                         }
                                         _.forEach([baseResultSet.revision, newResultSet.revision],
                                                   function(revision) {
-                                                      graphsLink += '&highlightedRevisions=' + revision;
+                                                      graphsLink += '&highlightedRevisions=' + revision.slice(0, 12);
                                                   });
 
                                         graphsLink += '&timerange=' + _.max(

--- a/ui/partials/perf/comparechooserctrl.html
+++ b/ui/partials/perf/comparechooserctrl.html
@@ -11,12 +11,12 @@
           <select id="original-project-selector" class="form-control" ng-model="originalProject" ng-options="project.name for project in projects"  ng-change="updateOriginalRevisionTips()"/>
           <label for="original-revision-input">Revision</label>
           <div class="form-group" ng-class="{'has-error': originalRevisionError}">
-            <input id="original-revision-input" maxlength="12" class="form-control" type="text" ng-model="originalRevision" placeholder="Select or enter a revision"/>
+            <input id="original-revision-input" maxlength="40" class="form-control" type="text" ng-model="originalRevision" placeholder="Select or enter a revision"/>
             <div class="input-group-btn">
               <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Recent <span class="caret"></span></button>
               <ul class="dropdown-menu dropdown-menu-right" ng-model="tipRevision">
-                <li ng-repeat="tip in originalTipList"><a ng-click="getOriginalTipRevision(tip.revision)">{{tip.revision}} {{tip.author}}</a></li>
+                <li ng-repeat="tip in originalTipList"><a ng-click="getOriginalTipRevision(tip.revision)">{{tip.revision | limitTo: 12}} {{tip.author}}</a></li>
               </ul>
             </div>
           </div>
@@ -30,13 +30,13 @@
           <select id="new-project-selector" class="form-control" ng-model="newProject" ng-options="project.name for project in projects" ng-change="updateNewRevisionTips();getPreviousRevision()"/>
           <label for="new-revision-input">Revision</label>
             <div class="form-group" ng-class="{'has-error': newRevisionError}">
-            <input id="new-revision-input" maxlength="12" class="form-control" type="text" ng-model="newRevision" placeholder="Select or enter a revision" ng-change="getPreviousRevision()"/>
+            <input id="new-revision-input" maxlength="40" class="form-control" type="text" ng-model="newRevision" placeholder="Select or enter a revision" ng-change="getPreviousRevision()"/>
             <div class="input-group-btn">
               <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Recent <span class="caret"></span></button>
               <ul class="dropdown-menu dropdown-menu-right" >
                 <li ng-repeat="tip in newTipList"><a ng-click="getNewTipRevision(tip.revision);getPreviousRevision()">
-                {{tip.revision}} {{tip.author}}
+                {{tip.revision | limitTo: 12}} {{tip.author}}
                 </a></li>
               </ul>
             </div>
@@ -53,7 +53,7 @@
       <div class="form-group button-container">
       <button type="submit" class="btn btn-primary btn-lg btn-block"
               ng-click="runCompare()"
-              ng-disabled="originalRevision.length !== 12 || newRevision.length !== 12">
+              ng-disabled="originalRevision.length < 12 || newRevision.length < 12">
         Compare revisions
       </button>
       </div>

--- a/ui/partials/perf/graphsctrl.html
+++ b/ui/partials/perf/graphsctrl.html
@@ -31,12 +31,16 @@
       <div id="overview-plot"></div>
       <div id="graph"></div>
       <div id="graph-bottom" ng-show="seriesList.length > 0">
-        Highlight revisions: 
-        <input type="text" maxlength="12" ng-change="updateHighlightedRevisions()" placeholder="12 character hg revision" ng-model="highlightedRevisions[0]"></input>
-        <span class="reset-highlight-button" ng-show="highlightedRevisions[0].length > 0" ng-click="resetHighlight(0)">&#10006;</span>
-        &nbsp;&nbsp;
-        <input type="text" maxlength="12" ng-change="updateHighlightedRevisions()" placeholder="12 character hg revision" ng-model="highlightedRevisions[1]"></input>
-        <span class="reset-highlight-button" ng-show="highlightedRevisions[1].length > 0" ng-click="resetHighlight(1)">&#10006;</span>
+        Highlight revisions:
+        <span ng-repeat="highlightedRevision in highlightedRevisions track by $index">
+          <input type="text"
+                 maxlength="40"
+                 ng-change="updateHighlightedRevisions()"
+                 placeholder="hg revision"
+                 ng-model="highlightedRevisions[$index]">
+            <span class="reset-highlight-button" ng-show="highlightedRevisions[$index].length > 0" ng-click="resetHighlight($index)">&#10006;</span>
+          </input>
+        </span>
         <div class="checkbox">
           <label>
             <input type="checkbox" ng-change="updateHighlightedRevisions()" ng-model="highlightAlerts">Highlight alerts</input>

--- a/ui/partials/perf/revisiondescribe.html
+++ b/ui/partials/perf/revisiondescribe.html
@@ -1,10 +1,10 @@
 <ul class="list-inline push-information">
   <li>
-    <strong>Base</strong> - <a href="{{originalRevision | getRevisionUrl:originalProject.name}}">{{originalRevision}}</a> ({{originalProject.name}}) - {{originalResultSet.author}} -
+    <strong>Base</strong> - <a href="{{originalRevision | getRevisionUrl:originalProject.name}}">{{originalRevision | limitTo: 12}}</a> ({{originalProject.name}}) - {{originalResultSet.author}} -
     <span>{{originalResultSet.comments}}</span>
   </li>
   <li>
-    <strong>New</strong> - <a href="{{newRevision | getRevisionUrl:newProject.name}}">{{newRevision}}</a> ({{newProject.name}}) - {{newResultSet.author}} -
+    <strong>New</strong> - <a href="{{newRevision | getRevisionUrl:newProject.name}}">{{newRevision | limitTo: 12}}</a> ({{newProject.name}}) - {{newResultSet.author}} -
     <span>{{newResultSet.comments}}</span>
   </li>
 </ul>


### PR DESCRIPTION
There was a bunch of code in the compare chooser which still assumed
12 character revisions everywhere which needed to be updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1393)
<!-- Reviewable:end -->
