### PR TITLE
Bug 1298539 - Make sure canceling a single job only works from the same push

### DIFF
--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -175,13 +175,13 @@ treeherderApp.controller('ResultSetCtrl', [
             $rootScope.$emit(thEvents.deleteRunnableJobs, $scope.resultset);
         };
 
-        $scope.getCancelJobsTitle = function() {
+        $scope.getCancelJobsTitle = function(revision) {
             if (!$scope.user || !$scope.user.loggedin) {
                 return "Must be logged in to cancel jobs";
             }
             var job = ThResultSetStore.getSelectedJob($scope.repoName).job;
             var singleJobSelected = job instanceof ThJobModel;
-            if (singleJobSelected) {
+            if (singleJobSelected && job.revision === revision) {
                 if ($scope.canCancelJobs()) {
                     return "Cancel selected job";
                 }
@@ -190,13 +190,13 @@ treeherderApp.controller('ResultSetCtrl', [
             return "Cancel all jobs";
         };
 
-        $scope.canCancelJobs = function() {
+        $scope.canCancelJobs = function(revision) {
             if (!$scope.user || !$scope.user.loggedin) {
                 return false;
             }
             var job = ThResultSetStore.getSelectedJob($scope.repoName).job;
             var singleJobSelected = job instanceof ThJobModel;
-            if (singleJobSelected) {
+            if (singleJobSelected && job.revision === revision) {
                 // Check whether the job can be cancelled
                 return job.state === "pending" || job.state === "running";
             }
@@ -209,7 +209,7 @@ treeherderApp.controller('ResultSetCtrl', [
                 return;
             }
             var job = ThResultSetStore.getSelectedJob($scope.repoName).job;
-            var singleJobSelected = job instanceof ThJobModel;
+            var singleJobSelected = job instanceof ThJobModel && job.revision === revision;
             var message = singleJobSelected ?
                           'This will cancel the selected job. !\n\nClick "OK" if you\'re sure.':
                           'This will cancel all pending and running jobs for revision ' + revision + '!\n\nClick "OK" if you\'re sure.';

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -25,10 +25,10 @@
     <span class="result-set-buttons">
       <span class="btn btn-sm btn-resultset cancel-all-jobs-btn"
             tabindex="0" role="button"
-            ng-attr-title="{{getCancelJobsTitle()}}"
+            ng-attr-title="{{getCancelJobsTitle(resultset.revision)}}"
             ng-show="currentRepo.repository_group.name == 'try' || user.is_staff"
             ignore-job-clear-on-click
-            ng-disabled="!canCancelJobs()"
+            ng-disabled="!canCancelJobs(resultset.revision)"
             ng-click="cancelJobs(resultset.revision)">
         <span class="fa fa-times-circle cancel-job-icon dim-quarter"
               ignore-job-clear-on-click></span>


### PR DESCRIPTION
When you select a single job and then press the cancel all jobs button,
the behavior of the cancel all jobs button so it cancels just the selected
job.

Prior to this patch, the selected job can be canceled no matter which
cancel all jobs button is clicked, even if the selected job is from a
different push. 

This patch only activates the selected job behavior when
the selected job is from the push where the cancel all jobs button was
pressed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1814)
<!-- Reviewable:end -->
