### PR TITLE
Bug 1279359 - Don't let percentComplete become NaN when the total number of jobs is 0

### DIFF
--- a/ui/js/directives/treeherder/resultsets.js
+++ b/ui/js/directives/treeherder/resultsets.js
@@ -15,11 +15,10 @@ treeherder.directive('thResultCounts', [
             link: function(scope, element, attrs) {
                 var setTotalCount = function() {
                     if (scope.resultset.job_counts) {
-
                         scope.inProgress = scope.resultset.job_counts.pending +
                             scope.resultset.job_counts.running;
                         var total = scope.resultset.job_counts.completed + scope.inProgress;
-                        scope.percentComplete = ((scope.resultset.job_counts.completed / total) * 100).toFixed(0);
+                        scope.percentComplete = total > 0 ? ((scope.resultset.job_counts.completed / total) * 100).toFixed(0) : undefined;
                         scope.resultset.job_counts.percentComplete = scope.percentComplete;
                     }
                 };


### PR DESCRIPTION
When a DONTBUILD push is in "Add new Jobs" mode, Treeherder reports the percentComplete as NaN. Coercing that into undefined prevents the page title from displaying "NaN%"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1582)
<!-- Reviewable:end -->
