### PR TITLE
Bug 1294525 - Break out Tinderbox fields in log parser

### DIFF
--- a/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.jobartifact.json
+++ b/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.jobartifact.json
@@ -1,14 +1,16 @@
 {
-  "job_details": [
-    {
-      "content_type": "raw_html",
-      "value": "<a href=http://hg.mozilla.org/releases/mozilla-esr17/rev/e2eecb449eeb title=\"Built from revision e2eecb449eeb\">rev:e2eecb449eeb</a>\r"
-    },
-    {
-      "content_type": "raw_html",
-      "value": "31776/<em class=\"testfail\">2</em>/40",
-      "title": "mochitest-browser-chrome"
-    }
-  ],
-  "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.txt.gz"
+    "job_details": [
+        {
+            "url": "http://hg.mozilla.org/releases/mozilla-esr17/rev/e2eecb449eeb",
+            "value": "rev:e2eecb449eeb",
+            "content_type": "raw_html",
+            "title": "Built from revision e2eecb449eeb"
+        },
+        {
+            "value": "31776/<em class=\"testfail\">2</em>/40",
+            "content_type": "raw_html",
+            "title": "mochitest-browser-chrome"
+        }
+    ],
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.txt.gz"
 }

--- a/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.jobartifact.json
+++ b/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.jobartifact.json
@@ -1,14 +1,16 @@
 {
-  "job_details": [
-    {
-      "content_type": "raw_html",
-      "value": "<a href=http://hg.mozilla.org/projects/ux/rev/546ccc10a18f title=\"Built from revision 546ccc10a18f\">rev:546ccc10a18f</a>"
-    },
-    {
-      "content_type": "raw_html",
-      "value": "7270/6",
-      "title": "jetpack"
-    }
-  ],
-  "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.txt.gz"
+    "job_details": [
+        {
+            "url": "http://hg.mozilla.org/projects/ux/rev/546ccc10a18f",
+            "value": "rev:546ccc10a18f",
+            "content_type": "raw_html",
+            "title": "Built from revision 546ccc10a18f"
+        },
+        {
+            "value": "7270/6",
+            "content_type": "raw_html",
+            "title": "jetpack"
+        }
+    ],
+    "logurl": "file:///home/vagrant/treeherder/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.txt.gz"
 }

--- a/ui/plugins/job_details/main.html
+++ b/ui/plugins/job_details/main.html
@@ -3,7 +3,7 @@
     <li ng-repeat="line in job_details | orderBy:'title'" class="small">
       <label>{{line.title ? line.title : 'Untitled data'}}:</label>
       <!-- URL provided -->
-      <a ng-if="line.url" title="{{line.value}}" href="{{line.url}}" target="_blank">{{line.value}}</a>
+      <a ng-if="line.url" title="{{line.title ? line.title : line.value}}" href="{{line.url}}" target="_blank">{{line.value}}</a>
       <span ng-if="line.url && line.value.endsWith('raw.log')">
         - <a title="{{line.value}}" href="https://mozilla.github.io/wptview/#/?urls={{line.url | encodeURIComponent}},{{job_details[buildernameIndex].value | encodeURIComponent}}">open in test results viewer</a>
       </span>


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1294525](https://bugzilla.mozilla.org/show_bug.cgi?id=1294525), or is an inspiration for similar fix :) This splits long TinderboxPrint lines like:

`TinderboxPrint:<a href=https://hg.mozilla.org/mozilla-central/rev/1a5b53a831e5 title='Built from mozilla-central revision 1a5b53a831e5'>moz:1a5b53a831e5</a>`

into manageable chunks and reduces the chance it bumps up against the 125 character string limit, which we'd like to keep.

Bug, note the "moz" line:

![before](https://cloud.githubusercontent.com/assets/3660661/18490040/49667a28-79ce-11e6-9a22-e987f49f3c5f.jpg)

Proposed, back to it's prior appearance:

![proposed](https://cloud.githubusercontent.com/assets/3660661/18490053/56d6e01c-79ce-11e6-91fd-b2c36e732f8a.jpg)

Tested on OSX 10.11.5:
Nightly **51.0a1 (2016-09-12) (64-bit)**

Adding @camd for review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1848)
<!-- Reviewable:end -->
