### PR TITLE
Bug 1313236 - Sync Vagrant/Travis MySQL config with that on production

### DIFF
--- a/puppet/files/mysql/my.cnf
+++ b/puppet/files/mysql/my.cnf
@@ -1,12 +1,22 @@
 # Overrides the mysql defaults in /etc/mysql/my.cnf
 # Any changes here will require a Vagrant re-provision to take effect.
+# NB: This file is only used by Vagrant/Travis, and must be kept in sync with
+# the RDS parameter group used by stage/prod:
+# https://github.com/mozilla-platform-ops/devservices-aws/blob/master/treeherder/rds.tf
 
 [mysqld]
-# Allow connections from the VM host and not just the loopback interface.
-bind-address        = 0.0.0.0
+# Allow connections from the Vagrant host and not just the loopback interface.
+bind-address="0.0.0.0"
+
+character_set_server="utf8"
+collation_server="utf8_bin"
+
+log_output="FILE"
+long_query_time="2"
+slow_query_log="1"
 
 # Ensure operations involving astral characters fail loudly,
 # rather than mysql silently replacing each each byte of the
 # original character with a U+FFFD replacement character.
 # See bug 1275425.
-sql_mode="STRICT_ALL_TABLES"
+sql_mode="NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES"


### PR DESCRIPTION
Stage/prod use the RDS parameter group defined here:
https://github.com/mozilla-platform-ops/devservices-aws/blob/master/treeherder/rds.tf

The slow query log changes aren't really useful for Vagrant/Travis, but it seemed less confusing than saying the files should be kept in sync minus a bunch of exceptions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1958)
<!-- Reviewable:end -->
