### PR TITLE
Bug 1245773 - Highlighting mozmake.EXE errors as well.

### DIFF
--- a/tests/log_parser/test_error_parser.py
+++ b/tests/log_parser/test_error_parser.py
@@ -12,6 +12,7 @@ ERROR_TEST_CASES = (
     "remoteFailed: [Failure instance: Traceback (failure with no frames): Foo.",
     "08:13:37 INFO - make: *** [test-integration-test] Error 1",
     "pymake\..\..\mozmake.exe: *** [buildsymbols] Error 11",
+    "pymake\..\..\mozmake.EXE: *** [buildsymbols] Error 11",
     "00:55:13 INFO - SUMMARY: AddressSanitizer: 64 byte(s) leaked in 1 allocation(s).",
     "Automation Error: Foo bar",
     "[taskcluster] Error: Task run time exceeded 7200 seconds.",

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -391,7 +391,7 @@ class ErrorParser(ParserBase):
         r"|:\d+: error:"
         r"| error R?C\d*:"
         r"|ERROR [45]\d\d:"
-        r"|mozmake\.exe(?:\[\d+\])?: \*\*\*"
+        r"|mozmake\.(?:exe|EXE)(?:\[\d+\])?: \*\*\*"
     ))
 
     RE_EXCLUDE_1_SEARCH = re.compile(r"TEST-(?:INFO|PASS) ")


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1423)
<!-- Reviewable:end -->
