### PR TITLE
Bug 1284990 - Use email address instead of username

### DIFF
--- a/tests/webapp/api/test_bugzilla.py
+++ b/tests/webapp/api/test_bugzilla.py
@@ -18,7 +18,7 @@ def test_create_bug(webapp, eleven_jobs_stored, activate_responses, test_user):
         print requestheaders
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
         assert requestdata['product'] == "Bugzilla"
-        assert requestdata['description'] == "Filed by: {}\n\nIntermittent Description".format(test_user.username)
+        assert requestdata['description'] == "Filed by: {}\n\nIntermittent Description".format(test_user.email.replace('@', " [at] "))
         assert requestdata['component'] == "Administration"
         assert requestdata['summary'] == "Intermittent summary"
         assert requestdata['comment_tags'] == "treeherder"

--- a/treeherder/webapp/api/bugzilla.py
+++ b/treeherder/webapp/api/bugzilla.py
@@ -23,7 +23,7 @@ class BugzillaViewSet(viewsets.ViewSet):
 
         params = request.data
         description = "Filed by: {}\n\n{}".format(
-            request.user.username,
+            request.user.email.replace('@', " [at] "),
             params.get("comment", "")
         )
         url = settings.BZ_API_URL + "/rest/bug"


### PR DESCRIPTION
I originally used usernames so I wouldn't be printing full email addresses
into bugs. Apparently older users in Treeherder have a readable name as
the username field, but newer users have a random string of
letters/numbers, which is much less useful.

This change uses the user's email address instead, splitting it at the '@'
and using the first part. This should still be relatively unique per user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1654)
<!-- Reviewable:end -->
