### PR TITLE
Bug 1265037 - Create an intermediate jobs model/table

### DIFF
--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -205,10 +205,10 @@ def test_ingest_running_to_retry_sample_job(jm, sample_data,
     assert jl[0]['result'] == 'retry'
     assert jl[0]['id'] == initial_job_id
 
-    assert Job.objects.count() == 1
-    intermediary_job = Job.objects.all()[0]
-    assert intermediary_job.project_specific_id == initial_job_id
-    assert intermediary_job.guid == job['job_guid']
+    # assert Job.objects.count() == 1
+    # intermediary_job = Job.objects.all()[0]
+    # assert intermediary_job.project_specific_id == initial_job_id
+    # assert intermediary_job.guid == job['job_guid']
 
 
 def test_ingest_running_to_retry_to_success_sample_job(jm, sample_data,
@@ -241,10 +241,10 @@ def test_ingest_running_to_retry_to_success_sample_job(jm, sample_data,
     assert jl[0]['result'] == 'retry'
     assert jl[0]['id'] == initial_job_id
 
-    assert Job.objects.count() == 1
-    intermediary_job = Job.objects.all()[0]
-    assert intermediary_job.project_specific_id == jl[0]['id']
-    assert intermediary_job.guid == job['job_guid']
+    # assert Job.objects.count() == 1
+    # intermediary_job = Job.objects.all()[0]
+    # assert intermediary_job.project_specific_id == jl[0]['id']
+    # assert intermediary_job.guid == job['job_guid']
 
     # now we simulate the complete SUCCESS version of the job coming in
     job['state'] = 'completed'
@@ -261,8 +261,8 @@ def test_ingest_running_to_retry_to_success_sample_job(jm, sample_data,
     assert jl[0]['id'] == initial_job_id
     assert jl[1]['result'] == 'success'
 
-    assert Job.objects.count() == 2
-    assert set(Job.objects.values_list('id', flat=True)) == set([j['id'] for j in jl])
+    # assert Job.objects.count() == 2
+    # assert set(Job.objects.values_list('id', flat=True)) == set([j['id'] for j in jl])
 
 
 def test_ingest_retry_sample_job_no_running(jm, sample_data,
@@ -289,8 +289,8 @@ def test_ingest_retry_sample_job_no_running(jm, sample_data,
     assert jl[0]['job_guid'] == retry_guid
     assert jl[0]['result'] == 'retry'
 
-    assert Job.objects.count() == 1
-    assert Job.objects.all()[0].guid == retry_guid
+    # assert Job.objects.count() == 1
+    # assert Job.objects.all()[0].guid == retry_guid
 
 
 def test_calculate_durations(jm, test_repository, mock_log_parser):
@@ -363,7 +363,7 @@ def test_cycle_all_data(jm, sample_data,
     # There should be no jobs or failure lines after cycling
     assert len(jobs_after) == 0
     assert FailureLine.objects.count() == 0
-    assert Job.objects.count() == 0
+    # assert Job.objects.count() == 0
 
 
 def test_cycle_one_job(jm, sample_data,
@@ -418,7 +418,7 @@ def test_cycle_one_job(jm, sample_data,
     assert len(jobs_to_be_deleted_after) == 0
 
     assert len(jobs_after) == len(jobs_before) - len(jobs_to_be_deleted)
-    assert len(jobs_after) == Job.objects.count()
+    # assert len(jobs_after) == Job.objects.count()
 
     assert (set(item.id for item in FailureLine.objects.all()) ==
             set(item.id for item in failure_lines_remaining))
@@ -564,7 +564,7 @@ def test_remove_existing_jobs_single_existing(jm, sample_data,
     jl = jm.get_job_list(0, 10)
     assert len(jl) == 1
 
-    assert Job.objects.count() == 1
+    # assert Job.objects.count() == 1
 
 
 def test_remove_existing_jobs_one_existing_one_new(jm, sample_data,
@@ -577,7 +577,7 @@ def test_remove_existing_jobs_one_existing_one_new(jm, sample_data,
     data = jm._remove_existing_jobs(sample_data.job_data[:2])
 
     assert len(data) == 1
-    assert Job.objects.count() == 1
+    # assert Job.objects.count() == 1
 
 
 def test_ingesting_skip_existing(jm, sample_data,
@@ -591,7 +591,7 @@ def test_ingesting_skip_existing(jm, sample_data,
 
     jl = jm.get_job_list(0, 10)
     assert len(jl) == 2
-    assert Job.objects.count() == 2
+    # assert Job.objects.count() == 2
 
 
 def test_ingest_job_with_updated_job_group(jm, sample_data, mock_log_parser,
@@ -701,7 +701,7 @@ def test_ingest_job_revision_hash_blank_revision(jm, test_repository,
     assert len(jl) == 1
     assert jl[0]["result_set_id"] == stored_resultsets["inserted_result_set_ids"][0]
 
-    assert Job.objects.count() == 1
+    # assert Job.objects.count() == 1
 
 
 def test_retry_on_operational_failure(jm, monkeypatch):

--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -12,6 +12,7 @@ from tests.sample_data_generator import (job_data,
 from treeherder.model.derived import ArtifactsModel
 from treeherder.model.models import (FailureClassification,
                                      FailureLine,
+                                     Job,
                                      JobDuration,
                                      JobGroup,
                                      TaskSetMeta)
@@ -204,6 +205,11 @@ def test_ingest_running_to_retry_sample_job(jm, sample_data,
     assert jl[0]['result'] == 'retry'
     assert jl[0]['id'] == initial_job_id
 
+    assert Job.objects.count() == 1
+    intermediary_job = Job.objects.all()[0]
+    assert intermediary_job.project_specific_id == initial_job_id
+    assert intermediary_job.guid == job['job_guid']
+
 
 def test_ingest_running_to_retry_to_success_sample_job(jm, sample_data,
                                                        sample_resultset, test_repository, mock_log_parser):
@@ -230,6 +236,16 @@ def test_ingest_running_to_retry_to_success_sample_job(jm, sample_data,
 
     jm.store_job_data(job_data)
 
+    jl = jm.get_job_list(0, 10)
+    assert len(jl) == 1
+    assert jl[0]['result'] == 'retry'
+    assert jl[0]['id'] == initial_job_id
+
+    assert Job.objects.count() == 1
+    intermediary_job = Job.objects.all()[0]
+    assert intermediary_job.project_specific_id == jl[0]['id']
+    assert intermediary_job.guid == job['job_guid']
+
     # now we simulate the complete SUCCESS version of the job coming in
     job['state'] = 'completed'
     job['result'] = 'success'
@@ -245,6 +261,9 @@ def test_ingest_running_to_retry_to_success_sample_job(jm, sample_data,
     assert jl[0]['id'] == initial_job_id
     assert jl[1]['result'] == 'success'
 
+    assert Job.objects.count() == 2
+    assert set(Job.objects.values_list('id', flat=True)) == set([j['id'] for j in jl])
+
 
 def test_ingest_retry_sample_job_no_running(jm, sample_data,
                                             sample_resultset, test_repository, mock_log_parser):
@@ -259,14 +278,19 @@ def test_ingest_retry_sample_job_no_running(jm, sample_data,
     job['state'] = 'completed'
     job['result'] = 'retry'
     # convert the job_guid to what it would be on a retry
-    job['job_guid'] = job['job_guid'] + "_" + str(job['end_timestamp'])[-5:]
+    retry_guid = job['job_guid'] + "_" + str(job['end_timestamp'])[-5:]
+    job['job_guid'] = retry_guid
 
     jm.store_job_data(job_data)
 
     jl = jm.get_job_list(0, 10)
 
     assert len(jl) == 1
+    assert jl[0]['job_guid'] == retry_guid
     assert jl[0]['result'] == 'retry'
+
+    assert Job.objects.count() == 1
+    assert Job.objects.all()[0].guid == retry_guid
 
 
 def test_calculate_durations(jm, test_repository, mock_log_parser):
@@ -339,6 +363,7 @@ def test_cycle_all_data(jm, sample_data,
     # There should be no jobs or failure lines after cycling
     assert len(jobs_after) == 0
     assert FailureLine.objects.count() == 0
+    assert Job.objects.count() == 0
 
 
 def test_cycle_one_job(jm, sample_data,
@@ -393,6 +418,7 @@ def test_cycle_one_job(jm, sample_data,
     assert len(jobs_to_be_deleted_after) == 0
 
     assert len(jobs_after) == len(jobs_before) - len(jobs_to_be_deleted)
+    assert len(jobs_after) == Job.objects.count()
 
     assert (set(item.id for item in FailureLine.objects.all()) ==
             set(item.id for item in failure_lines_remaining))
@@ -435,7 +461,8 @@ def test_cycle_all_data_in_chunks(jm, sample_data,
 
     # There should be no jobs after cycling
     assert len(jobs_after) == 0
-    assert len(FailureLine.objects.all()) == 0
+    assert Job.objects.count() == 0
+    assert FailureLine.objects.count() == 0
 
 
 def test_cycle_task_set_meta(jm):
@@ -537,6 +564,8 @@ def test_remove_existing_jobs_single_existing(jm, sample_data,
     jl = jm.get_job_list(0, 10)
     assert len(jl) == 1
 
+    assert Job.objects.count() == 1
+
 
 def test_remove_existing_jobs_one_existing_one_new(jm, sample_data,
                                                    sample_resultset, mock_log_parser):
@@ -548,6 +577,7 @@ def test_remove_existing_jobs_one_existing_one_new(jm, sample_data,
     data = jm._remove_existing_jobs(sample_data.job_data[:2])
 
     assert len(data) == 1
+    assert Job.objects.count() == 1
 
 
 def test_ingesting_skip_existing(jm, sample_data,
@@ -561,6 +591,7 @@ def test_ingesting_skip_existing(jm, sample_data,
 
     jl = jm.get_job_list(0, 10)
     assert len(jl) == 2
+    assert Job.objects.count() == 2
 
 
 def test_ingest_job_with_updated_job_group(jm, sample_data, mock_log_parser,
@@ -669,6 +700,8 @@ def test_ingest_job_revision_hash_blank_revision(jm, test_repository,
     jl = jm.get_job_list(0, 10)
     assert len(jl) == 1
     assert jl[0]["result_set_id"] == stored_resultsets["inserted_result_set_ids"][0]
+
+    assert Job.objects.count() == 1
 
 
 def test_retry_on_operational_failure(jm, monkeypatch):

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1784,17 +1784,18 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
         # create an intermediate representation of the job useful for doing
         # lookups (this will eventually become the main/only/primary jobs table
         # when we finish migrating away from Datasource, see bug 1178641
-        repository = Repository.objects.get(name=self.project)
-        for job_guid in jobs_to_update.keys():
-            # in the case of retries, we *update* the old job with a new guid,
-            # then create a new job with an old guid when the retry actually
-            # starts/completes
-            Job.objects.update_or_create(
-                repository=repository,
-                project_specific_id=job_id_lookup[job_guid]['id'],
-                defaults={
-                    'guid': job_guid
-                })
+        # (currently disabled while we do a migration, see bug 1265037)
+        # repository = Repository.objects.get(name=self.project)
+        # for job_guid in jobs_to_update.keys():
+        #    # in the case of retries, we *update* the old job with a new guid,
+        #    # then create a new job with an old guid when the retry actually
+        #    # starts/completes
+        #    Job.objects.update_or_create(
+        #        repository=repository,
+        #        project_specific_id=job_id_lookup[job_guid]['id'],
+        #        defaults={
+        #            'guid': job_guid
+        #        })
         return job_id_lookup
 
     def get_average_job_durations(self, reference_data_signatures):

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import time
 from collections import defaultdict
@@ -20,6 +21,7 @@ from treeherder.model.models import (BuildPlatform,
                                      ExclusionProfile,
                                      FailureClassification,
                                      FailureLine,
+                                     Job,
                                      JobDuration,
                                      JobGroup,
                                      JobType,
@@ -750,8 +752,10 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             # remove data from specified jobs tables that is older than max_timestamp
             self._execute_table_deletes(jobs_targets, 'jobs', sleep_time)
 
-            # Remove FailueLine entries for these jobs
+            # Remove FailueLine + intermediate job entries for these jobs
             orm_delete(FailureLine, FailureLine.objects.filter(job_guid__in=job_guid_list),
+                       chunk_size, sleep_time)
+            orm_delete(Job, Job.objects.filter(guid__in=job_guid_list),
                        chunk_size, sleep_time)
 
         return len(jobs_to_cycle)
@@ -1281,30 +1285,8 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 push_timestamps
             )
 
-        job_id_lookup = self._load_jobs(job_placeholders, job_guid_list)
-
-        # For each of these ``retry_job_guids`` the job_id_lookup will
-        # either contain the retry guid, or the root guid (based on whether we
-        # inserted, or skipped insertion to do an update).  So add in
-        # whichever is missing.
-        for retry_guid in retry_job_guids:
-            retry_guid_root = get_guid_root(retry_guid)
-            lookup_keys = job_id_lookup.keys()
-
-            if retry_guid in lookup_keys:
-                # this retry was inserted in the db at some point
-                if retry_guid_root not in lookup_keys:
-                    # the root isn't there because there was, for some reason,
-                    # never a pending/running version of this job
-                    retry_job = job_id_lookup[retry_guid]
-                    job_id_lookup[retry_guid_root] = retry_job
-
-            elif retry_guid_root in lookup_keys:
-                # if job_id_lookup contains the root, then the insert
-                # will have skipped, so we want to find that job
-                # when looking for the retry_guid for update later.
-                retry_job = job_id_lookup[retry_guid_root]
-                job_id_lookup[retry_guid] = retry_job
+        job_id_lookup = self._load_jobs(job_placeholders, job_guid_list,
+                                        retry_job_guids)
 
         # Need to iterate over log references separately since they could
         # be a different length. Replace job_guid with id in log url
@@ -1758,7 +1740,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 get_guid_root(job_guid)
             ])
 
-    def _load_jobs(self, job_placeholders, job_guid_list):
+    def _load_jobs(self, job_placeholders, job_guid_list, retry_job_guids):
 
         if not job_placeholders:
             return {}
@@ -1770,7 +1752,50 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
             placeholders=job_placeholders,
             executemany=True)
 
-        return self.get_job_ids_by_guid(job_guid_list)
+        job_id_lookup = self.get_job_ids_by_guid(job_guid_list)
+        jobs_to_update = copy.copy(job_id_lookup)
+
+        # For each of these ``retry_job_guids`` the job_id_lookup will
+        # either contain the retry guid, or the root guid (based on whether we
+        # inserted, or skipped insertion to do an update).  So add in
+        # whichever is missing.
+        for retry_guid in retry_job_guids:
+            retry_guid_root = get_guid_root(retry_guid)
+            lookup_keys = job_id_lookup.keys()
+
+            if retry_guid in lookup_keys:
+                # this retry was inserted in the db at some point
+                if retry_guid_root not in lookup_keys:
+                    # the root isn't there because there was, for some reason,
+                    # never a pending/running version of this job
+                    retry_job = job_id_lookup[retry_guid]
+                    job_id_lookup[retry_guid_root] = retry_job
+            elif retry_guid_root in lookup_keys:
+                # if job_id_lookup contains the root, then the insert
+                # will have skipped, so we want to find that job
+                # when looking for the retry_guid for update later.
+                retry_job = job_id_lookup[retry_guid_root]
+                job_id_lookup[retry_guid] = retry_job
+                # for the intermediate representation (see below), we only
+                # want to modify the job who was retriggered
+                del jobs_to_update[retry_guid_root]
+                jobs_to_update[retry_guid] = retry_job
+
+        # create an intermediate representation of the job useful for doing
+        # lookups (this will eventually become the main/only/primary jobs table
+        # when we finish migrating away from Datasource, see bug 1178641
+        repository = Repository.objects.get(name=self.project)
+        for job_guid in jobs_to_update.keys():
+            # in the case of retries, we *update* the old job with a new guid,
+            # then create a new job with an old guid when the retry actually
+            # starts/completes
+            Job.objects.update_or_create(
+                repository=repository,
+                project_specific_id=job_id_lookup[job_guid]['id'],
+                defaults={
+                    'guid': job_guid
+                })
+        return job_id_lookup
 
     def get_average_job_durations(self, reference_data_signatures):
         if not reference_data_signatures:

--- a/treeherder/model/management/commands/migrate_to_intermediate_jobs.py
+++ b/treeherder/model/management/commands/migrate_to_intermediate_jobs.py
@@ -1,0 +1,65 @@
+import time
+from optparse import make_option
+
+from django.core.management.base import BaseCommand
+from django.db import (IntegrityError,
+                       transaction)
+
+from treeherder.model.derived import JobsModel
+from treeherder.model.models import (Datasource,
+                                     Job,
+                                     Repository)
+
+
+class Command(BaseCommand):
+
+    help = 'Migrate existing jobs to intermediate jobs table'
+    option_list = BaseCommand.option_list + (
+        make_option('--project',
+                    action='append',
+                    dest='project',
+                    help='Filter deletion to particular project(s)',
+                    type='string'),
+        make_option('--interval',
+                    dest='interval',
+                    help='Wait specified interval between signature migrations',
+                    type='float',
+                    default=0.0))
+
+    def handle(self, *args, **options):
+        if options['project']:
+            projects = options['project']
+        else:
+            projects = Datasource.objects.values_list('project', flat=True)
+
+        for project in projects:
+            try:
+                repository = Repository.objects.get(name=project)
+            except:
+                continue
+            with JobsModel(project) as jm:
+                offset = 0
+                limit = 10000
+
+                while True:
+                    datasource_jobs = jm.get_job_list(offset, limit)
+                    if not datasource_jobs:
+                        break
+
+                    try:
+                        jobs_to_import = []
+                        for datasource_job in datasource_jobs:
+                            jobs_to_import.append(
+                                Job(repository=repository,
+                                    guid=datasource_job['job_guid'],
+                                    project_specific_id=datasource_job['id']))
+                        Job.objects.bulk_create(jobs_to_import)
+                    except IntegrityError:
+                        with transaction.atomic():
+                            for datasource_job in datasource_jobs:
+                                Job.objects.get_or_create(
+                                    repository=repository,
+                                    guid=datasource_job['job_guid'],
+                                    project_specific_id=datasource_job['id'])
+                    offset += limit
+                    time.sleep(options['interval'])

--- a/treeherder/model/migrations/0017_add_centralized_job_model.py
+++ b/treeherder/model/migrations/0017_add_centralized_job_model.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import treeherder.model.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0016_enforce repository name uniqueness'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Job',
+            fields=[
+                ('id', treeherder.model.fields.BigAutoField(serialize=False, primary_key=True)),
+                ('guid', models.CharField(unique=True, max_length=50, db_index=True)),
+                ('project_specific_id', models.PositiveIntegerField(db_index=True)),
+                ('repository', models.ForeignKey(to='model.Repository')),
+            ],
+            options={
+                'db_table': 'job',
+            },
+        ),
+        migrations.AlterUniqueTogether(
+            name='job',
+            unique_together=set([('repository', 'project_specific_id')]),
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -531,6 +531,31 @@ class JobDuration(models.Model):
         unique_together = ('signature', 'repository')
 
 
+class Job(models.Model):
+    """
+    Representation of a treeherder job
+
+    This is currently a transitional representation intended to assist in
+    cross referencing data between the per-project databases and those
+    objects in the Django ORM
+    """
+    id = BigAutoField(primary_key=True)
+    repository = models.ForeignKey(Repository)
+    guid = models.CharField(max_length=50, unique=True, db_index=True)
+    # indexing this column to make eventual migration of performance artifacts
+    # faster (since we'll need to cross-reference those row-by-row), see
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1265503
+    project_specific_id = models.PositiveIntegerField(db_index=True)
+
+    class Meta:
+        db_table = 'job'
+        unique_together = ('repository', 'project_specific_id')
+
+    def __str__(self):
+        return "{0} {1} {2} {3}".format(self.id, self.repository, self.guid,
+                                        self.project_specific_id)
+
+
 class FailureLineManager(models.Manager):
     def unmatched_for_job(self, repository, job_guid):
         return FailureLine.objects.filter(


### PR DESCRIPTION
Not really useful in-and-of-itself, but should be helpful by acting
as a centralized place to relate and map job information from what
is stored in the main treeherder database to what's in the per-project
databases. Eventually, we can extend this into a full-fledged jobs model.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1411)
<!-- Reviewable:end -->
