### PR TITLE
Bug 1163802 - For job cancellation only manually update pending jobs

### DIFF
--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -280,7 +280,9 @@ class JobsModel(TreeherderModelBase):
         job_guids = list(self.get_incomplete_job_guids(resultset_id))
         jobs = self.get_job_ids_by_guid(job_guids).values()
 
-        # Cancel all the jobs in the database...
+        # Mark pending jobs as cancelled to work around buildbot not including
+        # cancelled jobs in builds-4hr if they never started running.
+        # TODO: Remove when we stop using buildbot.
         self.execute(
             proc='jobs.updates.cancel_all',
             placeholders=[resultset_id],
@@ -364,6 +366,9 @@ class JobsModel(TreeherderModelBase):
 
         self._job_action_event(job, 'cancel', requester)
 
+        # Mark pending jobs as cancelled to work around buildbot not including
+        # cancelled jobs in builds-4hr if they never started running.
+        # TODO: Remove when we stop using buildbot.
         self.execute(
             proc='jobs.updates.cancel_job',
             placeholders=[job['job_guid']],

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -171,7 +171,7 @@
             "sql":"UPDATE `job`
                    SET    `state` = 'completed', `result` = 'usercancel'
                    WHERE  `result_set_id` = ?
-                   AND `state` <> 'completed'",
+                   AND `state` = 'pending'",
 
                 "host_type":"master_host"
         },
@@ -180,7 +180,7 @@
             "sql":"UPDATE `job`
                    SET    `state` = 'completed', `result` = 'usercancel'
                    WHERE  `job_guid` = ?
-                   AND `state` <> 'completed'",
+                   AND `state` = 'pending'",
 
                 "host_type":"master_host"
         },


### PR DESCRIPTION
If a buildbot job is cancelled whilst in the pending state, the resultant "no longer running" job does not appear in builds-4hr (due to buildbot limitations), which causes orphaned jobs in Treeherder.

To work around this, Treeherder pre-emptively updates the DB for jobs when a user cancels them using the Treeherder interface. This is not ideal, since the manual DB update can race with the job completing (if the job finished before buildapi had time to cancel it), or worse can show the job as cancelled even if the buildapi request failed to complete, leaving the job as running even though Treeherder's UI will show it as stopped.

We have to keep on performing this suboptimal workaround for pending jobs (until we stop using buildbot), but we can at least limit it to just the pending jobs case, since running jobs never needed this workaround in the first place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1539)
<!-- Reviewable:end -->
