### PR TITLE
Bug 1319300 - Move the pin counter to the pinboard btn

### DIFF
--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -97,8 +97,10 @@ input:focus::-moz-placeholder {
   font-size: 13px;
 }
 
-.icon-blue {
-  color: #68aae2;
+.icon-blue:hover,
+.icon-blue:focus,
+.icon-blue:active {
+  color: #68aae2 !important;
 }
 
 .icon-green:hover,

--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -173,10 +173,6 @@ div#info-panel .info-panel-navbar .navbar-nav > li.active a:focus {
   border-radius: 4px !important;
 }
 
-.pinned-job-count {
-  margin-left: 5px;
-}
-
 /*
  * Job details panel (left side)
  */

--- a/ui/css/treeherder-pinboard.css
+++ b/ui/css/treeherder-pinboard.css
@@ -1,7 +1,52 @@
-.pinboard-open-btn {
+.pinboard-btn {
   margin-top: -1px;
   background-color: #e6eef5 !important;
   color: #252c33 !important;
+}
+
+.pin-count-group {
+  display: inline-block;
+  position: relative;
+  top: -14px;
+  left: -3px;
+  height: 16px;
+  width: 16px;
+  border: 1px solid #2398ff;
+  border-radius: 8px;
+  background: white;
+}
+
+.pin-count-pulse {
+  animation: pin-count-pulse 0.4s;
+  -webkit-animation: pin-count-pulse 0.4s;
+}
+
+@keyframes pin-count-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(3); }
+}
+
+@-webkit-keyframes pin-count-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(3); }
+}
+
+.pin-count-text {
+  line-height: 14px;
+  font-size: 9px;
+  font-weight: bold;
+  text-align: center;
+  color: #2398ff;
+}
+
+.pin-count-group-3-digit {
+  height: 20px;
+  width: 20px;
+  border-radius: 10px;
+}
+
+.pin-count-text-3-digit {
+  line-height: 18px;
 }
 
 #pinboard-panel {

--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -170,6 +170,9 @@ treeherder.provider('thEvents', function() {
             // fired with a selected job on ctrl/cmd-click
             toggleJobPin: "job-togglepin-EVT",
 
+            // fired with api call to increment the pinned jobs
+            pulsePinCount: "pulse-pin-count-EVT",
+
             // fired with a selected job on 'r'
             jobRetrigger: "job-retrigger-EVT",
 

--- a/ui/js/services/pinboard.js
+++ b/ui/js/services/pinboard.js
@@ -70,6 +70,7 @@ treeherder.factory('thPinboard', [
                 if (api.spaceRemaining() > 0) {
                     pinnedJobs[job.id] = job;
                     api.count.numPinnedJobs = _.size(pinnedJobs);
+                    $rootScope.$emit(thEvents.pulsePinCount);
                 } else {
                     thNotify.send("Pinboard is already at maximum size of " + api.maxNumPinned,
                                   "danger");

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -301,6 +301,18 @@ treeherder.controller('PluginCtrl', [
             return thPinboard.count.numPinnedJobs;
         };
 
+        $scope.getCountPinnedTitle = function() {
+            var title = "";
+
+            if (thPinboard.count.numPinnedJobs === 1) {
+                title = "You have " + thPinboard.count.numPinnedJobs + " job pinned";
+            } else if (thPinboard.count.numPinnedJobs > 1) {
+                title = "You have " + thPinboard.count.numPinnedJobs + " jobs pinned";
+            }
+
+            return title;
+        };
+
         $scope.togglePinboardVisibility = function() {
             $scope.isPinboardVisible = !$scope.isPinboardVisible;
         };

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -45,15 +45,24 @@ treeherder.controller('PinboardCtrl', [
             }
         };
 
+        $scope.pulsePinCount = function() {
+            $( ".pin-count-group" ).addClass( "pin-count-pulse" );
+            $timeout(function() {
+                $( ".pin-count-group" ).removeClass( "pin-count-pulse" );
+            }, 700);
+        };
+
+        // Triggered on pin api events eg. from the job details navbar
+        $rootScope.$on(thEvents.pulsePinCount, function() {
+            $scope.pulsePinCount();
+        });
+
         $scope.pinJob = function(job) {
             thPinboard.pinJob(job);
             if (!$scope.selectedJob) {
                 $scope.viewJob(job);
             }
-        };
-
-        $scope.pinSelectedJob = function() {
-            thPinboard.pinJob($scope.selectedJob);
+            $scope.pulsePinCount();
         };
 
         $scope.unPinJob = function(id) {

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -73,15 +73,11 @@
               <li>
                 <a id="pin-job-btn" href=""
                    title="Add this job to the pinboard"
+                   class="icon-blue"
                    ng-click="pinboard_service.pinJob(selectedJob)">
-                  <span class="glyphicon glyphicon-pushpin"
-                        ng-class="{'icon-blue': (pinboard_service.count.numPinnedJobs > 0)}">
-                  </span>
-                  <span ng-show="pinboard_service.count.numPinnedJobs"
-                        class="pinned-job-count">{{getCountPinnedJobs()}}</span>
+                  <span class="glyphicon glyphicon-pushpin"></span>
                 </a>
               </li>
-
             </ul>
           </li>
           <li class="dropdown">
@@ -245,15 +241,18 @@
         <ul class="nav navbar-nav info-panel-navbar-controls">
           <li>
             <a href="" ng-click="togglePinboardVisibility()"
-               ng-class="{'pinboard-open-btn': isPinboardVisible}">
-              <span ng-hide="isPinboardVisible"
-                    title="Open the pinboard">Open pinboard&nbsp
-                    <span class="fa fa-angle-up"></span>
-              </span>
-              <span ng-show="isPinboardVisible"
-                    title="Close the pinboard">Close pinboard&nbsp
-                    <span class="fa fa-angle-down"></span>
-              </span>
+               class="pinboard-btn">
+              <div ng-attr-title="{{isPinboardVisible ? 'Close the pinboard' : 'Open the pinboard'}}">Pinboard
+                <div ng-if="pinboard_service.count.numPinnedJobs"
+                     title="{{getCountPinnedTitle()}}"
+                     class="pin-count-group"
+                     ng-class="{'pin-count-group-3-digit': (pinboard_service.count.numPinnedJobs > 99)}">
+                  <div class="pin-count-text"
+                       ng-class="{'pin-count-text-3-digit': (pinboard_service.count.numPinnedJobs > 99)}">
+                    {{getCountPinnedJobs()}}</div>
+                </div>
+                <span class="fa" ng-class="isPinboardVisible ? 'fa-angle-down' : 'fa-angle-up'"></span>
+              </div>
             </a>
           </li>
           <li>


### PR DESCRIPTION
This work fixes Bugzilla bug [1319300](https://bugzilla.mozilla.org/show_bug.cgi?id=1319300).

This moves the pin counter from the "Pin this job" button to the Pinboard collapse/expand button, as we had a user recently who interpreted its current location to mean job details actionbar buttons operate on all pinned jobs, which they do not.

The 'superscript' counter offset position below is intentional, to cue the user there is more "in" that button, particularly when closed.

I changed the closed Pinboard button to the native pinboard color, which seemed to make sense again for new users, to highlight its workflow importance.

Here's a static screen grab, showing the Pinboard closed, with 2 pinned jobs.

![movejobcount](https://cloud.githubusercontent.com/assets/3660661/20578037/3d455d48-b193-11e6-90eb-05654f73b16c.jpg)

The counter pulses when a job is pinned. This lets the user know the pin occurred, particularly if they have the Pinboard closed during pin, which we support.

We needed to add an event listener to facilitate the pin from the job details pin button, since it uses an api call rather than every other pin method (ie. shortcuts) which use available scope pin functions. Everything works nicely on Nightly and Chrome.

Tested on OSX 10.11.5:
Nightly **53.0a1 (2016-11-21) (64-bit)**
Chrome Release **54.0.2840.98 (64-bit)**

Adding @camd for visibility.