### PR TITLE
Bug 1277936 - Fix indentation issue that made update_autoclassification_bug a no-op.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -375,7 +375,7 @@ def test_matcher(request):
 
     class TreeherderUnitTestDetector(detectors.Detector):
         def __call__(self, failure_lines):
-            pass
+            return True
 
     MatcherManager._detector_funcs = {}
     MatcherManager._matcher_funcs = {}

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -676,13 +676,12 @@ class JobsModel(TreeherderModelBase):
 
     def update_autoclassification_bug(self, job_id, bug_number):
         failure_line = self.get_manual_classification_line(job_id)
-
         if failure_line is None:
             return
 
-            classification = failure_line.best_classification
-            if classification and classification.bug_number is None:
-                classification.set_bug(bug_number)
+        classification = failure_line.best_classification
+        if classification and classification.bug_number is None:
+            return classification.set_bug(bug_number)
 
     def calculate_durations(self, sample_window_seconds, debug):
         # Get the most recent timestamp from jobs


### PR DESCRIPTION
This wasn't a serious issue, it just meant that we would never infer a bug
number when a job was sheriffed using the non-autoclassification UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1564)
<!-- Reviewable:end -->
