### PR TITLE
Bug 1283202 - Stop concatenating retryId to the end of the taskId for…

### DIFF
--- a/tests/sample_data/pulse_consumer/job_data.json
+++ b/tests/sample_data/pulse_consumer/job_data.json
@@ -1,6 +1,6 @@
 [
   {
-    "taskId": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33",
+    "taskId": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33/0",
     "origin": {
       "kind": "hg.mozilla.org",
       "project": "set by test",
@@ -67,7 +67,7 @@
   },
 
   {
-    "taskId": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf34",
+    "taskId": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf34/0",
     "retryId": 0,
     "origin": {
       "kind": "hg.mozilla.org",
@@ -110,7 +110,7 @@
   },
 
   {
-    "taskId": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35",
+    "taskId": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35/0",
     "retryId": 0,
     "isRetried": true,
     "origin": {
@@ -206,7 +206,7 @@
 
   },
   {
-    "taskId": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35",
+    "taskId": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35/3",
     "retryId": 3,
     "origin": {
       "kind": "hg.mozilla.org",

--- a/tests/sample_data/pulse_consumer/transformed_job_data.json
+++ b/tests/sample_data/pulse_consumer/transformed_job_data.json
@@ -14,7 +14,7 @@
       },
       "artifacts": [
         {
-          "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33",
+          "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33/0",
           "type": "json",
           "blob": {
             "job_details": [
@@ -57,7 +57,7 @@
       ],
       "tier": 1,
       "job_symbol": "P",
-      "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33",
+      "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33/0",
       "product_name": "Oscillation Overthruster",
       "end_timestamp": 1419043197.0
     },
@@ -95,7 +95,7 @@
       "log_references": [],
       "tier": 1,
       "job_symbol": "P2",
-      "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf34",
+      "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf34/0",
       "product_name": "Oscillation Overthruster",
       "end_timestamp": 1419043197.0
     },
@@ -117,7 +117,7 @@
       },
       "artifacts": [
         {
-          "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35",
+          "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35/0",
           "type": "json",
           "blob": {
             "step_data": {
@@ -183,7 +183,7 @@
         {
           "type": "json",
           "blob": {"fee": "foo"},
-          "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35",
+          "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35/0",
           "name": "Bug suggestions"
         }
       ],
@@ -209,7 +209,7 @@
       ],
       "tier": 1,
       "job_symbol": "3",
-      "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35",
+      "job_guid": "d22c74d4aa6d2a1dcba96d95dccbd5fdca70cf35/0",
       "product_name": "unknown",
       "end_timestamp": 1419043197.0
     },

--- a/treeherder/etl/job_loader.py
+++ b/treeherder/etl/job_loader.py
@@ -69,7 +69,7 @@ class JobLoader:
         We can rely on the structure of ``pulse_job`` because it will
         already have been validated against the JSON Schema at this point.
         """
-        job_guid = self._get_job_guid(pulse_job)
+        job_guid = pulse_job["taskId"]
         x = {
             "job": {
                 "job_guid": job_guid,
@@ -126,13 +126,6 @@ class JobLoader:
             x["job"][k] = self._get_platform(platform_src)
 
         return x
-
-    def _get_job_guid(self, job):
-        guid_parts = [job["taskId"]]
-        retry_id = job.get("retryId", 0)
-        if retry_id > 0:
-            guid_parts.append(str(retry_id))
-        return "/".join(guid_parts)
 
     def _get_job_symbol(self, job):
         return "{}{}".format(


### PR DESCRIPTION
… job_guid from pulse

That value is already concatenated on the end of the job_guid from taskcluster

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1634)
<!-- Reviewable:end -->
