### PR TITLE
Bug 1281820 - Stop using bug suggestions artifacts

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -98,3 +98,5 @@ elasticsearch-dsl==2.0.0 --hash=sha256:d19a055b2c4f5b537dc4e3d8f3d7d8392d9c090f8
 urllib3==1.16 --hash=sha256:8a46ee9b6b4487ba994e97f9e5eab48513c9b3ebdddc630ee9a899e041147695
 
 certifi==2016.2.28 --hash=sha256:75c33d546e0a732a4606749cbadcd81929f30d8b814061ca93cde49933dbb860
+
+django-memoize==2.0.0 --hash sha256:bd35702eabdbd6dc0a11463c688e2b7f2e9f584ee489ba021a825bff486aa77f

--- a/tests/autoclassify/test_detect_intermittents.py
+++ b/tests/autoclassify/test_detect_intermittents.py
@@ -9,12 +9,9 @@ from .utils import (create_failure_lines,
                     test_line)
 
 
-def test_detect_intermittents(test_repository, activate_responses, jm, eleven_jobs_stored,
-                              failure_lines, classified_failures, retriggers):
-    retrigger = retriggers[0]
-
-    test_failure_lines = create_failure_lines(test_repository,
-                                              retrigger["job_guid"],
+def test_detect_intermittents(test_job, failure_lines, classified_failures,
+                              retriggered_job):
+    test_failure_lines = create_failure_lines(retriggered_job,
                                               [(test_line, {"subtest": "subtest2"}),
                                                (test_line, {"status": "TIMEOUT"}),
                                                (test_line, {"expected": "ERROR"}),
@@ -29,7 +26,8 @@ def test_detect_intermittents(test_repository, activate_responses, jm, eleven_jo
     MatcherManager._detector_funcs = {}
     detector = MatcherManager.register_detector(TestFailureDetector)
 
-    call_command('detect_intermittents', test_repository.name, retrigger['job_guid'])
+    call_command('detect_intermittents', retriggered_job.repository.name,
+                 retriggered_job.guid)
 
     assert ClassifiedFailure.objects.count() == len(old_failure_ids) + 4
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -352,20 +352,6 @@ def pulse_action_consumer(request):
 
 
 @pytest.fixture
-def mock_error_summary(monkeypatch):
-    bs_obj = ["foo", "bar"]
-
-    from treeherder.model import error_summary
-
-    def _get_error_summary(params):
-        return bs_obj
-
-    monkeypatch.setattr(error_summary, "get_error_summary", _get_error_summary)
-
-    return bs_obj
-
-
-@pytest.fixture
 def failure_lines(test_job, elasticsearch):
     from tests.autoclassify.utils import test_line, create_failure_lines
 

--- a/tests/e2e/test_client_job_ingestion.py
+++ b/tests/e2e/test_client_job_ingestion.py
@@ -10,11 +10,14 @@ from treeherder.client.thclient import client
 from treeherder.log_parser.parsers import StepParser
 from treeherder.model.derived import (ArtifactsModel,
                                       JobsModel)
+from treeherder.model.error_summary import get_error_summary
 from treeherder.model.models import (Job,
                                      JobDetail,
                                      JobLog,
                                      TextLogError,
                                      TextLogStep)
+
+from ..sampledata import SampleData
 
 
 @pytest.fixture
@@ -30,7 +33,8 @@ def text_log_summary_dict():
                  "result": "testfailed",
                  "errors": [
                      {"line": "12:34:13     INFO -  Assertion failure: addr % CellSize == 0, at ../../../js/src/gc/Heap.h:1041", "linenumber": 61918},
-                     {"line": "12:34:24  WARNING -  TEST-UNEXPECTED-FAIL | file:///builds/slave/talos-slave/test/build/tests/jsreftest/tests/jsreftest.html?test=ecma_5/JSON/parse-array-gc.js | Exited with code 1 during test run", "linenumber": 61919}, {"line": "12:34:37  WARNING -  PROCESS-CRASH | file:///builds/slave/talos-slave/test/build/tests/jsreftest/tests/jsreftest.html?test=ecma_5/JSON/parse-array-gc.js | application crashed [@ js::gc::Cell::tenuredZone() const]", "linenumber": 61922},
+                     {"line": "12:34:24  WARNING -  TEST-UNEXPECTED-FAIL | file:///builds/slave/talos-slave/test/build/tests/jsreftest/tests/jsreftest.html?test=ecma_5/JSON/parse-array-gc.js | Exited with code 1 during test run", "linenumber": 61919},
+                     {"line": "12:34:37  WARNING -  PROCESS-CRASH | file:///builds/slave/talos-slave/test/build/tests/jsreftest/tests/jsreftest.html?test=ecma_5/JSON/parse-array-gc.js | application crashed [@ js::gc::Cell::tenuredZone() const]", "linenumber": 61922},
                      {"line": "12:34:38    ERROR - Return code: 256", "linenumber": 64435}
                  ]},
                 {"name": "Build ./build-b2g-desktop.sh /home/worker/workspace", "started_linenumber": 1, "finished_linenumber": 1, "result": "success",
@@ -47,8 +51,7 @@ def check_artifacts(test_project,
                     job_guid,
                     parse_status,
                     num_artifacts,
-                    exp_artifact_names=None,
-                    exp_error_summary=None):
+                    exp_artifact_names=None):
 
     job_logs = JobLog.objects.filter(job__guid=job_guid)
     assert len(job_logs) == 1
@@ -68,9 +71,54 @@ def check_artifacts(test_project,
             artifact_names = {x['name'] for x in artifacts}
             assert set(artifact_names) == exp_artifact_names
 
-        if exp_error_summary:
-            act_bs_obj = [x['blob'] for x in artifacts if x['name'] == 'Bug suggestions'][0]
-            assert exp_error_summary == act_bs_obj
+
+def test_post_job_with_unparsed_log(test_project, result_set_stored,
+                                    mock_post_json, monkeypatch):
+    """
+    test submitting a job with an unparsed log parses the log,
+    generates an appropriate set of text log steps, and calls
+    get_error_summary (to warm the bug suggestions cache)
+    """
+
+    # create a wrapper around get_error_summary that records whether
+    # it's been called
+    mock_get_error_summary = MagicMock(name='get_error_summary',
+                                       wraps=get_error_summary)
+    import treeherder.model.error_summary
+    monkeypatch.setattr(treeherder.model.error_summary, 'get_error_summary',
+                        mock_get_error_summary)
+
+    log_url = "file://{0}".format(
+        SampleData().get_log_path("mozilla-central-macosx64-debug-bm65-build1-build15.txt.gz"))
+
+    tjc = client.TreeherderJobCollection()
+    job_guid = 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
+    tj = client.TreeherderJob({
+        'project': test_project,
+        'revision': result_set_stored[0]['revision'],
+        'job': {
+            'job_guid': job_guid,
+            'state': 'completed',
+            'log_references': [{
+                'url': log_url,
+                'name': 'buildbot_text',
+                'parse_status': 'pending'
+            }]
+        }
+    })
+    tjc.add(tj)
+    post_collection(test_project, tjc)
+
+    # show have 2 errors
+    assert TextLogError.objects.count() == 2
+    # verify that get_error_summary was called (to warm the bug suggestions
+    # cache)
+    assert mock_get_error_summary.called
+    # should have 2 error summary lines (aka bug suggestions)
+    assert len(get_error_summary(Job.objects.get(guid=job_guid))) == 2
+    # we still store bug suggestions for now
+    check_artifacts(test_project, job_guid, JobLog.PARSED, 1,
+                    {'Bug suggestions'})
 
 
 def test_post_job_with_parsed_log(test_project, result_set_stored,
@@ -107,6 +155,7 @@ def test_post_job_with_parsed_log(test_project, result_set_stored,
 
     post_collection(test_project, tjc)
 
+    # should have no artifacts
     check_artifacts(test_project, job_guid, JobLog.PARSED, 0)
 
     # ensure the parsing didn't happen
@@ -118,13 +167,12 @@ def test_post_job_with_text_log_summary_artifact_parsed(
         monkeypatch,
         result_set_stored,
         mock_post_json,
-        mock_error_summary,
         text_log_summary_dict,
         ):
     """
     test submitting a job with a pre-parsed log gets parse_status of
-    "parsed" and doesn't parse the log, but still generates
-    the bug suggestions.
+    "parsed" and doesn't parse the log, but we get the expected set of
+    text log steps/errors and bug suggestions.
     """
 
     mock_parse = MagicMock(name="parse_line")
@@ -155,57 +203,11 @@ def test_post_job_with_text_log_summary_artifact_parsed(
 
     post_collection(test_project, tjc)
 
+    # should have 4 error summary lines (aka bug suggestions)
+    assert len(get_error_summary(Job.objects.get(guid=job_guid))) == 4
+    # we still store bug suggestions for now
     check_artifacts(test_project, job_guid, JobLog.PARSED, 1,
-                    {'Bug suggestions'}, mock_error_summary)
-
-    # ensure the parsing didn't happen
-    assert mock_parse.called is False
-
-
-def test_post_job_with_text_log_summary_artifact_parsed_dict_blob(
-        test_project,
-        monkeypatch,
-        result_set_stored,
-        mock_post_json,
-        mock_error_summary,
-        text_log_summary_dict,
-        ):
-    """
-    test submitting a job with a pre-parsed log gets parse_status of
-    "parsed" and doesn't parse the log, but still generates
-    the bug suggestions.
-    """
-
-    mock_parse = MagicMock(name="parse_line")
-    monkeypatch.setattr(StepParser, 'parse_line', mock_parse)
-
-    job_guid = 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
-    tjc = client.TreeherderJobCollection()
-    tj = client.TreeherderJob({
-        'project': test_project,
-        'revision': result_set_stored[0]['revision'],
-        'job': {
-            'job_guid': job_guid,
-            'state': 'completed',
-            'log_references': [{
-                'url': 'http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/...',
-                'name': 'buildbot_text',
-                'parse_status': 'parsed'
-            }],
-            'artifacts': [{
-                "blob": text_log_summary_dict,
-                "type": "json",
-                "name": "text_log_summary",
-                "job_guid": job_guid
-            }]
-        }
-    })
-    tjc.add(tj)
-
-    post_collection(test_project, tjc)
-
-    check_artifacts(test_project, job_guid, JobLog.PARSED, 1,
-                    {'Bug suggestions'}, mock_error_summary)
+                    {'Bug suggestions'})
 
     # ensure the parsing didn't happen
     assert mock_parse.called is False
@@ -216,7 +218,6 @@ def test_post_job_with_text_log_summary_artifact_pending(
         monkeypatch,
         result_set_stored,
         mock_post_json,
-        mock_error_summary,
         text_log_summary_dict,
         ):
     """
@@ -255,8 +256,11 @@ def test_post_job_with_text_log_summary_artifact_pending(
 
     post_collection(test_project, tjc)
 
+    # should have 4 error summary lines (aka bug suggestions)
+    assert len(get_error_summary(Job.objects.get(guid=job_guid))) == 4
+    # check to make sure bug suggestions are stored
     check_artifacts(test_project, job_guid, JobLog.PARSED, 1,
-                    {'Bug suggestions'}, mock_error_summary)
+                    {'Bug suggestions'})
 
     # ensure the parsing didn't happen
     assert mock_parse.called is False
@@ -267,7 +271,6 @@ def test_post_job_artifacts_by_add_artifact(
         monkeypatch,
         result_set_stored,
         mock_post_json,
-        mock_error_summary,
         ):
     """
     test submitting a job with artifacts added by ``add_artifact``
@@ -362,8 +365,7 @@ def test_post_job_artifacts_by_add_artifact(
     }
 
     check_artifacts(test_project, job_guid, JobLog.PARSED, 2,
-                    {'Bug suggestions', 'privatebuild'},
-                    mock_error_summary)
+                    {'Bug suggestions', 'privatebuild'})
 
     # ensure the parsing didn't happen
     assert mock_parse.called is False

--- a/tests/log_parser/test_tasks.py
+++ b/tests/log_parser/test_tasks.py
@@ -88,13 +88,14 @@ def test_parse_log(jm, jobs_with_local_log, sample_resultset):
 
     # we should have just one artifact, "bug suggestions"
     assert len(job_artifacts) == 1
+
     # this log generates 4 job detail objects at present
     print JobDetail.objects.count() == 4
 
 
 def test_bug_suggestions_artifact(jm, jobs_with_local_log, sample_resultset, test_repository):
     """
-    check that at least 3 job_artifacts get inserted when running
+    check that a bug suggestions artifact gets inserted when running
     a parse_log task for a failed job, and that the number of
     bug search terms/suggestions matches the number of error lines.
     """

--- a/tests/model/derived/test_artifacts_model.py
+++ b/tests/model/derived/test_artifacts_model.py
@@ -14,7 +14,6 @@ xfail = pytest.mark.xfail
 
 def test_load_single_artifact(
         test_project, eleven_jobs_stored,
-        mock_error_summary,
         sample_data):
     """
     test loading a single artifact
@@ -49,7 +48,6 @@ def test_load_single_artifact(
 
 def test_load_artifact_second_time_fails(
         test_project, eleven_jobs_stored,
-        mock_error_summary,
         sample_data):
     """
     test loading two of the same named artifact only gets the first one

--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -5,8 +5,7 @@ import pytest
 from django.core.management import call_command
 
 from tests import test_utils
-from tests.autoclassify.utils import (create_bug_suggestions_failures,
-                                      create_failure_lines,
+from tests.autoclassify.utils import (create_failure_lines,
                                       create_text_log_errors,
                                       test_line)
 from tests.sample_data_generator import (job_data,
@@ -374,10 +373,10 @@ def test_cycle_one_job(jm, sample_data,
 
     extra_objects = {
         'failure_lines': (FailureLine,
-                          create_failure_lines(Job.objects.get(
-                              guid=job_not_deleted["job_guid"]),
-                                               [(test_line, {}),
-                                                (test_line, {"subtest": "subtest2"})])),
+                          create_failure_lines(
+                              Job.objects.get(guid=job_not_deleted["job_guid"]),
+                              [(test_line, {}),
+                               (test_line, {"subtest": "subtest2"})])),
         'job_details': (JobDetail, [JobDetail.objects.create(
             job=Job.objects.get(guid=job_not_deleted["job_guid"]),
             title='test',
@@ -831,10 +830,10 @@ def test_retry_on_operational_failure(jm, monkeypatch):
     assert retry_count['num'] == 20
 
 
-def test_update_autoclassification_bug(jm, test_job, test_job_2,
+def test_update_autoclassification_bug(test_job, test_job_2,
                                        classified_failures):
     # Job 1 has two failure lines so nothing should be updated
-    assert jm.update_autoclassification_bug(1, 1234) is None
+    assert test_job.update_autoclassification_bug(1234) is None
 
     failure_lines = create_failure_lines(test_job_2,
                                          [(test_line, {})])
@@ -843,7 +842,7 @@ def test_update_autoclassification_bug(jm, test_job, test_job_2,
     classified_failures[0].bug_number = None
     lines = [(item, {}) for item in FailureLine.objects.filter(job_guid=test_job_2.guid).values()]
     create_text_log_errors(test_job_2, lines)
-    create_bug_suggestions_failures(test_job_2, lines)
+
     assert test_job_2.update_autoclassification_bug(1234) == classified_failures[0]
     classified_failures[0].refresh_from_db()
     assert classified_failures[0].bug_number == 1234

--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -844,6 +844,6 @@ def test_update_autoclassification_bug(jm, test_job, test_job_2,
     lines = [(item, {}) for item in FailureLine.objects.filter(job_guid=test_job_2.guid).values()]
     create_text_log_errors(test_job_2, lines)
     create_bug_suggestions_failures(test_job_2, lines)
-    assert jm.update_autoclassification_bug(test_job_2.project_specific_id, 1234) == classified_failures[0]
+    assert test_job_2.update_autoclassification_bug(1234) == classified_failures[0]
     classified_failures[0].refresh_from_db()
     assert classified_failures[0].bug_number == 1234

--- a/tests/webapp/api/test_artifact_api.py
+++ b/tests/webapp/api/test_artifact_api.py
@@ -66,8 +66,7 @@ def test_artifact_detail_bad_project(webapp, jm):
 
 
 def test_artifact_create_text_log_summary(webapp, test_project, eleven_jobs_stored,
-                                          mock_post_json, mock_error_summary,
-                                          sample_data):
+                                          mock_post_json, sample_data):
     """
     test submitting a text_log_summary artifact which auto-generates bug suggestions
     """
@@ -93,7 +92,4 @@ def test_artifact_create_text_log_summary(webapp, test_project, eleven_jobs_stor
         })
 
     artifact_names = {x['name'] for x in artifacts}
-    act_bs_obj = [x['blob'] for x in artifacts if x['name'] == 'Bug suggestions'][0]
-
     assert set(artifact_names) == {'Bug suggestions'}
-    assert mock_error_summary == act_bs_obj

--- a/tests/webapp/api/test_classified_failure.py
+++ b/tests/webapp/api/test_classified_failure.py
@@ -353,7 +353,7 @@ def test_put_multiple_duplicate_2(webapp, classified_failures, test_user):
     assert resp.status_code == 400
 
 
-def test_get_matching_lines(webapp, test_repository, failure_lines, classified_failures):
+def test_get_matching_lines(webapp, test_job, failure_lines, classified_failures):
     """
     test getting a single failure line
     """
@@ -362,8 +362,7 @@ def test_get_matching_lines(webapp, test_repository, failure_lines, classified_f
         failure_line.best_classification = classified_failures[0]
         failure_line.save()
 
-    extra_lines = create_failure_lines(test_repository,
-                                       failure_lines[0].job_guid,
+    extra_lines = create_failure_lines(test_job,
                                        [(test_line, {"test": "test2", "line": 2}),
                                         (test_line, {"test": "test2", "subtest": "subtest2",
                                                      "line": 3})])

--- a/tests/webapp/api/test_failureline.py
+++ b/tests/webapp/api/test_failureline.py
@@ -139,7 +139,7 @@ def test_update_failure_line_mark_job(jm, test_job,
         assert failure_line.best_classification == classified_failures[1]
         assert failure_line.best_is_verified
 
-    assert jm.is_fully_verified(test_job.project_specific_id)
+    assert test_job.is_fully_verified()
 
     # should only be one, will assert if that isn't the case
     note = JobNote.objects.get(job=test_job)
@@ -189,7 +189,7 @@ def test_update_failure_line_mark_job_with_human_note(test_job,
 
         assert resp.status_code == 200
 
-    assert jm.is_fully_verified(job.project_specific_id)
+    assert job.is_fully_verified()
 
     # should only be one, will assert if that isn't the case
     note = JobNote.objects.get(job=job)
@@ -233,7 +233,7 @@ def test_update_failure_line_mark_job_with_auto_note(test_job,
 
         assert resp.status_code == 200
 
-    assert jm.is_fully_verified(test_job.project_specific_id)
+    assert test_job.is_fully_verified()
 
     notes = JobNote.objects.filter(job=test_job).order_by('-created')
     assert notes.count() == 2
@@ -294,7 +294,7 @@ def test_update_failure_lines(mock_autoclassify_jobs_true, jm,
         assert failure_line.best_is_verified
 
     for job in jobs:
-        assert jm.is_fully_verified(job.project_specific_id)
+        assert job.is_fully_verified()
 
         # will assert if we don't have exactly one job, which is what we want
         note = JobNote.objects.get(job=job)
@@ -375,7 +375,7 @@ def test_update_failure_line_all_ignore_mark_job(test_job,
         assert failure_line.best_classification is None
         assert failure_line.best_is_verified
 
-    assert jm.is_fully_verified(test_job.project_specific_id)
+    assert test_job.is_fully_verified()
 
     assert JobNote.objects.count() == 1
 
@@ -423,7 +423,7 @@ def test_update_failure_line_partial_ignore_mark_job(test_job,
             assert failure_line.best_classification == classified_failures[0]
         assert failure_line.best_is_verified
 
-    assert jm.is_fully_verified(test_job.project_specific_id)
+    assert test_job.is_fully_verified()
 
     # will assert if we don't have exactly one note for this job, which is
     # what we want

--- a/tests/webapp/api/test_text_log_summary_lines.py
+++ b/tests/webapp/api/test_text_log_summary_lines.py
@@ -3,7 +3,6 @@ from rest_framework.test import APIClient
 
 from treeherder.model.models import (BugJobMap,
                                      FailureLine,
-                                     Job,
                                      JobNote,
                                      TextLogSummary)
 

--- a/tests/webapp/api/test_text_log_summary_lines.py
+++ b/tests/webapp/api/test_text_log_summary_lines.py
@@ -3,6 +3,7 @@ from rest_framework.test import APIClient
 
 from treeherder.model.models import (BugJobMap,
                                      FailureLine,
+                                     Job,
                                      JobNote,
                                      TextLogSummary)
 
@@ -148,7 +149,7 @@ def test_put_verify_job(webapp, jm, test_job, text_summary_lines, test_user,
 
     assert resp.status_code == 200
 
-    assert jm.is_fully_verified(test_job.project_specific_id)
+    assert test_job.is_fully_verified()
 
     bug_job_items = BugJobMap.objects.filter(job=test_job)
     assert {item.bug_id for item in bug_job_items} == set(range(1, len(text_summary_lines) + 1))

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -139,6 +139,7 @@ INSTALLED_APPS = [
     'hawkrest',
     'corsheaders',
     'django_browserid',
+    'memoize',
     # treeherder apps
     'treeherder.model',
     'treeherder.webapp',
@@ -352,6 +353,9 @@ BUILDAPI_BUILDS4H_URL = "https://secure.pub.build.mozilla.org/builddata/buildjso
 ALLTHETHINGS_URL = "https://secure.pub.build.mozilla.org/builddata/reports/allthethings.json"
 TASKCLUSTER_TASKGRAPH_URL = 'https://queue.taskcluster.net/v1/task/{task_id}/artifacts/public/full-task-graph.json'
 
+# the amount of time we cache bug suggestion lookups (to speed up loading the bug
+# suggestions or autoclassify panels for recently finished jobs)
+BUG_SUGGESTION_CACHE_TIMEOUT = 86400
 
 # the max size of a posted request to treeherder client during Buildbot
 # data job ingestion.

--- a/treeherder/model/derived/artifacts.py
+++ b/treeherder/model/derived/artifacts.py
@@ -15,7 +15,6 @@ from treeherder.model.models import (Job,
                                      TextLogError,
                                      TextLogStep)
 
-from ..error_summary import is_helpful_search_term
 from .base import TreeherderModelBase
 
 logger = logging.getLogger(__name__)
@@ -326,19 +325,3 @@ class ArtifactsModel(TreeherderModelBase):
                 artifact['blob'] = json.dumps(blob)
 
         return artifacts
-
-    def bug_suggestions(self, job_id):
-        """Get the list of log lines and associated bug suggestions for a job"""
-        # TODO: Filter some junk from this
-        objs = self.get_job_artifact_list(
-            offset=0,
-            limit=1,
-            conditions={"job_id": set([("=", job_id)]),
-                        "name": set([("=", "Bug suggestions")]),
-                        "type": set([("=", "json")])})
-
-        lines = objs[0]["blob"] if objs else []
-        return lines
-
-    def filter_bug_suggestions(self, suggestion_lines):
-        return [item for item in suggestion_lines if is_helpful_search_term(item["search"])]

--- a/treeherder/model/error_summary.py
+++ b/treeherder/model/error_summary.py
@@ -2,6 +2,9 @@ import json
 import logging
 import re
 
+from memoize import memoize
+
+from treeherder.config.settings import BUG_SUGGESTION_CACHE_TIMEOUT
 from treeherder.model.models import (Bugscache,
                                      Job,
                                      TextLogError)
@@ -17,14 +20,15 @@ MOZHARNESS_RE = re.compile(
 REFTEST_RE = re.compile("\s+[=!]=\s+.*")
 
 
-def get_error_summary(job):
+@memoize(timeout=BUG_SUGGESTION_CACHE_TIMEOUT)
+def get_error_summary(job_id):
     """
     Create a list of bug suggestions for a job
     """
     error_summary = []
     terms_requested = {}
 
-    for err in TextLogError.objects.filter(step__job=job):
+    for err in TextLogError.objects.filter(step__job_id=job_id):
         # remove the mozharness prefix
         clean_line = get_mozharness_substring(err.line)
         search_terms = []
@@ -169,15 +173,19 @@ def is_helpful_search_term(search_term):
     return len(search_term) > 4 and not (search_term in blacklist)
 
 
+def get_filtered_error_lines(job):
+    return [item for item in get_error_summary(job.id) if
+            is_helpful_search_term(item["search"])]
+
+
 def load_error_summary(project, job_id):
     """Load new bug suggestions artifacts if we generate them."""
 
-    job = Job.objects.get(id=job_id)
     bug_suggestion_artifact = {
-        "job_guid": job.guid,
+        "job_guid": Job.objects.values_list('guid', flat=True).get(id=job_id),
         "name": 'Bug suggestions',
         "type": 'json',
-        "blob": json.dumps(get_error_summary(job))
+        "blob": json.dumps(get_error_summary(job_id))
     }
     from treeherder.model.derived import ArtifactsModel
     with ArtifactsModel(project) as artifacts_model:

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -1,5 +1,6 @@
 import django_filters
 from dateutil import parser
+from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import (filters,
                             viewsets)
 from rest_framework.decorators import (detail_route,
@@ -12,7 +13,9 @@ from rest_framework.status import (HTTP_400_BAD_REQUEST,
                                    HTTP_404_NOT_FOUND)
 
 from treeherder.model.derived import ArtifactsModel
+from treeherder.model.error_summary import get_error_summary
 from treeherder.model.models import (FailureLine,
+                                     Job,
                                      JobDetail,
                                      JobLog,
                                      OptionCollection,
@@ -237,18 +240,18 @@ class JobsViewSet(viewsets.ViewSet):
         return Response("No job with id: {0}".format(pk), status=HTTP_404_NOT_FOUND)
 
     @detail_route(methods=['get'])
-    @with_jobs
-    def text_log_summary(self, request, project, jm, pk=None):
+    def text_log_summary(self, request, project, pk=None):
         """
         Get a list of test failure lines for the job
         """
-        job = jm.get_job(pk)
-        if not job:
+        try:
+            job = Job.objects.get(repository__name=project,
+                                  project_specific_id=pk)
+        except ObjectDoesNotExist:
             return Response("No job with id: {0}".format(pk), status=HTTP_404_NOT_FOUND)
 
-        job = job[0]
         summary = TextLogSummary.objects.filter(
-            job_guid=job['job_guid']
+            job_guid=job.guid
         ).prefetch_related("lines").all()
 
         if len(summary) > 1:
@@ -258,24 +261,13 @@ class JobsViewSet(viewsets.ViewSet):
             return Response("No text_log_summary generated for job with id: {0}".format(pk),
                             status=HTTP_404_NOT_FOUND)
 
-        with ArtifactsModel(project) as am:
-            artifacts = am.get_job_artifact_list(
-                offset=0,
-                limit=1,
-                conditions={"job_id": set([("=", pk)]),
-                            "name": set([("=", "Bug suggestions")]),
-                            "type": set([("=", "json")])})
-            artifacts_by_name = {item["name"]: item for item in artifacts}
-
-        bug_suggestions = artifacts_by_name.get("Bug suggestions", {}).get("blob")
-
         summary = summary[0]
 
         lines_by_number = {error.line_number: error.line for error in
-                           TextLogError.objects.filter(step__job__guid=job['job_guid'])}
+                           TextLogError.objects.filter(step__job=job)}
 
         rv = serializers.TextLogSummarySerializer(summary).data
-        rv["bug_suggestions"] = bug_suggestions
+        rv["bug_suggestions"] = get_error_summary(job)
 
         for line in rv["lines"]:
             line["line"] = lines_by_number[line["line_number"]]
@@ -298,6 +290,19 @@ class JobsViewSet(viewsets.ViewSet):
         return Response(serializers.TextLogStepSerializer(textlog_steps,
                                                           many=True,
                                                           read_only=True).data)
+
+    @detail_route(methods=['get'])
+    def bug_suggestions(self, request, project, pk=None):
+        """
+        Gets a set of bug suggestions for this job
+        """
+        try:
+            job = Job.objects.get(repository__name=project,
+                                  project_specific_id=pk)
+        except ObjectDoesNotExist:
+            return Response("No job with id: {0}".format(pk), status=HTTP_404_NOT_FOUND)
+
+        return Response(get_error_summary(job))
 
     @detail_route(methods=['get'])
     @with_jobs

--- a/ui/index.html
+++ b/ui/index.html
@@ -113,6 +113,7 @@
         <script src="js/models/matcher.js"></script>
         <script src="js/models/failure_lines.js"></script>
         <script src="js/models/classified_failure.js"></script>
+        <script src="js/models/bug_suggestions.js"></script>
         <script src="js/models/text_log_step.js"></script>
         <script src="js/models/text_log_summary.js"></script>
         <script src="js/models/text_log_summary_line.js"></script>

--- a/ui/js/models/bug_suggestions.js
+++ b/ui/js/models/bug_suggestions.js
@@ -1,0 +1,6 @@
+"use strict";
+
+treeherder.factory('ThBugSuggestionsModel', [
+    '$resource', 'thUrl', function($resource, thUrl) {
+        return $resource(thUrl.getRootUrl('/project/:project/jobs/:jobId/bug_suggestions/'));
+    }]);

--- a/ui/plugins/failure_summary/controller.js
+++ b/ui/plugins/failure_summary/controller.js
@@ -1,18 +1,16 @@
 "use strict";
 
 treeherder.controller('BugsPluginCtrl', [
-    '$scope', '$rootScope', 'ThLog', 'ThJobArtifactModel', 'ThTextLogStepModel',
-    '$q', 'thTabs', '$timeout', 'thUrl', '$uibModal', '$location',
+    '$scope', '$rootScope', 'ThLog', 'ThTextLogStepModel',
+    'ThBugSuggestionsModel', '$q', 'thTabs', '$timeout', 'thUrl', '$uibModal',
+    '$location',
     function BugsPluginCtrl(
-        $scope, $rootScope, ThLog, ThJobArtifactModel, ThTextLogStepModel,
+        $scope, $rootScope, ThLog, ThTextLogStepModel, ThBugSuggestionsModel,
         $q, thTabs, $timeout, thUrl, $uibModal, $location) {
 
         var $log = new ThLog(this.constructor.name);
 
         $log.debug("bugs plugin initialized");
-
-        var timeoutPromise = null;
-        var requestPromise = null;
 
         $scope.bug_limit = 20;
         $scope.tabs = thTabs.tabs;
@@ -23,81 +21,58 @@ treeherder.controller('BugsPluginCtrl', [
         thTabs.tabs.failureSummary.update = function() {
             var newValue = thTabs.tabs.failureSummary.contentId;
             $scope.suggestions = [];
+            $scope.bugSuggestionsLoaded = false;
+
             if (angular.isDefined(newValue)) {
                 thTabs.tabs.failureSummary.is_loading = true;
-                // if there's an ongoing timeout, cancel it
-                if (timeoutPromise !== null) {
-                    $timeout.cancel(timeoutPromise);
-                }
-                // if there's a ongoing request, abort it
-                if (requestPromise !== null) {
-                    requestPromise.resolve();
-                }
 
-                requestPromise = $q.defer();
-
-                ThJobArtifactModel.get_list({
-                    name__in: "Bug suggestions",
-                    "type": "json",
-                    job_id: newValue
-                }, {timeout: requestPromise})
-                .then(function(artifact_list){
-                    // using a temporary array here to not trigger a
-                    // dirty check for every element pushed
-                    var suggestions = [];
-                    if(artifact_list.length > 0){
-                        var artifact = _.find(artifact_list, {"name": "Bug suggestions"});
-                        angular.forEach(artifact.blob, function (suggestion) {
-                            suggestion.bugs.too_many_open_recent = (
-                                suggestion.bugs.open_recent.length > $scope.bug_limit
-                            );
-                            suggestion.bugs.too_many_all_others = (
-                                suggestion.bugs.all_others.length > $scope.bug_limit
-                            );
-                            suggestion.valid_open_recent = (
-                                suggestion.bugs.open_recent.length > 0 &&
+                ThBugSuggestionsModel.query({
+                    project: $rootScope.repoName,
+                    jobId: newValue
+                }, function(suggestions) {
+                    suggestions.forEach(function(suggestion) {
+                        suggestion.bugs.too_many_open_recent = (
+                            suggestion.bugs.open_recent.length > $scope.bug_limit
+                        );
+                        suggestion.bugs.too_many_all_others = (
+                            suggestion.bugs.all_others.length > $scope.bug_limit
+                        );
+                        suggestion.valid_open_recent = (
+                            suggestion.bugs.open_recent.length > 0 &&
                                 !suggestion.bugs.too_many_open_recent
-                            );
-                            suggestion.valid_all_others = (
-                                suggestion.bugs.all_others.length > 0 &&
+                        );
+                        suggestion.valid_all_others = (
+                            suggestion.bugs.all_others.length > 0 &&
                                 !suggestion.bugs.too_many_all_others &&
                                 // If we have too many open_recent bugs, we're unlikely to have
                                 // relevant all_others bugs, so don't show them either.
                                 !suggestion.bugs.too_many_open_recent
-                            );
-                            suggestions.push(suggestion);
+                        );
+                    });
+
+                    // if we have no bug suggestions, populate with the raw errors from
+                    // the log (we can do this asynchronously, it should normally be
+                    // fast)
+                    if (!suggestions.length) {
+                        ThTextLogStepModel.query({
+                            project: $rootScope.repoName,
+                            jobId: newValue
+                        }, function(textLogSteps) {
+                            $scope.errors = textLogSteps
+                                .filter(step => step.result !== 'success')
+                                .map(function(step) {
+                                    return {
+                                        name: step.name,
+                                        result: step.result,
+                                        lvURL: thUrl.getLogViewerUrl(newValue) +
+                                            "#L" + step.finished_line_number
+                                    };
+                                });
                         });
-
-                        // if we have no bug suggestions, populate with the raw errors from
-                        // the log (we can do this asynchronously, it should normally be
-                        // fast)
-                        if (!suggestions.length) {
-                            ThTextLogStepModel.query({
-                                project: $rootScope.repoName,
-                                jobId: newValue
-                            }, function(textLogSteps) {
-                                $scope.errors = textLogSteps
-                                    .filter(step => step.result !== 'success')
-                                    .map(function(step) {
-                                        return {
-                                            name: step.name,
-                                            result: step.result,
-                                            lvURL: thUrl.getLogViewerUrl(newValue) +
-                                                "#L" + step.finished_line_number
-                                        };
-                                    });
-                            });
-                        }
-
-                        $scope.suggestions = suggestions;
-                        $scope.bugSuggestionsLoaded = true;
-                    } else if ($scope.selectedJob && $scope.logParseStatus === "parsed") {
-                        $scope.bugSuggestionsLoaded = false;
-                        // set a timer to re-run update() after 5 seconds
-                        timeoutPromise = $timeout(thTabs.tabs.failureSummary.update, 5000);
                     }
-                })
-                .finally(function () {
+
+                    $scope.suggestions = suggestions;
+                    $scope.bugSuggestionsLoaded = true;
                     thTabs.tabs.failureSummary.is_loading = false;
                 });
             }


### PR DESCRIPTION
Instead, generate the data when required. We will store the return value
of this in memcache for a day to ensure things are responsive for the sheriffs
when classifying recent failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1871)
<!-- Reviewable:end -->
