### PR TITLE
Bug 1318021 - (Part 1) Vagrant: Stop using log files for gunicorn/celery output

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: newrelic-admin run-program gunicorn treeherder.config.wsgi:application --log-file - --timeout 29 --max-requests 150
+web: newrelic-admin run-program gunicorn treeherder.config.wsgi:application --timeout 29 --max-requests 150
 worker_beat: newrelic-admin run-program celery -A treeherder beat
 worker_pushlog: newrelic-admin run-program celery -A treeherder worker -Q pushlog --maxtasksperchild=500 --concurrency=5
 worker_buildapi_pending: newrelic-admin run-program celery -A treeherder worker -Q buildapi_pending --maxtasksperchild=20 --concurrency=5

--- a/bin/run_celery_worker
+++ b/bin/run_celery_worker
@@ -8,13 +8,7 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-LOGFILE=/var/log/celery/celery_worker.log
-
-if [ ! -f $LOGFILE ]; then
-    touch $LOGFILE
-fi
-
 exec newrelic-admin run-program celery -A treeherder worker -c 3 \
      -Q default,cycle_data,calculate_durations,fetch_bugs,fetch_allthethings,generate_perf_alerts,detect_intermittents \
      -E --maxtasksperchild=500 \
-     --logfile=$LOGFILE -l INFO -n default.%h
+     -l INFO -n default.%h

--- a/bin/run_celery_worker_buildapi
+++ b/bin/run_celery_worker_buildapi
@@ -8,13 +8,7 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-LOGFILE=/var/log/celery/celery_worker_buildapi.log
-
-if [ ! -f $LOGFILE ]; then
-    touch $LOGFILE
-fi
-
 exec newrelic-admin run-program celery -A treeherder worker -Q buildapi_pending,buildapi_running,buildapi_4hr,store_pulse_jobs,store_pulse_resultsets \
-    --concurrency=5 --logfile=$LOGFILE -l INFO \
+    --concurrency=5 -l INFO \
     --maxtasksperchild=20 -n buildapi.%h
 

--- a/bin/run_celery_worker_hp
+++ b/bin/run_celery_worker_hp
@@ -8,12 +8,6 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-LOGFILE=/var/log/celery/celery_worker_hp.log
-
-if [ ! -f $LOGFILE ]; then
-    touch $LOGFILE
-fi
-
 exec newrelic-admin run-program celery -A treeherder worker -c 1 \
      -Q classification_mirroring,publish_to_pulse -E --maxtasksperchild=500 \
-     --logfile=$LOGFILE -l INFO -n hp.%h
+     -l INFO -n hp.%h

--- a/bin/run_celery_worker_log_parser
+++ b/bin/run_celery_worker_log_parser
@@ -8,12 +8,6 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-LOGFILE=/var/log/celery/celery_worker_log_parser.log
-
-if [ ! -f $LOGFILE ]; then
-    touch $LOGFILE
-fi
-
 exec newrelic-admin run-program celery -A treeherder worker \
     -Q \
 log_parser,\
@@ -24,5 +18,5 @@ log_crossreference_error_lines,\
 log_crossreference_error_lines_fail,\
 log_autoclassify,\
 log_autoclassify_fail\
-    --concurrency=10 --logfile=$LOGFILE -l INFO \
+    --concurrency=10 -l INFO \
     --maxtasksperchild=500 -n log_parser.%h

--- a/bin/run_celery_worker_pushlog
+++ b/bin/run_celery_worker_pushlog
@@ -8,14 +8,8 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-LOGFILE=/var/log/celery/celery_worker_pushlog.log
-
-if [ ! -f $LOGFILE ]; then
-    touch $LOGFILE
-fi
-
 exec newrelic-admin run-program celery -A treeherder worker \
     -Q pushlog \
-    --concurrency=5 --logfile=$LOGFILE -l INFO \
+    --concurrency=5 -l INFO \
     --maxtasksperchild=500 -n pushlog.%h
 

--- a/bin/run_celerybeat
+++ b/bin/run_celerybeat
@@ -8,10 +8,4 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-LOGFILE=/var/log/celery/celerybeat.log
-
-if [ ! -f $LOGFILE ]; then
-    touch $LOGFILE
-fi
-
-exec newrelic-admin run-program celery -A treeherder beat -f $LOGFILE
+exec newrelic-admin run-program celery -A treeherder beat

--- a/bin/run_gunicorn
+++ b/bin/run_gunicorn
@@ -10,24 +10,11 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 
 source /etc/profile.d/treeherder.sh
 
-LOGDIR=/var/log/gunicorn
-ACCESS_LOGFILE=$LOGDIR/treeherder_access.log
-ERROR_LOGFILE=$LOGDIR/treeherder_error.log
-
-if [ ! -f $ACCESS_LOGFILE ]; then
-    touch $ACCESS_LOGFILE
-fi
-
-if [ ! -f $ERROR_LOGFILE ]; then
-    touch $ERROR_LOGFILE
-fi
-
 NUM_WORKERS=5
 
 exec newrelic-admin run-program gunicorn -w $NUM_WORKERS \
     --max-requests=150 \
-    --access-logfile=$ACCESS_LOGFILE \
-    --error-logfile=$ERROR_LOGFILE treeherder.config.wsgi:application \
+    treeherder.config.wsgi:application \
     --keep-alive=3 \
     --log-level error \
     --timeout=30

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -45,12 +45,3 @@ If after a ``celery -A treeherder worker -B --concurrency 5`` you experience a s
    09:32:40,010: WARNING/MainProcess] celery@local ready.
 
 You should ctrl+c to shut down celery, remove the ``celerybeat-schedule`` file in the project root, and restart your worker.
-
-Where are my log files?
------------------------
-
-You can find the various services log files under
-  * /var/log/celery
-  * /var/log/gunicorn
-
-You may also want to inspect the main treeherder log file ~/treeherder/treeherder.log

--- a/puppet/files/treeherder/.profile
+++ b/puppet/files/treeherder/.profile
@@ -14,8 +14,6 @@ function thelp {
     echo "
     Treeherder-specific helpful aliases:
 
-    thlogs             - Open several top-priority logs in succession using \"less\"
-    thlogsdelete       - Delete all the top-priority logs
     thpurge            - Empty all databases and reset all queues (requires vagrant provision afterward)
     thqueues           - Output the status of the Treeherder celery queues
     thqueuespurge      - Empty all the treeherder celery queues
@@ -24,46 +22,6 @@ function thelp {
     thresetall         - Delete logs, purge queues and reset memcached
     tabname            - Set the title text of the current shell tab
     "
-}
-
-function tabname {
-  printf "\e]1;$1\a"
-}
-
-# the noteworthy treeherder logs for debugging
-TH_LOG_LIST=(
-/var/log/celery/celery_worker_log_parser.log
-/var/log/celery/worker_log_parser_err.log
-/var/log/celery/celery_worker_buildapi.log
-/var/log/celery/celery_worker_pushlog.log
-/var/log/celery/worker_buildapi_err.log
-/var/log/celery/celery_worker.log
-/var/log/celery/worker_pushlog_err.log
-/var/log/treeherder/treeherder.log
-/var/log/gunicorn/treeherder_error.log
-)
-
-function thlogs {
-    # walk through each log with ``less`` to check it out.
-    # quitting moves to the next log.
-
-    for i in "${TH_LOG_LIST[@]}"; do
-        if [ -f "$i" ]; then
-            tabname $i
-            less $i
-        fi
-    done
-    tabname vagrant
-}
-
-function thlogsdelete {
-    # delete all the logs in TH_LOG_LIST
-
-    for i in "${TH_LOG_LIST[@]}"; do
-        if [ -f "$i" ]; then
-            rm $i
-        fi
-    done
 }
 
 function thqueues {

--- a/puppet/manifests/classes/treeherder.pp
+++ b/puppet/manifests/classes/treeherder.pp
@@ -24,15 +24,4 @@ class treeherder {
       owner => "${APP_USER}",
       group  => "${APP_GROUP}",
     }
-
-    file { [
-      "/var/log/gunicorn",
-      "/var/log/celery",
-      "/var/log/treeherder",
-      ]:
-      ensure => "directory",
-      owner  => "${APP_USER}",
-      group  => "${APP_GROUP}",
-      mode   => 755,
-    }
 }

--- a/treeherder/config/settings_local.example.py
+++ b/treeherder/config/settings_local.example.py
@@ -18,18 +18,10 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'formatter': 'standard'
         },
-        'logfile': {
-            'level': 'DEBUG',
-            'class': 'logging.handlers.RotatingFileHandler',
-            'filename': '/var/log/treeherder/treeherder.log',
-            'maxBytes': 5 * 1024 * 1024,
-            'backupCount': 2,
-            'formatter': 'standard',
-        },
     },
     'loggers': {
         'django': {
-            'handlers': ['console', 'logfile'],
+            'handlers': ['console'],
             'level': 'INFO',
             'propagate': True,
         },
@@ -38,7 +30,7 @@ LOGGING = {
             'level': 'WARNING',
         },
         'treeherder': {
-            'handlers': ['console', 'logfile'],
+            'handlers': ['console'],
             'level': 'DEBUG',
             'propagate': False,
         }


### PR DESCRIPTION
Outputting to the console rather than a log file:
* is more user-friendly during development
* is more consistent with Heroku
* means the Vagrant-specific Django LOGGING config is now closer to the one in settings.py, and so more easily combined with it

Both gunicorn and celery default to outputting to stdout/stderr, so the `logfile` options can be omitted entirely.