### PR TITLE
Bug 1297671 - Add the example-addon-repo repository

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1016,4 +1016,18 @@
         "repository_group": 7,
         "description": "Network Security Services."
     }
+},
+{
+    "pk": 81,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "example-addon",
+        "url": "https://github.com/mozilla/example-addon-repo",
+        "branch": "master",
+        "active_status": "active",
+        "codebase": "example-addon-repo",
+        "repository_group": 7,
+        "description": "Example add-on repository for templates and best practices."
+    }
 }]


### PR DESCRIPTION
I'm currently working on setting up a repository that is intended for providing examples, best practices, testing examples and other templates that are useful for general add-on development especially for test pilot and system add-ons.

One of the pieces I'm adding is taskcluster integration. I will hopefully land that on master later today once github-taskcluster is working again.

In the meantime, I'd like to get treeherder set up ready for the repository so that I can demonstrate the integration available, and also use it to test out the current integration and work out if there's any missing bits or bugs that we need to get fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1804)
<!-- Reviewable:end -->
