### PR TITLE
Bug 1270182 - Travis: Enabling caching for the Ubuntu trusty jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,11 +55,14 @@ matrix:
     # Job 3: Python Tests Chunk A
     - env: python-tests-main
       # Once mysql 5.6 is available on the container infra, we should switch back
-      # to it, by setting `sudo: false`, so we can use caching for this job.
+      # to it for its faster boot time, by setting `sudo: false`.
       sudo: required
       dist: trusty
       language: python
       python: "2.7.11"
+      cache:
+        directories:
+          - ~/venv
       services:
         - rabbitmq
         - memcached
@@ -67,6 +70,10 @@ matrix:
         # Manually install mysql 5.6 since the default is v5.5.
         - sudo apt-get -qq update
         - sudo apt-get -qq install mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
+        # Create a clean virtualenv rather than using the one given to us,
+        # to work around: https://github.com/travis-ci/travis-ci/issues/4873
+        - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv ~/venv; fi
+        - source ~/venv/bin/activate
         - pip install --disable-pip-version-check --upgrade pip==8.1.1
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
@@ -76,11 +83,14 @@ matrix:
     # Job 4: Python Tests Chunk B
     - env: python-tests-e2e-etl-and-logparser
       # Once mysql 5.6 is available on the container infra, we should switch back
-      # to it, by setting `sudo: false`, so we can use caching for this job.
+      # to it for its faster boot time, by setting `sudo: false`.
       sudo: required
       dist: trusty
       language: python
       python: "2.7.11"
+      cache:
+        directories:
+          - ~/venv
       services:
         - rabbitmq
         - memcached
@@ -88,6 +98,10 @@ matrix:
         # Manually install mysql 5.6 since the default is v5.5.
         - sudo apt-get -qq update
         - sudo apt-get -qq install mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
+        # Create a clean virtualenv rather than using the one given to us,
+        # to work around: https://github.com/travis-ci/travis-ci/issues/4873
+        - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv ~/venv; fi
+        - source ~/venv/bin/activate
         - pip install --disable-pip-version-check --upgrade pip==8.1.1
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv ~/venv; fi
         - source ~/venv/bin/activate
-        - pip install -U pip==8.1.1
+        - pip install --disable-pip-version-check --upgrade pip==8.1.1
       install:
         - npm install
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
@@ -64,7 +64,7 @@ matrix:
         # Manually install mysql 5.6 since the default is v5.5.
         - sudo apt-get -qq update
         - sudo apt-get -qq install mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
-        - pip install -U pip==8.1.1
+        - pip install --disable-pip-version-check --upgrade pip==8.1.1
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
       script:
@@ -84,7 +84,7 @@ matrix:
         # Manually install mysql 5.6 since the default is v5.5.
         - sudo apt-get -qq update
         - sudo apt-get -qq install mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
-        - pip install -U pip==8.1.1
+        - pip install --disable-pip-version-check --upgrade pip==8.1.1
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
   include:
     # Each entry here creates another sub-job.
 
+    # Job 1: Linters
     - env: linters
       sudo: false
       language: python
@@ -31,6 +32,7 @@ matrix:
         - flake8 --show-source
         - isort --check-only --diff --quiet
 
+    # Job 2: Nodejs UI tests
     - env: ui-tests
       sudo: false
       language: node_js
@@ -50,6 +52,7 @@ matrix:
         - npm test
         - ./node_modules/.bin/grunt build --production
 
+    # Job 3: Python Tests Chunk A
     - env: python-tests-main
       # Once mysql 5.6 is available on the container infra, we should switch back
       # to it, by setting `sudo: false`, so we can use caching for this job.
@@ -70,6 +73,7 @@ matrix:
       script:
         - py.test tests/ --runslow --ignore=tests/e2e/ --ignore=tests/etl/ --ignore=tests/log_parser/
 
+    # Job 4: Python Tests Chunk B
     - env: python-tests-e2e-etl-and-logparser
       # Once mysql 5.6 is available on the container infra, we should switch back
       # to it, by setting `sudo: false`, so we can use caching for this job.


### PR DESCRIPTION
Since it's now supported:
https://blog.travis-ci.com/2016-05-03-caches-are-coming-to-everyone

This will reduce the job runtime by 60-80s.

Similar to the container job (job chunk 1), since we're now caching the virtualenv, we have to workaround the default virtualenv being polluted with existing packages (by creating a clean one in another directory), to avoid constant cache churn.

See individual commits for more info.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1453)
<!-- Reviewable:end -->
