### PR TITLE
Bug 1298464 - Handle errors in jobs with only one step

### DIFF
--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -310,12 +310,10 @@ logViewerApp.controller('LogviewerCtrl', [
         }
 
         function getStepFromLine(linenumber) {
-            var steps = $scope.artifact.step_data.steps;
-            for (var i = 1; i < steps.length; i++) {
-                if (steps[i].started_linenumber >= linenumber) {
-                    return steps[i-1];
-                }
-            }
+            return $scope.artifact.step_data.steps.find(function(step) {
+                return (step.started_linenumber <= linenumber &&
+                        step.finished_linenumber >= linenumber);
+            });
         }
 
         function getSelectedLines () {


### PR DESCRIPTION
When searching for the right step to jump to previously, we used
an algorithm that assumed we would have more than one step, which
isn't guaranteed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1812)
<!-- Reviewable:end -->
