### PR TITLE
Bug 1268333 - Ignore pygtk import lines properly

### DIFF
--- a/tests/log_parser/test_error_parser.py
+++ b/tests/log_parser/test_error_parser.py
@@ -29,7 +29,9 @@ NON_ERROR_TEST_CASES = (
     "07:51:08     INFO -  Caught Exception: Remote Device Error: unable to connect to panda-0501 after 5 attempts",
     "06:21:18     INFO -  I/GeckoDump(  730): 110 INFO TEST-UNEXPECTED-FAIL | foo | bar",
     "[taskcluster:info] Starting task",
-    "[taskcluster] Starting task"
+    "[taskcluster] Starting task",
+    "01:22:41     INFO -  ImportError: No module named pygtk",
+    "01:22:41     INFO -  ImportError: No module named pygtk\r\n"
 )
 
 

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -432,8 +432,7 @@ class ErrorParser(ParserBase):
             return True
 
         # Remove mozharness prefixes prior to matching
-        trimline = re.sub(self.RE_MOZHARNESS_PREFIX, "", line)
-
+        trimline = re.sub(self.RE_MOZHARNESS_PREFIX, "", line).rstrip()
         if self.RE_EXCLUDE_2_SEARCH.search(trimline):
             return False
 


### PR DESCRIPTION
Handle newlines after blacklisted strings and add unit tests for this case

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1781)
<!-- Reviewable:end -->
