### PR TITLE
Bug 1303102 - Use autocommit for the run_sql command

### DIFF
--- a/treeherder/model/management/commands/run_sql.py
+++ b/treeherder/model/management/commands/run_sql.py
@@ -75,8 +75,8 @@ class Command(BaseCommand):
             )
             try:
                 cursor = conn.cursor()
+                conn.autocommit(True)
                 cursor.execute(sql_code)
-                conn.commit()
                 self.stdout.write("Sql code executed on {}:".format(datasource))
                 for row in cursor:
                     self.stdout.write("  {}".format(row))


### PR DESCRIPTION
This prevents changes from being discarded if the DB connection timed out between the `.execute()` call being made, and it completing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1859)
<!-- Reviewable:end -->
