### PR TITLE
Bug 1317682 - Update Django from 1.8.15 to 1.8.16

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ whitenoise==3.2.2 --hash=sha256:90a576ecb938cfef3fd1dba0c82d10e8e9ff0acb6079d7ed
 # Used by the Whitenoise CLI tool to provide Brotli-compressed versions of static files.
 Brotli==0.5.2 --hash=sha256:3411b9acd2a2056e55084acf7a6ab3e4a8540c2ef37a4435bca62644e8aaf50e
 
-Django==1.8.15 --hash=sha256:e2e41aeb4fb757575021621dc28fceb9ad137879ae0b854067f1726d9a772807
+Django==1.8.16 --hash=sha256:cc3a95187788627dfdc94b41de908aadfc4241fabb3ceaef19f4bd3b89c0fdf7
 
 celery==3.1.24 --hash=sha256:25396191954521184cc15018f776a2a2278b04dd4213d94f795daef4b7961b4b
 

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -375,10 +375,7 @@ ORANGEFACTOR_HAWK_KEY = env("ORANGEFACTOR_HAWK_KEY", default=None)
 # this setting allows requests from any host
 CORS_ORIGIN_ALLOW_ALL = True
 
-# set ALLOWED_HOSTS to match your domain name.
-# An asterisk means everything but it's not secure.
-# IP addresses are also allowed. A dot is used to include all sub domains
-ALLOWED_HOSTS = env.list("TREEHERDER_ALLOWED_HOSTS", default=[".mozilla.org", ".allizom.org"])
+ALLOWED_HOSTS = [SITE_HOSTNAME]
 
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
1) Use the domain from `SITE_URL` to set `ALLOWED_HOSTS`:
One of the Django 1.8.16 security changes means that `ALLOWED_HOSTS` is now used even when `DEBUG` mode is enabled. As such, we must now set it in the Vagrant environment.

2) Update Django from 1.8.15 to 1.8.16:
https://www.djangoproject.com/weblog/2016/nov/01/security-releases/
https://docs.djangoproject.com/en/stable/releases/1.8.16/