### PR TITLE
Bug 1287950 - Update New Relic Python agent to 2.68.0.50

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -18,7 +18,7 @@ kombu==3.0.35 --hash=sha256:2c59a5e087d5895675cdb4d6a38a0aa147f0411366e68330a76e
 
 simplejson==3.8.2 --hash=sha256:d58439c548433adcda98e695be53e526ba940a4b9c44fb9a05d92cd495cdd47f
 
-newrelic==2.66.0.49 --hash=sha256:f95b90def0c86b6d4f859664ca411bae90da76345f23ed2de40531d39e2b32a1
+newrelic==2.68.0.50 --hash=sha256:3ac02183910fe41ab75485d05474164890b993d082dca5847b0e6d24cf166f89
 
 # Required by Django and datasource
 mysqlclient==1.3.7 --hash=sha256:c74a83b4cb2933d0e43370117eeebdfa03077ae72686d2df43d31879267f1f1b


### PR DESCRIPTION
Fixes Insights missing the HTTP status code amongst other things:
https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-268050

https://github.com/edmorley/newrelic-python-agent/compare/v2.66.0.49...v2.68.0.50

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1707)
<!-- Reviewable:end -->
