### PR TITLE
Bug 1229782 - Add an info icon for cases where the job name has a description hiding in a tooltip

### DIFF
--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -186,7 +186,10 @@
                  title="Open build directory in a new tab"
                  href={{job_log_url.buildUrl}} target="_blank">{{value}}</a>
               <span ng-switch-when="Job name"
-                    title="{{job.job_type_description}}">{{value}}</span>
+                    title="{{job.job_type_description}}">
+                    {{value}}
+                    <span ng-hide="job.job_type_description.length == 0" class="fa fa-info-circle"></span>
+              </span>
               <span ng-switch-default>{{value}}</span>
           </span>
         </li>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1642)
<!-- Reviewable:end -->
