### PR TITLE
Bug 1306369 -  Update common tasks log parser doc example

### DIFF
--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -20,7 +20,7 @@ Or for more control, run each tool individually:
   .. code-block:: bash
 
      vagrant ~/treeherder$ py.test tests/
-     vagrant ~/treeherder$ py.test tests/log_parser/test_utils.py
+     vagrant ~/treeherder$ py.test tests/log_parser/test_tasks.py
      vagrant ~/treeherder$ py.test tests/etl/test_buildapi.py -k test_ingest_builds4h_jobs
 
   To run all tests, including slow tests that are normally skipped, use:


### PR DESCRIPTION
This fixes Bugzilla bug [1306369](https://bugzilla.mozilla.org/show_bug.cgi?id=1306369).

This updates the docs log parser example to a test which currently exists in the repo. I chose the most recently touched test, which in this case is test_tasks.py.

Adding @wlach for review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1881)
<!-- Reviewable:end -->
