### PR TITLE
Bug 1310825 - Add a tab navigation shortcut

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -299,6 +299,15 @@ treeherderApp.controller('MainCtrl', [
                                  thJobNavSelectors.UNCLASSIFIED_FAILURES);
             }],
 
+            // Shortcut: select next job tab
+            [['t'], function() {
+                if ($scope.selectedJob) {
+                    $scope.$evalAsync(
+                        $rootScope.$emit(thEvents.selectNextTab)
+                    );
+                }
+            }],
+
             // Shortcut: retrigger selected job
             ['r', function() {
                 if ($scope.selectedJob) {

--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -161,6 +161,9 @@ treeherder.provider('thEvents', function() {
             // fired when the job details are loaded
             jobDetailLoaded: "job-detail-loaded-EVT",
 
+            // fired with a selected job on 't'
+            selectNextTab: "select-next-tab-EVT",
+
             // fired with a selected job on spacebar
             jobPin: "job-pin-EVT",
 

--- a/ui/partials/main/thShortcutTable.html
+++ b/ui/partials/main/thShortcutTable.html
@@ -31,6 +31,8 @@
         <td>Select previous unclassified failure</td></tr>
       <tr><td><span class="kbd">j</span> or <span class="kbd">n</span></td>
         <td>Select next unclassified failure</td></tr>
+      <tr><td class="kbd">t</td>
+        <td>Select next info tab</td></tr>
       <tr><td class="kbd">l</td>
         <td>Open the logviewer for the selected job</td></tr>
       <tr><td><span class="kbd">ctrl</span> or <span class="kbd">cmd</span></td>

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -426,6 +426,27 @@ treeherder.controller('PluginCtrl', [
             }
         });
 
+        $rootScope.$on(thEvents.selectNextTab, function() {
+            // Establish the visible tabs for the job
+            var visibleTabs = [];
+            for (var i in thTabs.tabOrder) {
+                if (thTabs.tabs[thTabs.tabOrder[i]].enabled) {
+                    visibleTabs.push(thTabs.tabOrder[i]);
+                }
+            }
+
+            // Establish where we are and increment one tab
+            var t = visibleTabs.indexOf(thTabs.selectedTab);
+            if (t === visibleTabs.length - 1) {
+                t = 0;
+            } else {
+                t++;
+            }
+
+            // Select that new tab
+            thTabs.showTab(visibleTabs[t], $scope.selectedJob.id);
+        });
+
         $scope.bug_job_map_list = [];
 
         $scope.classificationTypes = thClassificationTypes;


### PR DESCRIPTION
This work fixes Bugzilla bug [1310825](https://bugzilla.mozilla.org/show_bug.cgi?id=1310825).

This adds a keyboard shortcut **_t_** which cycles through the visible tabs for a selected job. I'd like to spend some more time with local integration testing; but everything seems to be working well. Perf jobs which have 5 tabs cycles properly, other jobs with 4 tabs cycle properly, cycling with other UI like the pinboard open seems fine, etc.

I didn't test the Auto Classification tab yet, but I don't think it would have issues. I find it very pleasant to use in conjunction with n,p,j,k during job navigation.

Tested on OSX 10.11.5:
Nightly **52.0a1 (2016-10-09) (64-bit)**
Chrome Latest Release **53.0.2785.143 (64-bit)**

Adding @KWierso and @camd for feedback or review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1930)
<!-- Reviewable:end -->
