### PR TITLE
Bug 1282872 - Fix exception retrying tasks.

### DIFF
--- a/tests/test_worker/test_task.py
+++ b/tests/test_worker/test_task.py
@@ -1,6 +1,23 @@
+from functools import wraps
+from threading import local
+
 import pytest
+from django.db.utils import OperationalError
 
 from treeherder.workers.task import retryable_task
+
+thread_data = local()
+
+
+def count_retries(f):
+    thread_data.retry_count = -1
+
+    @wraps(f)
+    def inner():
+        thread_data.retry_count += 1
+        f()
+
+    return inner
 
 
 @retryable_task()
@@ -16,12 +33,28 @@ def test_retryable_task():
 
 
 @retryable_task()
-def throwing_task(x, y):
+@count_retries
+def throwing_task():
     raise TypeError
 
 
 def test_retryable_task_throws():
-    "Test celery executes a task properly"
+    "Test celery immediately raises an error for a task that throws"
 
     with pytest.raises(TypeError):
-        throwing_task.delay(7, 3)
+        throwing_task.delay()
+    assert thread_data.retry_count == 0
+
+
+@retryable_task()
+@count_retries
+def throwing_task_should_retry():
+    raise OperationalError
+
+
+def test_retryable_task_throws_retry():
+    "Test celery executes a task properly"
+
+    with pytest.raises(OperationalError):
+        throwing_task_should_retry.delay()
+    assert thread_data.retry_count > 1

--- a/treeherder/workers/task.py
+++ b/treeherder/workers/task.py
@@ -24,6 +24,8 @@ class retryable_task(object):
                 # Implement exponential backoff with some randomness to prevent
                 # thundering herd type problems. Constant factor chosen so we get
                 # reasonable pause between the fastest retries.
-                f.retry(exc=e, countdown=10 * int(random.uniform(2, 3) ** f.request.retries))
+                timeout = 10 * int(random.uniform(2, 3) ** task_func.request.retries)
+                task_func.retry(exc=e, countdown=timeout)
 
-        return task(*self.task_args, **self.task_kwargs)(inner)
+        task_func = task(*self.task_args, **self.task_kwargs)(inner)
+        return task_func


### PR DESCRIPTION
Make retryable_task retry the actual task object, rather than trying to
call .retry on the wrapped function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1623)
<!-- Reviewable:end -->
