### PR TITLE
Bug 1271723 - Optimize updating machine and job_group reference data

### DIFF
--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1483,7 +1483,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                       'last_timestamp': machine_timestamp})
         if machine.last_timestamp < machine_timestamp:
             machine.last_timestamp = machine_timestamp
-            machine.save()
+            machine.save(update_fields=['last_timestamp'])
 
         # if a job with this symbol and name exists, always
         # use its default group (even if that group is different
@@ -1498,7 +1498,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 name=job.get('group_name') or 'unknown',
                 symbol=job.get('group_symbol') or 'unknown')
             job_type.job_group = job_group
-            job_type.save()
+            job_type.save(update_fields=['job_group'])
 
         product_name = job.get('product_name', 'unknown')
         if len(product_name.strip()) == 0:


### PR DESCRIPTION
We were updating every field for these unnecessarily in certain cases
(every time in the case of machine) which could be problematic if we
had a flood of updates, as we did today.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1483)
<!-- Reviewable:end -->
