### PR TITLE
Bug 1291307 - Stop using django-heroku-memcacheify

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 # HEROKU REQUIREMENTS
 
 -r requirements/common.txt
-
-django-heroku-memcacheify==1.0.0 --hash=sha256:971c63f9af5bee2884bbfd308457b6675b35b89a33cf42c1c4f0a554c324a563


### PR DESCRIPTION
Since it clobbers the settings we need to use on Heroku for making memcached connections via stunnel. In addition, it made the cache configuration very opaque, and doesn't use the latest best practices suggested on:
https://www.memcachier.com/documentation#django

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1824)
<!-- Reviewable:end -->
