### PR TITLE
Bug 1234247 - Only fetch missing pushlogs for completed jobs

### DIFF
--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -224,28 +224,6 @@ def test_ingest_running_job_fields(jm,
 #####################
 
 
-def test_ingest_pending_jobs_1_missing_resultset(jm,
-                                                 sample_resultset, mock_buildapi_pending_missing1_url,
-                                                 mock_post_json, mock_get_resultset,
-                                                 activate_responses):
-    """
-    Ensure the pending job with the missing resultset is queued for refetching
-    """
-    etl_process = PendingJobsProcess()
-    _do_missing_resultset_test(jm, etl_process)
-
-
-def test_ingest_running_jobs_1_missing_resultset(jm,
-                                                 sample_resultset, mock_buildapi_running_missing1_url,
-                                                 mock_post_json, mock_get_resultset,
-                                                 activate_responses):
-    """
-    Ensure the running job with the missing resultset is queued for refetching
-    """
-    etl_process = RunningJobsProcess()
-    _do_missing_resultset_test(jm, etl_process)
-
-
 def test_ingest_builds4h_jobs_1_missing_resultset(jm,
                                                   sample_resultset, mock_buildapi_builds4h_missing1_url,
                                                   mock_post_json, mock_log_parser, mock_get_resultset,

--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -416,9 +416,6 @@ class PendingRunningTransformerMixin(object):
                     th_job = th_collections[project].get_job(treeherder_data)
                     th_collections[project].add(th_job)
 
-        if missing_resultsets and not revision_filter:
-            common.fetch_missing_resultsets(source, missing_resultsets, logger)
-
         num_new_jobs = len(job_ids_seen_now.difference(job_ids_seen_last_time))
         logger.info("Imported %d %s jobs, skipped %d previously seen",
                     num_new_jobs, source, len(job_ids_seen_now) - num_new_jobs)


### PR DESCRIPTION
The long-term aim is to make the fetch missing pushlogs tasks redundant, by fixing the causes of missing pushes (if they're not already fixed).

However currently it's hard to identify whether it's still required, since the standard pushlog task can race with job ingestion, causing us to fetch 'missing' pushes that would have been otherwise retrieved fine.

By stopping the retrieval of missing pushes for pending/running jobs, we give the standard pushlog retrieval time to run, prior to the job being completed. If the push is still missing once we ingest the completed job, we'll run the fetch missing pushes task as before - as a last resort fall-back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1452)
<!-- Reviewable:end -->
