### PR TITLE
Bug 1299443 - Fix revision.txt on Heroku when SERVE_MINIFIED_UI is unset

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,12 +132,7 @@ module.exports = function(grunt) {
             main: {
                 files: [
                     { src:'contribute.json', dest:'dist/contribute.json', nonull: true },
-                    { src:'ui/robots.txt', dest:'dist/robots.txt', nonull: true },
-                    { src:'ui/index.html', dest:'dist/index.html', nonull: true },
-                    { src:'ui/userguide.html', dest:'dist/userguide.html', nonull: true },
-                    { src:'ui/logviewer.html', dest:'dist/logviewer.html', nonull: true },
-                    { src:'ui/failureviewer.html', dest:'dist/failureviewer.html', nonull: true },
-                    { src:'ui/perf.html', dest:'dist/perf.html', nonull: true }
+                    { cwd: 'ui/', src: '*', dest:'dist/', expand: true, filter: 'isFile', nonull: true },
                 ]
             },
             // Copy img dir

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,12 +1,12 @@
 #!/bin/bash -e
 # Tasks run by the Heroku Python buildpack after the compile step.
 
+# Make the current Git revision accessible at <site-root>/revision.txt
+echo $SOURCE_VERSION > ui/revision.txt
+
 # Create a `dist/` directory containing built/minified versions of the `ui/` assets.
 # Uses the node binaries/packages installed by the nodejs buildpack previously.
 ./node_modules/.bin/grunt build --production
-
-# Make the current Git revision accessible at <site-root>/revision.txt
-echo $SOURCE_VERSION > dist/revision.txt
 
 # Generate gzipped versions of files that would benefit from compression, that
 # WhiteNoise can then serve in preference to the originals. This is required


### PR DESCRIPTION
Previously `<site-root>/revision.txt` would 404 if `SERVE_MINIFIED_UI` was unset on Heroku, which would then cause the next deploy to fail.

It's now made available in both the `ui/` and `dist/` directories, so it can be found regardless of the value of `SERVE_MINIFIED_UI`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1832)
<!-- Reviewable:end -->
