### PR TITLE
Bug 1310016 - Persist DB connections for 5 mins to improve performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
     - LD_LIBRARY_PATH="$HOME/venv/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
     - BROKER_URL='amqp://guest:guest@localhost:5672//'
     - DATABASE_URL='mysql://root@localhost/test_treeherder'
-    - DATABASE_URL_RO='mysql://root@localhost/test_treeherder'
     - ELASTICSEARCH_URL='http://127.0.0.1:9200'
     - TREEHERDER_DJANGO_SECRET_KEY='secretkey-of-at-50-characters-to-pass-check-deploy'
 matrix:

--- a/puppet/files/treeherder/env.sh
+++ b/puppet/files/treeherder/env.sh
@@ -4,7 +4,6 @@ export LD_LIBRARY_PATH="/home/vagrant/venv/lib/x86_64-linux-gnu"
 export ENABLE_LOCAL_SETTINGS_FILE='True'
 export BROKER_URL='amqp://guest:guest@localhost//'
 export DATABASE_URL='mysql://root@localhost/treeherder'
-export DATABASE_URL_RO='$DATABASE_URL'
 export ELASTICSEARCH_URL='http://localhost:9200'
 
 export TREEHERDER_DEBUG='True'

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -536,7 +536,6 @@ TEMPLATE_DEBUG = DEBUG
 # ...which django-environ converts into the Django DB settings dict format.
 DATABASES = {
     'default': env.db_url('DATABASE_URL'),
-    'read_only': env.db_url('DATABASE_URL_RO')
 }
 
 # We're intentionally not using django-environ's query string options feature,

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -542,6 +542,8 @@ DATABASES = {
 # since it hides configuration outside of the repository, plus could lead to
 # drift between environments.
 for alias in DATABASES:
+    # Persist database connections for 5 minutes, to avoid expensive reconnects.
+    DATABASES[alias]['CONN_MAX_AGE'] = 300
     if DATABASES[alias]['HOST'] != 'localhost':
         # Use TLS when connecting to RDS.
         DATABASES[alias]['OPTIONS'] = {

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -265,19 +265,11 @@ class Datasource(models.Model):
         if 'OPTIONS' in settings.DATABASES['default']:
             master_host_config.update(settings.DATABASES['default']['OPTIONS'])
 
-        read_host_config = {
-            "host": settings.DATABASES['read_only']['HOST'],
-            "user": settings.DATABASES['read_only']['USER'],
-            "passwd": settings.DATABASES['read_only'].get('PASSWORD') or '',
-        }
-        if 'OPTIONS' in settings.DATABASES['read_only']:
-            read_host_config.update(settings.DATABASES['read_only']['OPTIONS'])
-
         data_source = {
             self.key: {
                 "hub": "MySQL",
                 "master_host": master_host_config,
-                "read_host": read_host_config,
+                "read_host": master_host_config,
                 "require_host_type": True,
                 "default_db": self.name,
                 "procs": [


### PR DESCRIPTION
**1) Bug 1288369 - Use TLS when connecting to RDS from Vagrant**
Previously if someone set `DATABASE_URL` in their Vagrant environment to a remote RDS instance, TLS wouldn't have been used. Now, using TLS depends not on the `IS_HEROKU` environment variable (which we should stop using anyway, since it goes against the 12-factor methodology), but the DB hostname itself.

The CA bundle path has been made relative, to allow it to work inside Vagrant as well as on Heroku.

I've bundled this change in here, since the refactor helps with the below.

**2) Bug 1310016 - Remove read_only DB config**
Since we no longer have a master-slave setup, and in all environments DATABASE_URL is identical to DATABASE_RO_URL.

**3) Bug 1310016 - Persist DB connections for 5 mins to improve performance**
By default Django doesn't perform any connection pooling, so closes the DB connection after each request:
https://docs.djangoproject.com/en/1.10/ref/settings/#conn-max-age

Reconnecting takes 20-40ms on production (due to use of TLS), which is avoided with this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1925)
<!-- Reviewable:end -->
