### PR TITLE
Bug 1272335 - Correct the ordering of CorsMiddleware

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -81,11 +81,11 @@ MIDDLEWARE_CLASSES = [middleware for middleware in [
     'django.middleware.gzip.GZipMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware' if ENABLE_DEBUG_TOOLBAR else False,
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
     'hawkrest.middleware.HawkResponseMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ] if middleware]


### PR DESCRIPTION
Since the docs say it should come before Django's `CommonMiddleware`:
https://github.com/ottoyiu/django-cors-headers#setup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1538)
<!-- Reviewable:end -->
