### PR TITLE
Bug 1277345 - Fix log exception during job ingestion

### DIFF
--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1803,7 +1803,9 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                     # (we'll pick them up later)
                     continue
                 jl, _ = JobLog.objects.get_or_create(
-                    job=job, name=name, url=url, status=status)
+                    job=job, name=name, url=url, defaults={
+                        'status': status
+                    })
                 job_log_list.append((jl, job_results[job_guid]))
 
             self.schedule_log_parsing(job_log_list)


### PR DESCRIPTION
When a log already exists with different state during job ingestion with
a non-default status, we should not change it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1549)
<!-- Reviewable:end -->
