### PR TITLE
Bug 1291882 - Work around duplicate build_platform and machine_platform

### DIFF
--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -1,7 +1,7 @@
 import logging
 import zlib
-import newrelic.agent
 
+import newrelic.agent
 import simplejson as json
 from django.core.exceptions import MultipleObjectsReturned
 from django.forms import model_to_dict

--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -1,7 +1,9 @@
 import logging
 import zlib
+import newrelic.agent
 
 import simplejson as json
+from django.core.exceptions import MultipleObjectsReturned
 from django.forms import model_to_dict
 
 from treeherder.etl.perf import load_perf_artifacts
@@ -113,9 +115,14 @@ class ArtifactsModel(TreeherderModelBase):
                                        job.guid))
                     job_detail_dict[k] = v[:max_field_length]
 
-            JobDetail.objects.get_or_create(
-                job=job,
-                **job_detail_dict)
+            # workaround for bug 1278711,  When that bug is fixed, then we
+            # can remove this fall-back.
+            try:
+                JobDetail.objects.get_or_create(
+                    job=job,
+                    **job_detail_dict)
+            except MultipleObjectsReturned as ex:
+                newrelic.agent.record_exception(ex)
 
     def store_performance_artifact(
             self, job_ids, performance_artifact_placeholders):

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -9,7 +9,8 @@ from itertools import chain
 import newrelic.agent
 from _mysql_exceptions import IntegrityError
 from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
+from django.core.exceptions import (MultipleObjectsReturned,
+                                    ObjectDoesNotExist)
 
 from treeherder.etl.common import get_guid_root
 from treeherder.model import (error_summary,


### PR DESCRIPTION
This will work around if the ``get_or_create`` for build_platform or machine_platform returns more than one object.  Job ingestion won't be stopped because of that error.   There are a few steps required to fix this problem, detailed in the bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1757)
<!-- Reviewable:end -->
