### PR TITLE
Bug 1066724 - Make ctrl+a select all in focused exclusion lists

### DIFF
--- a/ui/js/reactselect.js
+++ b/ui/js/reactselect.js
@@ -7,13 +7,28 @@ var ReactSelectComponent = React.createClass({
         side: React.PropTypes.string.isRequired,
         filter: React.PropTypes.string
     },
+    componentDidMount: function() {
+        var keyShortcuts = [
+            // Shortcut: select all
+            ['mod+a', function(ev) {
+                ev.preventDefault();
+                Array.prototype.slice.call(ev.target.options).map(function (op) {
+                    op.selected = true;
+                });
+            }]
+        ];
+        keyShortcuts.map(function(data) {
+            Mousetrap.bind(data[0], data[1]);
+        });
+    },
     render: function () {
         var filter = (this.props.filter || "").toLowerCase();
         var list = this.props.list || [];
+        var classList = [this.props.side, 'mousetrap'];
 
         return React.createElement(
             'select',
-            { className: this.props.side, multiple: true },
+            { className: classList.join(' '), multiple: true },
             list.sort().map(function (item, index) {
                 // only create the item if there is no filter, or if
                 // there is a filter and this matches as a substring.


### PR DESCRIPTION
Adds a keyboard shortcut to make ctrl+a select all items in reactlist
components like the exclusion lists in the admin view. This is default
behavior in chrome/ium, but not FF or IE.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1887)
<!-- Reviewable:end -->
