### PR TITLE
Bug 1272049 - Generalize vagrant and vbox install requirements

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,7 @@ Prerequisites
 -------------
 
 * If you are new to Mozilla or the A-Team, read the `A-Team Bootcamp`_.
-* Install Git_, Virtualbox_ and Vagrant_ 1.5+ (recent versions recommended).
+* Install Git_, Virtualbox_ and Vagrant_ (latest versions recommended).
 * Clone the `treeherder repo`_ from Github.
 * Windows only: Ensure MSYS ssh (ships with Git for Windows) is on the PATH, so Vagrant can find it (using PuTTY is more hassle).
 


### PR DESCRIPTION
This fixes Bugzilla bug [1272049](https://bugzilla.mozilla.org/show_bug.cgi?id=1272049).

This updates the Vagrant and VirtualBox installation requirements. So we don't refer to specific versions and instead encourage users to generally run the latest available releases.

Adding @edmorley for review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1486)
<!-- Reviewable:end -->
