### PR TITLE
Bug 1270454 - Allow skipping the Heroku pre_deploy script entirely

### DIFF
--- a/bin/pre_deploy
+++ b/bin/pre_deploy
@@ -2,6 +2,11 @@
 # Tasks run after the Heroku buildpack compile, but prior to the deploy.
 # Failures will block the deploy unless `IGNORE_PREDEPLOY_ERRORS` is set.
 
+if [[ -v SKIP_PREDEPLOY ]]; then
+    echo "-----> PRE-DEPLOY: Warning: Skipping pre-deploy!"
+    exit 0
+fi
+
 if [[ -v IGNORE_PREDEPLOY_ERRORS ]]; then
     echo "-----> PRE-DEPLOY: Warning: Ignoring errors during pre-deploy!"
 else


### PR DESCRIPTION
...by defining `SKIP_PREDEPLOY` in the environment.

This is useful in cases where we want to avoid potentially destructive actions (such as running migrations) from taking place, or know that the migration is just going to time out unless run by hand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1460)
<!-- Reviewable:end -->
