### PR TITLE
Bug 1284503 - Docs: List the error message shown for Hawk token expiry

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -100,7 +100,11 @@ set up (see :ref:`python-client`).
 
 Note: The system clock on the machines making requests must be correct
 (or more specifically, within 60 seconds of the Treeherder server time),
-otherwise authentication will fail.
+otherwise authentication will fail. In this case, the response body will be:
+
+.. code-block:: json
+
+    {"detail":"Hawk authentication failed: The token has expired. Is your system clock correct?"}
 
 .. _Hawk authentication mechanism: https://github.com/hueniverse/hawk
 


### PR DESCRIPTION
To make it clearer when submitters are hitting this case vs other authentication failure modes (like incorrect `client_id` or `secret`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1648)
<!-- Reviewable:end -->
