### PR TITLE
Bug 1292708 - Scroll job into view if it is hidden behind the navbar/header

### DIFF
--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -806,7 +806,7 @@ treeherder.directive('thCloneJobs', [
 
         var isOnScreen = function(el){
             var viewport = {};
-            viewport.top = $(window).scrollTop();
+            viewport.top = $(window).scrollTop() + $("#global-navbar-container").height();
             viewport.bottom = viewport.top + $(window).height() - $("#info-panel").height();
             var bounds = {};
             bounds.top = el.offset().top;


### PR DESCRIPTION
Edge case I apparently missed when testing Bug 1289651.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1763)
<!-- Reviewable:end -->
