### PR TITLE
Bug 1275589 - Shorten refresh duration of runnable jobs list to 4 hours

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -256,7 +256,7 @@ CELERYBEAT_SCHEDULE = {
     },
     'fetch-allthethings-every-day': {
         'task': 'fetch-allthethings',
-        'schedule': timedelta(days=1),
+        'schedule': timedelta(hours=4),
         'relative': True,
         'options': {
             'queue': "fetch_allthethings"


### PR DESCRIPTION
At once per day, it can stay out of date too long

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1533)
<!-- Reviewable:end -->
