### PR TITLE
Bug 1289156 - Final tweaks for libmysqlclient deploy on Heroku/SCL3

### DIFF
--- a/bin/pre_compile
+++ b/bin/pre_compile
@@ -22,4 +22,6 @@ export PATH="$CACHE_DIR/.heroku/python/bin:$VENDOR_DIR/bin:$PATH"
 # addition, `vendor-libmysqlclient.sh` cannot flatten the directory structure,
 # since `mysql_config` uses relative paths that include `x86_64-linux-gnu`.
 # As such, we have to create a symlink to ensure the library is found at runtime.
-ln -rsf "$VENDOR_DIR/lib/x86_64-linux-gnu/libmysqlclient.so.20" "$VENDOR_DIR/lib/libmysqlclient.so.20"
+if [[ ! -e "$VENDOR_DIR/lib/libmysqlclient.so" ]]; then
+    ln -srt "$VENDOR_DIR/lib/" "$VENDOR_DIR/lib/x86_64-linux-gnu/libmysqlclient.so"*
+fi

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -409,7 +409,7 @@ SILENCED_SYSTEM_CHECKS = [
 # Disable the libmysqlclient TLS system check on SCl3, since we're moving to
 # Heroku soon, so it's not worth the hassle of trying to get it updated from
 # the ancient 5.1.X, given the DB is behind a VPN and so doesn't use TLS anyway.
-if '.scl3.mozilla.com' in env('HOSTNAME', default=''):
+if '.scl3.mozilla.com' in env('DATABASE_URL'):
     SILENCED_SYSTEM_CHECKS.append('treeherder.E001')
 
 # Enable integration between autoclassifier and jobs


### PR DESCRIPTION
There's a strange bug when creating relative symlinks on top of an already existing symlink, in that the target resolves to the wrong file. As such, we now explicitly check for an existing symlink first, to avoid overwriting.

The SCL3 system check disabling has also been tweaked since #1770, since the `HOSTNAME` environment variable doesn't appear to be set during deploy, even though it appears in `env` on the same machine.

Yey for deployment code that can only really be tested by deploying \o/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1779)
<!-- Reviewable:end -->
