### PR TITLE
Bug 1185039 - Remove JobData* classes

### DIFF
--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -28,43 +28,6 @@ class CollectionNotStoredException(Exception):
         )
 
 
-class JobDataError(ValueError):
-    pass
-
-
-class JobData(dict):
-
-    """
-    Encapsulates data access from incoming test data structure.
-
-    All missing-data errors raise ``JobDataError`` with a useful
-    message. Unlike regular nested dictionaries, ``JobData`` keeps track of
-    context, so errors contain not only the name of the immediately-missing
-    key, but the full parent-key context as well.
-    """
-
-    def __init__(self, data, context=None):
-        """Initialize ``JobData`` with a data dict and a context list."""
-        self.context = context or []
-        super(JobData, self).__init__(data)
-
-    def __getitem__(self, name):
-        """Get a data value, raising ``JobDataError`` if missing."""
-        full_context = list(self.context) + [name]
-
-        try:
-            value = super(JobData, self).__getitem__(name)
-        except KeyError:
-            raise JobDataError("Missing data: {0}.".format(
-                "".join(["['{0}']".format(c) for c in full_context])))
-
-        # Provide the same behavior recursively to nested dictionaries.
-        if isinstance(value, dict):
-            value = self.__class__(value, full_context)
-
-        return value
-
-
 def make_request(url, method='GET', headers=None,
                  timeout=settings.REQUESTS_TIMEOUT, **kwargs):
     """A wrapper around requests to set defaults & call raise_for_status()."""


### PR DESCRIPTION
The only one that was actually used was JobDataError, which doesn't have any
advantage over the more generic ValueError.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1858)
<!-- Reviewable:end -->
