### PR TITLE
Bug 1250573 - Explicitly disable New Relic browser monitoring

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -9,3 +9,7 @@
 log_file = stdout
 # Turn on the capturing of request parameters.
 attributes.include = request.parameters.*
+# Disable client-side monitoring JS injection, due to there being no way for
+# users to opt-out. See:
+# https://groups.google.com/forum/#!topic/mozilla.dev.webdev/ragGTzhyY2w
+browser_monitoring.enabled = false


### PR DESCRIPTION
It's been switched off via the New Relic web UI config page for some time, however it makes sense to explicitly turn it off via the agent config (which cannot then be overridden by the web UI).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1450)
<!-- Reviewable:end -->
