### PR TITLE
Bug 1278746 - Skip over versions that are is_active: false

### DIFF
--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -181,6 +181,12 @@ treeherder.controller('BugFilerCtrl', [
             // Only request the versions because some products take quite a long time to fetch the full object
             $.ajax("https://bugzilla.mozilla.org/rest/product/" + productString + "?include_fields=versions").done(function(productJSON) {
                 var productObject = productJSON.products[0];
+
+                // Find the newest version for the product that is_active
+                var version = _.findLast(productObject.versions, function(version) {
+                    return version.is_active === true;
+                });
+
                 $http({
                     url: "api/bugzilla/create_bug/",
                     method: "POST",
@@ -189,8 +195,7 @@ treeherder.controller('BugFilerCtrl', [
                         "component": componentString,
                         "summary": summarystring,
                         "keywords": keywords,
-                        // XXX This takes the last version returned from the product query, probably should be smarter about this in the future...
-                        "version": productObject.versions[productObject.versions.length-1].name,
+                        "version": version.name,
                         "comment": descriptionStrings,
                         "comment_tags": "treeherder"
                     }


### PR DESCRIPTION
Breaking this out so it can land independently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1771)
<!-- Reviewable:end -->
