### PR TITLE
Bug 1303055 - Double the number of log processing workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -10,6 +10,6 @@ worker_read_pulse_jobs: newrelic-admin run-program ./manage.py read_pulse_jobs
 worker_read_pulse_resultsets: newrelic-admin run-program ./manage.py read_pulse_resultsets
 worker_default: newrelic-admin run-program celery -A treeherder worker -Q default,cycle_data,calculate_durations,fetch_bugs,detect_intermittents,fetch_allthethings,generate_perf_alerts --maxtasksperchild=50 --concurrency=3
 worker_hp: newrelic-admin run-program celery -A treeherder worker -Q classification_mirroring,publish_to_pulse --maxtasksperchild=50 --concurrency=1
-worker_log_parser: newrelic-admin run-program celery -A treeherder worker -Q log_parser,log_parser_fail,log_store_failure_lines,log_store_failure_lines_fail,log_crossreference_error_lines,log_crossreference_error_lines_fail,log_autoclassify,log_autoclassify_fail --maxtasksperchild=50 --concurrency=5
+worker_log_parser: newrelic-admin run-program celery -A treeherder worker -Q log_parser,log_parser_fail,log_store_failure_lines,log_store_failure_lines_fail,log_crossreference_error_lines,log_crossreference_error_lines_fail,log_autoclassify,log_autoclassify_fail --maxtasksperchild=50 --concurrency=7
 
 release: ./bin/pre_deploy

--- a/bin/run_celery_worker_log_parser
+++ b/bin/run_celery_worker_log_parser
@@ -26,5 +26,5 @@ log_crossreference_error_lines,\
 log_crossreference_error_lines_fail,\
 log_autoclassify,\
 log_autoclassify_fail\
-    --concurrency=5 --logfile=$LOGFILE -l INFO \
+    --concurrency=10 --logfile=$LOGFILE -l INFO \
     --maxtasksperchild=500 -n log_parser.%h


### PR DESCRIPTION
This should increase throughput, especially in cases where we are backlogged
due to network latency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1857)
<!-- Reviewable:end -->
