### PR TITLE
Bug 1246196 - Speed up getting similar jobs

### DIFF
--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -493,9 +493,7 @@
                     ON rs.id = j.result_set_id
                   WHERE 1
                   REP1
-                  GROUP BY j.id
-                  ORDER BY
-                    rs.push_timestamp DESC
+                  ORDER BY j.result_set_id DESC
                   ",
 
             "host_type":"read_host"

--- a/treeherder/model/sql/template_schema/project.sql.tmpl
+++ b/treeherder/model/sql/template_schema/project.sql.tmpl
@@ -144,6 +144,7 @@ CREATE TABLE `job` (
   KEY `idx_running` (`running_eta`),
   KEY `idx_tier` (`tier`),
   KEY `idx_active_status` (`active_status`),
+  KEY `idx_similar_jobs_query` (`result_set_id`, `option_collection_hash`, `build_platform_id`, `job_type_id`),
   CONSTRAINT `fk_result_set` FOREIGN KEY (`result_set_id`) REFERENCES `result_set` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION
- Order similar jobs by result set id, not push timestamp. Using push timestamp
  requires creating a temporary table and scanning through it, which is slow.
  Result set id gets the ordering right 99% of the time.
- Don't bother grouping by job id (not needed)
- Create a composite index on the keys used in the query (this will need to
  be added to production)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1500)

<!-- Reviewable:end -->
