### PR TITLE
Bug 1275589 - Prune runnable jobs

### DIFF
--- a/tests/etl/test_runnable_jobs.py
+++ b/tests/etl/test_runnable_jobs.py
@@ -1,0 +1,31 @@
+from treeherder.etl.allthethings import RunnableJobsProcess
+from treeherder.etl.buildbot import get_symbols_and_platforms
+from treeherder.model.models import (BuildPlatform,
+                                     JobType,
+                                     MachinePlatform,
+                                     Repository,
+                                     RunnableJob)
+
+
+def test_prune_old_runnable_job(jm, eleven_jobs_stored):
+
+    """
+
+    """
+    etl_process = RunnableJobsProcess()
+
+    RunnableJob.objects.create(build_platform=BuildPlatform.objects.first(),
+                               machine_platform=MachinePlatform.objects.first(),
+                               job_type=JobType.objects.first(),
+                               option_collection_hash='test1',
+                               ref_data_name='test1',
+                               build_system_type='test1',
+                               repository=Repository.objects.first())
+
+    buildername = "Android 4.2 x86 Emulator larch opt test androidx86-set-4"
+    sym_plat = get_symbols_and_platforms(buildername)
+    etl_process.load({jm.project: [sym_plat]})
+    rj = RunnableJob.objects.all()
+    assert len(rj) == 1
+
+    assert rj[0].ref_data_name == buildername

--- a/tests/etl/test_runnable_jobs.py
+++ b/tests/etl/test_runnable_jobs.py
@@ -10,7 +10,7 @@ from treeherder.model.models import (BuildPlatform,
 def test_prune_old_runnable_job(jm, eleven_jobs_stored):
 
     """
-
+    Test that a defunct buildername will be pruned
     """
     etl_process = RunnableJobsProcess()
 

--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -12,8 +12,7 @@ from tests.autoclassify.utils import (create_bug_suggestions_failures,
 from tests.sample_data_generator import (job_data,
                                          result_set)
 from treeherder.model.derived import ArtifactsModel
-from treeherder.model.models import (BuildPlatform,
-                                     FailureClassification,
+from treeherder.model.models import (FailureClassification,
                                      FailureLine,
                                      Job,
                                      JobDetail,
@@ -22,8 +21,6 @@ from treeherder.model.models import (BuildPlatform,
                                      JobLog,
                                      JobType,
                                      Machine,
-                                     MachinePlatform,
-                                     RunnableJob,
                                      TaskSetMeta)
 
 slow = pytest.mark.slow

--- a/treeherder/etl/allthethings.py
+++ b/treeherder/etl/allthethings.py
@@ -1,4 +1,5 @@
 import collections
+import datetime
 import logging
 from hashlib import sha1
 
@@ -51,6 +52,7 @@ class RunnableJobsProcess(AllthethingsTransformerMixin):
         active_repositories = Repository.objects.all().filter(
             active_status='active')
 
+        now = datetime.datetime.now()
         for repo in active_repositories:
             # Some active repositories might not have any buildbot
             # builders.
@@ -101,6 +103,9 @@ class RunnableJobsProcess(AllthethingsTransformerMixin):
                               'job_type': job_type,
                               'option_collection_hash': option_collection_hash,
                               'repository': repo})
+
+        # prune any buildernames that were not just touched/created
+        RunnableJob.objects.filter(last_touched__lt=now).delete()
 
     def run(self):
         all_the_things = fetch_json(settings.ALLTHETHINGS_URL)

--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -10,7 +10,6 @@ from treeherder.model.models import (Datasource,
                                      JobGroup,
                                      JobType,
                                      Machine,
-                                     RunnableJob,
                                      TaskSetMeta)
 from treeherder.model.utils import orm_delete
 
@@ -92,7 +91,6 @@ class Command(BaseCommand):
             used_machine_ids.update(set([machine_id[0] for machine_id in c.fetchall()]))
 
         JobType.objects.exclude(id__in=used_job_type_ids).delete()
-        RunnableJob.objects.exclude(job_type__id__in=used_job_type_ids).delete()
 
         used_job_group_ids = set(JobType.objects.values_list('job_group', flat=True))
         JobGroup.objects.exclude(id__in=used_job_group_ids).delete()

--- a/treeherder/webapp/api/runnable_jobs.py
+++ b/treeherder/webapp/api/runnable_jobs.py
@@ -1,5 +1,3 @@
-import datetime
-
 from rest_framework import viewsets
 from rest_framework.response import Response
 
@@ -22,8 +20,7 @@ class RunnableJobsViewSet(viewsets.ViewSet):
             'option').values_list('option__name', 'option_collection_hash')
 
         runnable_jobs = models.RunnableJob.objects.filter(
-            repository=repository,
-            last_touched__gte=datetime.datetime.now() - datetime.timedelta(weeks=1)
+            repository=repository
         ).select_related('build_platform', 'machine_platform',
                          'job_type', 'job_type__job_group')
 


### PR DESCRIPTION
The runnable jobs process used to add new buidlernames immediately, but wait till we cycle data to remove defunct ones.  This change will remove defunct ones at the same time we update for new ones.  

Added a test for this as well as removing the cycle data test for runnable jobs, since it's no longer done that way.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1587)
<!-- Reviewable:end -->
