### PR TITLE
Bug 1304047 - Clean up the Bugscache schema

### DIFF
--- a/treeherder/model/migrations/0043_bugscache_cleanup.py
+++ b/treeherder/model/migrations/0043_bugscache_cleanup.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0042_delete_tasksetmeta'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='bugscache',
+            name='id',
+            field=models.PositiveIntegerField(serialize=False, primary_key=True),
+        ),
+        migrations.AlterField(
+            model_name='bugscache',
+            name='modified',
+            field=models.DateTimeField(),
+        ),
+        migrations.AlterField(
+            model_name='bugscache',
+            name='status',
+            field=models.CharField(max_length=64, db_index=True),
+        ),
+
+        # These fulltext indexes were added via RunSQL commands in 0001_initial, but are not used.
+        migrations.RunSQL(
+            sql='ALTER TABLE bugscache DROP INDEX idx_crash_signature',
+            reverse_sql='CREATE FULLTEXT INDEX `idx_crash_signature` on bugscache (`crash_signature`);',
+        ),
+        migrations.RunSQL(
+            sql='ALTER TABLE bugscache DROP INDEX idx_keywords',
+            reverse_sql='CREATE FULLTEXT INDEX `idx_keywords` on bugscache (`keywords`);',
+        ),
+        migrations.RunSQL(
+            sql='ALTER TABLE bugscache DROP INDEX idx_all_full_text',
+            reverse_sql='CREATE FULLTEXT INDEX `idx_all_full_text` on bugscache (`summary`, `crash_signature`, `keywords`);',
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -210,14 +210,14 @@ class MachinePlatform(models.Model):
 
 @python_2_unicode_compatible
 class Bugscache(models.Model):
-    id = models.AutoField(primary_key=True)
-    status = models.CharField(max_length=64, blank=True, db_index=True)
+    id = models.PositiveIntegerField(primary_key=True)
+    status = models.CharField(max_length=64, db_index=True)
     resolution = models.CharField(max_length=64, blank=True, db_index=True)
     summary = models.CharField(max_length=255)
     crash_signature = models.TextField(blank=True)
     keywords = models.TextField(blank=True)
     os = models.CharField(max_length=64, blank=True)
-    modified = models.DateTimeField(null=True, blank=True)
+    modified = models.DateTimeField()
 
     class Meta:
         db_table = 'bugscache'


### PR DESCRIPTION
* Switches `id` from an auto_increment to an unsigned int.
* Stops allowing null/blank values for status/modified.
* Drops unused fulltext indexes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2004)
<!-- Reviewable:end -->
