### PR TITLE
Bug 1313074 - Remove unused class from autoclassification panel

### DIFF
--- a/ui/plugins/auto_classification/main.html
+++ b/ui/plugins/auto_classification/main.html
@@ -87,7 +87,7 @@
           {{ ::line.data.search }}
         </div>
         <div ng-if="line.status === 'verified'">
-          <span class="glyphicon glyphicon-star best-classification-star"></span>
+          <span class="glyphicon glyphicon-star"></span>
           <span class="line-option-text" ng-if="line.verifiedBugNumber">
             <a href="{{::getBugUrl(line.verifiedBugNumber) }}"
                target="_blank">Bug {{ ::line.verifiedBugNumber }} -


### PR DESCRIPTION
This fixes Bugzilla bug [1313074](https://bugzilla.mozilla.org/show_bug.cgi?id=1313074).

This removes what appears to be an unused class `best-classification-star` from the auto classification panel markup. As far as I can tell, it isn't referenced in the repo.

I had removed it as part of bug [1305565](https://bugzilla.mozilla.org/show_bug.cgi?id=1305565) but that won't likely land with the component based panel work under way. So removing it here in case it's forgotten about.

Adding @jgraham for review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1956)
<!-- Reviewable:end -->
