### PR TITLE
Bug 1301081 - Disable various menus when appropriate

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -17,6 +17,9 @@ treeherderApp.controller('MainCtrl', [
         // Query String param for selected job
         var QS_SELECTED_JOB = "selectedJob";
 
+        // Ensure user is available on initial page load
+        $rootScope.user = {};
+
         thClassificationTypes.load();
 
         $rootScope.getWindowTitle = function() {

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -44,7 +44,8 @@
       <span class="btn btn-sm btn-resultset trigger-new-jobs-btn"
             tabindex="0" role="button"
             title="Trigger new jobs"
-            ng-show="user.loggedin && showTriggerButton()"
+            ng-show="showTriggerButton()"
+            ng-disabled="!user.loggedin"
             ignore-job-clear-on-click
             ng-click="triggerNewJobs()">
            Trigger New Jobs

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -44,7 +44,7 @@
       <span class="btn btn-sm btn-resultset trigger-new-jobs-btn"
             tabindex="0" role="button"
             title="Trigger new jobs"
-            ng-show="showTriggerButton()"
+            ng-show="user.loggedin && showTriggerButton()"
             ignore-job-clear-on-click
             ng-click="triggerNewJobs()">
            Trigger New Jobs

--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -13,7 +13,7 @@
     <li><a target="_blank" ignore-job-clear-on-click
            title="Add new jobs to this resultset"
            href=""
-           ng-hide="resultset.isRunnableVisible"
+           ng-hide="!user.loggedin || resultset.isRunnableVisible"
            ng-click="showRunnableJobs()">Add new Jobs</a></li>
     <li><a target="_blank" ignore-job-clear-on-click
            title="Hide Runnable Jobs"

--- a/ui/partials/main/thPinboardPanel.html
+++ b/ui/partials/main/thPinboardPanel.html
@@ -66,23 +66,30 @@
      title="{{!hasPinnedJobs() ? 'No jobs pinned' : ''}}">
   <div class="btn-group">
     <button class="btn btn-default btn-xs save-btn"
-          title="{{ !hasPinnedJobs() ? 'No job selected' : 'Save all classification data' }}"
-          ng-click="save()"
-          ng-disabled="!canSaveClassifications()">save
+            title="{{ !user.loggedin && !canSaveClassifications() ?
+                      'Not logged in / default classification data / no job pinned' : 'Save all classification data' }}"
+            ng-click="save()"
+            ng-disabled=" !user.loggedin && !canSaveClassifications()">save
     </button>
     <button class="btn btn-default btn-xs dropdown-toggle save-btn-dropdown"
-          title="{{ !hasPinnedJobs() ? 'No pinned jobs' : 'Additional pinboard functions' }}"
-          ng-disabled="!hasPinnedJobs()"
-          data-toggle="dropdown">
+            title="{{ !hasPinnedJobs() ? 'No pinned jobs' : 'Additional pinboard functions' }}"
+            ng-disabled="!hasPinnedJobs()"
+            data-toggle="dropdown">
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu pull-right" role="menu">
-      <li><a ng-click="saveClassificationOnly()">Save classification only</a></li>
-      <li class="{{ !hasRelatedBugs() ? 'disabled' : '' }}"
-          title="{{ !hasRelatedBugs() ? 'No bugs selected' : '' }}">
-          <a ng-click="hasRelatedBugs() && saveBugsOnly()">Save bugs only</a>
-      </li>
-      <li><a ng-click="retriggerAllPinnedJobs()">Retrigger all</a></li>
+      <li class="{{ !user.loggedin && !canSaveClassifications() ? 'disabled' : '' }}"
+          title="{{ !user.loggedin && !canSaveClassifications() ?
+                    'Not logged in / default classification data / no job pinned' : 'Save classification only' }}">
+        <a ng-click="!canSaveClassifications() || saveClassificationOnly()">Save classification only</a></li>
+      <li class="{{ !user.loggedin || !hasRelatedBugs() ? 'disabled' : '' }}"
+          title="{{ !user.loggedin || !hasRelatedBugs() ?
+                    'Not logged in / no related bugs added' : 'Save bug classification data' }}">
+        <a ng-click="!canSaveClassifications() || saveBugsOnly()">Save bugs only</a></li>
+      <li class="{{ !user.loggedin ? 'disabled' : '' }}"
+          title="{{ !user.loggedin ? 'Must be logged in to retrigger all pinned jobs' : 'Repeat the pinned jobs'}}">
+        <a ng-disabled="!user.loggedin"
+           ng-click="!user.loggedin || retriggerAllPinnedJobs()">Retrigger all</a></li>
       <li><a ng-click="unPinAll()">Clear all</a></li>
     </ul>
   </div>

--- a/ui/partials/main/thPinboardPanel.html
+++ b/ui/partials/main/thPinboardPanel.html
@@ -63,13 +63,12 @@
 
 <!-- Save UI -->
 <div id="pinboard-controls" class="btn-group-vertical"
-     title="{{!hasPinnedJobs() ? 'No jobs pinned' : ''}}">
+     title="{{!hasPinnedJobs() ? 'No pinned jobs' : ''}}">
   <div class="btn-group">
     <button class="btn btn-default btn-xs save-btn"
-            title="{{ !user.loggedin && !canSaveClassifications() ?
-                      'Not logged in / default classification data / no job pinned' : 'Save all classification data' }}"
+            title="{{ saveUITitle('classification') }}"
             ng-click="save()"
-            ng-disabled=" !user.loggedin && !canSaveClassifications()">save
+            ng-disabled="!user.loggedin || !canSaveClassifications()">save
     </button>
     <button class="btn btn-default btn-xs dropdown-toggle save-btn-dropdown"
             title="{{ !hasPinnedJobs() ? 'No pinned jobs' : 'Additional pinboard functions' }}"
@@ -78,18 +77,15 @@
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu pull-right" role="menu">
-      <li class="{{ !user.loggedin && !canSaveClassifications() ? 'disabled' : '' }}"
-          title="{{ !user.loggedin && !canSaveClassifications() ?
-                    'Not logged in / default classification data / no job pinned' : 'Save classification only' }}">
-        <a ng-click="!canSaveClassifications() || saveClassificationOnly()">Save classification only</a></li>
+      <li class="{{ !user.loggedin || !canSaveClassifications() ? 'disabled' : '' }}"
+          title="{{ saveUITitle('classification') }}">
+        <a ng-click="!user.loggedin || !canSaveClassifications() || saveClassificationOnly()">Save classification only</a></li>
       <li class="{{ !user.loggedin || !hasRelatedBugs() ? 'disabled' : '' }}"
-          title="{{ !user.loggedin || !hasRelatedBugs() ?
-                    'Not logged in / no related bugs added' : 'Save bug classification data' }}">
-        <a ng-click="!canSaveClassifications() || saveBugsOnly()">Save bugs only</a></li>
+          title="{{ saveUITitle('bug') }}">
+        <a ng-click="!user.loggedin || !canSaveClassifications() || !hasRelatedBugs() || saveBugsOnly()">Save bugs only</a></li>
       <li class="{{ !user.loggedin ? 'disabled' : '' }}"
-          title="{{ !user.loggedin ? 'Must be logged in to retrigger all pinned jobs' : 'Repeat the pinned jobs'}}">
-        <a ng-disabled="!user.loggedin"
-           ng-click="!user.loggedin || retriggerAllPinnedJobs()">Retrigger all</a></li>
+          title="{{ !user.loggedin ? 'Not logged in' : 'Repeat the pinned jobs'}}">
+        <a ng-click="!user.loggedin || retriggerAllPinnedJobs()">Retrigger all</a></li>
       <li><a ng-click="unPinAll()">Clear all</a></li>
     </ul>
   </div>

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -128,6 +128,39 @@ treeherder.controller('PinboardCtrl', [
             return canSave;
         };
 
+        // Dyanmic btn/anchor title for classification save
+        $scope.saveUITitle = function(category) {
+            var title = "";
+
+            if (!$scope.user.loggedin) {
+                title = title.concat("not logged in / ");
+            }
+
+            if (category === "classification") {
+                if (!$scope.canSaveClassifications()) {
+                    title = title.concat("ineligible classification data / ");
+                }
+                if (!$scope.hasPinnedJobs()) {
+                    title = title.concat("no pinned jobs");
+                }
+            // We don't check pinned jobs because the menu dropdown handles it
+            } else if (category === "bug") {
+                if (!$scope.hasRelatedBugs()) {
+                    title = title.concat("no related bugs");
+                }
+            }
+
+            if (title === "") {
+                title = "Save " + category + " data";
+            } else {
+                // Cut off trailing "/ " if one exists, capitalize first letter
+                title = title.replace(/\/ $/,"");
+                title = title.replace(/^./, function(l) { return l.toUpperCase(); });
+            }
+
+            return title;
+        };
+
         $scope.hasPinnedJobs = function() {
             return thPinboard.hasPinnedJobs();
         };

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -120,12 +120,11 @@ treeherder.controller('PinboardCtrl', [
 
         $scope.canSaveClassifications = function() {
             var thisClass = $scope.classification;
-            var canSave = $scope.hasPinnedJobs() && (thPinboard.hasRelatedBugs() && $scope.user.loggedin ||
-                          thisClass.failure_classification_id !== 4 ||
-                          $rootScope.currentRepo.repository_group.name === "try" ||
-                          $rootScope.currentRepo.repository_group.name === "project repositories" ||
-                          (thisClass.failure_classification_id === 4 && thisClass.text.length > 0));
-            return canSave;
+            return $scope.hasPinnedJobs() && (thPinboard.hasRelatedBugs() && $scope.user.loggedin ||
+                   thisClass.failure_classification_id !== 4 ||
+                   $rootScope.currentRepo.repository_group.name === "try" ||
+                   $rootScope.currentRepo.repository_group.name === "project repositories" ||
+                   (thisClass.failure_classification_id === 4 && thisClass.text.length > 0));
         };
 
         // Dyanmic btn/anchor title for classification save

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -120,7 +120,7 @@ treeherder.controller('PinboardCtrl', [
 
         $scope.canSaveClassifications = function() {
             var thisClass = $scope.classification;
-            var canSave = $scope.hasPinnedJobs() && (thPinboard.hasRelatedBugs() ||
+            var canSave = $scope.hasPinnedJobs() && (thPinboard.hasRelatedBugs() && $scope.user.loggedin ||
                           thisClass.failure_classification_id !== 4 ||
                           $rootScope.currentRepo.repository_group.name === "try" ||
                           $rootScope.currentRepo.repository_group.name === "project repositories" ||


### PR DESCRIPTION
This work hopefully fixes Bugzilla bug [1301081](https://bugzilla.mozilla.org/show_bug.cgi?id=1301081).

This disables pinboard save menus when appropriate, and alters: **Save** (button), **Save classification only** (menu), **Save bugs only** (menu), **Retrigger all** (menu). 

The use cases are a bit complex, and span combinations of:

* try vs. non-try repos
* logged in vs. logged out
* related bugs only
* classifications only
* default classification vs. non-default (eg. intermittent vs. others)

Before:

![before](https://cloud.githubusercontent.com/assets/3660661/18356360/60c004c2-75ba-11e6-968f-1d6db6e4d3a7.jpg)

Proposed (Logged out with default settings they are dimmed - unless you are on Try):

![after](https://cloud.githubusercontent.com/assets/3660661/18356375/6d0ae94a-75ba-11e6-99a2-9efef9303356.jpg)

Everything seems generally ok, but there may be things I've missed since I've not been doing daily development. I've added a `$scope.user.loggedin` test to `canSaveClassifications()` as I'm not sure why it wouldn't have one.

The main Save button was fine blocking ng-click, but in the menus the markup need a change, so I used an `||` test to block the click for the menu list anchors - so we don't trigger the underlying function and launch a thNotify - which we still need for keyboard shortcut use cases.

Tested on OSX 10.11.5:
Nightly **51.0a1 (2016-09-07)**

Adding @wlach for review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1837)
<!-- Reviewable:end -->
