### PR TITLE
Bug 1301906 - Make sure linkifyClassifications filter gives usable results

### DIFF
--- a/tests/ui/unit/filtersSpec.js
+++ b/tests/ui/unit/filtersSpec.js
@@ -211,7 +211,7 @@ describe('linkifyClassifications filter', function() {
     it('linkifies classifications', function() {
         var linkifyClassifications = $filter('linkifyClassifications');
         expect(linkifyClassifications('1234567890ab', 'mozilla-central'))
-          .toEqual('<a href="https://hg.mozilla.org/mozilla/central/rev/1234567890ab">1234567890ab</a>');
+          .toEqual("<a href='https://hg.mozilla.org/mozilla/central/rev/1234567890ab'>1234567890ab</a>");
     });
 });
 

--- a/ui/js/filters.js
+++ b/ui/js/filters.js
@@ -33,7 +33,7 @@ treeherder.filter('linkifyClassifications', ['ThRepositoryModel', function(ThRep
         var repo = ThRepositoryModel.getRepo(projectName);
 
         if(repo.dvcs_type === "hg" && isSHA(str)) {
-            var hg_url = '<a href="' + repo.url + '/rev/' + str + '">' + str + '</a>';
+            var hg_url = "<a href=\'" + repo.url + "/rev/" + str + "\'>" + str + "</a>";
             str = hg_url;
         }
 


### PR DESCRIPTION
The filter as it was written returned already returned a valid string, but apparently somewhere between angular getting the filtered string back from the filter and it getting injected into the page as HTML, the quotes were breaking the element, causing it to be rendered incorrectly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1843)
<!-- Reviewable:end -->
