### PR TITLE
Bug 1294746 - Disable more autoclassify buttons when not logged in

### DIFF
--- a/ui/plugins/auto_classification/main.html
+++ b/ui/plugins/auto_classification/main.html
@@ -4,12 +4,12 @@
   <div class="failure-lines-actions" ng-if="status() === 'pending'">
     <button ng-if="failureLines"
             class="btn btn-primary btn-sm"
-            title="Ignore items with no autoclassification and nothing explicitly selected"
-            ng-disabled="!canIgnore()"
+            title="{{loggedIn() ? 'Ignore items with no autoclassification and nothing explicitly selected': 'Not logged in'}}"
+            ng-disabled="!canIgnore() || !loggedIn()"
             ng-click="ignoreClean()">Ignore Others</button><br>
     <button ng-if="failureLines"
             class="btn btn-primary btn-sm"
-            title="{{loggedIn() ? 'Save All' : 'Must be logged in to save classifications'}}"
+            title="{{loggedIn() ? 'Save All' : 'Not logged in'}}"
             ng-disabled="!canSaveAll()"
             ng-click="saveAll()">Save All</button>
   </div>
@@ -39,11 +39,13 @@
           <select
              ng-if="line.type === 'structured' && line.updateText.length > 1"
              ng-model="line.updateSelectOption"
+             title="{{loggedIn() ? 'Update selected classifications' : 'Not logged in'}}"
+             ng-disabled="!loggedIn()"
              ng-options="value for (key, value) in line.updateText"
              ></select><br>
           <button class="btn btn-xs btn-default"
-                  title="Select best match and click here"
-                  ng-disabled="!line.canSave"
+                  title="{{loggedIn() ? (line.canSave ? 'Select best match' : 'No changes to save') : 'Not logged in'}}"
+                  ng-disabled="!loggedIn() || !line.canSave"
                   ng-click="line.save()">Save</button>
         </span>
       </div>


### PR DESCRIPTION
So, this PR as-is:
1) Disables the "ignore others" button and changes the title for the button when not signed in.
2) Changes the titles for the line-specific "save" buttons and a select dropdown, and attempts to disable both when not signed in.

But those attempts to disable them don't appear to work, and I don't know why, since "loggedIn()" is working just above the ng-disabled's as part of the titles... @jgraham ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1784)
<!-- Reviewable:end -->
