### PR TITLE
Bug 1286463 - Update django-rest-swagger to 0.3.9

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -38,7 +38,7 @@ jsonschema==2.5.1 --hash=sha256:71e7b3bcf9fca408bcb65bb60892f375d3abdd2e4f296eee
 
 djangorestframework==3.3.3 --hash=sha256:4f47056ad798103fc9fb049dff8a67a91963bd215d31bad12ad72b891559ab16
 
-django-rest-swagger==0.3.7 --hash=sha256:bafb5e0a87683da88045bc8e1d849ba1222286820eb7b30f9552b7ad1e77972f
+django-rest-swagger==0.3.9 --hash=sha256:833ab05fad0078194efdfd6f90d4205f5259c9b21937665ed6d7629144f3e80b
 
 django-cors-headers==1.1.0 --hash=sha256:fcd96e2be47c8eef34c650e007a6d546e19e7ee61041b89edbbbbe7619aa3987
 


### PR DESCRIPTION
To pick up the XSS fix, plus:
https://github.com/marcgibbons/django-rest-swagger/blob/stable/0.3.x/CHANGELOG.md
https://github.com/marcgibbons/django-rest-swagger/compare/0.3.7...0.3.9

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1701)
<!-- Reviewable:end -->
