### PR TITLE
Bug 1290082 - Fix the display of server/API error messages in the UI

### DIFF
--- a/ui/js/directives/treeherder/persona.js
+++ b/ui/js/directives/treeherder/persona.js
@@ -2,10 +2,10 @@
 
 treeherder.directive('personaButtons', [
     '$http', '$q', '$log', '$rootScope',
-    'thServiceDomain', 'BrowserId', 'ThUserModel', 'thNotify',
+    'thServiceDomain', 'BrowserId', 'ThUserModel', 'thNotify', 'ThModelErrors',
     function(
         $http, $q, $log, $rootScope, thServiceDomain,
-        BrowserId, ThUserModel, thNotify) {
+        BrowserId, ThUserModel, thNotify, ThModelErrors) {
 
         return {
             restrict: "E",
@@ -69,7 +69,7 @@ treeherder.directive('personaButtons', [
                                     $rootScope.$broadcast('userChange');
                                 }, null);
                             },function(response){
-                                var message = "Login failed: " + response.status + " " + response.statusText;
+                                var message = ThModelErrors.format(response, "Login failed");
                                 thNotify.send(message, "danger", true);
 
                                 // logout if the verification failed

--- a/ui/js/models/error.js
+++ b/ui/js/models/error.js
@@ -19,20 +19,14 @@ treeherder.factory('ThModelErrors', [function() {
                                 found in the error object.
         */
         format: function(e, message) {
-            // If there is nothing in the server message return default...
-            if (!e || !e.data) {
-                return message;
+            // If we failed to authenticate for some reason return a nicer error message.
+            if (e.status === 401 || e.status === 403) {
+                return AUTH_ERROR_MSG;
             }
 
-            switch (e.status) {
-                case 401:
-                case 403:
-                    // If we failed to authenticate for some reason return a nicer
-                    // error message.
-                    return AUTH_ERROR_MSG;
-                default:
-                    return message + ':' + e.data.detail;
-            }
+            // If there is nothing in the server message use the HTTP response status.
+            var errorMessage = e.data.detail || e.status + ' ' + e.statusText;
+            return message + ': ' + errorMessage;
         }
     };
 }]);

--- a/ui/js/services/pinboard.js
+++ b/ui/js/services/pinboard.js
@@ -2,10 +2,10 @@
 
 treeherder.factory('thPinboard', [
     '$http', 'thUrl', 'ThJobClassificationModel', '$rootScope', 'thEvents',
-    'ThBugJobMapModel', 'thNotify', 'ThLog', 'ThResultSetStore',
+    'ThBugJobMapModel', 'thNotify', 'ThModelErrors', 'ThLog', 'ThResultSetStore',
     function(
         $http, thUrl, ThJobClassificationModel, $rootScope, thEvents,
-        ThBugJobMapModel, thNotify, ThLog, ThResultSetStore) {
+        ThBugJobMapModel, thNotify, ThModelErrors, ThLog, ThResultSetStore) {
 
         var $log = new ThLog("thPinboard");
 
@@ -25,13 +25,13 @@ treeherder.factory('thPinboard', [
                 classification.job_id = job.id;
                 classification.create().
                     success(function() {
-                        thNotify.send("Classification saved for " + job.platform + ": " + job.job_type_name, "success");
+                        thNotify.send("Classification saved for " + job.platform + " " + job.job_type_name, "success");
                     }).error(function(data) {
-                        var error = "Error saving classification for " + job.platform + ": " + job.job_type_name;
-                        if(data.detail === "Authentication credentials were not provided.") {
-                            error = "Authentication failed, try refreshing page and signing in again?";
-                        }
-                        thNotify.send(error, "danger");
+                        var message = "Error saving classification for " + job.platform + " " + job.job_type_name;
+                        thNotify.send(
+                            ThModelErrors.format(data, message),
+                            "danger"
+                        );
                         $log.debug("classification failed", data);
                     });
             }
@@ -46,13 +46,13 @@ treeherder.factory('thPinboard', [
                 });
                 bjm.create().
                     success(function() {
-                        thNotify.send("Bug association saved for " + job.platform + ": " + job.job_type_name, "success");
+                        thNotify.send("Bug association saved for " + job.platform + " " + job.job_type_name, "success");
                     }).error(function(data) {
-                        var error = "Error saving bug association for " + job.platform + ": " + job.job_type_name;
-                        if(data.detail === "Authentication credentials were not provided.") {
-                            error = "Authentication failed, try refreshing page and signing in again?";
-                        }
-                        thNotify.send(error, "danger");
+                        var message = "Error saving bug association for " + job.platform + " " + job.job_type_name;
+                        thNotify.send(
+                            ThModelErrors.format(data, message),
+                            "danger"
+                        );
                     });
             });
         };


### PR DESCRIPTION
**1) Make ThModelErrors use HTTP status code if no API message**

Previously if the server response wasn't valid json with a `detail` attribute, only the generic message from the `ThModelErrors.format()` call (eg "Unable to cancel job") would be displayed.

Now, `format()` will fall back to including the HTTP status code (and corresponding text description of that code) too.

We intentionally don't display the server response if it's not valid json, since in this case it's likely several hundreds lines of HTML from the load balancer. (And users can always inspect the response manually.)

**2) Use ThModelErrors for classification and persona errors**

There are still other API error cases that aren't yet using `ThModelErrors`, however these two cases are the most important for now, since otherwise the Heroku migration maintenance messages won't be displayed in the UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1880)
<!-- Reviewable:end -->
