### PR TITLE
Bug 1293264 - Show distinctive banner when user tries to cancel all jobs

### DIFF
--- a/ui/css/treeherder-resultsets.css
+++ b/ui/css/treeherder-resultsets.css
@@ -106,6 +106,10 @@ fieldset[disabled] .btn-resultset:hover {
   padding-left: 0;
 }
 
+.result-set .cancel-all-jobs-confirm {
+  padding: 8px 34px 0px 34px;
+}
+
 /*
  * Revision list
  */

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -28,8 +28,8 @@
             ng-attr-title="{{getCancelJobsTitle(resultset.revision)}}"
             ng-show="currentRepo.repository_group.name == 'try' || user.is_staff"
             ignore-job-clear-on-click
-            ng-disabled="!canCancelJobs(resultset.revision)"
-            ng-click="cancelJobs(resultset.revision)">
+            ng-disabled="!canCancelJobs()"
+            ng-click="confirmCancelAllJobs()">
         <span class="fa fa-times-circle cancel-job-icon dim-quarter"
               ignore-job-clear-on-click></span>
       </span>
@@ -53,8 +53,15 @@
       <th-action-button></th-action-button>
     </span>
   </div>
-
   <div class="result-set-body-divider"></div>
+  <div class="cancel-all-jobs-confirm animate-show" uib-collapse="!showConfirmCancelAll">
+    <div uib-alert class="alert-danger" close="hideConfirmCancelAll()">
+      <span class="fa fa-exclamation-triangle"/> This action will cancel all pending and running jobs for this push.
+      <i>It cannot be undone!</i>
+      &nbsp;
+      <button ng-click="cancelAllJobs(resultset.revision)" class="btn btn-xs btn-danger">Confirm</button>
+    </div>
+  </div>
   <!-- Job table -->
   <div class="result-set-body" th-clone-jobs ></div>
 </div>


### PR DESCRIPTION
This also reverts the previous behaviour where we'd cancel a single job
if one was selected. This new approach hopefully makes it harder to
accidentally delete all jobs when only intending to cancel one, while
still being intuitive if that's really what you want to do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1874)
<!-- Reviewable:end -->
