### PR TITLE
Bug 1266426 - Download PyYAML from a direct URL

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -61,8 +61,10 @@ functools32==3.2.3-2 --hash=sha256:f6253dfbe0538ad2e387bd8fdfd9293c925d63553f581
 # Required by django-rest-swagger
 Unipath==1.1 --hash=sha256:e6257e508d8abbfb6ddd8ec357e33589f1f48b1599127f23b017124d90b0fff7
 
-# Required by django-rest-swagger
-PyYAML==3.11 --hash=sha256:c36c938a872e5ff494938b33b14aaa156cb439ec67548fcab3535bb78b0846e8
+# Required by django-rest-swagger (PyYAML is distributed in two forms:
+# .zip and .tar.gz, and pip likes to switch between them:
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1266426)
+PyYAML==3.11 --hash=sha256:c36c938a872e5ff494938b33b14aaa156cb439ec67548fcab3535bb78b0846e8 --hash=sha256:19bb3ac350ef878dda84a62d37c7d5c17a137386dde9c2ce7249c7a21d7f6ac9
 
 # Used directly plus required by django-browserid, WebTest & responses
 requests==2.9.1 --hash=sha256:113fbba5531a9e34945b7d36b33a084e8ba5d0664b703c81a7c572d91919a5b8


### PR DESCRIPTION
Workaround for something changing in pypi that causes pip to prefer
the .zip version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1417)
<!-- Reviewable:end -->
