### PR TITLE
Bug 1278711 - Set pulse schema jobdetails field lengths higher

### DIFF
--- a/schemas/pulse-job.yml
+++ b/schemas/pulse-job.yml
@@ -297,14 +297,15 @@ properties:
             url:
               type: string
               format: url
+              maxLength: 512
             linkText:
               type: string
               minLength: 1
-              maxLength: 50
+              maxLength: 125
             label:
               type: string
               minLength: 1
-              maxLength: 50
+              maxLength: 70
           additionalProperties: false
           required:
           - url


### PR DESCRIPTION
This sets the field lengths to what they will be in a later PR for
the job_details model.  But these are still within the constraints
of the current field lengths for that table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1665)
<!-- Reviewable:end -->
