### PR TITLE
Bug 1294598 - File bugs from autoclassify panel

### DIFF
--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -3,14 +3,14 @@
 treeherder.controller('BugFilerCtrl', [
     '$scope', '$rootScope', '$uibModalInstance', '$http', 'summary', 'thBugzillaProductObject',
     'thPinboard', 'thEvents', 'fullLog', 'parsedLog', 'reftest', 'selectedJob', 'allFailures',
-    'thNotify',
+    'thNotify', 'fromAutoclassify',
     function BugFilerCtrl(
         $scope, $rootScope, $uibModalInstance, $http, summary, thBugzillaProductObject,
         thPinboard, thEvents, fullLog, parsedLog, reftest, selectedJob, allFailures,
-        thNotify) {
+        thNotify, fromAutoclassify) {
 
         $scope.omittedLeads = ["TEST-UNEXPECTED-FAIL", "PROCESS-CRASH", "TEST-UNEXPECTED-ERROR"];
-
+        $scope.fromAutoclassify = fromAutoclassify;
         /**
          *  'enter' from the product search input should initiate the search
          */
@@ -47,7 +47,12 @@ treeherder.controller('BugFilerCtrl', [
                 if(i !== 0) {
                     thisFailure += "\n";
                 }
-                thisFailure += allFailures[i].join(" | ");
+
+                if($scope.fromAutoclassify) {
+                    thisFailure += allFailures[i];
+                } else {
+                    thisFailure += allFailures[i].join(" | ");
+                }
             }
             $scope.thisFailure = thisFailure;
 

--- a/ui/plugins/auto_classification/main.html
+++ b/ui/plugins/auto_classification/main.html
@@ -49,6 +49,13 @@
       </div>
       <div class="classification-line-detail">
         <div ng-if="line.type == 'structured'">
+          <a class="btn btn-xs btn-default"
+                     prevent-default-on-left-click
+                     ng-show="user.loggedin && filerInAddress"
+                     ng-click="fileBug($index)"
+                     title="file a bug for this failure">
+                    <i class="fa fa-bug"></i>
+          </a>
           <span ng-if="line.data.action === 'test_result'">
             <span ng-class="{'ignored-line': line.status === 'ignored'}">
               <strong class="failure-line-status">{{ ::line.data.status }}</strong>
@@ -82,6 +89,13 @@
           </span>
         </div>
         <div ng-if="line.type == 'unstructured'">
+          <a class="btn btn-xs btn-default"
+                     prevent-default-on-left-click
+                     ng-show="user.loggedin && filerInAddress"
+                     ng-click="fileBug($index)"
+                     title="file a bug for this failure">
+                    <i class="fa fa-bug"></i>
+          </a>
           {{ ::line.data.search }}
         </div>
         <div ng-if="line.status === 'verified'">

--- a/ui/plugins/failure_summary/controller.js
+++ b/ui/plugins/failure_summary/controller.js
@@ -131,6 +131,9 @@ treeherder.controller('BugsPluginCtrl', [
                     },
                     allFailures: function() {
                         return allFailures;
+                    },
+                    fromAutoclassify: function() {
+                        return false;
                     }
                 }
             });


### PR DESCRIPTION
This adds the bug filer button to lines in the autoclassify panel. Looks like this:

![autoclassifyfiler](https://cloud.githubusercontent.com/assets/172215/17610515/97c7fd6c-5ff3-11e6-87b6-ae672de7a852.png)

From the limited testing I've done tonight, this has parsed out the same data to be sent on to Treeherder's server, which then passes it on to Bugzilla to create the bug. I've only tested on a few failed jobs, and only a few of the failure lines within those jobs, though.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1783)

<!-- Reviewable:end -->
