### PR TITLE
Bug 1276254 - Remove unnecessary usage of .read() when json decoding

### DIFF
--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -34,8 +34,7 @@ class DataSetup(unittest.TestCase):
             )
 
         with open(self.job_data_file_path) as f:
-            data = f.read()
-            self.job_data = json.loads(data)
+            self.job_data = json.load(f)
 
         # Load sample resultsets
         self.resultset_data = []
@@ -49,8 +48,7 @@ class DataSetup(unittest.TestCase):
             )
 
         with open(self.resultset_data_file_path) as f:
-            data = f.read()
-            self.resultset_data = json.loads(data)
+            self.resultset_data = json.load(f)
             for resultset in self.resultset_data:
                 for index, revision in enumerate(resultset['revisions']):
                     del revision['branch']
@@ -71,8 +69,7 @@ class DataSetup(unittest.TestCase):
             )
 
         with open(self.artifact_data_file_path) as f:
-            data = f.read()
-            self.artifact_data = json.loads(data)
+            self.artifact_data = json.load(f)
 
     def compare_structs(self, struct1, struct2):
         """Compare two dictionary structures"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -524,7 +524,7 @@ def mock_bugzilla_api_request(monkeypatch):
             "bug_list.json"
         )
         with open(bug_list_path) as f:
-            return json.loads(f.read())
+            return json.load(f)
 
     monkeypatch.setattr(treeherder.etl.bugzilla,
                         'fetch_json',

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -15,14 +15,14 @@ base_dir = os.path.dirname(__file__)
 def pending_jobs():
     """returns a list of buildapi pending jobs"""
     with open(os.path.join(base_dir, "pending.json")) as f:
-        return json.loads(f.read())
+        return json.load(f)
 
 
 @pytest.fixture
 def running_jobs():
     """returns a list of buildapi running jobs"""
     with open(os.path.join(base_dir, "running.json")) as f:
-        return json.loads(f.read())
+        return json.load(f)
 
 
 @pytest.fixture

--- a/tests/etl/test_pushlog.py
+++ b/tests/etl/test_pushlog.py
@@ -49,8 +49,8 @@ def test_ingest_hg_pushlog_already_stored(jm, test_base_dir,
 
     pushlog_path = os.path.join(test_base_dir, 'sample_data', 'hg_pushlog.json')
     with open(pushlog_path) as f:
-        pushlog_content = f.read()
-    pushes = json.loads(pushlog_content)['pushes'].values()
+        pushlog_json = json.load(f)
+    pushes = pushlog_json['pushes'].values()
     first_push, second_push = pushes[0:2]
 
     pushlog_fake_url = "http://www.thisismypushlog.com/?full=1&version=2"

--- a/tests/sample_data_generator.py
+++ b/tests/sample_data_generator.py
@@ -152,7 +152,7 @@ def result_set(**kwargs):
     )
 
     with open(source_file) as f:
-        defaults = json.loads(f.read())[0]
+        defaults = json.load(f)[0]
     defaults.update(kwargs)
 
     # ensure that the repository values for all the revisions have the

--- a/tests/sampledata.py
+++ b/tests/sampledata.py
@@ -10,7 +10,7 @@ class SampleData(object):
     def get_perf_data(cls, filename):
         with open("{0}/sample_data/artifacts/performance/{1}".format(
                 os.path.dirname(__file__), filename)) as f:
-            return json.loads(f.read())
+            return json.load(f)
 
     def __init__(self):
         self.job_data_file = "{0}/sample_data/job_data.txt".format(
@@ -48,7 +48,7 @@ class SampleData(object):
                 self.job_data.append(json.loads(line.strip()))
 
         with open(self.resultset_data_file) as f:
-            self.resultset_data = json.loads(f.read())
+            self.resultset_data = json.load(f)
 
             # ensure that the repository values for all the revisions have the
             # same name as the db test name in settings.  If this is not

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -234,7 +234,7 @@ def load_exp(filename):
     path = SampleData().get_log_path(filename)
     with open(path, "a+") as f:
         try:
-            return json.loads(f.read())
+            return json.load(f)
         except ValueError:
             # if it's not parse-able, return an empty dict
             return {}

--- a/tests/webapp/api/test_bugscache.py
+++ b/tests/webapp/api/test_bugscache.py
@@ -17,7 +17,7 @@ def sample_bugs(test_base_dir):
         'bug_list.json'
     )
     with open(filename) as f:
-        return json.loads(f.read())
+        return json.load(f)
 
 
 def _update_bugscache(bug_list):


### PR DESCRIPTION
By using `json.load()` instead of `json.loads()` we can pass the file object directly, rather than having to `.read()` it first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1527)
<!-- Reviewable:end -->
