### PR TITLE
Bug 1304354 - add a row for 32 bit Win 2012 builds

### DIFF
--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -17,7 +17,8 @@ treeherder.value("thPlatformMap", {
     "windows8-64": ["Windows 8 x64", 25],
     "windows10-32": ["Windows 10", 26],
     "windows10-64": ["Windows 10 x64", 27],
-    "windows2012-64": ["Windows 2012 x64", 28],
+    "windows2012-32": ["Windows 2012", 28],
+    "windows2012-64": ["Windows 2012 x64", 29],
 
     "android-2-2-armv6": ["Android 2.2 Armv6", 30],
     "android-2-2": ["Android 2.2", 31],


### PR DESCRIPTION
This PR creates a space for 32 bit Windows builds shown by _build_ platform rather than _test_ platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1867)
<!-- Reviewable:end -->
