### PR TITLE
Bug 1207598 - Add some tooltips for retrigger/backfill job buttons

### DIFF
--- a/ui/partials/main/thJobDetailsRetriggerMenu.html
+++ b/ui/partials/main/thJobDetailsRetriggerMenu.html
@@ -1,6 +1,6 @@
 <li>
-  <a ng-click="retriggerJob([selectedJob])">Retrigger job</a>
+  <a ng-click="retriggerJob([selectedJob])" title="Repeat the selected job">Retrigger job</a>
 </li>
 <li>
-  <a ng-click="backfillJob()">Backfill job</a>
+  <a ng-click="backfillJob()" title="Trigger jobs of this type on prior pushes, to fill in gaps where the job was not run">Backfill job</a>
 </li>


### PR DESCRIPTION
Would these be better on the `li` elements instead of the `a` elements within them? Do we have better strings to use?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1470)
<!-- Reviewable:end -->
