### PR TITLE
Bug 1251845 - Only generate performance alerts on specific repositories

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,7 +135,8 @@ def test_repository(transactional_db):
         active_status="active",
         codebase="gecko",
         repository_group_id=1,
-        description=""
+        description="",
+        performance_alerts_enabled=True
     )
     return r
 

--- a/tests/etl/test_perf_data_adapters.py
+++ b/tests/etl/test_perf_data_adapters.py
@@ -512,12 +512,12 @@ def test_alert_generation(test_project, test_repository,
         assert alert.amount_pct == 100
 
 
-def test_alert_generation_try(test_project, test_repository,
-                              perf_option_collection, perf_platform,
-                              perf_reference_data):
+def test_alert_generation_repo_no_alerts(test_project, test_repository,
+                                         perf_option_collection, perf_platform,
+                                         perf_reference_data):
     # validates that no alerts generated on "try" repos
-    test_repository.repository_group.name = "try"
-    test_repository.repository_group.save()
+    test_repository.performance_alerts_enabled = False
+    test_repository.save()
 
     _generate_perf_data_range(test_project, test_repository,
                               perf_option_collection, perf_platform,

--- a/treeherder/etl/perf.py
+++ b/treeherder/etl/perf.py
@@ -88,7 +88,6 @@ def _load_perf_artifact(project_name, reference_data, job_data, job_guid,
         platform=reference_data['machine_platform'])[0]
     repository = Repository.objects.get(
         name=project_name)
-    is_try_repository = repository.repository_group.name == 'try'
 
     # data for performance series
     job_id = job_data[job_guid]['id']
@@ -158,7 +157,7 @@ def _load_perf_artifact(project_name, reference_data, job_data, job_guid,
                 push_timestamp=push_timestamp,
                 defaults={'value': suite['value']})
             if (signature.should_alert is not False and datum_created and
-                (not is_try_repository)):
+                (repository.performance_alerts_enabled)):
                 generate_alerts.apply_async(args=[signature.id],
                                             routing_key='generate_perf_alerts')
 
@@ -214,7 +213,7 @@ def _load_perf_artifact(project_name, reference_data, job_data, job_guid,
             # property)
             if signature.should_alert or (signature.should_alert is None and
                                           (datum_created and
-                                           (not is_try_repository) and
+                                           repository.performance_alerts_enabled and
                                            suite.get('value') is None)):
                 generate_alerts.apply_async(args=[signature.id],
                                             routing_key='generate_perf_alerts')

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -22,7 +22,8 @@
         "active_status": "active",
         "codebase": "gecko",
         "repository_group": 1,
-        "description": ""
+        "description": "",
+        "performance_alerts_enabled": true
     }
 },
 {
@@ -61,7 +62,8 @@
         "active_status": "active",
         "codebase": "gecko",
         "repository_group": 2,
-        "description": ""
+        "description": "",
+        "performance_alerts_enabled": true
     }
 },
 {
@@ -74,7 +76,8 @@
         "active_status": "active",
         "codebase": "gecko",
         "repository_group": 2,
-        "description": ""
+        "description": "",
+        "performance_alerts_enabled": true
     }
 },
 {
@@ -87,7 +90,8 @@
         "active_status": "active",
         "codebase": "gecko",
         "repository_group": 2,
-        "description": ""
+        "description": "",
+        "performance_alerts_enabled": true
     }
 },
 {
@@ -178,7 +182,8 @@
         "active_status": "active",
         "codebase": "gecko",
         "repository_group": 1,
-        "description": ""
+        "description": "",
+        "performance_alerts_enabled": true
     }
 },
 {

--- a/treeherder/model/migrations/0013_add_enable_perfalert_property_to_repository.py
+++ b/treeherder/model/migrations/0013_add_enable_perfalert_property_to_repository.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0012_longer_platform_names'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='repository',
+            name='performance_alerts_enabled',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -90,6 +90,7 @@ class Repository(models.Model):
     codebase = models.CharField(max_length=50, blank=True, db_index=True)
     description = models.TextField(blank=True)
     active_status = models.CharField(max_length=7, blank=True, default='active', db_index=True)
+    performance_alerts_enabled = models.BooleanField(default=False)
 
     class Meta:
         db_table = 'repository'


### PR DESCRIPTION
Make a repository property on whether we should generate performance alerts,
default to false.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1403)
<!-- Reviewable:end -->
