### PR TITLE
Bug 1299861 - Stop storing buildapi_running artifacts

### DIFF
--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -369,20 +369,6 @@ class PendingRunningTransformerMixin(object):
 
                     if source == 'running':
                         new_job['start_timestamp'] = job['start_time']
-                        # We store the original values to help debugging.
-                        new_job['artifacts'].append(
-                            {
-                                'type': 'json',
-                                'name': 'buildapi_running',
-                                'log_urls': [],
-                                'blob': {
-                                    'revision': revision,
-                                    'request_ids': job['request_ids'],
-                                    'submitted_at': job['submitted_at'],
-                                    'start_time': job['start_time'],
-                                }
-                            }
-                        )
 
                     treeherder_data['job'] = new_job
 


### PR DESCRIPTION
They were only supposed to be used for debugging, but we haven't even
been using them for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1827)
<!-- Reviewable:end -->
