### PR TITLE
Bug 1302224 - Make sure raw log link in logviewer works

### DIFF
--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -49,7 +49,7 @@
             <a title="{{logError ? 'Raw log link no longer exists or has expired (click for path)' :
                       'Open the raw log in a new window'}}"
                target="_blank"
-               href="{{::rawLogURL}}">
+               href="{{rawLogURL}}">
               <span ng-class="logError ? 'fa-warning actionbtn-warning' : 'fa-file-text-o actionbtn-icon'"
                     class="fa"></span>
               <span>open raw log</span>


### PR DESCRIPTION
We need to update the template value on angular digest cycles, because
we can't count on the "raw log url" being available when we first render the
template (the job may still be loading).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1850)
<!-- Reviewable:end -->
