### PR TITLE
Bug 1200692 - Display current exclusion and revision state in tooltip

### DIFF
--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -153,6 +153,10 @@ th-watched-repo {
  * Right hand lower navbar
  */
 
+.revision-collapsed {
+    color: grey;
+}
+
 .group-state-nav-icon {
     width: 7px;
     display: inline-block;

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -42,7 +42,7 @@
 
         <!--Hidden Jobs Button-->
         <span class="btn btn-view-nav btn-sm btn-right-navbar"
-              title="Show/hide excluded jobs"
+              title="{{ !isSkippingExclusionProfiles ? 'Show excluded jobs' : 'Hide excluded jobs'}}"
               tabindex="0" role="button"
               ng-click="toggleExcludedJobs()">
           <i class="fa"
@@ -53,9 +53,11 @@
         <!--Toggle Revisions Button-->
         <span class="btn-group">
           <span class="btn btn-view-nav btn-sm btn-collapse-resultsets"
-                title="Show/hide revision list"
+                title="{{ allCollapsed('revision-list') ? 'Show revision list': 'Hide revision list'}}"
                 tabindex="0" role="button"
-                ng-click="toggleAllRevisions()"><i class="fa fa-code-fork"></i>
+                ng-click="toggleAllRevisions()">
+                <i class="fa fa-code-fork"
+                    ng-class="{'revision-collapsed': allCollapsed('revision-list')}"></i>
           </span>
         </span>
 


### PR DESCRIPTION
I added a scope to display exclusion state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1530)
<!-- Reviewable:end -->
