### PR TITLE
Bug 1283316 - Don't try to store tests with non-string identifiers in…

### DIFF
--- a/treeherder/model/search.py
+++ b/treeherder/model/search.py
@@ -1,4 +1,5 @@
 import logging
+import types
 from functools import wraps
 
 import certifi
@@ -75,6 +76,11 @@ class TestFailureLine(RoutedDocType):
     def from_model(cls, line):
         """Create a TestFailureLine object from a FailureLine model instance."""
         if line.action == "test_result":
+            if not type(line.test) in types.StringTypes:
+                # Reftests used to use tuple indicies, which we can't support
+                # this is fixed upstream, but we also need to handle it here to allow
+                # for older branches.
+                return
             rv = cls(job_guid=line.job_guid,
                      test=line.test,
                      subtest=line.subtest,


### PR DESCRIPTION
… elasticsearch.

Some test types, notably reftests before this was fixed upstream, try to
use tuples for the test id. This is incompatible with elastic search, so
just skip storing the failure line in elasticsearch in those cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1635)
<!-- Reviewable:end -->
