### PR TITLE
Bug 1276864 - Remove mozilla-esr38, comm-esr38 and alder repositories

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -778,7 +778,7 @@
         "dvcs_type": "hg",
         "name": "mozilla-esr38",
         "url": "https://hg.mozilla.org/releases/mozilla-esr38",
-        "active_status": "active",
+        "active_status": "onhold",
         "codebase": "gecko",
         "repository_group": 2,
         "description": ""
@@ -791,7 +791,7 @@
         "dvcs_type": "hg",
         "name": "comm-esr38",
         "url": "https://hg.mozilla.org/releases/comm-esr38",
-        "active_status": "active",
+        "active_status": "onhold",
         "codebase": "comm",
         "repository_group": 2,
         "description": ""

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -232,7 +232,7 @@
         "dvcs_type": "hg",
         "name": "alder",
         "url": "https://hg.mozilla.org/projects/alder",
-        "active_status": "active",
+        "active_status": "onhold",
         "codebase": "gecko",
         "repository_group": 6,
         "description": ""


### PR DESCRIPTION
Since bug 1276389 removed mozilla-esr38 and comm-esr38 and bug 1251285 disabled alder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1542)
<!-- Reviewable:end -->
