### PR TITLE
Bug 1272532 - Handle case where we get two different retry guids for a job

### DIFF
--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1773,7 +1773,8 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                 job_id_lookup[retry_guid] = retry_job
                 # for the intermediate representation (see below), we only
                 # want to modify the job who was retriggered
-                del jobs_to_update[retry_guid_root]
+                if retry_guid_root in jobs_to_update:
+                    del jobs_to_update[retry_guid_root]
                 jobs_to_update[retry_guid] = retry_job
 
         # create an intermediate representation of the job useful for doing


### PR DESCRIPTION
This is an obscure case (that we should probably handle better), but I
believe this patch should at least fix the new relic exception in the
common cases (specifically when we get the same retry with a different
guid in the same batch of jobs). This patch also adds a bunch of unit
tests to test ingesting batches of jobs containing retries. There are
many cases which still fail (which would probably never occur in real
life), but I'm going to put off fixing those for now -- see comments
in the unit tests for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1507)
<!-- Reviewable:end -->
