### PR TITLE
Bug 1293447 - Use a placeholder attribute instead of a separate element for placeholder text

### DIFF
--- a/ui/css/treeherder-pinboard.css
+++ b/ui/css/treeherder-pinboard.css
@@ -140,24 +140,12 @@
   width: 177px;
 }
 
-.classification-comment-container {
-  margin-top: 5px;
-  height: 20px;
-}
-
 .add-classification-input {
   width: 177px;
   height: 20px;
   padding: 0 0 0 3px;
   border-radius: 0;
   font-size: 12px;
-}
-
-.classification-comment-preload-txt {
-  position: relative;
-  top: -17px;
-  left: 5px;
-  pointer-events: none;
 }
 
 /*

--- a/ui/partials/main/thPinboardPanel.html
+++ b/ui/partials/main/thPinboardPanel.html
@@ -54,10 +54,8 @@
                class="form-control add-classification-input mousetrap"
                ng-model="classification.text"
                ng-click="allowKeys()"
+               placeholder="click to add comment"
                focus-this blur-this></input>
-        <span class="pinboard-preload-txt classification-comment-preload-txt"
-              ng-if="!classification.text">
-              click to add comment</span>
       </div>
     </form>
   </div>


### PR DESCRIPTION
The only change in functionality from using the separate element is that this placeholder goes away immediately when the input has focus, while the old, separate placeholder stayed until you started typing into the input. Not sure we care, though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1769)
<!-- Reviewable:end -->
