### PR TITLE
Bug 1280504 - add ability to filter by build system type

### DIFF
--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -70,6 +70,10 @@ treeherder.factory('thJobFilters', [
                 name: "buildername/jobname",
                 matchType: MATCH_TYPE.substr
             },
+            build_system_type: {
+                name: "build system",
+                matchType: MATCH_TYPE.substr
+            },
             job_type_name: {
                 name: "job name",
                 matchType: MATCH_TYPE.substr


### PR DESCRIPTION
So you can filter by "buildbot" or "taskcluster".  When other systems start using pulse ingestion, you'll be able to filter by whatever they put as their ``buildSystem``.  This is helpful for testing to see what jobs come from where.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1601)
<!-- Reviewable:end -->
