### PR TITLE
Bug 1277797 - Update to datasource 0.11.0

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -50,8 +50,8 @@ mozlog==3.2 --hash=sha256:9ecfb21801a5d9fdef28cb88abc096bb1a9551e86989ab68f113f0
 
 futures==3.0.5 --hash=sha256:f7f16b6bf9653a918a03f1f2c2d62aac0cd64b1bc088e93ea279517f6b61120b
 
-https://github.com/jeads/datasource/archive/v0.10.0.tar.gz#egg=datasource==0.10.0 \
-    --hash=sha256:7b62a9517c25750d03809076053758d5740de45a8c6c6d9194c2c0885b4a3ea2
+https://github.com/jeads/datasource/archive/v0.11.0.tar.gz#egg=datasource==0.11.0 \
+    --hash=sha256:c488520a23bf0ef9cfa5b7f794f30647bbda2e370d11d4fc7e928948e7829289
 
 # Required by jsonschema
 functools32==3.2.3-2 --hash=sha256:89d824aa6c358c421a234d7f9ee0bd75933a67c29588ce50aaa3acdf4d403fa0


### PR DESCRIPTION
To pick up Datasource's switch to mysqlclient:
https://github.com/jeads/datasource/releases/tag/v0.11.0

(Otherwise we still try to install MySQL-python alongside mysqlclient)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1675)
<!-- Reviewable:end -->
