### PR TITLE
Bug 1205747 - Ensure the retrigger/backfill menu gets styled

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -104,6 +104,11 @@ div#info-panel .info-panel-navbar .navbar-nav > li.active a:focus {
   color: #EEF0F2;
 }
 
+#retriggerLabel + ul.dropdown-menu > li > a:hover {
+  background-color: #f5f5f5 !important;
+  color: black !important;
+}
+
 #info-panel-content {
   position: relative; /* So we can absolutely position the loading overlay */
   height: 60%;


### PR DESCRIPTION
The menus in the app header navbar get a subtle grey background on hover.
For some reason, the same is not applying to the retrigger/backfill menu.
This patch just forces the same style change to occur for this menu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1893)
<!-- Reviewable:end -->
