### PR TITLE
Bug 1296267 - Use the same version of Elasticsearch on Travis/Vagrant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ matrix:
         - memcached
       before_install:
         - curl -o ~/elasticsearch-2.3.3.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.3/elasticsearch-2.3.3.deb && sudo dpkg -i --force-confnew ~/elasticsearch-2.3.3.deb
-        - sudo service elasticsearch restart
+        - sudo service elasticsearch start
         - while ! curl localhost:9200 &>/dev/null; do sleep 1; done
         - echo -e '\n[mysqld]\nsql_mode="STRICT_ALL_TABLES"\n' | sudo tee -a /etc/mysql/my.cnf
         - sudo service mysql restart
@@ -126,7 +126,7 @@ matrix:
         - memcached
       before_install:
         - curl -o ~/elasticsearch-2.3.3.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.3/elasticsearch-2.3.3.deb && sudo dpkg -i --force-confnew ~/elasticsearch-2.3.3.deb
-        - sudo service elasticsearch restart
+        - sudo service elasticsearch start
         - while ! curl localhost:9200 &>/dev/null; do sleep 1; done
         - echo -e '\n[mysqld]\nsql_mode="STRICT_ALL_TABLES"\n' | sudo tee -a /etc/mysql/my.cnf
         - sudo service mysql restart
@@ -164,7 +164,7 @@ matrix:
         - memcached
       before_install:
         - curl -o ~/elasticsearch-2.3.3.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.3/elasticsearch-2.3.3.deb && sudo dpkg -i --force-confnew ~/elasticsearch-2.3.3.deb
-        - sudo service elasticsearch restart
+        - sudo service elasticsearch start
         - while ! curl localhost:9200 &>/dev/null; do sleep 1; done
         - echo -e '\n[mysqld]\nsql_mode="STRICT_ALL_TABLES"\n' | sudo tee -a /etc/mysql/my.cnf
         - sudo service mysql restart

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
         - rabbitmq
         - memcached
       before_install:
-        - curl -o ~/elasticsearch-2.3.3.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.3/elasticsearch-2.3.3.deb && sudo dpkg -i --force-confnew ~/elasticsearch-2.3.3.deb
+        - curl -sSo ~/elasticsearch.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.5/elasticsearch-2.3.5.deb && sudo dpkg -i ~/elasticsearch.deb
         - sudo service elasticsearch start
         - while ! curl localhost:9200 &>/dev/null; do sleep 1; done
         - echo -e '\n[mysqld]\nsql_mode="STRICT_ALL_TABLES"\n' | sudo tee -a /etc/mysql/my.cnf
@@ -125,7 +125,7 @@ matrix:
         - rabbitmq
         - memcached
       before_install:
-        - curl -o ~/elasticsearch-2.3.3.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.3/elasticsearch-2.3.3.deb && sudo dpkg -i --force-confnew ~/elasticsearch-2.3.3.deb
+        - curl -sSo ~/elasticsearch.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.5/elasticsearch-2.3.5.deb && sudo dpkg -i ~/elasticsearch.deb
         - sudo service elasticsearch start
         - while ! curl localhost:9200 &>/dev/null; do sleep 1; done
         - echo -e '\n[mysqld]\nsql_mode="STRICT_ALL_TABLES"\n' | sudo tee -a /etc/mysql/my.cnf
@@ -163,7 +163,7 @@ matrix:
         - rabbitmq
         - memcached
       before_install:
-        - curl -o ~/elasticsearch-2.3.3.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.3/elasticsearch-2.3.3.deb && sudo dpkg -i --force-confnew ~/elasticsearch-2.3.3.deb
+        - curl -sSo ~/elasticsearch.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.5/elasticsearch-2.3.5.deb && sudo dpkg -i ~/elasticsearch.deb
         - sudo service elasticsearch start
         - while ! curl localhost:9200 &>/dev/null; do sleep 1; done
         - echo -e '\n[mysqld]\nsql_mode="STRICT_ALL_TABLES"\n' | sudo tee -a /etc/mysql/my.cnf

--- a/puppet/manifests/classes/elasticsearch.pp
+++ b/puppet/manifests/classes/elasticsearch.pp
@@ -1,5 +1,5 @@
 class elasticsearch {
-  package { 'openjdk-7-jre':
+  package { 'openjdk-7-jre-headless':
     ensure => installed
   }
 
@@ -11,7 +11,7 @@ class elasticsearch {
     ensure => running,
     enable => true,
     require => [
-      Package['openjdk-7-jre'],
+      Package['openjdk-7-jre-headless'],
       Package['elasticsearch'],
     ],
   }

--- a/puppet/manifests/classes/elasticsearch.pp
+++ b/puppet/manifests/classes/elasticsearch.pp
@@ -1,10 +1,16 @@
 class elasticsearch {
+  $es_version = "2.3.5"
+  $es_url = "https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/${es_version}/elasticsearch-${es_version}.deb"
+
   package { 'openjdk-7-jre-headless':
     ensure => installed
   }
 
-  package { 'elasticsearch':
-    ensure => installed
+  # Once we're using Ubuntu 16.04's newer dpkg we can pipe the download and skip creating a file.
+  exec { "install-elasticsearch":
+    user => "${APP_USER}",
+    command => "curl -sSo ${HOME_DIR}/elasticsearch.deb ${es_url} && sudo dpkg -i ${HOME_DIR}/elasticsearch.deb",
+    unless => "test \"$(dpkg-query --show --showformat='\${Version}' elasticsearch 2>&1)\" = '${es_version}'",
   }
 
   service { 'elasticsearch':
@@ -12,7 +18,7 @@ class elasticsearch {
     enable => true,
     require => [
       Package['openjdk-7-jre-headless'],
-      Package['elasticsearch'],
+      Exec['install-elasticsearch'],
     ],
   }
 }

--- a/puppet/manifests/classes/init.pp
+++ b/puppet/manifests/classes/init.pp
@@ -11,24 +11,10 @@ class init {
         creates => "/etc/apt/sources.list.d/fkrull-deadsnakes-python2_7-trusty.list",
     }
 
-    exec { "add_elasticsearch_signing_key":
-        command => "wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key --keyring /etc/apt/trusted.gpg.d/elasticsearch.gpg add -",
-        creates => "/etc/apt/trusted.gpg.d/elasticsearch.gpg",
-    }
-
-    # We cannot use `add-apt-repository` per:
-    # https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-repositories.html#_apt
-    exec { "add_elasticsearch_repo":
-        command => "echo 'deb http://packages.elastic.co/elasticsearch/2.x/debian stable main' | sudo tee -a /etc/apt/sources.list.d/elasticsearch-2.x.list",
-        creates => "/etc/apt/sources.list.d/elasticsearch-2.x.list",
-    }
-
     exec { "update_apt":
         command => "sudo apt-get update",
         require => [
             Exec["add_python27_ppa"],
-            Exec["add_elasticsearch_signing_key"],
-            Exec["add_elasticsearch_repo"],
         ]
     }
 }


### PR DESCRIPTION
* Travis: Updates Elasticsearch to 2.3.5 (for consistency with Vagrant, since it was pulling latest from the repo) and cleans up the install steps.
* Vagrant: Switches from `openjdk-7-jre` to the smaller `openjdk-7-jre-headless`, since Elasticsearch doesn't need the additional 144 dependencies of the former.
* Vagrant: Switches to downloading the Elasticsearch .deb archive manually and installing with dpkg (rather than using apt-get) - to reduce complexity & make more consistent with Travis.

For further details see the individual commit messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1795)
<!-- Reviewable:end -->
