### PR TITLE
Bug 1306859 - Enable the bug filer for is_staff users

### DIFF
--- a/ui/plugins/failure_summary/main.html
+++ b/ui/plugins/failure_summary/main.html
@@ -5,7 +5,7 @@
             <div class="job-tabs-content">
                 <a class="btn btn-xs btn-default"
                    prevent-default-on-left-click
-                   ng-show="user.loggedin && filerInAddress"
+                   ng-show="user.loggedin && (filerInAddress || user.is_staff)"
                    ng-click="fileBug($index)"
                    title="file a bug for this failure">
                   <i class="fa fa-bug"></i>


### PR DESCRIPTION
This makes the button appear for anyone that is logged in and either in
the is_staff group or has '&bugfiler' in the URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1891)
<!-- Reviewable:end -->
