### PR TITLE
Bug 1277797 - Switch from the MySQLdb driver to mysqlclient

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -20,8 +20,8 @@ simplejson==3.8.2 --hash=sha256:d58439c548433adcda98e695be53e526ba940a4b9c44fb9a
 
 newrelic==2.66.0.49 --hash=sha256:f95b90def0c86b6d4f859664ca411bae90da76345f23ed2de40531d39e2b32a1
 
-# Required by datasource
-MySQL-python==1.2.5 --hash=sha256:811040b647e5d5686f84db415efd697e6250008b112b6909ba77ac059e140c74
+# Required by Django and datasource
+mysqlclient==1.3.7 --hash=sha256:c74a83b4cb2933d0e43370117eeebdfa03077ae72686d2df43d31879267f1f1b
 
 # Required by celery
 billiard==3.3.0.23 --hash=sha256:692a2a5a55ee39a42bcb7557930e2541da85df9ea81c6e24827f63b80cd39d0b


### PR DESCRIPTION
Since the latter is actually being maintained, and is recommended by the Django docs:
https://docs.djangoproject.com/en/1.9/ref/databases/#mysql-db-api-drivers

mysqlclient has had several bug fixes as well as Python 3 support added since it forked from upstream 1.2.5:
https://github.com/PyMySQL/mysqlclient-python/blob/master/HISTORY

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1671)
<!-- Reviewable:end -->
