### PR TITLE
Bug 1301434 - Disable the detect-intermittents task by default

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -420,6 +420,7 @@ AUTOCLASSIFY_JOBS = env.bool("AUTOCLASSIFY_JOBS", default=True)
 # Ordered list of matcher classes to use during autoclassification
 AUTOCLASSIFY_MATCHERS = ["PreciseTestMatcher", "CrashSignatureMatcher",
                          "ElasticSearchTestMatcher"]
+DETECT_INTERMITTENTS = env.bool("DETECT_INTERMITTENTS", default=False)
 
 # timeout for requests to external sources
 # like ftp.mozilla.org or hg.mozilla.org


### PR DESCRIPTION
Since it occasionally causes queue backlogs and needs tweaking to be useful for the sheriffs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1838)
<!-- Reviewable:end -->
