### PR TITLE
make clear the name of the module

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -26,6 +26,12 @@ using pip:
 
     pip install treeherder-client
 
+It will install a module called `thclient` that you can access, for example:
+
+.. code-block:: python
+
+    from thclient import TreeherderClient
+
 By default the production Treeherder API will be used, however this can be
 overridden by passing a `server_url` argument to the `TreeherderClient`
 constructor:


### PR DESCRIPTION
This was my first stop in the docs and playing around with treeherder and just wasn't sure what the import was so had to go read some code. Thought it might be `treeherder`, or `treeherder_client`, I know its mentioned later on, but thought it would help anyone who didn't read the docs later on :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1720)
<!-- Reviewable:end -->
