### PR TITLE
Bug 1283880 - Fix display of compare subtest performance when branches differ

### DIFF
--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -574,7 +574,10 @@ perf.controller('CompareSubtestResultsCtrl', [
                                }
 
                                PhSeries.getSeriesList(
-                                   $scope.newProject.name, { parent_signature: $scope.newSignature }).then(function(newSeriesList) {
+                                   $scope.newProject.name, {
+                                       parent_signature: $scope.newSignature,
+                                       framework: $scope.filterOptions.framework
+                                   }).then(function(newSeriesList) {
                                        $scope.platformList = _.uniq(_.union(
                                            $scope.platformList,
                                            _.map(newSeriesList, 'platform')));


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1643)
<!-- Reviewable:end -->
