### PR TITLE
Bug 1240857 - Ignore job clear on majority of resultset action menu

### DIFF
--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -4,8 +4,9 @@
           type="button"
           title="Action menu"
           data-hover="dropdown"
-          data-delay="1000">
-    <span class="caret"></span>
+          data-delay="1000"
+          ignore-job-clear-on-click>
+    <span class="caret" ignore-job-clear-on-click></span>
   </button>
   <!-- Menu contents -->
   <ul class="dropdown-menu pull-right">
@@ -32,10 +33,10 @@
            href="" prevent-default-on-left-click
            ng-show="user.is_staff"
            ng-click="triggerAllTalosJobs(resultset.revision)">Trigger All Talos jobs</a></li>
-    <li><a target="_blank" ignore-job-clear-on-click
+    <li><a target="_blank"
            href="" prevent-default-on-left-click
            ng-click="setLocationSearchParam('tochange', resultset.revision)">Set as top of range</a></li>
-    <li><a target="_blank" ignore-job-clear-on-click
+    <li><a target="_blank"
            href="" prevent-default-on-left-click
            ng-click="setLocationSearchParam('fromchange', resultset.revision)">Set as bottom of range</a></li>
   </ul>


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1240857](https://bugzilla.mozilla.org/show_bug.cgi?id=1240857).

This keeps the job info panel up and the current job selected, when the user clicks or navigates the resultset action menu.

I tested it out and propose we keep the **Set as top of range** and **Set as bottom of range** entries clearing the selected job. Since you may have a job already selected in a different resultset which will lie outside the new range, and the entire page reloads anyway when either of those menus is invoked.

So this is what we can now do, with this fix:

![ignoreclearactionmenu](https://cloud.githubusercontent.com/assets/3660661/14753724/26d757a6-08a5-11e6-8f35-c52424873ad9.jpg)

I did not locally test these action menu entries if you guys wish to poke at them:
* Add new jobs
* Trigger Missing jobs
* Trigger All Talos jobs

But otherwise everything seems fine locally on Nightly and Chrome.

Tested on OSX 10.11.4:
Nightly **48.0a1 (2016-04-20)**
Chrome Latest Release **50.0.2661.86 (64-bit)**

Adding @camd for review and @KWierso for visibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1421)
<!-- Reviewable:end -->
