### PR TITLE
Bug 1297184 - Strip TaskCluster log prefix when parsing logs

### DIFF
--- a/tests/log_parser/test_error_parser.py
+++ b/tests/log_parser/test_error_parser.py
@@ -47,3 +47,23 @@ def test_successful_lines_not_matched(line):
     parser = ErrorParser()
     is_error_line = parser.is_error_line(line)
     assert not is_error_line
+
+
+def test_taskcluster_strip_prefix():
+    parser = ErrorParser()
+    assert not parser.is_taskcluster
+    assert not parser.artifact
+
+    # Prefix should not be stripped unless we see a
+    # [taskcluster...] line, causing error detection to fail.
+    parser.parse_line("[vcs 2016-09-07T19:03:02.188327Z] 23:57:52 ERROR - Return code: 1", 1)
+    assert not parser.is_taskcluster
+    assert not parser.artifact
+
+    parser.parse_line("[taskcluster 2016-09-07 19:02:55.114Z] Task ID: PWden6jYS4SfVKYj4p7y6w", 2)
+    assert parser.is_taskcluster
+    assert not parser.artifact
+
+    parser.parse_line("[vcs 2016-09-07T19:03:02.188327Z] 23:57:52 ERROR - Return code: 1", 3)
+    assert len(parser.artifact) == 1
+    assert parser.artifact[0]['linenumber'] == 3

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -408,11 +408,15 @@ class ErrorParser(ParserBase):
 
     RE_ERR_1_MATCH = re.compile(r"^\d+:\d+:\d+ +(?:ERROR|CRITICAL|FATAL) - ")
 
+    # [task 2016-08-18T17:50:56.955523Z]
+    RE_TASKCLUSTER_PREFIX = re.compile(r"^\[[^\]]+\]\s")
+
     RE_MOZHARNESS_PREFIX = re.compile(r"^\d+:\d+:\d+ +(?:DEBUG|INFO|WARNING) - +")
 
     def __init__(self):
         """A simple error detection sub-parser"""
         super(ErrorParser, self).__init__("errors")
+        self.is_taskcluster = False
 
     def add(self, line, lineno):
         self.artifact.append({
@@ -422,6 +426,15 @@ class ErrorParser(ParserBase):
 
     def parse_line(self, line, lineno):
         """Check a single line for an error.  Keeps track of the linenumber"""
+        # First line of TaskCluster logs almost certainly has this.
+        if line.startswith('[taskcluster '):
+            self.is_taskcluster = True
+
+        # For performance reasons, only do this if we have identified as
+        # a TC task.
+        if self.is_taskcluster:
+            line = re.sub(self.RE_TASKCLUSTER_PREFIX, "", line)
+
         if self.is_error_line(line):
             self.add(line, lineno)
 


### PR DESCRIPTION
Upcoming changes in bug 1295380 will change log output for many tests
in TaskCluster resulting in lines being prefixed with a timestamp and
the task step name. Unless these line prefixes are handled, it
confuses the error parser.

This commit detects logs as coming from TaskCluster and strips their
line prefix accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1836)
<!-- Reviewable:end -->
