### PR TITLE
Bug 1281309 - Report individual pushlog exceptions to New Relic

### DIFF
--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -1,6 +1,7 @@
 import logging
 import traceback
 
+import newrelic.agent
 import requests
 from django.core.cache import cache
 
@@ -135,6 +136,7 @@ class HgPushlogProcess(HgPushlogTransformerMixin):
                     collection.validate()
                     jm.store_result_set_data(collection.get_collection_data())
                 except Exception:
+                    newrelic.agent.record_exception()
                     errors.append({
                         "project": repository,
                         "collection": "result_set",


### PR DESCRIPTION
Since the `CollectionNotStoredException` exception raised later will contain a combination of all exceptions and is harder to follow in the New Relic UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1607)
<!-- Reviewable:end -->
