### PR TITLE
Bug 1263173 - Outside click clears popup

### DIFF
--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -231,6 +231,12 @@ perf.controller('GraphsCtrl', [
             }
         }
 
+        function closePopup() {
+            $scope.selectedDataPoint = null;
+            hideTooltip();
+            highlightDataPoints();
+        }
+
         function plotUnselected() {
             $scope.zoom = {};
             $scope.selectedDataPoint = null;
@@ -485,8 +491,16 @@ perf.controller('GraphsCtrl', [
                     zoomGraph();
                 });
 
-                //Closes popup on-click of "X"
-                $('#close-popup').bind("click", plotUnselected);
+                // Close popup onclick of corner close button
+                $('#close-popup').bind("click", closePopup);
+
+                // Close pop up when user clicks outside of the graph area
+                $('html').click(closePopup);
+
+                // Stop propagation when user clicks inside the graph area
+                $('#graph').click(function(event) {
+                    event.stopPropagation();
+                });
             });
         }
 


### PR DESCRIPTION
Using the button as specified. Using the hideTooltip function in place of plotUnselected. Use of previous code would have resulted in unnecessary deselection of a sub-plot, when clicking on the close button. @wlach Have a look.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1497)
<!-- Reviewable:end -->
