### PR TITLE
Bug 1270871 - Specify framework when generating compare URL in alerts

### DIFF
--- a/ui/partials/perf/alertsctrl.html
+++ b/ui/partials/perf/alertsctrl.html
@@ -125,7 +125,7 @@
           <span class="result-links">
             <a href="{{alert.getGraphsURL(alertSummary.resultSetMetadata.timeRange, alertSummary.repository, alertSummary.framework)}}" target="_blank">graph</a>
             <span> · </span>
-            <a href="#/comparesubtest?originalProject={{alertSummary.repository}}&originalRevision={{alertSummary.prevResultSetMetadata.revision}}&newProject={{alertSummary.repository}}&newRevision={{alertSummary.resultSetMetadata.revision}}&originalSignature={{alert.series_signature.signature_hash}}&newSignature={{alert.series_signature.signature_hash}}" target="_blank">subtests</a>
+            <a href="#/comparesubtest?originalProject={{alertSummary.repository}}&originalRevision={{alertSummary.prevResultSetMetadata.revision}}&newProject={{alertSummary.repository}}&newRevision={{alertSummary.resultSetMetadata.revision}}&originalSignature={{alert.series_signature.signature_hash}}&newSignature={{alert.series_signature.signature_hash}}&framework={{alertSummary.framework}}" target="_blank">subtests</a>
           </span>
         </td>
         <td class="alert-value">{{alert.prev_value}}</td>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1466)
<!-- Reviewable:end -->
