### PR TITLE
Bug 1271420 - Make classified failures consistent in the pinboard

### DIFF
--- a/ui/js/directives/treeherder/bottom_nav_panel.js
+++ b/ui/js/directives/treeherder/bottom_nav_panel.js
@@ -16,7 +16,7 @@ treeherder.directive('thPinnedJob', [
             link: function(scope, element, attrs) {
                 var unbindWatcher = scope.$watch("job", function(newValue) {
                     var resultState = thResultStatus(scope.job);
-                    scope.job.display = thResultStatusInfo(resultState);
+                    scope.job.display = thResultStatusInfo(resultState, scope.job.failure_classification_id);
                     scope.hoverText = getHoverText(scope.job);
 
                     if (scope.job.state === "completed") {


### PR DESCRIPTION
This work hopefully fixes Bugzilla bug [1271420](https://bugzilla.mozilla.org/show_bug.cgi?id=1271420).

This makes any and all jobs in the pinboard draw the same way as they do in the main job table, so that:
 
- failures are no longer always solid
- classified jobs carry their corresponding star icon

This might mean sometimes the star is truncated on longer job names, but longer job names are being truncated anyway, which is a separate issue.

Here's the new appearance (autoclassified failure shown):

![autoclassifiedpinboardproposed](https://cloud.githubusercontent.com/assets/3660661/15127755/11c8091e-1606-11e6-8af3-04811f51d313.jpg)

I created a separate pinboard scope variable for this property, rather than mucking with the existing job object properties. So when anyone changes thResultStatusInfo [here](https://github.com/mozilla/treeherder/blob/daf296dc30c030e8292b4915d5766b86c8b7dacf/ui/js/providers.js#L61-L148) we should get the changes for free in the pinboard.

Maybe there's a more consistent way to do it though. Everything seems fine locally on Nightly and Chrome with all the job types I've tried (success, testfailed, retry, busted, etc).

Tested on OSX 10.11.4:
Nightly **49.0a1 (2016-05-09)**
Chrome Latest Release **50.0.2661.94 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1474)
<!-- Reviewable:end -->
