### PR TITLE
Bug 1285925 - Remove unnecessary usages of the mock_post_json fixture

### DIFF
--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -88,7 +88,6 @@ def mock_buildapi_builds4h_missing_branch_url(activate_responses):
 
 def test_ingest_pending_jobs(jm,
                              mock_buildapi_pending_url,
-                             mock_post_json,
                              mock_log_parser,
                              mock_get_resultset):
     """
@@ -109,7 +108,6 @@ def test_ingest_pending_jobs(jm,
 
 def test_ingest_running_jobs(jm,
                              mock_buildapi_running_url,
-                             mock_post_json,
                              mock_log_parser,
                              mock_get_resultset):
     """
@@ -130,7 +128,6 @@ def test_ingest_running_jobs(jm,
 
 def test_ingest_builds4h_jobs(jm,
                               mock_buildapi_builds4h_url,
-                              mock_post_json,
                               mock_log_parser,
                               mock_get_resultset):
     """
@@ -152,7 +149,6 @@ def test_ingest_builds4h_jobs(jm,
 def test_ingest_running_to_complete_job(jm,
                                         mock_buildapi_running_url,
                                         mock_buildapi_builds4h_url,
-                                        mock_post_json,
                                         mock_log_parser,
                                         mock_get_resultset):
     """
@@ -183,7 +179,6 @@ def test_ingest_running_to_complete_job(jm,
 
 def test_ingest_running_job_fields(jm,
                                    mock_buildapi_running_url,
-                                   mock_post_json,
                                    mock_log_parser,
                                    mock_get_resultset):
     """
@@ -200,7 +195,7 @@ def test_ingest_running_job_fields(jm,
 
 def test_ingest_builds4h_jobs_1_missing_resultset(jm,
                                                   sample_resultset, mock_buildapi_builds4h_missing1_url,
-                                                  mock_post_json, mock_log_parser, mock_get_resultset):
+                                                  mock_log_parser, mock_get_resultset):
     """
     Ensure the builds4h job with the missing resultset is not ingested
     """
@@ -213,7 +208,7 @@ def test_ingest_builds4h_jobs_1_missing_resultset(jm,
 
 def test_ingest_builds4h_jobs_missing_branch(jm,
                                              sample_resultset, mock_buildapi_builds4h_missing_branch_url,
-                                             mock_post_json, mock_log_parser, mock_get_resultset):
+                                             mock_log_parser, mock_get_resultset):
     """
     Ensure the builds4h job with the missing branch is not ingested
     """

--- a/tests/etl/test_pushlog.py
+++ b/tests/etl/test_pushlog.py
@@ -9,7 +9,7 @@ from treeherder.etl.pushlog import HgPushlogProcess
 
 
 def test_ingest_hg_pushlog(jm, test_base_dir,
-                           test_repository, mock_post_json,
+                           test_repository,
                            activate_responses):
     """ingesting a number of pushes should populate result set and revisions"""
 
@@ -42,7 +42,7 @@ def test_ingest_hg_pushlog(jm, test_base_dir,
 
 
 def test_ingest_hg_pushlog_already_stored(jm, test_base_dir,
-                                          test_repository, mock_post_json, activate_responses):
+                                          test_repository, activate_responses):
     """test that trying to ingest a push already stored doesn't doesn't affect
     all the pushes in the request,
     e.g. trying to store [A,B] with A already stored, B will be stored"""
@@ -98,7 +98,7 @@ def test_ingest_hg_pushlog_already_stored(jm, test_base_dir,
 
 
 def test_ingest_hg_pushlog_cache_last_push(jm, test_repository,
-                                           test_base_dir, mock_post_json,
+                                           test_base_dir,
                                            activate_responses):
     """
     ingesting a number of pushes should cache the top revision of the last push
@@ -124,7 +124,7 @@ def test_ingest_hg_pushlog_cache_last_push(jm, test_repository,
 
 
 def test_empty_json_pushes(jm, test_base_dir,
-                           test_repository, mock_post_json,
+                           test_repository,
                            activate_responses):
     """
     Gracefully handle getting an empty list of pushes from json-pushes

--- a/tests/log_parser/test_tasks.py
+++ b/tests/log_parser/test_tasks.py
@@ -59,8 +59,7 @@ def mock_mozlog_get_log_handler(monkeypatch):
                         'get_log_handle', _get_log_handle)
 
 
-def test_parse_log(jm, jobs_with_local_log, sample_resultset,
-                   mock_post_json):
+def test_parse_log(jm, jobs_with_local_log, sample_resultset):
     """
     check that 2 job_artifacts get inserted when running a parse_log task for
     a successful job and that JobDetail objects get created
@@ -94,8 +93,7 @@ def test_parse_log(jm, jobs_with_local_log, sample_resultset,
     print JobDetail.objects.count() == 4
 
 
-def test_bug_suggestions_artifact(jm, jobs_with_local_log,
-                                  sample_resultset, test_repository, mock_post_json):
+def test_bug_suggestions_artifact(jm, jobs_with_local_log, sample_resultset, test_repository):
     """
     check that at least 3 job_artifacts get inserted when running
     a parse_log task for a failed job, and that the number of

--- a/tests/model/derived/test_artifacts_model.py
+++ b/tests/model/derived/test_artifacts_model.py
@@ -11,7 +11,7 @@ xfail = pytest.mark.xfail
 
 def test_load_single_artifact(
         test_project, eleven_jobs_stored,
-        mock_post_json, mock_error_summary,
+        mock_error_summary,
         sample_data):
     """
     test loading a single artifact
@@ -46,7 +46,7 @@ def test_load_single_artifact(
 
 def test_load_artifact_second_time_fails(
         test_project, eleven_jobs_stored,
-        mock_post_json, mock_error_summary,
+        mock_error_summary,
         sample_data):
     """
     test loading two of the same named artifact only gets the first one


### PR DESCRIPTION
All tests other than those testing the API no longer hit the API (as of bug 1211414), so don't need to use the `mock_post_json` fixture.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1668)
<!-- Reviewable:end -->
