### PR TITLE
Bug 1272435 - Specify backout date in perf regression template in business days

### DIFF
--- a/ui/js/controllers/perf/alerts.js
+++ b/ui/js/controllers/perf/alerts.js
@@ -79,24 +79,6 @@ perf.factory('PhBugs', [
                                 }
                                 return suiteName + tryTalosModifiers;
                             }));
-                            // they have 3 days from today to respond (if backout day
-                            // would be a Saturday or Sunday, delay until the following
-                            // Monday)
-                            var backoutDate = new Date(Date.now() + 3*86400*1000);
-                            if (backoutDate.getDay() === 6) {
-                                backoutDate.setDate(backoutDate.getDate() + 2);
-                            } else if (backoutDate.getDay() === 0) {
-                                backoutDate.setDate(backoutDate.getDate() + 1);
-                            }
-                            var dayMapping = {
-                                0: 'Sunday', // not used
-                                1: 'Monday',
-                                2: 'Tuesday',
-                                3: 'Wednesday',
-                                4: 'Thursday',
-                                5: 'Friday',
-                                6: 'Saturday' // not used
-                            };
                             var compiled = $interpolate(template)({
                                 revision: alertSummary.resultSetMetadata.revision,
                                 alertHref: window.location.origin + '/perf.html#/alerts?id=' +
@@ -104,8 +86,7 @@ perf.factory('PhBugs', [
                                 testDescriptions: testDescriptions.join('\n'),
                                 tryBuildPlatforms: tryBuildPlatforms.join(','),
                                 trySuites: trySuites.join(','),
-                                talosTestListSyntax: talosSuites.join(":"),
-                                backoutDay: dayMapping[backoutDate.getDay()]
+                                talosTestListSyntax: talosSuites.join(":")
                             });
                             var pushDate = dateFilter(
                                 alertSummary.resultSetMetadata.push_timestamp*1000,

--- a/ui/partials/perf/bugzilla_talos.tmpl
+++ b/ui/partials/perf/bugzilla_talos.tmpl
@@ -31,7 +31,7 @@ talos --develop -e [path]/firefox -a {{ talosTestListSyntax }}
 Making a decision:
 
 As the patch author we need your feedback to help us handle this regression.
-*** Please let us know your plans by {{ backoutDay }}, or the offending patch(es) will be backed out! ***
+*** Please let us know your plans within 3 business days, or the offending patch(es) will be backed out! ***
 
 Our wiki page outlines the common responses and expectations:
 


### PR DESCRIPTION
It's too hard/annoying to account for weekends and holidays when we specify
the day of the week. Business days are just easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1491)
<!-- Reviewable:end -->
