### PR TITLE
Bug 1263236 - Indicate jobs are ready in the DOM

### DIFF
--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -890,19 +890,21 @@ treeherder.directive('thCloneJobs', [
                         );
 
                         /**************
-                      Resultset job pollers updates can
-                      trigger re-rendering rows at anytime during a
-                      session, this can give the appearance of sluggishness
-                      in the UI. Use defer to avoid rendering jankiness
-                      here.
+                          Resultset job pollers updates can
+                          trigger re-rendering rows at anytime during a
+                          session, this can give the appearance of sluggishness
+                          in the UI. Use a timeout to avoid rendering jankiness
+                          here.
                         **************/
                         rsMap[resultSetId].rs_obj.platforms.forEach(function(platform) {
                             addAdditionalJobParameters(platform.groups);
                         });
-                        _.defer(
-                            generateJobElements,
-                            resultsetAggregateId,
-                            rsMap[resultSetId].rs_obj);
+                        $timeout(generateJobElements(
+                          resultsetAggregateId,
+                          rsMap[resultSetId].rs_obj
+                        )).then(function() {
+                            $rootScope.jobsReady = true;
+                        });
                     }
                 });
 

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -1,4 +1,6 @@
 <!-- Load progress bar -->
+<span class="hidden" ng-class="{'ready':jobsReady}"></span>
+
 <div class="progress progress-striped active"
      ng-show="isLoadingRsBatch.prepending && result_sets.length === 0">
   <div class="progress-bar"  role="progressbar" style="width: 100%"></div>


### PR DESCRIPTION
Here's my attempt - the `.ready` class is added to a new, hidden `span` once the first resultset has loaded its jobs and appended them to their containing element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1904)
<!-- Reviewable:end -->
