### PR TITLE
Bug 1116372 - Stop presenting "intermittent needs filing" as a classification type

### DIFF
--- a/ui/js/services/classifications.js
+++ b/ui/js/services/classifications.js
@@ -18,11 +18,14 @@ treeherder.factory('thClassificationTypes', [
         };
 
         var addClassification = function(cl) {
-            classifications[cl.id] = {
-                name: cl.name,
-                star: classificationColors[cl.id]
-            };
-            classificationOptions.push(cl);
+            // Don't present "intermittent needs filing" as an option
+            if(cl.id !== 6) {
+                classifications[cl.id] = {
+                    name: cl.name,
+                    star: classificationColors[cl.id]
+                };
+                classificationOptions.push(cl);
+            }
         };
 
         var load = function() {


### PR DESCRIPTION
This type seemed like a good idea in theory, but in practice is not very useful
without adding a new view that only shows failures classified as this
type, so we might as well drop the type.

This patch only prevents new failures from seeing it as an available
classification type. It does not migrate any existing failures classified
as this type or remove the type from the model.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1602)

<!-- Reviewable:end -->
