### PR TITLE
Bug 1289159 - Fix contribute.json so it parses and is available at site root

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,6 +131,7 @@ module.exports = function(grunt) {
 
             main: {
                 files: [
+                    { src:'contribute.json', dest:'dist/contribute.json', nonull: true },
                     { src:'ui/robots.txt', dest:'dist/robots.txt', nonull: true },
                     { src:'ui/index.html', dest:'dist/index.html', nonull: true },
                     { src:'ui/userguide.html', dest:'dist/userguide.html', nonull: true },

--- a/contribute.json
+++ b/contribute.json
@@ -10,15 +10,22 @@
     "home": "https://wiki.mozilla.org/EngineeringProductivity/Projects/Treeherder",
     "docs": "https://treeherder.readthedocs.io/",
     "irc": "irc://irc.mozilla.org/#treeherder",
-    "mailing-list": "https://groups.google.com/forum/#!forum/mozilla.tools.treeherder",
+    "mailing-list": "https://groups.google.com/forum/#!forum/mozilla.tools.treeherder"
   },
   "bugs": {
-    "list": "http://mzl.la/1sXfyqI",
+    "list": "https://bugzilla.mozilla.org/buglist.cgi?quicksearch=%3Atreeherder",
     "report": "https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree%20Management&component=Treeherder"
   },
   "urls": {
     "prod": "https://treeherder.mozilla.org/",
     "stage": "https://treeherder.allizom.org/"
   },
-  "keywords": ["css", "django", "jquery", "angular", "js", "python"]
+  "keywords": [
+    "css",
+    "django",
+    "jquery",
+    "angular",
+    "js",
+    "python"
+  ]
 }


### PR DESCRIPTION
* Make contribute.json valid json
* Make contribute.json available at site root (so web based tools can find it when eg automatically reporting bugs)

This boosts our HTTP Observatory score (with which all Mozilla sites are about to be analysed).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1725)
<!-- Reviewable:end -->
