### PR TITLE
Bug 1260805 - Make performance bug template configurable per-project

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -472,7 +472,7 @@ def client_credentials(request, test_user):
 
 
 @pytest.fixture
-def test_perf_framework():
+def test_perf_framework(transactional_db):
     from treeherder.perf.models import PerformanceFramework
     return PerformanceFramework.objects.create(
         name='test_talos')

--- a/treeherder/model/management/commands/load_initial_data.py
+++ b/treeherder/model/management/commands/load_initial_data.py
@@ -10,4 +10,5 @@ class Command(BaseCommand):
                      'repository_group',
                      'repository',
                      'failure_classification',
-                     'performance_framework')
+                     'performance_framework',
+                     'performance_bug_templates')

--- a/treeherder/perf/fixtures/performance_bug_templates.yaml
+++ b/treeherder/perf/fixtures/performance_bug_templates.yaml
@@ -1,0 +1,23 @@
+- model: perf.PerformanceBugTemplate
+  pk: 1
+  fields:
+    framework: 1
+    keywords: perf, regression
+    status_whiteboard: talos_regression
+    default_component: Untriaged
+    default_product: Firefox
+    cc_list: jmaher@mozilla.com, wlachance@mozilla.com, avihpit@yahoo.com
+    text: |
+      Talos has detected a Firefox performance regression from push {{ revision }}. As author of one of the patches included in that push, we need your help to address this regression.
+
+      This is a list of all known regressions and improvements related to the push: {{ alertHref }}
+
+      On the page above you can see an alert for each affected platform as well as a link to a graph showing the history of scores for this test. There is also a link to a treeherder page showing the Talos jobs in a pushlog format.
+
+      To learn more about the regressing test(s), please see: https://wiki.mozilla.org/Buildbot/Talos/Tests
+
+      For information on reproducing and debugging the regression, either on try or locally, see: https://wiki.mozilla.org/Buildbot/Talos/Running
+
+      *** Please let us know your plans within 3 business days, or the offending patch(es) will be backed out! ***
+
+      Our wiki page outlines the common responses and expectations: https://wiki.mozilla.org/Buildbot/Talos/RegressionBugsHandling

--- a/treeherder/perf/migrations/0017_performancebugtemplate.py
+++ b/treeherder/perf/migrations/0017_performancebugtemplate.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('perf', '0016_manually_created_alerts'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PerformanceBugTemplate',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('keywords', models.CharField(max_length=255)),
+                ('status_whiteboard', models.CharField(max_length=255)),
+                ('default_component', models.CharField(max_length=255)),
+                ('default_product', models.CharField(max_length=255)),
+                ('cc_list', models.CharField(max_length=255)),
+                ('text', models.TextField(max_length=4096)),
+                ('framework', models.OneToOneField(to='perf.PerformanceFramework')),
+            ],
+            options={
+                'db_table': 'performance_bug_template',
+            },
+        ),
+    ]

--- a/treeherder/perf/models.py
+++ b/treeherder/perf/models.py
@@ -293,3 +293,24 @@ class PerformanceAlert(models.Model):
     def __str__(self):
         return "{} {} {}%".format(self.summary, self.series_signature,
                                   self.amount_pct)
+
+
+class PerformanceBugTemplate(models.Model):
+    '''
+    Template for filing a bug or issue associated with a performance alert
+    '''
+    framework = models.OneToOneField(PerformanceFramework)
+
+    keywords = models.CharField(max_length=255)
+    status_whiteboard = models.CharField(max_length=255)
+    default_component = models.CharField(max_length=255)
+    default_product = models.CharField(max_length=255)
+    cc_list = models.CharField(max_length=255)
+
+    text = models.TextField(max_length=4096)
+
+    class Meta:
+        db_table = "performance_bug_template"
+
+    def __str__(self):
+        return '{} bug template'.format(self.framework.name)

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -14,6 +14,7 @@ from treeherder.model import models
 from treeherder.perf.alerts import get_alert_properties
 from treeherder.perf.models import (PerformanceAlert,
                                     PerformanceAlertSummary,
+                                    PerformanceBugTemplate,
                                     PerformanceDatum,
                                     PerformanceFramework,
                                     PerformanceSignature)
@@ -21,6 +22,7 @@ from treeherder.webapp.api.permissions import IsStaffOrReadOnly
 
 from .performance_serializers import (PerformanceAlertSerializer,
                                       PerformanceAlertSummarySerializer,
+                                      PerformanceBugTemplateSerializer,
                                       PerformanceFrameworkSerializer)
 
 
@@ -299,3 +301,10 @@ class PerformanceAlertViewSet(viewsets.ModelViewSet):
                 't_value': 1000
             })
         return Response({"alert_id": alert.id})
+
+
+class PerformanceBugTemplateViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = PerformanceBugTemplate.objects.all()
+    serializer_class = PerformanceBugTemplateSerializer
+    filter_backends = (filters.DjangoFilterBackend, filters.OrderingFilter)
+    filter_fields = ['framework']

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -3,6 +3,7 @@ from rest_framework import (exceptions,
 
 from treeherder.perf.models import (PerformanceAlert,
                                     PerformanceAlertSummary,
+                                    PerformanceBugTemplate,
                                     PerformanceFramework,
                                     PerformanceSignature)
 
@@ -106,3 +107,14 @@ class PerformanceAlertSummarySerializer(serializers.ModelSerializer):
         fields = ['id', 'result_set_id', 'prev_result_set_id',
                   'last_updated', 'repository', 'framework', 'alerts',
                   'related_alerts', 'status', 'bug_number']
+
+
+class PerformanceBugTemplateSerializer(serializers.ModelSerializer):
+
+    framework = serializers.SlugRelatedField(read_only=True,
+                                             slug_field='id')
+
+    class Meta:
+        model = PerformanceBugTemplate
+        fields = ['framework', 'keywords', 'status_whiteboard',
+                  'default_component', 'default_product', 'cc_list', 'text']

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -131,6 +131,9 @@ default_router.register(r'performance/alert',
 default_router.register(r'performance/framework',
                         performance_data.PerformanceFrameworkViewSet,
                         base_name='performance-frameworks')
+default_router.register(r'performance/bug-template',
+                        performance_data.PerformanceBugTemplateViewSet,
+                        base_name='performance-bug-template')
 default_router.register(r'bugzilla', bugzilla.BugzillaViewSet,
                         base_name='bugzilla')
 default_router.register(r'jobdetail', jobs.JobDetailViewSet,


### PR DESCRIPTION
Do this by storing the content of each template in the database (currently
we have just one, for Talos) and adding an API endpoint for fetching it.
For now, we will store the data that should be in each template in a
pre-loaded fixture. Bonus new feature: automatic population of a "CC" list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1579)
<!-- Reviewable:end -->
