### PR TITLE
Bug 1319441 - Skip cloud mirror when downloading logs from Taskcluster

### DIFF
--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -33,6 +33,9 @@ def make_request(url, method='GET', headers=None,
     """A wrapper around requests to set defaults & call raise_for_status()."""
     headers = headers or {}
     headers['User-Agent'] = settings.TREEHERDER_USER_AGENT
+    # Work around bug 1305768.
+    if 'queue.taskcluster.net' in url:
+        headers['x-taskcluster-skip-cache'] = 'true'
     response = requests.request(method,
                                 url,
                                 headers=headers,

--- a/treeherder/log_parser/artifactbuildercollection.py
+++ b/treeherder/log_parser/artifactbuildercollection.py
@@ -85,6 +85,9 @@ BuildbotPerformanceDataArtifactBuilder
         """Hook to get a handle to the log with this url"""
         req = urllib2.Request(url)
         req.add_header('User-Agent', settings.TREEHERDER_USER_AGENT)
+        # Work around bug 1305768.
+        if 'queue.taskcluster.net' in url:
+            req.add_header('x-taskcluster-skip-cache', 'true')
         return urllib2.urlopen(
            req,
            timeout=settings.REQUESTS_TIMEOUT


### PR DESCRIPTION
Cloud mirror cases periodic spikes in response time (bug 1305768), so we now use the new `x-taskcluster-skip-cache` header to skip it when downloading eg logs/taskgraphs/...:
https://docs.taskcluster.net/reference/platform/queue/references/api#getArtifact

Since the urllib2 usage is going to be replaced with the common requests code, and since this is hopefully a short-term workaround, hardcoding this at point of usage should be fine.