### PR TITLE
Swallow exceptions raised during datasource disconnect when there is a preexisting exception

### DIFF
--- a/treeherder/model/derived/base.py
+++ b/treeherder/model/derived/base.py
@@ -32,7 +32,15 @@ class TreeherderModelBase(object):
         return self
 
     def __exit__(self, type, value, traceback):
-        self.disconnect()
+        try:
+            self.disconnect()
+        except Exception as e:
+            if traceback:
+                # If there is an earlier exception swallow this one, since it is probably
+                # a result of the existing bad state
+                pass
+            else:
+                raise e
 
     def __str__(self):
         """String representation is project name."""


### PR DESCRIPTION
This prevents failures during disconnect masking the underlying problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1722)
<!-- Reviewable:end -->
