### PR TITLE
Bug 1266229 - Pulse ingestion fixes and updates

### DIFF
--- a/schemas/pulse-job.yml
+++ b/schemas/pulse-job.yml
@@ -8,11 +8,11 @@ type: "object"
 properties:
   taskId:
     title: "taskId"
-    descriptio: |
+    description: |
       This could just be what was formerly submitted as a job_guid in the
       REST API.
     type: "string"
-    pattern: "^[A-Za-z0-9_/+-]+$"
+    pattern: "^[A-Za-z0-9/+-]+$"
     minLength: 1
     maxLength: 50
   retryId:
@@ -39,7 +39,7 @@ properties:
             enum: ['hg.mozilla.org']
           project:
             type: "string"
-            pattern: "^[A-Za-z0-9_-]+$"
+            pattern: "^[\\w-]+$"
             minLength: 1
             maxLength: 50
           revision:
@@ -61,12 +61,12 @@ properties:
               This could be the organization or the individual git username
               depending on who owns the repo.
             type: "string"
-            pattern: "^[0-9a-f]+$"
+            pattern: "^[\\w-]+$"
             minLength: 1
             maxLength: 50
-          projectName:
+          project:
             type: "string"
-            pattern: "^[0-9a-f]+$"
+            pattern: "^[\\w-]+$"
             minLength: 1
             maxLength: 50
           revision:
@@ -84,7 +84,7 @@ properties:
         title: "jobSymbol"
         type: "string"
         # spaces and "?" are not valid for job symbols
-        pattern: "^[A-Za-z0-9._-]+$"
+        pattern: "^$|^[\\w.-]+$"
         minLength: 0
         maxLength: 25
       chunkId:
@@ -99,22 +99,25 @@ properties:
         title: "group symbol"
         type: "string"
         # spaces not valid for group symbols
-        pattern: "^[A-Za-z0-9/?_-]+$"
+        pattern: "^[\\w/?-]+$"
         minLength: 1
         maxLength: 25
       # could do without these if we require job type and group to exist prior
       jobName:
         title: "job name"
         type: "string"
+        pattern: "^[A-Za-z0-9\\s_-]+$"
         minLength: 1
         maxLength: 100
       groupName:
         title: "group name"
         type: "string"
-        pattern: "^[A-Za-z0-9_-]+$"
+        pattern: "^[\\w\\s-]+$"
         minLength: 1
         maxLength: 100
     required:
+      - jobName
+      - jobSymbol
       - groupSymbol
 
 
@@ -165,7 +168,7 @@ properties:
     items:
       title: "job guid"
       type: "string"
-      pattern: "^[A-Za-z0-9_/+-]+$"
+      pattern: "^[\\w/+-]+$"
       minLength: 1
       maxLength: 50
 
@@ -203,7 +206,7 @@ properties:
       type: "string"
       minLength: 1
       maxLength: 50
-      pattern: "^[A-Za-z0-9_-]+$"
+      pattern: "^[\\w-]+$"
 
   owner:
     description: |
@@ -359,6 +362,9 @@ properties:
   extra:
     type: "object"
     description: Extra information that Treeherder reads on a best-effort basis
+  version:
+    type: "integer"
+
 
 additionalProperties: false
 required:
@@ -367,6 +373,7 @@ required:
   - display
   - state
   - jobKind
+  - version
 
 definitions:
   machine:
@@ -374,26 +381,25 @@ definitions:
     properties:
       name:
         type: "string"
-        pattern: "^[A-Za-z0-9_-]+$"
+        pattern: "^[\\w-]+$"
         minLength: 1
         maxLength: 50
       platform:
         type: "string"
-        pattern: "^[A-Za-z0-9_-]+$"
+        pattern: "^[\\w-]+$"
         minLength: 1
-        maxLength: 25
+        maxLength: 100
       os:
         type: "string"
-        pattern: "^[A-Za-z0-9_-]+$"
+        pattern: "^[\\w-]+$"
         minLength: 1
         maxLength: 25
       architecture:
         type: "string"
-        pattern: "^[A-Za-z0-9_-]+$"
+        pattern: "^[\\w-]+$"
         minLength: 1
         maxLength: 25
     required:
-      - name
       - platform
       - os
       - architecture

--- a/tests/sample_data/pulse_consumer/job_data.json
+++ b/tests/sample_data/pulse_consumer/job_data.json
@@ -40,6 +40,7 @@
     "timeCompleted": "2014-12-19T18:39:57-08:00",
 
     "labels": ["debug"],
+    "version": 1,
 
     "logs": [
       {
@@ -101,7 +102,8 @@
     "labels": [
       "debug",
       "opt"
-    ]
+    ],
+    "version": 1
   },
 
   {
@@ -115,6 +117,7 @@
     },
 
     "display": {
+      "jobSymbol": "",
       "chunkId": 3,
       "jobName": "Pulse Ingestion Test",
       "groupSymbol": "PI",
@@ -144,6 +147,8 @@
     "timeScheduled": "2014-12-19T16:39:57-08:00",
     "timeStarted": "2014-12-19T17:39:57-08:00",
     "timeCompleted": "2014-12-19T18:39:57-08:00",
+
+    "version": 1,
 
     "logs": [
       {
@@ -205,6 +210,7 @@
     },
 
     "display": {
+      "jobSymbol": "",
       "chunkId": 3,
       "jobName": "Pulse Ingestion Test",
       "groupSymbol": "PI",
@@ -234,6 +240,8 @@
     "timeScheduled": "2014-12-19T16:39:57-08:00",
     "timeStarted": "2014-12-19T17:39:57-08:00",
     "timeCompleted": "2014-12-19T18:39:57-08:00",
+
+    "version": 1,
 
     "logs": [
       {

--- a/treeherder/model/migrations/0020_update_job_name_length.py
+++ b/treeherder/model/migrations/0020_update_job_name_length.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0019_bug_number_unique'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='jobgroup',
+            name='name',
+            field=models.CharField(max_length=100, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='jobtype',
+            name='name',
+            field=models.CharField(max_length=100, db_index=True),
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -309,7 +309,7 @@ class Datasource(models.Model):
 class JobGroup(models.Model):
     id = models.AutoField(primary_key=True)
     symbol = models.CharField(max_length=10, default='?', db_index=True)
-    name = models.CharField(max_length=50, db_index=True)
+    name = models.CharField(max_length=100, db_index=True)
     description = models.TextField(blank=True)
     active_status = models.CharField(max_length=7, blank=True, default='active', db_index=True)
 
@@ -350,7 +350,7 @@ class JobType(models.Model):
     id = models.AutoField(primary_key=True)
     job_group = models.ForeignKey(JobGroup, null=True, blank=True)
     symbol = models.CharField(max_length=10, default='?', db_index=True)
-    name = models.CharField(max_length=50, db_index=True)
+    name = models.CharField(max_length=100, db_index=True)
     description = models.TextField(blank=True)
     active_status = models.CharField(max_length=7, blank=True, default='active', db_index=True)
 


### PR DESCRIPTION
These changes were discovered to be needed after direct testing
against a Task Cluster exchange from the ``taskcluster-treeherder`` project with Pulse.

-Made some schema changes to be more precise for several fields
-Modified to job_loader to be more resilient to optional data being
missing
-Change the ``name`` field for job types and job groups to allow 100
  characters because some names were being truncated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1433)
<!-- Reviewable:end -->
