### PR TITLE
Bug 1278711 - Lower field lengths in job_detail table

### DIFF
--- a/tests/model/derived/test_artifacts_model.py
+++ b/tests/model/derived/test_artifacts_model.py
@@ -93,11 +93,13 @@ def test_load_long_job_details(test_project, eleven_jobs_stored):
     with JobsModel(test_project) as jobs_model:
         job = jobs_model.get_job_list(0, 1)[0]
 
-    max_field_length = JobDetail.MAX_FIELD_LENGTH
+    def max_length(field):
+        """Get the field's max_length for the JobDetail model"""
+        return JobDetail._meta.get_field(field).max_length
 
-    (long_title, long_value, long_url) = ('t' * (2 * max_field_length),
-                                          'v' * (2 * max_field_length),
-                                          'https://' + ('u' * (2 * max_field_length)))
+    (long_title, long_value, long_url) = ('t' * (2 * max_length("title")),
+                                          'v' * (2 * max_length("value")),
+                                          'https://' + ('u' * (2 * max_length("url"))))
     ji_artifact = {
         'type': 'json',
         'name': 'Job Info',
@@ -116,6 +118,6 @@ def test_load_long_job_details(test_project, eleven_jobs_stored):
     assert JobDetail.objects.count() == 1
 
     jd = JobDetail.objects.all()[0]
-    assert jd.title == long_title[:max_field_length]
-    assert jd.value == long_value[:max_field_length]
-    assert jd.url == long_url[:max_field_length]
+    assert jd.title == long_title[:max_length("title")]
+    assert jd.value == long_value[:max_length("value")]
+    assert jd.url == long_url[:max_length("url")]

--- a/treeherder/model/migrations/0035_job_detail_field_lengths_decrease.py
+++ b/treeherder/model/migrations/0035_job_detail_field_lengths_decrease.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0034_add_unique_together_build_machine_platform'),
+    ]
+
+    operations = [
+        # Trim the size of the values to meet the new size constraints
+        migrations.RunSQL(
+            ("UPDATE job_detail SET "
+             "  title = SUBSTRING(title, 1, 70), "
+             "  value = SUBSTRING(value, 1, 125)")
+        ),
+        migrations.AlterField(
+            model_name='jobdetail',
+            name='title',
+            field=models.CharField(max_length=70, null=True),
+        ),
+        migrations.AlterField(
+            model_name='jobdetail',
+            name='value',
+            field=models.CharField(max_length=125),
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -604,13 +604,12 @@ class JobDetail(models.Model):
     There can be (and usually is) more than one of these associated with
     each job
     '''
-    MAX_FIELD_LENGTH = 512
 
     id = BigAutoField(primary_key=True)
     job = FlexibleForeignKey(Job)
-    title = models.CharField(max_length=MAX_FIELD_LENGTH, null=True)
-    value = models.CharField(max_length=MAX_FIELD_LENGTH)
-    url = models.URLField(null=True, max_length=MAX_FIELD_LENGTH)
+    title = models.CharField(max_length=70, null=True)
+    value = models.CharField(max_length=125)
+    url = models.URLField(null=True, max_length=512)
 
     class Meta:
         db_table = "job_detail"


### PR DESCRIPTION
This is required in order to create a unique index on title,
value and job_id to prevent duplicates.  The index will be
created in a later PR.

This also uses update_or_create instead of get_or_create as
this will be the mechanism going forward to prevent duplicates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1666)
<!-- Reviewable:end -->
