### PR TITLE
Bug 1266229 - Enable pulse reading queues prior to turning on ingestion of jobs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -4,6 +4,7 @@ worker_pushlog: newrelic-admin run-program celery -A treeherder worker -Q pushlo
 worker_buildapi_pending: newrelic-admin run-program celery -A treeherder worker -Q buildapi_pending --maxtasksperchild=20 --concurrency=5
 worker_buildapi_running: newrelic-admin run-program celery -A treeherder worker -Q buildapi_running --maxtasksperchild=20 --concurrency=5
 worker_buildapi_4hr: newrelic-admin run-program celery -A treeherder worker -Q buildapi_4hr --maxtasksperchild=20 --concurrency=1
+worker_pulse_jobs: newrelic-admin run-program celery -A treeherder worker -Q store_pulse_jobs --maxtasksperchild=20 --concurrency=1
 worker_default: newrelic-admin run-program celery -A treeherder worker -Q default,cycle_data,calculate_durations,fetch_bugs,detect_intermittents,fetch_allthethings,generate_perf_alerts --maxtasksperchild=50 --concurrency=3
 worker_hp: newrelic-admin run-program celery -A treeherder worker -Q classification_mirroring,publish_to_pulse --maxtasksperchild=50 --concurrency=1
 worker_log_parser: newrelic-admin run-program celery -A treeherder worker -Q log_parser,log_parser_fail,log_store_failure_lines,log_store_failure_lines_fail,log_crossreference_error_lines,log_crossreference_error_lines_fail,log_autoclassify,log_autoclassify_fail,error_summary --maxtasksperchild=50 --concurrency=5

--- a/bin/run_celery_worker_buildapi
+++ b/bin/run_celery_worker_buildapi
@@ -14,7 +14,7 @@ if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec newrelic-admin run-program celery -A treeherder worker -Q buildapi_pending,buildapi_running,buildapi_4hr \
+exec newrelic-admin run-program celery -A treeherder worker -Q buildapi_pending,buildapi_running,buildapi_4hr,store_pulse_jobs \
     --concurrency=5 --logfile=$LOGFILE -l INFO \
     --maxtasksperchild=20 -n buildapi.%h
 

--- a/bin/run_read_pulse_jobs
+++ b/bin/run_read_pulse_jobs
@@ -8,10 +8,4 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-LOGFILE=/var/log/treeherder_ingest_from_pulse.log
-
-if [ ! -f $LOGFILE ]; then
-    touch $LOGFILE
-fi
-
-exec newrelic-admin run-program ./manage.py ingest_from_pulse
+exec newrelic-admin run-program ./manage.py read_pulse_jobs

--- a/docs/pulseload.rst
+++ b/docs/pulseload.rst
@@ -13,29 +13,18 @@ Configuration
 To specify the exchanges to read from, you can set environment variables in
 Vagrant, or in your ``config/settings_local.py`` file.  For example::
 
-    PULSE_DATA_INGESTION_EXCHANGES = [
+    PULSE_DATA_INGESTION_SOURCES = [
         {
-            "name": "exchange/treeherder-test/jobs",
+            "exchange": "exchange/treeherder-test/jobs",
+            "destinations": [
+                'treeherder-prod',
+                'treeherder-stage'
+            ],
             "projects": [
                 'mozilla-inbound'
-            ],
-            "destinations": [
-                'production',
-                'staging'
             ]
         }
     ]
-
-You also need to create the celery ``Queue`` for running pulse-related
-tasks. This can also be defined in the ``config/settings_local.py``
-file, but as it modifies an existing environment variable, it must be
-defined in an ``update(settings)`` function::
-
-    def update(settings):
-        from kombu import Exchange, Queue
-        settings['CELERY_QUEUES'].append(
-            Queue('store_pulse_jobs', Exchange('default'), routing_key='store_pulse_jobs'))
-
 
 To be able to ingest from exchanges, you need to create a Pulse user with
 `Pulse Guardian`_, so
@@ -43,7 +32,7 @@ Treeherder can create your Queues for listening to the Pulse exchanges.  For
 this, you must specify the connection URL in your environment variables or
 ``settings_local.py``.  For example::
 
-    PULSE_DATA_INGESTION_CONFIG = "amqp://mypulseuserid:mypassword@pulse.mozilla.org:5672/"
+    PULSE_DATA_INGESTION_CONFIG = "amqp://mypulseuserid:mypassword@pulse.mozilla.org:5671/?ssl=1"
 
 Ingesting Data
 --------------
@@ -65,7 +54,7 @@ all::
 To begin listening to the Pulse exchanges specified above, run this management
 command::
 
-    ./manage.py ingest_from_pulse
+    ./manage.py read_pulse_jobs
 
 Once that is running, you will see jobs start to appear from the Pulse
 exchanges.

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -210,6 +210,7 @@ CELERY_QUEUES = [
     Queue('calculate_durations', Exchange('default'), routing_key='calculate_durations'),
     Queue('fetch_bugs', Exchange('default'), routing_key='fetch_bugs'),
     Queue('generate_perf_alerts', Exchange('default'), routing_key='generate_perf_alerts'),
+    Queue('store_pulse_jobs', Exchange('default'), routing_key='store_pulse_jobs'),
 ]
 
 CELERY_ACCEPT_CONTENT = ['json']
@@ -438,7 +439,7 @@ PULSE_DATA_INGESTION_SOURCES = env.json(
 PULSE_API_URL = "https://pulse.mozilla.org/"
 
 # Used to specify the PulseGuardian account that will be used to create
-# ingestion queues for the exchanges specified in ``PULSE_DATA_INGESTION_EXCHANGES``.
+# ingestion queues for the exchanges specified in ``PULSE_DATA_INGESTION_SOURCES``.
 # See https://pulse.mozilla.org/whats_pulse for more info.
 # Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/?ssl=1"
 PULSE_DATA_INGESTION_CONFIG = env.url("PULSE_DATA_INGESTION_CONFIG", default="")

--- a/treeherder/etl/management/commands/read_pulse_jobs.py
+++ b/treeherder/etl/management/commands/read_pulse_jobs.py
@@ -9,9 +9,14 @@ from treeherder.etl.pulse_consumer import JobConsumer
 
 class Command(BaseCommand):
 
-    """Management command to ingest jobs from a set of pulse exchanges."""
+    """
+    Management command to read jobs from a set of pulse exchanges
 
-    help = "Ingest jobs from a set of pulse exchanges"
+    This adds the jobs to a celery queue called ``store_pulse_jobs`` which
+    does the actual storing of the jobs in the database.
+    """
+
+    help = "Read jobs from a set of pulse exchanges and queue for ingestion"
 
     def handle(self, *args, **options):
         config = settings.PULSE_DATA_INGESTION_CONFIG


### PR DESCRIPTION
This PR creates the ``store_pulse_jobs`` celery queues on Heroku and SCL3.  I also renamed the ``ingest_from_pulse`` mgmt command to be ``read_from_pulse`` to hopefully distinguish the reading from pulse queue from the actual storage of the jobs.  

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1532)
<!-- Reviewable:end -->
