### PR TITLE
Bug 1288202 - Ignore malformed PERFHERDER_DATA lines

### DIFF
--- a/tests/log_parser/test_performance_parser.py
+++ b/tests/log_parser/test_performance_parser.py
@@ -1,0 +1,12 @@
+from treeherder.log_parser.parsers import PerformanceParser
+
+
+def test_performance_log_parsing_malformed_perfherder_data():
+    """
+    If we have one malformed perfherder data line, we should just ignore
+    it and still be able to parse the next one
+    """
+    parser = PerformanceParser()
+    parser.parse_line("PERFHERDER_DATA: {oh noes i am not valid json}", 1)
+    parser.parse_line("PERFHERDER_DATA: {}", 2)
+    assert parser.get_artifact() == [{}]

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -1,10 +1,13 @@
 import datetime
 import json
+import logging
 import re
 
 from django.conf import settings
 
 from treeherder.etl.buildbot import RESULT_DICT
+
+logger = logging.getLogger(__name__)
 
 
 class ParserBase(object):
@@ -452,9 +455,12 @@ class PerformanceParser(ParserBase):
     def parse_line(self, line, lineno):
         match = self.RE_PERFORMANCE.match(line)
         if match:
-            # this will throw an exception if the json parsing breaks, but
-            # that's the behaviour we want
-            self.artifact.append(json.loads(match.group(1)))
+            try:
+                dict = json.loads(match.group(1))
+                self.artifact.append(dict)
+            except ValueError:
+                logger.warning("Unable to parse Perfherder data from line: %s",
+                               line)
             # don't mark as complete, in case there are multiple performance
             # artifacts
             # self.complete = True


### PR DESCRIPTION
Sometimes a non-valid PERFHERDER string can be found in a log because
of debugging code or other reasons. There's no reason to not parse the rest
of the log for a job if we find one of them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1714)
<!-- Reviewable:end -->
