### PR TITLE
Bug 1306889 - Help ensure bugfiler doesn't choke on xperf failures

### DIFF
--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -41,7 +41,7 @@ treeherder.controller('BugFilerCtrl', [
             var thisFailure = "";
             for(var i = 0; i < allFailures.length; i++) {
                 for(var j=0; j < $scope.omittedLeads.length; j++) {
-                    if(allFailures[i][0].search($scope.omittedLeads[j]) >= 0) {
+                    if(allFailures[i][0].search($scope.omittedLeads[j]) >= 0 && allFailures[i].length > 1) {
                         allFailures[i].shift();
                     }
                 }
@@ -67,7 +67,7 @@ treeherder.controller('BugFilerCtrl', [
             summary = summary.split(" | ");
 
             for(var i=0; i < $scope.omittedLeads.length; i++) {
-                if(summary[0].search($scope.omittedLeads[i]) >= 0) {
+                if(summary[0].search($scope.omittedLeads[i]) >= 0 && summary.length > 1) {
                     summary.shift();
                 }
             }


### PR DESCRIPTION
For whatever reasons, xperf failures are logged as "TEST-UNEXPECTED-FAIL :
xperf :" instead of "TEST-UNEXPECTED-FAIL | xperf |", which caused issues
with the bugfiler trying to split the failure line on |s. This patches
over the problem by not letting the summary array be reduced if there's
only one item left in the array.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1890)
<!-- Reviewable:end -->
