### PR TITLE
Bug 1275405 - Clean up the API permissions system

### DIFF
--- a/tests/webapp/api/test_auth.py
+++ b/tests/webapp/api/test_auth.py
@@ -1,4 +1,5 @@
 from mohawk import Sender
+from rest_framework import status
 from rest_framework.decorators import APIView
 from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory
@@ -46,6 +47,7 @@ def _get_hawk_response(client_id, secret, method='GET',
 def test_get_hawk_authorized(client_credentials):
     response = _get_hawk_response(client_credentials.client_id,
                                   str(client_credentials.secret))
+    assert response.status_code == status.HTTP_200_OK
     assert response.data == {'authenticated': True}
 
 
@@ -54,6 +56,7 @@ def test_get_hawk_unauthorized(client_credentials):
     client_credentials.save()
     response = _get_hawk_response(client_credentials.client_id,
                                   str(client_credentials.secret))
+    assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.data == {'detail': ('No authentication credentials '
                                         'found with id %s') % client_credentials.client_id}
 
@@ -62,6 +65,7 @@ def test_post_hawk_authorized(client_credentials):
     response = _get_hawk_response(client_credentials.client_id,
                                   str(client_credentials.secret), method='POST',
                                   content="{'this': 'that'}")
+    assert response.status_code == status.HTTP_200_OK
     assert response.data == {'authenticated': True}
 
 
@@ -71,6 +75,7 @@ def test_post_hawk_unauthorized(client_credentials):
     response = _get_hawk_response(client_credentials.client_id,
                                   str(client_credentials.secret), method='POST',
                                   content="{'this': 'that'}")
+    assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.data == {'detail': ('No authentication credentials '
                                         'found with id %s') % client_credentials.client_id}
 
@@ -79,5 +84,5 @@ def test_no_auth():
     request = factory.get(url)
     view = AuthenticatedView.as_view()
     response = view(request)
-
+    assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.data == {'detail': 'Authentication credentials were not provided.'}

--- a/tests/webapp/api/test_auth.py
+++ b/tests/webapp/api/test_auth.py
@@ -8,13 +8,13 @@ from treeherder.webapp.api import permissions
 
 
 class AuthenticatedView(APIView):
-    permission_classes = (permissions.HasHawkPermissions,)
+    permission_classes = (permissions.HasHawkPermissionsOrReadOnly,)
 
     def get(self, request, *args, **kwargs):
-        return Response({'authenticated': True})
+        return Response({'foo': 'bar'})
 
     def post(self, request, *args, **kwargs):
-        return Response({'authenticated': True})
+        return Response({'foo': 'bar'})
 
 factory = APIRequestFactory()
 url = 'http://testserver/'
@@ -48,7 +48,7 @@ def test_get_hawk_authorized(client_credentials):
     response = _get_hawk_response(client_credentials.client_id,
                                   str(client_credentials.secret))
     assert response.status_code == status.HTTP_200_OK
-    assert response.data == {'authenticated': True}
+    assert response.data == {'foo': 'bar'}
 
 
 def test_get_hawk_unauthorized(client_credentials):
@@ -65,8 +65,8 @@ def test_get_no_auth():
     request = factory.get(url)
     view = AuthenticatedView.as_view()
     response = view(request)
-    assert response.status_code == status.HTTP_403_FORBIDDEN
-    assert response.data == {'detail': 'Authentication credentials were not provided.'}
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == {'foo': 'bar'}
 
 
 def test_post_hawk_authorized(client_credentials):
@@ -74,7 +74,7 @@ def test_post_hawk_authorized(client_credentials):
                                   str(client_credentials.secret), method='POST',
                                   content="{'this': 'that'}")
     assert response.status_code == status.HTTP_200_OK
-    assert response.data == {'authenticated': True}
+    assert response.data == {'foo': 'bar'}
 
 
 def test_post_hawk_unauthorized(client_credentials):

--- a/tests/webapp/api/test_auth.py
+++ b/tests/webapp/api/test_auth.py
@@ -57,7 +57,7 @@ def test_get_hawk_unauthorized(client_credentials):
     response = _get_hawk_response(client_credentials.client_id,
                                   str(client_credentials.secret))
     assert response.status_code == status.HTTP_403_FORBIDDEN
-    assert response.data == {'detail': ('No authentication credentials '
+    assert response.data == {'detail': ('No authorised credentials '
                                         'found with id %s') % client_credentials.client_id}
 
 
@@ -84,7 +84,7 @@ def test_post_hawk_unauthorized(client_credentials):
                                   str(client_credentials.secret), method='POST',
                                   content="{'this': 'that'}")
     assert response.status_code == status.HTTP_403_FORBIDDEN
-    assert response.data == {'detail': ('No authentication credentials '
+    assert response.data == {'detail': ('No authorised credentials '
                                         'found with id %s') % client_credentials.client_id}
 
 

--- a/tests/webapp/api/test_auth.py
+++ b/tests/webapp/api/test_auth.py
@@ -47,8 +47,6 @@ def _get_hawk_response(client_id, secret, method='GET',
 
 
 def test_get_hawk_authorized(client_credentials):
-    client_credentials.authorized = True
-    client_credentials.save()
     response = _get_hawk_response(client_credentials.client_id,
                                   str(client_credentials.secret))
     assert response.data == {'authenticated': True}
@@ -64,8 +62,6 @@ def test_get_hawk_unauthorized(client_credentials):
 
 
 def test_post_hawk_authorized(client_credentials):
-    client_credentials.authorized = True
-    client_credentials.save()
     response = _get_hawk_response(client_credentials.client_id,
                                   str(client_credentials.secret), method='POST',
                                   content="{'this': 'that'}")

--- a/tests/webapp/api/test_auth.py
+++ b/tests/webapp/api/test_auth.py
@@ -61,6 +61,14 @@ def test_get_hawk_unauthorized(client_credentials):
                                         'found with id %s') % client_credentials.client_id}
 
 
+def test_get_no_auth():
+    request = factory.get(url)
+    view = AuthenticatedView.as_view()
+    response = view(request)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.data == {'detail': 'Authentication credentials were not provided.'}
+
+
 def test_post_hawk_authorized(client_credentials):
     response = _get_hawk_response(client_credentials.client_id,
                                   str(client_credentials.secret), method='POST',
@@ -80,8 +88,8 @@ def test_post_hawk_unauthorized(client_credentials):
                                         'found with id %s') % client_credentials.client_id}
 
 
-def test_no_auth():
-    request = factory.get(url)
+def test_post_no_auth():
+    request = factory.post(url)
     view = AuthenticatedView.as_view()
     response = view(request)
     assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -315,6 +315,9 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
         'hawkrest.HawkAuthentication',
     ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
+    ),
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 

--- a/treeherder/webapp/api/auth.py
+++ b/treeherder/webapp/api/auth.py
@@ -1,5 +1,5 @@
 import newrelic.agent
-from rest_framework import exceptions
+from rest_framework.exceptions import AuthenticationFailed
 
 from treeherder.credentials.models import Credentials
 
@@ -9,8 +9,7 @@ def hawk_lookup(id):
         newrelic.agent.add_custom_parameter("hawk_client_id", id)
         credentials = Credentials.objects.get(client_id=id, authorized=True)
     except Credentials.DoesNotExist:
-        raise exceptions.AuthenticationFailed(
-            'No authentication credentials found with id %s' % id)
+        raise AuthenticationFailed('No authorised credentials found with id %s' % id)
 
     return {
         'id': id,

--- a/treeherder/webapp/api/bug.py
+++ b/treeherder/webapp/api/bug.py
@@ -1,5 +1,4 @@
 from rest_framework import viewsets
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.status import HTTP_404_NOT_FOUND
 
@@ -10,7 +9,6 @@ from .serializers import BugJobMapSerializer
 
 
 class BugJobMapViewSet(viewsets.ViewSet):
-    permission_classes = (IsAuthenticatedOrReadOnly,)
 
     def create(self, request, project):
         """

--- a/treeherder/webapp/api/bugzilla.py
+++ b/treeherder/webapp/api/bugzilla.py
@@ -2,7 +2,6 @@ import requests
 from django.conf import settings
 from rest_framework import viewsets
 from rest_framework.decorators import list_route
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.status import HTTP_400_BAD_REQUEST
 
@@ -10,7 +9,6 @@ from treeherder.etl.common import make_request
 
 
 class BugzillaViewSet(viewsets.ViewSet):
-    permission_classes = (IsAuthenticatedOrReadOnly,)
 
     @list_route(methods=['post'])
     def create_bug(self, request):

--- a/treeherder/webapp/api/classifiedfailure.py
+++ b/treeherder/webapp/api/classifiedfailure.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 import rest_framework_filters as filters
 from rest_framework import viewsets
 from rest_framework.decorators import detail_route
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.status import (HTTP_200_OK,
                                    HTTP_400_BAD_REQUEST,
@@ -23,7 +22,6 @@ class ClassifiedFailureFilter(filters.FilterSet):
 
 
 class ClassifiedFailureViewSet(viewsets.ModelViewSet):
-    permission_classes = (IsAuthenticatedOrReadOnly,)
     serializer_class = serializers.ClassifiedFailureSerializer
     queryset = ClassifiedFailure.objects.all()
     filter_class = ClassifiedFailureFilter

--- a/treeherder/webapp/api/failureline.py
+++ b/treeherder/webapp/api/failureline.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from django.db import transaction
 from rest_framework import (mixins,
                             viewsets)
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.status import (HTTP_200_OK,
                                    HTTP_400_BAD_REQUEST,
@@ -17,7 +16,6 @@ from treeherder.webapp.api.utils import as_dict
 
 
 class FailureLineViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
-    permission_classes = (IsAuthenticatedOrReadOnly,)
     queryset = FailureLine.objects.prefetch_related("matches", "matches__matcher").all()
     serializer_class = serializers.FailureLineNoStackSerializer
 

--- a/treeherder/webapp/api/note.py
+++ b/treeherder/webapp/api/note.py
@@ -1,6 +1,5 @@
 from rest_framework import viewsets
 from rest_framework.exceptions import ParseError
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.status import HTTP_404_NOT_FOUND
 
@@ -11,11 +10,10 @@ from .serializers import JobNoteSerializer
 
 
 class NoteViewSet(viewsets.ViewSet):
-    permission_classes = (IsAuthenticatedOrReadOnly,)
-
     """
     This viewset is responsible for the note endpoint.
     """
+
     def retrieve(self, request, project, pk=None):
         """
         GET method implementation for a note detail

--- a/treeherder/webapp/api/permissions.py
+++ b/treeherder/webapp/api/permissions.py
@@ -10,9 +10,7 @@ class IsStaffOrReadOnly(permissions.BasePermission):
 
     def has_permission(self, request, view):
         return (request.method in permissions.SAFE_METHODS or
-                request.user and
-                request.user.is_authenticated() and
-                request.user.is_staff)
+                request.user and request.user.is_staff)
 
 
 class IsOwnerOrReadOnly(permissions.BasePermission):

--- a/treeherder/webapp/api/permissions.py
+++ b/treeherder/webapp/api/permissions.py
@@ -32,21 +32,11 @@ class IsOwnerOrReadOnly(permissions.BasePermission):
         return obj.user == request.user
 
 
-class HasHawkPermissions(permissions.BasePermission):
-
-    def has_permission(self, request, view):
-        hawk_header = 'hawk.receiver'
-
-        if hawk_header in request.META and isinstance(request.META[hawk_header], Receiver):
-            return True
-        return False
-
-
 class HasHawkPermissionsOrReadOnly(permissions.BasePermission):
 
     def has_permission(self, request, view):
-
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        return HasHawkPermissions().has_permission(request, view)
+        hawk_header = request.META.get('hawk.receiver')
+        return hawk_header and isinstance(hawk_header, Receiver)

--- a/treeherder/webapp/api/text_log_summary.py
+++ b/treeherder/webapp/api/text_log_summary.py
@@ -1,6 +1,5 @@
 import rest_framework_filters as filters
 from rest_framework import viewsets
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
 from treeherder.model.models import TextLogSummary
 from treeherder.webapp.api import (pagination,
@@ -14,7 +13,6 @@ class TextLogSummaryFilter(filters.FilterSet):
 
 
 class TextLogSummaryViewSet(viewsets.ModelViewSet):
-    permission_classes = (IsAuthenticatedOrReadOnly,)
     serializer_class = serializers.TextLogSummarySerializer
     queryset = TextLogSummary.objects.all()
     filter_class = TextLogSummaryFilter

--- a/treeherder/webapp/api/text_log_summary_line.py
+++ b/treeherder/webapp/api/text_log_summary_line.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 
 import rest_framework_filters as filters
 from rest_framework import viewsets
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.status import (HTTP_200_OK,
                                    HTTP_400_BAD_REQUEST,
@@ -21,7 +20,6 @@ class TextLogSummaryLineFilter(filters.FilterSet):
 
 
 class TextLogSummaryLineViewSet(viewsets.ModelViewSet):
-    permission_classes = (IsAuthenticatedOrReadOnly,)
     serializer_class = serializers.TextLogSummaryLineSerializer
     queryset = TextLogSummaryLine.objects.all()
     filter_class = TextLogSummaryLineFilter


### PR DESCRIPTION
* Refactors test_auth.py to increase test coverage and prepare for later changes.
* Clarifies the error message shown to clients when the specified Hawk `client_id` was not authorised/found.
* Merges the redundant `HasHawkPermissions` into `HasHawkPermissionsOrReadOnly`.
* Removes unnecessary checks inside `IsStaffOrReadOnly`.
* Sets an API-wide default of the `IsAuthenticatedOrReadOnly` permissions class (which accepts either Hawk or Django user authentication), which prevents us from adding new API endpoints that are writeable even by anyone, even in they are not logged in.

These changes also simplify my work in bug 1277304 / #1627, since there are now fewer places to adjust when trying to block all writes when down for maintenance.

As always, see individual commit messages for more details :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1740)
<!-- Reviewable:end -->
