### PR TITLE
Bug 1266229 - More fixes and tweaks prior to turning on Pulse ingestion

### DIFF
--- a/schemas/pulse-job.yml
+++ b/schemas/pulse-job.yml
@@ -106,13 +106,13 @@ properties:
       jobName:
         title: "job name"
         type: "string"
-        pattern: "^[A-Za-z0-9\\s_-]+$"
+        pattern: "^[A-Za-z0-9\\s_,\\+\\[\\]\\(\\)-]+$"
         minLength: 1
         maxLength: 100
       groupName:
         title: "group name"
         type: "string"
-        pattern: "^[\\w\\s-]+$"
+        pattern: "^[\\w,\\+\\s\\[\\]\\(\\)-]+$"
         minLength: 1
         maxLength: 100
     required:

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -175,6 +175,10 @@ LOGGING = {
         'treeherder': {
             'handlers': ['console'],
             'level': 'ERROR',
+        },
+        'kombu': {
+            'handlers': ['console'],
+            'level': 'WARNING',
         }
     }
 }
@@ -404,13 +408,13 @@ PULSE_EXCHANGE_NAMESPACE = env("PULSE_EXCHANGE_NAMESPACE", default=None)
 # exchanges for testing purposes on local machines.
 # Treeherder will subscribe with routing keys that are all combinations of
 # ``project`` and ``destination`` in the form of:
-#     <project>.<destination>
+#     <destination>.<project>
 # Wildcards such as ``#`` and ``*`` are supported for either field.
-PULSE_DATA_INGESTION_EXCHANGES = env.json(
-    "PULSE_DATA_INGESTION_EXCHANGES",
+PULSE_DATA_INGESTION_SOURCES = env.json(
+    "PULSE_DATA_INGESTION_SOURCES",
     default=[
         # {
-        #     "name": "exchange/taskcluster-treeherder/jobs",
+        #     "name": "exchange/taskcluster-treeherder/v1/jobs",
         #     "projects": [
         #         'mozilla-central',
         #         'mozilla-inbound'
@@ -435,22 +439,25 @@ PULSE_DATA_INGESTION_EXCHANGES = env.json(
         # ... other CI systems
     ])
 
+# Used for making API calls to pulse, such as detecting bindings on the current
+# ingestion queue.
+PULSE_API_URL = "https://pulse.mozilla.org/"
+
 # Used to specify the PulseGuardian account that will be used to create
 # ingestion queues for the exchanges specified in ``PULSE_DATA_INGESTION_EXCHANGES``.
 # See https://pulse.mozilla.org/whats_pulse for more info.
-# Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/"
+# Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/?ssl=1"
 PULSE_DATA_INGESTION_CONFIG = env.url("PULSE_DATA_INGESTION_CONFIG", default="")
+
 
 # Whether the Queues created for pulse ingestion are durable or not.
 # For local data ingestion, you probably should set this to False
-PULSE_DATA_INGESTION_QUEUES_DURABLE = env.bool("PULSE_DATA_INGESTION_QUEUES_DURABLE",
-                                               default=True)
+PULSE_DATA_INGESTION_QUEUES_DURABLE = True
 
 # Whether the Queues created for pulse ingestion auto-delete after connections
 # are closed.
 # For local data ingestion, you probably should set this to True
-PULSE_DATA_INGESTION_QUEUES_AUTO_DELETE = env.bool("PULSE_DATA_INGESTION_QUEUES_AUTO_DELETE",
-                                                   default=False)
+PULSE_DATA_INGESTION_QUEUES_AUTO_DELETE = False
 
 # The git-ignored settings_local.py file should only be used for local development.
 if env.bool("ENABLE_LOCAL_SETTINGS_FILE", default=False):

--- a/treeherder/etl/management/commands/ingest_from_pulse.py
+++ b/treeherder/etl/management/commands/ingest_from_pulse.py
@@ -1,14 +1,10 @@
-import logging
-from urlparse import urlparse
-
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from kombu import (Connection,
                    Exchange)
 
+from treeherder.etl.common import fetch_json
 from treeherder.etl.pulse_consumer import JobConsumer
-
-logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -19,35 +15,69 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         config = settings.PULSE_DATA_INGESTION_CONFIG
-        userid = urlparse(config).username
-        durable = settings.PULSE_DATA_INGESTION_QUEUES_DURABLE
-        auto_delete = settings.PULSE_DATA_INGESTION_QUEUES_AUTO_DELETE
-        connection = Connection(config)
-        consumer = JobConsumer(connection)
+        sources = settings.PULSE_DATA_INGESTION_SOURCES
+        # get the existing bindings for the queue
+        bindings = []
+        new_bindings = []
 
-        try:
-            for exchange_obj in settings.PULSE_DATA_INGESTION_EXCHANGES:
-                exchange = Exchange(exchange_obj["name"], type="topic")
-                exchange(connection).declare(passive=True)
-                self.stdout.write("Connected to Pulse Exchange: {}".format(
-                    exchange_obj["name"]))
+        with Connection(config) as connection:
+            consumer = JobConsumer(connection)
+            try:
+                bindings = self.get_bindings(consumer.queue_name)["bindings"]
+            except Exception:
+                self.stderr.write(
+                    "ERROR: Unable to fetch existing bindings for {}".format(
+                        consumer.queue_name))
+                self.stderr.write("ERROR: Data ingestion may proceed, but no bindings will be pruned")
 
-                for project in exchange_obj["projects"]:
-                    queue_name = "queue/{}/".format(userid)
-                    for destination in exchange_obj['destinations']:
-                        routing_key = "{}.{}".format(project, destination)
-                        consumer.listen_to(
-                            exchange,
-                            routing_key,
-                            queue_name,
-                            durable,
-                            auto_delete)
+            for source in sources:
+                # When creating this exchange object, it is important that it
+                # be set to ``passive=True``.  This will prevent any attempt by
+                # Kombu to actually create the exchange.
+                exchange = Exchange(source["exchange"], type="topic",
+                                    passive=True)
+                # ensure the exchange exists.  Throw an error if it doesn't
+                exchange(connection).declare()
+
+                for project in source["projects"]:
+                    for destination in source['destinations']:
+                        routing_key = "{}.{}".format(destination, project)
+                        consumer.bind_to(exchange, routing_key)
+                        new_binding_str = self.get_binding_str(exchange.name,
+                                                               routing_key)
+                        new_bindings.append(new_binding_str)
+
                         self.stdout.write(
-                            "Pulse message consumer listening to : {} {}".format(
-                                exchange.name,
-                                routing_key
+                            "Pulse queue {} bound to: {}".format(
+                                consumer.queue_name,
+                                new_binding_str
                             ))
 
-            consumer.run()
-        finally:
-            consumer.close()
+            # Now prune any bindings from the our queue that were not
+            # established above.
+            # This indicates that they are no longer in the config, and should
+            # therefore be removed from the durable queue bindings list.
+            for binding in bindings:
+                if binding["source"]:
+                    binding_str = self.get_binding_str(binding["source"],
+                                                       binding["routing_key"])
+
+                    if binding_str not in new_bindings:
+                        consumer.unbind_from(Exchange(binding["source"]),
+                                             binding["routing_key"])
+                        self.stdout.write("Unbound from: {}".format(binding_str))
+
+            try:
+                consumer.run()
+            except KeyboardInterrupt:
+                self.stdout.write("Pulse listening stopped...")
+
+    def get_binding_str(self, exchange, routing_key):
+        """Use consistent string format for binding comparisons"""
+        return "{} {}".format(exchange, routing_key)
+
+    def get_bindings(self, queue_name):
+        """Get list of bindings from the pulse API"""
+        return fetch_json("{}queue/{}/{}".format(settings.PULSE_API_URL,
+                                                 queue_name,
+                                                 "bindings"))

--- a/treeherder/etl/tasks/pulse_tasks.py
+++ b/treeherder/etl/tasks/pulse_tasks.py
@@ -1,14 +1,18 @@
 """
 This module contains tasks related to pulse job ingestion
 """
+import newrelic.agent
 from celery import task
 
 from treeherder.etl.job_loader import JobLoader
 
 
 @task(name='store-pulse-jobs')
-def store_pulse_jobs(job_list):
+def store_pulse_jobs(job_list, exchange, routing_key):
     """
     Fetches the jobs pending from pulse exchanges and loads them.
     """
+    newrelic.agent.add_custom_parameter("exchange", exchange)
+    newrelic.agent.add_custom_parameter("routing_key", routing_key)
+
     JobLoader().process_job_list(job_list)


### PR DESCRIPTION
This contains several tweaks and fixes that allow us to ingest data from
a real Task Cluster owned exchange.

One of the main fixes is the way I was binding to the exchange and
routing keys with the same Queue.  Before, it was re-creating the Queue,
so would miss some of the bindings.

This PR stops just short of actually turning ingestion on.  I figured I'd do that in the next PR to add it to the ``procfile`` and the queue in ``settings.py``

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1431)
<!-- Reviewable:end -->
