### PR TITLE
Bug 1295250 - Add the ability to whitelist certain short filenames in error_summary.py

### DIFF
--- a/tests/model/test_error_summary.py
+++ b/tests/model/test_error_summary.py
@@ -53,6 +53,20 @@ PIPE_DELIMITED_LINE_TEST_CASES = (
             "| application crashed [@ jemalloc_crash]"
         ),
         'webgl-resize-test.html'
+    ),
+    (
+        (
+            "TEST-UNEXPECTED-ERROR "
+            "| damp | psutil.TimeoutExpired timeout after 3000 seconds (pid=3332, name=u'firefox.exe')"
+        ),
+        'damp'
+    ),
+    (
+        (
+            "TEST-UNEXPECTED-ERROR "
+            "| tps | psutil.TimeoutExpired timeout after 3000 seconds (pid=3332, name=u'firefox.exe')"
+        ),
+        'tps'
     )
 )
 

--- a/treeherder/model/error_summary.py
+++ b/treeherder/model/error_summary.py
@@ -166,7 +166,18 @@ def is_helpful_search_term(search_term):
 
     ]
 
-    return len(search_term) > 4 and not (search_term in blacklist)
+    shortname_whitelist = [
+        'damp',
+        'tps'
+    ]
+
+    if search_term in blacklist:
+        return False
+
+    if search_term in shortname_whitelist:
+        return True
+
+    return len(search_term) > 4
 
 
 def get_artifacts_that_need_bug_suggestions(artifact_list):


### PR DESCRIPTION
Not really familiar with preferred python styling for that really long, broken `return` line. 

Local tests suggest everything still passes correctly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1787)

<!-- Reviewable:end -->
