### PR TITLE
Bug 1283074 - Make exponent for task retry backoff close to 2

### DIFF
--- a/treeherder/workers/task.py
+++ b/treeherder/workers/task.py
@@ -24,7 +24,7 @@ class retryable_task(object):
                 # Implement exponential backoff with some randomness to prevent
                 # thundering herd type problems. Constant factor chosen so we get
                 # reasonable pause between the fastest retries.
-                timeout = 10 * int(random.uniform(2, 3) ** task_func.request.retries)
+                timeout = 10 * int(random.uniform(1.9, 2.1) ** task_func.request.retries)
                 task_func.retry(exc=e, countdown=timeout)
 
         task_func = task(*self.task_args, **self.task_kwargs)(inner)


### PR DESCRIPTION
This prevents over-long retries or too mcuh variation (the distribution
is centred around 3 hours with thoretical minima and maxima at about 2
and 4 hours). That's not a very long time if we have infra issues, but
is longer than the old one hour limit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1629)
<!-- Reviewable:end -->
