### PR TITLE
Bug 1304253 - Pass the repository name to the API when retriggering

### DIFF
--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -330,6 +330,7 @@ treeherder.controller('PluginCtrl', [
                 ThJobModel.retrigger($scope.repoName, job_id_list).then(function() {
                     // XXX: Remove this after 1134929 is resolved.
                     return ThJobDetailModel.getJobDetails({"title": "buildbot_request_id",
+                                                           "repository": $scope.repoName,
                                                            "job_id__in": job_id_list.join(',')})
                         .then(function(data) {
                             var requestIdList = _.pluck(data, 'value');


### PR DESCRIPTION
Since after bug 1280039, retriggers error with:
"Unable to send retrigger: Must also filter on repository if filtering on job id".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1868)
<!-- Reviewable:end -->
