### PR TITLE
Bug 1281463 - The log parser fetches the JobLog object twice for each log

### DIFF
--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -104,7 +104,7 @@ def parse_log(project, job_guid, job_log, _priority):
     """
     post_log_artifacts(project,
                        job_guid,
-                       job_log.url,
+                       job_log,
                        parse_log)
 
 

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -6,8 +6,7 @@ from django.conf import settings
 from django.core.management import call_command
 
 from treeherder.autoclassify.tasks import autoclassify
-from treeherder.log_parser.utils import (extract_text_log_artifacts,
-                                         post_log_artifacts)
+from treeherder.log_parser.utils import post_log_artifacts
 from treeherder.model.models import JobLog
 from treeherder.workers.taskset import (create_taskset,
                                         taskset)
@@ -106,8 +105,7 @@ def parse_log(project, job_guid, job_log, _priority):
     post_log_artifacts(project,
                        job_guid,
                        job_log.url,
-                       parse_log,
-                       extract_text_log_artifacts)
+                       parse_log)
 
 
 @task(name='store-failure-lines', max_retries=10)

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -37,7 +37,7 @@ def extract_text_log_artifacts(project, log_url, job_guid):
 
 def post_log_artifacts(project,
                        job_guid,
-                       job_log_url,
+                       job_log,
                        retry_task):
     """Post a list of artifacts to a job."""
     def _retry(e):
@@ -47,11 +47,9 @@ def post_log_artifacts(project,
         # .retry() raises a RetryTaskError exception,
         # so nothing after this function will be executed
 
-    log_description = "%s %s (%s)" % (project, job_guid, job_log_url)
+    log_url = job_log.url
+    log_description = "%s %s (%s)" % (project, job_guid, log_url)
     logger.debug("Downloading/parsing log for %s", log_description)
-
-    job_log = JobLog.objects.get(job__guid=job_guid,
-                                 url=job_log_url)
 
     credentials = Credentials.objects.get(client_id=settings.ETL_CLIENT_ID)
     client = TreeherderClient(
@@ -62,7 +60,7 @@ def post_log_artifacts(project,
     )
 
     try:
-        artifact_list = extract_text_log_artifacts(project, job_log_url, job_guid)
+        artifact_list = extract_text_log_artifacts(project, log_url, job_guid)
     except Exception as e:
         job_log.update_status(JobLog.FAILED)
 

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -38,8 +38,7 @@ def extract_text_log_artifacts(project, log_url, job_guid):
 def post_log_artifacts(project,
                        job_guid,
                        job_log_url,
-                       retry_task,
-                       extract_artifacts_cb):
+                       retry_task):
     """Post a list of artifacts to a job."""
     def _retry(e):
         # Initially retry after 1 minute, then for each subsequent retry
@@ -63,7 +62,7 @@ def post_log_artifacts(project,
     )
 
     try:
-        artifact_list = extract_artifacts_cb(project, job_log_url, job_guid)
+        artifact_list = extract_text_log_artifacts(project, job_log_url, job_guid)
     except Exception as e:
         job_log.update_status(JobLog.FAILED)
 

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -51,14 +51,6 @@ def post_log_artifacts(project,
     log_description = "%s %s (%s)" % (project, job_guid, log_url)
     logger.debug("Downloading/parsing log for %s", log_description)
 
-    credentials = Credentials.objects.get(client_id=settings.ETL_CLIENT_ID)
-    client = TreeherderClient(
-        protocol=settings.TREEHERDER_REQUEST_PROTOCOL,
-        host=settings.TREEHERDER_REQUEST_HOST,
-        client_id=credentials.client_id,
-        secret=str(credentials.secret),
-    )
-
     try:
         artifact_list = extract_text_log_artifacts(project, log_url, job_guid)
     except Exception as e:
@@ -90,6 +82,14 @@ def post_log_artifacts(project,
     for artifact in artifact_list:
         ta = tac.get_artifact(artifact)
         tac.add(ta)
+
+    credentials = Credentials.objects.get(client_id=settings.ETL_CLIENT_ID)
+    client = TreeherderClient(
+        protocol=settings.TREEHERDER_REQUEST_PROTOCOL,
+        host=settings.TREEHERDER_REQUEST_HOST,
+        client_id=credentials.client_id,
+        secret=str(credentials.secret),
+    )
 
     try:
         client.post_collection(project, tac)

--- a/treeherder/webapp/api/job_log_url.py
+++ b/treeherder/webapp/api/job_log_url.py
@@ -18,7 +18,7 @@ class JobLogUrlViewSet(viewsets.ReadOnlyModelViewSet):
             'id': log.id,
             'name': log.name,
             'url': log.url,
-            'parse_status': log.STATUSES[log.status][1]
+            'parse_status': log.get_status_display(),
         }
 
     def retrieve(self, request, project, pk=None):


### PR DESCRIPTION
Removes the unnecessary second fetching of the JobLog object & some other cleanup.

See individual commit messages for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1611)
<!-- Reviewable:end -->
