### PR TITLE
Bug 1220164 - Add a simple collapse/expand button per push

### DIFF
--- a/ui/css/treeherder-resultsets.css
+++ b/ui/css/treeherder-resultsets.css
@@ -14,6 +14,24 @@
   justify-content: space-between;
 }
 
+.result-set-collapser {
+  margin-left:-30px;
+  width:30px;
+}
+
+.result-set .result-set-collapser::before {
+  content: "+";
+}
+
+
+.result-set[collapsed] .result-set-collapser::before {
+  content: "-";
+}
+
+.result-set[collapsed] > :not(.result-set-bar) {
+  display:none;
+}
+
 .result-set-left {
   display: flex;
   display: -webkit-flex;

--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -197,6 +197,15 @@ treeherderApp.controller('ResultSetCtrl', [
             });
         };
 
+        $scope.togglePushCollapse = function(evt) {
+            var target = evt.target.parentNode.parentNode;
+            if(target.getAttribute("collapsed") === "true") {
+                target.removeAttribute("collapsed");
+            } else {
+                target.setAttribute("collapsed", "true");
+            }
+        };
+
         $scope.triggerMissingJobs = function(revision) {
             if (!window.confirm('This will trigger all missing jobs for revision ' + revision + '!\n\nClick "OK" if you want to proceed.')) {
                 return;

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -11,6 +11,9 @@
      data-id="{{::resultset.id}}">
 
   <div class="result-set-bar">
+    <button class="result-set-collapser btn btn-sm btn-resultset"
+            title="Collapse/expand this push"
+            ng-click="togglePushCollapse($event)" />
     <span class="result-set-left">
       <span class="result-set-title-left">
         <span>


### PR DESCRIPTION
This adds a button to the left of each push header, allowing the user to
collapse or expand all details about this push. It does this by setting an
attribute on the push as a whole, and hiding non-header parts of the push
when that attribute is set. Clicking the button again will remove that
attribute from the push, causing the rest of the push's information to be
displayed again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1910)
<!-- Reviewable:end -->
