### PR TITLE
Bug 1124278 - Add New Relic custom attributes for more celery tasks

### DIFF
--- a/treeherder/autoclassify/tasks.py
+++ b/treeherder/autoclassify/tasks.py
@@ -1,5 +1,6 @@
 import logging
 
+import newrelic.agent
 from celery import task
 from django.core.management import call_command
 
@@ -10,6 +11,8 @@ logger = logging.getLogger(__name__)
 
 @task(name='autoclassify', max_retries=10)
 def autoclassify(project, job_guid):
+    newrelic.agent.add_custom_parameter("project", project)
+    newrelic.agent.add_custom_parameter("job_guid", job_guid)
     try:
         logger.info('Running autoclassify')
         call_command('autoclassify', project, job_guid)
@@ -22,6 +25,8 @@ def autoclassify(project, job_guid):
 
 @task(name='detect-intermittents', max_retries=10)
 def detect_intermittents(project, job_guid):
+    newrelic.agent.add_custom_parameter("project", project)
+    newrelic.agent.add_custom_parameter("job_guid", job_guid)
     try:
         logger.info('Running detect intermittents')
         # TODO: Make this list configurable

--- a/treeherder/etl/tasks/buildapi_tasks.py
+++ b/treeherder/etl/tasks/buildapi_tasks.py
@@ -1,6 +1,7 @@
 """
 This module contains
 """
+import newrelic.agent
 from celery import task
 
 from treeherder.etl.allthethings import RunnableJobsProcess
@@ -61,5 +62,6 @@ def fetch_hg_push_log(repo_name, repo_url):
     """
     Run a HgPushlog etl process
     """
+    newrelic.agent.add_custom_parameter("repo_name", repo_name)
     process = HgPushlogProcess()
     process.run(repo_url + '/json-pushes/?full=1&version=2', repo_name)

--- a/treeherder/etl/tasks/classification_mirroring_tasks.py
+++ b/treeherder/etl/tasks/classification_mirroring_tasks.py
@@ -1,3 +1,4 @@
+import newrelic.agent
 from celery import task
 
 from treeherder.etl.classification_mirroring import ElasticsearchDocRequest
@@ -9,6 +10,9 @@ def submit_elasticsearch_doc(project, job_id, bug_id, classification_timestamp, 
     Mirror the classification to Elasticsearch using a post request, until
     OrangeFactor is rewritten to use Treeherder's API directly.
     """
+    newrelic.agent.add_custom_parameter("project", project)
+    newrelic.agent.add_custom_parameter("job_id", job_id)
+    newrelic.agent.add_custom_parameter("bug_id", bug_id)
     try:
         req = ElasticsearchDocRequest(project, job_id, bug_id, classification_timestamp, who)
         req.generate_request_body()

--- a/treeherder/model/tasks.py
+++ b/treeherder/model/tasks.py
@@ -1,5 +1,6 @@
 import os
 
+import newrelic.agent
 from celery import task
 from django.conf import settings
 from django.core.management import call_command
@@ -70,6 +71,10 @@ def publish_job_action(project, action, job_id, requester):
     :param job_id str: The job id the action was requested for.
     :param requester str: The email address associated with the request.
     """
+    newrelic.agent.add_custom_parameter("project", project)
+    newrelic.agent.add_custom_parameter("action", action)
+    newrelic.agent.add_custom_parameter("job_id", job_id)
+    newrelic.agent.add_custom_parameter("requester", requester)
     publisher = pulse_connection.get_publisher()
     if not publisher:
         return
@@ -96,6 +101,10 @@ def publish_job_action(project, action, job_id, requester):
 
 @task(name='publish-resultset-action')
 def publish_resultset_action(project, action, resultset_id, requester, times=1):
+    newrelic.agent.add_custom_parameter("project", project)
+    newrelic.agent.add_custom_parameter("action", action)
+    newrelic.agent.add_custom_parameter("resultset_id", resultset_id)
+    newrelic.agent.add_custom_parameter("requester", requester)
     publisher = pulse_connection.get_publisher()
     if not publisher:
         return
@@ -113,6 +122,9 @@ def publish_resultset_action(project, action, resultset_id, requester, times=1):
 @task(name='publish-resultset-runnable-job-action')
 def publish_resultset_runnable_job_action(project, resultset_id, requester,
                                           buildernames):
+    newrelic.agent.add_custom_parameter("project", project)
+    newrelic.agent.add_custom_parameter("resultset_id", resultset_id)
+    newrelic.agent.add_custom_parameter("requester", requester)
     publisher = pulse_connection.get_publisher()
     if not publisher:
         return
@@ -135,5 +147,5 @@ def populate_error_summary(project, artifacts):
     If any of them have ``error_lines``, then we generate the
     ``bug suggestions`` artifact from them.
     """
-
+    newrelic.agent.add_custom_parameter("project", project)
     load_error_summary(project, artifacts)

--- a/treeherder/perf/tasks.py
+++ b/treeherder/perf/tasks.py
@@ -1,3 +1,4 @@
+import newrelic.agent
 from celery import task
 
 from treeherder.perf.alerts import generate_new_alerts_in_series
@@ -6,5 +7,6 @@ from treeherder.perf.models import PerformanceSignature
 
 @task(name='generate-alerts')
 def generate_alerts(signature_id):
+    newrelic.agent.add_custom_parameter("signature_id", signature_id)
     signature = PerformanceSignature.objects.get(id=signature_id)
     generate_new_alerts_in_series(signature)

--- a/treeherder/webapp/api/auth.py
+++ b/treeherder/webapp/api/auth.py
@@ -6,8 +6,7 @@ from treeherder.credentials.models import Credentials
 
 def hawk_lookup(id):
     try:
-        newrelic.agent.add_custom_parameter("hawk_user", id)
-        # add the hawk id to the params of every call by default
+        newrelic.agent.add_custom_parameter("hawk_client_id", id)
         credentials = Credentials.objects.get(client_id=id, authorized=True)
     except Credentials.DoesNotExist:
         raise exceptions.AuthenticationFailed(


### PR DESCRIPTION
Requests made to the Treeherder API have their URLs and other request metadata recorded by the New Relic agent, which helps when debugging. 

However background celery tasks have no such URL or request metadata, so really benefit from the addition of custom attributes. These are then shown in the New Relic errors dashboard, slow transaction traces and in the Insights analysis tool:
https://docs.newrelic.com/docs/agents/manage-apm-agents/agent-metrics/collect-custom-attributes
https://docs.newrelic.com/docs/agents/python-agent/customization-extension/python-transaction-api#add_custom_parameter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1543)
<!-- Reviewable:end -->
