### PR TITLE
Bug 1278711 - Increase mysql max index size with innodb_large_prefix=on

### DIFF
--- a/puppet/files/mysql/my.cnf
+++ b/puppet/files/mysql/my.cnf
@@ -4,7 +4,7 @@
 # You can copy this to one of:
 # - "/etc/mysql/my.cnf" to set global options,
 # - "~/.my.cnf" to set user-specific options.
-# 
+#
 # One can use all long options that the program supports.
 # Run program with --help to get a list of available options and with
 # --print-defaults to see which it would actually understand and use.
@@ -110,7 +110,8 @@ max_binlog_size         = 100M
 # * SQL mode
 #
 sql_mode="STRICT_ALL_TABLES"
-
+innodb_large_prefix=on
+innodb_file_format=barracuda
 
 [mysqldump]
 quick


### PR DESCRIPTION
This is needed so that we can create larger unique indexes to prevent
duplicates on the job_detail table.  We want to create an index unique
on ``value``, ``title``, and ``job_id``.  But ``value`` is varchar(512)
and so the index would be too large without these settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1599)
<!-- Reviewable:end -->
