### PR TITLE
Bug 1315818 - Vagrant: Use localhost instead of local.treeherder.m.o

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,8 +15,12 @@ def puppet_provisioner(config)
 end
 
 Vagrant.configure("2") do |config|
-  config.vm.network "private_network", ip: "192.168.33.10"
-  config.vm.network "forwarded_port", guest: 80, host: 8000
+  # required for NFS to work
+  config.vm.network "private_network", type: "dhcp"
+  # for web server access from host
+  config.vm.network "forwarded_port", guest: 80, host: 8000, host_ip: "127.0.0.1"
+  # for DB access from host
+  config.vm.network "forwarded_port", guest: 3306, host: 3308, host_ip: "127.0.0.1"
 
   config.vm.synced_folder ".", "/home/vagrant/treeherder", type: "nfs"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,8 +15,8 @@ def puppet_provisioner(config)
 end
 
 Vagrant.configure("2") do |config|
-  config.vm.hostname = "local.treeherder.mozilla.org"
   config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network "forwarded_port", guest: 80, host: 8000
 
   config.vm.synced_folder ".", "/home/vagrant/treeherder", type: "nfs"
 

--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -63,7 +63,7 @@ On our development (vagrant) instance we have `django-debug-toolbar
 <http://django-debug-toolbar.readthedocs.io/>`_ installed, which can give
 information on exactly what SQL is run to generate individual API
 endpoints. Just navigate to an endpoint
-(example: http://local.treeherder.mozilla.org/api/repository/) and
+(example: http://localhost:8000/api/repository/) and
 you should see the toolbar to your right.
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,13 +36,6 @@ Setting up Vagrant
   it is almost guranteed that some things *will break* in
   hard-to-diagnose ways if vagrant provision is not run to completion.
 
-* While the previous command is running, use the time to add this line to your **host** machine's /etc/hosts:
-
-  .. code-block:: bash
-
-     # Copy this line verbatim (do not adjust the IP)
-     192.168.33.10    local.treeherder.mozilla.org
-
 * Once the virtual machine is set up, connect to it using:
 
   .. code-block:: bash
@@ -74,7 +67,7 @@ Starting a local Treeherder instance
 
   this is more convenient because it automatically refreshes every time there's a change in the code.
 
-* Visit http://local.treeherder.mozilla.org in your browser. Note: There will be no data to display until the ingestion tasks are run.
+* Visit http://localhost:8000 in your browser. Note: There will be no data to display until the ingestion tasks are run.
 
 Running the ingestion tasks
 ---------------------------
@@ -103,7 +96,7 @@ the jobs associated with any single push generated in the last 4 hours
 
      vagrant ~/treeherder$ ./manage.py ingest_push mozilla-inbound 63f8a47cfdf5
 
-If running this locally, replace `63f8a47cfdf5` with a recent revision (= pushed within 
+If running this locally, replace `63f8a47cfdf5` with a recent revision (= pushed within
 the last four hours) on mozilla-inbound.
 
 You can further restrict the amount of data to a specific type of job

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -6,7 +6,7 @@ resultset, job, and performance data it stores internally. To allow
 inspection of this API, we use Swagger_, which provides a friendly
 browsable interface to Treeherder's API endpoints. After setting up a
 local instance of Treeherder, you can access Swagger at
-http://local.treeherder.mozilla.org/docs/. You can also view it on
+http://localhost:8000/docs/. You can also view it on
 our production instance at https://treeherder.mozilla.org/docs/.
 
 .. _Swagger: http://swagger.io/
@@ -45,7 +45,7 @@ constructor:
     client = TreeherderClient(server_url='https://treeherder.allizom.org')
 
     # Local vagrant instance
-    client = TreeherderClient(server_url='http://local.treeherder.mozilla.org')
+    client = TreeherderClient(server_url='http://localhost:8000')
 
 When using the Python client, don't forget to set up logging in the
 caller so that any API error messages are output, like so:

--- a/puppet/files/varnish/default.vcl
+++ b/puppet/files/varnish/default.vcl
@@ -1,6 +1,5 @@
 # We use Varnish even for development, since gunicorn/runserver default to 127.0.0.1:8000,
-# and to be accessible from outside the VM we'd have to use 0.0.0.0. In addition, to serve
-# on port 80 we'd have to run gunicorn/runserver with sudo or use authbind.
+# and to be accessible from outside the VM we'd have to use 0.0.0.0.
 backend gunicorn {
     .host = "127.0.0.1";
     .port = "8000";

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -11,12 +11,6 @@ Exec {
     path => "${VENV_DIR}/bin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin",
 }
 
-line {"etc-hosts":
-  file => "/etc/hosts",
-  line => "127.0.0.1 local.treeherder.mozilla.org",
-  ensure => "present"
-}
-
 file {"/etc/profile.d/treeherder.sh":
     ensure => "link",
     target => "${PROJ_DIR}/puppet/files/treeherder/env.sh",

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -339,7 +339,7 @@ DISALLOWED_USER_AGENTS = (
     re.compile(r'^ActiveData-ETL'),
 )
 
-SITE_URL = env("SITE_URL", default="http://local.treeherder.mozilla.org")
+SITE_URL = env("SITE_URL", default="http://localhost:8000/")
 SITE_HOSTNAME = urlparse(SITE_URL).hostname
 APPEND_SLASH = False
 
@@ -400,9 +400,6 @@ SECURE_BROWSER_XSS_FILTER = True
 X_FRAME_OPTIONS = 'DENY'
 
 SILENCED_SYSTEM_CHECKS = [
-    # We can't set SECURE_HSTS_INCLUDE_SUBDOMAINS since the development
-    # environment has a SITE_URL of http://local.treeherder.mozilla.org.
-    'security.W005',
     # We can't set CSRF_COOKIE_HTTPONLY to True since the requests to the API
     # made using Angular's `httpProvider` require access to the cookie.
     'security.W017',

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -400,6 +400,9 @@ SECURE_BROWSER_XSS_FILTER = True
 X_FRAME_OPTIONS = 'DENY'
 
 SILENCED_SYSTEM_CHECKS = [
+    # We can't set SECURE_HSTS_INCLUDE_SUBDOMAINS since the development
+    # environment has a SITE_URL of http://local.treeherder.mozilla.org.
+    'security.W005',
     # We can't set CSRF_COOKIE_HTTPONLY to True since the requests to the API
     # made using Angular's `httpProvider` require access to the cookie.
     'security.W017',

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -385,8 +385,7 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 if SITE_URL.startswith('https://'):
     SECURE_SSL_REDIRECT = True
-    # TODO: Uncomment once the Vagrant/Travis SITE_URLs aren't fake subdomains of stage/prod.
-    # SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_SECONDS = int(timedelta(days=365).total_seconds())
     # Mark session and CSRF cookies as being HTTPS-only.
     CSRF_COOKIE_SECURE = True
@@ -400,9 +399,6 @@ SECURE_BROWSER_XSS_FILTER = True
 X_FRAME_OPTIONS = 'DENY'
 
 SILENCED_SYSTEM_CHECKS = [
-    # We can't set SECURE_HSTS_INCLUDE_SUBDOMAINS since the development
-    # environment has a SITE_URL of http://local.treeherder.mozilla.org.
-    'security.W005',
     # We can't set CSRF_COOKIE_HTTPONLY to True since the requests to the API
     # made using Angular's `httpProvider` require access to the cookie.
     'security.W017',


### PR DESCRIPTION
I think I should also address ``security.W005`` in the  ``SILENCED_SYSTEM_CHECKS`` of ``settings.py``.  Though it seems the tests need it.  Ed: would you advise the right thing to do here?  :)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/1974)
<!-- Reviewable:end -->
