### PR TITLE
Bug 1284289 - Improvements to celery task retrying & New Relic reporting

### DIFF
--- a/treeherder/etl/tasks/classification_mirroring_tasks.py
+++ b/treeherder/etl/tasks/classification_mirroring_tasks.py
@@ -1,10 +1,10 @@
 import newrelic.agent
-from celery import task
 
 from treeherder.etl.classification_mirroring import ElasticsearchDocRequest
+from treeherder.workers.task import retryable_task
 
 
-@task(name="submit-elasticsearch-doc", max_retries=10, time_limit=30)
+@retryable_task(name="submit-elasticsearch-doc", max_retries=10, time_limit=30)
 def submit_elasticsearch_doc(project, job_id, bug_id, classification_timestamp, who):
     """
     Mirror the classification to Elasticsearch using a post request, until
@@ -13,14 +13,6 @@ def submit_elasticsearch_doc(project, job_id, bug_id, classification_timestamp, 
     newrelic.agent.add_custom_parameter("project", project)
     newrelic.agent.add_custom_parameter("job_id", job_id)
     newrelic.agent.add_custom_parameter("bug_id", bug_id)
-    try:
-        req = ElasticsearchDocRequest(project, job_id, bug_id, classification_timestamp, who)
-        req.generate_request_body()
-        req.send_request()
-    except Exception as e:
-        # Initially retry after 1 minute, then for each subsequent retry
-        # lengthen the retry time by another minute.
-        submit_elasticsearch_doc.retry(exc=e, countdown=(1 + submit_elasticsearch_doc.request.retries) * 60)
-        # this exception will be raised once the number of retries
-        # exceeds max_retries
-        raise
+    req = ElasticsearchDocRequest(project, job_id, bug_id, classification_timestamp, who)
+    req.generate_request_body()
+    req.send_request()

--- a/treeherder/log_parser/failureline.py
+++ b/treeherder/log_parser/failureline.py
@@ -36,8 +36,7 @@ def fetch_log(job_log):
     try:
         log_text = fetch_text(job_log.url)
     except HTTPError as e:
-        job_log.status = JobLog.FAILED
-        job_log.save()
+        job_log.update_status(JobLog.FAILED)
         if e.response is not None and e.response.status_code in (403, 404):
             logger.warning("Unable to retrieve log for %s: %s",
                            job_log.url, e)
@@ -94,8 +93,7 @@ def create(repository, job_guid, job_log, log_list):
         FailureLine.objects.create(repository=repository, job_guid=job_guid, job_log=job_log,
                                    **failure_line)
         for failure_line in log_list]
-    job_log.status == JobLog.PARSED
-    job_log.save()
+    job_log.update_status(JobLog.PARSED)
     return failure_lines
 
 

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -113,15 +113,11 @@ def parse_log(project, job_guid, job_log, _priority):
 @parser_task
 def store_failure_lines(project, job_guid, job_log, priority):
     """This task is a wrapper for the store_failure_lines command."""
-    try:
-        logger.debug('Running store_failure_lines for job %s' % job_guid)
-        failureline.store_failure_lines(project, job_guid, job_log)
-        if settings.AUTOCLASSIFY_JOBS:
-            autoclassify.apply_async(args=[project, job_guid],
-                                     routing_key="autoclassify.%s" % priority)
-
-    except Exception as e:
-        store_failure_lines.retry(exc=e, countdown=(1 + store_failure_lines.request.retries) * 60)
+    logger.debug('Running store_failure_lines for job %s' % job_guid)
+    failureline.store_failure_lines(project, job_guid, job_log)
+    if settings.AUTOCLASSIFY_JOBS:
+        autoclassify.apply_async(args=[project, job_guid],
+                                 routing_key="autoclassify.%s" % priority)
 
 
 @retryable_task(name='crossreference-error-lines', max_retries=10)

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -102,10 +102,7 @@ def parse_log(project, job_guid, job_log, _priority):
     """
     Call ArtifactBuilderCollection on the given job.
     """
-    post_log_artifacts(project,
-                       job_guid,
-                       job_log,
-                       parse_log)
+    post_log_artifacts(project, job_guid, job_log)
 
 
 @retryable_task(name='store-failure-lines', max_retries=10)

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -130,7 +130,4 @@ def crossreference_error_lines(project, job_guid):
     newrelic.agent.add_custom_parameter("project", project)
     newrelic.agent.add_custom_parameter("job_guid", job_guid)
     logger.debug("Running crossreference-error-lines for %s" % job_guid)
-    try:
-        call_command('crossreference_error_lines', project, job_guid)
-    except Exception, e:
-        crossreference_error_lines.retry(exc=e, countdown=(1 + crossreference_error_lines.request.retries) * 60)
+    call_command('crossreference_error_lines', project, job_guid)

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -50,26 +50,23 @@ def post_log_artifacts(project, job_guid, job_log):
         # the job fails, so just warn about it -- see
         # https://bugzilla.mozilla.org/show_bug.cgi?id=1154248)
         if isinstance(e, urllib2.HTTPError) and e.code in (403, 404):
-            logger.warning("Unable to retrieve log for %s: %s",
-                           log_description, e)
+            logger.warning("Unable to retrieve log for %s: %s", log_description, e)
             return
 
-        # possibly recoverable http error (e.g. problems on our end)
         if isinstance(e, urllib2.URLError):
-            logger.error("Failed to download log for %s: %s",
-                         log_description, e)
-        # parse error or other unrecoverable error
+            # possibly recoverable http error (e.g. problems on our end)
+            logger.error("Failed to download log for %s: %s", log_description, e)
         else:
-            logger.error("Failed to download/parse log for %s: %s",
-                         log_description, e)
+            # parse error or other unrecoverable error
+            logger.error("Failed to download/parse log for %s: %s", log_description, e)
         raise
 
     try:
         create_artifacts(project, artifact_list)
         job_log.update_status(JobLog.PARSED)
-        logger.debug("Finished posting artifact for %s %s", project, job_guid)
+        logger.debug("Stored artifact for %s %s", project, job_guid)
     except Exception as e:
-        logger.error("Failed to upload parsed artifact for %s: %s", log_description, e)
+        logger.error("Failed to store parsed artifact for %s: %s", log_description, e)
         raise
 
 

--- a/treeherder/workers/task.py
+++ b/treeherder/workers/task.py
@@ -25,7 +25,7 @@ class retryable_task(object):
                 # thundering herd type problems. Constant factor chosen so we get
                 # reasonable pause between the fastest retries.
                 timeout = 10 * int(random.uniform(1.9, 2.1) ** task_func.request.retries)
-                task_func.retry(exc=e, countdown=timeout)
+                raise task_func.retry(exc=e, countdown=timeout)
 
         task_func = task(*self.task_args, **self.task_kwargs)(inner)
         return task_func

--- a/treeherder/workers/task.py
+++ b/treeherder/workers/task.py
@@ -2,6 +2,7 @@ import random
 import zlib
 from functools import wraps
 
+import newrelic.agent
 from celery import task
 from django.db.utils import (IntegrityError,
                              ProgrammingError)
@@ -30,10 +31,25 @@ class retryable_task(object):
             except self.NON_RETRYABLE_EXCEPTIONS:
                 raise
             except Exception as e:
+                number_of_prior_retries = task_func.request.retries
+                # Whilst the New Relic agent does report the exception that caused a retry,
+                # it does so in a form like:
+                #   `celery.exceptions:Retry: Retry in 640s: error('Error -3 while decompressing: incorrect header check',)`
+                # ...which causes all retry exceptions to be lumped together in the same
+                # `celery.exceptions:Retry` group. The original exception is then only
+                # reported to New Relic once the max number of retries has been reached.
+                # As such we manually report the retried exceptions to New Relic here, so
+                # that the original exception is shown verbatim immediately, and then filter
+                # out the automatic `celery.exceptions:Retry` exceptions via the web UI. See:
+                # https://docs.newrelic.com/docs/agents/python-agent/back-end-services/python-agent-celery#ignoring-task-retry-errors
+                params = {
+                    "number_of_prior_retries": number_of_prior_retries,
+                }
+                newrelic.agent.record_exception(params=params)
                 # Implement exponential backoff with some randomness to prevent
                 # thundering herd type problems. Constant factor chosen so we get
                 # reasonable pause between the fastest retries.
-                timeout = 10 * int(random.uniform(1.9, 2.1) ** task_func.request.retries)
+                timeout = 10 * int(random.uniform(1.9, 2.1) ** number_of_prior_retries)
                 raise task_func.retry(exc=e, countdown=timeout)
 
         task_func = task(*self.task_args, **self.task_kwargs)(inner)

--- a/treeherder/workers/task.py
+++ b/treeherder/workers/task.py
@@ -1,4 +1,5 @@
 import random
+import zlib
 from functools import wraps
 
 from celery import task
@@ -13,6 +14,8 @@ class retryable_task(object):
         TypeError,
         IntegrityError,
         ProgrammingError,
+        # eg during log decompression
+        zlib.error,
     )
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This improves task retrying, such that we now:
* no longer accidentally wrap several log related tasks in two nested retry cycles (for a total of 100 retries)
* reduce code duplication
* no longer retry `zlib.error` exceptions (seen when we hit bug 1284360)
* manually report the exceptions that caused tasks to retry, rather than relying on the messy automatic `celery.exceptions:Retry`, where everything is lumped into one group

This should reduce some of the log parser backlogs we've been seeing recently, as well as make it easier to interpret exceptions using the Error Analytics view in New Relic.

See individual commit messages for more information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1711)
<!-- Reviewable:end -->
