### PR TITLE
Bug 1266229 - Allocate Heroku dynos for pulse queue reading

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -4,7 +4,8 @@ worker_pushlog: newrelic-admin run-program celery -A treeherder worker -Q pushlo
 worker_buildapi_pending: newrelic-admin run-program celery -A treeherder worker -Q buildapi_pending --maxtasksperchild=20 --concurrency=5
 worker_buildapi_running: newrelic-admin run-program celery -A treeherder worker -Q buildapi_running --maxtasksperchild=20 --concurrency=5
 worker_buildapi_4hr: newrelic-admin run-program celery -A treeherder worker -Q buildapi_4hr --maxtasksperchild=20 --concurrency=1
-worker_pulse_jobs: newrelic-admin run-program celery -A treeherder worker -Q store_pulse_jobs --maxtasksperchild=20 --concurrency=1
+worker_store_pulse_jobs: newrelic-admin run-program celery -A treeherder worker -Q store_pulse_jobs --maxtasksperchild=20 --concurrency=1
+worker_read_pulse_jobs: newrelic-admin run-program ./manage.py read_pulse_jobs
 worker_default: newrelic-admin run-program celery -A treeherder worker -Q default,cycle_data,calculate_durations,fetch_bugs,detect_intermittents,fetch_allthethings,generate_perf_alerts --maxtasksperchild=50 --concurrency=3
 worker_hp: newrelic-admin run-program celery -A treeherder worker -Q classification_mirroring,publish_to_pulse --maxtasksperchild=50 --concurrency=1
 worker_log_parser: newrelic-admin run-program celery -A treeherder worker -Q log_parser,log_parser_fail,log_store_failure_lines,log_store_failure_lines_fail,log_crossreference_error_lines,log_crossreference_error_lines_fail,log_autoclassify,log_autoclassify_fail,error_summary --maxtasksperchild=50 --concurrency=5


### PR DESCRIPTION
This ca be turned on or off based on the number of dynos assigned to it.  By default, it will get zero, so it'll be a no-op, till we flip the switch in the Heroku dashboard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1566)
<!-- Reviewable:end -->
