### PR TITLE
Bug 1283859 - Fix quoting of MATCH ... AGAINST in bugscache search

### DIFF
--- a/tests/etl/test_bugzilla.py
+++ b/tests/etl/test_bugzilla.py
@@ -10,8 +10,8 @@ def test_bz_api_process(mock_bugzilla_api_request):
     process.run()
 
     # the number of rows inserted should equal to the number of bugs
-    assert Bugscache.objects.count() == 16
+    assert Bugscache.objects.count() == 17
 
     # test that a second ingestion of the same bugs doesn't insert new rows
     process.run()
-    assert Bugscache.objects.count() == 16
+    assert Bugscache.objects.count() == 17

--- a/tests/model/test_bugscache.py
+++ b/tests/model/test_bugscache.py
@@ -52,6 +52,10 @@ BUG_SEARCHES = (
         [1054456]
     ),
     (
+        "[taskcluster:error]  Command \" [./test-macosx.sh --no-read-buildbot-config --installer-url=https://q",
+        [100]
+    ),
+    (
         "should not be match_d",
         []
     ),

--- a/tests/sample_data/bug_list.json
+++ b/tests/sample_data/bug_list.json
@@ -194,6 +194,18 @@
             "resolution": "",
             "op_sys": "Unspecified",
             "last_change_time": "2016-07-25T01:04:15Z"
+        },
+        {
+            "status": "NEW",
+            "id": 100,
+            "summary": "Intermittent [taskcluster:error]  Command \" [./test-macosx.sh --no-read-buildbot-config --installer-url=https://queue.taskcluster.net/v1/task/Qs1_DYVKQASBhy0o_Uo4jA/artifacts/public/build/target.dmg --test-packages-url=https://queue.taskcluster.net/v1/task/Qs1_DYVKQASBhy0o_Uo4jA/artifacts/public/build/target.test_packages.json --mochitest-suite=plain-gpu,chrome-gpu,browser-chrome-gpu --allow-software-gl-layers --total-chunk=1 --this-chunk=1 --download-symbols=ondemand] \" failed to run:  exit status 2",
+            "cf_crash_signature": "",
+            "keywords": [
+                "intermittent-failure"
+            ],
+            "resolution": "",
+            "op_sys": "Unspecified",
+            "last_change_time": "2016-07-25T01:04:15Z"
         }
     ]
 }

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -153,7 +153,7 @@ class Bugscache(models.Model):
         # 90 days ago
         time_limit = datetime.datetime.now() - datetime.timedelta(days=90)
         # Wrap search term so it is used as a phrase in the full-text search.
-        search_term_fulltext = search_term.join('""')
+        search_term_fulltext = '"%s"' % search_term.replace("\"", "")
         # Substitute escape and wildcard characters, so the search term is used
         # literally in the LIKE statement.
         search_term_like = search_term.replace('=', '==').replace(


### PR DESCRIPTION
It appears that the intent of this code is to to a phrase match of the
search string against the bug summary for relevance matching. However
the code incorrectly tried to quote the string and as a result failed
to handle special characters in the AGAINST clause (e.g. + - ~ >
etc.). This change simply removes any existing quote characters from
the string and places the entire thing in quotes. Per the MySQL
documentations:

 > A phrase that is enclosed within double quote (") characters
   matches only rows that contain the phrase literally, as it was
   typed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1914)
<!-- Reviewable:end -->
