### PR TITLE
Bug 1280660 - Cache refdata lookups during job ingestion

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -44,6 +44,8 @@ django-cors-headers==1.1.0 --hash=sha256:fcd96e2be47c8eef34c650e007a6d546e19e7ee
 
 django-browserid==2.0.1 --hash=sha256:ab3a6cb78121b34816a99548596b9b66d8fec9b51d5709a21d15b243ea6ad8ad
 
+django-memoize==1.3.1 --hash=sha256:022dae63815b261cab034dff9ef4b8ec578ff1bba5c79d60ba4bbc2ed639b680
+
 jsonfield==1.0.3 --hash=sha256:7e7f73a675c518712badd783279e26d164140f3fc2ed7a32102c3d08a6a2a4a7
 
 mozlog==3.2 --hash=sha256:9ecfb21801a5d9fdef28cb88abc096bb1a9551e86989ab68f113f0fc6b6fd3a1

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -514,6 +514,8 @@ CACHES = {
 
 KEY_PREFIX = TREEHERDER_MEMCACHED_KEY_PREFIX
 
+REFDATA_CACHE_TIMEOUT = 86400  # refdata should not be cached forever
+
 # Celery broker setup
 BROKER_URL = env('BROKER_URL')
 


### PR DESCRIPTION
This saves a database round trip, which can be a significant percentage
of the time taken during these operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1604)
<!-- Reviewable:end -->
