### PR TITLE
Bug 1229025 - Document treeherder-client logging

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -5,7 +5,7 @@ Treeherder provides a REST API which can be used to query for all the
 resultset, job, and performance data it stores internally. To allow
 inspection of this API, we use Swagger_, which provides a friendly
 browsable interface to Treeherder's API endpoints. After setting up a
-local instance of treeherder, you can access Swagger at
+local instance of Treeherder, you can access Swagger at
 http://local.treeherder.mozilla.org/docs/. You can also view it on
 our production instance at https://treeherder.mozilla.org/docs/.
 
@@ -19,7 +19,7 @@ Python Client
 
 We provide a library, called treeherder-client, to simplify
 interacting with the REST API. It is maintained inside the
-Treeherder repository, but you can install your own copy from pypi
+Treeherder repository, but you can install your own copy from PyPI
 using pip:
 
 .. code-block:: bash
@@ -52,7 +52,7 @@ can be set like so:
 Authentication
 --------------
 
-A treeherder client instance should identify itself to the server
+A Treeherder client instance should identify itself to the server
 via the `Hawk authentication mechanism`_. To apply for credentials or
 create some for local testing, see :ref:`managing-api-credentials`
 below.

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -26,6 +26,17 @@ using pip:
 
     pip install treeherder-client
 
+When using the Python client, don't forget to set up logging in the
+caller so that any API error messages are output, like so:
+
+.. code-block:: python
+
+    import logging
+
+    logging.basicConfig()
+
+For verbose output, pass ``level=logging.DEBUG`` to ``basicConfig()``.
+
 
 User Agents
 -----------
@@ -57,13 +68,17 @@ via the `Hawk authentication mechanism`_. To apply for credentials or
 create some for local testing, see :ref:`managing-api-credentials`
 below.
 
-Once your credentials are set up, pass them via the `client_id` and
-`secret` parameters to TreeherderClient's constructor:
+Once your credentials are set up, if you are using the Python client
+pass them via the `client_id` and `secret` parameters to
+TreeherderClient's constructor:
 
 .. code-block:: python
 
     client = TreeherderClient(protocol='https', host='treeherder.mozilla.org', client_id='hawk_id', secret='hawk_secret')
     client.post_collection('mozilla-central', tac)
+
+To diagnose problems when authenticating, ensure Python logging has been
+set up (see :ref:`python-client`).
 
 Note: The system clock on the machines making requests must be correct
 (or more specifically, within 60 seconds of the Treeherder server time),

--- a/docs/retrieving_data.rst
+++ b/docs/retrieving_data.rst
@@ -1,10 +1,9 @@
 Retrieving Data
 ===============
 
-The treeherder-client library described in :doc:`api`
-also has some convenience methods to query the Treeherder API. It is
-still in active development, but already has methods for getting
-resultset and job information.
+The :ref:`Python client <python-client>` also has some convenience
+methods to query the Treeherder API. It is still in active development,
+but already has methods for getting resultset and job information.
 
 Here's a simple example which prints the start timestamp of all the
 jobs associated with the last 10 result sets on mozilla-central:


### PR DESCRIPTION
Since several people have not had logging set up when trying to debug issues using the client/API, so instead of a helpful error message (eg reminding them to sync their clock for Hawk auth), they get:
`No handlers could be found for logger "thclient.client"`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1535)
<!-- Reviewable:end -->
