### PR TITLE
[DO NOT MERGE] Bug 1277304/1307741 - Migration-day changes for SCL3 only

### DIFF
--- a/bin/run_celerybeat
+++ b/bin/run_celerybeat
@@ -14,4 +14,12 @@ if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec newrelic-admin run-program celery -A treeherder beat -f $LOGFILE
+# Celery beat disabled so new periodic tasks are not scheduled,
+# since we want to reduce the queues to zero, ready for the migration.
+# exec newrelic-admin run-program celery -A treeherder beat -f $LOGFILE
+
+# If we just exited the script, supervisor would keep on trying to restart it.
+while true; do
+    echo "$(date) Celery beat process is disabled for Heroku migration." >> $LOGFILE
+    sleep 30
+done

--- a/bin/run_read_pulse_jobs
+++ b/bin/run_read_pulse_jobs
@@ -8,4 +8,12 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-exec newrelic-admin run-program ./manage.py read_pulse_jobs
+# Pulse ingestion disabled since we want to reduce the queues to zero,
+# ready for the migration. Jobs will just build up in Pulse in the meantime.
+# exec newrelic-admin run-program ./manage.py read_pulse_jobs
+
+# If we just exited the script, supervisor would keep on trying to restart it.
+while true; do
+    echo "$(date) read_pulse_jobs process is disabled for Heroku migration."
+    sleep 30
+done

--- a/bin/run_read_pulse_resultsets
+++ b/bin/run_read_pulse_resultsets
@@ -8,4 +8,12 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-exec newrelic-admin run-program ./manage.py read_pulse_resultsets
+# Pulse ingestion disabled since we want to reduce the queues to zero,
+# ready for the migration. Resultsets will just build up in Pulse in the meantime.
+# exec newrelic-admin run-program ./manage.py read_pulse_resultsets
+
+# If we just exited the script, supervisor would keep on trying to restart it.
+while true; do
+    echo "$(date) read_pulse_resultsets process is disabled for Heroku migration."
+    sleep 30
+done

--- a/tests/e2e/test_client_job_ingestion.py
+++ b/tests/e2e/test_client_job_ingestion.py
@@ -16,6 +16,8 @@ from treeherder.model.models import (Job,
                                      TextLogError,
                                      TextLogStep)
 
+pytestmark = pytest.mark.skip(reason='Maintenance mode')
+
 
 @pytest.fixture
 def text_log_summary_dict():

--- a/tests/e2e/test_jobs_loaded.py
+++ b/tests/e2e/test_jobs_loaded.py
@@ -1,7 +1,10 @@
+import pytest
 from django.core.urlresolvers import reverse
 from webtest import TestApp
 
 from treeherder.config.wsgi import application
+
+pytestmark = pytest.mark.skip(reason='Maintenance mode')
 
 
 def test_pending_job_available(jm, pending_jobs_stored):

--- a/tests/e2e/test_perf_ingestion.py
+++ b/tests/e2e/test_perf_ingestion.py
@@ -1,10 +1,14 @@
 import copy
 
+import pytest
+
 from tests.test_utils import post_collection
 from treeherder.client.thclient import client
 from treeherder.perf.models import (PerformanceDatum,
                                     PerformanceFramework,
                                     PerformanceSignature)
+
+pytestmark = pytest.mark.skip(reason='Maintenance mode')
 
 
 def test_post_perf_artifact(jobs_ds, test_repository, result_set_stored,

--- a/tests/webapp/api/test_artifact_api.py
+++ b/tests/webapp/api/test_artifact_api.py
@@ -7,6 +7,7 @@ from treeherder.client.thclient import client
 from treeherder.model.derived import (ArtifactsModel,
                                       JobsModel)
 
+pytestmark = pytest.mark.skip(reason='Maintenance mode')
 xfail = pytest.mark.xfail
 
 

--- a/tests/webapp/api/test_bug_job_map_api.py
+++ b/tests/webapp/api/test_bug_job_map_api.py
@@ -8,6 +8,8 @@ from rest_framework.test import APIClient
 from treeherder.model.models import (BugJobMap,
                                      Job)
 
+pytestmark = pytest.mark.skip(reason='Maintenance mode')
+
 
 @pytest.mark.parametrize('test_no_auth,test_duplicate_handling', [
     (True, False),

--- a/tests/webapp/api/test_bugzilla.py
+++ b/tests/webapp/api/test_bugzilla.py
@@ -1,8 +1,11 @@
 import json
 
+import pytest
 import responses
 from django.core.urlresolvers import reverse
 from rest_framework.test import APIClient
+
+pytestmark = pytest.mark.skip(reason='Maintenance mode')
 
 
 def test_create_bug(webapp, eleven_jobs_stored, activate_responses, test_user):

--- a/tests/webapp/api/test_classified_failure.py
+++ b/tests/webapp/api/test_classified_failure.py
@@ -1,9 +1,12 @@
+import pytest
 from django.core.urlresolvers import reverse
 from rest_framework.test import APIClient
 
 from tests.autoclassify.utils import (create_failure_lines,
                                       test_line)
 from treeherder.model.models import ClassifiedFailure
+
+pytestmark = pytest.mark.skip(reason='Maintenance mode')
 
 
 def test_get_classified_failure(webapp, classified_failures):

--- a/tests/webapp/api/test_failureline.py
+++ b/tests/webapp/api/test_failureline.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from django.core.urlresolvers import reverse
 from rest_framework.test import APIClient
 
@@ -14,6 +15,8 @@ from treeherder.model.models import (BugJobMap,
                                      Matcher,
                                      MatcherManager)
 from treeherder.model.search import TestFailureLine
+
+pytestmark = pytest.mark.skip(reason='Maintenance mode')
 
 
 def test_get_failure_line(webapp, eleven_jobs_stored, jm, failure_lines):

--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -13,6 +13,8 @@ from treeherder.model.models import (ExclusionProfile,
                                      TextLogStep)
 from treeherder.webapp.api.jobs import JobsViewSet
 
+pytestmark = pytest.mark.skip(reason='Maintenance mode')
+
 
 def test_job_list(webapp, eleven_jobs_stored, test_repository):
     """

--- a/tests/webapp/api/test_middleware.py
+++ b/tests/webapp/api/test_middleware.py
@@ -1,0 +1,43 @@
+import json
+
+from django.core.urlresolvers import reverse
+from rest_framework.status import (HTTP_200_OK,
+                                   HTTP_503_SERVICE_UNAVAILABLE)
+from rest_framework.test import APITestCase
+
+from treeherder.config.middleware import ReadOnlyMaintenanceMiddleware
+
+
+class ReadOnlyMaintenanceMiddlewareTests(APITestCase):
+
+    def _assert_request_was_blocked(self, response):
+        assert response.status_code == HTTP_503_SERVICE_UNAVAILABLE
+        assert json.loads(response.content) == {'detail': ReadOnlyMaintenanceMiddleware.message}
+
+    def test_whitenoise_get_allowed(self):
+        response = self.client.get('/')
+        assert response.status_code == HTTP_200_OK
+
+    def test_api_get_allowed(self):
+        response = self.client.get(reverse('classified-failure-list'))
+        assert response.status_code == HTTP_200_OK
+
+    def test_api_post_blocked(self):
+        response = self.client.post(reverse('bugzilla-create-bug'))
+        self._assert_request_was_blocked(response)
+
+    def test_api_put_blocked(self):
+        response = self.client.put(reverse('bugzilla-create-bug'))
+        self._assert_request_was_blocked(response)
+
+    def test_api_delete_blocked(self):
+        response = self.client.delete(reverse('bugzilla-create-bug'))
+        self._assert_request_was_blocked(response)
+
+    def test_django_admin_post_blocked(self):
+        response = self.client.post('/admin/')
+        self._assert_request_was_blocked(response)
+
+    def test_persona_login_post_blocked(self):
+        response = self.client.post(reverse('browserid.login'))
+        self._assert_request_was_blocked(response)

--- a/tests/webapp/api/test_note_api.py
+++ b/tests/webapp/api/test_note_api.py
@@ -7,6 +7,8 @@ from rest_framework.test import APIClient
 from treeherder.model.models import (Job,
                                      JobNote)
 
+pytestmark = pytest.mark.skip(reason='Maintenance mode')
+
 
 def test_note_list(webapp, sample_notes, jm, test_user):
     """

--- a/tests/webapp/api/test_performance_alerts_api.py
+++ b/tests/webapp/api/test_performance_alerts_api.py
@@ -9,6 +9,8 @@ from treeherder.perf.models import (PerformanceAlert,
                                     PerformanceAlertSummary,
                                     PerformanceDatum)
 
+pytestmark = pytest.mark.skip(reason='Maintenance mode')
+
 
 def test_alerts_get(webapp, test_repository, test_perf_alert):
     resp = webapp.get(reverse('performance-alerts-list'))

--- a/tests/webapp/api/test_performance_alertsummary_api.py
+++ b/tests/webapp/api/test_performance_alertsummary_api.py
@@ -1,8 +1,11 @@
+import pytest
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from rest_framework.test import APIClient
 
 from treeherder.perf.models import PerformanceAlertSummary
+
+pytestmark = pytest.mark.skip(reason='Maintenance mode')
 
 
 def test_alert_summaries_get(webapp, test_perf_alert_summary,

--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -1,5 +1,6 @@
 import copy
 
+import pytest
 from django.core.urlresolvers import reverse
 from rest_framework.test import APIClient
 
@@ -9,6 +10,8 @@ from treeherder.model.models import (FailureClassification,
                                      Job,
                                      JobNote)
 from treeherder.webapp.api import utils
+
+pytestmark = pytest.mark.skip(reason='Maintenance mode')
 
 
 def test_resultset_list(webapp, eleven_jobs_stored, jm, test_project):

--- a/tests/webapp/api/test_text_log_summary_lines.py
+++ b/tests/webapp/api/test_text_log_summary_lines.py
@@ -1,3 +1,4 @@
+import pytest
 from django.core.urlresolvers import reverse
 from rest_framework.test import APIClient
 
@@ -5,6 +6,8 @@ from treeherder.model.models import (BugJobMap,
                                      FailureLine,
                                      JobNote,
                                      TextLogSummary)
+
+pytestmark = pytest.mark.skip(reason='Maintenance mode')
 
 
 def test_get_summary_line(webapp, text_summary_lines):

--- a/treeherder/config/middleware.py
+++ b/treeherder/config/middleware.py
@@ -1,0 +1,18 @@
+from django.http import JsonResponse
+from rest_framework.permissions import SAFE_METHODS
+from rest_framework.status import HTTP_503_SERVICE_UNAVAILABLE
+
+
+class ReadOnlyMaintenanceMiddleware(object):
+    """
+    Return an HTTP503 for all requests apart from those that are read-only.
+    """
+
+    status_code = HTTP_503_SERVICE_UNAVAILABLE
+    message = 'Site is in read-only mode for scheduled maintenance'
+
+    def process_request(self, request):
+        if request.method in SAFE_METHODS:
+            return
+
+        return JsonResponse(data={'detail': self.message}, status=self.status_code)

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -87,6 +87,7 @@ MIDDLEWARE_CLASSES = [middleware for middleware in [
     # Allows both Django static files and those specified via `WHITENOISE_ROOT`
     # to be served by WhiteNoise, avoiding the need for Apache/nginx on Heroku.
     'treeherder.config.whitenoise_custom.CustomWhiteNoise',
+    'treeherder.config.middleware.ReadOnlyMaintenanceMiddleware',
     'django.middleware.gzip.GZipMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware' if ENABLE_DEBUG_TOOLBAR else False,
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/treeherder/workers/task.py
+++ b/treeherder/workers/task.py
@@ -1,4 +1,3 @@
-import random
 import zlib
 from functools import wraps
 
@@ -49,10 +48,8 @@ class retryable_task(object):
                     "number_of_prior_retries": number_of_prior_retries,
                 }
                 newrelic.agent.record_exception(params=params)
-                # Implement exponential backoff with some randomness to prevent
-                # thundering herd type problems. Constant factor chosen so we get
-                # reasonable pause between the fastest retries.
-                timeout = 10 * int(random.uniform(1.9, 2.1) ** number_of_prior_retries)
+                # Retry after 5 seconds, so we can empty the queues faster.
+                timeout = 5
                 raise task_func.retry(exc=e, countdown=timeout)
 
         task_func = task(*self.task_args, **self.task_kwargs)(inner)

--- a/ui/index.html
+++ b/ui/index.html
@@ -34,6 +34,12 @@
                     <ng-include src="'partials/main/thShortcutTable.html'"></ng-include>
                  </div>
                </div>
+               <div id="onscreen-shortcuts" ng-if="maintenanceInfoShowing"
+                    stop-propagation-on-left-click>
+                 <div class="col-xs-8">
+                    <ng-include src="'partials/main/thMaintenanceInfo.html'"></ng-include>
+                 </div>
+               </div>
             </div>
             <div id="global-navbar-container">
                 <ng-include id="th-global-top-nav-panel"

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -393,6 +393,7 @@ treeherderApp.controller('MainCtrl', [
                 $scope.$evalAsync($scope.setSettingsPanelShowing(false));
                 $scope.$evalAsync($scope.closeJob());
                 $scope.$evalAsync($scope.setOnscreenShortcutsShowing(false));
+                $scope.$evalAsync($scope.setMaintenanceInfoShowing(false));
             }],
 
             // Shortcut: clear the pinboard
@@ -549,6 +550,14 @@ treeherderApp.controller('MainCtrl', [
             $scope.onscreenShortcutsShowing = tf;
             $scope.onscreenOverlayShowing = tf;
         };
+
+        $scope.maintenanceInfoShowing = false;
+        $scope.setMaintenanceInfoShowing = function(tf) {
+            $scope.maintenanceInfoShowing = tf;
+            $scope.onscreenOverlayShowing = tf;
+        };
+
+        $scope.$evalAsync($scope.setMaintenanceInfoShowing(true));
 
         $scope.isFilterPanelShowing = false;
         $scope.setFilterPanelShowing = function(tf) {

--- a/ui/partials/main/persona_buttons.html
+++ b/ui/partials/main/persona_buttons.html
@@ -1,19 +1,4 @@
-<span class="dropdown"
-      ng-if="user.loggedin">
-  <button id="logoutLabel" title="Logged in as: {{user.email}}" role="button"
-          data-toggle="dropdown" data-target="#"
-          class="btn btn-view-nav btn-right-navbar nav-persona-btn">
-    <div class="nav-user-icon">
-      <span class="fa fa-user pull-left"></span>
-    </div>
-    <span class="fa fa-angle-down lightgray"></span>
-  </button>
-  <ul class="dropdown-menu" role="menu" aria-labelledby="logoutLabel"
-      ng-include="'partials/main/thLogoutMenu.html'">
-  </ul>
-</span>
-
 <a class="btn btn-view-nav btn-right-navbar nav-login-btn"
-   title="Log in for additional functionality"
-   ng-if="!user.loggedin" ng-click="login()">
-   <span>Login / Register</span></a>
+   title="Login disabled"
+   ng-click="setMaintenanceInfoShowing(true)">
+   <span>Login disabled</span></a>

--- a/ui/partials/main/thMaintenanceInfo.html
+++ b/ui/partials/main/thMaintenanceInfo.html
@@ -1,0 +1,27 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3><span class="fa fa-wrench fa-lg fa-flip-horizontal"></span>
+      Maintenance in progress
+      <a ng-show="maintenanceInfoShowing"
+         ng-click="setMaintenanceInfoShowing(false)"
+         class="pull-right" href="" title="Close">
+        <span class="fa fa-times lightgray"></span>
+      </a>
+    </h3>
+  </div>
+  <div class="panel-body panel-spacing">
+    <p>Treeherder is in read-only mode for the next 30 minutes, whilst the
+       <a href="https://groups.google.com/forum/#!topic/mozilla.tools.treeherder/t51FXTK-3k0">SCL3 to Heroku datacenter migration</a>
+       takes place.</p>
+    <p>During this time:</p>
+    <ul>
+      <li>Users will be unable to make changes (eg classifying failures).</li>
+      <li>Existing pushes/results can be viewed, however new data will not
+          appear until after the migration is complete.</li>
+    </ul>
+    <p>Follow along in <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1307741">bug 1307741</a>
+       or <a href="irc://irc.mozilla.org/treeherder">#treeherder</a>.</p>
+    <p>Best wishes,</p>
+    <p>&mdash; The Treeherder team</p>
+  </div>
+</div>


### PR DESCRIPTION
On migration day, this branch will be deployed to SCL3 (but not to Heroku) to prepare for the switchover to Heroku. These changes will never be merged to master.

During the migration, the celery queues must reach zero, since unlike the MySQL database, anything left in the SCL3 rabbitmq instance will not be transferred to the Heroku one.

At the point at which the DB replication is shut off, we must also ensure no new DB writes are occurring in SCL3.

As such, this commit:
* Adds a dismissible maintenance overlay to the main Treeherder page, so users are informed of the downtime. The login buttons are also disabled, and made to re-show the maintenance info.
* Blocks any requests to the site that are not of type GET/HEAD/OPTIONS, from any user (whether Django or Hawk authenticated). This will prevent job submissions as well as user failure classifications/admin panel changes and so on.
* Disables the celery beat process, so new periodic tasks (such as pushlog/builds-4hr fetching, cycle_data etc) are not scheduled.
* Disables the pulse ingestion process, to stop pulling in new Taskcluster jobs from their Pulse queue. Jobs will safely build up in Pulse in the meantime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1627)
<!-- Reviewable:end -->
