### PR TITLE
Bug 1265188 - Make sure to check for existing identical classification when trying to update the bug number.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -369,25 +369,31 @@ def failure_classifications():
 
 
 @pytest.fixture
-def classified_failures(request, jm, eleven_jobs_stored, failure_lines,
-                        failure_classifications):
-    from treeherder.model.models import ClassifiedFailure, FailureMatch, MatcherManager
+def test_matcher(request):
     from treeherder.autoclassify import detectors
-
-    job_1 = jm.get_job(1)[0]
+    from treeherder.model.models import MatcherManager
 
     class TreeherderUnitTestDetector(detectors.Detector):
         def __call__(self, failure_lines):
             pass
 
-    test_matcher = MatcherManager._detector_funcs = {}
-    test_matcher = MatcherManager._matcher_funcs = {}
+    MatcherManager._detector_funcs = {}
+    MatcherManager._matcher_funcs = {}
     test_matcher = MatcherManager.register_detector(TreeherderUnitTestDetector)
 
     def finalize():
         MatcherManager._detector_funcs = {}
         MatcherManager._matcher_funcs = {}
     request.addfinalizer(finalize)
+
+    return test_matcher
+
+
+@pytest.fixture
+def classified_failures(request, jm, eleven_jobs_stored, failure_lines,
+                        failure_classifications, test_matcher):
+    from treeherder.model.models import ClassifiedFailure, FailureMatch
+    job_1 = jm.get_job(1)[0]
 
     classified_failures = []
 

--- a/tests/model/test_classified_failure.py
+++ b/tests/model/test_classified_failure.py
@@ -1,0 +1,43 @@
+from decimal import Decimal
+
+from treeherder.model.models import (ClassifiedFailure,
+                                     FailureMatch)
+
+
+def test_set_bug(classified_failures):
+    rv = classified_failures[0].set_bug(1234)
+    assert rv == classified_failures[0]
+    assert classified_failures[0].bug_number == 1234
+
+
+def test_set_bug_duplicate(failure_lines, classified_failures, test_matcher):
+    classified_failures[0].bug_number = 1234
+    classified_failures[0].save()
+    match = failure_lines[0].matches.all()[0]
+    match.score = 0.7
+    match.save()
+    # Add a FailureMatch that will have the same (failure_line_id, classified_failure_id)
+    # as another FailureMatch when classified_failure[1] is replaced by classified_failure[0]
+    duplicate_match = FailureMatch(
+        failure_line=failure_lines[0],
+        classified_failure=classified_failures[1],
+        matcher=test_matcher.db_object,
+        score=0.8)
+    duplicate_match.save()
+    assert len(failure_lines[0].matches.all()) == 2
+    rv = classified_failures[1].set_bug(1234)
+    assert rv == classified_failures[0]
+    assert rv.bug_number == 1234
+    for item in failure_lines:
+        item.refresh_from_db()
+    match.refresh_from_db()
+    # Check that we updated the best classification that previously pointed
+    # to the now-defunct classified_failures[0]
+    assert failure_lines[1].best_classification == classified_failures[0]
+    # Check that we only have one match for the first failure line
+    matches = failure_lines[0].matches.all()
+    assert len(matches) == 1
+    # Check we picked the better of the two scores for the new match.
+    assert matches[0].score == Decimal("0.8")
+    # Ensure we deleted the ClassifiedFailure on which we tried to set the bug
+    assert len(ClassifiedFailure.objects.filter(id=classified_failures[1].id)) == 0

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -679,16 +679,15 @@ class JobsModel(TreeherderModelBase):
             debug_show=self.DEBUG
         )
 
-    def update_autoclassification_bug(self, job_id, bug_id):
+    def update_autoclassification_bug(self, job_id, bug_number):
         failure_line = self.get_manual_classification_line(job_id)
 
         if failure_line is None:
             return
 
-        classification = failure_line.best_classification
-        if classification and classification.bug_number is None:
-            classification.bug_number = bug_id
-            classification.save()
+            classification = failure_line.best_classification
+            if classification and classification.bug_number is None:
+                classification.set_bug(bug_number)
 
     def calculate_durations(self, sample_window_seconds, debug):
         # Get the most recent timestamp from jobs


### PR DESCRIPTION
When setting the bug number for a classified failure, first check for an
classified failure that already has that bug number, and if one exists,
update all references to the classified failure being changed to instead
point at the existing classification

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1438)
<!-- Reviewable:end -->
