### PR TITLE
Bug 1294149 - Process errorsummary logs from TaskCluster submissions.

### DIFF
--- a/tests/sample_data/pulse_consumer/transformed_job_data.json
+++ b/tests/sample_data/pulse_consumer/transformed_job_data.json
@@ -53,6 +53,11 @@
           "url": "http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/tinderbox-builds/mozilla-inbound-linux64/mozilla-inbound_linux64_spidermonkey-warnaserr-bm57-build1-build352.txt.gz",
           "parse_status": "pending",
           "name": "builds-4h"
+        },
+        {
+          "url": "http://mozilla-releng-blobs.s3.amazonaws.com/blobs/Mozilla-Inbound-Non-PGO/sha512/05c7f57df6583c6351c6b49e439e2678e0f43c2e5b66695ea7d096a7519e1805f441448b5ffd4cc3b80b8b2c74b244288fda644f55ed0e226ef4e25ba02ca466",
+          "parse_status": "pending",
+          "name": "errorsummary_json"
         }
       ],
       "tier": 1,

--- a/treeherder/etl/job_loader.py
+++ b/treeherder/etl/job_loader.py
@@ -239,6 +239,21 @@ class JobLoader:
                 "url": logref["url"],
                 "parse_status": "parsed" if "steps" in logref else "pending"
             })
+        log_references.extend(self._get_errorsummary_log_references(job))
+        return log_references
+
+    def _get_errorsummary_log_references(self, job):
+        log_references = []
+        try:
+            links = job["jobInfo"]["links"]
+        except KeyError:
+            return []
+        for link in links:
+            text = link.get("linkText", "")
+            if "url" in link and text.endswith("_errorsummary.log"):
+                log_references.append({"name": "errorsummary_json",
+                                       "url": link["url"],
+                                       "parse_status": "pending"})
         return log_references
 
     def _get_option_collection(self, job):


### PR DESCRIPTION
errorsummary logs containing failure lines are, for historical reasons,
not supplied as normal logs, but are in the jobInfo property of TC
submissions. Therefore in order to be processed as for buildbot we need
to extract this data from there and add it to the other log data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1777)
<!-- Reviewable:end -->
