### PR TITLE
Bug 1269416 - Just stop checking if we're in a tag

### DIFF
--- a/ui/js/filters.js
+++ b/ui/js/filters.js
@@ -108,11 +108,6 @@ treeherder.filter('initials', function() {
     };
 });
 
-function inTag(str, index, start, end) {
-    var prePart = str.substr(0, index);
-    return prePart.split(start).length > prePart.split(end).length;
-}
-
 treeherder.filter('highlightCommonTerms', function() {
     return function(input) {
         var compareStr = Array.prototype.slice.call(arguments, 1).filter(
@@ -124,10 +119,7 @@ treeherder.filter('highlightCommonTerms', function() {
 
         angular.forEach(tokens, function(elem) {
             if (elem.length > 0) {
-                input = input.replace(new RegExp("(^|\\W)(" + elem + ")($|\\W)", "gi"), function(match, prefix, token, suffix, index, str) {
-                    if (inTag(str, index, "<", ">") || inTag(str, index, "&", ";")){
-                        return match;
-                    }
+                input = input.replace(new RegExp("(^|\\W)(" + elem + ")($|\\W)", "gi"), function(match, prefix, token, suffix) {
                     return prefix + "<strong>" + token + "</strong>" + suffix;
                 });
             }

--- a/ui/plugins/auto_classification/main.html
+++ b/ui/plugins/auto_classification/main.html
@@ -92,7 +92,7 @@
             <a href="{{::getBugUrl(line.verifiedBugNumber) }}"
                target="_blank">Bug {{ ::line.verifiedBugNumber }} -
               <span ng-if="line.verifiedBugSummary"
-                    ng-bind-html="line.verifiedBugSummary | escapeHTML | highlightCommonTerms:line.test:line.data.subtest:line.data.status:line.status.expected"></span>
+                    ng-bind-html="line.verifiedBugSummary | escapeHTML | highlightCommonTerms:line.test:line.data.subtest:line.data.status:line.status.expected:line.data.message"></span>
             </a>
           </span>
         </div>
@@ -121,7 +121,7 @@
                   <a href="{{::getBugUrl(option.bugNumber) }}"
                      target="_blank">Bug {{::option.bugNumber}} -
                     <span ng-if="line.type === 'structured'"
-                          ng-bind-html="option.bugSummary | escapeHTML | highlightCommonTerms:line.data.test:line.data.subtest:line.data.status:line.data.expected"></span>
+                          ng-bind-html="option.bugSummary | escapeHTML | highlightCommonTerms:line.data.test:line.data.subtest:line.data.status:line.data.expected:line.data.message"></span>
                     <span ng-if="line.type === 'unstructured'"
                           ng-bind-html="option.bugSummary | escapeHTML | highlightCommonTerms:line.data.search_terms"></span>
                   </a>


### PR DESCRIPTION
This option just stops checking if we're in a tag. Nothing appears to be worse off for this, and it highlights more things that should be highlighted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1818)
<!-- Reviewable:end -->
