### PR TITLE
Bug 1268485 - Add elasticsearch to local Vagrant environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 Vagrant.require_version ">= 1.5.0"
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty32"
+  config.vm.box = "ubuntu/trusty64"
 
   config.vm.hostname = "local.treeherder.mozilla.org"
   config.vm.network "private_network", ip: "192.168.33.10"

--- a/puppet/manifests/classes/elasticsearch.pp
+++ b/puppet/manifests/classes/elasticsearch.pp
@@ -1,0 +1,18 @@
+class elasticsearch {
+  package { 'openjdk-7-jre':
+    ensure => installed
+  }
+
+  package { 'elasticsearch':
+    ensure => installed
+  }
+
+  service { 'elasticsearch':
+    ensure => running,
+    enable => true,
+    require => [
+      Package['openjdk-7-jre'],
+      Package['elasticsearch'],
+    ],
+  }
+}

--- a/puppet/manifests/classes/init.pp
+++ b/puppet/manifests/classes/init.pp
@@ -11,8 +11,24 @@ class init {
         creates => "/etc/apt/sources.list.d/fkrull-deadsnakes-python2_7-trusty.list",
     }
 
+    exec { "add_elasticsearch_signing_key":
+        command => "wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key --keyring /etc/apt/trusted.gpg.d/elasticsearch.gpg add -",
+        creates => "/etc/apt/trusted.gpg.d/elasticsearch.gpg",
+    }
+
+    # We cannot use `add-apt-repository` per:
+    # https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-repositories.html#_apt
+    exec { "add_elasticsearch_repo":
+        command => "echo 'deb http://packages.elastic.co/elasticsearch/2.x/debian stable main' | sudo tee -a /etc/apt/sources.list.d/elasticsearch-2.x.list",
+        creates => "/etc/apt/sources.list.d/elasticsearch-2.x.list",
+    }
+
     exec { "update_apt":
         command => "sudo apt-get update",
-        require => Exec["add_python27_ppa"],
+        require => [
+            Exec["add_python27_ppa"],
+            Exec["add_elasticsearch_signing_key"],
+            Exec["add_elasticsearch_repo"],
+        ]
     }
 }

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -55,7 +55,8 @@ file {"${PROJ_DIR}/treeherder/config/settings_local.py":
 class vagrant {
     class {
         init: before => Class["mysql"];
-        mysql: before  => Class["python"];
+        mysql: before  => Class["elasticsearch"];
+        elasticsearch: before  => Class["python"];
         python: before => Class["varnish"];
         varnish: before => Class["treeherder"];
         treeherder: before => Class["rabbitmq"];


### PR DESCRIPTION
**1) Vagrant: Switch to a 64bit Ubuntu base image:**
Since no packages for Elasticsearch 2.x+ are available for 32bit.
This also makes Vagrant consistent with stage/prod/Heroku/Travis.

**2) Vagrant: Install/run an Elasticsearch instance:**
Since it's required for fuzzy auto-classification in bug 1268484. 

Follows the steps here:
https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-repositories.html

Test using:
`curl -X GET localhost:9200`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1435)
<!-- Reviewable:end -->
