### PR TITLE
Bug 1269747 - Group job/group info together as one token for job title

### DIFF
--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -24,13 +24,19 @@ treeherder.factory('ThJobModel', [
         };
 
         ThJobModel.prototype.get_title = function() {
+            // we want to join the group and type information together
+            // so we can search for it as one token (useful when
+            // we want to do a search on something like `fxup-esr(`)
+            var symbolInfo = (this.job_group_symbol === '?') ? '' :
+                this.job_group_symbol;
+            symbolInfo += "(" + this.job_type_symbol + ")";
+
             return _.filter([
                 thPlatformName(this.platform),
                 this.platform_option,
                 (this.job_group_name === 'unknown') ? undefined : this.job_group_name,
                 this.job_type_name,
-                this.job_group_symbol === '?' ? undefined : this.job_group_symbol,
-                "(" + this.job_type_symbol + ")"
+                symbolInfo
             ]).join(' ');
         };
 


### PR DESCRIPTION
This lets us search for strings like `fxup-esr(` (and was the old
behaviour before we accidentally regressed in bug 1267102)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1448)
<!-- Reviewable:end -->
