### PR TITLE
Bug 1263236 - Indicate initial page is loaded in css - DO NOT MERGE

### DIFF
--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -1,5 +1,6 @@
 <!-- Load progress bar -->
-<div class="progress progress-striped active"
+<div class="progress progress-striped active" id="load-resultsets-progress-bar"
+     ng-class="{'page-loaded': !isLoadingRsBatch.prepending && result_sets.length !=0 && !isLoadingJobs}"
      ng-show="isLoadingRsBatch.prepending && result_sets.length === 0">
   <div class="progress-bar"  role="progressbar" style="width: 100%"></div>
 </div>
@@ -106,9 +107,11 @@
 <!-- End resultset clone target -->
 
 <!-- New resultsets progress bar -->
-<div class="progress progress-striped active"
+<div class="progress progress-striped active" id="new-resultsets-progress-bar"
      ng-show="isLoadingRsBatch.appending">
-  <div class="progress-bar"  role="progressbar" style="width: 100%"></div>
+  <div class="progress-bar"
+       ng-class="{'page-loaded': result_sets.length != 0 && !isLoadingRsBatch.appending && !isLoadingJobs}"
+       role="progressbar" style="width: 100%"></div>
 </div>
 
 <!-- Get next resultsets footer -->


### PR DESCRIPTION
This work hopefully fixes bug [1263236](https://bugzilla.mozilla.org/show_bug.cgi?id=1263236).

This adds a `page-loaded` class per the bug request, so when either the page load is complete with an initial resultset(s), or a 'get next 10, 20, 50' resultset load is complete, the two related progress bar elements which are then hidden, have that class applied.

This should allow test automation to not fire on the DOM prematurely, and the scripts can test and wait until the classes are present on both elements.

Perhaps a more economical way would be to just test for the existing ng-hide ng-show on both elements using their new ids `new-resultsets-progress-bar` and `load-resultsets-progress-bar`. But whatever the WebQA team prefers. :)

Everything seems to be behaving as I'd expect, from what I can evaluate in inspector after the load.

Tested on OSX 10.11.5:
Nightly **50.0a1 (2016-07-12)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1719)
<!-- Reviewable:end -->
