### PR TITLE
Bug 1313698 - Disable perf alerts for fx-team as it is read-only

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -183,7 +183,7 @@
         "codebase": "gecko",
         "repository_group": 1,
         "description": "",
-        "performance_alerts_enabled": true
+        "performance_alerts_enabled": false
     }
 },
 {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1963)
<!-- Reviewable:end -->
