### PR TITLE
Bug 1294096 - Fix test that times out due to external HTTP requests

### DIFF
--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -740,7 +740,7 @@ def test_remove_existing_jobs_one_existing_one_new(jm, sample_data,
     assert Job.objects.count() == 1
 
 
-def test_new_job_in_exclusion_profile(jm, sample_data, sample_resultset,
+def test_new_job_in_exclusion_profile(jm, sample_data, sample_resultset, mock_log_parser,
                                       test_sheriff, test_project):
     job = sample_data.job_data[1]
     platform = job["job"]["machine_platform"]["platform"]


### PR DESCRIPTION
Previously test_new_job_in_exclusion_profile was attempting to download logs from ftp.mozilla.org, due to the log parser not being mocked, which caused intermittent test timeouts on Travis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1776)
<!-- Reviewable:end -->
