### PR TITLE
Bug 1285539 - Fix 'manage.py check --deploy' on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ matrix:
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
         - pip install --disable-pip-version-check --upgrade pip==8.1.1
-        # Manually create the test database (required by the Django system checks), since
-        # this job doesn't run pytest which would normally have created it for us.
-        - mysql -u root -e 'create database test_treeherder;'
       install:
         - npm install
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
@@ -35,13 +32,6 @@ matrix:
         - python lints/queuelint.py
         - flake8 --show-source
         - isort --check-only --diff --quiet
-        # Several security features in settings.py (eg setting HSTS headers) are conditional on
-        # 'https://' being in the site URL. In addition, we override the test environment's debug
-        # value so the tests pass. The real environment variable will be checked during deployment.
-        # Replace grep with `--fail-level WARNING` once we're using Django 1.10, since in
-        # previous versions an exit code of 1 is hard-coded to only ERROR and above:
-        # https://github.com/django/django/commit/287532588941d2941e19c4cd069bcbd8af889203
-        - SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' ./manage.py check --deploy  2>&1 | awk '/^WARNINGS/{err=1} {print} END{exit err}'
 
     # Job 2: Nodejs UI tests
     - env: ui-tests
@@ -95,9 +85,19 @@ matrix:
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
         - pip install --disable-pip-version-check --upgrade pip==8.1.1
+        # Create the test database for `manage.py check --deploy`.
+        - mysql -u root -e 'create database test_treeherder;'
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
       script:
+        # Several security features in settings.py (eg setting HSTS headers) are conditional on
+        # 'https://' being in the site URL. In addition, we override the test environment's debug
+        # value so the tests pass. The real environment variable will be checked during deployment.
+        # Replace grep with `--fail-level WARNING` once we're using Django 1.10, since in
+        # previous versions an exit code of 1 is hard-coded to only ERROR and above:
+        # https://github.com/django/django/commit/287532588941d2941e19c4cd069bcbd8af889203
+        # The pipefail ensures exceptions during the command still cause the step to fail.
+        - set -o pipefail; SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' ./manage.py check --deploy 2>&1 | awk '/^WARNINGS/{err=1} {print} END{exit err}'
         - py.test tests/ --runslow --ignore=tests/e2e/ --ignore=tests/etl/ --ignore=tests/log_parser/ --ignore=tests/webapp/
 
     # Job 4: Python Tests Chunk B


### PR DESCRIPTION
The `manage.py check --deploy` command causes the Django models to be initialised, which requires Elasticsearch to be accessible, if `ELASTICSEARCH_URL` is set. The variable is set globally for the Travis runs, however for the linters job (which is where `check --deploy` was previously being run) Elasticsearch isn't actually installed.

Whilst we could have just unset `ELASTICSEARCH_URL` for the linters job, it's best to move the test to the main Python job chunk, since:
* The command doesn't only hit Elasticsearch, but also the DB, and the linters job is running the older mysql 5.5, rather than mysql 5.6. 
* Whilst Elasticsearch isn't currently enabled for anywhere other than the prototype Heroku instance, we'll soon be using it everywhere, so should get `check --deploy` to actually test what we plan to deploy.

Note: The exception during `check --deploy` was not turning the Travis run red, due to `check --deploy` being piped to awk. When we update to Django 1.10 the awk workaround can be removed, however in the meantime we can use the bash `pipefail` option to ensure the exit code from the `manage.py` command propagates through to the one that Travis sees.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1670)
<!-- Reviewable:end -->
