### PR TITLE
Bug 1270236 - Update ReadtheDocs links to the new .io domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ treeherder
 [![Python Requirements Status](https://requires.io/github/mozilla/treeherder/requirements.svg?branch=master)](https://requires.io/github/mozilla/treeherder/requirements/?branch=master)
 [![Node Dependency Status](https://david-dm.org/mozilla/treeherder.svg)](https://david-dm.org/mozilla/treeherder)
 [![Node devDependency Status](https://david-dm.org/mozilla/treeherder/dev-status.svg)](https://david-dm.org/mozilla/treeherder#info=devDependencies)
-[![Documentation Status](https://readthedocs.org/projects/treeherder/badge/?version=latest)](https://readthedocs.org/projects/treeherder/?badge=latest)
+[![Documentation Status](http://readthedocs.org/projects/treeherder/badge/?version=latest)](https://treeherder.readthedocs.io/?badge=latest)
 
 
 #### Description
@@ -16,9 +16,9 @@ Treeherder exists on two instances, [stage](https://treeherder.allizom.org) for 
 
 
 #### Installation
-The steps to run Treeherder are provided [here](https://treeherder.readthedocs.org/installation.html).
+The steps to run Treeherder are provided [here](https://treeherder.readthedocs.io/installation.html).
 
-The steps to run only the UI are provided [here](https://treeherder.readthedocs.org/ui/installation.html).
+The steps to run only the UI are provided [here](https://treeherder.readthedocs.io/ui/installation.html).
 
 
 #### Links
@@ -27,6 +27,6 @@ Visit our project tracking Wiki at:
 https://wiki.mozilla.org/EngineeringProductivity/Projects/Treeherder
 
 Visit our **readthedocs** page for other setup and configuration at:
-https://treeherder.readthedocs.org/
+https://treeherder.readthedocs.io/
 
 File any bugs you may encounter [here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&component=Treeherder).

--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -41,7 +41,7 @@ Or for more control, run each tool individually:
 
   For more options, see ``py.test --help`` or http://pytest.org/latest/usage.html
 
-* `flake8 <https://flake8.readthedocs.org/>`_:
+* `flake8 <https://flake8.readthedocs.io/>`_:
 
   .. code-block:: bash
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -117,7 +117,7 @@ omit the `-B`:
      (venv)vagrant@local:~/treeherder$ celery -A treeherder worker
 
 
-.. _A-Team Bootcamp: https://ateam-bootcamp.readthedocs.org
+.. _A-Team Bootcamp: https://ateam-bootcamp.readthedocs.io
 .. _Git: https://git-scm.com
 .. _Vagrant: https://www.vagrantup.com
 .. _Virtualbox: https://www.virtualbox.org

--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -66,7 +66,7 @@ class HgPushlogTransformerMixin(object):
 class HgPushlogProcess(HgPushlogTransformerMixin,
                        ClientLoaderMixin):
     # For more info on Mercurial Pushes, see:
-    #   https://mozilla-version-control-tools.readthedocs.org/en/latest/hgmo/pushlog.html
+    #   https://mozilla-version-control-tools.readthedocs.io/en/latest/hgmo/pushlog.html
 
     def extract(self, url):
         try:

--- a/ui/partials/main/thHelpMenu.html
+++ b/ui/partials/main/thHelpMenu.html
@@ -9,7 +9,7 @@
     Development Documentation</a>
 </li>
 <li>
-  <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder" target="_blank">
+  <a href="https://wiki.mozilla.org/EngineeringProductivity/Projects/Treeherder" target="_blank">
     <span class="fa fa-file-word-o midgray"></span>
     Project Wiki</a>
 </li>

--- a/ui/partials/main/thHelpMenu.html
+++ b/ui/partials/main/thHelpMenu.html
@@ -4,7 +4,7 @@
     User Guide</a>
 </li>
 <li>
-  <a href="https://treeherder.readthedocs.org" target="_blank">
+  <a href="https://treeherder.readthedocs.io/" target="_blank">
     <span class="fa fa-file-code-o midgray"></span>
     Development Documentation</a>
 </li>

--- a/ui/partials/perf/helpMenu.html
+++ b/ui/partials/perf/helpMenu.html
@@ -1,5 +1,5 @@
 <li>
-  <a href="https://treeherder.readthedocs.org" target="_blank">
+  <a href="https://treeherder.readthedocs.io/" target="_blank">
     <span class="fa fa-file-code-o midgray"></span>
     Development Documentation</a>
 </li>

--- a/ui/partials/perf/helpMenu.html
+++ b/ui/partials/perf/helpMenu.html
@@ -4,7 +4,7 @@
     Development Documentation</a>
 </li>
 <li>
-  <a href="https://wiki.mozilla.org/Auto-tools/Projects/Perfherder" target="_blank">
+  <a href="https://wiki.mozilla.org/EngineeringProductivity/Projects/Perfherder" target="_blank">
     <span class="fa fa-file-word-o midgray"></span>
     Project Wiki</a>
 </li>

--- a/ui/userguide.html
+++ b/ui/userguide.html
@@ -24,11 +24,11 @@
           File a bug</a> /
         <a href="https://github.com/mozilla/treeherder">
           Source</a> /
-        <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder#Contributing">
+        <a href="https://wiki.mozilla.org/EngineeringProductivity/Projects/Treeherder#Contributing">
           Contributing</a>
       </h5>
       For anything else visit our
-      <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder">
+      <a href="https://wiki.mozilla.org/EngineeringProductivity/Projects/Treeherder">
         Project Wiki</a>
       or ask us on IRC in
       <a href="irc://irc.mozilla.org/treeherder">#treeherder</a>


### PR DESCRIPTION
RTD has moved project docs from PROJECT.readthedocs.org to PROJECT.readthedocs.io for security reasons.

There is currently a redirect in place, however RTD's mass email requested people update links since it won't be there forever.

Also updates a few wiki page links for pages that have moved after the A-Team rename.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1457)
<!-- Reviewable:end -->
