### PR TITLE
Bug 1271571 - Remove workaround for broken l10n dep jobs

### DIFF
--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -109,20 +109,6 @@ def should_skip_revision(revision, revision_filter):
     return False
 
 
-def is_blacklisted_buildername(buildername):
-    if buildername.endswith(' l10n dep'):
-        # These l10n jobs specify the l10n repo revision under 'revision', rather
-        # than the gecko revision. If we did not skip these, it would result in
-        # fetch_missing_resultsets requests that were guaranteed to 404.
-        # This needs to be fixed upstream in builds-*.js by bug 1125433.
-        # We have to blacklist by buildername rather than comparing the
-        # l10n_revision property, since the latter is not available in
-        # builds-{pending,running}.
-        logger.info("Skipping blacklisted buildername: %s", buildername)
-        return True
-    return False
-
-
 def generate_revision_hash(revisions):
     """
     Builds the revision hash for a set of revisions


### PR DESCRIPTION
Bug 1090289 added handling for the l10n jobs that had invalid revision-branch combinations. However these jobs are no longer running (see bug 1125433 / bug 1221391), so the workaround can now be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1478)
<!-- Reviewable:end -->
