### PR TITLE
Bug 1261424 - Add btn ids and classes for treeherder-tests

### DIFF
--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -24,7 +24,7 @@
     </span>
     <th-result-counts class="result-counts"></th-result-counts>
     <span class="result-set-buttons">
-      <span class="btn btn-sm btn-resultset"
+      <span class="btn btn-sm btn-resultset cancel-all-jobs-btn"
             tabindex="0" role="button"
             title="Cancel all jobs in this resultset"
             ng-show="currentRepo.repository_group.name == 'try' || user.is_staff"
@@ -33,7 +33,7 @@
         <span class="fa fa-times-circle cancel-job-icon dim-quarter"
               ignore-job-clear-on-click></span>
       </span>
-      <span class="btn btn-sm btn-resultset"
+      <span class="btn btn-sm btn-resultset pin-all-jobs-btn"
             tabindex="0" role="button"
             title="Pin all available jobs in this resultset"
             ignore-job-clear-on-click
@@ -41,7 +41,7 @@
         <span class="glyphicon glyphicon-pushpin"
               ignore-job-clear-on-click></span>
       </span>
-      <span class="btn btn-sm btn-resultset"
+      <span class="btn btn-sm btn-resultset trigger-new-jobs-btn"
             tabindex="0" role="button"
             title="Trigger new jobs"
             ng-show="showTriggerButton()"

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -51,7 +51,8 @@
           </li>
 
           <li ng-repeat="job_log_url in job_log_urls">
-            <a class="raw-log-icon"
+            <a id="raw-log-btn"
+               class="raw-log-icon"
                title="Open the raw log in a new window"
                target="_blank"
                href="{{::job_log_url.url}}"
@@ -70,7 +71,7 @@
             <!--the first 3 items are in the same box-->
             <ul class="nav navbar-nav">
               <li>
-                <a href="" prevent-default-on-left-click
+                <a id="pin-job-btn" href="" prevent-default-on-left-click
                    title="Add this job to the pinboard"
                    ng-click="pinboard_service.pinJob(selectedJob)">
                   <span class="glyphicon glyphicon-pushpin"


### PR DESCRIPTION
This fixes Buzilla bug [1261424](https://bugzilla.mozilla.org/show_bug.cgi?id=1261424).

In this PR we add a unique id for the job details action bar pin button, and add a few other useful id's and classes at the same time for future [treeherder-tests](https://github.com/mozilla/treeherder-tests) selection.

Tested on OSX 10.11.4:
Nightly **49.0a1 (2016-05-09)**
Chrome Latest Release **50.0.2661.94 (64-bit)**

Adding @wlach for review and @rbillings for visibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1484)
<!-- Reviewable:end -->
