### PR TITLE
Bug 1277080 - Pulse config fixes for env.url variable

### DIFF
--- a/treeherder/etl/management/commands/ingest_from_pulse.py
+++ b/treeherder/etl/management/commands/ingest_from_pulse.py
@@ -15,12 +15,15 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         config = settings.PULSE_DATA_INGESTION_CONFIG
+        assert config, "PULSE_DATA_INGESTION_CONFIG must be set"
         sources = settings.PULSE_DATA_INGESTION_SOURCES
+        assert sources, "PULSE_DATA_INGESTION_SOURCES must be set"
+
         # get the existing bindings for the queue
         bindings = []
         new_bindings = []
 
-        with Connection(config) as connection:
+        with Connection(config.geturl()) as connection:
             consumer = JobConsumer(connection)
             try:
                 bindings = self.get_bindings(consumer.queue_name)["bindings"]
@@ -28,7 +31,8 @@ class Command(BaseCommand):
                 self.stderr.write(
                     "ERROR: Unable to fetch existing bindings for {}".format(
                         consumer.queue_name))
-                self.stderr.write("ERROR: Data ingestion may proceed, but no bindings will be pruned")
+                self.stderr.write("ERROR: Data ingestion may proceed, "
+                                  "but no bindings will be pruned")
 
             for source in sources:
                 # When creating this exchange object, it is important that it

--- a/treeherder/etl/pulse_consumer.py
+++ b/treeherder/etl/pulse_consumer.py
@@ -1,5 +1,4 @@
 import logging
-from urlparse import urlparse
 
 from django.conf import settings
 from kombu import Queue
@@ -22,7 +21,7 @@ class JobConsumer(ConsumerMixin):
         if not config:
             raise ValueError("PULSE_DATA_INGESTION_CONFIG is required for the "
                              "JobConsumer class.")
-        self.queue_name = "queue/{}/jobs".format(urlparse(config).username)
+        self.queue_name = "queue/{}/jobs".format(config.username)
 
     def get_consumers(self, Consumer, channel):
         return [


### PR DESCRIPTION
settings.PULSE_DATA_INGESTION_CONFIG will be read in from the env
variable as a url ParseResult, not a string.  So this adjusts to
that change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1546)
<!-- Reviewable:end -->
