### PR TITLE
Bug 1302844 - Remove redundant information from text log artifacts

### DIFF
--- a/docs/submitting_data.rst
+++ b/docs/submitting_data.rst
@@ -636,7 +636,6 @@ log name.  You must specify the name in two places for this to work.
     {
         "blob":{
             "step_data": {
-                "all_errors": [ ],
                 "steps": [
                     {
                         "errors": [ ],
@@ -645,9 +644,6 @@ log name.  You must specify the name in two places for this to work.
                         "finished_linenumber": 1,
                         "finished": "2015-07-08 06:13:46",
                         "result": "success",
-                        "duration": 2671,
-                        "order": 0,
-                        "error_count": 0
                     }
                 ],
                 "errors_truncated": false

--- a/schemas/text-log-summary-artifact.yml
+++ b/schemas/text-log-summary-artifact.yml
@@ -7,20 +7,6 @@ properties:
       step_data:
         type: object
         properties:
-          all_errors:
-            type: array
-            items:
-              type: object
-              properties:
-                line:
-                  type: string
-                linenumber:
-                  type: integer
-              additionalProperties: false
-              required:
-              - line
-              - linenumber
-            additionalItems: false
           steps:
             type: array
             items:
@@ -49,12 +35,6 @@ properties:
                 finished:
                   type: string
                   format: date-time
-                error_count:
-                  type: integer
-                duration:
-                  type: integer
-                order:
-                  type: integer
                 result:
                   type: string
                   enum: [busted, testfailed, exception, success, canceled, unknown, retry, skipped]
@@ -65,9 +45,6 @@ properties:
               - started_linenumber
               - finished_linenumber
               - finished
-              - error_count
-              - duration
-              - order
               - result
               additionalProperties: false
             additionalItems: false
@@ -75,7 +52,6 @@ properties:
             type: boolean
         additionalProperties: false
         required:
-        - all_errors
         - steps
         - errors_truncated
       logurl:

--- a/tests/client/data/artifact_data.json
+++ b/tests/client/data/artifact_data.json
@@ -11,7 +11,6 @@
     {
         "blob": {
             "step_data": {
-                "all_errors": [],
                 "steps": [
                     {
                         "errors": [],
@@ -19,10 +18,7 @@
                         "started": "2014-03-07 07:12:03.636406",
                         "started_linenumber": 8,
                         "finished_linenumber": 10,
-                        "finished": "2014-03-07 07:12:03.636818",
-                        "error_count": 0,
-                        "duration": 0.00041199999999999999,
-                        "order": 0
+                        "finished": "2014-03-07 07:12:03.636818"
                     },
                     {
                         "errors": [],
@@ -30,10 +26,7 @@
                         "started": "2014-03-07 07:12:03.637105",
                         "started_linenumber": 12,
                         "finished_linenumber": 55,
-                        "finished": "2014-03-07 07:12:03.879738",
-                        "error_count": 0,
-                        "duration": 0.24263299999999999,
-                        "order": 1
+                        "finished": "2014-03-07 07:12:03.879738"
                     },
                     {
                         "errors": [],
@@ -41,10 +34,7 @@
                         "started": "2014-03-07 07:12:03.880087",
                         "started_linenumber": 57,
                         "finished_linenumber": 58,
-                        "finished": "2014-03-07 07:12:03.924320",
-                        "error_count": 0,
-                        "duration": 0.044233000000000001,
-                        "order": 2
+                        "finished": "2014-03-07 07:12:03.924320"
                     },
                     {
                         "errors": [],
@@ -52,10 +42,7 @@
                         "started": "2014-03-07 07:12:03.924713",
                         "started_linenumber": 60,
                         "finished_linenumber": 101,
-                        "finished": "2014-03-07 07:12:04.181933",
-                        "error_count": 0,
-                        "duration": 0.25722,
-                        "order": 3
+                        "finished": "2014-03-07 07:12:04.181933"
                     },
                     {
                         "errors": [],
@@ -63,10 +50,7 @@
                         "started": "2014-03-07 07:12:04.182263",
                         "started_linenumber": 103,
                         "finished_linenumber": 144,
-                        "finished": "2014-03-07 07:12:08.199403",
-                        "error_count": 0,
-                        "duration": 4.0171400000000004,
-                        "order": 4
+                        "finished": "2014-03-07 07:12:08.199403"
                     },
                     {
                         "errors": [],
@@ -74,10 +58,7 @@
                         "started": "2014-03-07 07:12:08.199729",
                         "started_linenumber": 146,
                         "finished_linenumber": 194,
-                        "finished": "2014-03-07 07:12:12.978266",
-                        "error_count": 0,
-                        "duration": 4.778537,
-                        "order": 5
+                        "finished": "2014-03-07 07:12:12.978266"
                     },
                     {
                         "errors": [],
@@ -85,10 +66,7 @@
                         "started": "2014-03-07 07:12:12.978609",
                         "started_linenumber": 196,
                         "finished_linenumber": 238,
-                        "finished": "2014-03-07 07:12:13.389483",
-                        "error_count": 0,
-                        "duration": 0.41087400000000002,
-                        "order": 6
+                        "finished": "2014-03-07 07:12:13.389483"
                     },
                     {
                         "errors": [],
@@ -96,10 +74,7 @@
                         "started": "2014-03-07 07:12:13.389785",
                         "started_linenumber": 240,
                         "finished_linenumber": 283,
-                        "finished": "2014-03-07 07:12:13.658294",
-                        "error_count": 0,
-                        "duration": 0.268509,
-                        "order": 7
+                        "finished": "2014-03-07 07:12:13.658294"
                     },
                     {
                         "errors": [],
@@ -107,10 +82,7 @@
                         "started": "2014-03-07 07:12:13.658595",
                         "started_linenumber": 285,
                         "finished_linenumber": 286,
-                        "finished": "2014-03-07 07:12:13.670954",
-                        "error_count": 0,
-                        "duration": 0.012359,
-                        "order": 8
+                        "finished": "2014-03-07 07:12:13.670954"
                     },
                     {
                         "errors": [],
@@ -118,10 +90,7 @@
                         "started": "2014-03-07 07:12:13.671280",
                         "started_linenumber": 288,
                         "finished_linenumber": 290,
-                        "finished": "2014-03-07 07:12:13.671644",
-                        "error_count": 0,
-                        "duration": 0.00036400000000000001,
-                        "order": 9
+                        "finished": "2014-03-07 07:12:13.671644"
                     },
                     {
                         "errors": [],
@@ -129,10 +98,7 @@
                         "started": "2014-03-07 07:12:13.671901",
                         "started_linenumber": 292,
                         "finished_linenumber": 97498,
-                        "finished": "2014-03-07 07:22:58.578709",
-                        "error_count": 0,
-                        "duration": 644.90680799999996,
-                        "order": 10
+                        "finished": "2014-03-07 07:22:58.578709"
                     },
                     {
                         "errors": [],
@@ -140,10 +106,7 @@
                         "started": "2014-03-07 07:22:58.584633",
                         "started_linenumber": 97500,
                         "finished_linenumber": 97543,
-                        "finished": "2014-03-07 07:22:58.850768",
-                        "error_count": 0,
-                        "duration": 0.26613500000000001,
-                        "order": 11
+                        "finished": "2014-03-07 07:22:58.850768"
                     },
                     {
                         "errors": [],
@@ -151,10 +114,7 @@
                         "started": "2014-03-07 07:22:58.851093",
                         "started_linenumber": 97545,
                         "finished_linenumber": 97586,
-                        "finished": "2014-03-07 07:22:59.078797",
-                        "error_count": 0,
-                        "duration": 0.22770399999999999,
-                        "order": 12
+                        "finished": "2014-03-07 07:22:59.078797"
                     },
                     {
                         "errors": [],
@@ -162,10 +122,7 @@
                         "started": "2014-03-07 07:22:59.079128",
                         "started_linenumber": 97588,
                         "finished_linenumber": 97590,
-                        "finished": "2014-03-07 07:23:00.519294",
-                        "error_count": 0,
-                        "duration": 1.4401660000000001,
-                        "order": 13
+                        "finished": "2014-03-07 07:23:00.519294"
                     }
                 ]
             },
@@ -187,7 +144,6 @@
     {
         "blob": {
             "step_data": {
-                "all_errors": [],
                 "steps": [
                     {
                         "errors": [],
@@ -195,10 +151,7 @@
                         "started": "2014-03-07 07:18:22.729550",
                         "started_linenumber": 8,
                         "finished_linenumber": 10,
-                        "finished": "2014-03-07 07:18:22.729923",
-                        "error_count": 0,
-                        "duration": 0.00037300000000000001,
-                        "order": 0
+                        "finished": "2014-03-07 07:18:22.729923"
                     },
                     {
                         "errors": [],
@@ -206,10 +159,7 @@
                         "started": "2014-03-07 07:18:22.730379",
                         "started_linenumber": 12,
                         "finished_linenumber": 60,
-                        "finished": "2014-03-07 07:18:22.774796",
-                        "error_count": 0,
-                        "duration": 0.044416999999999998,
-                        "order": 1
+                        "finished": "2014-03-07 07:18:22.774796"
                     },
                     {
                         "errors": [],
@@ -217,10 +167,7 @@
                         "started": "2014-03-07 07:18:22.775105",
                         "started_linenumber": 62,
                         "finished_linenumber": 63,
-                        "finished": "2014-03-07 07:18:22.819873",
-                        "error_count": 0,
-                        "duration": 0.044768000000000002,
-                        "order": 2
+                        "finished": "2014-03-07 07:18:22.819873"
                     },
                     {
                         "errors": [],
@@ -228,10 +175,7 @@
                         "started": "2014-03-07 07:18:22.820284",
                         "started_linenumber": 65,
                         "finished_linenumber": 111,
-                        "finished": "2014-03-07 07:18:22.858509",
-                        "error_count": 0,
-                        "duration": 0.038225000000000002,
-                        "order": 3
+                        "finished": "2014-03-07 07:18:22.858509"
                     },
                     {
                         "errors": [],
@@ -239,10 +183,7 @@
                         "started": "2014-03-07 07:18:22.858795",
                         "started_linenumber": 113,
                         "finished_linenumber": 159,
-                        "finished": "2014-03-07 07:18:22.907592",
-                        "error_count": 0,
-                        "duration": 0.048797,
-                        "order": 4
+                        "finished": "2014-03-07 07:18:22.907592"
                     },
                     {
                         "errors": [],
@@ -250,10 +191,7 @@
                         "started": "2014-03-07 07:18:22.907870",
                         "started_linenumber": 161,
                         "finished_linenumber": 214,
-                        "finished": "2014-03-07 07:18:26.841475",
-                        "error_count": 0,
-                        "duration": 3.933605,
-                        "order": 5
+                        "finished": "2014-03-07 07:18:26.841475"
                     },
                     {
                         "errors": [],
@@ -261,10 +199,7 @@
                         "started": "2014-03-07 07:18:26.841785",
                         "started_linenumber": 216,
                         "finished_linenumber": 263,
-                        "finished": "2014-03-07 07:18:27.404940",
-                        "error_count": 0,
-                        "duration": 0.56315499999999996,
-                        "order": 6
+                        "finished": "2014-03-07 07:18:27.404940"
                     },
                     {
                         "errors": [],
@@ -272,10 +207,7 @@
                         "started": "2014-03-07 07:18:27.405297",
                         "started_linenumber": 265,
                         "finished_linenumber": 313,
-                        "finished": "2014-03-07 07:18:27.750008",
-                        "error_count": 0,
-                        "duration": 0.34471099999999999,
-                        "order": 7
+                        "finished": "2014-03-07 07:18:27.750008"
                     },
                     {
                         "errors": [],
@@ -283,10 +215,7 @@
                         "started": "2014-03-07 07:18:27.753553",
                         "started_linenumber": 315,
                         "finished_linenumber": 316,
-                        "finished": "2014-03-07 07:18:27.908032",
-                        "error_count": 0,
-                        "duration": 0.15447900000000001,
-                        "order": 8
+                        "finished": "2014-03-07 07:18:27.908032"
                     },
                     {
                         "errors": [],
@@ -294,10 +223,7 @@
                         "started": "2014-03-07 07:18:27.908301",
                         "started_linenumber": 318,
                         "finished_linenumber": 320,
-                        "finished": "2014-03-07 07:18:27.908645",
-                        "error_count": 0,
-                        "duration": 0.00034400000000000001,
-                        "order": 9
+                        "finished": "2014-03-07 07:18:27.908645"
                     },
                     {
                         "errors": [],
@@ -305,10 +231,7 @@
                         "started": "2014-03-07 07:18:27.908937",
                         "started_linenumber": 322,
                         "finished_linenumber": 1739,
-                        "finished": "2014-03-07 07:24:06.327614",
-                        "error_count": 0,
-                        "duration": 338.418677,
-                        "order": 10
+                        "finished": "2014-03-07 07:24:06.327614"
                     },
                     {
                         "errors": [],
@@ -316,10 +239,7 @@
                         "started": "2014-03-07 07:24:06.332695",
                         "started_linenumber": 1741,
                         "finished_linenumber": 1789,
-                        "finished": "2014-03-07 07:24:06.361854",
-                        "error_count": 0,
-                        "duration": 0.029159000000000001,
-                        "order": 11
+                        "finished": "2014-03-07 07:24:06.361854"
                     },
                     {
                         "errors": [],
@@ -327,10 +247,7 @@
                         "started": "2014-03-07 07:24:06.362241",
                         "started_linenumber": 1791,
                         "finished_linenumber": 1837,
-                        "finished": "2014-03-07 07:24:06.380120",
-                        "error_count": 0,
-                        "duration": 0.017878999999999999,
-                        "order": 12
+                        "finished": "2014-03-07 07:24:06.380120"
                     },
                     {
                         "errors": [],
@@ -338,10 +255,7 @@
                         "started": "2014-03-07 07:24:06.380445",
                         "started_linenumber": 1839,
                         "finished_linenumber": 1841,
-                        "finished": "2014-03-07 07:24:10.781191",
-                        "error_count": 0,
-                        "duration": 4.4007459999999998,
-                        "order": 13
+                        "finished": "2014-03-07 07:24:10.781191"
                     }
                 ]
             },
@@ -363,7 +277,6 @@
     {
         "blob": {
             "step_data": {
-                "all_errors": [],
                 "steps": [
                     {
                         "errors": [],
@@ -371,10 +284,7 @@
                         "started": "2014-03-07 07:14:41.792299",
                         "started_linenumber": 8,
                         "finished_linenumber": 10,
-                        "finished": "2014-03-07 07:14:41.792958",
-                        "error_count": 0,
-                        "duration": 0.00065899999999999997,
-                        "order": 0
+                        "finished": "2014-03-07 07:14:41.792958"
                     },
                     {
                         "errors": [],
@@ -382,10 +292,7 @@
                         "started": "2014-03-07 07:14:41.793432",
                         "started_linenumber": 12,
                         "finished_linenumber": 56,
-                        "finished": "2014-03-07 07:14:41.858335",
-                        "error_count": 0,
-                        "duration": 0.064903000000000002,
-                        "order": 1
+                        "finished": "2014-03-07 07:14:41.858335"
                     },
                     {
                         "errors": [],
@@ -393,10 +300,7 @@
                         "started": "2014-03-07 07:14:41.858813",
                         "started_linenumber": 58,
                         "finished_linenumber": 59,
-                        "finished": "2014-03-07 07:14:41.893872",
-                        "error_count": 0,
-                        "duration": 0.035059,
-                        "order": 2
+                        "finished": "2014-03-07 07:14:41.893872"
                     },
                     {
                         "errors": [],
@@ -404,10 +308,7 @@
                         "started": "2014-03-07 07:14:41.894339",
                         "started_linenumber": 61,
                         "finished_linenumber": 103,
-                        "finished": "2014-03-07 07:14:41.990805",
-                        "error_count": 0,
-                        "duration": 0.096465999999999996,
-                        "order": 3
+                        "finished": "2014-03-07 07:14:41.990805"
                     },
                     {
                         "errors": [],
@@ -415,10 +316,7 @@
                         "started": "2014-03-07 07:14:41.991277",
                         "started_linenumber": 105,
                         "finished_linenumber": 147,
-                        "finished": "2014-03-07 07:14:42.387667",
-                        "error_count": 0,
-                        "duration": 0.39639000000000002,
-                        "order": 4
+                        "finished": "2014-03-07 07:14:42.387667"
                     },
                     {
                         "errors": [],
@@ -426,10 +324,7 @@
                         "started": "2014-03-07 07:14:42.388135",
                         "started_linenumber": 149,
                         "finished_linenumber": 198,
-                        "finished": "2014-03-07 07:14:46.490504",
-                        "error_count": 0,
-                        "duration": 4.1023690000000004,
-                        "order": 5
+                        "finished": "2014-03-07 07:14:46.490504"
                     },
                     {
                         "errors": [],
@@ -437,10 +332,7 @@
                         "started": "2014-03-07 07:14:46.491031",
                         "started_linenumber": 200,
                         "finished_linenumber": 243,
-                        "finished": "2014-03-07 07:14:46.959315",
-                        "error_count": 0,
-                        "duration": 0.46828399999999998,
-                        "order": 6
+                        "finished": "2014-03-07 07:14:46.959315"
                     },
                     {
                         "errors": [],
@@ -448,10 +340,7 @@
                         "started": "2014-03-07 07:14:46.959819",
                         "started_linenumber": 245,
                         "finished_linenumber": 289,
-                        "finished": "2014-03-07 07:14:47.217313",
-                        "error_count": 0,
-                        "duration": 0.257494,
-                        "order": 7
+                        "finished": "2014-03-07 07:14:47.217313"
                     },
                     {
                         "errors": [],
@@ -459,10 +348,7 @@
                         "started": "2014-03-07 07:14:47.217835",
                         "started_linenumber": 291,
                         "finished_linenumber": 292,
-                        "finished": "2014-03-07 07:14:47.238172",
-                        "error_count": 0,
-                        "duration": 0.020337000000000001,
-                        "order": 8
+                        "finished": "2014-03-07 07:14:47.238172"
                     },
                     {
                         "errors": [],
@@ -470,10 +356,7 @@
                         "started": "2014-03-07 07:14:47.238666",
                         "started_linenumber": 294,
                         "finished_linenumber": 296,
-                        "finished": "2014-03-07 07:14:47.239335",
-                        "error_count": 0,
-                        "duration": 0.000669,
-                        "order": 9
+                        "finished": "2014-03-07 07:14:47.239335"
                     },
                     {
                         "errors": [],
@@ -481,10 +364,7 @@
                         "started": "2014-03-07 07:14:47.239846",
                         "started_linenumber": 298,
                         "finished_linenumber": 10126,
-                        "finished": "2014-03-07 07:24:34.027012",
-                        "error_count": 0,
-                        "duration": 586.78716599999996,
-                        "order": 10
+                        "finished": "2014-03-07 07:24:34.027012"
                     },
                     {
                         "errors": [],
@@ -492,10 +372,7 @@
                         "started": "2014-03-07 07:24:34.028119",
                         "started_linenumber": 10128,
                         "finished_linenumber": 10172,
-                        "finished": "2014-03-07 07:24:34.086304",
-                        "error_count": 0,
-                        "duration": 0.058185000000000001,
-                        "order": 11
+                        "finished": "2014-03-07 07:24:34.086304"
                     },
                     {
                         "errors": [],
@@ -503,10 +380,7 @@
                         "started": "2014-03-07 07:24:34.086806",
                         "started_linenumber": 10174,
                         "finished_linenumber": 10216,
-                        "finished": "2014-03-07 07:24:34.129472",
-                        "error_count": 0,
-                        "duration": 0.042666000000000003,
-                        "order": 12
+                        "finished": "2014-03-07 07:24:34.129472"
                     },
                     {
                         "errors": [],
@@ -514,10 +388,7 @@
                         "started": "2014-03-07 07:24:34.129930",
                         "started_linenumber": 10218,
                         "finished_linenumber": 10220,
-                        "finished": "2014-03-07 07:24:38.385365",
-                        "error_count": 0,
-                        "duration": 4.2554350000000003,
-                        "order": 13
+                        "finished": "2014-03-07 07:24:38.385365"
                     }
                 ]
             },
@@ -539,7 +410,6 @@
     {
         "blob": {
             "step_data": {
-                "all_errors": [],
                 "steps": [
                     {
                         "errors": [],
@@ -547,10 +417,7 @@
                         "started": "2014-03-07 07:14:34.298831",
                         "started_linenumber": 8,
                         "finished_linenumber": 10,
-                        "finished": "2014-03-07 07:14:34.299526",
-                        "error_count": 0,
-                        "duration": 0.00069499999999999998,
-                        "order": 0
+                        "finished": "2014-03-07 07:14:34.299526"
                     },
                     {
                         "errors": [],
@@ -558,10 +425,7 @@
                         "started": "2014-03-07 07:14:34.299969",
                         "started_linenumber": 12,
                         "finished_linenumber": 56,
-                        "finished": "2014-03-07 07:14:36.493319",
-                        "error_count": 0,
-                        "duration": 2.1933500000000001,
-                        "order": 1
+                        "finished": "2014-03-07 07:14:36.493319"
                     },
                     {
                         "errors": [],
@@ -569,10 +433,7 @@
                         "started": "2014-03-07 07:14:36.493812",
                         "started_linenumber": 58,
                         "finished_linenumber": 59,
-                        "finished": "2014-03-07 07:14:36.842727",
-                        "error_count": 0,
-                        "duration": 0.34891499999999998,
-                        "order": 2
+                        "finished": "2014-03-07 07:14:36.842727"
                     },
                     {
                         "errors": [],
@@ -580,10 +441,7 @@
                         "started": "2014-03-07 07:14:36.843133",
                         "started_linenumber": 61,
                         "finished_linenumber": 103,
-                        "finished": "2014-03-07 07:14:36.917108",
-                        "error_count": 0,
-                        "duration": 0.073974999999999999,
-                        "order": 3
+                        "finished": "2014-03-07 07:14:36.917108"
                     },
                     {
                         "errors": [],
@@ -591,10 +449,7 @@
                         "started": "2014-03-07 07:14:36.917553",
                         "started_linenumber": 105,
                         "finished_linenumber": 147,
-                        "finished": "2014-03-07 07:14:38.049526",
-                        "error_count": 0,
-                        "duration": 1.1319729999999999,
-                        "order": 4
+                        "finished": "2014-03-07 07:14:38.049526"
                     },
                     {
                         "errors": [],
@@ -602,10 +457,7 @@
                         "started": "2014-03-07 07:14:38.050029",
                         "started_linenumber": 149,
                         "finished_linenumber": 198,
-                        "finished": "2014-03-07 07:14:53.802561",
-                        "error_count": 0,
-                        "duration": 15.752532,
-                        "order": 5
+                        "finished": "2014-03-07 07:14:53.802561"
                     },
                     {
                         "errors": [],
@@ -613,10 +465,7 @@
                         "started": "2014-03-07 07:14:53.803111",
                         "started_linenumber": 200,
                         "finished_linenumber": 243,
-                        "finished": "2014-03-07 07:14:54.140737",
-                        "error_count": 0,
-                        "duration": 0.33762599999999998,
-                        "order": 6
+                        "finished": "2014-03-07 07:14:54.140737"
                     },
                     {
                         "errors": [],
@@ -624,10 +473,7 @@
                         "started": "2014-03-07 07:14:54.141318",
                         "started_linenumber": 245,
                         "finished_linenumber": 289,
-                        "finished": "2014-03-07 07:14:54.330501",
-                        "error_count": 0,
-                        "duration": 0.18918299999999999,
-                        "order": 7
+                        "finished": "2014-03-07 07:14:54.330501"
                     },
                     {
                         "errors": [],
@@ -635,10 +481,7 @@
                         "started": "2014-03-07 07:14:54.330976",
                         "started_linenumber": 291,
                         "finished_linenumber": 292,
-                        "finished": "2014-03-07 07:14:54.354151",
-                        "error_count": 0,
-                        "duration": 0.023175000000000001,
-                        "order": 8
+                        "finished": "2014-03-07 07:14:54.354151"
                     },
                     {
                         "errors": [],
@@ -646,10 +489,7 @@
                         "started": "2014-03-07 07:14:54.354709",
                         "started_linenumber": 294,
                         "finished_linenumber": 296,
-                        "finished": "2014-03-07 07:14:54.355354",
-                        "error_count": 0,
-                        "duration": 0.00064499999999999996,
-                        "order": 9
+                        "finished": "2014-03-07 07:14:54.355354"
                     },
                     {
                         "errors": [],
@@ -657,10 +497,7 @@
                         "started": "2014-03-07 07:14:54.355786",
                         "started_linenumber": 298,
                         "finished_linenumber": 17699,
-                        "finished": "2014-03-07 07:22:43.052819",
-                        "error_count": 0,
-                        "duration": 468.69703299999998,
-                        "order": 10
+                        "finished": "2014-03-07 07:22:43.052819"
                     },
                     {
                         "errors": [],
@@ -668,10 +505,7 @@
                         "started": "2014-03-07 07:22:43.085835",
                         "started_linenumber": 17701,
                         "finished_linenumber": 17745,
-                        "finished": "2014-03-07 07:22:43.401531",
-                        "error_count": 0,
-                        "duration": 0.31569599999999998,
-                        "order": 11
+                        "finished": "2014-03-07 07:22:43.401531"
                     },
                     {
                         "errors": [],
@@ -679,10 +513,7 @@
                         "started": "2014-03-07 07:22:43.402049",
                         "started_linenumber": 17747,
                         "finished_linenumber": 17789,
-                        "finished": "2014-03-07 07:22:43.451869",
-                        "error_count": 0,
-                        "duration": 0.049820000000000003,
-                        "order": 12
+                        "finished": "2014-03-07 07:22:43.451869"
                     },
                     {
                         "errors": [],
@@ -690,10 +521,7 @@
                         "started": "2014-03-07 07:22:43.452327",
                         "started_linenumber": 17791,
                         "finished_linenumber": 17793,
-                        "finished": "2014-03-07 07:22:48.221966",
-                        "error_count": 0,
-                        "duration": 4.7696389999999997,
-                        "order": 13
+                        "finished": "2014-03-07 07:22:48.221966"
                     }
                 ]
             },
@@ -715,7 +543,6 @@
     {
         "blob": {
             "step_data": {
-                "all_errors": [],
                 "steps": [
                     {
                         "errors": [],
@@ -723,10 +550,7 @@
                         "started": "2014-03-07 07:14:30.412431",
                         "started_linenumber": 8,
                         "finished_linenumber": 10,
-                        "finished": "2014-03-07 07:14:30.413108",
-                        "error_count": 0,
-                        "duration": 0.00067699999999999998,
-                        "order": 0
+                        "finished": "2014-03-07 07:14:30.413108"
                     },
                     {
                         "errors": [],
@@ -734,10 +558,7 @@
                         "started": "2014-03-07 07:14:30.413529",
                         "started_linenumber": 12,
                         "finished_linenumber": 56,
-                        "finished": "2014-03-07 07:14:30.758181",
-                        "error_count": 0,
-                        "duration": 0.34465200000000001,
-                        "order": 1
+                        "finished": "2014-03-07 07:14:30.758181"
                     },
                     {
                         "errors": [],
@@ -745,10 +566,7 @@
                         "started": "2014-03-07 07:14:30.758641",
                         "started_linenumber": 58,
                         "finished_linenumber": 59,
-                        "finished": "2014-03-07 07:14:30.805123",
-                        "error_count": 0,
-                        "duration": 0.046482000000000002,
-                        "order": 2
+                        "finished": "2014-03-07 07:14:30.805123"
                     },
                     {
                         "errors": [],
@@ -756,10 +574,7 @@
                         "started": "2014-03-07 07:14:30.805562",
                         "started_linenumber": 61,
                         "finished_linenumber": 103,
-                        "finished": "2014-03-07 07:14:30.859079",
-                        "error_count": 0,
-                        "duration": 0.053517000000000002,
-                        "order": 3
+                        "finished": "2014-03-07 07:14:30.859079"
                     },
                     {
                         "errors": [],
@@ -767,10 +582,7 @@
                         "started": "2014-03-07 07:14:30.859546",
                         "started_linenumber": 105,
                         "finished_linenumber": 147,
-                        "finished": "2014-03-07 07:14:31.271884",
-                        "error_count": 0,
-                        "duration": 0.41233799999999998,
-                        "order": 4
+                        "finished": "2014-03-07 07:14:31.271884"
                     },
                     {
                         "errors": [],
@@ -778,10 +590,7 @@
                         "started": "2014-03-07 07:14:31.272719",
                         "started_linenumber": 149,
                         "finished_linenumber": 198,
-                        "finished": "2014-03-07 07:14:36.816646",
-                        "error_count": 0,
-                        "duration": 5.543927,
-                        "order": 5
+                        "finished": "2014-03-07 07:14:36.816646"
                     },
                     {
                         "errors": [],
@@ -789,10 +598,7 @@
                         "started": "2014-03-07 07:14:36.817194",
                         "started_linenumber": 200,
                         "finished_linenumber": 243,
-                        "finished": "2014-03-07 07:14:38.062517",
-                        "error_count": 0,
-                        "duration": 1.245323,
-                        "order": 6
+                        "finished": "2014-03-07 07:14:38.062517"
                     },
                     {
                         "errors": [],
@@ -800,10 +606,7 @@
                         "started": "2014-03-07 07:14:38.062993",
                         "started_linenumber": 245,
                         "finished_linenumber": 289,
-                        "finished": "2014-03-07 07:14:38.241590",
-                        "error_count": 0,
-                        "duration": 0.17859700000000001,
-                        "order": 7
+                        "finished": "2014-03-07 07:14:38.241590"
                     },
                     {
                         "errors": [],
@@ -811,10 +614,7 @@
                         "started": "2014-03-07 07:14:38.242080",
                         "started_linenumber": 291,
                         "finished_linenumber": 292,
-                        "finished": "2014-03-07 07:14:38.267092",
-                        "error_count": 0,
-                        "duration": 0.025012,
-                        "order": 8
+                        "finished": "2014-03-07 07:14:38.267092"
                     },
                     {
                         "errors": [],
@@ -822,10 +622,7 @@
                         "started": "2014-03-07 07:14:38.267614",
                         "started_linenumber": 294,
                         "finished_linenumber": 296,
-                        "finished": "2014-03-07 07:14:38.268277",
-                        "error_count": 0,
-                        "duration": 0.00066299999999999996,
-                        "order": 9
+                        "finished": "2014-03-07 07:14:38.268277"
                     },
                     {
                         "errors": [],
@@ -833,10 +630,7 @@
                         "started": "2014-03-07 07:14:38.268708",
                         "started_linenumber": 298,
                         "finished_linenumber": 32014,
-                        "finished": "2014-03-07 07:24:06.398324",
-                        "error_count": 0,
-                        "duration": 568.12961600000006,
-                        "order": 10
+                        "finished": "2014-03-07 07:24:06.398324"
                     },
                     {
                         "errors": [],
@@ -844,10 +638,7 @@
                         "started": "2014-03-07 07:24:06.403049",
                         "started_linenumber": 32016,
                         "finished_linenumber": 32060,
-                        "finished": "2014-03-07 07:24:06.464080",
-                        "error_count": 0,
-                        "duration": 0.061031000000000002,
-                        "order": 11
+                        "finished": "2014-03-07 07:24:06.464080"
                     },
                     {
                         "errors": [],
@@ -855,10 +646,7 @@
                         "started": "2014-03-07 07:24:06.464585",
                         "started_linenumber": 32062,
                         "finished_linenumber": 32104,
-                        "finished": "2014-03-07 07:24:06.507310",
-                        "error_count": 0,
-                        "duration": 0.042724999999999999,
-                        "order": 12
+                        "finished": "2014-03-07 07:24:06.507310"
                     },
                     {
                         "errors": [],
@@ -866,10 +654,7 @@
                         "started": "2014-03-07 07:24:06.507796",
                         "started_linenumber": 32106,
                         "finished_linenumber": 32108,
-                        "finished": "2014-03-07 07:24:11.035626",
-                        "error_count": 0,
-                        "duration": 4.5278299999999998,
-                        "order": 13
+                        "finished": "2014-03-07 07:24:11.035626"
                     }
                 ]
             },

--- a/tests/e2e/test_client_job_ingestion.py
+++ b/tests/e2e/test_client_job_ingestion.py
@@ -304,8 +304,6 @@ def test_post_job_artifacts_by_add_artifact(
     tls_blob = json.dumps({
         "logurl": "https://autophone-dev.s3.amazonaws.com/pub/mozilla.org/mobile/tinderbox-builds/mozilla-inbound-android-api-9/1432676531/en-US/autophone-autophone-s1s2-s1s2-nytimes-local.ini-1-nexus-one-1.log",
         "step_data": {
-            "all_errors": [
-            ],
             "steps": [{
                 "name": "foobar",
                 "result": "testfailed",

--- a/tests/log_parser/test_artifact_builder_collection.py
+++ b/tests/log_parser/test_artifact_builder_collection.py
@@ -50,7 +50,6 @@ def test_all_builders_complete():
     exp = {
         "text_log_summary": {
             "step_data": {
-                "all_errors": [],
                 "steps": [],
                 "errors_truncated": False
             },

--- a/tests/log_parser/test_step_parser.py
+++ b/tests/log_parser/test_step_parser.py
@@ -15,11 +15,3 @@ def test_date_without_milliseconds():
     parser = StepParser()
     dt = parser.parsetime('2015-01-20 16:42:33')
     assert dt == datetime(2015, 1, 20, 16, 42, 33)
-
-
-def test_date_with_invalid_month():
-    """Gracefully handle a date whose month is invalid."""
-    parser = StepParser()
-    parser.start_step(1, timestamp='2016-00-04 19:44:35.838000')
-    parser.end_step(2, timestamp='2016-00-04 19:47:12.880000')
-    assert parser.current_step['duration'] is None

--- a/tests/model/derived/test_artifacts_model.py
+++ b/tests/model/derived/test_artifacts_model.py
@@ -142,9 +142,6 @@ def test_load_non_ascii_textlog_errors(test_project, eleven_jobs_stored):
                         'started_linenumber': 8,
                         'finished_linenumber': 10,
                         'finished': '2016-05-10 12:44:23.104394',
-                        'error_count': 0,
-                        'duration': 0,
-                        'order': 0,
                         'result': 'success',
                         'errors': [
                             {

--- a/tests/sample_data/artifacts/text_log_summary.json
+++ b/tests/sample_data/artifacts/text_log_summary.json
@@ -1,24 +1,6 @@
 {
     "blob": {
         "step_data": {
-            "all_errors": [
-                {
-                    "line": "05:35:49     INFO -  2018 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Should be able to get objectStore - expected PASS",
-                    "linenumber": 8151
-                },
-                {
-                    "line": "05:35:49     INFO -  2019 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Should be able to get index - expected PASS",
-                    "linenumber": 8152
-                },
-                {
-                    "line": "05:35:49     INFO -  2023 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Ordering is correct. - expected PASS",
-                    "linenumber": 8156
-                },
-                {
-                    "line": "05:35:49     INFO -  2024 INFO TEST-UNEXPECTED-FAIL | dom/indexedDB/test/test_transaction_lifetimes.html | Worker: uncaught exception [http://mochi.test:8888/tests/dom/indexedDB/test/unit/test_transaction_lifetimes.js:45]: ': InvalidStateError: An attempt was made to use an object that is not, or is no longer, usable' - expected PASS",
-                    "linenumber": 8157
-                }
-            ],
             "steps": [
                 {
                     "errors": [ ],
@@ -27,9 +9,6 @@
                     "started_linenumber": 8,
                     "finished_linenumber": 10,
                     "finished": "2015-04-15 05:25:03.168795",
-                    "error_count": 0,
-                    "duration": 0,
-                    "order": 0,
                     "result": "success"
                 },
                 {
@@ -39,9 +18,6 @@
                     "started_linenumber": 12,
                     "finished_linenumber": 40,
                     "finished": "2015-04-15 05:25:03.597219",
-                    "error_count": 0,
-                    "duration": 0,
-                    "order": 1,
                     "result": "success"
                 },
                 {
@@ -51,9 +27,6 @@
                     "started_linenumber": 42,
                     "finished_linenumber": 43,
                     "finished": "2015-04-15 05:25:03.726142",
-                    "error_count": 0,
-                    "duration": 0,
-                    "order": 2,
                     "result": "success"
                 },
                 {
@@ -63,9 +36,6 @@
                     "started_linenumber": 45,
                     "finished_linenumber": 71,
                     "finished": "2015-04-15 05:25:03.777120",
-                    "error_count": 0,
-                    "duration": 0,
-                    "order": 3,
                     "result": "success"
                 },
                 {
@@ -75,9 +45,6 @@
                     "started_linenumber": 73,
                     "finished_linenumber": 75,
                     "finished": "2015-04-15 05:25:03.777817",
-                    "error_count": 0,
-                    "duration": 0,
-                    "order": 4,
                     "result": "success"
                 },
                 {
@@ -87,9 +54,6 @@
                     "started_linenumber": 77,
                     "finished_linenumber": 114,
                     "finished": "2015-04-15 05:25:03.945448",
-                    "error_count": 0,
-                    "duration": 0,
-                    "order": 5,
                     "result": "success"
                 },
                 {
@@ -99,9 +63,6 @@
                     "started_linenumber": 116,
                     "finished_linenumber": 146,
                     "finished": "2015-04-15 05:25:04.682022",
-                    "error_count": 0,
-                    "duration": 1,
-                    "order": 6,
                     "result": "success"
                 },
                 {
@@ -111,9 +72,6 @@
                     "started_linenumber": 148,
                     "finished_linenumber": 174,
                     "finished": "2015-04-15 05:25:05.278125",
-                    "error_count": 0,
-                    "duration": 1,
-                    "order": 7,
                     "result": "success"
                 },
                 {
@@ -123,9 +81,6 @@
                     "started_linenumber": 176,
                     "finished_linenumber": 210,
                     "finished": "2015-04-15 05:25:11.964370",
-                    "error_count": 0,
-                    "duration": 7,
-                    "order": 8,
                     "result": "success"
                 },
                 {
@@ -135,9 +90,6 @@
                     "started_linenumber": 212,
                     "finished_linenumber": 239,
                     "finished": "2015-04-15 05:25:12.506740",
-                    "error_count": 0,
-                    "duration": 1,
-                    "order": 9,
                     "result": "success"
                 },
                 {
@@ -147,9 +99,6 @@
                     "started_linenumber": 241,
                     "finished_linenumber": 269,
                     "finished": "2015-04-15 05:25:12.700263",
-                    "error_count": 0,
-                    "duration": 0,
-                    "order": 10,
                     "result": "success"
                 },
                 {
@@ -159,9 +108,6 @@
                     "started_linenumber": 271,
                     "finished_linenumber": 272,
                     "finished": "2015-04-15 05:25:12.730239",
-                    "error_count": 0,
-                    "duration": 0,
-                    "order": 11,
                     "result": "success"
                 },
                 {
@@ -171,9 +117,6 @@
                     "started_linenumber": 274,
                     "finished_linenumber": 276,
                     "finished": "2015-04-15 05:25:12.730832",
-                    "error_count": 0,
-                    "duration": 0,
-                    "order": 12,
                     "result": "success"
                 },
                 {
@@ -200,9 +143,6 @@
                     "started_linenumber": 278,
                     "finished_linenumber": 9248,
                     "finished": "2015-04-15 05:36:51.808779",
-                    "error_count": 4,
-                    "duration": 699,
-                    "order": 13,
                     "result": "testfailed"
                 },
                 {
@@ -212,9 +152,6 @@
                     "started_linenumber": 9250,
                     "finished_linenumber": 9280,
                     "finished": "2015-04-15 05:36:51.871786",
-                    "error_count": 0,
-                    "duration": 0,
-                    "order": 14,
                     "result": "success"
                 },
                 {
@@ -224,9 +161,6 @@
                     "started_linenumber": 9282,
                     "finished_linenumber": 9308,
                     "finished": "2015-04-15 05:36:51.927004",
-                    "error_count": 0,
-                    "duration": 0,
-                    "order": 15,
                     "result": "success"
                 },
                 {
@@ -236,9 +170,6 @@
                     "started_linenumber": 9310,
                     "finished_linenumber": 9311,
                     "finished": "2015-04-15 05:36:51.927750",
-                    "error_count": 0,
-                    "duration": 0,
-                    "order": 16,
                     "result": "skipped"
                 }
             ],

--- a/tests/sample_data/logs/crash-1.logview.json
+++ b/tests/sample_data/logs/crash-1.logview.json
@@ -1,23 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "Assertion failure: !(addr & GC_CELL_MASK), at e:/builds/moz2_slave/mozilla-central-win32-debug/build/js/src/jsgc.cpp:425", 
-                "linenumber": 38365
-            }, 
-            {
-                "line": "NEXT ERROR <#err1> TEST-UNEXPECTED-FAIL | /tests/dom/tests/mochitest/ajax/jquery/test_jQuery.html | Exited with code -1073741819 during test run", 
-                "linenumber": 38373
-            }, 
-            {
-                "line": "PROCESS-CRASH | /tests/dom/tests/mochitest/ajax/jquery/test_jQuery.html | application crashed (minidump found)", 
-                "linenumber": 38376
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | automationutils.processLeakLog() | missing output line for total leaks!", 
-                "linenumber": 39521
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -26,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -38,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -67,10 +43,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 39766, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 4
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -79,10 +52,7 @@
                 "started_linenumber": 39768, 
                 "finished_linenumber": 39812, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -91,10 +61,7 @@
                 "started_linenumber": 39814, 
                 "finished_linenumber": 39816, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/crash-2.logview.json
+++ b/tests/sample_data/logs/crash-2.logview.json
@@ -1,35 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "10536 ERROR TEST-UNEXPECTED-FAIL | /tests/layout/base/tests/test_flush_on_paint.html | Test timed out.", 
-                "linenumber": 40138
-            }, 
-            {
-                "line": "37733 ERROR TEST-UNEXPECTED-FAIL | /tests/layout/base/tests/test_mozPaintCount.html | Test timed out.", 
-                "linenumber": 67346
-            }, 
-            {
-                "line": "132016 ERROR TEST-UNEXPECTED-FAIL | /tests/modules/plugin/test/test_painting.html | partially clipped plugin painted once - got 0, expected 1", 
-                "linenumber": 178796
-            }, 
-            {
-                "line": "132017 ERROR TEST-UNEXPECTED-FAIL | /tests/modules/plugin/test/test_painting.html | painted after invalidate - got 1, expected 2", 
-                "linenumber": 178797
-            }, 
-            {
-                "line": "PROCESS-CRASH | Main app process exited normally | application crashed (minidump found)", 
-                "linenumber": 179725
-            }, 
-            {
-                "line": "PROCESS-CRASH | Main app process exited normally | application crashed (minidump found)", 
-                "linenumber": 179851
-            }, 
-            {
-                "line": "PROCESS-CRASH | Main app process exited normally | application crashed (minidump found)", 
-                "linenumber": 180176
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -38,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -50,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -91,10 +55,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 180434, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 7
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -103,10 +64,7 @@
                 "started_linenumber": 180436, 
                 "finished_linenumber": 180480, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -115,10 +73,7 @@
                 "started_linenumber": 180482, 
                 "finished_linenumber": 180484, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/crash-mac-1.logview.json
+++ b/tests/sample_data/logs/crash-mac-1.logview.json
@@ -1,27 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "6635 ERROR TEST-UNEXPECTED-FAIL | chrome://mochikit/content/chrome/modules/plugin/test/test_crash_notify_no_report.xul | Test timed out.", 
-                "linenumber": 30595
-            }, 
-            {
-                "line": "6638 ERROR TEST-UNEXPECTED-FAIL | chrome://mochikit/content/chrome/modules/plugin/test/test_crash_submit.xul | [SimpleTest/SimpleTest.js, window.onerror] An error occurred - ok is not defined at chrome://mochikit/content/chrome/modules/plugin/test/test_crash_notify_no_report.xul:26", 
-                "linenumber": 30607
-            }, 
-            {
-                "line": "PROCESS-CRASH | Main app process exited normally | application crashed (minidump found)", 
-                "linenumber": 79978
-            }, 
-            {
-                "line": "PROCESS-CRASH | Main app process exited normally | application crashed (minidump found)", 
-                "linenumber": 80214
-            }, 
-            {
-                "line": "PROCESS-CRASH | Main app process exited normally | application crashed (minidump found)", 
-                "linenumber": 80367
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -30,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -42,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -75,10 +47,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 80585, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 5
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -87,10 +56,7 @@
                 "started_linenumber": 80587, 
                 "finished_linenumber": 80631, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -99,10 +65,7 @@
                 "started_linenumber": 80633, 
                 "finished_linenumber": 80635, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/crashtest-timeout.logview.json
+++ b/tests/sample_data/logs/crashtest-timeout.logview.json
@@ -1,11 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "REFTEST TEST-UNEXPECTED-FAIL | file:///home/cltbld/talos-slave/mozilla-central_fedora64_test-crashtest/build/reftest/tests/modules/plugin/test/crashtests/522512-1.html | timed out waiting for reftest-wait to be removed (after onload fired)", 
-                "linenumber": 28405
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -14,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -26,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -43,10 +31,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 28720, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 1
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -55,10 +40,7 @@
                 "started_linenumber": 28722, 
                 "finished_linenumber": 28766, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -67,10 +49,7 @@
                 "started_linenumber": 28768, 
                 "finished_linenumber": 28770, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/jsreftest-fail.logview.json
+++ b/tests/sample_data/logs/jsreftest-fail.logview.json
@@ -1,211 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "TypeError: invalid XML name <x/>[0]", 
-                "linenumber": 26935
-            }, 
-            {
-                "line": "NEXT ERROR <#err1> REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 6 of test -", 
-                "linenumber": 77428
-            }, 
-            {
-                "line": "NEXT ERROR <#err2> REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 7 of test -", 
-                "linenumber": 77435
-            }, 
-            {
-                "line": "NEXT ERROR <#err3> REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 8 of test -", 
-                "linenumber": 77442
-            }, 
-            {
-                "line": "NEXT ERROR <#err4> REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 9 of test -", 
-                "linenumber": 77449
-            }, 
-            {
-                "line": "NEXT ERROR <#err5> REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 10 of test -", 
-                "linenumber": 77456
-            }, 
-            {
-                "line": "NEXT ERROR <#err6> REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 11 of test -", 
-                "linenumber": 77463
-            }, 
-            {
-                "line": "NEXT ERROR <#err7> REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 12 of test -", 
-                "linenumber": 77470
-            }, 
-            {
-                "line": "REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 13 of test -", 
-                "linenumber": 77477
-            }, 
-            {
-                "line": "REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 14 of test -", 
-                "linenumber": 77484
-            }, 
-            {
-                "line": "REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 15 of test -", 
-                "linenumber": 77491
-            }, 
-            {
-                "line": "568786: \"Assertion failure: !(attrs & (JSPROP_GETTER | JSPROP_SETTER)),\" with Object.defineProperty", 
-                "linenumber": 80717
-            }, 
-            {
-                "line": "ReferenceError: foo is not defined", 
-                "linenumber": 83922
-            }, 
-            {
-                "line": "InternalError: script stack space quota is exhausted", 
-                "linenumber": 84364
-            }, 
-            {
-                "line": "SyntaxError: property name a appears more than once in object literal", 
-                "linenumber": 85639
-            }, 
-            {
-                "line": "SyntaxError: property name 1 appears more than once in object literal", 
-                "linenumber": 85641
-            }, 
-            {
-                "line": "TypeError: redeclaration of const 5", 
-                "linenumber": 85643
-            }, 
-            {
-                "line": "TypeError: variable v redeclares argument", 
-                "linenumber": 85741
-            }, 
-            {
-                "line": "TypeError: redeclaration of const document", 
-                "linenumber": 85966
-            }, 
-            {
-                "line": "InternalError: script stack space quota is exhausted", 
-                "linenumber": 86509
-            }, 
-            {
-                "line": "InternalError: script stack space quota is exhausted", 
-                "linenumber": 86515
-            }, 
-            {
-                "line": "InternalError: too much recursion", 
-                "linenumber": 88173
-            }, 
-            {
-                "line": "TypeError: anonymous function does not always return a value", 
-                "linenumber": 88222
-            }, 
-            {
-                "line": "TypeError: anonymous function does not always return a value", 
-                "linenumber": 88224
-            }, 
-            {
-                "line": "SyntaxError: return not in function", 
-                "linenumber": 88484
-            }, 
-            {
-                "line": "SyntaxError: syntax error", 
-                "linenumber": 88878
-            }, 
-            {
-                "line": "STATUS: Do not assert: Assertion failed: \"need a way to EOT now, since this is trace end\": 0", 
-                "linenumber": 89486
-            }, 
-            {
-                "line": "ReferenceError: a is not defined | undefined | 45", 
-                "linenumber": 89791
-            }, 
-            {
-                "line": "TypeError: z is not a function", 
-                "linenumber": 90060
-            }, 
-            {
-                "line": "SyntaxError: return not in function", 
-                "linenumber": 90066
-            }, 
-            {
-                "line": "TypeError: 6 is not a function", 
-                "linenumber": 90510
-            }, 
-            {
-                "line": "TypeError: p.z = [1].some(function (y) {return y > 0;}) ? 4 : [6] is not a function", 
-                "linenumber": 90570
-            }, 
-            {
-                "line": "TypeError: (void 0) is undefined", 
-                "linenumber": 91297
-            }, 
-            {
-                "line": "ReferenceError: d is not defined", 
-                "linenumber": 91434
-            }, 
-            {
-                "line": "ReferenceError: d is not defined", 
-                "linenumber": 91435
-            }, 
-            {
-                "line": "TypeError: [15].some([].watch) is not a function", 
-                "linenumber": 91664
-            }, 
-            {
-                "line": "TypeError: null has no properties", 
-                "linenumber": 91725
-            }, 
-            {
-                "line": "TypeError: (void 0) is undefined", 
-                "linenumber": 91894
-            }, 
-            {
-                "line": "TypeError: already executing generator iter.send", 
-                "linenumber": 91911
-            }, 
-            {
-                "line": "TypeError: already executing generator iter.next", 
-                "linenumber": 91917
-            }, 
-            {
-                "line": "TypeError: already executing generator iter.close", 
-                "linenumber": 91923
-            }, 
-            {
-                "line": "SyntaxError: let declaration not directly within block", 
-                "linenumber": 92193
-            }, 
-            {
-                "line": "SyntaxError: let declaration not directly within block", 
-                "linenumber": 92199
-            }, 
-            {
-                "line": "SyntaxError: let declaration not directly within block", 
-                "linenumber": 92205
-            }, 
-            {
-                "line": "SyntaxError: let declaration not directly within block", 
-                "linenumber": 92211
-            }, 
-            {
-                "line": "ReferenceError: d is not defined", 
-                "linenumber": 92321
-            }, 
-            {
-                "line": "TypeError: missing argument 1 when calling function watch", 
-                "linenumber": 92347
-            }, 
-            {
-                "line": "TypeError: [] is not a function", 
-                "linenumber": 92794
-            }, 
-            {
-                "line": "TypeError: XML filter is applied to non-XML value NaN", 
-                "linenumber": 92840
-            }, 
-            {
-                "line": "TypeError: null has no properties", 
-                "linenumber": 93348
-            }, 
-            {
-                "line": "STATUS: Assertion failure: staticLevel == script->staticLevel, at ../jsobj.cpp", 
-                "linenumber": 93457
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -214,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -226,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -443,10 +231,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 99130, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 51
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -455,10 +240,7 @@
                 "started_linenumber": 99132, 
                 "finished_linenumber": 99176, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -467,10 +249,7 @@
                 "started_linenumber": 99178, 
                 "finished_linenumber": 99180, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/jsreftest-timeout-crash.logview.json
+++ b/tests/sample_data/logs/jsreftest-timeout-crash.logview.json
@@ -1,19 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "TypeError: invalid XML name <x/>[0]", 
-                "linenumber": 26621
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | file:///Users/cltbld/talos-slave/mozilla-central_leopard_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/Array/15.4.4.3-1.js | application timed out after 330 seconds with no output", 
-                "linenumber": 75757
-            }, 
-            {
-                "line": "PROCESS-CRASH | file:///Users/cltbld/talos-slave/mozilla-central_leopard_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/Array/15.4.4.3-1.js | application crashed (minidump found)", 
-                "linenumber": 75761
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -22,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -34,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -59,10 +39,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 75808, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 3
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -71,10 +48,7 @@
                 "started_linenumber": 75810, 
                 "finished_linenumber": 75854, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -83,10 +57,7 @@
                 "started_linenumber": 75856, 
                 "finished_linenumber": 75858, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/large-number-of-error-lines.logview.json
+++ b/tests/sample_data/logs/large-number-of-error-lines.logview.json
@@ -1,407 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "10:33:08     INFO -  19 INFO TEST-UNEXPECTED-FAIL | toolkit/components/passwordmgr/test/browser/browser_passwordmgr_fields.js | Test timed out - expected PASS", 
-                "linenumber": 1343
-            }, 
-            {
-                "line": "10:33:08     INFO -  26 INFO TEST-UNEXPECTED-FAIL | toolkit/components/passwordmgr/test/browser/browser_passwordmgr_fields.js | Found a Toolkit:PasswordManager after previous test timed out - expected PASS", 
-                "linenumber": 1350
-            }, 
-            {
-                "line": "10:33:52     INFO -  32 INFO TEST-UNEXPECTED-FAIL | toolkit/components/passwordmgr/test/browser/browser_passwordmgr_observers.js | Test timed out - expected PASS", 
-                "linenumber": 1357
-            }, 
-            {
-                "line": "10:33:52     INFO -  38 INFO TEST-UNEXPECTED-FAIL | toolkit/components/passwordmgr/test/browser/browser_passwordmgr_observers.js | Found a Toolkit:PasswordManager after previous test timed out - expected PASS", 
-                "linenumber": 1363
-            }, 
-            {
-                "line": "10:33:52     INFO -  39 INFO TEST-UNEXPECTED-FAIL | toolkit/components/passwordmgr/test/browser/browser_passwordmgr_observers.js | Found a Toolkit:PasswordManagerExceptions after previous test timed out - expected PASS", 
-                "linenumber": 1364
-            }, 
-            {
-                "line": "10:34:37     INFO -  45 INFO TEST-UNEXPECTED-FAIL | toolkit/components/passwordmgr/test/browser/browser_passwordmgr_sort.js | Test timed out - expected PASS", 
-                "linenumber": 1371
-            }, 
-            {
-                "line": "10:34:38     INFO -  51 INFO TEST-UNEXPECTED-FAIL | toolkit/components/passwordmgr/test/browser/browser_passwordmgr_sort.js | Found a Toolkit:PasswordManager after previous test timed out - expected PASS", 
-                "linenumber": 1377
-            }, 
-            {
-                "line": "10:45:04     INFO -  67 ERROR TEST-UNEXPECTED-TIMEOUT | toolkit/components/passwordmgr/test/browser/browser_passwordmgr_switchtab.js | application timed out after 330 seconds with no output on toolkit/components/passwordmgr/test/browser", 
-                "linenumber": 1402
-            }, 
-            {
-                "line": "10:45:04     INFO -  68 ERROR TEST-UNEXPECTED-FAIL | toolkit/components/passwordmgr/test/browser/browser_passwordmgr_switchtab.js | application terminated with exit code 6", 
-                "linenumber": 1405
-            }, 
-            {
-                "line": "10:45:16  WARNING -  PROCESS-CRASH | toolkit/components/passwordmgr/test/browser/browser_passwordmgr_switchtab.js | application crashed [@ libc-2.15.so + 0xe8403]", 
-                "linenumber": 1413
-            }, 
-            {
-                "line": "10:48:53     INFO -  229 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/browser_about.js | Test timed out - expected PASS", 
-                "linenumber": 4875
-            }, 
-            {
-                "line": "10:48:53     INFO -  236 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/browser_about.js | Found a tab after previous test timed out: about:addons - expected PASS", 
-                "linenumber": 4882
-            }, 
-            {
-                "line": "10:48:53     INFO -  238 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/browser_about.js | Found a  after previous test timed out - expected PASS", 
-                "linenumber": 4884
-            }, 
-            {
-                "line": "10:48:53  WARNING -  TEST-UNEXPECTED-FAIL | unknown test url | uncaught exception - ReferenceError: info is not defined at chrome://mochitests/content/browser/toolkit/mozapps/extensions/test/browser/browser_about.js:60", 
-                "linenumber": 4887
-            }, 
-            {
-                "line": "10:52:09     INFO -  394 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/browser_select_compatoverrides.js | Test timed out - expected PASS", 
-                "linenumber": 8136
-            }, 
-            {
-                "line": "10:52:54     INFO -  428 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/browser_select_confirm.js | Test timed out - expected PASS", 
-                "linenumber": 8191
-            }, 
-            {
-                "line": "10:52:54     INFO -  435 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/browser_select_confirm.js | Found a  after previous test timed out - expected PASS", 
-                "linenumber": 8198
-            }, 
-            {
-                "line": "10:53:39     INFO -  457 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/browser_select_selection.js | Test timed out - expected PASS", 
-                "linenumber": 8236
-            }, 
-            {
-                "line": "10:53:39     INFO -  464 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/browser_select_selection.js | Found a  after previous test timed out - expected PASS", 
-                "linenumber": 8243
-            }, 
-            {
-                "line": "10:54:25     INFO -  487 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/browser_select_update.js | Test timed out - expected PASS", 
-                "linenumber": 8282
-            }, 
-            {
-                "line": "10:54:25     INFO -  494 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/browser_select_update.js | Found a  after previous test timed out - expected PASS", 
-                "linenumber": 8289
-            }, 
-            {
-                "line": "10:56:18     INFO -  557 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_about.js | Test timed out - expected PASS", 
-                "linenumber": 12179
-            }, 
-            {
-                "line": "10:56:18     INFO -  558 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_about.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12180
-            }, 
-            {
-                "line": "10:57:03     INFO -  579 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug557943.js | Test timed out - expected PASS", 
-                "linenumber": 12211
-            }, 
-            {
-                "line": "10:57:04     INFO -  580 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug557943.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12212
-            }, 
-            {
-                "line": "10:58:34     INFO -  602 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug562854.js | Test timed out - expected PASS", 
-                "linenumber": 12245
-            }, 
-            {
-                "line": "10:58:34     INFO -  603 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug562854.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12246
-            }, 
-            {
-                "line": "11:00:04     INFO -  625 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug562890.js | Test timed out - expected PASS", 
-                "linenumber": 12280
-            }, 
-            {
-                "line": "11:00:04     INFO -  626 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug562890.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12281
-            }, 
-            {
-                "line": "11:00:49     INFO -  648 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug562899.js | Test timed out - expected PASS", 
-                "linenumber": 12317
-            }, 
-            {
-                "line": "11:00:49     INFO -  649 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug562899.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12318
-            }, 
-            {
-                "line": "11:01:34     INFO -  667 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug562992.js | Test timed out - expected PASS", 
-                "linenumber": 12346
-            }, 
-            {
-                "line": "11:01:35     INFO -  668 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug562992.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12347
-            }, 
-            {
-                "line": "11:02:20     INFO -  684 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug567127.js | Test timed out - expected PASS", 
-                "linenumber": 12370
-            }, 
-            {
-                "line": "11:02:20     INFO -  685 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug567127.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12371
-            }, 
-            {
-                "line": "11:03:05     INFO -  699 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug567137.js | Test timed out - expected PASS", 
-                "linenumber": 12392
-            }, 
-            {
-                "line": "11:03:05     INFO -  700 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug567137.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12393
-            }, 
-            {
-                "line": "11:03:50     INFO -  718 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug572561.js | Test timed out - expected PASS", 
-                "linenumber": 12421
-            }, 
-            {
-                "line": "11:03:50     INFO -  719 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug572561.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12422
-            }, 
-            {
-                "line": "11:04:35     INFO -  738 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug577990.js | Test timed out - expected PASS", 
-                "linenumber": 12451
-            }, 
-            {
-                "line": "11:04:35     INFO -  739 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug577990.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12452
-            }, 
-            {
-                "line": "11:05:21     INFO -  758 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug580298.js | Test timed out - expected PASS", 
-                "linenumber": 12481
-            }, 
-            {
-                "line": "11:05:21     INFO -  759 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug580298.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12482
-            }, 
-            {
-                "line": "11:06:06     INFO -  774 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug581076.js | Test timed out - expected PASS", 
-                "linenumber": 12504
-            }, 
-            {
-                "line": "11:06:06     INFO -  775 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug581076.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12505
-            }, 
-            {
-                "line": "11:06:51     INFO -  794 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug586574.js | Test timed out - expected PASS", 
-                "linenumber": 12534
-            }, 
-            {
-                "line": "11:06:51     INFO -  795 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug586574.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12535
-            }, 
-            {
-                "line": "11:07:36     INFO -  815 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug587970.js | Test timed out - expected PASS", 
-                "linenumber": 12565
-            }, 
-            {
-                "line": "11:07:36     INFO -  816 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug587970.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12566
-            }, 
-            {
-                "line": "11:08:22     INFO -  835 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug590347.js | Test timed out - expected PASS", 
-                "linenumber": 12595
-            }, 
-            {
-                "line": "11:08:22     INFO -  836 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug590347.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12596
-            }, 
-            {
-                "line": "11:09:07     INFO -  855 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug591465.js | Test timed out - expected PASS", 
-                "linenumber": 12625
-            }, 
-            {
-                "line": "11:09:07     INFO -  856 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug591465.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12626
-            }, 
-            {
-                "line": "11:09:52     INFO -  875 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug591663.js | Test timed out - expected PASS", 
-                "linenumber": 12655
-            }, 
-            {
-                "line": "11:09:52     INFO -  876 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug591663.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12656
-            }, 
-            {
-                "line": "11:10:37     INFO -  891 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug596336.js | Test timed out - expected PASS", 
-                "linenumber": 12678
-            }, 
-            {
-                "line": "11:10:37     INFO -  892 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug596336.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12679
-            }, 
-            {
-                "line": "11:11:23     INFO -  911 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug608316.js | Test timed out - expected PASS", 
-                "linenumber": 12708
-            }, 
-            {
-                "line": "11:11:23     INFO -  912 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug608316.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12709
-            }, 
-            {
-                "line": "11:12:08     INFO -  927 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug610764.js | Test timed out - expected PASS", 
-                "linenumber": 12731
-            }, 
-            {
-                "line": "11:12:08     INFO -  928 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug610764.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12732
-            }, 
-            {
-                "line": "11:12:53     INFO -  943 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug618502.js | Test timed out - expected PASS", 
-                "linenumber": 12754
-            }, 
-            {
-                "line": "11:12:53     INFO -  944 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug618502.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12755
-            }, 
-            {
-                "line": "11:13:38     INFO -  958 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug679604.js | Test timed out - expected PASS", 
-                "linenumber": 12776
-            }, 
-            {
-                "line": "11:13:38     INFO -  959 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug679604.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12777
-            }, 
-            {
-                "line": "11:14:23     INFO -  977 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug714593.js | Test timed out - expected PASS", 
-                "linenumber": 12805
-            }, 
-            {
-                "line": "11:14:23     INFO -  978 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_bug714593.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12806
-            }, 
-            {
-                "line": "11:15:54     INFO -  998 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_debug_button.js | Test timed out - expected PASS", 
-                "linenumber": 12836
-            }, 
-            {
-                "line": "11:15:54     INFO -  999 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_debug_button.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12837
-            }, 
-            {
-                "line": "11:17:24     INFO -  1023 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_details.js | Test timed out - expected PASS", 
-                "linenumber": 12871
-            }, 
-            {
-                "line": "11:17:24     INFO -  1024 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_details.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12872
-            }, 
-            {
-                "line": "11:18:09     INFO -  1039 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_dragdrop.js | Test timed out - expected PASS", 
-                "linenumber": 12894
-            }, 
-            {
-                "line": "11:18:09     INFO -  1040 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_dragdrop.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12895
-            }, 
-            {
-                "line": "11:19:39     INFO -  1055 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_eula.js | Test timed out - expected PASS", 
-                "linenumber": 12917
-            }, 
-            {
-                "line": "11:19:39     INFO -  1056 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_eula.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12918
-            }, 
-            {
-                "line": "11:20:25     INFO -  1073 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_globalwarnings.js | Test timed out - expected PASS", 
-                "linenumber": 12942
-            }, 
-            {
-                "line": "11:20:25     INFO -  1074 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_globalwarnings.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 12943
-            }, 
-            {
-                "line": "11:21:10     INFO -  1115 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_inlinesettings.js | Test timed out - expected PASS", 
-                "linenumber": 13017
-            }, 
-            {
-                "line": "11:21:10     INFO -  1116 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_inlinesettings.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 13018
-            }, 
-            {
-                "line": "11:21:55     INFO -  1157 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_inlinesettings_custom.js | Test timed out - expected PASS", 
-                "linenumber": 13091
-            }, 
-            {
-                "line": "11:21:55     INFO -  1158 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_inlinesettings_custom.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 13092
-            }, 
-            {
-                "line": "11:22:40     INFO -  1202 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_inlinesettings_info.js | Test timed out - expected PASS", 
-                "linenumber": 13171
-            }, 
-            {
-                "line": "11:22:40     INFO -  1203 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_inlinesettings_info.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 13172
-            }, 
-            {
-                "line": "11:24:11     INFO -  1219 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_install.js | Test timed out - expected PASS", 
-                "linenumber": 13195
-            }, 
-            {
-                "line": "11:24:11     INFO -  1220 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_install.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 13196
-            }, 
-            {
-                "line": "11:24:56     INFO -  1238 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_list.js | Test timed out - expected PASS", 
-                "linenumber": 13224
-            }, 
-            {
-                "line": "11:24:56     INFO -  1239 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_list.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 13225
-            }, 
-            {
-                "line": "11:25:41     INFO -  1258 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_manualupdates.js | Test timed out - expected PASS", 
-                "linenumber": 13254
-            }, 
-            {
-                "line": "11:25:41     INFO -  1259 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_manualupdates.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 13255
-            }, 
-            {
-                "line": "11:26:27     INFO -  1276 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_pluginprefs.js | Test timed out - expected PASS", 
-                "linenumber": 13291
-            }, 
-            {
-                "line": "11:26:27     INFO -  1277 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_pluginprefs.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 13292
-            }, 
-            {
-                "line": "11:27:12     INFO -  1295 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_recentupdates.js | Test timed out - expected PASS", 
-                "linenumber": 13320
-            }, 
-            {
-                "line": "11:27:12     INFO -  1296 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_recentupdates.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 13321
-            }, 
-            {
-                "line": "11:28:42     INFO -  1316 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_searching.js | Test timed out - expected PASS", 
-                "linenumber": 13351
-            }, 
-            {
-                "line": "11:28:42     INFO -  1317 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_searching.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 13352
-            }, 
-            {
-                "line": "11:29:28     INFO -  1336 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_sorting.js | Test timed out - expected PASS", 
-                "linenumber": 13381
-            }, 
-            {
-                "line": "11:29:28     INFO -  1337 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_sorting.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 13382
-            }, 
-            {
-                "line": "11:30:13     INFO -  1356 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_sorting_plugins.js | Test timed out - expected PASS", 
-                "linenumber": 13411
-            }, 
-            {
-                "line": "11:30:13     INFO -  1357 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_sorting_plugins.js | Found unexpected Addons:Manager window still open -", 
-                "linenumber": 13412
-            }, 
-            {
-                "line": "11:31:54     INFO -  1403 INFO TEST-UNEXPECTED-FAIL | toolkit/mozapps/extensions/test/browser/test-window/browser_about.js | Test timed out - expected PASS", 
-                "linenumber": 13623
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -410,9 +8,6 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2015-01-22 10:29:53.296573", 
-                "error_count": 0, 
-                "duration": 0, 
-                "order": 0, 
                 "result": "success"
             }, 
             {
@@ -422,9 +17,6 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 37, 
                 "finished": "2015-01-22 10:29:53.408820", 
-                "error_count": 0, 
-                "duration": 0, 
-                "order": 1, 
                 "result": "success"
             }, 
             {
@@ -434,9 +26,6 @@
                 "started_linenumber": 39, 
                 "finished_linenumber": 40, 
                 "finished": "2015-01-22 10:29:53.450124", 
-                "error_count": 0, 
-                "duration": 0, 
-                "order": 2, 
                 "result": "success"
             }, 
             {
@@ -446,9 +35,6 @@
                 "started_linenumber": 42, 
                 "finished_linenumber": 65, 
                 "finished": "2015-01-22 10:29:53.518076", 
-                "error_count": 0, 
-                "duration": 0, 
-                "order": 3, 
                 "result": "success"
             }, 
             {
@@ -458,9 +44,6 @@
                 "started_linenumber": 67, 
                 "finished_linenumber": 69, 
                 "finished": "2015-01-22 10:29:53.518865", 
-                "error_count": 0, 
-                "duration": 0, 
-                "order": 4, 
                 "result": "success"
             }, 
             {
@@ -470,9 +53,6 @@
                 "started_linenumber": 71, 
                 "finished_linenumber": 94, 
                 "finished": "2015-01-22 10:29:53.611941", 
-                "error_count": 0, 
-                "duration": 0, 
-                "order": 5, 
                 "result": "success"
             }, 
             {
@@ -482,9 +62,6 @@
                 "started_linenumber": 96, 
                 "finished_linenumber": 127, 
                 "finished": "2015-01-22 10:29:59.025351", 
-                "error_count": 0, 
-                "duration": 5, 
-                "order": 6, 
                 "result": "success"
             }, 
             {
@@ -494,9 +71,6 @@
                 "started_linenumber": 129, 
                 "finished_linenumber": 153, 
                 "finished": "2015-01-22 10:29:59.667828", 
-                "error_count": 0, 
-                "duration": 1, 
-                "order": 7, 
                 "result": "success"
             }, 
             {
@@ -506,9 +80,6 @@
                 "started_linenumber": 155, 
                 "finished_linenumber": 180, 
                 "finished": "2015-01-22 10:30:00.236152", 
-                "error_count": 0, 
-                "duration": 1, 
-                "order": 8, 
                 "result": "success"
             }, 
             {
@@ -518,9 +89,6 @@
                 "started_linenumber": 182, 
                 "finished_linenumber": 183, 
                 "finished": "2015-01-22 10:30:00.275536", 
-                "error_count": 0, 
-                "duration": 0, 
-                "order": 9, 
                 "result": "success"
             }, 
             {
@@ -530,9 +98,6 @@
                 "started_linenumber": 185, 
                 "finished_linenumber": 187, 
                 "finished": "2015-01-22 10:30:00.276399", 
-                "error_count": 0, 
-                "duration": 0, 
-                "order": 10, 
                 "result": "success"
             }, 
             {
@@ -943,9 +508,6 @@
                 "started_linenumber": 189, 
                 "finished_linenumber": 17614, 
                 "finished": "2015-01-22 12:14:23.234476", 
-                "error_count": 181, 
-                "duration": 6263, 
-                "order": 11, 
                 "result": "busted"
             }, 
             {
@@ -955,9 +517,6 @@
                 "started_linenumber": 17616, 
                 "finished_linenumber": 17643, 
                 "finished": "2015-01-22 12:14:23.317817", 
-                "error_count": 0, 
-                "duration": 0, 
-                "order": 12, 
                 "result": "success"
             }, 
             {
@@ -967,9 +526,6 @@
                 "started_linenumber": 17645, 
                 "finished_linenumber": 17668, 
                 "finished": "2015-01-22 12:14:23.387528", 
-                "error_count": 0, 
-                "duration": 0, 
-                "order": 13, 
                 "result": "success"
             }, 
             {
@@ -979,9 +535,6 @@
                 "started_linenumber": 17670, 
                 "finished_linenumber": 17671, 
                 "finished": "2015-01-22 12:14:23.388290", 
-                "error_count": 0, 
-                "duration": 0, 
-                "order": 14, 
                 "result": "skipped"
             }
         ], 

--- a/tests/sample_data/logs/leaks-1.logview.json
+++ b/tests/sample_data/logs/leaks-1.logview.json
@@ -1,31 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "TEST-UNEXPECTED-FAIL | automationutils.processLeakLog() | leaked 599603 bytes during test execution", 
-                "linenumber": 145445
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | automationutils.processLeakLog() | leaked 168 instances of AtomImpl with size 40 bytes each (6720 bytes total)", 
-                "linenumber": 145446
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | automationutils.processLeakLog() | leaked 1 instance of BackstagePass with size 48 bytes", 
-                "linenumber": 145447
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | automationutils.processLeakLog() | leaked 2 instances of CSSImportRuleImpl with size 88 bytes each (176 bytes total)", 
-                "linenumber": 145448
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | automationutils.processLeakLog() | leaked 46 instances of CSSImportantRule with size 32 bytes each (1472 bytes total)", 
-                "linenumber": 145449
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | automationutils.processLeakLog() | leaked 13 instances of CSSNameSpaceRuleImpl with size 80 bytes each (1040 bytes total)", 
-                "linenumber": 145450
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -34,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -46,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -83,10 +51,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 147796, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 6
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -95,10 +60,7 @@
                 "started_linenumber": 147798, 
                 "finished_linenumber": 147842, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -107,10 +69,7 @@
                 "started_linenumber": 147844, 
                 "finished_linenumber": 147846, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/mochitest-test-end.logview.json
+++ b/tests/sample_data/logs/mochitest-test-end.logview.json
@@ -1,15 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "TEST-UNEXPECTED-FAIL | chrome://mochitests/content/browser/browser/components/places/tests/browser/browser_forgetthissite_single.js | Test timed out", 
-                "linenumber": 45
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | chrome://mochitests/content/browser/browser/components/places/tests/browser/browser_forgetthissite_single.js | Test timed out", 
-                "linenumber": 34259
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -18,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -30,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -51,10 +35,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 83579, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 2
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -63,10 +44,7 @@
                 "started_linenumber": 83581, 
                 "finished_linenumber": 83625, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -75,10 +53,7 @@
                 "started_linenumber": 83627, 
                 "finished_linenumber": 83629, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/mozilla-central-win32-pgo-bm85-build1-build111.logview.json
+++ b/tests/sample_data/logs/mozilla-central-win32-pgo-bm85-build1-build111.logview.json
@@ -1,6 +1,5 @@
 {
     "step_data": {
-        "all_errors": [], 
         "steps": [
             {
                 "errors": [], 
@@ -9,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 91, 
                 "finished": "2014-06-29 22:30:17.733586", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -21,10 +17,7 @@
                 "started_linenumber": 93, 
                 "finished_linenumber": 95, 
                 "finished": "2014-06-29 22:30:17.734323", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -33,10 +26,7 @@
                 "started_linenumber": 97, 
                 "finished_linenumber": 180, 
                 "finished": "2014-06-29 22:30:17.852754", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 2, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -45,10 +35,7 @@
                 "started_linenumber": 182, 
                 "finished_linenumber": 263, 
                 "finished": "2014-06-29 22:30:29.974564", 
-                "result": "success", 
-                "duration": 12, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -57,10 +44,7 @@
                 "started_linenumber": 265, 
                 "finished_linenumber": 353, 
                 "finished": "2014-06-29 22:30:44.923107", 
-                "result": "success", 
-                "duration": 15, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -69,10 +53,7 @@
                 "started_linenumber": 355, 
                 "finished_linenumber": 438, 
                 "finished": "2014-06-29 22:30:45.044162", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 5, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -81,10 +62,7 @@
                 "started_linenumber": 440, 
                 "finished_linenumber": 522, 
                 "finished": "2014-06-29 22:30:45.166864", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 6, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -93,10 +71,7 @@
                 "started_linenumber": 524, 
                 "finished_linenumber": 709, 
                 "finished": "2014-06-29 22:40:58.302111", 
-                "result": "success", 
-                "duration": 613, 
-                "order": 7, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -105,10 +80,7 @@
                 "started_linenumber": 711, 
                 "finished_linenumber": 808, 
                 "finished": "2014-06-29 22:41:00.825003", 
-                "result": "success", 
-                "duration": 3, 
-                "order": 8, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -117,10 +89,7 @@
                 "started_linenumber": 810, 
                 "finished_linenumber": 811, 
                 "finished": "2014-06-29 22:41:00.825811", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 9, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -129,10 +98,7 @@
                 "started_linenumber": 813, 
                 "finished_linenumber": 896, 
                 "finished": "2014-06-29 22:41:00.948217", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 10, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -141,10 +107,7 @@
                 "started_linenumber": 898, 
                 "finished_linenumber": 981, 
                 "finished": "2014-06-29 22:41:01.066839", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 11, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -153,10 +116,7 @@
                 "started_linenumber": 983, 
                 "finished_linenumber": 1064, 
                 "finished": "2014-06-29 22:41:01.185636", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 12, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -165,10 +125,7 @@
                 "started_linenumber": 1066, 
                 "finished_linenumber": 1156, 
                 "finished": "2014-06-29 22:41:06.592065", 
-                "result": "success", 
-                "duration": 5, 
-                "order": 13, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -177,10 +134,7 @@
                 "started_linenumber": 1158, 
                 "finished_linenumber": 1240, 
                 "finished": "2014-06-29 22:41:07.116755", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 14, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -189,10 +143,7 @@
                 "started_linenumber": 1242, 
                 "finished_linenumber": 1336, 
                 "finished": "2014-06-29 22:41:07.635397", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 15, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -201,10 +152,7 @@
                 "started_linenumber": 1338, 
                 "finished_linenumber": 1339, 
                 "finished": "2014-06-29 22:41:07.757331", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 16, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -213,10 +161,7 @@
                 "started_linenumber": 1341, 
                 "finished_linenumber": 1514, 
                 "finished": "2014-06-29 22:53:53.500864", 
-                "result": "success", 
-                "duration": 766, 
-                "order": 17, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -225,10 +170,7 @@
                 "started_linenumber": 1516, 
                 "finished_linenumber": 1598, 
                 "finished": "2014-06-29 22:53:53.723762", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 18, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -237,10 +179,7 @@
                 "started_linenumber": 1600, 
                 "finished_linenumber": 1602, 
                 "finished": "2014-06-29 22:53:53.724565", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 19, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -249,10 +188,7 @@
                 "started_linenumber": 1604, 
                 "finished_linenumber": 1688, 
                 "finished": "2014-06-29 22:53:54.184027", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 20, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -261,10 +197,7 @@
                 "started_linenumber": 1690, 
                 "finished_linenumber": 1782, 
                 "finished": "2014-06-29 22:53:54.304847", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 21, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -273,10 +206,7 @@
                 "started_linenumber": 1784, 
                 "finished_linenumber": 1907, 
                 "finished": "2014-06-29 22:53:56.138113", 
-                "result": "success", 
-                "duration": 2, 
-                "order": 22, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -285,10 +215,7 @@
                 "started_linenumber": 1909, 
                 "finished_linenumber": 1990, 
                 "finished": "2014-06-29 22:53:56.257351", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 23, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -297,10 +224,7 @@
                 "started_linenumber": 1992, 
                 "finished_linenumber": 1997, 
                 "finished": "2014-06-29 22:53:56.469662", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 24, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -309,10 +233,7 @@
                 "started_linenumber": 1999, 
                 "finished_linenumber": 56727, 
                 "finished": "2014-06-30 02:21:57.813004", 
-                "result": "success", 
-                "duration": 12481, 
-                "order": 25, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -321,10 +242,7 @@
                 "started_linenumber": 56729, 
                 "finished_linenumber": 56813, 
                 "finished": "2014-06-30 02:21:57.958564", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 26, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -333,10 +251,7 @@
                 "started_linenumber": 56815, 
                 "finished_linenumber": 56898, 
                 "finished": "2014-06-30 02:22:00.177483", 
-                "result": "success", 
-                "duration": 2, 
-                "order": 27, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -345,10 +260,7 @@
                 "started_linenumber": 56900, 
                 "finished_linenumber": 56983, 
                 "finished": "2014-06-30 02:22:00.298879", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 28, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -357,10 +269,7 @@
                 "started_linenumber": 56985, 
                 "finished_linenumber": 56986, 
                 "finished": "2014-06-30 02:22:00.313580", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 29, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -369,10 +278,7 @@
                 "started_linenumber": 56988, 
                 "finished_linenumber": 57087, 
                 "finished": "2014-06-30 02:22:01.356388", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 30, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -381,10 +287,7 @@
                 "started_linenumber": 57089, 
                 "finished_linenumber": 57820, 
                 "finished": "2014-06-30 02:27:10.574663", 
-                "result": "success", 
-                "duration": 309, 
-                "order": 31, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -393,10 +296,7 @@
                 "started_linenumber": 57822, 
                 "finished_linenumber": 58321, 
                 "finished": "2014-06-30 02:34:37.112183", 
-                "result": "success", 
-                "duration": 447, 
-                "order": 32, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -405,10 +305,7 @@
                 "started_linenumber": 58323, 
                 "finished_linenumber": 62457, 
                 "finished": "2014-06-30 02:36:25.733582", 
-                "result": "success", 
-                "duration": 109, 
-                "order": 33, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -417,10 +314,7 @@
                 "started_linenumber": 62459, 
                 "finished_linenumber": 62541, 
                 "finished": "2014-06-30 02:36:50.759546", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 34, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -429,10 +323,7 @@
                 "started_linenumber": 62543, 
                 "finished_linenumber": 62626, 
                 "finished": "2014-06-30 02:36:50.883981", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 35, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -441,10 +332,7 @@
                 "started_linenumber": 62628, 
                 "finished_linenumber": 62711, 
                 "finished": "2014-06-30 02:36:51.003225", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 36, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -453,10 +341,7 @@
                 "started_linenumber": 62713, 
                 "finished_linenumber": 62796, 
                 "finished": "2014-06-30 02:36:51.727337", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 37, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -465,10 +350,7 @@
                 "started_linenumber": 62798, 
                 "finished_linenumber": 62881, 
                 "finished": "2014-06-30 02:36:51.852435", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 38, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -477,10 +359,7 @@
                 "started_linenumber": 62883, 
                 "finished_linenumber": 66692, 
                 "finished": "2014-06-30 02:38:19.792708", 
-                "result": "success", 
-                "duration": 88, 
-                "order": 39, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -489,10 +368,7 @@
                 "started_linenumber": 66694, 
                 "finished_linenumber": 66776, 
                 "finished": "2014-06-30 02:38:20.178990", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 40, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -501,10 +377,7 @@
                 "started_linenumber": 66778, 
                 "finished_linenumber": 66861, 
                 "finished": "2014-06-30 02:38:20.299869", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 41, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -513,10 +386,7 @@
                 "started_linenumber": 66863, 
                 "finished_linenumber": 66946, 
                 "finished": "2014-06-30 02:38:20.422898", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 42, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -525,10 +395,7 @@
                 "started_linenumber": 66948, 
                 "finished_linenumber": 67031, 
                 "finished": "2014-06-30 02:38:20.746602", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 43, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -537,10 +404,7 @@
                 "started_linenumber": 67033, 
                 "finished_linenumber": 67116, 
                 "finished": "2014-06-30 02:38:20.866610", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 44, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -549,10 +413,7 @@
                 "started_linenumber": 67118, 
                 "finished_linenumber": 67201, 
                 "finished": "2014-06-30 02:38:20.988577", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 45, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -561,10 +422,7 @@
                 "started_linenumber": 67203, 
                 "finished_linenumber": 67286, 
                 "finished": "2014-06-30 02:38:21.111717", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 46, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -573,10 +431,7 @@
                 "started_linenumber": 67288, 
                 "finished_linenumber": 67371, 
                 "finished": "2014-06-30 02:38:21.235722", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 47, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -585,10 +440,7 @@
                 "started_linenumber": 67373, 
                 "finished_linenumber": 67550, 
                 "finished": "2014-06-30 02:38:44.118836", 
-                "result": "success", 
-                "duration": 23, 
-                "order": 48, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -597,10 +449,7 @@
                 "started_linenumber": 67552, 
                 "finished_linenumber": 67553, 
                 "finished": "2014-06-30 02:38:44.120762", 
-                "result": "skipped", 
-                "duration": 0, 
-                "order": 49, 
-                "error_count": 0
+                "result": "skipped"
             }, 
             {
                 "errors": [], 
@@ -609,10 +458,7 @@
                 "started_linenumber": 67555, 
                 "finished_linenumber": 67662, 
                 "finished": "2014-06-30 02:38:51.041903", 
-                "result": "success", 
-                "duration": 7, 
-                "order": 50, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -621,10 +467,7 @@
                 "started_linenumber": 67664, 
                 "finished_linenumber": 67771, 
                 "finished": "2014-06-30 02:38:51.425600", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 51, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -633,10 +476,7 @@
                 "started_linenumber": 67773, 
                 "finished_linenumber": 69359, 
                 "finished": "2014-06-30 02:40:35.920512", 
-                "result": "success", 
-                "duration": 104, 
-                "order": 52, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -645,10 +485,7 @@
                 "started_linenumber": 69361, 
                 "finished_linenumber": 79220, 
                 "finished": "2014-06-30 02:45:56.094867", 
-                "result": "success", 
-                "duration": 320, 
-                "order": 53, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -657,10 +494,7 @@
                 "started_linenumber": 79222, 
                 "finished_linenumber": 79224, 
                 "finished": "2014-06-30 02:45:56.743970", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 54, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50.logview.json
+++ b/tests/sample_data/logs/mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50.logview.json
@@ -1,6 +1,5 @@
 {
     "step_data": {
-        "all_errors": [], 
         "steps": [
             {
                 "errors": [], 
@@ -9,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:39:57.839226", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -21,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 42, 
                 "finished": "2013-06-05 12:39:58.346114", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -33,10 +26,7 @@
                 "started_linenumber": 44, 
                 "finished_linenumber": 45, 
                 "finished": "2013-06-05 12:39:58.614586", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 2, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -45,10 +35,7 @@
                 "started_linenumber": 47, 
                 "finished_linenumber": 75, 
                 "finished": "2013-06-05 12:39:58.723069", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -57,10 +44,7 @@
                 "started_linenumber": 77, 
                 "finished_linenumber": 105, 
                 "finished": "2013-06-05 12:39:58.831972", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -69,10 +53,7 @@
                 "started_linenumber": 107, 
                 "finished_linenumber": 142, 
                 "finished": "2013-06-05 12:40:01.114413", 
-                "result": "success", 
-                "duration": 2, 
-                "order": 5, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -81,10 +62,7 @@
                 "started_linenumber": 144, 
                 "finished_linenumber": 173, 
                 "finished": "2013-06-05 12:40:01.335999", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 6, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -93,10 +71,7 @@
                 "started_linenumber": 175, 
                 "finished_linenumber": 205, 
                 "finished": "2013-06-05 12:40:01.520234", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 7, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -105,10 +80,7 @@
                 "started_linenumber": 207, 
                 "finished_linenumber": 209, 
                 "finished": "2013-06-05 12:40:01.521320", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 8, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -117,10 +89,7 @@
                 "started_linenumber": 211, 
                 "finished_linenumber": 3369, 
                 "finished": "2013-06-05 12:57:55.646752", 
-                "result": "success", 
-                "duration": 1074, 
-                "order": 9, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -129,10 +98,7 @@
                 "started_linenumber": 3371, 
                 "finished_linenumber": 3401, 
                 "finished": "2013-06-05 12:57:55.793402", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 10, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -141,10 +107,7 @@
                 "started_linenumber": 3403, 
                 "finished_linenumber": 3433, 
                 "finished": "2013-06-05 12:58:55.994641", 
-                "result": "success", 
-                "duration": 60, 
-                "order": 11, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141.logview.json
+++ b/tests/sample_data/logs/mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141.logview.json
@@ -1,6 +1,5 @@
 {
     "step_data": {
-        "all_errors": [], 
         "steps": [
             {
                 "errors": [], 
@@ -9,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:55:02.794485", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -21,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 36, 
                 "finished": "2013-06-05 12:55:03.579905", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -33,10 +26,7 @@
                 "started_linenumber": 38, 
                 "finished_linenumber": 39, 
                 "finished": "2013-06-05 12:55:05.429410", 
-                "result": "success", 
-                "duration": 2, 
-                "order": 2, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -45,10 +35,7 @@
                 "started_linenumber": 41, 
                 "finished_linenumber": 63, 
                 "finished": "2013-06-05 12:55:05.711713", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -57,10 +44,7 @@
                 "started_linenumber": 65, 
                 "finished_linenumber": 87, 
                 "finished": "2013-06-05 12:55:05.951055", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -69,10 +53,7 @@
                 "started_linenumber": 89, 
                 "finished_linenumber": 118, 
                 "finished": "2013-06-05 12:55:08.587665", 
-                "result": "success", 
-                "duration": 3, 
-                "order": 5, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -81,10 +62,7 @@
                 "started_linenumber": 120, 
                 "finished_linenumber": 143, 
                 "finished": "2013-06-05 12:55:09.070938", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 6, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -93,10 +71,7 @@
                 "started_linenumber": 145, 
                 "finished_linenumber": 169, 
                 "finished": "2013-06-05 12:55:09.553968", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 7, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -105,10 +80,7 @@
                 "started_linenumber": 171, 
                 "finished_linenumber": 173, 
                 "finished": "2013-06-05 12:55:09.555053", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 8, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -117,10 +89,7 @@
                 "started_linenumber": 175, 
                 "finished_linenumber": 11552, 
                 "finished": "2013-06-05 13:02:38.681825", 
-                "result": "success", 
-                "duration": 449, 
-                "order": 9, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -129,10 +98,7 @@
                 "started_linenumber": 11554, 
                 "finished_linenumber": 11578, 
                 "finished": "2013-06-05 13:02:38.876303", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 10, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -141,10 +107,7 @@
                 "started_linenumber": 11580, 
                 "finished_linenumber": 11609, 
                 "finished": "2013-06-05 13:03:00.115654", 
-                "result": "success", 
-                "duration": 21, 
-                "order": 11, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/mozilla-central_ubuntu64_hw_test-androidx86-set-4-bm103-tests1-linux-build369.logview.json
+++ b/tests/sample_data/logs/mozilla-central_ubuntu64_hw_test-androidx86-set-4-bm103-tests1-linux-build369.logview.json
@@ -1,15 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "09:14:00     INFO -  org.json.JSONException: Unterminated string at character 23963 of {\"reason\":\"android-anr-report\",\"slug\":\"5e99c087-ebb5-4091-b5c8-75bd0889509c\",\"payload\":{\"ver\":1,\"simpleMeasurements\":{\"uptime\":0},\"info\":{\"reason\":\"android-anr-report\",\"OS\":\"Android\",\"version\":\"17\",\"appID\":\"{aa3c5121-dab2-40e2-81ca-7ea25febc110}\",\"appVersion\":\"33.0a1\",\"appName\":\"Fennec\",\"appBuildID\":\"20140717073317\",\"appUpdateChannel\":\"default\",\"platformBuildID\":\"20140717073317\",\"locale\":\"en-US\",\"cpucount\":1,\"", 
-                "linenumber": 3544
-            }, 
-            {
-                "line": "09:14:00     INFO -  17 INFO TEST-UNEXPECTED-FAIL | testANRReporter | Exception caught - org.json.JSONException: Unterminated string at character 23963 of {\"reason\":\"android-anr-report\",\"slug\":\"5e99c087-ebb5-4091-b5c8-75bd0889509c\",\"payload\":{\"ver\":1,\"simpleMeasurements\":{\"uptime\":0},\"info\":{\"reason\":\"android-anr-report\",\"OS\":\"Android\",\"version\":\"17\",\"appID\":\"{aa3c5121-dab2-40e2-81ca-7ea25febc110}\",\"appVersion\":\"33.0a1\",\"appName\":\"Fennec\",\"appBuildID\":\"20140717073317\",\"appUpdateChannel\":\"default", 
-                "linenumber": 3571
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -18,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2014-07-17 08:45:18.802011", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -30,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 56, 
                 "finished": "2014-07-17 08:45:18.854874", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -42,10 +26,7 @@
                 "started_linenumber": 58, 
                 "finished_linenumber": 59, 
                 "finished": "2014-07-17 08:45:18.904210", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 2, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -54,10 +35,7 @@
                 "started_linenumber": 61, 
                 "finished_linenumber": 103, 
                 "finished": "2014-07-17 08:45:18.943479", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -66,10 +44,7 @@
                 "started_linenumber": 105, 
                 "finished_linenumber": 147, 
                 "finished": "2014-07-17 08:45:19.043322", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -78,10 +53,7 @@
                 "started_linenumber": 149, 
                 "finished_linenumber": 198, 
                 "finished": "2014-07-17 08:45:21.830887", 
-                "result": "success", 
-                "duration": 3, 
-                "order": 5, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -90,10 +62,7 @@
                 "started_linenumber": 200, 
                 "finished_linenumber": 243, 
                 "finished": "2014-07-17 08:45:22.037742", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 6, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -102,10 +71,7 @@
                 "started_linenumber": 245, 
                 "finished_linenumber": 289, 
                 "finished": "2014-07-17 08:45:22.126650", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 7, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -114,10 +80,7 @@
                 "started_linenumber": 291, 
                 "finished_linenumber": 292, 
                 "finished": "2014-07-17 08:45:22.140342", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 8, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -126,10 +89,7 @@
                 "started_linenumber": 294, 
                 "finished_linenumber": 296, 
                 "finished": "2014-07-17 08:45:22.141210", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 9, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -147,10 +107,7 @@
                 "started_linenumber": 298, 
                 "finished_linenumber": 10231, 
                 "finished": "2014-07-17 09:18:15.066397", 
-                "result": "testfailed", 
-                "duration": 1973, 
-                "order": 10, 
-                "error_count": 2
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -159,10 +116,7 @@
                 "started_linenumber": 10233, 
                 "finished_linenumber": 10279, 
                 "finished": "2014-07-17 09:18:15.266212", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 11, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -171,10 +125,7 @@
                 "started_linenumber": 10281, 
                 "finished_linenumber": 10323, 
                 "finished": "2014-07-17 09:18:15.290870", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 12, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -183,10 +134,7 @@
                 "started_linenumber": 10325, 
                 "finished_linenumber": 10369, 
                 "finished": "2014-07-17 09:18:22.104200", 
-                "result": "success", 
-                "duration": 7, 
-                "order": 13, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.logview.json
+++ b/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.logview.json
@@ -1,15 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "TEST-UNEXPECTED-FAIL | chrome://mochitests/content/browser/dom/tests/browser/browser_ConsoleAPITests.js | Exception thrown in CO_observe: TypeError: Components.utils.isXrayWrapper is not a function", 
-                "linenumber": 26698
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | chrome://mochitests/content/browser/dom/tests/browser/browser_ConsoleAPITests.js | Test timed out", 
-                "linenumber": 26705
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -18,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -30,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -42,10 +26,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 62, 
                 "finished": "2013-06-05 12:51:50.898723", 
-                "result": "success", 
-                "duration": 2, 
-                "order": 2, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -54,10 +35,7 @@
                 "started_linenumber": 64, 
                 "finished_linenumber": 110, 
                 "finished": "2013-06-05 12:51:51.050525", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -66,10 +44,7 @@
                 "started_linenumber": 112, 
                 "finished_linenumber": 158, 
                 "finished": "2013-06-05 12:51:51.285053", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -78,10 +53,7 @@
                 "started_linenumber": 160, 
                 "finished_linenumber": 204, 
                 "finished": "2013-06-05 12:52:04.344452", 
-                "result": "success", 
-                "duration": 13, 
-                "order": 5, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -90,10 +62,7 @@
                 "started_linenumber": 206, 
                 "finished_linenumber": 257, 
                 "finished": "2013-06-05 12:52:27.906228", 
-                "result": "success", 
-                "duration": 24, 
-                "order": 6, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -102,10 +71,7 @@
                 "started_linenumber": 259, 
                 "finished_linenumber": 305, 
                 "finished": "2013-06-05 12:52:28.096555", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 7, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -114,10 +80,7 @@
                 "started_linenumber": 307, 
                 "finished_linenumber": 373, 
                 "finished": "2013-06-05 12:52:28.689661", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 8, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -126,10 +89,7 @@
                 "started_linenumber": 375, 
                 "finished_linenumber": 419, 
                 "finished": "2013-06-05 12:53:56.014058", 
-                "result": "success", 
-                "duration": 87, 
-                "order": 9, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -138,10 +98,7 @@
                 "started_linenumber": 421, 
                 "finished_linenumber": 484, 
                 "finished": "2013-06-05 12:54:02.983974", 
-                "result": "success", 
-                "duration": 7, 
-                "order": 10, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -150,10 +107,7 @@
                 "started_linenumber": 486, 
                 "finished_linenumber": 530, 
                 "finished": "2013-06-05 12:54:06.858348", 
-                "result": "success", 
-                "duration": 4, 
-                "order": 11, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -162,10 +116,7 @@
                 "started_linenumber": 532, 
                 "finished_linenumber": 534, 
                 "finished": "2013-06-05 12:54:06.859521", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 12, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -174,10 +125,7 @@
                 "started_linenumber": 536, 
                 "finished_linenumber": 538, 
                 "finished": "2013-06-05 12:54:06.860629", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 13, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -186,10 +134,7 @@
                 "started_linenumber": 540, 
                 "finished_linenumber": 586, 
                 "finished": "2013-06-05 12:54:07.047366", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 14, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -198,10 +143,7 @@
                 "started_linenumber": 588, 
                 "finished_linenumber": 590, 
                 "finished": "2013-06-05 12:54:07.048555", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 15, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -210,10 +152,7 @@
                 "started_linenumber": 592, 
                 "finished_linenumber": 665, 
                 "finished": "2013-06-05 12:54:22.389733", 
-                "result": "success", 
-                "duration": 15, 
-                "order": 16, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -222,10 +161,7 @@
                 "started_linenumber": 667, 
                 "finished_linenumber": 714, 
                 "finished": "2013-06-05 12:54:22.547237", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 17, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -234,10 +170,7 @@
                 "started_linenumber": 716, 
                 "finished_linenumber": 761, 
                 "finished": "2013-06-05 12:54:23.359326", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 18, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -246,10 +179,7 @@
                 "started_linenumber": 763, 
                 "finished_linenumber": 807, 
                 "finished": "2013-06-05 12:54:55.231690", 
-                "result": "success", 
-                "duration": 32, 
-                "order": 19, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -267,10 +197,7 @@
                 "started_linenumber": 809, 
                 "finished_linenumber": 54423, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 20, 
-                "error_count": 2
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -279,10 +206,7 @@
                 "started_linenumber": 54425, 
                 "finished_linenumber": 54469, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 21, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -291,10 +215,7 @@
                 "started_linenumber": 54471, 
                 "finished_linenumber": 54473, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 22, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122.logview.json
+++ b/tests/sample_data/logs/mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122.logview.json
@@ -1,55 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "12:46:31     INFO -  Assertion failure: pNew->iVersion == pSub->iVersion, at ../../../storage/src/TelemetryVFS.cpp:357", 
-                "linenumber": 825
-            }, 
-            {
-                "line": "12:46:31  WARNING -  TEST-UNEXPECTED-FAIL | automation.py | Exited with code 11 during test run", 
-                "linenumber": 826
-            }, 
-            {
-                "line": "12:46:37  WARNING -  PROCESS-CRASH | automation.py | application crashed [@ xOpen]", 
-                "linenumber": 829
-            }, 
-            {
-                "line": "12:46:38    ERROR - Return code: 1", 
-                "linenumber": 1600
-            }, 
-            {
-                "line": "12:46:40     INFO -  Assertion failure: pNew->iVersion == pSub->iVersion, at ../../../storage/src/TelemetryVFS.cpp:357", 
-                "linenumber": 1632
-            }, 
-            {
-                "line": "12:46:40  WARNING -  TEST-UNEXPECTED-FAIL | automation.py | Exited with code 11 during test run", 
-                "linenumber": 1633
-            }, 
-            {
-                "line": "12:46:46  WARNING -  PROCESS-CRASH | automation.py | application crashed [@ xOpen]", 
-                "linenumber": 1636
-            }, 
-            {
-                "line": "12:46:46    ERROR - Return code: 1", 
-                "linenumber": 2283
-            }, 
-            {
-                "line": "12:46:48     INFO -  Assertion failure: pNew->iVersion == pSub->iVersion, at ../../../storage/src/TelemetryVFS.cpp:357", 
-                "linenumber": 2315
-            }, 
-            {
-                "line": "12:46:48  WARNING -  TEST-UNEXPECTED-FAIL | automation.py | Exited with code 11 during test run", 
-                "linenumber": 2316
-            }, 
-            {
-                "line": "12:46:55  WARNING -  PROCESS-CRASH | automation.py | application crashed [@ xOpen]", 
-                "linenumber": 2319
-            }, 
-            {
-                "line": "12:46:55    ERROR - Return code: 1", 
-                "linenumber": 3062
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -58,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:44:58.843804", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -70,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 52, 
                 "finished": "2013-06-05 12:44:58.975106", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -82,10 +26,7 @@
                 "started_linenumber": 54, 
                 "finished_linenumber": 55, 
                 "finished": "2013-06-05 12:44:59.037644", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 2, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -94,10 +35,7 @@
                 "started_linenumber": 57, 
                 "finished_linenumber": 95, 
                 "finished": "2013-06-05 12:44:59.112857", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -106,10 +44,7 @@
                 "started_linenumber": 97, 
                 "finished_linenumber": 135, 
                 "finished": "2013-06-05 12:44:59.201908", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -118,10 +53,7 @@
                 "started_linenumber": 137, 
                 "finished_linenumber": 182, 
                 "finished": "2013-06-05 12:45:02.180652", 
-                "result": "success", 
-                "duration": 3, 
-                "order": 5, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -130,10 +62,7 @@
                 "started_linenumber": 184, 
                 "finished_linenumber": 223, 
                 "finished": "2013-06-05 12:45:02.421021", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 6, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -142,10 +71,7 @@
                 "started_linenumber": 225, 
                 "finished_linenumber": 265, 
                 "finished": "2013-06-05 12:45:02.558016", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 7, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -154,10 +80,7 @@
                 "started_linenumber": 267, 
                 "finished_linenumber": 269, 
                 "finished": "2013-06-05 12:45:02.559173", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 8, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -215,10 +138,7 @@
                 "started_linenumber": 271, 
                 "finished_linenumber": 3070, 
                 "finished": "2013-06-05 12:46:55.430095", 
-                "result": "testfailed", 
-                "duration": 113, 
-                "order": 9, 
-                "error_count": 12
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -227,10 +147,7 @@
                 "started_linenumber": 3072, 
                 "finished_linenumber": 3114, 
                 "finished": "2013-06-05 12:46:55.479840", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 10, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -239,10 +156,7 @@
                 "started_linenumber": 3116, 
                 "finished_linenumber": 3118, 
                 "finished": "2013-06-05 12:46:57.867188", 
-                "result": "success", 
-                "duration": 2, 
-                "order": 11, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/multiple-timeouts.logview.json
+++ b/tests/sample_data/logs/multiple-timeouts.logview.json
@@ -1,51 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "TEST-UNEXPECTED-FAIL | chrome://mochikit/content/browser/browser/components/sessionstore/test/browser/browser_480148.js | Test timed out", 
-                "linenumber": 130983
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | chrome://mochikit/content/browser/browser/components/sessionstore/test/browser/browser_480148.js | Found a browser window after previous test timed out", 
-                "linenumber": 130987
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | chrome://mochikit/content/browser/browser/components/sessionstore/test/browser/browser_480148.js | Found a browser window after previous test timed out", 
-                "linenumber": 130990
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | chrome://mochikit/content/browser/browser/components/sessionstore/test/browser/browser_480148.js | Found a browser window after previous test timed out", 
-                "linenumber": 130993
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | chrome://mochikit/content/browser/browser/components/sessionstore/test/browser/browser_480148.js | Found a browser window after previous test timed out", 
-                "linenumber": 130996
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | chrome://mochikit/content/browser/browser/components/sessionstore/test/browser/browser_480148.js | Found a browser window after previous test timed out", 
-                "linenumber": 130999
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | chrome://mochikit/content/browser/browser/components/sessionstore/test/browser/browser_480148.js | Found a browser window after previous test timed out", 
-                "linenumber": 131002
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | chrome://mochikit/content/browser/browser/components/sessionstore/test/browser/browser_522545.js | Test timed out", 
-                "linenumber": 133780
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | chrome://mochikit/content/browser/browser/components/sessionstore/test/browser/browser_524745.js | application timed out after 330 seconds with no output", 
-                "linenumber": 133959
-            }, 
-            {
-                "line": "command timed out: 1200 seconds without output", 
-                "linenumber": 133961
-            }, 
-            {
-                "line": "buildbot.slave.commands.TimeoutError: command timed out: 1200 seconds without output", 
-                "linenumber": 133965
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -54,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -66,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -123,10 +71,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 169837, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 11
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -135,10 +80,7 @@
                 "started_linenumber": 169839, 
                 "finished_linenumber": 169883, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -147,10 +89,7 @@
                 "started_linenumber": 169885, 
                 "finished_linenumber": 169887, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/opt-objc-exception.logview.json
+++ b/tests/sample_data/logs/opt-objc-exception.logview.json
@@ -1,15 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "        SimpleTest._logResult(test, \"TEST-PASS\", \"TEST-UNEXPECTED-FAIL\");", 
-                "linenumber": 24003
-            }, 
-            {
-                "line": "      SimpleTest._logResult(test, \"TEST-UNEXPECTED-PASS\", \"TEST-KNOWN-FAIL\");", 
-                "linenumber": 24031
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -18,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -30,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -51,10 +35,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 48681, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 2
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -63,10 +44,7 @@
                 "started_linenumber": 48683, 
                 "finished_linenumber": 48727, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -75,10 +53,7 @@
                 "started_linenumber": 48729, 
                 "finished_linenumber": 48731, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/reftest-fail-crash.logview.json
+++ b/tests/sample_data/logs/reftest-fail-crash.logview.json
@@ -1,27 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "REFTEST TEST-UNEXPECTED-FAIL | file:///C:/talos-slave/test/build/reftest/tests/layout/reftests/svg/tspan-rotate-02.svg | image comparison (==)", 
-                "linenumber": 77772
-            }, 
-            {
-                "line": "PROCESS-CRASH | Main app process exited normally | application crashed (minidump found)", 
-                "linenumber": 85070
-            }, 
-            {
-                "line": "PROCESS-CRASH | Main app process exited normally | application crashed (minidump found)", 
-                "linenumber": 85274
-            }, 
-            {
-                "line": "PROCESS-CRASH | Main app process exited normally | application crashed (minidump found)", 
-                "linenumber": 85478
-            }, 
-            {
-                "line": "PROCESS-CRASH | Main app process exited normally | application crashed (minidump found)", 
-                "linenumber": 85682
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -30,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -42,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -75,10 +47,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 85981, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 5
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -87,10 +56,7 @@
                 "started_linenumber": 85983, 
                 "finished_linenumber": 86027, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -99,10 +65,7 @@
                 "started_linenumber": 86029, 
                 "finished_linenumber": 86031, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/reftest-jserror.logview.json
+++ b/tests/sample_data/logs/reftest-jserror.logview.json
@@ -1,11 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "REFTEST TEST-UNEXPECTED-FAIL | | EXCEPTION: [Exception... \"Component returned failure code: 0x8000ffff (NS_ERROR_UNEXPECTED) [nsIPrefBranch2.getBoolPref]\"  nsresult: \"0x8000ffff (NS_ERROR_UNEXPECTED)\"  location: \"JS frame :: chrome://reftest/content/reftest.js :: anonymous :: line 461\"  data: no]", 
-                "linenumber": 23521
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -14,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -26,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -43,10 +31,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 23576, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 1
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -55,10 +40,7 @@
                 "started_linenumber": 23578, 
                 "finished_linenumber": 23622, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -67,10 +49,7 @@
                 "started_linenumber": 23624, 
                 "finished_linenumber": 23626, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/reftest-opt-fail.logview.json
+++ b/tests/sample_data/logs/reftest-opt-fail.logview.json
@@ -1,11 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "REFTEST TEST-UNEXPECTED-FAIL | file:///Users/cltbld/talos-slave/mozilla-central_snowleopard_test-reftest/build/reftest/tests/layout/reftests/image/background-image-zoom-1.html |", 
-                "linenumber": 34908
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -14,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -26,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -43,10 +31,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 42582, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 1
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -55,10 +40,7 @@
                 "started_linenumber": 42584, 
                 "finished_linenumber": 42628, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -67,10 +49,7 @@
                 "started_linenumber": 42630, 
                 "finished_linenumber": 42632, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/reftest-timeout.logview.json
+++ b/tests/sample_data/logs/reftest-timeout.logview.json
@@ -1,19 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "TEST-UNEXPECTED-FAIL | automation.py | application timed out after 60 seconds with no output", 
-                "linenumber": 24690
-            }, 
-            {
-                "line": "command timed out: 1200 seconds without output", 
-                "linenumber": 24692
-            }, 
-            {
-                "line": "buildbot.slave.commands.TimeoutError: command timed out: 1200 seconds without output", 
-                "linenumber": 24696
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -22,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -34,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -59,10 +39,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 24944, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 3
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -71,10 +48,7 @@
                 "started_linenumber": 24946, 
                 "finished_linenumber": 24990, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -83,10 +57,7 @@
                 "started_linenumber": 24992, 
                 "finished_linenumber": 24994, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/taskcluster-missing-finish-step-marker.logview.json
+++ b/tests/sample_data/logs/taskcluster-missing-finish-step-marker.logview.json
@@ -1,11 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "[taskcluster] Error: Task timeout after 3600 seconds. Force killing container.", 
-                "linenumber": 1550
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -14,9 +8,6 @@
                 "started_linenumber": 0, 
                 "finished_linenumber": 14, 
                 "finished": null, 
-                "error_count": 0, 
-                "duration": null, 
-                "order": 0, 
                 "result": "unknown"
             }, 
             {
@@ -26,9 +17,6 @@
                 "started_linenumber": 14, 
                 "finished_linenumber": 24, 
                 "finished": "2015-08-12 16:42:31.715643", 
-                "error_count": 0, 
-                "duration": 3, 
-                "order": 1, 
                 "result": "success"
             }, 
             {
@@ -38,9 +26,6 @@
                 "started_linenumber": 25, 
                 "finished_linenumber": 26, 
                 "finished": null, 
-                "error_count": 0, 
-                "duration": null, 
-                "order": 2, 
                 "result": "unknown"
             }, 
             {
@@ -55,9 +40,6 @@
                 "started_linenumber": 26, 
                 "finished_linenumber": 1551, 
                 "finished": null, 
-                "error_count": 1, 
-                "duration": null, 
-                "order": 3, 
                 "result": "unknown"
             }
         ], 

--- a/tests/sample_data/logs/tinderbox-exception.logview.json
+++ b/tests/sample_data/logs/tinderbox-exception.logview.json
@@ -1,19 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "remoteFailed: [Failure instance: Traceback (failure with no frames): <class 'twisted.internet.error.ConnectionLost'>: Connection to the other side was lost in a non-clean fashion.", 
-                "linenumber": 30331
-            }, 
-            {
-                "line": "remoteFailed: [Failure instance: Traceback: <type 'exceptions.AttributeError'>: 'NoneType' object has no attribute 'callRemote'", 
-                "linenumber": 30341
-            }, 
-            {
-                "line": "exceptions.AttributeError: 'NoneType' object has no attribute 'callRemote'", 
-                "linenumber": 30558
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -22,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -34,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -59,10 +39,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 30568, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 3
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -71,10 +48,7 @@
                 "started_linenumber": 30570, 
                 "finished_linenumber": 30614, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -83,10 +57,7 @@
                 "started_linenumber": 30616, 
                 "finished_linenumber": 30618, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.logview.json
+++ b/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.logview.json
@@ -1,31 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "TEST-UNEXPECTED-FAIL | tests/test-addon-page.test that add-on page has no chrome | chrome is not visible for addon page - false == true", 
-                "linenumber": 2390
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | tests/test-addon-page.test that add-on page with hash and querystring has no chrome | chrome is not visible for addon page - false == true", 
-                "linenumber": 2408
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | tests/test-addon-page.test that add-on page with hash has no chrome | chrome is not visible for addon page - false == true", 
-                "linenumber": 2426
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | tests/test-addon-page.test that add-on page with querystring has no chrome | chrome is not visible for addon page - false == true", 
-                "linenumber": 2444
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | tests/test-widget.testNavigationBarWidgets | \"Camera / Microphone Access\" != \"2nd widget\"", 
-                "linenumber": 9845
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | tests/test-widget.testNavigationBarWidgets | \"Bookmarks\" != \"3rd widget\"", 
-                "linenumber": 9865
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -34,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 13:01:44.725458", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -46,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 13:01:44.726485", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -58,10 +26,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 56, 
                 "finished": "2013-06-05 13:01:44.769939", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 2, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -70,10 +35,7 @@
                 "started_linenumber": 58, 
                 "finished_linenumber": 98, 
                 "finished": "2013-06-05 13:01:44.803354", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -82,10 +44,7 @@
                 "started_linenumber": 100, 
                 "finished_linenumber": 140, 
                 "finished": "2013-06-05 13:01:44.875656", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -94,10 +53,7 @@
                 "started_linenumber": 142, 
                 "finished_linenumber": 180, 
                 "finished": "2013-06-05 13:01:45.250095", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 5, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -106,10 +62,7 @@
                 "started_linenumber": 182, 
                 "finished_linenumber": 227, 
                 "finished": "2013-06-05 13:02:01.869535", 
-                "result": "success", 
-                "duration": 17, 
-                "order": 6, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -118,10 +71,7 @@
                 "started_linenumber": 229, 
                 "finished_linenumber": 269, 
                 "finished": "2013-06-05 13:02:01.910811", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 7, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -130,10 +80,7 @@
                 "started_linenumber": 271, 
                 "finished_linenumber": 320, 
                 "finished": "2013-06-05 13:02:02.036732", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 8, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -142,10 +89,7 @@
                 "started_linenumber": 322, 
                 "finished_linenumber": 360, 
                 "finished": "2013-06-05 13:02:02.667440", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 9, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -154,10 +98,7 @@
                 "started_linenumber": 362, 
                 "finished_linenumber": 421, 
                 "finished": "2013-06-05 13:02:14.651874", 
-                "result": "success", 
-                "duration": 12, 
-                "order": 10, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -166,10 +107,7 @@
                 "started_linenumber": 423, 
                 "finished_linenumber": 461, 
                 "finished": "2013-06-05 13:02:22.926059", 
-                "result": "success", 
-                "duration": 8, 
-                "order": 11, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -178,10 +116,7 @@
                 "started_linenumber": 463, 
                 "finished_linenumber": 465, 
                 "finished": "2013-06-05 13:02:22.927223", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 12, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -190,10 +125,7 @@
                 "started_linenumber": 467, 
                 "finished_linenumber": 469, 
                 "finished": "2013-06-05 13:02:22.928267", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 13, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -202,10 +134,7 @@
                 "started_linenumber": 471, 
                 "finished_linenumber": 473, 
                 "finished": "2013-06-05 13:02:22.929347", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 14, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -214,10 +143,7 @@
                 "started_linenumber": 475, 
                 "finished_linenumber": 550, 
                 "finished": "2013-06-05 13:02:52.272641", 
-                "result": "success", 
-                "duration": 29, 
-                "order": 15, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -226,10 +152,7 @@
                 "started_linenumber": 552, 
                 "finished_linenumber": 593, 
                 "finished": "2013-06-05 13:02:52.350154", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 16, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -238,10 +161,7 @@
                 "started_linenumber": 595, 
                 "finished_linenumber": 641, 
                 "finished": "2013-06-05 13:02:52.387987", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 17, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -250,10 +170,7 @@
                 "started_linenumber": 643, 
                 "finished_linenumber": 681, 
                 "finished": "2013-06-05 13:02:52.671040", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 18, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -287,10 +204,7 @@
                 "started_linenumber": 683, 
                 "finished_linenumber": 11828, 
                 "finished": "2013-06-05 13:10:29.331890", 
-                "result": "testfailed", 
-                "duration": 457, 
-                "order": 19, 
-                "error_count": 6
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -299,10 +213,7 @@
                 "started_linenumber": 11830, 
                 "finished_linenumber": 11868, 
                 "finished": "2013-06-05 13:10:29.462254", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 20, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -311,10 +222,7 @@
                 "started_linenumber": 11870, 
                 "finished_linenumber": 11872, 
                 "finished": "2013-06-05 13:10:31.487768", 
-                "result": "success", 
-                "duration": 2, 
-                "order": 21, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/xpcshell-crash.logview.json
+++ b/tests/sample_data/logs/xpcshell-crash.logview.json
@@ -1,15 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "TEST-UNEXPECTED-FAIL | c:\\talos-slave\\test\\build\\xpcshell\\tests\\services\\sync\\tests\\unit\\test_service_detect_upgrade.js | test failed (with xpcshell return code: -2147483645), see following log:", 
-                "linenumber": 5124
-            }, 
-            {
-                "line": "PROCESS-CRASH | c:\\talos-slave\\test\\build\\xpcshell\\tests\\services\\sync\\tests\\unit\\test_service_detect_upgrade.js | application crashed (minidump found)", 
-                "linenumber": 5671
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -18,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -30,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -51,10 +35,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 7407, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 2
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -63,10 +44,7 @@
                 "started_linenumber": 7409, 
                 "finished_linenumber": 7453, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -75,10 +53,7 @@
                 "started_linenumber": 7455, 
                 "finished_linenumber": 7457, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/xpcshell-multiple.logview.json
+++ b/tests/sample_data/logs/xpcshell-multiple.logview.json
@@ -1,15 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "TEST-UNEXPECTED-FAIL | /home/cltbld/talos-slave/test/build/xpcshell/tests/netwerk/test/unit/test_socks.js | test failed (with xpcshell return code: 0), see following log:", 
-                "linenumber": 4228
-            }, 
-            {
-                "line": "TEST-UNEXPECTED-FAIL | /home/cltbld/talos-slave/test/build/xpcshell/head.js | exception thrown from do_timeout callback: [Exception... \"Component returned failure code: 0x80004005 (NS_ERROR_FAILURE) [nsIProcess.kill]\"  nsresult: \"0x80004005 (NS_ERROR_FAILURE)\"  location: \"JS frame :: /home/cltbld/talos-slave/test/build/xpcshell/tests/netwerk/test/unit/test_socks.js :: <TOP_LEVEL> :: line 446\"  data: no] - See following stack:", 
-                "linenumber": 4311
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -18,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -30,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -51,10 +35,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 5735, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 2
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -63,10 +44,7 @@
                 "started_linenumber": 5737, 
                 "finished_linenumber": 5781, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -75,10 +53,7 @@
                 "started_linenumber": 5783, 
                 "finished_linenumber": 5785, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/logs/xpcshell-timeout.logview.json
+++ b/tests/sample_data/logs/xpcshell-timeout.logview.json
@@ -1,15 +1,5 @@
 {
     "step_data": {
-        "all_errors": [
-            {
-                "line": "command timed out: 1200 seconds without output", 
-                "linenumber": 26902
-            }, 
-            {
-                "line": "buildbot.slave.commands.TimeoutError: command timed out: 1200 seconds without output", 
-                "linenumber": 26906
-            }
-        ], 
         "steps": [
             {
                 "errors": [], 
@@ -18,10 +8,7 @@
                 "started_linenumber": 8, 
                 "finished_linenumber": 10, 
                 "finished": "2013-06-05 12:51:48.768393", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 0, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -30,10 +17,7 @@
                 "started_linenumber": 12, 
                 "finished_linenumber": 14, 
                 "finished": "2013-06-05 12:51:48.769473", 
-                "result": "success", 
-                "duration": 0, 
-                "order": 1, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [
@@ -51,10 +35,7 @@
                 "started_linenumber": 16, 
                 "finished_linenumber": 27154, 
                 "finished": "2013-06-05 13:15:39.235146", 
-                "result": "testfailed", 
-                "duration": 1244, 
-                "order": 2, 
-                "error_count": 2
+                "result": "testfailed"
             }, 
             {
                 "errors": [], 
@@ -63,10 +44,7 @@
                 "started_linenumber": 27156, 
                 "finished_linenumber": 27200, 
                 "finished": "2013-06-05 13:16:04.014823", 
-                "result": "success", 
-                "duration": 25, 
-                "order": 3, 
-                "error_count": 0
+                "result": "success"
             }, 
             {
                 "errors": [], 
@@ -75,10 +53,7 @@
                 "started_linenumber": 27202, 
                 "finished_linenumber": 27204, 
                 "finished": "2013-06-05 13:16:04.963614", 
-                "result": "success", 
-                "duration": 1, 
-                "order": 4, 
-                "error_count": 0
+                "result": "success"
             }
         ], 
         "errors_truncated": false

--- a/tests/sample_data/pulse_consumer/transformed_job_data.json
+++ b/tests/sample_data/pulse_consumer/transformed_job_data.json
@@ -126,20 +126,6 @@
           "type": "json",
           "blob": {
             "step_data": {
-              "all_errors": [
-                {
-                  "line": "14:38:05     INFO -  PROCESS | 16672 | [Child 17361] ###!!! ABORT: Aborting on channel error.: file /builds/slave/m-in-l64-000000000000000000000/build/src/ipc/glue/MessageChannel.cpp, line 1823",
-                  "linenumber": 3211
-                },
-                {
-                  "line": "14:38:05     INFO -  TEST-UNEXPECTED-ERROR | tart | TIMEOUT: TART",
-                  "linenumber": 3212
-                },
-                {
-                  "line": "14:38:05    ERROR -  Traceback (most recent call last):",
-                  "linenumber": 3213
-                }
-              ],
               "steps": [
                 {
                   "errors": [],
@@ -148,7 +134,6 @@
                   "started_linenumber": 231,
                   "finished_linenumber": 232,
                   "finished": "2016-02-02T14:27:05-08:00",
-                  "error_count": 0,
                   "order": 0,
                   "result": "success"
                 },
@@ -172,7 +157,6 @@
                   "started_linenumber": 234,
                   "finished_linenumber": 3269,
                   "finished": "2016-02-02T14:38:09-08:00",
-                  "error_count": 3,
                   "order": 1,
                   "result": "testfailed"
                 }

--- a/treeherder/etl/job_loader.py
+++ b/treeherder/etl/job_loader.py
@@ -181,15 +181,11 @@ class JobLoader:
         if "logs" in job:
             for log in job["logs"]:
                 if "steps" in log:
-                    all_errors = []
                     old_steps = log["steps"]
                     new_steps = []
 
                     for idx, step in enumerate(old_steps):
                         errors = step.get("errors", [])
-                        error_count = len(errors)
-                        if error_count:
-                            all_errors.extend(errors)
 
                         new_steps.append({
                             "name": step["name"],
@@ -199,14 +195,12 @@ class JobLoader:
                             "started_linenumber": step["lineStarted"],
                             "finished_linenumber": step["lineFinished"],
                             "errors": errors,
-                            "error_count": error_count,
                             "order": idx
                         })
 
                     return {
                         "blob": {
                             "step_data": {
-                                "all_errors": all_errors,
                                 "steps": new_steps,
                                 "errors_truncated": log.get("errorsTruncated")
                             },


### PR DESCRIPTION
Now that they are only an intermediary format, we can remove data
from them that isn't needed to interpret them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1854)
<!-- Reviewable:end -->
