### PR TITLE
Bug 1285923 - Remove unused mock_fetch_json fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,17 +285,6 @@ def mock_post_json(monkeypatch, client_credentials):
 
 
 @pytest.fixture
-def mock_fetch_json(monkeypatch):
-    def _fetch_json(url, params=None):
-        response = TestApp(application).get(url, params=params, status=200)
-        return response.json
-
-    import treeherder.etl.common
-    monkeypatch.setattr(treeherder.etl.common,
-                        'fetch_json', _fetch_json)
-
-
-@pytest.fixture
 def activate_responses(request):
 
     responses.start()

--- a/tests/log_parser/test_tasks.py
+++ b/tests/log_parser/test_tasks.py
@@ -60,7 +60,7 @@ def mock_mozlog_get_log_handler(monkeypatch):
 
 
 def test_parse_log(jm, jobs_with_local_log, sample_resultset,
-                   mock_post_json, mock_fetch_json):
+                   mock_post_json):
     """
     check that 2 job_artifacts get inserted when running a parse_log task for
     a successful job and that JobDetail objects get created
@@ -95,8 +95,7 @@ def test_parse_log(jm, jobs_with_local_log, sample_resultset,
 
 
 def test_bug_suggestions_artifact(jm, jobs_with_local_log,
-                                  sample_resultset, test_repository, mock_post_json,
-                                  mock_fetch_json):
+                                  sample_resultset, test_repository, mock_post_json):
     """
     check that at least 3 job_artifacts get inserted when running
     a parse_log task for a failed job, and that the number of


### PR DESCRIPTION
Bug 1280910 made the bug suggestions generation during log parsing no longer hit the bugscache Treeherder API, so we no longer need to mock the request to it.

Any future uses of `fetch_json()` during tests would be better mocked using the responses library instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1669)
<!-- Reviewable:end -->
