### PR TITLE
Bug 1318893 - Fix click behaviour for job groups

### DIFF
--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -36,6 +36,15 @@
   background-color: rgb(208, 228, 250);
 }
 
+.group-symbol {
+  background: transparent;
+  padding: 0px;
+  border: 0px;
+  vertical-align: 0;
+  line-height: 1.32;
+  cursor: pointer;
+}
+
 .group-symbol:hover {
   background-color: rgba(208, 228, 250, 0.51);
   cursor: pointer;

--- a/ui/index.html
+++ b/ui/index.html
@@ -204,10 +204,10 @@
             <span class="platform-group" style="display: {{ display }};">
                 <span class="disabled job-group" title="{{ name }}"
                       data-grkey="{{ grkey }}">
-                    <span class="group-symbol"
+                    <button class="btn group-symbol"
                           ignore-job-clear-on-click>{{ symbol }}{{(tier) ?
                       '<span class="small text-muted">[tier ' + tier + ']</span>': ""}}
-                    </span>
+                    </button>
                     <span class="group-content">
                         <span class="group-job-list">
                             {{ btnHTML }}


### PR DESCRIPTION
Do this by making the job groups a clickable button, which is incidentally
also better behaviour for screen readers (since it gives a hint that the
element is clickable)