### PR TITLE
Bug 1286240 - Docs: Install 'wheel' at the same time as 'twine'

### DIFF
--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -201,7 +201,7 @@ Releasing a new version of the Python client
 
   .. code-block:: bash
 
-      > pip install -U twine
+      > pip install -U twine wheel
       > cd treeherder/client/
       > rm -rf dist/*
       > python setup.py sdist bdist_wheel


### PR DESCRIPTION
Since if the wheel package is not installed, it results in:
`error: invalid command 'bdist_wheel'`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1678)
<!-- Reviewable:end -->
