### PR TITLE
Bug 1200501 - Proxy reftest analyzer from hg.mozilla.org

### DIFF
--- a/treeherder/config/urls.py
+++ b/treeherder/config/urls.py
@@ -7,7 +7,7 @@ from django_browserid.admin import site as browserid_admin
 from treeherder.credentials.urls import urlpatterns as credentials_patterns
 from treeherder.embed import urls as embed_urls
 from treeherder.webapp.api import urls as api_urls
-from treeherder.webapp.views import LoginView
+from treeherder.webapp.views import LoginView, ReftestAnalyzerView
 
 browserid_admin.copy_registry(admin.site)
 
@@ -18,6 +18,7 @@ urlpatterns = [
    url(r'^admin/', include(browserid_admin.urls)),
    url(r'^docs/', include('rest_framework_swagger.urls')),
    url(r'^credentials/', include(credentials_patterns)),
+   url(r'^reftest-analyzer$', ReftestAnalyzerView.as_view(), name='reftest_analyzer'),
    url(r'', include('django_browserid.urls')),
 ]
 

--- a/treeherder/webapp/views.py
+++ b/treeherder/webapp/views.py
@@ -1,5 +1,6 @@
-from django.views.generic import TemplateView
-
+from django.http import HttpResponse
+from django.views.generic import TemplateView, View
+import requests
 
 class LoginView(TemplateView):
     template_name = 'webapp/persona_login.html'
@@ -10,3 +11,19 @@ class LoginView(TemplateView):
         # Django_browserid will validate this so it's safe to pass it through.
         context['next'] = self.request.GET.get('next')
         return context
+
+
+class ReftestAnalyzerView(View):
+    """Proxy for the reftest analyzer.
+
+    hg.mozilla.org doesn't serve appropriate Content-Type headers. So proxy
+    the content and add the appropriate header.
+    """
+    ANALYZER_URL = 'https://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml'
+
+    def get(self):
+        r = requests.get(self.ANALYZER_URL, timeout=5)
+        response = HttpResponse(content=r.data(), status=r.status_code,
+                                content_type='text/html')
+
+        return response

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -60,7 +60,7 @@
           <li ng-if="isReftest()">
             <a title="Open the Reftest Analyser in a new window"
                target="_blank"
-               href="http://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl={{::artifact.logurl}}&only_show_unexpected=1">
+               href="reftest-analyzer#logurl={{::artifact.logurl}}&only_show_unexpected=1">
               <span class="fa fa-bar-chart-o actionbtn-icon"></span>
               <span>open analyser</span>
             </a>

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -99,7 +99,7 @@
           <li ng-if="isReftest()" ng-repeat="job_log_url in job_log_urls">
             <a title="Launch the Reftest Analyser in a new window"
                target="_blank"
-               href="http://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl={{::job_log_url.url}}&only_show_unexpected=1">
+               href="reftest-analyzer.xhtml#logurl={{::job_log_url.url}}&only_show_unexpected=1">
               <span class="fa fa-bar-chart-o"></span>
             </a>
           </li>


### PR DESCRIPTION
We don't want hg.mozilla.org advertising Content-Type headers.
Treeherder currently sends people to hg.mozilla.org to run the
reftest analyzer.

This commit introduces a very simple proxy endpoint on Treeherder
that fetches the reftest analyzer from hg.mozilla.org, adds a
Content-Type header, and sends the raw bits to the client.

URLs referencing hg.mozilla.org have been updated to use the
new proxy endpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1509)
<!-- Reviewable:end -->
