### PR TITLE
Bug 1277304 - Migration-day changes for SCL3 only [DO NOT MERGE]

### DIFF
--- a/bin/run_celerybeat
+++ b/bin/run_celerybeat
@@ -14,4 +14,12 @@ if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec newrelic-admin run-program celery -A treeherder beat -f $LOGFILE
+# Celery beat disabled so new periodic tasks are not scheduled,
+# since we want to reduce the queues to zero, ready for the migration.
+# exec newrelic-admin run-program celery -A treeherder beat -f $LOGFILE
+
+# If we just exited the script, supervisor would keep on trying to restart it.
+while true; do
+    echo "$(date) Celery beat process is disabled for Heroku migration." >> $LOGFILE
+    sleep 30
+done

--- a/bin/run_read_pulse_jobs
+++ b/bin/run_read_pulse_jobs
@@ -8,4 +8,12 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-exec newrelic-admin run-program ./manage.py read_pulse_jobs
+# Pulse ingestion disabled since we want to reduce the queues to zero,
+# ready for the migration. Jobs will just build up in Pulse in the meantime.
+# exec newrelic-admin run-program ./manage.py read_pulse_jobs
+
+# If we just exited the script, supervisor would keep on trying to restart it.
+while true; do
+    echo "$(date) read_pulse_jobs process is disabled for Heroku migration."
+    sleep 30
+done

--- a/tests/webapp/api/test_performance_alerts_api.py
+++ b/tests/webapp/api/test_performance_alerts_api.py
@@ -55,7 +55,7 @@ def test_alerts_put(webapp, test_repository, test_perf_alert, test_user,
     webapp.put_json(reverse('performance-alerts-list') + '1/', {
         'related_summary_id': 2,
         'status': PerformanceAlert.DOWNSTREAM
-    }, status=403)
+    }, status=503)
     assert PerformanceAlert.objects.get(id=1).related_summary_id is None
 
     # verify that we fail if authenticated, but not staff
@@ -65,7 +65,7 @@ def test_alerts_put(webapp, test_repository, test_perf_alert, test_user,
         'related_summary_id': 2,
         'status': PerformanceAlert.DOWNSTREAM
     }, format='json')
-    assert resp.status_code == 403
+    assert resp.status_code == 503
     assert PerformanceAlert.objects.get(id=1).related_summary_id is None
 
     # verify that we succeed if authenticated + staff
@@ -75,15 +75,15 @@ def test_alerts_put(webapp, test_repository, test_perf_alert, test_user,
         'related_summary_id': 2,
         'status': PerformanceAlert.DOWNSTREAM
     }, format='json')
-    assert resp.status_code == 200
-    assert PerformanceAlert.objects.get(id=1).related_summary_id == 2
+    assert resp.status_code == 503
+    assert PerformanceAlert.objects.get(id=1).related_summary_id == None
 
     # verify that we can unset it too
     resp = client.put(reverse('performance-alerts-list') + '1/', {
         'related_summary_id': None,
         'status': PerformanceAlert.UNTRIAGED
     }, format='json')
-    assert resp.status_code == 200
+    assert resp.status_code == 503
     assert PerformanceAlert.objects.get(id=1).related_summary_id is None
 
 
@@ -112,14 +112,14 @@ def test_alerts_post(webapp, test_repository, test_perf_signature,
 
     # verify that we fail if not authenticated
     webapp.post_json(reverse('performance-alerts-list'),
-                     alert_create_post_blob, status=403)
+                     alert_create_post_blob, status=503)
 
     # verify that we fail if authenticated, but not staff
     client = APIClient()
     client.force_authenticate(user=test_user)
     resp = client.post(reverse('performance-alerts-list'),
                        alert_create_post_blob)
-    assert resp.status_code == 403
+    assert resp.status_code == 503
     assert PerformanceAlert.objects.count() == 0
 
     # verify that we succeed if staff + authenticated
@@ -127,18 +127,18 @@ def test_alerts_post(webapp, test_repository, test_perf_signature,
     client.force_authenticate(user=test_sheriff)
     resp = client.post(reverse('performance-alerts-list'),
                        alert_create_post_blob)
-    assert resp.status_code == 200
-    assert PerformanceAlert.objects.count() == 1
+    assert resp.status_code == 503
+    assert PerformanceAlert.objects.count() == 0
 
-    alert = PerformanceAlert.objects.all()[0]
-    assert alert.status == PerformanceAlert.UNTRIAGED
-    assert alert.manually_created
-    assert alert.amount_pct == 100
-    assert alert.amount_abs == 1
-    assert alert.prev_value == 1
-    assert alert.new_value == 2
-    assert alert.is_regression
-    assert alert.summary.id == 1
+    # alert = PerformanceAlert.objects.all()[0]
+    # assert alert.status == PerformanceAlert.UNTRIAGED
+    # assert alert.manually_created
+    # assert alert.amount_pct == 100
+    # assert alert.amount_abs == 1
+    # assert alert.prev_value == 1
+    # assert alert.new_value == 2
+    # assert alert.is_regression
+    # assert alert.summary.id == 1
 
 
 def test_alerts_post_insufficient_data(test_repository,
@@ -155,5 +155,5 @@ def test_alerts_post_insufficient_data(test_repository,
 
         resp = client.post(reverse('performance-alerts-list'),
                            new_post_blob)
-        assert resp.status_code == 400
+        assert resp.status_code == 503
         assert PerformanceAlert.objects.count() == 0

--- a/tests/webapp/api/test_performance_alertsummary_api.py
+++ b/tests/webapp/api/test_performance_alertsummary_api.py
@@ -50,7 +50,7 @@ def test_alert_summaries_put(webapp, test_repository, test_perf_signature,
     # verify that we fail if not authenticated
     webapp.put_json(reverse('performance-alert-summaries-list') + '1/', {
         'status': 1
-    }, status=403)
+    }, status=503)
     assert PerformanceAlertSummary.objects.get(id=1).status == 0
 
     # verify that we fail if authenticated, but not staff
@@ -59,7 +59,7 @@ def test_alert_summaries_put(webapp, test_repository, test_perf_signature,
     resp = client.put(reverse('performance-alert-summaries-list') + '1/', {
         'status': 1
     }, format='json')
-    assert resp.status_code == 403
+    assert resp.status_code == 503
     assert PerformanceAlertSummary.objects.get(id=1).status == 0
 
     # verify that we succeed if authenticated + staff
@@ -68,8 +68,8 @@ def test_alert_summaries_put(webapp, test_repository, test_perf_signature,
     resp = client.put(reverse('performance-alert-summaries-list') + '1/', {
         'status': 1
     }, format='json')
-    assert resp.status_code == 200
-    assert PerformanceAlertSummary.objects.get(id=1).status == 1
+    assert resp.status_code == 503
+    assert PerformanceAlertSummary.objects.get(id=1).status == 0
 
 
 def test_alert_summary_post(webapp, test_repository, test_perf_signature):
@@ -84,7 +84,7 @@ def test_alert_summary_post(webapp, test_repository, test_perf_signature):
 
     # verify that we fail if not authenticated
     webapp.post_json(reverse('performance-alert-summaries-list'), post_blob,
-                     status=403)
+                     status=503)
     assert PerformanceAlertSummary.objects.count() == 0
 
     # verify that we fail if authenticated, but not staff
@@ -94,7 +94,7 @@ def test_alert_summary_post(webapp, test_repository, test_perf_signature):
                                is_staff=False)
     client.force_authenticate(user=user)
     resp = client.post(reverse('performance-alert-summaries-list'), post_blob)
-    assert resp.status_code == 403
+    assert resp.status_code == 503
     assert PerformanceAlertSummary.objects.count() == 0
 
     # verify that we succeed if authenticated + staff
@@ -104,18 +104,18 @@ def test_alert_summary_post(webapp, test_repository, test_perf_signature):
                                is_staff=True)
     client.force_authenticate(user=user)
     resp = client.post(reverse('performance-alert-summaries-list'), post_blob)
-    assert resp.status_code == 200
+    assert resp.status_code == 503
 
-    assert PerformanceAlertSummary.objects.count() == 1
-    alert_summary = PerformanceAlertSummary.objects.all()[0]
-    assert alert_summary.repository == test_repository
-    assert alert_summary.framework == test_perf_signature.framework
-    assert alert_summary.prev_result_set_id == post_blob['prev_result_set_id']
-    assert alert_summary.result_set_id == post_blob['result_set_id']
-    assert resp.data['alert_summary_id'] == alert_summary.id
+    assert PerformanceAlertSummary.objects.count() == 0
+    # alert_summary = PerformanceAlertSummary.objects.all()[0]
+    # assert alert_summary.repository == test_repository
+    # assert alert_summary.framework == test_perf_signature.framework
+    # assert alert_summary.prev_result_set_id == post_blob['prev_result_set_id']
+    # assert alert_summary.result_set_id == post_blob['result_set_id']
+    # assert resp.data['alert_summary_id'] == alert_summary.id
 
     # verify that we don't create a new performance alert summary if one
     # already exists (but also don't throw an error)
-    resp = client.post(reverse('performance-alert-summaries-list'), post_blob)
-    assert resp.status_code == 200
-    assert PerformanceAlertSummary.objects.count() == 1
+    # resp = client.post(reverse('performance-alert-summaries-list'), post_blob)
+    # assert resp.status_code == 200
+    # assert PerformanceAlertSummary.objects.count() == 1

--- a/treeherder/config/whitenoise_custom.py
+++ b/treeherder/config/whitenoise_custom.py
@@ -21,15 +21,18 @@ class CustomWhiteNoise(WhiteNoiseMiddleware):
         super(CustomWhiteNoise, self).update_files_dictionary(*args)
         index_page_suffix = '/' + self.INDEX_NAME
         index_name_length = len(self.INDEX_NAME)
-        directory_indexes = {}
+        updated_files_dict = {}
+        maintenance_page = self.files.get('/maintenance.html')
         for url, static_file in self.files.items():
+            # Serve the maintenance page instead of any other static file content.
+            updated_files_dict[url] = maintenance_page
             if url.endswith(index_page_suffix):
                 # For each index file found, add a corresponding URL->content mapping
                 # for the file's parent directory, so that the index page is served for
                 # the bare directory URL ending in '/'.
                 parent_directory_url = url[:-index_name_length]
-                directory_indexes[parent_directory_url] = static_file
-        self.files.update(directory_indexes)
+                updated_files_dict[parent_directory_url] = maintenance_page
+        self.files.update(updated_files_dict)
 
     def find_file(self, url):
         """Add support for serving index pages for directory paths when in DEBUG mode."""

--- a/treeherder/webapp/api/exceptions.py
+++ b/treeherder/webapp/api/exceptions.py
@@ -1,7 +1,8 @@
 import logging
 
 from rest_framework import exceptions
-from rest_framework.status import HTTP_404_NOT_FOUND
+from rest_framework.status import (HTTP_404_NOT_FOUND,
+                                   HTTP_503_SERVICE_UNAVAILABLE)
 from rest_framework.views import exception_handler as drf_exc_handler
 
 from treeherder.model.derived import (DatasetNotFoundError,
@@ -13,6 +14,11 @@ logger = logging.getLogger(__name__)
 class ResourceNotFoundException(exceptions.APIException):
     status_code = HTTP_404_NOT_FOUND
     default_detail = "Resource not found"
+
+
+class DownForMaintenance(exceptions.APIException):
+    status_code = HTTP_503_SERVICE_UNAVAILABLE
+    default_detail = 'Service is down for maintenance.'
 
 
 def exception_handler(exc, context):

--- a/ui/maintenance.html
+++ b/ui/maintenance.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<!-- Adapted from https://gist.github.com/pitch-gist/2999707 -->
+<title>Maintenance in progress</title>
+<style>
+  h1 { font-size: 42px; }
+  body { text-align: center; padding: 150px; font: 20px Helvetica, sans-serif; color: #333; }
+  article { display: block; text-align: left; width: 650px; margin: 0 auto; }
+</style>
+
+<article>
+    <h1>Maintenance in progress</h1>
+    <div>
+        <p>Treeherder's scheduled SCL3 to Heroku datacenter migration is currently taking place, and should be complete within the next hour or two. Follow along in <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1277304">bug 1277304</a> or <a href="irc://irc.mozilla.org/treeherder">#treeherder</a>.</p>
+        <p>Best wishes,</p>
+        <p>&mdash; The Treeherder team</p>
+    </div>
+</article>


### PR DESCRIPTION
On migration day, this branch will be deployed to SCL3 (but not to Heroku) to prepare for the switchover to Heroku. These changes will never be merged to master.

During the migration, the celery queues must reach zero, since unlike the MySQL database, anything left in the SCL3 rabbitmq instance will not be transferred to the Heroku one. 

At the point at which the DB replication is shut off, we must also ensure no new DB writes are occurring in SCL3.

As such, this commit:
* Adds a maintenance page served instead of all UI assets (served with an HTTP 200 status code, rather than 503, so Zeus doesn't take the webheads out of rotation), so users are informed of the downtime.
* Disables the celery beat process, so new periodic tasks (such as pushlog/builds-4hr fetching, cycle_data etc) are not scheduled.
* Disables the pulse ingestion process (we're only using this on stage currently, but may be on prod soon), to stop pulling in new Taskcluster jobs from their Pulse queue. Jobs will safely build up in Pulse in the meantime.
* Disables API changes made by any third party Hawk user (eg taskcluster or autophone), to prevent jobs table writes and resultant log parser tasks.
* Disables API changes made by Django-authenticated users (eg for the sheriffing visibility profiles or classifying failures).
* Allows the `treeherder-etl` Hawk client id to continue to make changes via the API, so that the Treeherder ETL tasks (eg log parsing) can continue to run, to empty the queues out. (The queues will soon empty, due to the celery beat task and third party API changes being disabled)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1626)
<!-- Reviewable:end -->
