### PR TITLE
Bug 1268705 - fix logviewer job details fields

### DIFF
--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -226,7 +226,7 @@ logViewerApp.controller('LogviewerCtrl', [
 
                 // other properties, in order of appearance
                 $scope.logProperties = [
-                    {label: "Job", value: jobStr},
+                    {label: "Job", value: $scope.logViewerTitle},
                     {label: "Machine", value: job.machine_name},
                     {label: "Start", value: dateFilter(job.start_timestamp*1000, thDateFormat)},
                     {label: "End", value: dateFilter(job.end_timestamp*1000, thDateFormat)}


### PR DESCRIPTION
This var ``jobStr`` no longer exists.  Should use the ``scope.logViewerTitle`` instead now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1432)
<!-- Reviewable:end -->
