### PR TITLE
Bug 1285004 - Use angular's httpParamSerializer in perf controllers

### DIFF
--- a/ui/js/controllers/perf/alerts.js
+++ b/ui/js/controllers/perf/alerts.js
@@ -1,9 +1,9 @@
 "use strict";
 
 perf.factory('PhBugs', [
-    '$http', '$templateRequest', '$interpolate', 'dateFilter', 'thServiceDomain', 'phAlertStatusMap', 'mcTalosConfigUrl',
+    '$http', '$httpParamSerializer', '$templateRequest', '$interpolate', 'dateFilter', 'thServiceDomain', 'phAlertStatusMap', 'mcTalosConfigUrl',
     'phTalosDocumentationMap', 'phTrySyntaxBuildPlatformMap', 'phTrySyntaxTalosModifierMap',
-    function($http, $templateRequest, $interpolate, dateFilter, thServiceDomain, phAlertStatusMap, mcTalosConfigUrl,
+    function($http, $httpParamSerializer, $templateRequest, $interpolate, dateFilter, thServiceDomain, phAlertStatusMap, mcTalosConfigUrl,
              phTalosDocumentationMap, phTrySyntaxBuildPlatformMap, phTrySyntaxTalosModifierMap) {
         return {
             fileTalosBug: function(alertSummary) {
@@ -44,7 +44,7 @@ perf.factory('PhBugs', [
                         alertSummary.resultSetMetadata.revision + " (" +
                         pushDate + ")";
                     window.open(
-                        "https://bugzilla.mozilla.org/enter_bug.cgi?" + _.map({
+                        "https://bugzilla.mozilla.org/enter_bug.cgi?" + $httpParamSerializer({
                             cc: template.cc_list,
                             comment: compiledText,
                             component: template.default_component,
@@ -52,9 +52,7 @@ perf.factory('PhBugs', [
                             keywords: template.keywords,
                             short_desc: bugTitle,
                             status_whiteboard: template.status_whiteboard
-                        }, function(v, k) {
-                            return k + '=' + encodeURIComponent(v);
-                        }).join('&'));
+                        }));
                 });
             }
         };

--- a/ui/js/controllers/perf/e10s.js
+++ b/ui/js/controllers/perf/e10s.js
@@ -3,10 +3,10 @@
 perf.value('e10sDefaultTimeRange', 86400 * 2);
 
 perf.controller('e10sCtrl', [
-    '$state', '$stateParams', '$scope', '$rootScope', '$q', '$http',
+    '$state', '$stateParams', '$scope', '$rootScope', '$q', '$http', '$httpParamSerializer',
     'ThRepositoryModel', 'ThResultSetModel', 'PhSeries', 'PhCompare',
     'thServiceDomain', 'thDefaultRepo', 'phTimeRanges', 'e10sDefaultTimeRange',
-    function e10sCtrl($state, $stateParams, $scope, $rootScope, $q, $http,
+    function e10sCtrl($state, $stateParams, $scope, $rootScope, $q, $http, $httpParamSerializer,
                       ThRepositoryModel, ThResultSetModel, PhSeries, PhCompare,
                       thServiceDomain, thDefaultRepo, phTimeRanges,
                       e10sDefaultTimeRange) {
@@ -137,30 +137,27 @@ perf.controller('e10sCtrl', [
                                         }))
                                 }];
                                 if (resultsMap['base'][baseSig].hasSubTests) {
-                                    var params = [
-                                        ['baseSignature', baseSig],
-                                        ['e10sSignature', e10sSig],
-                                        ['repo', $scope.selectedRepo.name]
-                                    ];
+                                    var params = {
+                                        baseSignature: baseSig,
+                                        e10sSignature: e10sSig,
+                                        repo: $scope.selectedRepo.name
+                                    };
                                     if ($scope.revision) {
-                                        params.push(['revision', $scope.revision]);
+                                        params.revision = $scope.revision;
                                     } else {
-                                        params.push(['timerange',
-                                                     $scope.selectedTimeRange.value]);
+                                        params.timerange = $scope.selectedTimeRange.value;
                                     }
                                     cmap.links.push({
                                         title: 'subtests',
-                                        href: 'perf.html#/e10s_comparesubtest?' + _.map(
-                                            params, function(kv) { return kv[0] + '=' + kv[1]; }).join('&')
+                                        href: 'perf.html#/e10s_comparesubtest?' + $httpParamSerializer(params)
                                     });
+                                    if (!$scope.compareResults[testName]) {
+                                        $scope.compareResults[testName] = [cmap];
+                                    } else {
+                                        $scope.compareResults[testName].push(cmap);
+                                    }
                                 }
-                                if (!$scope.compareResults[testName]) {
-                                    $scope.compareResults[testName] = [cmap];
-                                } else {
-                                    $scope.compareResults[testName].push(cmap);
-                                }
-                            }
-                        });
+                            }});
                     });
                 });
             });

--- a/ui/js/models/perf/alerts.js
+++ b/ui/js/models/perf/alerts.js
@@ -1,9 +1,9 @@
 "use strict";
 
 treeherder.factory('PhAlerts', [
-    '$http', '$q', 'thServiceDomain', 'ThOptionCollectionModel', 'PhSeries',
+    '$http', '$httpParamSerializer', '$q', 'thServiceDomain', 'ThOptionCollectionModel', 'PhSeries',
     'phAlertSummaryStatusMap', 'phAlertStatusMap', 'thPerformanceBranches',
-    function($http, $q, thServiceDomain, ThOptionCollectionModel, PhSeries,
+    function($http, $httpParamSerializer, $q, thServiceDomain, ThOptionCollectionModel, PhSeries,
              phAlertSummaryStatusMap, phAlertStatusMap, thPerformanceBranches) {
 
         var Alert = function(alertData, optionCollectionMap) {
@@ -50,7 +50,7 @@ treeherder.factory('PhAlerts', [
                 urlParameters.newRevision = alertSummary.resultSetMetadata.revision;
             }
 
-            return endpoint + '?' + _.map(urlParameters, function(v, k) {return k + '=' + v;}).join('&');
+            return endpoint + '?' + $httpParamSerializer(urlParameters);
         };
         Alert.prototype.modify = function(modification) {
             return $http.put(thServiceDomain +

--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -96,9 +96,9 @@ treeherder.factory('PhSeries', ['$http', 'thServiceDomain', 'ThOptionCollectionM
     };
 }]);
 
-perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
+perf.factory('PhCompare', [ '$q', '$http', '$httpParamSerializer', 'thServiceDomain', 'PhSeries',
                             'math', 'phTimeRanges',
-                            function($q, $http, thServiceDomain, PhSeries, math, phTimeRanges) {
+                            function($q, $http, $httpParamSerializer, thServiceDomain, PhSeries, math, phTimeRanges) {
 
                                 // Used for t_test: default stddev if both sets have only a single value - 15%.
                                 // Should be rare case and it's unreliable, but at least have something.
@@ -359,17 +359,17 @@ perf.factory('PhCompare', [ '$q', '$http', 'thServiceDomain', 'PhSeries',
                                         });
                                     },
                                     getGraphsLink: function(seriesList, resultSets) {
-                                        var graphsLink = 'perf.html#/graphs?' +
-                                            _.union(
-                                                _.map(seriesList, function(series) {
-                                                    return 'series=[' + [
-                                                        series.projectName,
-                                                        series.signature, 1,
-                                                        series.frameworkId ] + ']';
-                                                }), _.map(resultSets, function(resultSet) {
-                                                    return 'highlightedRevisions=' +
-                                                        resultSet.revision.slice(0, 12);
-                                                })).join('&');
+                                        var graphsLink = 'perf.html#/graphs?' + $httpParamSerializer({
+                                            series: _.map(seriesList, function(series) {
+                                                return [
+                                                    series.projectName,
+                                                    series.signature, 1,
+                                                    series.frameworkId ];
+                                            }),
+                                            highlightedRevisions: _.map(resultSets, function(resultSet) {
+                                                return resultSet.revision.slice(0, 12);
+                                            })
+                                        });
 
                                         if (resultSets) {
                                             graphsLink += '&timerange=' + _.max(


### PR DESCRIPTION
Here are changes to 2 of the files which use _.map. 

In https://github.com/mozilla/treeherder/blob/master/ui/js/perf.js#L372
_.map is being operated on an array and not an object, whereas, $httpParamSerializer works only on objects.

Also do you want me to make changes to the file which you had changed as an example?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1658)
<!-- Reviewable:end -->
