### PR TITLE
Bug 1233164 - Remove incorrect unique constraint on failure_line

### DIFF
--- a/treeherder/model/migrations/0024_remove_failure_line_unique.py
+++ b/treeherder/model/migrations/0024_remove_failure_line_unique.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0023_simplify_machine_model'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='failureline',
+            unique_together=set([]),
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -645,9 +645,6 @@ class FailureLine(models.Model):
 
     class Meta:
         db_table = 'failure_line'
-        unique_together = (
-            ('job_guid', 'line')
-        )
         index_together = (
             ('job_guid', 'repository'),
             # The test and subtest indicies are length 50 and 25, respectively


### PR DESCRIPTION
This is causing errors. In the future it will be replaced by a
more correct constraint that makes failure lines unique per log

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1511)
<!-- Reviewable:end -->
