### PR TITLE
Bug 1286702 - Fix hostname extraction in server_supports_tls()

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -341,7 +341,7 @@ DISALLOWED_USER_AGENTS = (
 )
 
 SITE_URL = env("SITE_URL", default="http://local.treeherder.mozilla.org")
-SITE_HOSTNAME = urlparse(SITE_URL).netloc
+SITE_HOSTNAME = urlparse(SITE_URL).hostname
 APPEND_SLASH = False
 
 BUILDAPI_PENDING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-pending.js"

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -12,7 +12,7 @@ env = environ.Env()
 
 
 def server_supports_tls(url):
-    hostname = urlparse(url).netloc
+    hostname = urlparse(url).hostname
     # Services such as RabbitMQ/Elasticsearch running on Travis/Vagrant
     # or in SCl3 do not support TLS. We could try adding locally using
     # self-signed certs, but until Travis has support it's not overly useful.


### PR DESCRIPTION
urlparse's `netloc` attribute (which I'd copied from the `SITE_HOSTNAME` usage elsewhere in settings.py) includes the port number as well as the hostname, and so was causing the SCL3 hostname check to not match (since the environment variable there includes the default port, even though it doesn't need to), meaning TLS was enabled for celery on SCL3 when the rabbitmq instance there doesn't support it.

Also changes `SITE_HOSTNAME` to use what we really wanted, which was `hostname` not `netloc`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1753)
<!-- Reviewable:end -->
