### PR TITLE
Bug 1169944 - Use the New Relic wrapper when running scripts locally too

### DIFF
--- a/bin/run_celery_worker
+++ b/bin/run_celery_worker
@@ -8,17 +8,13 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then
-    NEWRELIC_ADMIN="newrelic-admin run-program"
-fi
-
 LOGFILE=/var/log/celery/celery_worker.log
 
 if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec $NEWRELIC_ADMIN celery -A treeherder worker -c 3 \
+exec newrelic-admin run-program celery -A treeherder worker -c 3 \
      -Q default,cycle_data,calculate_durations,fetch_bugs,fetch_allthethings,generate_perf_alerts,detect_intermittents \
      -E --maxtasksperchild=500 \
      --logfile=$LOGFILE -l INFO -n default.%h

--- a/bin/run_celery_worker_buildapi
+++ b/bin/run_celery_worker_buildapi
@@ -8,17 +8,13 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then
-    NEWRELIC_ADMIN="newrelic-admin run-program"
-fi
-
 LOGFILE=/var/log/celery/celery_worker_buildapi.log
 
 if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec $NEWRELIC_ADMIN celery -A treeherder worker -Q buildapi_pending,buildapi_running,buildapi_4hr \
+exec newrelic-admin run-program celery -A treeherder worker -Q buildapi_pending,buildapi_running,buildapi_4hr \
     --concurrency=5 --logfile=$LOGFILE -l INFO \
     --maxtasksperchild=20 -n buildapi.%h
 

--- a/bin/run_celery_worker_hp
+++ b/bin/run_celery_worker_hp
@@ -8,16 +8,12 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then
-    NEWRELIC_ADMIN="newrelic-admin run-program"
-fi
-
 LOGFILE=/var/log/celery/celery_worker_hp.log
 
 if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec $NEWRELIC_ADMIN celery -A treeherder worker -c 1 \
+exec newrelic-admin run-program celery -A treeherder worker -c 1 \
      -Q classification_mirroring,publish_to_pulse -E --maxtasksperchild=500 \
      --logfile=$LOGFILE -l INFO -n hp.%h

--- a/bin/run_celery_worker_log_parser
+++ b/bin/run_celery_worker_log_parser
@@ -8,17 +8,13 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then
-    NEWRELIC_ADMIN="newrelic-admin run-program"
-fi
-
 LOGFILE=/var/log/celery/celery_worker_log_parser.log
 
 if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec $NEWRELIC_ADMIN celery -A treeherder worker \
+exec newrelic-admin run-program celery -A treeherder worker \
     -Q \
 parse_job_logs,\
 parse_job_logs_fail,\

--- a/bin/run_celery_worker_pushlog
+++ b/bin/run_celery_worker_pushlog
@@ -8,17 +8,13 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then
-    NEWRELIC_ADMIN="newrelic-admin run-program"
-fi
-
 LOGFILE=/var/log/celery/celery_worker_pushlog.log
 
 if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec $NEWRELIC_ADMIN celery -A treeherder worker \
+exec newrelic-admin run-program celery -A treeherder worker \
     -Q pushlog,fetch_missing_push_logs \
     --concurrency=5 --logfile=$LOGFILE -l INFO \
     --maxtasksperchild=500 -n pushlog.%h

--- a/bin/run_celerybeat
+++ b/bin/run_celerybeat
@@ -8,14 +8,10 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then
-    NEWRELIC_ADMIN="newrelic-admin run-program"
-fi
-
 LOGFILE=/var/log/celery/celerybeat.log
 
 if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec $NEWRELIC_ADMIN celery -A treeherder beat -f $LOGFILE
+exec newrelic-admin run-program celery -A treeherder beat -f $LOGFILE

--- a/bin/run_gunicorn
+++ b/bin/run_gunicorn
@@ -10,10 +10,6 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-if [[ ${NEW_RELIC_LICENSE_KEY+isset} = isset ]]; then
-    NEWRELIC_ADMIN="newrelic-admin run-program"
-fi
-
 LOGDIR=/var/log/gunicorn
 ACCESS_LOGFILE=$LOGDIR/treeherder_access.log
 ERROR_LOGFILE=$LOGDIR/treeherder_error.log
@@ -28,7 +24,7 @@ fi
 
 NUM_WORKERS=5
 
-exec $NEWRELIC_ADMIN gunicorn -w $NUM_WORKERS \
+exec newrelic-admin run-program gunicorn -w $NUM_WORKERS \
     --max-requests=150 \
     --access-logfile=$ACCESS_LOGFILE \
     --error-logfile=$ERROR_LOGFILE treeherder.config.wsgi:application \


### PR DESCRIPTION
Previously if the `bin/` directory scripts were run in the Vagrant environment, the processes run would not have been started via the New Relic wrapper command, since the New Relic licence key is not set.

For greater consistency between Vagrant and production, the wrapper command is now always used. 

This works since `NEW_RELIC_DEVELOPER_MODE` is defined in the Vagrant environment (thanks to a previous commit in the same bug), which prevents the agent from trying to submit real data:
https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/python-agent-configuration#developer_mode

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1451)
<!-- Reviewable:end -->
