### PR TITLE
Bug 1310727 - Switch to new download URLs for libmysqlclient

### DIFF
--- a/bin/vendor-libmysqlclient.sh
+++ b/bin/vendor-libmysqlclient.sh
@@ -33,8 +33,8 @@ VERSION="5.7.14"
 PACKAGE_URLS=(
     # We have to use packages from mysql.com since there is no Ubuntu distro
     # release available for MySQL 5.7 on Ubuntu 14.04.
-    "https://cdn.mysql.com/Downloads/MySQL-5.7/libmysqlclient20_${VERSION}-1ubuntu14.04_amd64.deb"
-    "https://cdn.mysql.com/Downloads/MySQL-5.7/libmysqlclient-dev_${VERSION}-1ubuntu14.04_amd64.deb"
+    "https://cdn.mysql.com/archives/mysql-5.7/libmysqlclient20_${VERSION}-1ubuntu14.04_amd64.deb"
+    "https://cdn.mysql.com/archives/mysql-5.7/libmysqlclient-dev_${VERSION}-1ubuntu14.04_amd64.deb"
 )
 
 # Skip vendoring if libmysqlclient-dev's `mysql_config` exists and reports the correct version.


### PR DESCRIPTION
The packages have been moved under the archives path, since there are newer releases now available. The official download link has remained unchanged, however it's a 302 redirect to a non-HTTPS version of these links, so we intentionally deep-link, even if it means the URLs will occasionally need updating.

Fixes the 404 whilst Vagrant provisioning, and failures that would occur with a clean cache on Heroku/Travis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1931)
<!-- Reviewable:end -->
