### PR TITLE
Bug 1291882 - Add unique_together index on build_platform table

### DIFF
--- a/treeherder/model/migrations/0034_add_unique_together_build_machine_platform.py
+++ b/treeherder/model/migrations/0034_add_unique_together_build_machine_platform.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0033_add_branch_field_to_repository'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='buildplatform',
+            unique_together=set([('os_name', 'platform', 'architecture')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='machineplatform',
+            unique_together=set([('os_name', 'platform', 'architecture')]),
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -67,6 +67,7 @@ class BuildPlatform(models.Model):
 
     class Meta:
         db_table = 'build_platform'
+        unique_together = ("os_name", "platform", "architecture")
 
     def __str__(self):
         return "{0} {1} {2}".format(
@@ -119,6 +120,7 @@ class MachinePlatform(models.Model):
 
     class Meta:
         db_table = 'machine_platform'
+        unique_together = ("os_name", "platform", "architecture")
 
     def __str__(self):
         return "{0} {1} {2}".format(


### PR DESCRIPTION
Also to the machine_platform table.

This is necessary because we use a get_or_create() on these
tables, but without the unique index, we can (and did) get
duplicates which then blocked data ingestion of jobs on try.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1759)
<!-- Reviewable:end -->
