### PR TITLE
Bug 1279193 - Use a sliding time window, with a maximum execution time, for autoclassification.

### DIFF
--- a/treeherder/autoclassify/matchers.py
+++ b/treeherder/autoclassify/matchers.py
@@ -1,11 +1,16 @@
 import logging
+import time
 from abc import (ABCMeta,
                  abstractmethod)
 from collections import namedtuple
+from datetime import (datetime,
+                      timedelta)
 
 from django.db.models import Q
 
-from treeherder.model.models import (FailureMatch,
+from treeherder.autoclassify.management.commands.autoclassify import AUTOCLASSIFY_GOOD_ENOUGH_RATIO
+from treeherder.model.models import (FailureLine,
+                                     FailureMatch,
                                      MatcherManager)
 
 logger = logging.getLogger(__name__)
@@ -35,6 +40,45 @@ ignored_line = (Q(failure_line__best_classification=None) &
                 Q(failure_line__best_is_verified=True))
 
 
+def time_window(queryset, interval, time_budget_ms, match_filter):
+    upper_cutoff = datetime.now()
+    lower_cutoff = upper_cutoff - interval
+    matches = []
+
+    time_budget = time_budget_ms / 1000. if time_budget_ms is not None else None
+    t0 = time.time()
+
+    min_date = FailureLine.objects.order_by("id")[0].created
+
+    count = 0
+    while True:
+        count += 1
+        window_queryset = queryset.filter(
+            failure_line__created__range=(lower_cutoff, upper_cutoff))
+        logger.debug("[time_window] Queryset: %s" % window_queryset.query)
+        match = window_queryset.first()
+        if match is not None:
+            matches.append(match)
+            if match.score >= AUTOCLASSIFY_GOOD_ENOUGH_RATIO:
+                break
+        upper_cutoff = lower_cutoff
+        lower_cutoff = upper_cutoff - interval
+        if upper_cutoff < min_date:
+            break
+
+        if time_budget_ms is not None and time.time() - t0 > time_budget:
+            # Putting the condition at the end of the loop ensures that we always
+            # run it once, which is useful for testing
+            break
+
+    logger.debug("[time_window] Used %i queries" % count)
+    if matches:
+        matches.sort(key=match_filter)
+        return matches[0]
+    else:
+        return None
+
+
 class PreciseTestMatcher(Matcher):
     """Matcher that looks for existing failures with identical tests and identical error
     message."""
@@ -44,23 +88,26 @@ class PreciseTestMatcher(Matcher):
         for failure_line in failure_lines:
             logger.debug("Looking for test match in failure %d" % failure_line.id)
 
-            if failure_line.action == "test_result":
-                matching_failures = FailureMatch.objects.filter(
-                    failure_line__action="test_result",
-                    failure_line__test=failure_line.test,
-                    failure_line__subtest=failure_line.subtest,
-                    failure_line__status=failure_line.status,
-                    failure_line__expected=failure_line.expected,
-                    failure_line__message=failure_line.message).exclude(
-                        ignored_line | Q(failure_line__job_guid=failure_line.job_guid)
-                    ).order_by("-score", "-classified_failure")
+            if failure_line.action != "test_result" or failure_line.message is None:
+                continue
 
-                best_match = matching_failures.first()
-                if best_match:
-                    logger.debug("Matched using precise test matcher")
-                    rv.append(Match(failure_line,
-                                    best_match.classified_failure,
-                                    best_match.score))
+            matching_failures = FailureMatch.objects.filter(
+                failure_line__action="test_result",
+                failure_line__test=failure_line.test,
+                failure_line__subtest=failure_line.subtest,
+                failure_line__status=failure_line.status,
+                failure_line__expected=failure_line.expected,
+                failure_line__message=failure_line.message).exclude(
+                    ignored_line | Q(failure_line__job_guid=failure_line.job_guid)
+                ).order_by("-score", "-classified_failure")
+
+            best_match = time_window(matching_failures, timedelta(days=7), 500,
+                                     lambda x: (-x.score, -x.classified_failure_id))
+            if best_match:
+                logger.debug("Matched using precise test matcher")
+                rv.append(Match(failure_line,
+                                best_match.classified_failure,
+                                best_match.score))
         return rv
 
 
@@ -69,6 +116,7 @@ class CrashSignatureMatcher(Matcher):
 
     def __call__(self, failure_lines):
         rv = []
+
         for failure_line in failure_lines:
             if (failure_line.action != "crash" or failure_line.signature is None
                 or failure_line.signature == "None"):
@@ -80,17 +128,21 @@ class CrashSignatureMatcher(Matcher):
                 ).select_related('failure_line').order_by(
                     "-score",
                     "-classified_failure")
+
+            score_multiplier = 10
             matching_failures_same_test = matching_failures.filter(
                 failure_line__test=failure_line.test)
-            best_match = matching_failures_same_test.first()
+
+            best_match = time_window(matching_failures_same_test, timedelta(days=7), 250,
+                                     lambda x: (-x.score, -x.classified_failure_id))
             if not best_match:
-                best_match = matching_failures.first()
+                score_multiplier = 8
+                best_match = time_window(matching_failures, timedelta(days=7), 250,
+                                         lambda x: (-x.score, -x.classified_failure_id))
+
             if best_match:
                 logger.debug("Matched using crash signature matcher")
-                score = best_match.score
-                # Add a made-up factor to reduce the goodness of the match
-                if failure_line.test != best_match.failure_line.test:
-                    score = 8 * score / 10
+                score = best_match.score * score_multiplier / 10
                 rv.append(Match(failure_line,
                                 best_match.classified_failure,
                                 score))

--- a/treeherder/model/migrations/0028_test_match_created_index.py
+++ b/treeherder/model/migrations/0028_test_match_created_index.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0027_failure_line_idx_signature_test'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            """
+            DROP INDEX failure_line_test_idx ON failure_line;
+            CREATE INDEX failure_line_test_idx ON failure_line (test(50), subtest(25), status, expected, created);
+            DROP INDEX failure_line_signature_test_idx ON failure_line;
+            CREATE INDEX failure_line_signature_test_idx ON failure_line (signature(25), test(50), created);
+            """,
+            """
+            DROP INDEX failure_line_test_idx ON failure_line;
+            CREATE INDEX failure_line_test_idx ON failure_line (test(50), subtest(25), status, expected);
+            DROP INDEX failure_line_signature_idx ON failure_line;
+            CREATE INDEX failure_line_signature_test_idx ON failure_line (signature(50), test);
+            """,
+            state_operations=[migrations.AlterIndexTogether(
+                name='failureline',
+                index_together=set([('test', 'subtest', 'status', 'expected', 'created'),
+                                    ('job_guid', 'repository'),
+                                    ('signature', 'test', 'created')])),])
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -683,8 +683,8 @@ class FailureLine(models.Model):
         index_together = (
             ('job_guid', 'repository'),
             # The test and subtest indicies are length 50 and 25, respectively
-            ('test', 'subtest', 'status', 'expected'),
-            ('signature', 'test')
+            ('test', 'subtest', 'status', 'expected', 'created'),
+            ('signature', 'test', 'created')
         )
         unique_together = (
             ('job_log',  'line')


### PR DESCRIPTION
First try to select only failure lines from the last 7 days. If that
didn't find a good enough match, select from the 7 days before that, and
so on. If running the queries has taken more than a set time limit,
stop looking at further time ranges.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1580)
<!-- Reviewable:end -->
