### PR TITLE
Bug 1302529 - Add store_pulse_resultsets to bin script

### DIFF
--- a/bin/run_celery_worker_buildapi
+++ b/bin/run_celery_worker_buildapi
@@ -14,7 +14,7 @@ if [ ! -f $LOGFILE ]; then
     touch $LOGFILE
 fi
 
-exec newrelic-admin run-program celery -A treeherder worker -Q buildapi_pending,buildapi_running,buildapi_4hr,store_pulse_jobs \
+exec newrelic-admin run-program celery -A treeherder worker -Q buildapi_pending,buildapi_running,buildapi_4hr,store_pulse_jobs,store_pulse_resultsets \
     --concurrency=5 --logfile=$LOGFILE -l INFO \
     --maxtasksperchild=20 -n buildapi.%h
 

--- a/treeherder/etl/resultset_loader.py
+++ b/treeherder/etl/resultset_loader.py
@@ -24,16 +24,18 @@ class ResultsetLoader:
             transformed_data = transformer.transform(repo.name)
 
             with JobsModel(repo.name) as jobs_model:
-                logger.info("Storing resultset for {} {}".format(
+                logger.info("Storing resultset for {} {} {}".format(
                     repo.name,
-                    transformer.repo_url))
+                    transformer.repo_url,
+                    transformer.branch))
                 jobs_model.store_result_set_data([transformed_data])
 
         except ObjectDoesNotExist:
             newrelic.agent.record_custom_event("skip_unknown_repository",
                                                message_body["details"])
-            logger.warn("Skipping unsupported repo: {}".format(
-                transformer.repo_url))
+            logger.warn("Skipping unsupported repo: {} {}".format(
+                transformer.repo_url,
+                transformer.branch))
         except Exception as ex:
             newrelic.agent.record_exception(exc=ex)
             logger.exception("Error transforming resultset", exc_info=ex)

--- a/treeherder/etl/tasks/pulse_tasks.py
+++ b/treeherder/etl/tasks/pulse_tasks.py
@@ -2,13 +2,13 @@
 This module contains tasks related to pulse job ingestion
 """
 import newrelic.agent
-from celery import task
 
 from treeherder.etl.job_loader import JobLoader
 from treeherder.etl.resultset_loader import ResultsetLoader
+from treeherder.workers.task import retryable_task
 
 
-@task(name='store-pulse-jobs')
+@retryable_task(name='store-pulse-jobs', max_retries=10)
 def store_pulse_jobs(job_list, exchange, routing_key):
     """
     Fetches the jobs pending from pulse exchanges and loads them.
@@ -19,7 +19,7 @@ def store_pulse_jobs(job_list, exchange, routing_key):
     JobLoader().process_job_list(job_list)
 
 
-@task(name='store-pulse-resultsets')
+@retryable_task(name='store-pulse-resultsets', max_retries=10)
 def store_pulse_resultsets(body, exchange, routing_key):
     """
     Fetches the resultsets pending from pulse exchanges and loads them.


### PR DESCRIPTION
Also make the pulse tasks retryable_tasks as well as
add a field to logging for pulse resultsets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1847)
<!-- Reviewable:end -->
