### PR TITLE
Bug 1302689 - Update Django from 1.8.14 to 1.8.15

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -10,7 +10,7 @@ whitenoise==3.2 --hash=sha256:13e5d6673c7c0805c73037b7745e027141a8e39c5b6ba669b6
 https://github.com/google/brotli/archive/v0.3.0.zip#egg=Brotli==0.3.0 \
     --hash=sha256:0e1e88c74b5a4c9c39123fe8adfdce6262c80524398367420475716389d70791
 
-Django==1.8.14 --hash=sha256:1716747f7e0fbee6e2c1c0bcdb74307139d441a79eb4dcc97d206c615e1ded15
+Django==1.8.15 --hash=sha256:e2e41aeb4fb757575021621dc28fceb9ad137879ae0b854067f1726d9a772807
 
 celery==3.1.23 --hash=sha256:eaf5dee3becbc35c7754a2d4482d53bdf72ea3f85dd258525259983262081474
 


### PR DESCRIPTION
To pick up the security fix:
https://www.djangoproject.com/weblog/2016/sep/26/security-releases/
https://docs.djangoproject.com/en/stable/releases/1.8.15/
https://github.com/django/django/compare/1.8.14...1.8.15

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1878)
<!-- Reviewable:end -->
