### PR TITLE
Bug 1271256 - Fix always passing tests in test_throttling.py

### DIFF
--- a/tests/webapp/api/test_throttling.py
+++ b/tests/webapp/api/test_throttling.py
@@ -34,12 +34,12 @@ def test_no_throttle():
 
     response = MockView.as_view()(request)
     # first request ok
-    response.status_code == 200
+    assert response.status_code == 200
 
     for i in range(1):
         response = MockView.as_view()(request)
     # subsequent requests still ok
-    response.status_code == 200
+    assert response.status_code == 200
 
 
 def test_hawk_client_throttle(monkeypatch):
@@ -50,7 +50,7 @@ def test_hawk_client_throttle(monkeypatch):
     response = MockView.as_view()(request)
 
     # first request, everything ok
-    response.status_code == 200
+    assert response.status_code == 200
 
     for i in range(1):
         response = MockView.as_view()(request)


### PR DESCRIPTION
The lack of the `assert` statement meant they would have always passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1472)
<!-- Reviewable:end -->
