### PR TITLE
Bug 1088204 - Notify the user when the server's revision has changed from when the page was loaded

### DIFF
--- a/ui/css/treeherder-navbar-panels.css
+++ b/ui/css/treeherder-navbar-panels.css
@@ -78,3 +78,12 @@
 .field-filter-placeholder a {
     cursor: pointer;
 }
+
+/*
+ * Update notification panel
+ */
+
+.update-alert-panel {
+    border-radius: 0px;
+    margin-bottom: 0px;
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -39,6 +39,7 @@
                             src="'partials/main/thGlobalTopNavPanel.html'">
                 </ng-include>
             </div>
+            <ng-include src="'partials/main/thTreeherderUpdateBar.html'"></ng-include>
             <div id="th-global-content" class="th-global-content"
                  ng-click="clearJobOnClick($event)">
                 <span class="th-view-content" ng-cloak>

--- a/ui/partials/main/thTreeherderUpdateBar.html
+++ b/ui/partials/main/thTreeherderUpdateBar.html
@@ -1,0 +1,6 @@
+<!-- Show this when the Treeherder server has updated -->
+<div class="alert alert-info update-alert-panel" ng-show="serverChangedDelayed" ng-cloak>
+  <i class="fa fa-info-circle" aria-hidden="true"></i>
+  Treeherder has updated. To pick up the changes, you can reload the page
+  <button ng-click="updateButtonClick()" class="btn btn-xs btn-danger">Reload</button>
+</div>

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -4,6 +4,13 @@
     <span>
       <form role="search" class="form-inline">
 
+        <span class="btn btn-sm btn-view-nav nav-menu-btn" 
+              ng-show="serverChanged" ng-cloak
+              ng-click="updateButtonClick()"
+              id="revisionChangedLabel"
+              title="New version of Treeherder has been deployed. Reload to pick up changes.">
+          <span class="fa fa-exclamation-circle" />&nbsp;Treeherder update available
+        </span>
         <!--Unclassified Failures Button-->
         <span class="btn btn-sm"
               title="Loaded failures / Toggle filtering for unclassified failures"


### PR DESCRIPTION
This lets the user know if the server's version has changed since loading the page. 

On the initial page load, a request is made to load revision.txt. If it can load revision.txt (doesn't appear to be present if I'm running with vagrant via bin/run_gunicorn or manage.py, though for testing purposes, I manually created the file and it seems to work), it stores the revision as $rootScope.serverRev. 

Responses from the resultset api now include the current revision used on the server side.

The two values are compared on the UI side, and if they differ, a notification is shown to the user.

I'd be open to better ideas on how to get the server-side revision rather than adding gitpython, allowing raw git commands to be run on the server.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1901)

<!-- Reviewable:end -->
