### PR TITLE
Bug 1207460 - Split retrigger menu into separate btns

### DIFF
--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -81,7 +81,7 @@ input:focus::-moz-placeholder {
 .logviewer-icon {
   width: 14px;
   height: 16px;
-  vertical-align: text-bottom;
+  vertical-align: text-top;
   opacity: 0.7;
 }
 
@@ -105,6 +105,12 @@ input:focus::-moz-placeholder {
 .icon-green:focus,
 .icon-green:active {
   color: #0de00d !important;
+}
+
+.icon-cyan:hover,
+.icon-cyan:focus,
+.icon-cyan:active {
+  color: #00ffff !important;
 }
 
 .icon-superscript {

--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -37,17 +37,23 @@ div#info-panel .navbar-nav > ul {
   height: 32px;
 }
 
-div#info-panel .navbar-nav > li > a {
+div#info-panel .navbar-nav > li > a,
+div#info-panel .navbar-nav > li > button {
   padding: 6px 15px;
   line-height: 19px;
 }
 
+div#info-panel .navbar-nav > li > button {
+  border: none;
+  background: transparent;
+}
 /* Use a loaded image, rather than an icon, so it needs to be slightly shorter */
 div#info-panel .navbar-nav > li > a#logviewer-btn {
   line-height: 18px;
 }
 
 div#info-panel .navbar-nav > li > a.disabled,
+div#info-panel .navbar-nav > li > button.disabled,
 ul.actionbar-menu > li.disabled {
   cursor: not-allowed;
   text-decoration: none;
@@ -161,8 +167,8 @@ div#info-panel .info-panel-navbar .navbar-nav > li.active a:focus {
  * Job details action bar
  */
 
-.actionbar-nav > li:not(:first-child) {
-  /* Preserve left side padding on our first icon but keep others compact */
+.actionbar-nav > li {
+  /* Override padding on all icons to keep compact */
   padding: 0 !important;
 }
 
@@ -182,8 +188,8 @@ div#info-panel .info-panel-navbar .navbar-nav > li.active a:focus {
  */
 
 #job-details-panel {
-  width: 250px;
-  min-width: 250px;
+  width: 252px;
+  min-width: 252px;
 }
 
 #job-details-panel .content-spacer {

--- a/ui/partials/main/thJobDetailsRetriggerMenu.html
+++ b/ui/partials/main/thJobDetailsRetriggerMenu.html
@@ -1,7 +1,0 @@
-<li>
-  <a ng-click="retriggerJob([selectedJob])" title="Repeat the selected job">Retrigger job</a>
-</li>
-<li ng-class="canBackfill() ? '' : 'disabled'"
-    ng-attr-title="{{canBackfill() ? backfillEnabledString : backfillDisabledString}}">
-  <a ng-disabled="!canBackfill()" ng-click="backfillJob()">Backfill job</a>
-</li>

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -371,12 +371,32 @@ treeherder.controller('PluginCtrl', [
 
         // Can we backfill? At the moment, this only ensures we're not in a 'try' repo.
         $scope.canBackfill = function() {
-            return $scope.currentRepo && $scope.currentRepo.repository_group.name !== 'try';
+            return $scope.user.loggedin && $scope.currentRepo &&
+                   $scope.currentRepo.repository_group.name !== 'try';
         };
 
-        $scope.backfillEnabledString = "Trigger jobs of this type on prior pushes, " +
-                                       "to fill in gaps where the job was not run";
-        $scope.backfillDisabledString = "Backfilling not available in this repository";
+        $scope.backfillButtonTitle = function() {
+            var title = "";
+
+            if (!$scope.user.loggedin) {
+                title = title.concat("must be logged in to backfill a job / ");
+            }
+
+            if ($scope.currentRepo.repository_group.name === 'try') {
+                title = title.concat("backfill not available in this repository");
+            }
+
+            if (title === "") {
+                title = "Trigger jobs of ths type on prior pushes " +
+                        "to fill in gaps where the job was not run";
+            } else {
+                // Cut off trailing "/ " if one exists, capitalize first letter
+                title = title.replace(/\/ $/,"");
+                title = title.replace(/^./, function(l) { return l.toUpperCase(); });
+            }
+
+            return title;
+        };
 
         $scope.cancelJob = function() {
             if ($scope.user.loggedin) {

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -68,33 +68,34 @@
             </a>
           </li>
           <li>
-            <!--the first 3 items are in the same box-->
-            <ul class="nav navbar-nav">
-              <li>
-                <a id="pin-job-btn" href=""
-                   title="Add this job to the pinboard"
-                   ng-click="pinboard_service.pinJob(selectedJob)">
-                  <span class="glyphicon glyphicon-pushpin"
-                        ng-class="{'icon-blue': (pinboard_service.count.numPinnedJobs > 0)}">
-                  </span>
-                  <span ng-show="pinboard_service.count.numPinnedJobs"
-                        class="pinned-job-count">{{getCountPinnedJobs()}}</span>
-                </a>
-              </li>
-
-            </ul>
-          </li>
-          <li class="dropdown">
-            <a id="retriggerLabel"
-               ng-attr-title="{{user.loggedin ? 'Retrigger or backfill this job' :
-                              'Must be logged in to retrigger a job'}}"
-               ng-class="user.loggedin ? 'icon-green' : 'disabled'" href="" data-toggle="dropdown">
-              <span class="fa fa-repeat"></span>&nbsp
-              <span class="fa fa-angle-down lightgray"></span>
+            <a id="pin-job-btn" href=""
+               title="Add this job to the pinboard"
+               ng-click="pinboard_service.pinJob(selectedJob)">
+              <span class="glyphicon glyphicon-pushpin"
+                    ng-class="{'icon-blue': (pinboard_service.count.numPinnedJobs > 0)}">
+              </span>
+              <span ng-show="pinboard_service.count.numPinnedJobs"
+                    class="pinned-job-count">{{getCountPinnedJobs()}}</span>
             </a>
-            <ul class="dropdown-menu actionbar-menu" role="menu" aria-labelledby="retriggerLabel"
-                ng-include src="'partials/main/thJobDetailsRetriggerMenu.html'">
-            </ul>
+          </li>
+          <li>
+            <button id="retrigger-btn" href=""
+               ng-attr-title="{{user.loggedin ? 'Repeat the selected job' :
+                              'Must be logged in to retrigger a job'}}"
+               ng-class="user.loggedin ? 'icon-green' : 'disabled'"
+               ng-disabled="!user.loggedin"
+               ng-click="retriggerJob([selectedJob])">
+              <span class="fa fa-repeat"></span>
+            </button>
+          </li>
+          <li>
+            <button id="backfill-btn" href=""
+               ng-attr-title="{{backfillButtonTitle()}}"
+               ng-class="canBackfill() ? 'icon-cyan' : 'disabled'"
+               ng-disabled="!canBackfill()"
+               ng-click="backfillJob()">
+              <span class="fa fa-arrow-down"></span>
+            </button>
           </li>
           <li ng-if="isReftest()" ng-repeat="job_log_url in job_log_urls">
             <a title="Launch the Reftest Analyser in a new window"


### PR DESCRIPTION
This includes all the work from reverted PR https://github.com/mozilla/treeherder/pull/1960 and adds some missing ng-clicks. It also switches them to real buttons in the markup to the block the click through, and adds a new title generator for backfill.

I will test this logged in w/vagrant locally once I get an LDAP reset, given the Persona transition/expiry this month. If any of the usual suspects (@wlach @KWierso  @camd) who have login ability want to test this locally, feel free :) Specific cases to check:

-  disabled cursor, 'disable state' tooltips and disabled click through, when logged out or on Try
- enabled cursor, tooltips and successful Retrigger and Backfill, when logged in and not on Try

I will comment on the new parts of the PR that weren't reviewed previously.

Tested to the extent I can at present, on:

Tested on OSX 10.11.5:
Nightly **53.0a1 (2016-11-21) (64-bit)**