### PR TITLE
Fix Bug 1249341 - Add "Retrigger All" to Info Panel dropdown

### DIFF
--- a/ui/partials/main/thJobDetailsRetriggerMenu.html
+++ b/ui/partials/main/thJobDetailsRetriggerMenu.html
@@ -1,6 +1,9 @@
 <li>
   <a ng-click="retriggerJob([selectedJob])" title="Repeat the selected job">Retrigger job</a>
 </li>
+<li title="Repeat the pinned jobs">
+  <a ng-disabled="!getCountPinnedJobs()" ng-click="retriggerAllPinnedJobs()">Retrigger all pinned jobs</a>
+</li>
 <li ng-class="canBackfill() ? '' : 'disabled'"
     ng-attr-title="{{canBackfill() ? backfillEnabledString : backfillDisabledString}}">
   <a ng-disabled="!canBackfill()" ng-click="backfillJob()">Backfill job</a>

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -316,6 +316,12 @@ treeherder.controller('PluginCtrl', [
                    ($scope.job.state === "pending" || $scope.job.state === "running");
         };
 
+        $scope.retriggerAllPinnedJobs = function() {
+            if ($scope.user.loggedin && $scope.getCountPinnedJobs()) {
+                $rootScope.$emit('retriggerAllPinnedJobs');
+            }
+        };
+
         $scope.retriggerJob = function(jobs) {
             if ($scope.user.loggedin) {
                 var job_id_list = _.pluck(jobs, 'id');

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -38,6 +38,10 @@ treeherder.controller('PinboardCtrl', [
             }
         });
 
+        $rootScope.$on('retriggerAllPinnedJobs', function() {
+            $scope.retriggerAllPinnedJobs();
+        });
+
         $scope.toggleJobPin = function(job) {
             thPinboard.toggleJobPin(job);
             if (!$scope.selectedJob) {


### PR DESCRIPTION
The best solution, IMO, is to simply duplicate the retrigger all link in the dropdown, even though this action isn't specific to the info pane -- I do think it's reasonable to have the link there.