### PR TITLE
Bug 1284626 - Update talos regression filing template

### DIFF
--- a/treeherder/perf/fixtures/performance_bug_templates.yaml
+++ b/treeherder/perf/fixtures/performance_bug_templates.yaml
@@ -2,11 +2,11 @@
   pk: 1
   fields:
     framework: 1
-    keywords: perf, regression
-    status_whiteboard: talos_regression
+    keywords: perf, regression, talos-regression
+    status_whiteboard:
     default_component: Untriaged
     default_product: Firefox
-    cc_list: jmaher@mozilla.com, wlachance@mozilla.com, avihpit@yahoo.com
+    cc_list: jmaher@mozilla.com, wlachance@mozilla.com, avihpit@yahoo.com, rwood@mozilla.com, ashiue@mozilla.com
     text: |
       Talos has detected a Firefox performance regression from push {{ revision }}. As author of one of the patches included in that push, we need your help to address this regression.
 


### PR DESCRIPTION
* We now have a keyword in bugzilla for talos-regression which we should use
  instead of the whiteboard (it's faster)
* Add Robert and Allison to the default CC list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1651)
<!-- Reviewable:end -->
