### PR TITLE
Bug 1310974 - Perform autoclassification after crossreferencing error lines

### DIFF
--- a/treeherder/log_parser/crossreference.py
+++ b/treeherder/log_parser/crossreference.py
@@ -44,7 +44,7 @@ def _crossreference(job):
     # If we don't have failure lines and text log errors nothing will happen
     # so return early
     if not (failure_lines.exists() and text_log_errors.exists()):
-        return []
+        return False
 
     summary = TextLogSummary.objects.create(job_guid=job.guid,
                                             repository=job.repository)
@@ -79,6 +79,8 @@ def _crossreference(job):
             break
         logger.error("Failed to match structured line '%s' to an unstructured line" %
                      (leftover[1].pattern,))
+
+    return bool(summary_lines)
 
 
 def structured_iterator(failure_lines):


### PR DESCRIPTION
In the short term this change is a small negative as it will slow down
autoclassification tasks. However it's a necessary step to future
changes that will put the autoclassification results on the text log
error table and allow autoclassification of non-structured lines.

As part of this, we remove the use of callback tasks and just schedule
the crossreference task to run after the parser tasks. This is simpler
and reflects the fact that we only schedule one parser task at a time
now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1955)
<!-- Reviewable:end -->
