### PR TITLE
Bug 1278800 - Fix 'scope is not defined' error from getCancelJobsTitle

### DIFF
--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -178,7 +178,7 @@ treeherderApp.controller('ResultSetCtrl', [
         };
 
         $scope.getCancelJobsTitle = function() {
-            if (!scope.user || !$scope.user.loggedin) {
+            if (!$scope.user || !$scope.user.loggedin) {
                 return "Must be logged in to cancel jobs";
             }
             var job = ThResultSetStore.getSelectedJob($scope.repoName).job;


### PR DESCRIPTION
```
Error: [$interpolate:interr] Can't interpolate: {{getCancelJobsTitle()}}
ReferenceError: scope is not defined
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1677)
<!-- Reviewable:end -->
