### PR TITLE
Bug 1277955 - Add support for revision_hash to pulse jobs

### DIFF
--- a/schemas/pulse-job.yml
+++ b/schemas/pulse-job.yml
@@ -33,6 +33,9 @@ properties:
   origin:
     oneOf:
       - type: "object"
+        description: |
+          PREFERRED: An HG job that only has a revision.  This is for all
+          jobs going forward.
         properties:
           kind:
             type: "string"
@@ -50,6 +53,29 @@ properties:
           pushLogID:
             type: "integer"
         required: [kind, project, revision]
+
+      - type: "object"
+        description: |
+          BACKWARD COMPATABILITY: An HG job that only has a revision_hash.
+          Some repos like mozilla-beta have not yet merged in the code that
+          allows them access to the revision.
+        properties:
+          kind:
+            type: "string"
+            enum: ['hg.mozilla.org']
+          project:
+            type: "string"
+            pattern: "^[\\w-]+$"
+            minLength: 1
+            maxLength: 50
+          revision_hash:
+            type: "string"
+            pattern: "^[0-9a-f]+$"
+            minLength: 40
+            maxLength: 40
+          pushLogID:
+            type: "integer"
+        required: [kind, project, revision_hash]
 
       - type: "object"
         properties:

--- a/tests/etl/test_job_loader.py
+++ b/tests/etl/test_job_loader.py
@@ -4,7 +4,8 @@ import pytest
 
 from treeherder.etl.job_loader import JobLoader
 from treeherder.model.derived.artifacts import ArtifactsModel
-from treeherder.model.models import (JobDetail,
+from treeherder.model.models import (Job,
+                                     JobDetail,
                                      JobLog)
 
 
@@ -59,6 +60,26 @@ def test_ingest_pulse_jobs(pulse_jobs, test_project, jm, result_set_stored,
         assert len(artifacts) == 3
 
     assert JobDetail.objects.count() == 2
+
+
+def test_ingest_pulse_jobs_with_revision_hash(pulse_jobs, test_project, jm,
+                                              result_set_stored,
+                                              mock_log_parser):
+    """
+    Ingest a revision_hash job with the JobLoader used by Pulse
+    """
+
+    jl = JobLoader()
+    rs = jm.get_result_set_list(0, 10)[0]
+    revision_hash = rs["revision_hash"]
+    for job in pulse_jobs:
+        origin = job["origin"]
+        del(origin["revision"])
+        origin["revision_hash"] = revision_hash
+
+    jl.process_job_list(pulse_jobs)
+
+    assert Job.objects.count() == 4
 
 
 def test_transition_pending_running_complete(first_job, jm, mock_log_parser):


### PR DESCRIPTION
Some repos are longer-lived and do not yet have the Task Cluster
code that allows them to submit tasks with a revision.  They only
have the older code to submit revision_hash.  This prevents the
jobs from being ingested via Pulse.  This commit adds support
for revision_hash until a time when it's no longer needed.

I created Bug 1277956 to remind me to remove this support when its no longer needed.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1559)
<!-- Reviewable:end -->
