### PR TITLE
Bug 1240211 - Disable the checkbox for the single remaining selected tier

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -204,6 +204,11 @@ treeherderApp.controller('MainCtrl', [
          * This new solution uses a simple model scope object and update function
          * to keep things in sync.
          */
+
+        $scope.isSingleTierSelected = function() {
+            return _.without(_.values($scope.tiers), false).length === 1;
+        };
+
         $scope.isTierShowing = function(tier) {
             return thJobFilters.isFilterSetToShow("tier", tier);
         };

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -27,11 +27,12 @@
               role="menu">
             <li ng-repeat="tier in jobFilters.tiers">
               <div class="checkbox dropdown-link">
-                <label>
+                <label title="{{(isSingleTierSelected() && tiers[tier] == true) ? 'Must have at least one tier selected at all times' : ''}}">
                   <input id="tier-checkbox"
                          type="checkbox"
                          class="dropdown-checkboxk"
                          ng-model="tiers[tier]"
+                         ng-disabled="isSingleTierSelected() && tiers[tier] == true"
                          ng-change="tierToggled(tier)">
                   tier {{::tier}}
                 </label>


### PR DESCRIPTION
This disables the checkbox for the final selected tier so that you can't unselect all tiers, avoiding the "bug" where tiers 1 and 2 get automatically reselected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1841)
<!-- Reviewable:end -->
