### PR TITLE
Bug 1310972 - Use job id as input to log parsing tasks

### DIFF
--- a/tests/autoclassify/test_detect_intermittents.py
+++ b/tests/autoclassify/test_detect_intermittents.py
@@ -26,8 +26,9 @@ def test_detect_intermittents(test_job, failure_lines, classified_failures,
     MatcherManager._detector_funcs = {}
     detector = MatcherManager.register_detector(TestFailureDetector)
 
-    call_command('detect_intermittents', retriggered_job.repository.name,
-                 retriggered_job.guid)
+    # This allows us to test that the command works and avoids the
+    # issue that the task is a no-op for !mozilla-inbound
+    call_command('detect_intermittents', str(test_job.id))
 
     assert ClassifiedFailure.objects.count() == len(old_failure_ids) + 4
 

--- a/tests/log_parser/test_crossreference_error_lines.py
+++ b/tests/log_parser/test_crossreference_error_lines.py
@@ -19,8 +19,7 @@ def test_crossreference_error_lines(test_job):
     create_failure_lines(test_job, lines)
     create_text_log_errors(test_job, lines)
 
-    call_command('crossreference_error_lines', test_job.repository.name,
-                 test_job.guid)
+    call_command('crossreference_error_lines', str(test_job.id))
 
     summary = TextLogSummary.objects.all()
     assert len(summary) == 1
@@ -55,8 +54,7 @@ def test_crossreference_error_lines_truncated(test_job):
                          lines[:-1] + [({"action": "truncated"}, {})])
     create_text_log_errors(test_job, lines)
 
-    call_command('crossreference_error_lines', test_job.repository.name,
-                 test_job.guid)
+    call_command('crossreference_error_lines', str(test_job.id))
 
     summary_lines = TextLogSummaryLine.objects.all()
     assert len(summary_lines) == len(lines)
@@ -64,7 +62,6 @@ def test_crossreference_error_lines_truncated(test_job):
 
 
 def test_crossreference_error_lines_missing(test_job):
-
     lines = [(test_line, {}),
              (test_line, {"subtest": "subtest2"}),
              (test_line, {"status": "TIMEOUT"}),
@@ -75,8 +72,7 @@ def test_crossreference_error_lines_missing(test_job):
     create_failure_lines(test_job, lines[1:])
     create_text_log_errors(test_job, lines)
 
-    call_command('crossreference_error_lines', test_job.repository.name,
-                 test_job.guid)
+    call_command('crossreference_error_lines', str(test_job.id))
 
     failure_lines = FailureLine.objects.all()
     summary_lines = TextLogSummaryLine.objects.all()

--- a/tests/log_parser/test_store_failure_lines.py
+++ b/tests/log_parser/test_store_failure_lines.py
@@ -26,7 +26,7 @@ def test_store_error_summary(activate_responses, test_repository, jm, eleven_job
 
     log_obj = JobLog.objects.create(job=job, name="errorsummary_json", url=log_url)
 
-    store_failure_lines(jm.project, job.guid, log_obj)
+    store_failure_lines(log_obj)
 
     assert FailureLine.objects.count() == 1
 
@@ -52,7 +52,7 @@ def test_store_error_summary_truncated(activate_responses, test_repository, jm,
 
     log_obj = JobLog.objects.create(job=job, name="errorsummary_json", url=log_url)
 
-    store_failure_lines(jm.project, job.guid, log_obj)
+    store_failure_lines(log_obj)
 
     assert FailureLine.objects.count() == 5 + 1
 
@@ -76,7 +76,7 @@ def test_store_error_summary_astral(activate_responses, test_repository, jm,
 
     log_obj = JobLog.objects.create(job=job, name="errorsummary_json", url=log_url)
 
-    store_failure_lines(jm.project, job.guid, log_obj)
+    store_failure_lines(log_obj)
 
     assert FailureLine.objects.count() == 1
 
@@ -106,7 +106,7 @@ def test_store_error_summary_404(activate_responses, test_repository, jm, eleven
 
     log_obj = JobLog.objects.create(job=job, name="errorsummary_json", url=log_url)
 
-    store_failure_lines(jm.project, job.guid, log_obj)
+    store_failure_lines(log_obj)
 
     log_obj.refresh_from_db()
     assert log_obj.status == JobLog.FAILED
@@ -125,7 +125,7 @@ def test_store_error_summary_500(activate_responses, test_repository, jm, eleven
     log_obj = JobLog.objects.create(job=job, name="errorsummary_json", url=log_url)
 
     with pytest.raises(HTTPError):
-        store_failure_lines(jm.project, job.guid, log_obj)
+        store_failure_lines(log_obj)
 
     log_obj.refresh_from_db()
     assert log_obj.status == JobLog.FAILED
@@ -150,18 +150,18 @@ def test_store_error_summary_duplicate(activate_responses, test_repository, jm, 
     job = Job.objects.get(guid=jm.get_job(1)[0]['job_guid'])
     log_obj = JobLog.objects.create(job=job, name="errorsummary_json", url=log_url)
 
-    write_failure_lines(test_repository, job.guid, log_obj, [{"action": "log",
-                                                              "level": "debug",
-                                                              "message": "test",
-                                                              "line": 1}])
-    write_failure_lines(test_repository, job.guid, log_obj, [{"action": "log",
-                                                              "level": "debug",
-                                                              "message": "test",
-                                                              "line": 1},
-                                                             {"action": "log",
-                                                              "level": "debug",
-                                                              "message": "test 1",
-                                                              "line": 2}])
+    write_failure_lines(log_obj, [{"action": "log",
+                                   "level": "debug",
+                                   "message": "test",
+                                   "line": 1}])
+    write_failure_lines(log_obj, [{"action": "log",
+                                   "level": "debug",
+                                   "message": "test",
+                                   "line": 1},
+                                  {"action": "log",
+                                   "level": "debug",
+                                   "message": "test 1",
+                                   "line": 2}])
 
     assert FailureLine.objects.count() == 2
 
@@ -179,7 +179,7 @@ def test_store_error_summary_elastic_search(activate_responses, test_repository,
 
     log_obj = JobLog.objects.create(job=job, name="errorsummary_json", url=log_url)
 
-    store_failure_lines(jm.project, job.guid, log_obj)
+    store_failure_lines(log_obj)
 
     assert FailureLine.objects.count() == 1
 

--- a/treeherder/autoclassify/autoclassify.py
+++ b/treeherder/autoclassify/autoclassify.py
@@ -1,0 +1,84 @@
+import logging
+from collections import defaultdict
+
+from django.db.utils import IntegrityError
+
+from treeherder.model.derived import JobsModel
+from treeherder.model.models import (FailureLine,
+                                     FailureMatch,
+                                     JobNote,
+                                     Matcher)
+
+logger = logging.getLogger(__name__)
+
+# The minimum goodness of match we need to mark a particular match as the best match
+AUTOCLASSIFY_CUTOFF_RATIO = 0.7
+# A goodness of match after which we will not run further detectors
+AUTOCLASSIFY_GOOD_ENOUGH_RATIO = 0.9
+
+
+def match_errors(job):
+    # Only try to autoclassify where we have a failure status; sometimes there can be
+    # error lines even in jobs marked as passing.
+
+    with JobsModel(job.repository.name) as jm:
+        ds_job = jm.get_job(job.project_specific_id)[0]
+        if ds_job["result"] not in ["testfailed", "busted", "exception"]:
+            return
+
+    unmatched_failures = set(FailureLine.objects.unmatched_for_job(job))
+
+    if not unmatched_failures:
+        return
+
+    matches, all_matched = find_matches(unmatched_failures)
+    update_db(job, matches, all_matched)
+
+
+def find_matches(unmatched_failures):
+    all_matches = set()
+
+    for matcher in Matcher.objects.registered_matchers():
+        matches = matcher(unmatched_failures)
+        for match in matches:
+            logger.info("Matched failure %i with intermittent %i" %
+                        (match.failure_line.id, match.classified_failure.id))
+            all_matches.add((matcher.db_object, match))
+            if match.score >= AUTOCLASSIFY_GOOD_ENOUGH_RATIO:
+                unmatched_failures.remove(match.failure_line)
+
+        if not unmatched_failures:
+            break
+
+    return all_matches, len(unmatched_failures) == 0
+
+
+def update_db(job, matches, all_matched):
+    matches_by_failure_line = defaultdict(set)
+    for item in matches:
+        matches_by_failure_line[item[1].failure_line].add(item)
+
+    for failure_line, matches in matches_by_failure_line.iteritems():
+        for matcher, match in matches:
+            try:
+                FailureMatch.objects.create(
+                    score=match.score,
+                    matcher=matcher,
+                    classified_failure=match.classified_failure,
+                    failure_line=failure_line)
+            except IntegrityError:
+                logger.warning(
+                    "Tried to create duplicate match for failure line %i with matcher %i and classified_failure %i" %
+                    (failure_line.id, matcher.id, match.classified_failure.id))
+        best_match = failure_line.best_automatic_match(AUTOCLASSIFY_CUTOFF_RATIO)
+        if best_match:
+            failure_line.best_classification = best_match.classified_failure
+            failure_line.save()
+
+    if all_matched:
+        if job.is_fully_autoclassified():
+            # We don't want to add a job note after an autoclassification if there is already
+            # one and after a verification if there is already one not supplied by the
+            # autoclassifier
+            if not JobNote.objects.filter(job=job).exists():
+                JobNote.objects.create_autoclassify_job_note(job)

--- a/treeherder/autoclassify/detect_intermittents.py
+++ b/treeherder/autoclassify/detect_intermittents.py
@@ -1,0 +1,76 @@
+import logging
+
+from treeherder.model.derived import JobsModel
+from treeherder.model.models import (FailureLine,
+                                     Job,
+                                     Matcher)
+
+from .autoclassify import (AUTOCLASSIFY_CUTOFF_RATIO,
+                           match_errors)
+
+logger = logging.getLogger(__name__)
+
+
+def detect(test_job):
+    with JobsModel(test_job.repository.name) as jm:
+        ds_jobs = jm.get_job_repeats(test_job.guid)
+        jobs_by_guid = {item["job_guid"]: item for item in ds_jobs}
+        jobs = Job.objects.filter(repository=test_job.repository,
+                                  guid__in=jobs_by_guid.keys())
+        assert len(jobs) == len(ds_jobs)
+        for item in jobs:
+            guid = item.guid
+            jobs_by_guid[guid] = (item, jobs_by_guid[guid])
+        jobs = jobs_by_guid.values()
+
+    # The approach here is currently to look for new intermittents to add, one at a time
+    # and then rerun the matching on other jobs
+    # TODO: limit the possible matches to those that have just been added
+    if len(jobs) <= 1:
+        logger.debug("Too few jobs in the current set")
+        return
+
+    # For now conservatively assume that we can only mark new intermittents if
+    # one run in the current set fully passes
+    if not any(ds_job["result"] == "success" for _, ds_job in jobs):
+        logger.debug("No successful jobs to compare against")
+        return
+
+    failures_by_job = FailureLine.objects.for_jobs(*(job for job, _ in jobs))
+
+    for job, ds_job in jobs:
+        logger.info("Looking for new intermittents from job %s" % (job.guid,))
+        job_failures = failures_by_job.get(job.guid)
+        if job_failures is None:
+            logger.debug("Job has no failures")
+            continue
+
+        new_matches = {}
+
+        unmatched_lines = [item for item in job_failures if
+                           not item.classified_failures.count()]
+
+        for detector in Matcher.objects.registered_detectors():
+            unmatched_lines = [item for item in unmatched_lines if item.id not in new_matches]
+
+            if unmatched_lines:
+                logger.debug("Found %i unmatched lines" % len(unmatched_lines))
+            detected_indicies = detector(unmatched_lines)
+
+            for index in detected_indicies:
+                failure = unmatched_lines[index]
+                classification, failure_match = failure.set_classification(detector.db_object)
+                new_matches[failure.id] = (classification, failure_match)
+
+        if new_matches:
+            failure_lines = [item for item in job_failures if item.id in new_matches]
+            for failure_line in failure_lines:
+                classification, failure_match = new_matches[failure_line.id]
+                if failure_match.score > AUTOCLASSIFY_CUTOFF_RATIO:
+                    failure_line.best_classification = classification
+                    failure_line.save()
+            for job, ds_job in jobs:
+                if job == test_job:
+                    continue
+                logger.debug("Trying rematch on job %s" % (job.guid))
+                match_errors(job)

--- a/treeherder/autoclassify/management/commands/autoclassify.py
+++ b/treeherder/autoclassify/management/commands/autoclassify.py
@@ -1,106 +1,20 @@
-import logging
-from collections import defaultdict
-
 from django.core.management.base import (BaseCommand,
                                          CommandError)
-from django.db.utils import IntegrityError
 
-from treeherder.model.derived import JobsModel
-from treeherder.model.models import (FailureLine,
-                                     FailureMatch,
-                                     Job,
-                                     JobNote,
-                                     Matcher)
-
-logger = logging.getLogger(__name__)
-
-# The minimum goodness of match we need to mark a particular match as the best match
-AUTOCLASSIFY_CUTOFF_RATIO = 0.7
-# A goodness of match after which we will not run further detectors
-AUTOCLASSIFY_GOOD_ENOUGH_RATIO = 0.9
+from treeherder.autoclassify.autoclassify import match_errors
+from treeherder.model.models import Job
 
 
 class Command(BaseCommand):
-    args = '<job_guid>, <repository>'
+    args = '<id>'
     help = 'Mark failures on a job.'
 
     def handle(self, *args, **options):
 
-        if not len(args) == 2:
-            raise CommandError('2 arguments required, %s given' % len(args))
-        repository, job_guid = args
+        if len(args) != 1:
+            raise CommandError('1 argument required, %s given' % len(args))
 
-        with JobsModel(repository) as jm:
-            match_errors(repository, jm, job_guid)
+        job_id, = args
 
-
-def match_errors(repository, jm, job_guid):
-    job = jm.get_job_ids_by_guid([job_guid]).get(job_guid)
-
-    if not job:
-        logger.error('autoclassify: No job for '
-                     '{0} job_guid {1}'.format(repository, job_guid))
-        return
-
-    # Only try to autoclassify where we have a failure status; sometimes there can be
-    # error lines even in jobs marked as passing.
-    if job["result"] not in ["testfailed", "busted", "exception"]:
-        return
-
-    unmatched_failures = set(FailureLine.objects.unmatched_for_job(repository, job_guid))
-
-    if not unmatched_failures:
-        return
-
-    matches, all_matched = find_matches(unmatched_failures)
-    update_db(job_guid, matches, all_matched)
-
-
-def find_matches(unmatched_failures):
-    all_matches = set()
-
-    for matcher in Matcher.objects.registered_matchers():
-        matches = matcher(unmatched_failures)
-        for match in matches:
-            logger.info("Matched failure %i with intermittent %i" %
-                        (match.failure_line.id, match.classified_failure.id))
-            all_matches.add((matcher.db_object, match))
-            if match.score >= AUTOCLASSIFY_GOOD_ENOUGH_RATIO:
-                unmatched_failures.remove(match.failure_line)
-
-        if not unmatched_failures:
-            break
-
-    return all_matches, len(unmatched_failures) == 0
-
-
-def update_db(job_guid, matches, all_matched):
-    matches_by_failure_line = defaultdict(set)
-    for item in matches:
-        matches_by_failure_line[item[1].failure_line].add(item)
-
-    for failure_line, matches in matches_by_failure_line.iteritems():
-        for matcher, match in matches:
-            try:
-                FailureMatch.objects.create(
-                    score=match.score,
-                    matcher=matcher,
-                    classified_failure=match.classified_failure,
-                    failure_line=failure_line)
-            except IntegrityError:
-                logger.warning(
-                    "Tried to create duplicate match for failure line %i with matcher %i and classified_failure %i" %
-                    (failure_line.id, matcher.id, match.classified_failure.id))
-        best_match = failure_line.best_automatic_match(AUTOCLASSIFY_CUTOFF_RATIO)
-        if best_match:
-            failure_line.best_classification = best_match.classified_failure
-            failure_line.save()
-
-    if all_matched:
-        job = Job.objects.get(guid=job_guid)
-        if job.is_fully_autoclassified():
-            # We don't want to add a job note after an autoclassification if there is already
-            # one and after a verification if there is already one not supplied by the
-            # autoclassifier
-            if not JobNote.objects.filter(job=job).exists():
-                JobNote.objects.create_autoclassify_job_note(job)
+        job = Job.objects.select_related("repository").get(id=job_id)
+        match_errors(job)

--- a/treeherder/autoclassify/management/commands/detect_intermittents.py
+++ b/treeherder/autoclassify/management/commands/detect_intermittents.py
@@ -1,83 +1,17 @@
-import logging
-
 from django.core.management.base import (BaseCommand,
                                          CommandError)
 
-from treeherder.model.derived import JobsModel
-from treeherder.model.models import (FailureLine,
-                                     Matcher)
-
-from .autoclassify import (AUTOCLASSIFY_CUTOFF_RATIO,
-                           match_errors)
-
-logger = logging.getLogger(__name__)
+from treeherder.autoclassify.detect_intermittents import detect
+from treeherder.model.models import Job
 
 
 class Command(BaseCommand):
-    args = '<repository>, <job_guid>'
+    args = '<job_id>'
     help = 'Look for new intermittents in a job'
 
     def handle(self, *args, **options):
-        if not len(args) == 2:
-            raise CommandError('2 arguments required, %s given' % len(args))
-        repository, job_guid = args
-
-        with JobsModel(repository) as jm:
-            jobs = jm.get_job_repeats(job_guid)
-            add_new_intermittents(repository, jm, jobs)
-
-
-def add_new_intermittents(repository, jm, jobs):
-    # The approach here is currently to look for new intermittents to add, one at a time
-    # and then rerun the matching on other jobs
-    # TODO: limit the possible matches to those that have just been added
-    if len(jobs) <= 1:
-        logger.debug("Too few jobs in the current set")
-        return
-
-    # For now conservatively assume that we can only mark new intermittents if
-    # one run in the current set fully passes
-    if not any(job["result"] == "success" for job in jobs):
-        logger.debug("No successful jobs to compare against")
-        return
-
-    failures_by_job = FailureLine.objects.for_jobs(*jobs)
-
-    for job in jobs:
-        logger.info("Looking for new intermittents from job %s" % (job["job_guid"]))
-        if not job["job_guid"] in failures_by_job:
-            logger.debug("Job has no failures")
-            continue
-
-        new_matches = {}
-
-        job_failures = failures_by_job[job["job_guid"]]
-
-        unmatched_lines = [item for item in job_failures if
-                           not item.classified_failures.count()]
-
-        for detector in Matcher.objects.registered_detectors():
-
-            unmatched_lines = [item for item in unmatched_lines if item.id not in new_matches]
-
-            if unmatched_lines:
-                logger.debug("Found %i unmatched lines" % len(unmatched_lines))
-            detected_indicies = detector(unmatched_lines)
-
-            for index in detected_indicies:
-                failure = unmatched_lines[index]
-                classification, failure_match = failure.set_classification(detector.db_object)
-                new_matches[failure.id] = (classification, failure_match)
-
-        if new_matches:
-            failure_lines = [item for item in job_failures if item.id in new_matches]
-            for failure_line in failure_lines:
-                classification, failure_match = new_matches[failure_line.id]
-                if failure_match.score > AUTOCLASSIFY_CUTOFF_RATIO:
-                    failure_line.best_classification = classification
-                    failure_line.save()
-            for rematch_job in jobs:
-                if rematch_job == job:
-                    continue
-                logger.debug("Trying rematch on job %s" % (rematch_job["job_guid"]))
-                match_errors(repository, jm, rematch_job["job_guid"])
+        if not len(args) == 1:
+            raise CommandError('1 argument required, %s given' % len(args))
+        job_id, = args
+        job = Job.objects.select_related('repository').get(id=job_id)
+        detect(job)

--- a/treeherder/autoclassify/matchers.py
+++ b/treeherder/autoclassify/matchers.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.db.models import Q
 from elasticsearch_dsl.query import Match as ESMatch
 
-from treeherder.autoclassify.management.commands.autoclassify import AUTOCLASSIFY_GOOD_ENOUGH_RATIO
+from treeherder.autoclassify.autoclassify import AUTOCLASSIFY_GOOD_ENOUGH_RATIO
 from treeherder.model.models import (ClassifiedFailure,
                                      FailureLine,
                                      FailureMatch,

--- a/treeherder/autoclassify/tasks.py
+++ b/treeherder/autoclassify/tasks.py
@@ -2,31 +2,33 @@ import logging
 
 import newrelic.agent
 from django.conf import settings
-from django.core.management import call_command
 
 from treeherder import celery_app
+from treeherder.autoclassify.autoclassify import match_errors
+from treeherder.autoclassify.detect_intermittents import detect
+from treeherder.model.models import Job
 from treeherder.workers.task import retryable_task
 
 logger = logging.getLogger(__name__)
 
 
 @retryable_task(name='autoclassify', max_retries=10)
-def autoclassify(project, job_guid):
-    newrelic.agent.add_custom_parameter("project", project)
-    newrelic.agent.add_custom_parameter("job_guid", job_guid)
+def autoclassify(job_id):
+    newrelic.agent.add_custom_parameter("job_id", job_id)
     logger.info('Running autoclassify')
-    call_command('autoclassify', project, job_guid)
+    job = Job.objects.select_related("repository").get(id=job_id)
+    match_errors(job)
     if settings.DETECT_INTERMITTENTS:
         celery_app.send_task('detect-intermittents',
-                             [project, job_guid],
+                             [job_id],
                              routing_key='detect_intermittents')
 
 
 @retryable_task(name='detect-intermittents', max_retries=10)
-def detect_intermittents(project, job_guid):
-    newrelic.agent.add_custom_parameter("project", project)
-    newrelic.agent.add_custom_parameter("job_guid", job_guid)
+def detect_intermittents(job_id):
+    newrelic.agent.add_custom_parameter("job_id", job_id)
     logger.info('Running detect intermittents')
     # TODO: Make this list configurable
-    if project == "mozilla-inbound":
-        call_command('detect_intermittents', project, job_guid)
+    job = Job.objects.select_related('repository').get(id=job_id)
+    if job.repository.name == "mozilla-inbound":
+        detect(job)

--- a/treeherder/log_parser/crossreference.py
+++ b/treeherder/log_parser/crossreference.py
@@ -1,0 +1,114 @@
+import logging
+import re
+
+from mozlog.formatters.tbplformatter import TbplFormatter
+
+from treeherder.model.models import (FailureLine,
+                                     TextLogError,
+                                     TextLogSummary,
+                                     TextLogSummaryLine)
+
+logger = logging.getLogger(__name__)
+
+
+def crossreference_job(job):
+    """Populate the TextLogSummary and TextLogSummaryLine tables for a
+    job. Specifically this function tries to match the
+    unstructured error lines with the corresponding structured error lines, relying on
+    the fact that serialization of mozlog (and hence errorsummary files) is determinisic
+    so we can reserialize each structured error line and perform an in-order textual
+    match.
+
+    :job: - Job for which to perform the crossreferencing
+    """
+    failure_lines = FailureLine.objects.filter(job_guid=job.guid)
+
+    text_log_errors = TextLogError.objects.filter(
+        step__job=job).order_by('line_number')
+
+    # If we don't have failure lines and text log errors nothing will happen
+    # so return early
+    if not (failure_lines.exists() and text_log_errors.exists()):
+        return []
+
+    summary, _ = TextLogSummary.objects.get_or_create(job_guid=job.guid,
+                                                      repository=job.repository)
+
+    match_iter = structured_iterator(failure_lines)
+    failure_line, regexp = match_iter.next()
+
+    summary_lines = []
+
+    # For each error in the text log, try to match the next unmatched
+    # structured log line
+    for error in text_log_errors:
+        if regexp and regexp.match(error.line.strip()):
+            logger.debug("Matched '%s'" % (error.line,))
+            summary_lines.append(TextLogSummaryLine(
+                summary=summary,
+                line_number=error.line_number,
+                failure_line=failure_line))
+            failure_line, regexp = match_iter.next()
+        else:
+            logger.debug("Failed to match '%s'" % (error.line,))
+            summary_lines.append(TextLogSummaryLine(
+                summary=summary,
+                line_number=error.line_number,
+                failure_line=None))
+
+    TextLogSummaryLine.objects.bulk_create(summary_lines)
+    # We should have exhausted all structured lines
+    for leftover in match_iter:
+        # We can have a line without a pattern at the end if the log is truncated
+        if leftover[1] is None:
+            break
+        logger.error("Failed to match structured line '%s' to an unstructured line" %
+                     (leftover[1].pattern,))
+
+
+def structured_iterator(failure_lines):
+    """Map failure_lines to a (failure_line, regexp) iterator where the
+    regexp will match an unstructured line corresponding to that structured line.
+
+    :param failure_lines: Iterator of FailureLine objects
+    """
+    to_regexp = ErrorSummaryReConvertor()
+    for failure_line in failure_lines:
+        yield failure_line, to_regexp(failure_line)
+    while True:
+        yield None, None
+
+
+class ErrorSummaryReConvertor(object):
+    def __init__(self):
+        """Stateful function for generating a regexp that matches TBPL formatted output
+        corresponding to a specific FailureLine"""
+        self._formatter = TbplFormatter()
+
+    def __call__(self, failure_line):
+        if failure_line.action == "test_result":
+            action = "test_status" if failure_line.subtest is not None else "test_end"
+        elif failure_line.action == "truncated":
+            return None
+        else:
+            action = failure_line.action
+
+        msg = getattr(self._formatter, action)(as_dict(failure_line)).split("\n", 1)[0]
+
+        return re.compile(r".*%s$" % (re.escape(msg.strip())))
+
+
+def as_dict(failure_line):
+    """Convert a FailureLine into a dict in the format expected as input to
+    mozlog formatters.
+
+    :param failure_line: The FailureLine to convert."""
+    rv = {"action": failure_line.action,
+          "line_number": failure_line.line}
+    for key in ["test", "subtest", "status", "expected", "message", "signature", "level",
+                "stack", "stackwalk_stdout", "stackwalk_stderr"]:
+        value = getattr(failure_line, key)
+        if value is not None:
+            rv[key] = value
+
+    return rv

--- a/treeherder/log_parser/management/commands/crossreference_error_lines.py
+++ b/treeherder/log_parser/management/commands/crossreference_error_lines.py
@@ -1,144 +1,27 @@
 import logging
-import re
 
 from django.core.management.base import (BaseCommand,
                                          CommandError)
-from mozlog.formatters.tbplformatter import TbplFormatter
 
-from treeherder.model.derived import JobsModel
-from treeherder.model.models import (FailureLine,
-                                     Repository,
-                                     TextLogError,
-                                     TextLogSummary,
-                                     TextLogSummaryLine)
+from treeherder.log_parser.crossreference import crossreference_job
+from treeherder.model.models import Job
 
 logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    args = '<repository>, <job_guid>'
+    args = '<job_id>'
     help = 'Download, parse and store the given failure summary log.'
 
     def handle(self, *args, **options):
         logger.debug("crossreference_error_lines command")
-        if not len(args) == 2:
-            raise CommandError('2 arguments required, %s given' % len(args))
+        if len(args) != 1:
+            raise CommandError('1 argument required, %s given' % len(args))
 
-        repository_name, job_guid = args
+        job_id, = args
 
         try:
-            repository = Repository.objects.get(name=repository_name, active_status='active')
-        except Repository.DoesNotExist:
-            raise CommandError('Unknown repository %s' % repository_name)
-
-        failure_lines = FailureLine.objects.filter(repository=repository,
-                                                   job_guid=job_guid)
-
-        with JobsModel(repository_name) as jm:
-            job = jm.get_job_ids_by_guid([job_guid]).get(job_guid)
-            if job is None:
-                logger.error('crossreference_error_lines: No job for '
-                             '{0} job_guid {1}'.format(repository, job_guid))
-                return
-
-        text_log_errors = TextLogError.objects.filter(
-            step__job__guid=job_guid).order_by('line_number')
-        self.crossreference_error_lines(repository,
-                                        job_guid,
-                                        failure_lines,
-                                        text_log_errors)
-
-    def crossreference_error_lines(self, repository, job_guid, failure_lines,
-                                   text_log_errors):
-        """Populate the TextLogSummary and TextLogSummaryLine tables for a
-        job. Specifically this function tries to match the
-        unstructured error lines with the corresponding structured error lines, relying on
-        the fact that serialization of mozlog (and hence errorsummary files) is determinisic
-        so we can reserialize each structured error line and perform an in-order textual
-        match.
-
-        :param repository: Repository containing the job
-        :param job_guid: guid for the job being crossreferenced
-        :param failure_lines: List of FailureLine objects for this job
-        :param text_log_errors: text log error lines for this job"""
-
-        summary, _ = TextLogSummary.objects.get_or_create(job_guid=job_guid,
-                                                          repository=repository)
-
-        match_iter = structured_iterator(failure_lines)
-        failure_line, regexp = match_iter.next()
-
-        summary_lines = []
-
-        # For each error in the text log, try to match the next unmatched
-        # structured log line
-        for error in text_log_errors:
-            if regexp and regexp.match(error.line.strip()):
-                logger.debug("Matched '%s'" % (error.line,))
-                summary_lines.append(TextLogSummaryLine(
-                    summary=summary,
-                    line_number=error.line_number,
-                    failure_line=failure_line))
-                failure_line, regexp = match_iter.next()
-            else:
-                logger.debug("Failed to match '%s'" % (error.line,))
-                summary_lines.append(TextLogSummaryLine(
-                    summary=summary,
-                    line_number=error.line_number,
-                    failure_line=None))
-
-        TextLogSummaryLine.objects.bulk_create(summary_lines)
-        # We should have exhausted all structured lines
-        for leftover in match_iter:
-            # We can have a line without a pattern at the end if the log is truncated
-            if leftover[1] is None:
-                break
-            logger.error("Failed to match structured line '%s' to an unstructured line" % (leftover[1].pattern,))
-
-
-def structured_iterator(failure_lines):
-    """Map failure_lines to a (failure_line, regexp) iterator where the
-    regexp will match an unstructured line corresponding to that structured line.
-
-    :param failure_lines: Iterator of FailureLine objects
-    """
-    to_regexp = ErrorSummaryReConvertor()
-    for failure_line in failure_lines:
-        yield failure_line, to_regexp(failure_line)
-    while True:
-        yield None, None
-
-
-class ErrorSummaryReConvertor(object):
-    def __init__(self):
-        """Stateful function for generating a regexp that matches TBPL formatted output
-        corresponding to a specific FailureLine"""
-        self._formatter = TbplFormatter()
-
-    def __call__(self, failure_line):
-        if failure_line.action == "test_result":
-            action = "test_status" if failure_line.subtest is not None else "test_end"
-        elif failure_line.action == "truncated":
-            return None
-        else:
-            action = failure_line.action
-
-        msg = getattr(self._formatter, action)(as_dict(failure_line)).split("\n", 1)[0]
-
-        return re.compile(r".*%s$" % (re.escape(msg.strip())))
-
-
-def as_dict(failure_line):
-    """Convert a FailureLine into a dict in the format expected as input to
-    mozlog formatters.
-
-    :param failure_line: The FailureLine to convert."""
-    rv = {"action": failure_line.action,
-          "line_number": failure_line.line}
-    for key in ["test", "subtest", "status", "expected", "message", "signature", "level",
-                "stack", "stackwalk_stdout", "stackwalk_stderr"]:
-        value = getattr(failure_line, key)
-        if value is not None:
-            rv[key] = value
-
-    return rv
+            job = Job.objects.get(id=job_id)
+        except Job.DoesNotExist:
+            raise CommandError('Unknown job id %s' % job_id)
+        crossreference_job(job)

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -2,11 +2,12 @@ import logging
 
 import newrelic.agent
 from django.conf import settings
-from django.core.management import call_command
 
 from treeherder.autoclassify.tasks import autoclassify
+from treeherder.log_parser.crossreference import crossreference_job
 from treeherder.log_parser.utils import post_log_artifacts
-from treeherder.model.models import JobLog
+from treeherder.model.models import (Job,
+                                     JobLog)
 from treeherder.workers.task import retryable_task
 from treeherder.workers.taskset import (create_taskset,
                                         taskset)
@@ -20,19 +21,18 @@ def parser_task(f):
     """Decorator that ensures that log parsing task has not already run,
     and also adds New Relic annotations.
     """
-    def inner(project, job_guid, job_log_id, priority):
-        newrelic.agent.add_custom_parameter("project", project)
-        newrelic.agent.add_custom_parameter("job_guid", job_guid)
+    def inner(job_log_id, priority):
         newrelic.agent.add_custom_parameter("job_log_id", job_log_id)
-        job_log = JobLog.objects.get(id=job_log_id)
+        job_log = JobLog.objects.select_related("job").get(id=job_log_id)
         newrelic.agent.add_custom_parameter("job_log_name", job_log.name)
         newrelic.agent.add_custom_parameter("job_log_url", job_log.url)
-        newrelic.agent.add_custom_parameter("job_log_status_prior", job_log.get_status_display())
+        newrelic.agent.add_custom_parameter("job_log_status_prior",
+                                            job_log.get_status_display())
         if job_log.status == JobLog.PARSED:
             logger.info("log already parsed")
             return True
 
-        return f(project, job_guid, job_log, priority)
+        return f(job_log, priority)
 
     inner.__name__ = f.__name__
     inner.__doc__ = f.__doc__
@@ -40,7 +40,7 @@ def parser_task(f):
     return inner
 
 
-def parse_job_log(project, func_name, routing_key, job_guid, job_log_id):
+def parse_job_log(func_name, routing_key, job_log):
     """
     Schedule the log-related tasks to parse an individual log
     """
@@ -58,16 +58,13 @@ def parse_job_log(project, func_name, routing_key, job_guid, job_log_id):
 
     callback_group = []
 
-    logger.debug("parse_job_log for job %s (%s, %s)", job_guid, func_name,
-                 routing_key)
+    logger.debug("parse_job_log for job log %s (%s, %s)",
+                 job_log.id, func_name, routing_key)
     priority = routing_key.rsplit(".", 1)[1]
     if task_priorities[priority] > task_priorities[callback_priority]:
         callback_priority = priority
 
-    signature = task_funcs[func_name].si(project,
-                                         job_guid,
-                                         job_log_id,
-                                         priority)
+    signature = task_funcs[func_name].si(job_log.id, priority)
     signature.set(routing_key=routing_key)
 
     if func_name in ["parse_log", "store_failure_lines"]:
@@ -76,7 +73,7 @@ def parse_job_log(project, func_name, routing_key, job_guid, job_log_id):
         signature.apply_async()
 
     if callback_group:
-        callback = crossreference_error_lines.si(project, job_guid)
+        callback = crossreference_error_lines.si(job_log.job.id)
         callback.set(routing_key="crossreference_error_lines.%s" %
                      callback_priority)
         create_taskset(callback_group, callback)
@@ -85,29 +82,31 @@ def parse_job_log(project, func_name, routing_key, job_guid, job_log_id):
 @retryable_task(name='log-parser', max_retries=10)
 @taskset
 @parser_task
-def parse_log(project, job_guid, job_log, _priority):
+def parse_log(job_log, _priority):
     """
     Call ArtifactBuilderCollection on the given job.
     """
-    post_log_artifacts(project, job_guid, job_log)
+    post_log_artifacts(job_log)
 
 
 @retryable_task(name='store-failure-lines', max_retries=10)
 @taskset
 @parser_task
-def store_failure_lines(project, job_guid, job_log, priority):
-    """This task is a wrapper for the store_failure_lines command."""
-    logger.debug('Running store_failure_lines for job %s' % job_guid)
-    failureline.store_failure_lines(project, job_guid, job_log)
+def store_failure_lines(job_log, priority):
+    """Store the failure lines from a log corresponding to the structured
+    errorsummary file."""
+    logger.debug('Running store_failure_lines for job %s' % job_log.job.id)
+    failureline.store_failure_lines(job_log)
     if settings.AUTOCLASSIFY_JOBS:
-        autoclassify.apply_async(args=[project, job_guid],
+        autoclassify.apply_async(args=[job_log.job.id],
                                  routing_key="autoclassify.%s" % priority)
 
 
 @retryable_task(name='crossreference-error-lines', max_retries=10)
-def crossreference_error_lines(project, job_guid):
-    """This task is a wrapper for the crossreference error lines command."""
-    newrelic.agent.add_custom_parameter("project", project)
-    newrelic.agent.add_custom_parameter("job_guid", job_guid)
-    logger.debug("Running crossreference-error-lines for %s" % job_guid)
-    call_command('crossreference_error_lines', project, job_guid)
+def crossreference_error_lines(job_id):
+    """Match structured (FailureLine) and unstructured (TextLogError) lines
+    for a job."""
+    newrelic.agent.add_custom_parameter("job_id", job_id)
+    logger.debug("Running crossreference-error-lines for job %s" % job_id)
+    job = Job.objects.get(id=job_id)
+    crossreference_job(job)

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -10,17 +10,17 @@ from treeherder.model.models import JobLog
 logger = logging.getLogger(__name__)
 
 
-def extract_text_log_artifacts(project, log_url, job_guid):
+def extract_text_log_artifacts(job_log):
     """Generate a set of artifacts by parsing from the raw text log."""
 
     # parse a log given its url
-    artifact_bc = ArtifactBuilderCollection(log_url)
+    artifact_bc = ArtifactBuilderCollection(job_log.url)
     artifact_bc.parse()
 
     artifact_list = []
     for name, artifact in artifact_bc.artifacts.items():
         artifact_list.append({
-            "job_guid": job_guid,
+            "job_guid": job_log.job.guid,
             "name": name,
             "type": 'json',
             "blob": json.dumps(artifact)
@@ -29,14 +29,12 @@ def extract_text_log_artifacts(project, log_url, job_guid):
     return artifact_list
 
 
-def post_log_artifacts(project, job_guid, job_log):
+def post_log_artifacts(job_log):
     """Post a list of artifacts to a job."""
-    log_url = job_log.url
-    log_description = "%s %s (%s)" % (project, job_guid, log_url)
-    logger.debug("Downloading/parsing log for %s", log_description)
+    logger.debug("Downloading/parsing log for log %s", job_log.id)
 
     try:
-        artifact_list = extract_text_log_artifacts(project, log_url, job_guid)
+        artifact_list = extract_text_log_artifacts(job_log)
     except Exception as e:
         job_log.update_status(JobLog.FAILED)
 
@@ -45,24 +43,25 @@ def post_log_artifacts(project, job_guid, job_log):
         # the job fails, so just warn about it -- see
         # https://bugzilla.mozilla.org/show_bug.cgi?id=1154248)
         if isinstance(e, urllib2.HTTPError) and e.code in (403, 404):
-            logger.warning("Unable to retrieve log for %s: %s", log_description, e)
+            logger.warning("Unable to retrieve log for %s: %s", job_log.id, e)
             return
 
         if isinstance(e, urllib2.URLError):
             # possibly recoverable http error (e.g. problems on our end)
-            logger.error("Failed to download log for %s: %s", log_description, e)
+            logger.error("Failed to download log for %s: %s", job_log.id, e)
         else:
             # parse error or other unrecoverable error
-            logger.error("Failed to download/parse log for %s: %s", log_description, e)
+            logger.error("Failed to download/parse log for %s: %s", job_log.id, e)
         raise
 
     try:
         serialized_artifacts = ArtifactsModel.serialize_artifact_json_blobs(
             artifact_list)
+        project = job_log.job.repository.name
         with ArtifactsModel(project) as artifacts_model:
             artifacts_model.load_job_artifacts(serialized_artifacts)
         job_log.update_status(JobLog.PARSED)
-        logger.debug("Stored artifact for %s %s", project, job_guid)
+        logger.debug("Stored artifact for %s %s", project, job_log.job.id)
     except Exception as e:
-        logger.error("Failed to store parsed artifact for %s: %s", log_description, e)
+        logger.error("Failed to store parsed artifact for %s: %s", job_log.id, e)
         raise

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -1250,7 +1250,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
                         'status': parse_status
                     })
 
-                self._schedule_log_parsing(job_guid, jl, result)
+                self._schedule_log_parsing(jl, result)
 
         return (job_guid, signature_hash)
 
@@ -1274,7 +1274,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
 
         return job_id_lookup
 
-    def _schedule_log_parsing(self, job_guid, job_log, result):
+    def _schedule_log_parsing(self, job_log, result):
         """Kick off the initial task that parses the log data.
 
         log_data is a list of job log objects and the result for that job
@@ -1307,8 +1307,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
         else:
             routing_key += ".normal"
 
-        parse_job_log(self.project, func_name, routing_key, job_guid,
-                      job_log.id)
+        parse_job_log(func_name, routing_key, job_log)
 
     def _get_last_insert_id(self):
         """Return last-inserted ID."""

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -957,16 +957,17 @@ class JobNote(models.Model):
 
 
 class FailureLineManager(models.Manager):
-    def unmatched_for_job(self, repository, job_guid):
+    def unmatched_for_job(self, job):
         return FailureLine.objects.filter(
-            job_guid=job_guid,
-            repository__name=repository,
+            job_guid=job.guid,
+            repository=job.repository,
             classified_failures=None,
         )
 
     def for_jobs(self, *jobs, **filters):
-        failures = FailureLine.objects.filter(job_guid__in=[item["job_guid"] for item in jobs],
-                                              **filters)
+        failures = FailureLine.objects.filter(
+            job_guid__in=[item.guid for item in jobs],
+            **filters)
         failures_by_job = defaultdict(list)
         for item in failures:
             failures_by_job[item.job_guid].append(item)


### PR DESCRIPTION
Now that log information is in the main treeherder database use the id
information there as the input to the log parsing and autoclassification
tasks.

As part of the same change there is a mild refactor of the
autoclassification related tasks to not go through the call_command
infrastructure as this is just unnecessary overhead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1932)
<!-- Reviewable:end -->
