### PR TITLE
Bug 1287140 - Restrict job detail filters to a small set

### DIFF
--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -332,6 +332,7 @@ class JobDetailViewSet(viewsets.ReadOnlyModelViewSet):
 
         class Meta:
             model = JobDetail
+            fields = ['job_guid', 'job__guid', 'job_id__in', 'repository']
 
     filter_backends = (filters.DjangoFilterBackend, filters.OrderingFilter)
     filter_class = JobDetailFilter


### PR DESCRIPTION
We were allowing filtering on any of the model's properties, which caused
djangorestframework to try and render some ridiculous things in the browsable
api renderer (including an option form with every single job in treeherder)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1694)
<!-- Reviewable:end -->
