### PR TITLE
Bug 1281944 - Make job-panel classification star match job color

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -197,9 +197,49 @@ div#info-panel .info-panel-navbar .navbar-nav > li.active a:focus {
   margin: 2px 0px;
 }
 
-#job-details-panel .star,
-#job-details-panel .star-o {
-  color: #f0ad4e;
+/*
+ * Classification stars
+ * These generally match the job button colors
+ */
+
+.star-success {
+  color: rgba(2, 130, 51, 0.75);
+}
+
+.star-testfailed {
+  color: #dd6602;
+}
+
+.star-busted {
+  color: #90010a;
+}
+
+.star-skipped {
+  color: rgb(101, 191, 221);
+}
+
+.star-exception {
+  color: #6f0296;
+}
+
+.star-retry {
+  color: #283aa2;
+}
+
+.star-unknown {
+  color: #fbd890;
+}
+
+.star-usercancel {
+  color: #ff40d9;
+}
+.star-coalesced {
+  color: #488ae9;
+}
+
+.star-pending,
+.star-running {
+  color: grey;
 }
 
 #job-details-panel em.testfail {

--- a/ui/js/directives/treeherder/bottom_nav_panel.js
+++ b/ui/js/directives/treeherder/bottom_nav_panel.js
@@ -51,15 +51,16 @@ treeherder.directive('thFailureClassification', [
     function ($parse, thClassificationTypes) {
         return {
             scope: {
-                failureId: "="
+                failureId: "=",
+                jobResult: "="
             },
             link: function(scope, element, attrs) {
-                scope.$watch('failureId', function(newVal) {
-                    if (newVal) {
-                        scope.classification = thClassificationTypes.classifications[newVal];
-                        scope.badgeColorClass=scope.classification.star;
+                scope.$watch('[failureId, jobResult]', function() {
+                    if (scope.failureId) {
+                        scope.classification = thClassificationTypes.classifications[scope.failureId];
                         scope.hoverText=scope.classification.name;
-                        scope.iconCls = (newVal === 7 ? "glyphicon-star-empty" : "glyphicon glyphicon-star") + " star";
+                        scope.iconCls = (scope.failureId === 7 ? "glyphicon-star-empty" : "glyphicon glyphicon-star") +
+                                         " star-" + scope.jobResult;
                     }
                 });
             },

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -119,7 +119,8 @@
       <ul ng-if="classifications.length > 0 || bugs.length > 0"
           class="list-unstyled content-spacer">
         <li ng-if="classifications.length > 0">
-          <span th-failure-classification failure-id="classifications[0].failure_classification_id"></span>
+          <span th-failure-classification failure-id="classifications[0].failure_classification_id"
+                job-result="job.result"></span>
           <a target="_blank" ng-repeat="bug in bugs"
              href="{{ getBugUrl(bug.bug_id) }}"
              title="View bug {{bug.bug_id}}"><em> {{bug.bug_id}}</em></a>


### PR DESCRIPTION
This work hopefully fixes Bugzilla bug [1281944](https://bugzilla.mozilla.org/show_bug.cgi?id=1281944).

This makes the job details classification star match the actual job result color for the selected job. Prior they were always orange (testfailed), which wasn't accurate for other result types.

**Before** (see orange classification star in lower left details panel):

![exceptioncurrent](https://cloud.githubusercontent.com/assets/3660661/16748787/321ce6fc-4794-11e6-96c2-7e8cdf4496cc.jpg)

**Proposed** (now purple here):

![exceptionproposed](https://cloud.githubusercontent.com/assets/3660661/16748797/3f94e438-4794-11e6-8e1e-f26c48c8eaff.jpg)

A big thanks to @camd for helping work through some of the angular stuff with me, to correctly access the job result property in the directive. I wasn't able to use the existing css color classes for the main jobs table because of their interdependence with before and after selectors, which messes up the star rendering in job details. So I replicated the color properties.

I have a few css colors to sort out, so marking this PR as DNM for now. Perhaps all the result types aren't necessary, or I might consolidate a few more together.

Tested on OSX 10.11.5:
Nightly **50.0a1 (2016-06-17)**
Chrome Latest Release **51.0.2704.103 (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1674)
<!-- Reviewable:end -->
