### PR TITLE
Bug 1289830 - Block ActiveData's user agent due to excessive requests

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -338,6 +338,8 @@ DISALLOWED_USER_AGENTS = (
     re.compile(r'^libcurl/'),
     re.compile(r'^Python-urllib/'),
     re.compile(r'^python-requests/'),
+    # ActiveData blocked for excessive API requests (bug 1289830)
+    re.compile(r'^ActiveData-ETL'),
 )
 
 SITE_URL = env("SITE_URL", default="http://local.treeherder.mozilla.org")


### PR DESCRIPTION
ActiveData's scraping of Treeherder's API has caused responsiveness and performance issues for other users of Treeherder on several occasions, so is being blocked until we can decide upon a less detrimental way for ActiveData to obtain this data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1798)
<!-- Reviewable:end -->
