### PR TITLE
Bug 1283865 - remove pattern requirements for pulse job display fields

### DIFF
--- a/schemas/pulse-job.yml
+++ b/schemas/pulse-job.yml
@@ -120,8 +120,6 @@ properties:
       jobSymbol:
         title: "jobSymbol"
         type: "string"
-        # spaces and "?" are not valid for job symbols
-        pattern: "^$|^[\\w.-]+$"
         minLength: 0
         maxLength: 25
       chunkId:
@@ -135,21 +133,16 @@ properties:
       groupSymbol:
         title: "group symbol"
         type: "string"
-        # spaces not valid for group symbols
-        pattern: "^[\\w/?-]+$"
         minLength: 1
         maxLength: 25
-      # could do without these if we require job type and group to exist prior
       jobName:
         title: "job name"
         type: "string"
-        pattern: "^[A-Za-z0-9\\s_,\\+\\[\\]\\(\\)-]+$"
         minLength: 1
         maxLength: 100
       groupName:
         title: "group name"
         type: "string"
-        pattern: "^[\\w,\\+\\s\\[\\]\\(\\)-]+$"
         minLength: 1
         maxLength: 100
     required:


### PR DESCRIPTION
Several existing jobs are already out of compliance with these patterns
and there is no existing way to tell task definition developers how to
comply with our required patterns.

created bug 1283866 in Taskcluster for that tool/workflow

This removes the pattern requirements.  If we ever decide that we DO
need these patterns, we can create that tool and then fix old task
definitions to comply.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1639)
<!-- Reviewable:end -->
