### PR TITLE
Bug 1201982 - Add fa-pencil on hover for sheriff panel job exclusion entries

### DIFF
--- a/ui/css/treeherder-navbar-panels.css
+++ b/ui/css/treeherder-navbar-panels.css
@@ -105,16 +105,16 @@
 }
 
 .sheriff-panel-delete-icon {
-  padding-right: 25px;
-  font-size: 12px;
-  color: #bababa;
+    padding-right: 25px;
+    font-size: 12px;
+    color: #bababa;
 }
 
 .sheriff-panel-btn {
-  padding-left: 0;
-  padding-right: 0;
-  border: none;
-  background: #fff;
+    padding-left: 0;
+    padding-right: 0;
+    border: none;
+    background: #fff;
 }
 
 a.sheriff-panel-btn {
@@ -123,35 +123,44 @@ a.sheriff-panel-btn {
 }
 
 .sheriff-panel-text-btn {
-  color: #337ab7;
+    color: #337ab7;
 }
 
 .sheriff-panel-text-btn-disabled {
-  color: initial;
+    color: initial;
 }
 
 .sheriff-panel-excluded-job {
-  margin-right: 20px;
+    margin-right: 10px;
 }
 
 .sheriff-panel-exclusion-profiles-row td:first-child {
-  /* Aligns second column nicely under Exclusion profile tab
-   * if no profile is longer than the default container */
-  width: 119px;
+    /* Aligns second column nicely under Exclusion profile tab
+     * if no profile is longer than the default container */
+    width: 119px;
 }
 
 .sheriff-panel-exclusion-profiles-row td:first-child > button {
-  /* Handle long profile names within the button */
-  white-space: nowrap;
+    /* Handle long profile names within the button */
+    white-space: nowrap;
 }
 
 .sheriff-panel-job-exclusions-row td:first-child {
-  /* Aligns second column nicely under Job exclusion tab
-   * if no exclusion is longer than the default container */
-  width: 138px;
+    /* Aligns second column nicely under Job exclusion tab
+     * if no exclusion is longer than the default container */
+    width: 138px;
 }
 
 .sheriff-panel-job-exclusions-row td:first-child > button {
-  /* Handle long exclusion names within the button */
-  white-space: nowrap;
+    /* Handle long exclusion names within the button */
+    white-space: nowrap;
+}
+
+.sheriff-panel-text-btn > .sheriff-panel-profile-edit-button,
+.sheriff-panel-text-btn-disabled > .sheriff-panel-profile-edit-button {
+    opacity:0;
+}
+
+.sheriff-panel-text-btn:hover > .sheriff-panel-profile-edit-button {
+    opacity:1 !important;
 }

--- a/ui/partials/main/thSheriffPanel.html
+++ b/ui/partials/main/thSheriffPanel.html
@@ -60,7 +60,9 @@
                   ng-class="!user.is_staff ? 'sheriff-panel-text-btn-disabled' :
                            'sheriff-panel-text-btn'"
                   ng-attr-title="{{!user.is_staff ? '' : 'Modify this exclusion'}}">
-            &#8226; {{::exclusions_map[exclusion].name}}</button>
+            &#8226; {{::exclusions_map[exclusion].name}}
+            <span class="fa fa-pencil sheriff-panel-profile-edit-button"></span>
+          </button>
         </td>
         <td>
           <!-- Delete profile button -->


### PR DESCRIPTION
This adds a pencil icon when you hover over a job exclusion in the sheriff
panel list. 

Also included are some spacing fixes for CSS around the
changes I made.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1471)
<!-- Reviewable:end -->
