### PR TITLE
Bug 1276355 - Fix IntegrityError for idx_revision_hash on resultset creation

### DIFF
--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -2048,7 +2048,8 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                     result['push_timestamp'],
                     result.get('active_status', 'active'),
                     top_revision,
-                    short_top_revision
+                    short_top_revision,
+                    revision_hash
                 ]
             )
             where_in_list.append('%s')

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -71,6 +71,7 @@
                     FROM `result_set`
                     WHERE `long_revision` = ?
                     OR `short_revision` = ?
+                    OR revision_hash = ?
                 )",
 
             "host_type":"master_host"
@@ -246,7 +247,9 @@
                    `push_timestamp` = ?,
                    `active_status` = ?
                 WHERE long_revision = ?
-                  OR short_revision = ?",
+                  OR short_revision = ?
+                  OR revision_hash = ?
+                  ",
 
             "host_type":"master_host"
         }


### PR DESCRIPTION
Found this while testing the pulse ingestion from Task Cluster

When updating or inserting a resultset record, we need to check against
the revision_hash value because, while revision_hash is on its way out, we
do still use it as a fallback and there is a unique index for it.

This error can occur as a race condition when a job is being ingested that
does not yet have a resultset, but during ingestion, the resultset is
created in parallel.  So the process ingesting the job tries to insert
the resultset and gets the index violation.  This check will prevent that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1531)
<!-- Reviewable:end -->
