### PR TITLE
Bug 1245158 - Make Python client requests use connection pooling + enable auth for GETs

### DIFF
--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -474,7 +474,7 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
             client_id='client-abc',
             secret='secret123',
             )
-        auth = client.auth
+        auth = client.session.auth
         assert isinstance(auth, HawkAuth)
         expected_credentials = {
             'id': 'client-abc',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,7 +251,7 @@ def eleven_jobs_stored(jm, sample_data, sample_resultset, test_repository, mock_
 @pytest.fixture
 def mock_post_json(monkeypatch, client_credentials):
     def _post_json(th_client, project, endpoint, data, timeout=None):
-        auth = th_client.auth
+        auth = th_client.session.auth
         if not auth:
             auth = HawkAuth(id=client_credentials.client_id,
                             key=str(client_credentials.secret))

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -638,6 +638,10 @@ class TreeherderClient(object):
         self.protocol = protocol
         self.timeout = timeout
 
+        # Using a session gives us automatic keep-alive/connection pooling.
+        self.session = requests.Session()
+        self.session.headers.update(self.REQUEST_HEADERS)
+
         if client_id and secret:
             self.auth = HawkAuth(id=client_id, key=secret)
         else:
@@ -683,8 +687,7 @@ class TreeherderClient(object):
         else:
             uri = self._get_project_uri(project, endpoint)
 
-        resp = requests.get(uri, timeout=timeout, params=params,
-                            headers=self.REQUEST_HEADERS)
+        resp = self.session.get(uri, params=params, timeout=timeout)
         try:
             resp.raise_for_status()
         except HTTPError:
@@ -702,9 +705,7 @@ class TreeherderClient(object):
 
         uri = self._get_project_uri(project, endpoint)
 
-        resp = requests.post(uri, json=data,
-                             headers=self.REQUEST_HEADERS,
-                             timeout=timeout, auth=self.auth)
+        resp = self.session.post(uri, json=data, timeout=timeout, auth=self.auth)
 
         try:
             resp.raise_for_status()

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -643,9 +643,7 @@ class TreeherderClient(object):
         self.session.headers.update(self.REQUEST_HEADERS)
 
         if client_id and secret:
-            self.auth = HawkAuth(id=client_id, key=secret)
-        else:
-            self.auth = None
+            self.session.auth = HawkAuth(id=client_id, key=secret)
 
     def _get_project_uri(self, project, endpoint):
 
@@ -705,7 +703,7 @@ class TreeherderClient(object):
 
         uri = self._get_project_uri(project, endpoint)
 
-        resp = self.session.post(uri, json=data, timeout=timeout, auth=self.auth)
+        resp = self.session.post(uri, json=data, timeout=timeout)
 
         try:
             resp.raise_for_status()


### PR DESCRIPTION
* Use responses instead of mock in the Python client tests
* Make Python client requests use connection pooling
* Send auth headers for Python client GETs too

See individual commits for more details :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1589)
<!-- Reviewable:end -->
