### PR TITLE
Bug 1285046 - Add a tooltip and info icon for the exceeded bug suggestions message

### DIFF
--- a/ui/plugins/failure_summary/controller.js
+++ b/ui/plugins/failure_summary/controller.js
@@ -13,6 +13,9 @@ treeherder.controller('BugsPluginCtrl', [
         var requestPromise = null;
 
         var bug_limit = 20;
+        $scope.bug_limit_title_string = "This search for suggestions has exceeded " +  bug_limit + " results, " +
+                                        "and is likely not a useful search, so suggestions are not being shown.\n" +
+                                        "Filing a new bug with a more specific title would probably help.";
         $scope.tabs = thTabs.tabs;
 
         $scope.filerInAddress = false;

--- a/ui/plugins/failure_summary/main.html
+++ b/ui/plugins/failure_summary/main.html
@@ -64,7 +64,10 @@
             </ul>
 
             <mark ng-if="suggestion.bugs.too_many_open_recent || (suggestion.bugs.too_many_all_others && !suggestion.valid_open_recent)"
-                    >Exceeded max bug suggestions</mark>
+                  ng-attr-title="{{bug_limit_title_string}}">
+                  Exceeded max bug suggestions
+                  <span class="fa fa-info-circle"></span>
+            </mark>
 
         </li>
 


### PR DESCRIPTION
Happy to take a better tooltip string, couldn't think of anything better offhand in the time I was working on this patch...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1655)
<!-- Reviewable:end -->
