### PR TITLE
Bug 1284432 - Use SQL ON DELETE to propogate job-related deletions.

### DIFF
--- a/treeherder/model/migrations/0033_job_delete_cascade.py
+++ b/treeherder/model/migrations/0033_job_delete_cascade.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+import treeherder.model.fields
+
+
+def db_func(direction, table, apps, schema_editor):
+    assert direction in ("forward", "reverse")
+    cursor = schema_editor.connection.cursor()
+    cursor.execute("""SELECT CONSTRAINT_NAME
+                        FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+                        WHERE
+                          REFERENCED_TABLE_SCHEMA = 'treeherder' AND
+                          TABLE_NAME = %s AND
+                          REFERENCED_TABLE_NAME = 'job'""", [table])
+
+    fk_row = cursor.fetchone()
+    if fk_row:
+        fk_name = fk_row[0]
+        try:
+            cursor.execute("""ALTER TABLE %s DROP FOREIGN KEY %s""" % (table, fk_name))
+        except:
+            pass
+
+    cursor.execute("""ALTER TABLE %s
+                        ADD CONSTRAINT %s_fk_job_id
+                        FOREIGN KEY (`job_id`)
+                        REFERENCES `job` (`id`)
+                        %s;""" % (table, table, "ON DELETE CASCADE" if direction == "forward" else ""))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0032_bugjobmap_jobnote_models'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='bugjobmap',
+            name='job',
+            field=treeherder.model.fields.FlexibleForeignKey(to='model.Job', on_delete=django.db.models.deletion.DO_NOTHING),
+        ),
+
+        migrations.AlterField(
+            model_name='jobdetail',
+            name='job',
+            field=treeherder.model.fields.FlexibleForeignKey(to='model.Job', on_delete=django.db.models.deletion.DO_NOTHING),
+        ),
+
+        migrations.AlterField(
+            model_name='joblog',
+            name='job',
+            field=treeherder.model.fields.FlexibleForeignKey(to='model.Job', on_delete=django.db.models.deletion.DO_NOTHING),
+        ),
+
+        migrations.AlterField(
+            model_name='jobnote',
+            name='job',
+            field=treeherder.model.fields.FlexibleForeignKey(to='model.Job', on_delete=django.db.models.deletion.DO_NOTHING),
+        ),
+
+        migrations.RunPython(lambda x,y: db_func("forward", "bug_job_map", x, y),
+                             lambda x,y: db_func("reverse", "bug_job_map", x, y),
+                             atomic=False),
+
+        migrations.RunPython(lambda x,y: db_func("forward", "job_detail", x, y),
+                             lambda x,y: db_func("reverse", "job_detail", x, y),
+                             atomic=False),
+
+        migrations.RunPython(lambda x,y: db_func("forward", "job_log", x, y),
+                             lambda x,y: db_func("reverse", "job_log", x, y),
+                             atomic=False),
+
+        migrations.RunPython(lambda x,y: db_func("forward", "job_note", x, y),
+                             lambda x,y: db_func("reverse", "job_note", x, y),
+                             atomic=False),
+
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -604,7 +604,8 @@ class JobDetail(models.Model):
     MAX_FIELD_LENGTH = 512
 
     id = BigAutoField(primary_key=True)
-    job = FlexibleForeignKey(Job)
+    job = FlexibleForeignKey(Job,
+                             on_delete=models.DO_NOTHING)
     title = models.CharField(max_length=MAX_FIELD_LENGTH, null=True)
     value = models.CharField(max_length=MAX_FIELD_LENGTH)
     url = models.URLField(null=True, max_length=MAX_FIELD_LENGTH)
@@ -634,7 +635,8 @@ class JobLog(models.Model):
                 (PARSED, 'parsed'),
                 (FAILED, 'failed'))
 
-    job = FlexibleForeignKey(Job)
+    job = FlexibleForeignKey(Job,
+                             on_delete=models.DO_NOTHING)
     name = models.CharField(max_length=50)
     url = models.URLField(max_length=255)
     status = models.IntegerField(choices=STATUSES, default=PENDING)
@@ -663,7 +665,8 @@ class BugJobMap(models.Model):
     '''
     id = BigAutoField(primary_key=True)
 
-    job = FlexibleForeignKey(Job)
+    job = FlexibleForeignKey(Job,
+                             on_delete=models.DO_NOTHING)
     bug_id = models.PositiveIntegerField(db_index=True)
     created = models.DateTimeField(default=timezone.now)
     user = models.ForeignKey(User, null=True)  # null if autoclassified
@@ -724,7 +727,8 @@ class JobNote(models.Model):
     '''
     id = BigAutoField(primary_key=True)
 
-    job = FlexibleForeignKey(Job)
+    job = FlexibleForeignKey(Job,
+                             on_delete=models.DO_NOTHING)
     failure_classification = models.ForeignKey(FailureClassification)
     user = models.ForeignKey(User, null=True)  # null if autoclassified
     text = models.TextField()


### PR DESCRIPTION
This is expected to perform better than the django solution which has to
load the relationships before performing the deletions.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1733)

<!-- Reviewable:end -->
