### PR TITLE
WIP Bug 1123814 - Desktop notifications

### DIFF
--- a/ui/css/treeherder-navbar-panels.css
+++ b/ui/css/treeherder-navbar-panels.css
@@ -167,3 +167,8 @@ a.sheriff-panel-btn {
 .sheriff-panel-text-btn:hover > .sheriff-panel-profile-edit-button {
     opacity:1 !important;
 }
+
+.watched-pushes-menu ul {
+	width: 175px;
+	padding: 10px;
+}

--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -89,18 +89,26 @@ treeherderApp.controller('JobsCtrl', [
 
 
 treeherderApp.controller('ResultSetCtrl', [
-    '$scope', '$rootScope', '$http', 'ThLog', '$location',
+    '$scope', '$rootScope', '$http', 'ThLog', '$location', '$interval',
     'thUrl', 'thServiceDomain', 'thResultStatusInfo', 'thDateFormat',
     'ThResultSetStore', 'thEvents', 'thJobFilters', 'thNotify',
     'thBuildApi', 'thPinboard', 'ThResultSetModel', 'dateFilter',
     'ThModelErrors', 'ThJobModel',
     function ResultSetCtrl(
-        $scope, $rootScope, $http, ThLog, $location,
+        $scope, $rootScope, $http, ThLog, $location, $interval,
         thUrl, thServiceDomain, thResultStatusInfo, thDateFormat,
         ThResultSetStore, thEvents, thJobFilters, thNotify,
         thBuildApi, thPinboard, ThResultSetModel, dateFilter, ThModelErrors, ThJobModel) {
 
         var $log = new ThLog(this.constructor.name);
+
+        // These have to be $rootScope because $scope is per-push, which makes this useless
+        $rootScope.watchedResultsets = [];
+        $rootScope.watchedResultsetsInterval = undefined;
+        $rootScope.removeFromWatchedResultsets = function(rs) {
+            var i = $rootScope.watchedResultsets.indexOf(rs);
+            $rootScope.watchedResultsets.splice(i,1);
+        };
 
         $scope.getCountClass = function(resultStatus) {
             return thResultStatusInfo(resultStatus).btnClass;
@@ -130,6 +138,58 @@ treeherderApp.controller('ResultSetCtrl', [
                 });
 
         };
+
+        $scope.notifyWhenDone = function(revision) {
+            Notification.requestPermission().then(function(result) {
+                if(result === "granted") {
+                    if($rootScope.watchedResultsets.length === 0) {
+                        if(!angular.isDefined($rootScope.watchedResultsetsInterval)) {
+                            $rootScope.watchedResultsetsInterval = $interval(function() {
+                                $rootScope.watchedResultsets.forEach(function(revision) {
+                                    var resultsets = ThResultSetStore.getResultSetsArray($scope.repoName);
+                                    resultsets.forEach(function(rs) {
+                                        if(rs.revision === revision) {
+                                            var percent = rs.job_counts.percentComplete;
+                                            if(percent === 100) {
+                                                spawnNotification("Push completed", revision, revision);
+                                                $rootScope.removeFromWatchedResultsets(revision);
+                                            } else {
+                                                console.log(percent);
+                                            }
+                                        }
+                                    });
+                                });
+                            }, 10000);
+                        }
+
+                    }
+                    if($rootScope.watchedResultsets.indexOf(revision) >= 0) {
+                        thNotify.send("This revision is already being watched", "warning");
+                        // I guess this could be a toggle and remove revision from watchedResultsets?
+                    } else {
+                        $rootScope.watchedResultsets.push(revision);
+                        thNotify.send("Watching revision: " + revision);
+                    }
+                } else if(result === "denied") {
+                    thNotify.send("Notifications for " + document.domain + " denied.",
+                                  "danger", "true");
+                }
+            });
+        };
+
+        function spawnNotification(title, body, tag) {
+            var options = {
+                body: body,
+                icon: "img/tree_open.png",
+                tag: tag
+            };
+            var n = new Notification(title, options);
+            n.addEventListener('click', notification_clicked);
+        }
+
+        function notification_clicked(evt) {
+            console.log(evt.target);
+        }
 
         $scope.toggleRevisions = function() {
 

--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -33,6 +33,10 @@
            href=""
            ng-show="user.is_staff"
            ng-click="triggerAllTalosJobs(resultset.revision)">Trigger All Talos jobs</a></li>
+    <li><a target="_blank" ignore-job-clear-on-click
+           href=""
+           ng-show="true"
+           ng-click="notifyWhenDone(resultset.revision)">Notify me when complete</a></li>
     <li><a target="_blank"
            href="{{toChangeValue()}}&tochange={{resultset.revision}}" prevent-default-on-left-click
            ng-click="setLocationSearchParam('tochange', resultset.revision)">Set as top of range</a></li>

--- a/ui/partials/main/thGlobalTopNavPanel.html
+++ b/ui/partials/main/thGlobalTopNavPanel.html
@@ -14,6 +14,27 @@
     </span>
 
     <span class="navbar-right">
+      <!-- Watched Pushes Menu -->
+      <span class="dropdown">
+        <span th-checkbox-dropdown-container class="watched-pushes-menu dropdown">
+          <button id="watchedPushesLabel" title="Infrastructure status" role="button"
+                  ng-show="watchedResultsets.length > 0"
+                  data-toggle="dropdown" data-target="#"
+                  class="btn btn-view-nav btn-right-navbar nav-menu-btn">Watched Pushes
+            <span class="fa fa-angle-down lightgray"></span>
+          </button>
+          <ul class="dropdown-menu" role="menu" aria-labelledby="watchedPushesLabel">
+              <span>
+                  <li>Click button to remove</li>
+                  <li role="presentation" class="divider" ng-hide="$first"></li>
+                  <li ng-repeat="rs in watchedResultsets">
+                      <button ng-click="removeFromWatchedResultsets(rs)" target="_blank">{{rs | limitTo: 12}}</button>
+                  </li>
+              </span>
+          </ul>
+        </span>
+      </span>
+            
       <!-- Sheriffing Button -->
       <span class="btn btn-view-nav btn-right-navbar nav-menu-btn"
             ng-class="{'active': (isSheriffPanelShowing)}"


### PR DESCRIPTION
When the new actionmenu button is pressed, the selected revision is added
to a list and an interval function is started.

When the interval function is run, each revision in the list is checked
for percentComplete. If that is 100%, a desktop notification is shown and
the revision is removed from the list. 

This only works while the page is currently loaded. A future PR could
implement a serviceworker that could run outside of the page, but that's
more than I want to work on for a WIP.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1698)

<!-- Reviewable:end -->
