### PR TITLE
Bug 1330795 - Skip taskcluster jobs without treeherder metadata in runnable jobs

### DIFF
--- a/treeherder/webapp/api/runnable_jobs.py
+++ b/treeherder/webapp/api/runnable_jobs.py
@@ -78,8 +78,16 @@ class RunnableJobsViewSet(viewsets.ViewSet):
                 'result': 'runnable'})
 
         for label, node in tc_graph.iteritems():
+            extra = node['task'].get('extra')
+            if not extra or not extra.get('treeherder'):
+                # some tasks don't have the treeherder information we need
+                # to be able to display them (and are not intended to be
+                # displayed). skip.
+                continue
+            else:
+                treeherder_options = extra['treeherder']
+
             task_metadata = node['task']['metadata']
-            treeherder_options = node['task']['extra']['treeherder']
             build_platform = treeherder_options.get('machine', {}).get('platform', '')
 
             # Not all tasks have a group name


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1835)
<!-- Reviewable:end -->
