### PR TITLE
Bug 1270682 - Stop selecting the spaces around a revision when double-clicking a revision

### DIFF
--- a/ui/css/treeherder-resultsets.css
+++ b/ui/css/treeherder-resultsets.css
@@ -129,6 +129,7 @@ fieldset[disabled] .btn-resultset:hover {
 .revision-holder {
   padding-left: 20px;
   padding-right: 11px;
+  display: inline-block;
 }
 
 .revision-comment {


### PR DESCRIPTION
This apparently helps prevent selecting text outside of the current element, which incidentally is exactly what I want to do here.


The other options that seemed to work but were a lot bigger/weirder changes were to:
1. Try adding click event handlers to force the selection to get trimmed to just the revision text, but that seems overkill to just select a single word of text.
2. Mangle the HTML in index.html so that there were no spaces between the closing </a> tag, the closing </span> tag, and the opening of the following <span> tag. Besides being ugly HTML, I think it only worked for selecting just the revision text on a triple-click.
3. Switch out the <span> for a <div>. This also caused things to shift onto new lines, which I'd then have to counter with more CSS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1463)
<!-- Reviewable:end -->
