### PR TITLE
Bug 1271334 - Remove drf-extensions since it's no longer used

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -40,8 +40,6 @@ djangorestframework==3.3.3 --hash=sha256:4f47056ad798103fc9fb049dff8a67a91963bd2
 
 django-rest-swagger==0.3.6 --hash=sha256:3221a674416c6016d77b187a28515cd5eadff89b9dfa16af50dc650853714efc
 
-drf-extensions==0.2.8 --hash=sha256:9aafa131f66afbe316e0e5f5b0a23699411f5be25aa74188d1e0773179cd341b
-
 django-cors-headers==1.1.0 --hash=sha256:fcd96e2be47c8eef34c650e007a6d546e19e7ee61041b89edbbbbe7619aa3987
 
 django-browserid==2.0.1 --hash=sha256:ab3a6cb78121b34816a99548596b9b66d8fec9b51d5709a21d15b243ea6ad8ad

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -126,7 +126,6 @@ INSTALLED_APPS = [
     'django.contrib.admin',
     # 3rd party apps
     'rest_framework',
-    'rest_framework_extensions',
     'rest_framework_swagger',
     'hawkrest',
     'corsheaders',
@@ -530,10 +529,6 @@ API_HOSTNAME = SITE_URL
 BROWSERID_AUDIENCES = [SITE_URL]
 
 SWAGGER_SETTINGS = {"enabled_methods": ['get', ]}
-
-REST_FRAMEWORK_EXTENSIONS = {
-    'DEFAULT_CACHE_RESPONSE_TIMEOUT': 60 * 15
-}
 
 HAWK_CREDENTIALS_LOOKUP = 'treeherder.webapp.api.auth.hawk_lookup'
 


### PR DESCRIPTION
The last usage of it was removed in bug 1229203.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1473)
<!-- Reviewable:end -->
