### PR TITLE
Bug 1308669 - BugFiler product selection improvements

### DIFF
--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -92,12 +92,21 @@ treeherder.controller('BugFilerCtrl', [
         $scope.findProduct = function() {
             $scope.suggestedProducts = [];
             var failurePath = $uibModalInstance.parsedSummary[0][0];
+
+            // If the "TEST-UNEXPECTED-foo" isn't one of the omitted ones, use the next piece in the summary
+            if(failurePath.includes("TEST-UNEXPECTED-")) {
+                failurePath = $uibModalInstance.parsedSummary[0][1];
+            }
             var failurePathRoot = failurePath.split("/")[0];
 
             // Look up the product via the root of the failure's file path
             if(thBugzillaProductObject[failurePathRoot]) {
                 $scope.suggestedProducts.push(thBugzillaProductObject[failurePathRoot][0]);
-                $scope.selection.selectedProduct = $scope.suggestedProducts[0];
+            }
+
+            // Some job types are special, lets explicitly handle them.
+            if(selectedJob.job_group_name.includes("Web Platform")) {
+                $scope.suggestedProducts.push("Testing :: web-platform-tests");
             }
 
             // Look up product suggestions via Bugzilla's api
@@ -122,6 +131,8 @@ treeherder.controller('BugFilerCtrl', [
                     $scope.selection.selectedProduct = $scope.suggestedProducts[0];
                 });
             }
+
+            $scope.selection.selectedProduct = $scope.suggestedProducts[0];
         };
 
         /*


### PR DESCRIPTION
This just makes sure that when the selected failing job is a wpt test, the
Testing :: web-platform-tests product/component pair is offerred as a
suggestion.

This also helps make sure we don't try to use "TEST-UNEXPECTED-foo" as a
potential path root for the initial product searches, because that makes
the feature fail to find anything if the "TEST-UNEXPECTED-foo" isn't
omitted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1909)
<!-- Reviewable:end -->
