### PR TITLE
Bug 1207460 - Split retrigger menu into separate btns

### DIFF
--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -81,7 +81,7 @@ input:focus::-moz-placeholder {
 .logviewer-icon {
   width: 14px;
   height: 16px;
-  vertical-align: text-bottom;
+  vertical-align: text-top;
   opacity: 0.7;
 }
 
@@ -105,6 +105,12 @@ input:focus::-moz-placeholder {
 .icon-green:focus,
 .icon-green:active {
   color: #0de00d !important;
+}
+
+.icon-cyan:hover,
+.icon-cyan:focus,
+.icon-cyan:active {
+  color: #00ffff !important;
 }
 
 .icon-superscript {

--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -161,8 +161,8 @@ div#info-panel .info-panel-navbar .navbar-nav > li.active a:focus {
  * Job details action bar
  */
 
-.actionbar-nav > li:not(:first-child) {
-  /* Preserve left side padding on our first icon but keep others compact */
+.actionbar-nav > li {
+  /* Override padding on all icons to keep compact */
   padding: 0 !important;
 }
 
@@ -182,8 +182,8 @@ div#info-panel .info-panel-navbar .navbar-nav > li.active a:focus {
  */
 
 #job-details-panel {
-  width: 250px;
-  min-width: 250px;
+  width: 252px;
+  min-width: 252px;
 }
 
 #job-details-panel .content-spacer {

--- a/ui/partials/main/thJobDetailsRetriggerMenu.html
+++ b/ui/partials/main/thJobDetailsRetriggerMenu.html
@@ -1,7 +1,0 @@
-<li>
-  <a ng-click="retriggerJob([selectedJob])" title="Repeat the selected job">Retrigger job</a>
-</li>
-<li ng-class="canBackfill() ? '' : 'disabled'"
-    ng-attr-title="{{canBackfill() ? backfillEnabledString : backfillDisabledString}}">
-  <a ng-disabled="!canBackfill()" ng-click="backfillJob()">Backfill job</a>
-</li>

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -68,33 +68,31 @@
             </a>
           </li>
           <li>
-            <!--the first 3 items are in the same box-->
-            <ul class="nav navbar-nav">
-              <li>
-                <a id="pin-job-btn" href=""
-                   title="Add this job to the pinboard"
-                   ng-click="pinboard_service.pinJob(selectedJob)">
-                  <span class="glyphicon glyphicon-pushpin"
-                        ng-class="{'icon-blue': (pinboard_service.count.numPinnedJobs > 0)}">
-                  </span>
-                  <span ng-show="pinboard_service.count.numPinnedJobs"
-                        class="pinned-job-count">{{getCountPinnedJobs()}}</span>
-                </a>
-              </li>
-
-            </ul>
-          </li>
-          <li class="dropdown">
-            <a id="retriggerLabel"
-               ng-attr-title="{{user.loggedin ? 'Retrigger or backfill this job' :
-                              'Must be logged in to retrigger a job'}}"
-               ng-class="user.loggedin ? 'icon-green' : 'disabled'" href="" data-toggle="dropdown">
-              <span class="fa fa-repeat"></span>&nbsp
-              <span class="fa fa-angle-down lightgray"></span>
+            <a id="pin-job-btn" href=""
+               title="Add this job to the pinboard"
+               ng-click="pinboard_service.pinJob(selectedJob)">
+              <span class="glyphicon glyphicon-pushpin"
+                    ng-class="{'icon-blue': (pinboard_service.count.numPinnedJobs > 0)}">
+              </span>
+              <span ng-show="pinboard_service.count.numPinnedJobs"
+                    class="pinned-job-count">{{getCountPinnedJobs()}}</span>
             </a>
-            <ul class="dropdown-menu actionbar-menu" role="menu" aria-labelledby="retriggerLabel"
-                ng-include src="'partials/main/thJobDetailsRetriggerMenu.html'">
-            </ul>
+          </li>
+          <li>
+            <a id="retrigger-btn" href=""
+               ng-attr-title="{{user.loggedin ? 'Retrigger this job' :
+                              'Must be logged in to retrigger a job'}}"
+               ng-class="user.loggedin ? 'icon-green' : 'disabled'">
+              <span class="fa fa-repeat"></span>
+            </a>
+          </li>
+          <li>
+            <a id="backfill-btn" href=""
+               ng-attr-title="{{user.loggedin ? 'Backfill this job' :
+                              'Must be logged in to backfill a job'}}"
+               ng-class="user.loggedin ? 'icon-cyan' : 'disabled'">
+              <span class="fa fa-arrow-down"></span>
+            </a>
           </li>
           <li ng-if="isReftest()" ng-repeat="job_log_url in job_log_urls">
             <a title="Launch the Reftest Analyser in a new window"


### PR DESCRIPTION
This work fixes Bugzilla bug [1207460](https://bugzilla.mozilla.org/show_bug.cgi?id=1207460).

This splits the retrigger/backfill menu back out into separate buttons. I managed to consume only 2px more in width for the job-details-panel than what we had before, since it appears the reftest and cancel icon never coexist - we achieved 1 icon of economy, while adding the backfill icon.

Current:

![backfillcurrent](https://cloud.githubusercontent.com/assets/3660661/19775702/43010f66-9c3f-11e6-87fc-f08673622bdb.jpg)

Proposed:

![backfillproposed](https://cloud.githubusercontent.com/assets/3660661/19775725/4e7d6344-9c3f-11e6-9941-7ed5a4120198.jpg)

My screen grab above is a bit misleading in the sense I'm showing the disabled tooltip, with the enabled appearance, just to illustrate the color in the PR.

I provided a selection of other possible svg icons other than `fa-arrow-down` in the bug [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1207460#c9). @jgraham favored it as a start point.

The `cyan` color was a bit arbitrary, other than keeping it in the same family of saturation and luminance as the green retrigger. If anyone has a hex color they want instead, let me know.

I defer to user consensus whether or not this PR gets used. Given there's a keyboard shortcut for rapid/repeated retrigger invocations, I don't mind either way :)

Tested on OSX 10.11.5:
Nightly **52.0a1 (2016-10-26) (64-bit)**
Chrome Latest Release **54.0.2840.71 (64-bit)**

Adding @KWierso for visibility.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1960)

<!-- Reviewable:end -->
