### PR TITLE
Bug 1236067 - Make 'Set as top of range' and 'Set as bottom of range' links work when middle-clicked

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -406,6 +406,18 @@ treeherderApp.controller('MainCtrl', [
             );
         };
 
+        $scope.fromChangeValue = function() {
+            var url = window.location.href;
+            url = url.replace("&fromchange=" + $location.search()["fromchange"], "");
+            return url;
+        };
+
+        $scope.toChangeValue = function() {
+            var url = window.location.href;
+            url = url.replace("&tochange=" + $location.search()["tochange"], "");
+            return url;
+        };
+
         $scope.setLocationSearchParam = function(param, value) {
             $location.search(param, value);
         };

--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -34,10 +34,10 @@
            ng-show="user.is_staff"
            ng-click="triggerAllTalosJobs(resultset.revision)">Trigger All Talos jobs</a></li>
     <li><a target="_blank"
-           href="" prevent-default-on-left-click
+           href="{{toChangeValue()}}&tochange={{resultset.revision}}" prevent-default-on-left-click
            ng-click="setLocationSearchParam('tochange', resultset.revision)">Set as top of range</a></li>
     <li><a target="_blank"
-           href="" prevent-default-on-left-click
+           href="{{fromChangeValue()}}&fromchange={{resultset.revision}}" prevent-default-on-left-click
            ng-click="setLocationSearchParam('fromchange', resultset.revision)">Set as bottom of range</a></li>
   </ul>
 </span>


### PR DESCRIPTION
Not totally happy with this, but it appears to do what I want it to do. 

It even seems to handle me changing the other query string parameters, preserving their new values. I guess that's some angular magic happening behind the scenes...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1464)
<!-- Reviewable:end -->
