### PR TITLE
Bug 1259494 - Allow non-sheriffs to backfill & retrigger missing jobs

### DIFF
--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -14,7 +14,6 @@ from treeherder.model.models import (FailureLine,
                                      TextLogSummary)
 from treeherder.webapp.api import (permissions,
                                    serializers)
-from treeherder.webapp.api.permissions import IsStaffOrReadOnly
 from treeherder.webapp.api.utils import (UrlQueryFilter,
                                          with_jobs)
 
@@ -177,7 +176,7 @@ class JobsViewSet(viewsets.ViewSet):
         else:
             return Response({"message": "All jobs successfully retriggered."})
 
-    @detail_route(methods=['post'], permission_classes=[IsStaffOrReadOnly])
+    @detail_route(methods=['post'], permission_classes=[IsAuthenticated])
     @with_jobs
     def backfill(self, request, project, jm, pk=None):
         """

--- a/treeherder/webapp/api/resultset.py
+++ b/treeherder/webapp/api/resultset.py
@@ -148,7 +148,7 @@ class ResultSetViewSet(viewsets.ViewSet):
         except Exception as ex:
             return Response("Exception: {0}".format(ex), 404)
 
-    @detail_route(methods=['post'], permission_classes=[permissions.IsStaffOrReadOnly])
+    @detail_route(methods=['post'], permission_classes=[IsAuthenticated])
     @with_jobs
     def trigger_missing_jobs(self, request, project, jm, pk=None):
         """
@@ -164,7 +164,7 @@ class ResultSetViewSet(viewsets.ViewSet):
         except Exception as ex:
             return Response("Exception: {0}".format(ex), 404)
 
-    @detail_route(methods=['post'], permission_classes=[permissions.IsStaffOrReadOnly])
+    @detail_route(methods=['post'], permission_classes=[IsAuthenticated])
     @with_jobs
     def trigger_all_talos_jobs(self, request, project, jm, pk=None):
         """


### PR DESCRIPTION
For now permission decisions should be made in pulse_actions.

In the future Treeherder will use Taskcluster scopes (bug 1273092) or accessTokens (bug 1273096).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1508)
<!-- Reviewable:end -->
