### PR TITLE
Bug 1274610 - Use platform field to group jobs instead of build_platform

### DIFF
--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -1060,12 +1060,12 @@ treeherder.factory('ThResultSetStore', [
                 // search for the right platform
                 var job = jobList[i];
                 var platform = _.find(groupedJobs.platforms, function(platform){
-                    return job.build_platform === platform.name &&
+                    return job.platform === platform.name &&
                         job.platform_option === platform.option;
                 });
                 if(_.isUndefined(platform)){
                     platform = {
-                        name: job.build_platform,
+                        name: job.platform,
                         option: job.platform_option,
                         groups: []
                     };


### PR DESCRIPTION
The values for these two fields is almost ALWAYS identical.  But when it's not, then it matters.  We should always use the ``platform`` field to aggregate jobs by platform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1522)
<!-- Reviewable:end -->
