### PR TITLE
Bug 1277575 - Don't fail the task when autoclassification encounters a duplicate FailureMatch

### DIFF
--- a/treeherder/autoclassify/management/commands/autoclassify.py
+++ b/treeherder/autoclassify/management/commands/autoclassify.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 
 from django.core.management.base import (BaseCommand,
                                          CommandError)
+from django.db.utils import IntegrityError
 
 from treeherder.model.derived import JobsModel
 from treeherder.model.models import (FailureLine,
@@ -12,7 +13,9 @@ from treeherder.model.models import (FailureLine,
 logger = logging.getLogger(__name__)
 
 # The minimum goodness of match we need to mark a particular match as the best match
-AUTOCLASSIFY_CUTOFF_RATIO = 0.8
+AUTOCLASSIFY_CUTOFF_RATIO = 0.7
+# A goodness of match after which we will not run further detectors
+AUTOCLASSIFY_GOOD_ENOUGH_RATIO = 0.9
 
 
 class Command(BaseCommand):
@@ -44,30 +47,50 @@ def match_errors(repository, jm, job_guid):
     if job["result"] not in ["testfailed", "busted", "exception"]:
         return
 
-    unmatched_failures = FailureLine.objects.unmatched_for_job(repository, job_guid)
+    unmatched_failures = set(FailureLine.objects.unmatched_for_job(repository, job_guid))
 
     if not unmatched_failures:
         return
 
-    all_matched = set()
+    matches, all_matched = find_matches(unmatched_failures)
+    update_db(jm, job_id, matches, all_matched)
+
+
+def find_matches(unmatched_failures):
+    all_matches = set()
 
     for matcher in Matcher.objects.registered_matchers():
         matches = matcher(unmatched_failures)
         for match in matches:
-            match.failure_line.matches.add(
-                FailureMatch(score=match.score,
-                             matcher=matcher.db_object,
-                             classified_failure=match.classified_failure))
-            match.failure_line.save()
             logger.info("Matched failure %i with intermittent %i" %
                         (match.failure_line.id, match.classified_failure.id))
-            all_matched.add(match.failure_line)
+            all_matches.add((matcher.db_object, match))
+            if match.score >= AUTOCLASSIFY_GOOD_ENOUGH_RATIO:
+                unmatched_failures.remove(match.failure_line)
 
-        if all_lines_matched(unmatched_failures):
+        if not unmatched_failures:
             break
 
-    for failure_line in all_matched:
-        # TODO: store all matches
+    return all_matches, len(unmatched_failures) == 0
+
+
+def update_db(jm, job_id, matches, all_matched):
+    matches_by_failure_line = defaultdict(set)
+    for item in matches:
+        matches_by_failure_line[item[1].failure_line].add(item)
+
+    for failure_line, matches in matches_by_failure_line.iteritems():
+        for matcher, match in matches:
+            try:
+                FailureMatch.objects.create(
+                    score=match.score,
+                    matcher=matcher,
+                    classified_failure=match.classified_failure,
+                    failure_line=failure_line)
+            except IntegrityError:
+                logger.warning(
+                    "Tried to create duplicate match for failure line %i with matcher %i and classified_failure %i" %
+                    (failure_line.id, matcher.id, match.classified_failure.id))
         best_match = failure_line.best_automatic_match(AUTOCLASSIFY_CUTOFF_RATIO)
         if best_match:
             failure_line.best_classification = best_match.classified_failure


### PR DESCRIPTION
Refactor the code slightly by forward-porting the changes from the
elasticsearch branch that cause us to optimise out further matching when
we find a match that is considered good enough. Also wrap the creation
of a FailureMatch in a try/except block so that we don't fail if there
is an existing FailureMatch for the same line/classification which could
happen if the task previously failed for an unrelated reason. This gives
higher granularity than just putting the entire task in a transaction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1569)
<!-- Reviewable:end -->
