### PR TITLE
Bug 1267683 - Prevent default scripting user agents from interacting with Treeherder

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -1,3 +1,4 @@
+import re
 from datetime import timedelta
 from urlparse import urlparse
 
@@ -316,6 +317,15 @@ REST_FRAMEWORK = {
     ),
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
+
+# User agents which will be blocked from making requests to the site.
+DISALLOWED_USER_AGENTS = (
+    # Note: This intentionally does not match the command line curl
+    # tool's default User Agent, only the library used by eg PHP.
+    re.compile(r'^libcurl/'),
+    re.compile(r'^Python-urllib/'),
+    re.compile(r'^python-requests/'),
+)
 
 SITE_URL = env("SITE_URL", default="http://local.treeherder.mozilla.org")
 SITE_HOSTNAME = urlparse(SITE_URL).netloc


### PR DESCRIPTION
In the past we've had infra incidents caused by excessive use of Treeherder's API. To make the accidental cases of these easier to diagnose, consumers of our API should set an appropriate user agent.

To enforce this, common default user agents are now blacklisted using the Django common middleware:
https://docs.djangoproject.com/en/1.8/ref/middleware/#module-django.middleware.common
https://docs.djangoproject.com/en/1.8/ref/settings/#disallowed-user-agents

Requests to the API that match one of the blacklisted user agents will received an HTTP 403 response with content `Forbidden user agent`.

Bug 1230222 has whittled down the number of undesired user agents - prior to this landing I'll double check any remaining and fix them/announce on the mailing lists etc.

Edit: The docs changes have now been split out to #1534 so they can land in advance, giving something for the newsgroup post to link to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1482)
<!-- Reviewable:end -->
