### PR TITLE
Bug 1100414 - Parse mozharness steps

### DIFF
--- a/tests/log_parser/test_step_parser.py
+++ b/tests/log_parser/test_step_parser.py
@@ -6,20 +6,24 @@ from treeherder.log_parser.parsers import StepParser
 def test_date_with_milliseconds():
     """Handle buildbot dates that have a decimal on the seconds."""
     parser = StepParser()
-    dt = parser.parsetime('2015-01-20 16:42:33.352621')
+    dt = parser._parse_full_timestamp('2015-01-20 16:42:33.352621')
     assert dt == datetime(2015, 1, 20, 16, 42, 33, 352621)
 
 
 def test_date_without_milliseconds():
     """Handle buildbot dates that DON'T have a decimal on the seconds."""
     parser = StepParser()
-    dt = parser.parsetime('2015-01-20 16:42:33')
+    dt = parser._parse_full_timestamp('2015-01-20 16:42:33')
     assert dt == datetime(2015, 1, 20, 16, 42, 33)
 
 
 def test_date_with_invalid_month():
     """Gracefully handle a date whose month is invalid."""
     parser = StepParser()
-    parser.start_step(1, timestamp='2016-00-04 19:44:35.838000')
-    parser.end_step(2, timestamp='2016-00-04 19:47:12.880000')
+
+    assert parser._parse_full_timestamp('2016-00-04 19:44:35.838000') is None
+    assert parser._parse_full_timestamp('2016-00-04 19:47:12.880000') is None
+
+    parser.start_step(1, when=None)
+    parser.end_step(2, when=None)
     assert parser.current_step['duration'] is None

--- a/tests/log_parser/test_step_parser.py
+++ b/tests/log_parser/test_step_parser.py
@@ -27,3 +27,44 @@ def test_date_with_invalid_month():
     parser.start_step(1, when=None)
     parser.end_step(2, when=None)
     assert parser.current_step['duration'] is None
+
+
+def test_parse_buildbot_and_mozharness():
+    parser = StepParser()
+
+    lines = [
+        "========= Started 'c:/mozilla-build/python27/python -u ...' (results: 0, elapsed: 25 mins, 40 secs) (at 2016-05-08 13:05:28.575691) =========",
+        'c:/mozilla-build/python27/python' '-u' 'scripts/scripts/desktop_unittest.py' '--cfg' 'unittests/win_unittest.py' '--mochitest-suite' 'plain-chunked' '--total-chunks' '5' '--this-chunk' '1' '--blob-upload-branch' 'try' '--download-symbols' 'ondemand',
+        'in dir C:\slave\test\. (timeout 1800 secs) (maxTime 7200 secs)',
+        'watching logfiles {}',
+        '13:05:28    INFO - #####',
+        '13:05:28    INFO - ##### Running clobber step.',
+        '13:05:28    INFO - #####',
+        '13:05:28    INFO - Running pre - action listener: _resource_record_pre_action',
+        '13:07:03    INFO - #####',
+        '13:07:03    INFO - ##### Finished clobber step (success)',
+        '13:07:03    INFO - #####',
+        '13:07:03    INFO - #####',
+        '13:07:03    INFO - ##### Running read-buildbot-config step.',
+        '13:07:03    INFO - #####',
+        '13:07:03    INFO - Running pre - action listener: _resource_record_pre_action',
+        '13:07:03    INFO - Running main action method: read_buildbot_config',
+        '13:07:03    INFO - #####',
+        '13:07:03    INFO - ##### Finished read-buildbot-config step (success)',
+        '13:07:03    INFO - #####',
+        "========= Finished 'c:/mozilla-build/python27/python -u ...' (results: 0, elapsed: 25 mins, 40 secs) (at 2016-05-08 13:31:08.718641) =========",
+    ]
+
+    for i, l in enumerate(lines):
+        parser.parse_line(l, i)
+
+    parser.finish_parse(i)
+
+    assert len(parser.steps) == 3
+
+    assert parser.steps[1].name == 'clobber'
+    assert parser.steps[1].result == 'success'
+    assert parser.steps[1].duration == 95
+    assert parser.steps[2].name == 'read-buildbot-config'
+    assert parser.steps[2].result == 'success'
+    assert parser.steps[2].duration == 0

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -88,6 +88,7 @@ class StepParser(ParserBase):
         }
         self.sub_parser = ErrorParser()
         self.state = self.STATES['awaiting_first_step']
+        self._step_times = []
 
     def parse_line(self, line, lineno):
         """Parse a single line of the log.
@@ -171,9 +172,10 @@ class StepParser(ParserBase):
                 # in Taskcluster's logs when content falls between the step marker lines.
                 self.end_step(lineno)
             # Start a new step using the extracted step metadata.
+            dt = self._parse_full_timestamp(step_marker_match.group('timestamp'))
             self.start_step(lineno,
                             name=step_marker_match.group('name'),
-                            timestamp=step_marker_match.group('timestamp'))
+                            when=dt)
             return
 
         # This is a "step finished" marker line.
@@ -183,23 +185,25 @@ class StepParser(ParserBase):
             return
 
         # Close out the current step using the extracted step metadata.
+        dt = self._parse_full_timestamp(step_marker_match.group('timestamp'))
         self.end_step(lineno,
-                      timestamp=step_marker_match.group('timestamp'),
+                      when=dt,
                       result_code=int(step_marker_match.group('result_code')))
 
-    def start_step(self, lineno, name="Unnamed step", timestamp=None):
+    def start_step(self, lineno, name="Unnamed step", when=None):
         """Create a new step and update the state to reflect we're now in the middle of a step."""
         self.state = self.STATES['step_in_progress']
         self.stepnum += 1
         self.steps.append({
             "name": name,
-            "started": timestamp,
+            "started": when.isoformat() if when else None,
             "started_linenumber": lineno,
             "order": self.stepnum,
             "errors": [],
         })
+        self._step_times.append([when, None])
 
-    def end_step(self, lineno, timestamp=None, result_code=None):
+    def end_step(self, lineno, when=None, result_code=None):
         """Fill in the current step's summary and update the state to show the current step has ended."""
         self.state = self.STATES['step_finished']
         step_errors = self.sub_parser.get_artifact()
@@ -208,7 +212,7 @@ class StepParser(ParserBase):
             step_errors = step_errors[:settings.PARSER_MAX_STEP_ERROR_LINES]
             self.artifact["errors_truncated"] = True
         self.current_step.update({
-            "finished": timestamp,
+            "finished": when.isoformat() if when else None,
             "finished_linenumber": lineno,
             # Whilst the result code is present on both the start and end buildbot-style step
             # markers, for Taskcluster logs the start marker line lies about the result, since
@@ -218,7 +222,11 @@ class StepParser(ParserBase):
             "errors": step_errors,
             "error_count": step_error_count
         })
-        self.current_step["duration"] = self.calculate_duration()
+
+        started = self.current_step['started']
+        self.current_step["duration"] = self.calculate_duration(started, when)
+        self._step_times[-1][1] = when
+
         # Append errors from current step to "all_errors" field
         self.artifact["all_errors"].extend(step_errors)
         # reset the sub_parser for the next step
@@ -235,30 +243,25 @@ class StepParser(ParserBase):
             # that occurs at the end of the log.
             self.end_step(last_lineno_seen)
 
-    def parsetime(self, match):
+    def _parse_full_timestamp(self, match):
         """Convert a string date into a datetime."""
         # DATE_FORMAT expects a decimal on the seconds.  If it's not
         # present, we must add it so the date parsing does not fail.
         if "." not in match:
             match = "{0}.0".format(match)
-        return datetime.datetime.strptime(match, self.DATE_FORMAT)
 
-    def calculate_duration(self):
+        try:
+            return datetime.datetime.strptime(match, self.DATE_FORMAT)
+        except ValueError:
+            return None
+
+    def calculate_duration(self, started, finished):
         """Sets duration for the step in seconds."""
-        started_string = self.current_step["started"]
-        finished_string = self.current_step["finished"]
-        if not (started_string and finished_string):
+        if not (started and finished):
             # Handle the dummy steps (created to hold Taskcluster log content that
             # is between step markers), which have no recorded start/finish time.
             return None
-        try:
-            start_time = self.parsetime(started_string)
-            finish_time = self.parsetime(finished_string)
-        except ValueError:
-            # Gracefully fail if the dates were malformed in the log,
-            # otherwise we won't get an error summary at all.
-            return None
-        td = finish_time - start_time
+        td = finished - started
         secs = (
             td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6
         ) / 10.0**6

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -66,6 +66,17 @@ class StepParser(ParserBase):
     RE_STEP_MARKER = re.compile(r'={9} (?P<marker_type>Started|Finished) (?P<name>.*?) '
                                 r'\(results: (?P<result_code>\d+), elapsed: .*?\) '
                                 r'\(at (?P<timestamp>.*?)\)')
+
+    # 13:05:28 INFO - ##### Running clobber step.
+    # 13:07:03 INFO - ##### Finished clobber step (success)
+    RE_MOZHARNESS_STEP_MARKER = re.compile(r'(?P<hour>\d{2}):'
+                                           r'(?P<minute>\d{2}):'
+                                           r'(?P<second>\d{2})'
+                                           r'\s+INFO - ##### '
+                                           r'(?P<marker_type>Running|Finished) '
+                                           r'(?P<name>.*) step'
+                                           r'(?:\.|(?:\((?P<status>success|failure)\)))?')
+
     STATES = {
         # The initial state until we record the first step.
         "awaiting_first_step": 0,
@@ -146,8 +157,9 @@ class StepParser(ParserBase):
             return
 
         step_marker_match = self.RE_STEP_MARKER.match(line)
+        mh_step_marker_match = self.RE_MOZHARNESS_STEP_MARKER.search(line)
 
-        if not step_marker_match:
+        if not step_marker_match and not mh_step_marker_match:
             # This is a normal log line, rather than a step marker. (The common case.)
             if self.state != self.STATES['step_in_progress']:
                 # We don't have an in-progress step, so need to start one, even though this
@@ -162,33 +174,57 @@ class StepParser(ParserBase):
         # This is either a "step started" or "step finished" marker line, eg:
         # ========= Started foo (results: 0, elapsed: 0 secs) (at 2015-08-17 02:33:56.353866) =========
         # ========= Finished foo (results: 0, elapsed: 0 secs) (at 2015-08-17 02:33:56.354301) =========
+        if step_marker_match:
+            if step_marker_match.group('marker_type') == 'Started':
+                if self.state == self.STATES['step_in_progress']:
+                    # We're partway through a step (ie: haven't seen a "step finished" marker line),
+                    # but have now reached the "step started" marker for the next step. Before we
+                    # can start the new step, we have to clean up the previous one - albeit using
+                    # generic step metadata, since there was no "step finished" marker. This occurs
+                    # in Taskcluster's logs when content falls between the step marker lines.
+                    self.end_step(lineno)
+                # Start a new step using the extracted step metadata.
+                dt = self._parse_full_timestamp(step_marker_match.group('timestamp'))
+                self.start_step(lineno,
+                                name=step_marker_match.group('name'),
+                                when=dt)
+                return
 
-        if step_marker_match.group('marker_type') == 'Started':
-            if self.state == self.STATES['step_in_progress']:
-                # We're partway through a step (ie: haven't seen a "step finished" marker line),
-                # but have now reached the "step started" marker for the next step. Before we
-                # can start the new step, we have to clean up the previous one - albeit using
-                # generic step metadata, since there was no "step finished" marker. This occurs
-                # in Taskcluster's logs when content falls between the step marker lines.
-                self.end_step(lineno)
-            # Start a new step using the extracted step metadata.
+            if self.state != self.STATES['step_in_progress']:
+                # We're not in the middle of a step, so can't finish one. Just ignore the marker line.
+                return
+
+            # Close out the current step using the extracted step metadata.
             dt = self._parse_full_timestamp(step_marker_match.group('timestamp'))
-            self.start_step(lineno,
-                            name=step_marker_match.group('name'),
-                            when=dt)
-            return
+            self.end_step(lineno,
+                          when=dt,
+                          result_code=int(step_marker_match.group('result_code')))
 
-        # This is a "step finished" marker line.
+        # Or a Mozharness variation, eg:
+        # 13:05:28 INFO - ##### Running clobber step.
+        # 13:07:03 INFO - ##### Finished clobber step (success)
+        else:
+            # Must be a mozharness step marker.
+            if mh_step_marker_match.group('marker_type') == 'Running':
+                if self.state == self.STATES['step_in_progress']:
+                    self.end_step(lineno)
 
-        if self.state != self.STATES['step_in_progress']:
-            # We're not in the middle of a step, so can't finish one. Just ignore the marker line.
-            return
+                dt = self._mozharness_time_to_datetime(mh_step_marker_match)
+                self.start_step(lineno,
+                                name=mh_step_marker_match.group('name'),
+                                when=dt)
+                return
 
-        # Close out the current step using the extracted step metadata.
-        dt = self._parse_full_timestamp(step_marker_match.group('timestamp'))
-        self.end_step(lineno,
-                      when=dt,
-                      result_code=int(step_marker_match.group('result_code')))
+            if self.state != self.STATES['step_in_progress']:
+                return
+
+            if mh_step_marker_match.group('status') == 'success':
+                result_code = 0
+            else:
+                result_code = 1
+
+            dt = self._mozharness_time_to_datetime(mh_step_marker_match)
+            self.end_step(lineno, result_code=result_code, when=dt)
 
     def start_step(self, lineno, name="Unnamed step", when=None):
         """Create a new step and update the state to reflect we're now in the middle of a step."""
@@ -266,6 +302,38 @@ class StepParser(ParserBase):
             td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6
         ) / 10.0**6
         return int(round(secs))
+
+    def _mozharness_time_to_datetime(self, m):
+        """Take a match from a mozharness step and convert to a datetime."""
+
+        # The time component is in the log. The date component
+        # isn't. Try to grab it from the previous step.
+        try:
+            start, finish = self._step_times[-1]
+        except IndexError:
+            # We don't know what the date is. Abort.
+            return None
+
+        # Use the latest available date.
+        if finish:
+            dt = finish
+        elif start:
+            dt = start
+        else:
+            return None
+
+        try:
+            t = datetime.time(int(m.group('hour')),
+                              int(m.group('minute')),
+                              int(m.group('second')))
+
+            # If we wrapped to the next day, add a day to the date component.
+            if t < dt.time():
+                dt = dt + datetime.timedelta(days=1)
+
+            return datetime.datetime.combine(dt.date(), t)
+        except ValueError:
+            return None
 
     @property
     def steps(self):


### PR DESCRIPTION
Here's my first attempt to add parsing of mozharness steps into the log parser.

The date parsing is pretty hacky. I'm tempted to modify mozharness to print full ISO 8601 timestamps so we can simplify the code.

I have _not_ tested this. I'm having issues getting the Vagrant environment working. I boot Windows 10 on my home desktop and I'm having difficulty getting Vagrant to play nice with Hyper-V. I'll probably be able to do Vagrant foo from my MBP tomorrow. In the mean time, here's some code to look at.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1477)

<!-- Reviewable:end -->
