### PR TITLE
Bug 1279213 - Simplify the Python client's handling of server url & timeouts

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -26,6 +26,21 @@ using pip:
 
     pip install treeherder-client
 
+By default the production Treeherder API will be used, however this can be
+overridden by passing a `server_url` argument to the `TreeherderClient`
+constructor:
+
+.. code-block:: python
+
+    # Treeherder production
+    client = TreeherderClient()
+
+    # Treeherder stage
+    client = TreeherderClient(server_url='https://treeherder.allizom.org')
+
+    # Local vagrant instance
+    client = TreeherderClient(server_url='http://local.treeherder.mozilla.org')
+
 When using the Python client, don't forget to set up logging in the
 caller so that any API error messages are output, like so:
 
@@ -74,8 +89,11 @@ TreeherderClient's constructor:
 
 .. code-block:: python
 
-    client = TreeherderClient(protocol='https', host='treeherder.mozilla.org', client_id='hawk_id', secret='hawk_secret')
+    client = TreeherderClient(client_id='hawk_id', secret='hawk_secret')
     client.post_collection('mozilla-central', tac)
+
+Remember to point the Python client at the Treeherder instance to which
+the credentials belong - see :ref:`here <python-client>` for more details.
 
 To diagnose problems when authenticating, ensure Python logging has been
 set up (see :ref:`python-client`).
@@ -108,7 +126,8 @@ To generate credentials in the Vagrant instance run the following:
       (venv)vagrant@local:~/treeherder$ ./manage.py create_credentials my-client-id treeherder@mozilla.com "Description"
 
 The generated Hawk ``secret`` will be output to the console, which should then
-be passed along with the chosen ``client_id`` to the TreeherderClient constructor.
+be passed along with the chosen ``client_id``, and Vagrant instance ``server_url``
+to the TreeherderClient constructor.
 For more details see the :doc:`submitting_data` section.
 
 Generating and using credentials on treeherder stage or production

--- a/docs/retrieving_data.rst
+++ b/docs/retrieving_data.rst
@@ -5,6 +5,9 @@ The :ref:`Python client <python-client>` also has some convenience
 methods to query the Treeherder API. It is still in active development,
 but already has methods for getting resultset and job information.
 
+See the :ref:`Python client <python-client>` section for how to control
+which Treeherder instance will be accessed by the client.
+
 Here's a simple example which prints the start timestamp of all the
 jobs associated with the last 10 result sets on mozilla-central:
 
@@ -12,7 +15,7 @@ jobs associated with the last 10 result sets on mozilla-central:
 
     from thclient import TreeherderClient
 
-    client = TreeherderClient(protocol='https', host='treeherder.mozilla.org')
+    client = TreeherderClient()
 
     resultsets = client.get_resultsets('mozilla-central') # gets last 10 by default
     for resultset in resultsets:

--- a/docs/submitting_data.rst
+++ b/docs/submitting_data.rst
@@ -11,6 +11,9 @@ structures can be extended with new properties as needed, there is a
 minimal validation protocol applied that confirms the bare minimum
 parts of the structures are defined.
 
+See the :ref:`Python client <python-client>` section for how to control
+which Treeherder instance will be accessed by the client.
+
 Authentication is covered :ref:`here <authentication>`.
 
 
@@ -196,8 +199,7 @@ data structures to send, do something like this.
 
     # See the authentication section below for details on how to get a
     # hawk id and secret
-    client = TreeherderClient(protocol='https', host='treeherder.mozilla.org',
-                              client_id='hawk_id', secret='hawk_secret')
+    client = TreeherderClient(client_id='hawk_id', secret='hawk_secret')
 
     # Post the result collection to a project
     #
@@ -265,8 +267,7 @@ structures to send, do something like this:
                 )
         tjc.add(tj)
 
-    client = TreeherderClient(protocol='https', host='treeherder.mozilla.org',
-                              client_id='hawk_id', secret='hawk_secret')
+    client = TreeherderClient(client_id='hawk_id', secret='hawk_secret')
     client.post_collection('mozilla-central', tjc)
 
 If you want to use `TreeherderArtifactCollection` to build up the job
@@ -291,8 +292,7 @@ artifacts data structures to send, do something like this:
         tac.add(ta)
 
     # Send the collection to treeherder
-    client = TreeherderClient(protocol='https', host='treeherder.mozilla.org',
-                              client_id='hawk_id', secret='hawk_secret')
+    client = TreeherderClient(client_id='hawk_id', secret='hawk_secret')
     client.post_collection('mozilla-central', tac)
 
 If you don't want to use `TreeherderResultCollection` or
@@ -313,8 +313,7 @@ data structures directly and add them to the collection.
         # add resultset to collection
         trc.add(trs)
 
-    client = TreeherderClient(protocol='https', host='treeherder.mozilla.org',
-                              client_id='hawk_id', secret='hawk_secret')
+    client = TreeherderClient(client_id='hawk_id', secret='hawk_secret')
     client.post_collection('mozilla-central', trc)
 
 .. code-block:: python
@@ -331,8 +330,7 @@ data structures directly and add them to the collection.
         # add job to collection
         tjc.add(tj)
 
-    client = TreeherderClient(protocol='https', host='treeherder.mozilla.org',
-                              client_id='hawk_id', secret='hawk_secret')
+    client = TreeherderClient(client_id='hawk_id', secret='hawk_secret')
     client.post_collection('mozilla-central', tjc)
 
 In the same way, if you don't want to use `TreeherderArtifactCollection` to
@@ -353,8 +351,7 @@ add them to the collection.
         # add artifact to collection
         tac.add(ta)
 
-    client = TreeherderClient(protocol='https', host='treeherder.mozilla.org',
-                              client_id='hawk_id', secret='hawk_secret')
+    client = TreeherderClient(client_id='hawk_id', secret='hawk_secret')
     client.post_collection('mozilla-central', tac)
 
 Job artifacts format

--- a/tests/client/test_perfherder_client.py
+++ b/tests/client/test_perfherder_client.py
@@ -10,7 +10,7 @@ class PerfherderClientTest(unittest.TestCase):
     @responses.activate
     def test_get_performance_signatures(self):
         pc = PerfherderClient()
-        url = pc._get_project_uri('mozilla-central', pc.PERFORMANCE_SIGNATURES_ENDPOINT)
+        url = pc._get_endpoint_url(pc.PERFORMANCE_SIGNATURES_ENDPOINT, project='mozilla-central')
         content = {
             'signature1': {'cheezburgers': 1},
             'signature2': {'hamburgers': 2},
@@ -31,7 +31,7 @@ class PerfherderClientTest(unittest.TestCase):
     def test_get_performance_data(self):
         pc = PerfherderClient()
 
-        url = '{}?{}'.format(pc._get_project_uri('mozilla-central', pc.PERFORMANCE_DATA_ENDPOINT),
+        url = '{}?{}'.format(pc._get_endpoint_url(pc.PERFORMANCE_DATA_ENDPOINT, project='mozilla-central'),
                              'signatures=signature1&signatures=signature2')
         content = {
             'signature1': [{'value': 1}, {'value': 2}],

--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -396,8 +396,7 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
             tjc.add(tjc.get_job(job))
 
         client = TreeherderClient(
-            protocol='http',
-            host='host',
+            server_url='http://host',
             client_id='client-abc',
             secret='secret123',
             )
@@ -423,8 +422,7 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
             trc.add(trc.get_resultset(resultset))
 
         client = TreeherderClient(
-            protocol='http',
-            host='host',
+            server_url='http://host',
             client_id='client-abc',
             secret='secret123',
             )
@@ -450,8 +448,7 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
             tac.add(tac.get_artifact(artifact))
 
         client = TreeherderClient(
-            protocol='http',
-            host='host',
+            server_url='http://host',
             client_id='client-abc',
             secret='secret123',
             )

--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -408,7 +408,7 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
             self.assertEqual(posted_json, tjc.get_collection_data())
             return (200, {}, '{"message": "Job successfully updated"}')
 
-        url = client._get_project_uri('project', tjc.endpoint_base)
+        url = client._get_endpoint_url(tjc.endpoint_base, project='project')
         responses.add_callback(responses.POST, url, match_querystring=True,
                                callback=request_callback, content_type='application/json')
 
@@ -435,7 +435,7 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
             self.assertEqual(posted_json, trc.get_collection_data())
             return (200, {}, '{"message": "well-formed JSON stored", "resultsets": [123, 456]}')
 
-        url = client._get_project_uri('project', trc.endpoint_base)
+        url = client._get_endpoint_url(trc.endpoint_base, project='project')
         responses.add_callback(responses.POST, url, match_querystring=True,
                                callback=request_callback, content_type='application/json')
 
@@ -462,7 +462,7 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
             self.assertEqual(posted_json, tac.get_collection_data())
             return (200, {}, '{"message": "Artifacts stored successfully"}')
 
-        url = client._get_project_uri('project', tac.endpoint_base)
+        url = client._get_endpoint_url(tac.endpoint_base, project='project')
         responses.add_callback(responses.POST, url, match_querystring=True,
                                callback=request_callback, content_type='application/json')
 
@@ -486,7 +486,7 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
     @responses.activate
     def test_get_job(self):
         tdc = TreeherderClient()
-        url = tdc._get_project_uri("mozilla-inbound", tdc.JOBS_ENDPOINT)
+        url = tdc._get_endpoint_url(tdc.JOBS_ENDPOINT, project='mozilla-inbound')
         content = {
             "meta": {"count": 3,
                      "repository": "mozilla-inbound",
@@ -502,7 +502,7 @@ class TreeherderClientTest(DataSetup, unittest.TestCase):
     @responses.activate
     def test_get_results(self):
         tdc = TreeherderClient()
-        url = tdc._get_project_uri("mozilla-inbound", tdc.RESULTSET_ENDPOINT)
+        url = tdc._get_endpoint_url(tdc.RESULTSET_ENDPOINT, project='mozilla-inbound')
         content = {
             "meta": {"count": 3, "repository": "mozilla-inbound",
                      "offset": 0},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -256,8 +256,8 @@ def mock_post_json(monkeypatch, client_credentials):
             auth = HawkAuth(id=client_credentials.client_id,
                             key=str(client_credentials.secret))
         app = TestApp(application)
-        uri = th_client._get_project_uri(project, endpoint)
-        req = Request('POST', uri, json=data, auth=auth)
+        url = th_client._get_endpoint_url(endpoint, project=project)
+        req = Request('POST', url, json=data, auth=auth)
         prepped_request = req.prepare()
 
         return getattr(app, 'post')(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,7 +250,7 @@ def eleven_jobs_stored(jm, sample_data, sample_resultset, test_repository, mock_
 
 @pytest.fixture
 def mock_post_json(monkeypatch, client_credentials):
-    def _post_json(th_client, project, endpoint, data, timeout=None):
+    def _post_json(th_client, project, endpoint, data):
         auth = th_client.session.auth
         if not auth:
             auth = HawkAuth(id=client_credentials.client_id,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ from treeherder.model import models
 
 def post_collection(project, th_collection):
 
-    client = TreeherderClient(protocol='http', host='localhost')
+    client = TreeherderClient(server_url='http://localhost')
     return client.post_collection(project, th_collection)
 
 

--- a/tests/webapp/api/test_artifact_api.py
+++ b/tests/webapp/api/test_artifact_api.py
@@ -84,7 +84,7 @@ def test_artifact_create_text_log_summary(webapp, test_project, eleven_jobs_stor
     })
     tac.add(ta)
 
-    cli = client.TreeherderClient(protocol='http', host='localhost')
+    cli = client.TreeherderClient(server_url='http://localhost')
     cli.post_collection(test_project,  tac)
 
     with ArtifactsModel(test_project) as artifacts_model:
@@ -129,7 +129,7 @@ def test_artifact_create_text_log_summary_and_bug_suggestions(
         'job_guid': job['job_guid']
     }))
 
-    cli = client.TreeherderClient(protocol='http', host='localhost')
+    cli = client.TreeherderClient(server_url='http://localhost')
     cli.post_collection(test_project, tac)
 
     with ArtifactsModel(test_project) as artifacts_model:

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -621,7 +621,7 @@ class TreeherderClient(object):
 
     def __init__(
             self, protocol='https', host='treeherder.mozilla.org',
-            timeout=120, client_id=None, secret=None):
+            timeout=30, client_id=None, secret=None):
         """
         :param protocol: protocol to use (http or https)
         :param host: treeherder host to post to

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -645,17 +645,15 @@ class TreeherderClient(object):
         if client_id and secret:
             self.session.auth = HawkAuth(id=client_id, key=secret)
 
-    def _get_project_uri(self, project, endpoint):
+    def _get_endpoint_url(self, endpoint, project=None):
 
-        return '{0}://{1}/api/project/{2}/{3}/'.format(
-            self.protocol, self.host, project, endpoint
+        if project:
+            return '{0}://{1}/api/project/{2}/{3}/'.format(
+                self.protocol, self.host, project, endpoint
             )
 
-    def _get_uri(self, endpoint):
-        uri = '{0}://{1}/api/{2}/'.format(
+        return '{0}://{1}/api/{2}/'.format(
             self.protocol, self.host, endpoint)
-
-        return uri
 
     def _get_json_list(self, endpoint, project=None, **params):
         if "count" in params and (params["count"] is None or params["count"] > self.MAX_COUNT):
@@ -677,12 +675,9 @@ class TreeherderClient(object):
             return self._get_json(endpoint, project=project, **params)["results"]
 
     def _get_json(self, endpoint, project=None, **params):
-        if project is None:
-            uri = self._get_uri(endpoint)
-        else:
-            uri = self._get_project_uri(project, endpoint)
+        url = self._get_endpoint_url(endpoint, project=project)
 
-        resp = self.session.get(uri, params=params, timeout=self.timeout)
+        resp = self.session.get(url, params=params, timeout=self.timeout)
         try:
             resp.raise_for_status()
         except HTTPError:
@@ -695,9 +690,9 @@ class TreeherderClient(object):
         return resp.json()
 
     def _post_json(self, project, endpoint, data):
-        uri = self._get_project_uri(project, endpoint)
+        url = self._get_endpoint_url(endpoint, project=project)
 
-        resp = self.session.post(uri, json=data, timeout=self.timeout)
+        resp = self.session.post(url, json=data, timeout=self.timeout)
 
         try:
             resp.raise_for_status()

--- a/treeherder/client/thclient/perfherder.py
+++ b/treeherder/client/thclient/perfherder.py
@@ -112,8 +112,8 @@ class PerfherderClient(TreeherderClient):
         '''
         Gets a set of performance signatures associated with a project and time range
         '''
-        return PerformanceSignatureCollection(self._get_json(
-            self.PERFORMANCE_SIGNATURES_ENDPOINT, None, project, **params))
+        results = self._get_json(self.PERFORMANCE_SIGNATURES_ENDPOINT, project, **params)
+        return PerformanceSignatureCollection(results)
 
     def get_performance_data(self, project, **params):
         '''
@@ -121,7 +121,6 @@ class PerfherderClient(TreeherderClient):
 
         You can specify which signatures to get by passing signature to this function
         '''
-        results = self._get_json(self.PERFORMANCE_DATA_ENDPOINT, None, project,
-                                 **params)
+        results = self._get_json(self.PERFORMANCE_DATA_ENDPOINT, project, **params)
 
         return {k: PerformanceSeries(v) for k, v in results.items()}

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -16,9 +16,6 @@ DEBUG = env.bool("TREEHERDER_DEBUG", default=False)
 ENABLE_DEBUG_TOOLBAR = env.bool("ENABLE_DEBUG_TOOLBAR", False)
 DEBUG_TOOLBAR_PATCH_SETTINGS = False  # disable django debug toolbar automatic configuration
 
-TREEHERDER_REQUEST_PROTOCOL = env("TREEHERDER_REQUEST_PROTOCOL", default="http")
-TREEHERDER_REQUEST_HOST = env("TREEHERDER_REQUEST_HOST", default="local.treeherder.mozilla.org")
-
 # Default to retaining data for ~4 months.
 DATA_CYCLE_DAYS = env.int("DATA_CYCLE_DAYS", default=120)
 

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from urlparse import urlparse
 
 import environ
 from kombu import (Exchange,
@@ -320,6 +321,7 @@ REST_FRAMEWORK = {
 }
 
 SITE_URL = env("SITE_URL", default="http://local.treeherder.mozilla.org")
+SITE_HOSTNAME = urlparse(SITE_URL).netloc
 APPEND_SLASH = False
 
 BUILDAPI_PENDING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-pending.js"
@@ -388,7 +390,7 @@ AUTOCLASSIFY_JOBS = env.bool("AUTOCLASSIFY_JOBS", default=False)
 # timeout for requests to external sources
 # like ftp.mozilla.org or hg.mozilla.org
 REQUESTS_TIMEOUT = 30
-TREEHERDER_USER_AGENT = 'treeherder/{}'.format(TREEHERDER_REQUEST_HOST)
+TREEHERDER_USER_AGENT = 'treeherder/{}'.format(SITE_HOSTNAME)
 
 # The pulse uri that is passed to kombu
 PULSE_URI = env("PULSE_URI", default="amqps://guest:guest@pulse.mozilla.org/")

--- a/treeherder/etl/th_publisher.py
+++ b/treeherder/etl/th_publisher.py
@@ -16,8 +16,7 @@ def post_treeherder_collections(th_collections, chunk_size=1):
     credentials = Credentials.objects.get(client_id=settings.ETL_CLIENT_ID)
 
     cli = TreeherderClient(
-        protocol=settings.TREEHERDER_REQUEST_PROTOCOL,
-        host=settings.TREEHERDER_REQUEST_HOST,
+        server_url=settings.SITE_URL,
         client_id=credentials.client_id,
         secret=str(credentials.secret),
     )

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -85,8 +85,7 @@ def post_log_artifacts(project,
 
     credentials = Credentials.objects.get(client_id=settings.ETL_CLIENT_ID)
     client = TreeherderClient(
-        protocol=settings.TREEHERDER_REQUEST_PROTOCOL,
-        host=settings.TREEHERDER_REQUEST_HOST,
+        server_url=settings.SITE_URL,
         client_id=credentials.client_id,
         secret=str(credentials.secret),
     )

--- a/treeherder/model/management/commands/import_reference_data.py
+++ b/treeherder/model/management/commands/import_reference_data.py
@@ -1,5 +1,4 @@
 from optparse import make_option
-from urlparse import urlparse
 
 from django.core.management.base import BaseCommand
 
@@ -29,9 +28,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        server_params = urlparse(options['server'])
-        c = TreeherderClient(protocol=server_params.scheme,
-                             host=server_params.netloc)
+        c = TreeherderClient(server_url=options['server'])
 
         # options / option collection hashes
         for (uuid, props) in c.get_option_collection_hash().iteritems():

--- a/treeherder/perf/management/commands/import_perf_data.py
+++ b/treeherder/perf/management/commands/import_perf_data.py
@@ -1,6 +1,5 @@
 import datetime
 from optparse import make_option
-from urlparse import urlparse
 
 import concurrent.futures
 from django.core.management.base import (BaseCommand,
@@ -152,12 +151,9 @@ class Command(BaseCommand):
             raise CommandError("Need to (only) specify project/branch")
         project = args[0]
 
-        server_params = urlparse(options['server'])
-
         time_interval = options['time_interval']
 
-        pc = PerfherderClient(protocol=server_params.scheme,
-                              host=server_params.netloc)
+        pc = PerfherderClient(server_url=options['server'])
         signatures = pc.get_performance_signatures(
             project,
             interval=time_interval)

--- a/treeherder/perf/management/commands/test_analyze_perf.py
+++ b/treeherder/perf/management/commands/test_analyze_perf.py
@@ -1,5 +1,4 @@
 from optparse import make_option
-from urlparse import urlparse
 
 from django.conf import settings
 from django.core.management.base import (BaseCommand,
@@ -22,7 +21,7 @@ class Command(BaseCommand):
         make_option('--server',
                     action='store',
                     dest='server',
-                    default=None,
+                    default=settings.SITE_URL,
                     help='Server to get data from, default to local instance'),
         make_option('--time-interval',
                     action='store',
@@ -48,20 +47,11 @@ class Command(BaseCommand):
                                           testname] + test_options])
 
     def handle(self, *args, **options):
-        if options['server']:
-            server_params = urlparse(options['server'])
-            server_protocol = server_params.scheme
-            server_host = server_params.netloc
-        else:
-            server_protocol = settings.TREEHERDER_REQUEST_PROTOCOL
-            server_host = settings.TREEHERDER_REQUEST_HOST
-
         if not options['project']:
             raise CommandError("Must specify at least one project with "
                                "--project")
 
-        pc = PerfherderClient(protocol=server_protocol,
-                              host=server_host)
+        pc = PerfherderClient(server_url=options['server'])
 
         option_collection_hash = pc.get_option_collection_hash()
 


### PR DESCRIPTION
This combines the `protocol` and `host` parameters into a new `server_url` parameter to avoid the easily-made mistake of omitting `protocol` when submitting to a local Vagrant instance, as well as reducing the number of config variables users of the client have to keep track of.

In addition:
* The per-method `timeout` parameters have also been removed for simplicity (I couldn't find any consumers of them using GitHub code search)
* The default timeout has been lowered from 120s to 30s
* The Treeherder environment variables `TREEHERDER_REQUEST_PROTOCOL` and `TREEHERDER_REQUEST_HOST` are now no longer required
* General python client cleanup

See individual commit messages for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1610)
<!-- Reviewable:end -->
