### PR TITLE
Bug 1303433 - Fix cancelling a single job from the UI

### DIFF
--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -202,7 +202,7 @@ treeherderApp.controller('ResultSetCtrl', [
                     // XXX: Remove this after 1134929 is resolved.
                     ThJobDetailModel.getJobDetails({
                         title: "buildbot_request_id",
-                        job_id: job.id
+                        job_guid: job.guid
                     }).then(function(data) {
                         // non-buildbot jobs will have no request id, and that's ok (they
                         // are covered above)


### PR DESCRIPTION
The /jobdetail/ endpoint doesn't currently support filtering by job id,
we need to pass the guid instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1861)
<!-- Reviewable:end -->
