### PR TITLE
Bug 1281412 - Fix timezones with pulse ingestion

### DIFF
--- a/tests/sample_data/pulse_consumer/job_data.json
+++ b/tests/sample_data/pulse_consumer/job_data.json
@@ -184,7 +184,7 @@
               }
             ],
             "name": "'/tools/buildbot/bin/python scripts/scripts/talos_script.py ...' failed",
-            "timeStarted": "2016-02-02T14:27:05-07:00",
+            "timeStarted": "2016-02-02T14:27:05-08:00",
             "lineStarted": 234,
             "lineFinished": 3269,
             "timeFinished": "2016-02-02T14:38:09-08:00",

--- a/treeherder/etl/job_loader.py
+++ b/treeherder/etl/job_loader.py
@@ -1,5 +1,5 @@
+import calendar
 import logging
-import time
 from collections import defaultdict
 
 import jsonschema
@@ -300,4 +300,4 @@ class JobLoader:
         return validated_jobs
 
     def _to_timestamp(self, datestr):
-        return time.mktime(parser.parse(datestr).timetuple())
+        return calendar.timegm(parser.parse(datestr).utctimetuple())


### PR DESCRIPTION
The pulse ingestion was throwing away the UTC timezone that came from Task Cluster and applying the local timezone.  That's how ``time.mktime`` works.  Now we parse the time, get the time tuple in UTC and create the timextamp with ``calendar.timegm`` which expects UTC times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1619)
<!-- Reviewable:end -->
