### PR TITLE
Bug 1124278 - Adjust the New Relic custom attributes for the log parser

### DIFF
--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -26,7 +26,9 @@ def parser_task(f):
         newrelic.agent.add_custom_parameter("job_guid", job_guid)
         newrelic.agent.add_custom_parameter("job_log_id", job_log_id)
         job_log = JobLog.objects.get(id=job_log_id)
-        newrelic.agent.add_custom_parameter("job_log_status", job_log.status)
+        newrelic.agent.add_custom_parameter("job_log_name", job_log.name)
+        newrelic.agent.add_custom_parameter("job_log_url", job_log.url)
+        newrelic.agent.add_custom_parameter("job_log_status_prior", job_log.get_status_display())
         if job_log.status == JobLog.PARSED:
             logger.info("log already parsed")
             return True


### PR DESCRIPTION
* Adds the name and url for each `JobLog`, to save having to look them up using the id.
* Renames the status attribute to make it clearer that it refers to the status that was set prior to the task starting (eg helps answer if the log was already successfully parsed or had previously failed).
* Switches the status to the human-readable status descriptions (such as "pending") rather than the status code, using `Model.get_FOO_display()`:
https://docs.djangoproject.com/en/1.8/ref/models/instances/#django.db.models.Model.get%5FFOO%5Fdisplay

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1583)
<!-- Reviewable:end -->
