### PR TITLE
Bug 1270239 - Docs: Remove the redundant sphinx_rtd_theme workaround

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,8 @@
 import os
 import sys
 
+import sphinx_rtd_theme
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -106,13 +108,8 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-if not os.environ.get('READTHEDOCS'):
-    # Only import and set the theme if we're building docs locally:
-    # https://docs.readthedocs.org/en/latest/theme.html#how-do-i-use-this-locally-and-on-read-the-docs
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
The workaround that allowed using sphinx_rtd_theme when building locally, is no longer required. See:
https://github.com/rtfd/readthedocs.org/pull/2115

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1458)
<!-- Reviewable:end -->
