### PR TITLE
Bug 1066286 - Implement a mobile view for treeherder

### DIFF
--- a/ui/css/treeherder-resultsets.css
+++ b/ui/css/treeherder-resultsets.css
@@ -1,3 +1,124 @@
+@media (min-width: 601px) {
+  .repo-select {
+    display:none;
+  }
+  
+  .result-set-mobile-bar {
+    display:none;
+  }
+  
+  th-result-counts div.progress {
+    display:none;
+  }
+}
+
+@media (max-width: 600px) {
+  #info-panel {
+    display: none!important;
+  }
+  .result-set-body:not([show-mobile-revisions]):not([show-mobile-jobs]) {
+    display: none;
+  }
+  .result-set-body:not([show-mobile-revisions]) .revision-list {
+    display: none !important;
+  }
+  .result-set-body:not([show-mobile-jobs]) .job-list {
+    display: none;
+  }
+  
+  .navbar-right > :not(persona-buttons):not(#settingsButton) {
+    display: none;
+  }
+  
+  .result-set-mobile-bar > span > th-action-button .btn {
+    width: 100%;
+  }
+  
+  persona-buttons {
+    float: right;
+  }
+  
+  th-watched-repo {
+    display: none;
+  }
+  
+  th-author > span > a {
+    text-overflow: ellipsis;
+  }
+  
+  .result-set-bar, .result-set-body-divider {
+    display:none!important;
+  }
+  
+  .result-set-mobile-bar {
+    border: 1px solid gray;
+    padding: 5px;
+    margin: 5px;
+    text-align: center;
+  }
+
+  th-result-counts div.progress {
+    margin: 5px;
+  }
+
+  th-result-counts > span > span {
+    display: none;
+  }
+  
+  .result-set-mobile-bar > .btn {
+    width:45%;
+  }
+
+  /* SHOW REVISION LIST STUFF */
+  .result-set[show-mobile-revisions] .result-set-body {
+    display: block;
+  }
+  .result-set[show-mobile-revisions] .result-set-body .revision-list {
+    width: 100%;
+    padding: 5px;
+    margin: 5px;
+    display: block !important;
+  }
+  .result-set[show-mobile-revisions] .result-set-body .revision-list li {
+    border: 1px solid gray;
+    padding: 5px;
+  }
+  .result-set[show-mobile-revisions] .result-set-body .revision-list .revision > .revision-holder {
+    padding-left: unset;
+  }
+  .result-set[show-mobile-revisions] .result-set-body .revision-list .revision > span:nth-of-type(3) {
+    display: block;
+  }
+  .result-set[show-mobile-revisions] .result-set-body .revision-list .revision > span:nth-of-type(3) em {
+    white-space: pre-wrap;
+  }
+  /* END SHOW REVISION LIST STUFF */
+
+  /* SHOW JOB LIST STUFF */
+  .result-set[show-mobile-jobs] .result-set-body {
+    display: block;
+  }
+  .result-set[show-mobile-jobs] .result-set-body .job-list {
+    width:100%;
+    padding: 5px;
+    margin: 5px;
+    display: unset;
+  }
+  .result-set[show-mobile-jobs] .result-set-body .job-list table {
+    border: 1px solid gray;
+    padding: 5px;
+  }
+  .result-set[show-mobile-jobs] .result-set-body .job-list table tr {
+    border: 1px solid gray;
+  }
+  .result-set[show-mobile-jobs] .result-set-body .job-list table .platform {
+    width: 12%;
+    min-width: 12%;
+  }
+  /* END SHOW JOB LIST STUFF */
+
+}
+
 /*
  * Resultset bar
  */

--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -121,6 +121,17 @@ treeherderApp.controller('ResultSetCtrl', [
 
         };
 
+        $scope.toggleMobileVisibility = function(evt, id, type) {
+            var attribute = "show-mobile-" + type;
+            var target = evt.target;
+            var pushElement = target.parentNode.parentNode;
+            if(pushElement.getAttribute(attribute)) {
+                pushElement.removeAttribute(attribute);
+            } else {
+                pushElement.setAttribute(attribute, "true");
+            }
+        };
+
         /**
          * Pin all jobs that pass the global filters.
          *

--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -10,6 +10,21 @@
      class="result-set"
      data-id="{{::resultset.id}}">
 
+  <div class="result-set-mobile-bar">
+    <th-author author="{{::resultset.author}}"></th-author>
+    <span style="float:right;"><th-action-button></th-action-button></span>
+    <div>
+      <a href="{{::revisionResultsetFilterUrl}}"
+       title="View only this resultset"
+       ignore-job-clear-on-click>{{resultset.revision | limitTo : 12}}
+      <span class="fa fa-external-link icon-superscript"></span></a> - {{::resultsetDateStr}}
+    </div>
+    <th-result-counts class="result-counts"></th-result-counts>
+    
+    <button ng-click="toggleMobileVisibility($event,resultset.id,'revisions')" class="revisions-btn btn">Revisions</button>
+    <button ng-click="toggleMobileVisibility($event,resultset.id,'jobs')" class="jobs-btn btn">Jobs</button>
+  </div>
+
   <div class="result-set-bar">
     <span class="result-set-left">
       <span class="result-set-title-left">

--- a/ui/partials/main/thGlobalTopNavPanel.html
+++ b/ui/partials/main/thGlobalTopNavPanel.html
@@ -34,7 +34,7 @@
       </span>
 
       <!-- Repos Menu -->
-      <span ng-controller="RepositoryMenuCtrl" >
+      <span id="repoMenu" ng-controller="RepositoryMenuCtrl" >
         <span th-checkbox-dropdown-container class="dropdown">
           <button id="repoLabel" title="Watch a repo" role="button"
                   data-toggle="dropdown" data-target="#"
@@ -80,6 +80,7 @@
 
       <!-- Settings Button - currently suppressed -->
       <span ng-show="false"
+            id="settingsButton"
             class="btn btn-view-nav btn-right-navbar nav-menu-btn"
             ng-class="{'active': (isSettingsPanelShowing)}"
             ng-click="setSettingsPanelShowing(!isSettingsPanelShowing)"

--- a/ui/partials/main/thResultCounts.html
+++ b/ui/partials/main/thResultCounts.html
@@ -2,4 +2,8 @@
   <span ng-if="percentComplete == 100">- Complete -</span>
   <span ng-if="percentComplete < 100"
         title="Proportion of jobs that are complete">{{percentComplete}}% - {{inProgress}} in progress</span>
+  <uib-progressbar ng-cloak class="progress-striped" ng-class="{active: percentComplete != 100}" max="100" value="percentComplete">
+      <span ng-if="percentComplete == 100">- Complete -</span>
+      <span ng-if="percentComplete < 100">{{percentComplete}}% - {{inProgress}} in progress</span>
+  </uib-progressbar>
 </span>

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -1,5 +1,14 @@
 <div id="watched-repo-navbar" class="th-context-navbar watched-repo-navbar clearfix">
   <th-watched-repo ng-repeat="(name, repoData) in repoModel.watchedRepos"></th-watched-repo>
+  <span class="repo-select" ng-controller="RepositoryMenuCtrl" >
+      <select ng-cloak onchange="document.location = '#/jobs?repo=' + this.value.trim()">
+          <optgroup ng-repeat="(group_order, group) in groupedRepos()" label="{{::group.name}}">
+              <option ng-repeat="repo in group.repos | orderBy : 'name'" ng-selected="repo.name === repoName">
+                  {{::repo.name}}
+              </option>
+          </optgroup>
+      </select>
+  </span>
   <div class="navbar-right">
     <span>
       <form role="search" class="form-inline">


### PR DESCRIPTION
This adds a more mobile-friendly view for Treeherder at smaller screen
sizes.

Not everything is working (nothing happens if you select a job in the mobile view), and there should probably be some way to opt out of the mobile view so you can use the full desktop site, but I was bored this weekend and got this far.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1911)

<!-- Reviewable:end -->
