### PR TITLE
Bug 1302754 - Update the docs copyright to 2016

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Treeherder'
-copyright = u'2014, Mozilla'
+copyright = u'2016, Mozilla'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Treeherder'
-copyright = u'2016, Mozilla'
+copyright = u'2016, Mozilla and other contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
This fixes Bugzilla bug [1302754](https://bugzilla.mozilla.org/show_bug.cgi?id=1302754).

Our footer copyright appeared to be out of date. I dug around to see if there's a way to have it update on the fly but with Sphinx it appears to be a manual process.

Adding @wlach for review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1852)
<!-- Reviewable:end -->
