### PR TITLE
Bug 1278711 - Add unique together indexs to JobDetail

### DIFF
--- a/tests/model/derived/test_artifacts_model.py
+++ b/tests/model/derived/test_artifacts_model.py
@@ -116,7 +116,7 @@ def test_load_duplicate_job_details_fails(
         artifacts_model.load_job_artifacts([ji_artifact])
         artifacts_model.load_job_artifacts([ji_artifact])
 
-        assert JobDetail.objects.count() == 1
+    assert JobDetail.objects.count() == 1
 
 
 def test_load_long_job_details(test_project, eleven_jobs_stored):

--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -104,8 +104,9 @@ class ArtifactsModel(TreeherderModelBase):
                 'value': job_detail['value'],
                 'url': job_detail.get('url')
             }
-            max_field_length = JobDetail.MAX_FIELD_LENGTH
             for (k, v) in job_detail_dict.iteritems():
+                max_field_length = JobDetail.MAX_TITLE_LENGTH \
+                    if k == 'title' else JobDetail.MAX_FIELD_LENGTH
                 if v is not None and len(v) > max_field_length:
                     logger.warning("Job detail '{}' for job_guid {} too long, "
                                    "truncating".format(

--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -115,6 +115,7 @@ class ArtifactsModel(TreeherderModelBase):
 
             JobDetail.objects.get_or_create(
                 job=job,
+                defaults=job_detail_dict,
                 **job_detail_dict)
 
     def store_performance_artifact(

--- a/treeherder/model/migrations/0028_add_jobdetail_unique_together_idx.py
+++ b/treeherder/model/migrations/0028_add_jobdetail_unique_together_idx.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0027_failure_line_idx_signature_test'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='jobdetail',
+            name='title',
+            field=models.CharField(max_length=100, null=True),
+        ),
+        migrations.AlterUniqueTogether(
+            name='jobdetail',
+            unique_together=set([('job', 'title', 'value')]),
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -562,10 +562,11 @@ class JobDetail(models.Model):
     each job
     '''
     MAX_FIELD_LENGTH = 512
+    MAX_TITLE_LENGTH = 100
 
     id = BigAutoField(primary_key=True)
     job = FlexibleForeignKey(Job)
-    title = models.CharField(max_length=100, null=True)
+    title = models.CharField(max_length=MAX_TITLE_LENGTH, null=True)
     value = models.CharField(max_length=MAX_FIELD_LENGTH)
     url = models.URLField(null=True, max_length=MAX_FIELD_LENGTH)
 

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -572,8 +572,10 @@ class JobDetail(models.Model):
 
     class Meta:
         db_table = "job_detail"
-        # max index size is 767 for innoDB.  So we can't include
-        # url AND value in the same index.  Value should be sufficient.
+        # Ensure that we have unique records for ``job``, ``title`` and
+        # ``value``.  We consider duplication in those fields with a different
+        # ``url`` to be unsupported.  Unique ``url``s should also have unique
+        # ``value``s.
         unique_together = ("job", "title", "value")
 
     def __str__(self):

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -572,13 +572,8 @@ class JobDetail(models.Model):
     class Meta:
         db_table = "job_detail"
         # max index size is 767 for innoDB.  So we can't include
-        # url AND value in the same index.  Many records have BOTH those
-        # fields filled, so we need that uniqueness.  Therefore, we
-        # have to use two indexes.
-        unique_together = (
-            ("job", "title", "value"),
-            ("job", "title", "url"),
-        )
+        # url AND value in the same index.  Value should be sufficient.
+        unique_together = ("job", "title", "value")
 
     def __str__(self):
         return "{0} {1} {2} {3} {4}".format(self.id,

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -565,12 +565,20 @@ class JobDetail(models.Model):
 
     id = BigAutoField(primary_key=True)
     job = FlexibleForeignKey(Job)
-    title = models.CharField(max_length=MAX_FIELD_LENGTH, null=True)
+    title = models.CharField(max_length=100, null=True)
     value = models.CharField(max_length=MAX_FIELD_LENGTH)
     url = models.URLField(null=True, max_length=MAX_FIELD_LENGTH)
 
     class Meta:
         db_table = "job_detail"
+        # max index size is 767 for innoDB.  So we can't include
+        # url AND value in the same index.  Many records have BOTH those
+        # fields filled, so we need that uniqueness.  Therefore, we
+        # have to use two indexes.
+        unique_together = (
+            ("job", "title", "value"),
+            ("job", "title", "url"),
+        )
 
     def __str__(self):
         return "{0} {1} {2} {3} {4}".format(self.id,


### PR DESCRIPTION
This should help prevent the errors with getting more than one job on ``get_or_create``.  I opted for 2 uniqueness indexes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1578)
<!-- Reviewable:end -->
