### PR TITLE
Bug 1289156 - Vendor libmysqlclient 5.7 to protect against CVE-2015-3152

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 env:
   global:
+    # Ensure the vendored libmysqlclient library can be found at run-time.
+    - LD_LIBRARY_PATH="$HOME/venv/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
     - BROKER_URL='amqp://guest:guest@localhost:5672//'
     - DATABASE_URL='mysql://root@localhost/test_treeherder'
     - DATABASE_URL_RO='mysql://root@localhost/test_treeherder'
@@ -85,6 +87,7 @@ matrix:
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
         - pip install --disable-pip-version-check --upgrade pip==8.1.1
+        - ./bin/vendor-libmysqlclient.sh ~/venv
         # Create the test database for `manage.py check --deploy`.
         - mysql -u root -e 'create database test_treeherder;'
       install:
@@ -132,6 +135,7 @@ matrix:
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
         - pip install --disable-pip-version-check --upgrade pip==8.1.1
+        - ./bin/vendor-libmysqlclient.sh ~/venv
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
       script:
@@ -169,6 +173,7 @@ matrix:
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
         - pip install --disable-pip-version-check --upgrade pip==8.1.1
+        - ./bin/vendor-libmysqlclient.sh ~/venv
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
       script:

--- a/bin/pre_compile
+++ b/bin/pre_compile
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Tasks run by the Heroku Python buildpack prior to the compile step.
+
+# Make non-zero exit codes & other errors fatal.
+set -euo pipefail
+
+VENDOR_DIR=".heroku/vendor"
+
+# Hacks to work around pre_compile being run before cache is restored.
+# Remove when this PR is merged:
+# https://github.com/heroku/heroku-buildpack-python/pull/321
+VENDOR_DIR="$CACHE_DIR/$VENDOR_DIR"
+mkdir -p "$VENDOR_DIR"
+export PATH="$VENDOR_DIR/bin:$PATH"
+
+./bin/vendor-libmysqlclient.sh "$VENDOR_DIR"
+
+# The existing value for `LD_LIBRARY_PATH` only includes `$VENDOR_DIR/lib` and not
+# also the `x86_64-linux-gnu` directory that the libmysqlclient package will create
+# inside it. Directories in `LD_LIBRARY_PATH` are not searched recursively and we
+# cannot add additional directories, since `pre_compile` is run in a sub-shell. In
+# addition, `vendor-libmysqlclient.sh` cannot flatten the directory structure,
+# since `mysql_config` uses relative paths that include `x86_64-linux-gnu`.
+# As such, we have to create a symlink to ensure the library is found at runtime.
+ln -rsf "$VENDOR_DIR/lib/x86_64-linux-gnu/libmysqlclient.so.20" "$VENDOR_DIR/lib/libmysqlclient.so.20"

--- a/bin/vendor-libmysqlclient.sh
+++ b/bin/vendor-libmysqlclient.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# The latest versions of libmysqlclient 5.5/5.6 (used by mysqlclient) are still
+# vulnerable to TLS stripping, even after last year's backports of 5.7.x fixes:
+#   - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3152
+#   - https://bugzilla.mozilla.org/show_bug.cgi?id=1289156
+#   - http://bugs.mysql.com/bug.php?id=82383
+#
+# Ideally we'd just use the standalone Connector/C library instead of the
+# libmysqlclient packages, however the latest release is too old:
+#   - http://bugs.mysql.com/bug.php?id=82448
+#
+# Heroku's cedar-14 stack comes with libmysqlclient 5.5.x, so until it is updated
+# to 5.7.x (https://github.com/heroku/stack-images/pull/38) we must manually vendor
+# 5.7.X ourselves, so that connections between the Heroku dynos and our public RDS
+# instances are secure. We can do this and still remain on MySQL server 5.6, since
+# newer client releases are backwards compatible with older server versions.
+#
+# Whilst the Vagrant/Travis MySQL instances don't use TLS (and so aren't affected),
+# we still want them to use libmysqlclient 5.7, to be consistent with production.
+#
+# Usage:
+#    ./bin/vendor-libmysqlclient.sh "foo/vendor-dir"
+#
+# NB: The `foo/vendor-dir/bin` directory must be on the PATH ahead of `/usr/bin`
+# during pip install (so mysqlclient finds `mysql_config`), and `LD_LIBRARY_PATH`
+# must include `foo/vendor-dir/lib/x86_64-linux-gnu` at Python runtime.
+
+# Make non-zero exit codes & other errors fatal.
+set -euo pipefail
+
+VENDOR_DIR="$1"
+VERSION="5.7.14"
+PACKAGE_URLS=(
+    # We have to use packages from mysql.com since there is no Ubuntu distro
+    # release available for MySQL 5.7 on Ubuntu 14.04.
+    "https://cdn.mysql.com/Downloads/MySQL-5.7/libmysqlclient20_${VERSION}-1ubuntu14.04_amd64.deb"
+    "https://cdn.mysql.com/Downloads/MySQL-5.7/libmysqlclient-dev_${VERSION}-1ubuntu14.04_amd64.deb"
+)
+
+# Skip vendoring if libmysqlclient-dev's `mysql_config` exists and reports the correct version.
+if [[ "$(mysql_config --version 2>&1)" == "$VERSION" ]]; then
+    exit 0
+fi
+
+echo "-----> Vendoring libmysqlclient $VERSION."
+
+# We manually extract the packages rather than using apt-get install, since:
+#  - On Heroku we don't have sudo, so need to vendor the package somewhere other
+#    than the standard `/usr/{bin,lib,include}` locations.
+#  - For Vagrant/Travis we have to install mysql-server-5.6 (we have to test against
+#    against the same server version as used in production) and there are unresolvable
+#    packaging conflicts between it and libmysqlclient 5.7, if installed with apt-get.
+#  - The compiled binary releases of libmysqlclient aren't available as a tar archive.
+for url in "${PACKAGE_URLS[@]}"; do
+    # Use `dpkg-deb`'s filesystem tarfile mode along with `tar`, rather than just
+    # `dpkg --extract`, since the latter doesn't support removing the `/./usr/`
+    # directory prefix itself, and so would require error-prone directory shuffling
+    # afterwards. The `share` directory and static library files are not used, so are
+    # excluded to reduce the slug/cache size (and thus transfer times) on Heroku/Travis.
+    curl -sS "$url" \
+      | dpkg-deb --fsys-tarfile /dev/stdin \
+      | tar -x --strip-components=2 --exclude="./usr/share" --exclude="*.a" -C "$VENDOR_DIR"
+done
+
+if [[ -n "$(pip show mysqlclient)" ]]; then
+    # The mysqlclient Python package won't pick up the new version of libmysqlclient
+    # unless it's recompiled against it. However unless we purge the old package, pip
+    # won't know to reinstall, since the version of mysqlclient itself hasn't changed.
+    echo "-----> Uninstalling mysqlclient to force recompilation during pip install."
+    pip uninstall -yq mysqlclient
+fi

--- a/puppet/manifests/classes/mysql.pp
+++ b/puppet/manifests/classes/mysql.pp
@@ -3,10 +3,6 @@ class mysql {
     ensure => installed
   }
 
-  package { 'libmysqld-dev':
-    ensure => installed
-  }
-
   service { 'mysql':
     ensure => running,
     enable => true,

--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -3,7 +3,7 @@ class python {
   package{[# Python2.7 is already installed, but we need to update it to the
            # latest version from the third party PPA.
            "python2.7",
-           # Required by MySQLdb.
+           # Required by mysqlclient.
            "python-dev",
            # Required by pylibmc.
            "libmemcached-dev",
@@ -48,8 +48,17 @@ class python {
     user => "${APP_USER}",
   }
 
+  exec {"vendor-libmysqlclient":
+    command => "${PROJ_DIR}/bin/vendor-libmysqlclient.sh ${VENV_DIR}",
+    require => Exec["create-virtualenv"],
+    user => "${APP_USER}",
+  }
+
   exec{"pip-install-common":
-    require => Exec['create-virtualenv'],
+    require => [
+      Exec['create-virtualenv'],
+      Exec['vendor-libmysqlclient'],
+    ],
     user => "${APP_USER}",
     cwd => '/tmp',
     command => "${VENV_DIR}/bin/pip install --disable-pip-version-check --require-hashes -r ${PROJ_DIR}/requirements/common.txt",

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -19,7 +19,7 @@ $RABBITMQ_PASSWORD = 'guest'
 $RABBITMQ_VHOST = '/'
 
 Exec {
-    path => "/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin",
+    path => "${VENV_DIR}/bin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin",
 }
 
 line {"etc-hosts":
@@ -30,6 +30,9 @@ line {"etc-hosts":
 
 file {"/etc/profile.d/treeherder.sh":
     content => "
+# Ensure the vendored libmysqlclient library can be found at run-time.
+export LD_LIBRARY_PATH='${VENV_DIR}/lib/x86_64-linux-gnu'
+
 export ENABLE_LOCAL_SETTINGS_FILE='True'
 export BROKER_URL='amqp://${RABBITMQ_USER}:${RABBITMQ_PASSWORD}@localhost:5672/${RABBITMQ_VHOST}'
 export DATABASE_URL='mysql://${DB_USER}:${DB_PASS}@localhost/treeherder'

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,24 @@
+import pytest
+from mock import patch
+
+from treeherder import checks
+
+
+@pytest.mark.parametrize("version", ['5.7.11', '5.7.14'])
+@patch("treeherder.checks.get_client_info")
+def test_check_libmysqlclient_version_secure(mock_client_info, version):
+    """Ensure the system check passes for libmysqlclient >= 5.7.11."""
+    mock_client_info.return_value = version
+    result = checks.check_libmysqlclient_version(None)
+    assert result == []
+
+
+@pytest.mark.parametrize("version", ['5.5.49', '5.7.10'])
+@patch("treeherder.checks.get_client_info")
+def test_check_libmysqlclient_version_insecure(mock_client_info, version):
+    """Ensure the system check fails for libmysqlclient < 5.7.11."""
+    mock_client_info.return_value = version
+    result = checks.check_libmysqlclient_version(None)
+    assert len(result) == 1
+    assert result[0].id == "treeherder.E001"
+    assert version in result[0].msg

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,5 +1,6 @@
 import MySQLdb
 import pytest
+from _mysql_exceptions import OperationalError
 from celery import current_app
 from django.conf import settings
 from django.core.cache import cache
@@ -16,6 +17,34 @@ def db_conn():
         passwd=db_config.get('PASSWORD') or '',
         **db_options
     )
+
+
+def test_mysqlclient_tls_enforced():
+    """
+    Test that if a CA certificate is specified, the connection won't fall back to
+    plaintext, if the server doesn't support TLS (or if a MITM attacker strips it).
+
+    If mysqlclient has been compiled against a vulnerable version of libmysqlclient
+    then this test will fail. There is overlap between this and our custom Django system
+    check for ensuring mysqlclient has been compiled against libmysqlclient >= 5.7.11,
+    however there advantages in having both:
+      * the system check is run during deploy, unlike this test
+      * however this test is more thorough since it actually checks TLS behaviour and not
+        just version numbers (but this method cannot be used in the system check run
+        during production deployment, since it relies on having a MySQL server instance
+        that doesn't support TLS, to emulate the TLS being stripped by an attacker)
+    """
+    db_config = settings.DATABASES['default']
+    with pytest.raises(OperationalError) as e:
+        MySQLdb.connect(
+            host=db_config['HOST'],
+            user=db_config['USER'],
+            passwd=db_config.get('PASSWORD') or '',
+            ssl={
+                'ca': 'foo/bar.pem',
+            }
+        )
+    assert "SSL connection error" in str(e.value)
 
 
 def test_no_missing_migrations():

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -8,11 +8,12 @@ from django.core.management import call_command
 
 @pytest.fixture
 def db_conn():
-    db_options = settings.DATABASES['default'].get('OPTIONS', {})
+    db_config = settings.DATABASES['default']
+    db_options = db_config.get('OPTIONS', {})
     return MySQLdb.connect(
-        host=settings.DATABASES['default']['HOST'],
-        user=settings.DATABASES['default']['USER'],
-        passwd=settings.DATABASES['default'].get('PASSWORD') or '',
+        host=db_config['HOST'],
+        user=db_config['USER'],
+        passwd=db_config.get('PASSWORD') or '',
         **db_options
     )
 

--- a/treeherder/__init__.py
+++ b/treeherder/__init__.py
@@ -3,6 +3,9 @@ import os
 # Django starts so that shared_task will use this app.
 from .celery import app as celery_app  # noqa
 
+# Register our custom Django system checks.
+import treeherder.checks  # noqa
+
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/treeherder/checks.py
+++ b/treeherder/checks.py
@@ -1,0 +1,25 @@
+from _mysql import get_client_info
+from django.core.checks import (Error,
+                                Tags,
+                                register)
+
+
+def version_to_tuple(version):
+    """Converts a version string like `"5.7.0"` into the tuple `(5, 7, 0)`."""
+    return tuple(int(v) for v in version.split('.'))
+
+
+@register(Tags.security)
+def check_libmysqlclient_version(app_configs, **kwargs):
+    """
+    Check mysqlclient has been compiled against a version of libmysqlclient
+    that isn't vulnerable to TLS stripping. See vendor-libmysqclient.sh.
+    """
+    # get_client_info() returns the libmysqlclient version as a string of form `5.7.0`.
+    libmysqlclient_version = get_client_info()
+    if version_to_tuple(libmysqlclient_version) < (5, 7, 11):
+        msg = ("mysqlclient has been compiled against an insecure version "
+               "of libmysqlclient (%s)." % libmysqlclient_version)
+        hint = "If using Vagrant, run `vagrant provision` and re-login."
+        return [Error(msg, hint=hint, id="treeherder.E001")]
+    return []

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -406,6 +406,12 @@ SILENCED_SYSTEM_CHECKS = [
     'security.W017',
 ]
 
+# Disable the libmysqlclient TLS system check on SCl3, since we're moving to
+# Heroku soon, so it's not worth the hassle of trying to get it updated from
+# the ancient 5.1.X, given the DB is behind a VPN and so doesn't use TLS anyway.
+if '.scl3.mozilla.com' in env('HOSTNAME', default=''):
+    SILENCED_SYSTEM_CHECKS.append('treeherder.E001')
+
 # Enable integration between autoclassifier and jobs
 AUTOCLASSIFY_JOBS = env.bool("AUTOCLASSIFY_JOBS", default=True)
 # Ordered list of matcher classes to use during autoclassification


### PR DESCRIPTION
**1) Vendor libmysqlclient 5.7 on Heroku, Travis and in the Vagrant environment**
The latest versions of libmysqlclient 5.5/5.6 (used by mysqlclient) are still vulnerable to TLS stripping, even after last year's backports of 5.7.x fixes:
  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3152
  - http://bugs.mysql.com/bug.php?id=82383

Ideally we'd just use the standalone Connector/C library instead of the libmysqlclient packages, however the latest release is too old (http://bugs.mysql.com/bug.php?id=82448).

Heroku's cedar-14 stack comes with libmysqlclient 5.5.x, so until it is updated to 5.7.x (see heroku/stack-images#38) we must manually vendor 5.7.x ourselves, so that connections between the Heroku dynos and our public RDS instances are secure. We can do this and still remain on MySQL server 5.6, since newer client releases are backwards compatible with older server versions.

Whilst the Vagrant/Travis MySQL instances don't use TLS (and so aren't affected), we still want them to use libmysqlclient 5.7, to be consistent with production.

Installing the newer libmysqlclient isn't sufficient on it's own. Any packages compiled against the older version (in our case mysqlclient) need to be recompiled. We ensure this happens by pip uninstalling the existing package if it was already installed.

**2)  Add a Django system check for libmysqlclient >= 5.7.11**
This registers a custom Django system check (that is run as part of `./manage.py check` during testing/deploys, and also prior to commands such as migrate), to check that mysqlclient has been compiled against a version of libmysqlclient that isn't vulnerable to TLS stripping. See:
https://docs.djangoproject.com/en/1.8/topics/checks/#writing-your-own-checks

**3) Add a test to check mysqlclient TLS can't be downgraded**
If mysqlclient has been compiled against a vulnerable version of libmysqlclient then this test will fail. There is overlap between this and our custom Django system check for ensuring mysqlclient has been compiled against libmysqlclient >= 5.7.11, however there advantages in having both:
* the system check is run during deploy, unlike this test
* however this test is more thorough since it actually checks TLS behaviour and not just version numbers (but this method cannot be used in the system check run during production deployment, since it relies on having a MySQL server instance that doesn't support TLS, to emulate the TLS being stripped by an attacker)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1770)
<!-- Reviewable:end -->
