### PR TITLE
Bug 1289156 - Update the Heroku PATH workaround so pip can be found

### DIFF
--- a/bin/pre_compile
+++ b/bin/pre_compile
@@ -11,7 +11,7 @@ VENDOR_DIR=".heroku/vendor"
 # https://github.com/heroku/heroku-buildpack-python/pull/321
 VENDOR_DIR="$CACHE_DIR/$VENDOR_DIR"
 mkdir -p "$VENDOR_DIR"
-export PATH="$VENDOR_DIR/bin:$PATH"
+export PATH="$CACHE_DIR/.heroku/python/bin:$VENDOR_DIR/bin:$PATH"
 
 ./bin/vendor-libmysqlclient.sh "$VENDOR_DIR"
 

--- a/bin/vendor-libmysqlclient.sh
+++ b/bin/vendor-libmysqlclient.sh
@@ -62,7 +62,7 @@ for url in "${PACKAGE_URLS[@]}"; do
       | tar -x --strip-components=2 --exclude="./usr/share" --exclude="*.a" -C "$VENDOR_DIR"
 done
 
-if [[ -n "$(pip show mysqlclient)" ]]; then
+if [[ -n "$(which pip && pip show mysqlclient)" ]]; then
     # The mysqlclient Python package won't pick up the new version of libmysqlclient
     # unless it's recompiled against it. However unless we purge the old package, pip
     # won't know to reinstall, since the version of mysqlclient itself hasn't changed.


### PR DESCRIPTION
The Heroku pre_compile script is currently run prior to the cache being restored (https://github.com/heroku/heroku-buildpack-python/pull/321), which means we have to tweak PATH so vendor-libmysqlclient.sh can find the binaries from the cache instead of the app directory.

However the workaround added in #1770 only added one of the two extra required PATHs, this adds the other.

Prior to this the buildpack compile would output:
> ./bin/vendor-libmysqlclient.sh: line 65: pip: command not found

...and so wouldn't purge the old mysqlclient package, which is needed to force recompilation against the newer libmysqlclient.

Once the PR against heroku-buildpack-python is merged, these workarounds can be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1775)
<!-- Reviewable:end -->
