### PR TITLE
Bug 1314079 - Reactivate the projects/graphics branch

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -193,7 +193,7 @@
         "dvcs_type": "hg",
         "name": "graphics",
         "url": "https://hg.mozilla.org/projects/graphics",
-        "active_status": "onhold",
+        "active_status": "active",
         "codebase": "gecko",
         "repository_group": 6,
         "description": ""


### PR DESCRIPTION
This branch will be used for the Quantum Render work, and we want it displayed on TreeHerder as there will be CI jobs running on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1966)
<!-- Reviewable:end -->
