### PR TITLE
Bug 1267102 - Be more efficient about storing job title + search information

### DIFF
--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -3,11 +3,11 @@
 logViewerApp.controller('LogviewerCtrl', [
     '$anchorScroll', '$http', '$location', '$q', '$rootScope', '$scope',
     '$timeout', 'ThJobArtifactModel', 'ThLog', 'ThLogSliceModel', 'ThJobModel', 'thNotify',
-    'dateFilter', 'thJobSearchStr', 'ThResultSetModel', 'thDateFormat', 'thReftestStatus',
+    'dateFilter', 'ThResultSetModel', 'thDateFormat', 'thReftestStatus',
     function Logviewer(
         $anchorScroll, $http, $location, $q, $rootScope, $scope,
         $timeout, ThJobArtifactModel, ThLog, ThLogSliceModel, ThJobModel, thNotify,
-        dateFilter, thJobSearchStr, ThResultSetModel, thDateFormat, thReftestStatus) {
+        dateFilter, ThResultSetModel, thDateFormat, thReftestStatus) {
 
         var $log = new ThLog('LogviewerCtrl');
 
@@ -217,10 +217,8 @@ logViewerApp.controller('LogviewerCtrl', [
 
             $scope.logProperties = [];
             ThJobModel.get($scope.repoName, $scope.job_id).then(function(job) {
-                var jobStr = thJobSearchStr(job);
-
                 // set the title of the browser window/tab
-                $scope.logViewerTitle = "Log for " + jobStr;
+                $scope.logViewerTitle = job.get_title();
 
                 // set the result value and shading color class
                 $scope.result = {label: "Result", value: job.result};

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -6,13 +6,13 @@ treeherder.directive('thCloneJobs', [
     'thServiceDomain', 'thResultStatusInfo', 'thEvents', 'thAggregateIds',
     'thJobFilters', 'thResultStatusObject', 'ThResultSetStore',
     'ThJobModel', 'linkifyBugsFilter', 'thResultStatus', 'thPlatformName',
-    'thJobSearchStr', 'thNotify', '$timeout',
+    'thNotify', '$timeout',
     function(
         $rootScope, $http, ThLog, thUrl, thCloneHtml,
         thServiceDomain, thResultStatusInfo, thEvents, thAggregateIds,
         thJobFilters, thResultStatusObject, ThResultSetStore,
         ThJobModel, linkifyBugsFilter, thResultStatus, thPlatformName,
-        thJobSearchStr, thNotify, $timeout){
+        thNotify, $timeout){
 
         var $log = new ThLog("thCloneJobs");
 
@@ -192,7 +192,6 @@ treeherder.directive('thCloneJobs', [
                         // Keep track of visibility with this property. This
                         // way down stream job consumers don't need to repeatedly
                         // call showJob
-                        job.searchStr = thJobSearchStr(job) + ' ' + job.ref_data_name  + ' ' + job.signature;
                         job.visible = filterWithRunnable(job);
                     });
                     gi.grpCountList.hide();
@@ -642,7 +641,6 @@ treeherder.directive('thCloneJobs', [
                     // Keep track of visibility with this property. This
                     // way down stream job consumers don't need to repeatedly
                     // call showJob
-                    job.searchStr = thJobSearchStr(job) + ' ' + job.ref_data_name  + ' ' + job.signature;
                     job.visible = filterWithRunnable(job);
                 });
                 if (isGroupExpanded(gi.jgObj)) {
@@ -912,7 +910,6 @@ treeherder.directive('thCloneJobs', [
                     // Keep track of visibility with this property. This
                     // way down stream job consumers don't need to repeatedly
                     // call showJob
-                    job.searchStr = thJobSearchStr(job) + ' ' + job.ref_data_name  + ' ' + job.signature;
                     job.visible = filterWithRunnable(job);
                 });
             });

--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('ThJobModel', [
-    '$http', 'ThLog', 'thUrl', '$q',
-    function($http, ThLog, thUrl, $q) {
+    '$http', 'ThLog', 'thUrl', 'thPlatformName', '$q',
+    function($http, ThLog, thUrl, thPlatformName, $q) {
         // ThJobModel is the js counterpart of job
 
         var ThJobModel = function(data) {
@@ -21,6 +21,25 @@ treeherder.factory('ThJobModel', [
             return Math.round(
                 parseInt(this.running_eta) /60
             );
+        };
+
+        ThJobModel.prototype.get_title = function() {
+            return _.filter([
+                thPlatformName(this.platform),
+                this.platform_option,
+                (this.job_group_name === 'unknown') ? undefined : this.job_group_name,
+                this.job_type_name,
+                this.job_group_symbol === '?' ? undefined : this.job_group_symbol,
+                "(" + this.job_type_symbol + ")"
+            ]).join(' ');
+        };
+
+        ThJobModel.prototype.get_search_str = function() {
+            return _.filter([
+                this.get_title(),
+                this.ref_data_name,
+                (this.signature !== this.ref_data_name) ? this.signature : undefined
+            ]).join(' ');
         };
 
         ThJobModel.get_uri = function(repoName){return thUrl.getProjectUrl("/jobs/", repoName);};

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -469,11 +469,14 @@ treeherder.factory('thJobFilters', [
          * object.
          */
         var _getJobFieldValue = function(job, field) {
-            var result = job[field];
             if (field === 'platform') {
-                result = thPlatformName(result) + " " + job.platform_option;
+                return thPlatformName(result) + " " + job.platform_option;
+            } else if (field === 'searchStr') {
+                // lazily get this to avoid storing redundant information
+                return job.get_search_str();
             }
-            return result;
+
+            return job[field];
         };
 
         /**

--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -243,20 +243,6 @@ treeherder.factory('thPlatformName', [
         };
     }]);
 
-treeherder.factory('thJobSearchStr', [
-    'thPlatformName',
-    function(thPlatformName) {
-
-        return function(job) {
-            return thPlatformName(job.platform) + ' ' +
-                job.platform_option + ' ' +
-                (job.job_group_name === 'unknown' ? '' : job.job_group_name + ' ') +
-                job.job_type_name + ' ' +
-                (job.job_group_symbol === '?' ? '' : job.job_group_symbol) +
-                "(" + job.job_type_symbol + ")";
-        };
-    }]);
-
 treeherder.factory('thExtendProperties', [
     /* Version of _.extend that works with property descriptors */
     function() {

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -6,7 +6,7 @@ treeherder.controller('PluginCtrl', [
     'numberFilter', 'ThBugJobMapModel', 'thResultStatus', 'thJobFilters',
     'ThResultSetModel', 'ThLog', '$q', 'thPinboard', 'ThJobArtifactModel',
     'thBuildApi', 'thNotify', 'ThJobLogUrlModel', 'ThModelErrors', 'thTabs',
-    '$timeout', 'thJobSearchStr', 'thReftestStatus', 'ThResultSetStore',
+    '$timeout', 'thReftestStatus', 'ThResultSetStore',
     'PhSeries', 'thServiceDomain', 'ThFailureLinesModel',
     function PluginCtrl(
         $scope, $rootScope, $location, $http, thUrl, ThJobClassificationModel,
@@ -14,7 +14,7 @@ treeherder.controller('PluginCtrl', [
         numberFilter, ThBugJobMapModel, thResultStatus, thJobFilters,
         ThResultSetModel, ThLog, $q, thPinboard, ThJobArtifactModel,
         thBuildApi, thNotify, ThJobLogUrlModel, ThModelErrors, thTabs,
-        $timeout, thJobSearchStr, thReftestStatus, ThResultSetStore, PhSeries,
+        $timeout, thReftestStatus, ThResultSetStore, PhSeries,
         thServiceDomain, ThFailureLinesModel) {
 
         var $log = new ThLog("PluginCtrl");
@@ -163,7 +163,7 @@ treeherder.controller('PluginCtrl', [
                     }
 
                     // filtering values for data fields and signature
-                    $scope.jobSearchStr = thJobSearchStr($scope.job);
+                    $scope.jobSearchStr = $scope.job.get_title();
                     $scope.jobSearchSignature = $scope.job.signature;
                     $scope.jobSearchStrHref = getJobSearchStrHref($scope.jobSearchStr);
                     $scope.jobSearchSignatureHref = getJobSearchStrHref($scope.job.signature);


### PR DESCRIPTION
Since we only need it when actually filtering the job list, just dynamically
calculate there instead of keeping a (potentially large amount) of redundant
data in memory constantly. It doesn't take long to recalculate this relative
to other expenses (such as recalculating the DOM).

Since we were storing about 200 characters per job, and that a typical push
has upwards of 2000 jobs, this can save up to 2 megabytes on the default
treeherder view of 5 pushes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1424)
<!-- Reviewable:end -->
