### PR TITLE
Bug 1277300 - Fix astral plan character hack to work with UCS2 python

### DIFF
--- a/treeherder/log_parser/failureline.py
+++ b/treeherder/log_parser/failureline.py
@@ -73,11 +73,28 @@ def replace_astral(log_iter):
         yield item
 
 
+def char_to_codepoint_ucs4(x):
+    return ord(x)
+
+
+def char_to_codepoint_ucs2(x):
+    return (0x10000 + (ord(x[0]) - 0xD800) * 0x400 +
+            (ord(x[1]) - 0xDC00))
+
+
 # Regexp that matches all non-BMP unicode characters.
-filter_re = re.compile(ur"([\U00010000-\U0010FFFF])", re.U)
+if len(u"\U0010FFFF") == 1:
+    filter_re = re.compile(ur"([\U00010000-\U0010FFFF])", re.U)
+    char_to_codepoint = char_to_codepoint_ucs4
+else:
+    # Python is compiled as the UCS2 variant so we have to match two
+    # bytes in a surrogate pair. Then we have to decode the two bytes
+    # according to UTF16 rules to get a single codepoint
+    filter_re = re.compile(ur"([\uD800-\uDBFF][\uDC00-\uDFFF])", re.U)
+    char_to_codepoint = char_to_codepoint_ucs2
 
 
 def astral_filter(text):
     if text is None:
         return text
-    return filter_re.sub(lambda x: "<U+%s>" % hex(ord(x.group(1)))[2:].zfill(6).upper(), text)
+    return filter_re.sub(lambda x: "<U+%s>" % hex(char_to_codepoint(x.group(0)))[2:].zfill(6).upper(), text)


### PR DESCRIPTION
Python can either be compiled in UCS2 mode or UCS4 mode, which differ in
how non-BMP characters are represented. In the former they are
represented by a (user-exposed) surrogate pair so that a single astral
codepoint is encoded in a string of length 2. In the latter all
characters are represented by a single 4 byte value and all characters
have a string length of 1 e.g. len(u"\U0010FFFF") is 2 in UCS2 python
and 1 in UCS4 python.

Several functions don't work identically between the two variants
e.g. ord() will only accept a single python character and
ord(u"\U0010FFFF") will either succeed or fail depending on the compile
time options. Similarly, regexps can't directly work with characters
outside the BMP in UCS2 Python, and one must instead match the
individual parts of the surrogate pair.

This is obviously a terrible design mistake, but it's important to us
because although most environments use the forgiving/sane UCS4
configuration, Heroku currently uses edge-case-happy UCS2
configuration. Therefore where we are dealing with non-BMP characters we
must add in individual codepaths for each variant.

There is probably a moral in this story about why "just make it an
option" is generally a terrible idea.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1547)
<!-- Reviewable:end -->
