### PR TITLE
Bug 1312544 - Support for Hyper-V

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,19 +4,7 @@
 # We require 1.5+ due to specifying only the box name and not config.vm.box_url.
 Vagrant.require_version ">= 1.5.0"
 
-Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
-
-  config.vm.hostname = "local.treeherder.mozilla.org"
-  config.vm.network "private_network", ip: "192.168.33.10"
-
-  config.vm.synced_folder ".", "/home/vagrant/treeherder", type: "nfs"
-
-  config.vm.provider "virtualbox" do |vb|
-    vb.name = "treeherder"
-    vb.memory = "2048"
-  end
-
+def puppet_provisioner(config)
   config.vm.provision "puppet" do |puppet|
     puppet.manifests_path = "puppet/manifests"
     puppet.manifest_file = "vagrant.pp"
@@ -24,5 +12,32 @@ Vagrant.configure("2") do |config|
     # enable this to see verbose and debug puppet output
     #puppet.options = "--verbose --debug"
   end
+end
 
+Vagrant.configure("2") do |config|
+  config.vm.hostname = "local.treeherder.mozilla.org"
+  config.vm.network "private_network", ip: "192.168.33.10"
+
+  config.vm.synced_folder ".", "/home/vagrant/treeherder", type: "nfs"
+
+  config.vm.provider "virtualbox" do |vb, override|
+    override.vm.box = "ubuntu/trusty64"
+    vb.name = "treeherder"
+    vb.memory = "2048"
+
+    puppet_provisioner(override)
+  end
+
+  config.vm.provider "hyperv" do |hv, override|
+    override.vm.box = "ericmann/trusty64"
+    hv.vmname = "treeherder"
+    hv.memory = "2048"
+
+    # Hyper-V box doesn't have Puppet installed. So install it manually.
+    override.vm.provision "install-puppet", type: "shell" do |s|
+      s.inline = "apt-get update && apt-get -y install puppet"
+    end
+
+    puppet_provisioner(override)
+  end
 end


### PR DESCRIPTION
Vagrant wants to use Virtualbox by default on Windows. Unfortunately, Virtualbox doesn't work when Hyper-V - the VM provider built into Windows itself - is running.

This commit modifies the Vagrantfile to support Hyper-V.

The obvious change is the addition of a new provider block for Hyper-V. It overrides the default box to use one that is compatible with Hyper-V.

The non-obvious change is the refactor of the provisioner logic.

The Hyper-V box doesn't have Puppet installed. So we need to install Puppet in a provisioner before the Puppet provisioner runs. But due to the way Vagrantfiles are evaluated, we can't just insert the provisioner in the hyperv provider block. So, this commit relies on the fact that Vagrantfiles are really Ruby scripts that return a data structure. The code for configuring the Puppet provisioner is factored into a function. The provisioners are then moved to a provider override block so we can guarantee the order they are registered in. It is a bit ugly, but it gets the job done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1949)
<!-- Reviewable:end -->
