### PR TITLE
Bug 1304091 - For job information, don't return incorrect job log links

### DIFF
--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -63,6 +63,7 @@ class JobsViewSet(viewsets.ViewSet):
                                       kwargs={"project": jm.project, "pk": job["id"]})
         job["logs"] = []
         for (name, url) in JobLog.objects.filter(
+                job__repository__name=jm.project,
                 job__project_specific_id=job['id']).values_list('name', 'url'):
             job["logs"].append({'name': name, 'url': url})
 


### PR DESCRIPTION
In the /jobs/XXXX/ endpoint, we were just keying off the job id when
trying to figure out which log information to return. This could result
in additional (incorrect) data being returned for the case that
there were jobs with the same project specific id value in multiple
repositories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1864)
<!-- Reviewable:end -->
