### PR TITLE
Bug 1318011 - Remove support for settings_local.py

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,5 +6,3 @@ omit =
   */migrations/*
   treeherder/config/wsgi.py
   treeherder/config/settings.py
-  treeherder/config/settings_local.py
-  treeherder/config/settings_local.example.py

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ node_modules/
 \#*
 
 # Treeherder-specific
-deployment/update/commander_settings.py
 dist/
 docs/_build/
 treeherder/media/

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ node_modules/
 deployment/update/commander_settings.py
 dist/
 docs/_build/
-treeherder/config/settings_local.py
 treeherder/media/
 treeherder/static/
 treeherder/webapp/log_cache/

--- a/docs/pulseload.rst
+++ b/docs/pulseload.rst
@@ -10,8 +10,7 @@ posting your own data.
 Configuration
 -------------
 
-To specify the exchanges to read from, you can set environment variables in
-Vagrant, or in your ``config/settings_local.py`` file.  For example::
+Specify the exchanges to read from using environment variables. For example::
 
     PULSE_DATA_INGESTION_SOURCES = [
         {

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -16,11 +16,6 @@ file {"/etc/profile.d/treeherder.sh":
     target => "${PROJ_DIR}/puppet/files/treeherder/env.sh",
 }
 
-file {"${PROJ_DIR}/treeherder/config/settings_local.py":
-     replace => "no",
-     source => "${PROJ_DIR}/treeherder/config/settings_local.example.py",
-}
-
 class vagrant {
     class {
         init: before => Class["mysql"];

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -184,6 +184,41 @@ LOGGING = {
     }
 }
 
+if DEBUG:
+    # TODO: Fold this into the logging config above, as part of bug 1318021.
+    LOGGING = {
+        'version': 1,
+        'disable_existing_loggers': True,
+        'formatters': {
+            'standard': {
+                'format': "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
+            },
+        },
+        'handlers': {
+            'console': {
+                'level': 'DEBUG',
+                'class': 'logging.StreamHandler',
+                'formatter': 'standard'
+            },
+        },
+        'loggers': {
+            'django': {
+                'handlers': ['console'],
+                'level': 'INFO',
+                'propagate': True,
+            },
+            'hawkrest': {
+                'handlers': ['console'],
+                'level': 'WARNING',
+            },
+            'treeherder': {
+                'handlers': ['console'],
+                'level': 'DEBUG',
+                'propagate': False,
+            }
+        }
+    }
+
 CELERY_QUEUES = [
     Queue('default', Exchange('default'), routing_key='default'),
     # queue for failed jobs/logs

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -141,7 +141,8 @@ INSTALLED_APPS = [
     'treeherder.credentials',
 ]
 
-LOCAL_APPS = []
+if ENABLE_DEBUG_TOOLBAR:
+    INSTALLED_APPS.append('debug_toolbar')
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
@@ -504,8 +505,6 @@ if env.bool("ENABLE_LOCAL_SETTINGS_FILE", default=False):
             del globals()['update']
     except ImportError:
         pass
-
-INSTALLED_APPS += LOCAL_APPS
 
 TEMPLATE_DEBUG = DEBUG
 

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -453,8 +453,6 @@ PULSE_EXCHANGE_NAMESPACE = env("PULSE_EXCHANGE_NAMESPACE", default=None)
 
 # Specifies the Pulse exchanges Treeherder will ingest data from.  This list
 # will be updated as new applications come online that Treeherder supports.
-# Can be overridden in settings_local.py to specify fewer or completely different
-# exchanges for testing purposes on local machines.
 # Treeherder will subscribe with routing keys that are all combinations of
 # ``project`` and ``destination`` in the form of:
 #     <destination>.<project>
@@ -527,19 +525,6 @@ PULSE_DATA_INGESTION_QUEUES_AUTO_DELETE = False
 
 GITHUB_CLIENT_ID = env("GITHUB_CLIENT_ID", default=None)
 GITHUB_CLIENT_SECRET = env("GITHUB_CLIENT_SECRET", default=None)
-
-# The git-ignored settings_local.py file should only be used for local development.
-if env.bool("ENABLE_LOCAL_SETTINGS_FILE", default=False):
-    # Note: All the configs below this import will take precedence over what is
-    # defined in settings_local.py!
-    try:
-        assert "update" not in globals()
-        from .settings_local import *
-        if "update" in globals():
-            update(globals())
-            del globals()['update']
-    except ImportError:
-        pass
 
 TEMPLATE_DEBUG = DEBUG
 

--- a/treeherder/config/settings_local.example.py
+++ b/treeherder/config/settings_local.example.py
@@ -1,9 +1,6 @@
 # Switch to using a different bugzilla instance
 BZ_API_URL = "https://bugzilla-dev.allizom.org"
 
-# Applications useful for development, e.g. debug_toolbar, django_extensions.
-LOCAL_APPS = ['debug_toolbar']
-
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': True,

--- a/treeherder/config/settings_local.example.py
+++ b/treeherder/config/settings_local.example.py
@@ -1,3 +1,0 @@
-# Switch to using a different bugzilla instance
-BZ_API_URL = "https://bugzilla-dev.allizom.org"
-

--- a/treeherder/config/settings_local.example.py
+++ b/treeherder/config/settings_local.example.py
@@ -1,35 +1,3 @@
 # Switch to using a different bugzilla instance
 BZ_API_URL = "https://bugzilla-dev.allizom.org"
 
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': True,
-    'formatters': {
-        'standard': {
-            'format': "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
-        },
-    },
-    'handlers': {
-        'console': {
-            'level': 'DEBUG',
-            'class': 'logging.StreamHandler',
-            'formatter': 'standard'
-        },
-    },
-    'loggers': {
-        'django': {
-            'handlers': ['console'],
-            'level': 'INFO',
-            'propagate': True,
-        },
-        'hawkrest': {
-            'handlers': ['console'],
-            'level': 'WARNING',
-        },
-        'treeherder': {
-            'handlers': ['console'],
-            'level': 'DEBUG',
-            'propagate': False,
-        }
-    }
-}


### PR DESCRIPTION
It has been the source of Vagrant-environment confusion multiple times in the past, and in an environment-variable-centric world really isn't the best way to achieve local custom configuration.

Specifically:
* It doesn't show up in `git status` (by design) so people don't even realise they are running custom settings, that cause later breakage (bug 1291038 and bug 1320479 are just two examples).
* It exists on the host, and not in the VM, so persists even after a `vagrant destroy`, thwarting people's attempts to reset back to defaults.
* The only real use-case for it is IMO actually an anti-feature, in that it encourages people to squirrel away development environment tips & tricks, rather than landing them on master where everyone could benefit. For one-off local changes people should use either environment variables, or just modify settings.py along with the PR they are working on.