### PR TITLE
Bug 1278711 - Add unique together index to JobDetail model/table

### DIFF
--- a/treeherder/model/migrations/0027_jobdetail_unique_together_20160607_1447.py
+++ b/treeherder/model/migrations/0027_jobdetail_unique_together_20160607_1447.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0026_failure_line_job_log_id'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='jobdetail',
+            unique_together=set([('job', 'title', 'value', 'url')]),
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -571,6 +571,7 @@ class JobDetail(models.Model):
 
     class Meta:
         db_table = "job_detail"
+        unique_together = ("job", "title", "value", "url")
 
     def __str__(self):
         return "{0} {1} {2} {3} {4}".format(self.id,


### PR DESCRIPTION
During job ingestion, we can sometimes get an error of
MultipleObjectsReturned when creating a JobDetail record.  Adding
an index for uniqueness will prevent us from getting that while
using the get_or_create model function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1573)
<!-- Reviewable:end -->
