### PR TITLE
Bug 1289138 - Remove explicit enabling of rules that are enabled by default

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,14 +5,6 @@
     },
     "extends": "eslint:recommended",
     "rules": {
-        // Default rules we've disabled until the failures are fixed.
-        // Remove a line to enable the rule.
-        "comma-dangle": 2,
-        "no-console": 2,
-        "no-redeclare": 2,
-        "no-undef": 2,
-        "no-unused-vars": 2,
-
         // Non-default rules we've chosen to enable.
         "accessor-pairs": 2,
         "comma-style": 2,


### PR DESCRIPTION
Now that these rules are working, we don't need to explicitly enable them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1785)
<!-- Reviewable:end -->
