### PR TITLE
Bug 1312459 - Disable autoclassify panel by default

### DIFF
--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -56,7 +56,6 @@ treeherder.controller('PluginCtrl', [
         // phase of this feature.
         var showAutoClassifyTab = function() {
             thTabs.tabs.autoClassification.enabled = ($location.search().autoclassify === true ||
-                                                      ($rootScope.user && $rootScope.user.is_staff) ||
                                                       $location.host().indexOf('herokuapp.com') !== -1) &&
                                                       $location.search().noautoclassify !== true;
         };


### PR DESCRIPTION
Adding &autoclassify to the url still allows it to be enabled.
This will allow the feature to be refactored rather than spending
lots of time investigating sub-issues in the current implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1948)
<!-- Reviewable:end -->
