### PR TITLE
Bug 1318474 - Fix job note deletion

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,9 @@ from webtest.app import TestApp
 from treeherder.client import TreeherderClient
 from treeherder.config.wsgi import application
 from treeherder.model.derived.jobs import JobsModel
-from treeherder.model.models import Push
+from treeherder.model.models import (Job,
+                                     JobNote,
+                                     Push)
 
 
 def pytest_addoption(parser):
@@ -260,6 +262,23 @@ def eleven_job_blobs(jm, sample_data, sample_resultset, test_repository, mock_lo
 def eleven_jobs_stored(jm, failure_classifications, eleven_job_blobs):
     """stores a list of 11 job samples"""
     jm.store_job_data(eleven_job_blobs)
+
+
+@pytest.fixture
+def eleven_jobs_with_notes(jm, sample_data, eleven_jobs_stored, test_user,
+                           failure_classifications, test_repository):
+    """provide 11 jobs with job notes."""
+
+    jobs = jm.get_job_list(0, 10)
+
+    for ds_job in jobs:
+        for fcid in [2, 3]:
+            job = Job.objects.get(project_specific_id=ds_job['id'],
+                                  repository=test_repository)
+            JobNote.objects.create(job=job,
+                                   failure_classification_id=fcid,
+                                   user=test_user,
+                                   text="you look like a man-o-lantern")
 
 
 @pytest.fixture

--- a/tests/model/test_job_notes.py
+++ b/tests/model/test_job_notes.py
@@ -1,0 +1,20 @@
+from treeherder.model.models import (Job,
+                                     JobNote)
+
+
+def test_note_deletion(eleven_jobs_with_notes):
+    job = Job.objects.get(id=1)
+    # verify that default classification is last note's
+    # classification
+    assert job.failure_classification_id == 3
+
+    # delete second failure classification, verify that we now have first one
+    JobNote.objects.get(job=job, failure_classification_id=3).delete()
+    job = Job.objects.get(id=1)
+    assert job.failure_classification_id == 2
+
+    # delete second failure classification, verify that we have unclassified
+    # status
+    JobNote.objects.get(job=job).delete()
+    job = Job.objects.get(id=1)
+    assert job.failure_classification_id == 1

--- a/tests/webapp/api/test_note_api.py
+++ b/tests/webapp/api/test_note_api.py
@@ -8,7 +8,7 @@ from treeherder.model.models import (Job,
                                      JobNote)
 
 
-def test_note_list(webapp, sample_notes, jm, test_user):
+def test_note_list(webapp, eleven_jobs_with_notes, jm, test_user):
     """
     test retrieving a list of notes from the note-list endpoint
     """
@@ -31,7 +31,7 @@ def test_note_list(webapp, sample_notes, jm, test_user):
                                          job__project_specific_id=job_id)]
 
 
-def test_note_detail(webapp, sample_notes, test_user, jm):
+def test_note_detail(webapp, eleven_jobs_with_notes, test_user, jm):
     """
     test retrieving a single note from the notes-detail
     endpoint.
@@ -48,7 +48,7 @@ def test_note_detail(webapp, sample_notes, test_user, jm):
     assert resp.json == {
         "id": 1,
         "job_id": note.job.project_specific_id,
-        "failure_classification_id": 1,
+        "failure_classification_id": 2,
         "who": test_user.email,
         "created": note.created.isoformat(),
         "text": "you look like a man-o-lantern"
@@ -123,7 +123,7 @@ def test_create_note(webapp, eleven_jobs_stored, mock_message_broker, jm,
 
 
 @pytest.mark.parametrize('test_no_auth', [True, False])
-def test_delete_note(webapp, sample_notes, mock_message_broker, jm,
+def test_delete_note(webapp, eleven_jobs_with_notes, mock_message_broker, jm,
                      test_sheriff, test_no_auth):
     """
     test deleting a single note via endpoint

--- a/tests/webapp/conftest.py
+++ b/tests/webapp/conftest.py
@@ -2,8 +2,6 @@ import pytest
 from webtest.app import TestApp
 
 from treeherder.config import wsgi
-from treeherder.model.models import (Job,
-                                     JobNote)
 
 
 @pytest.fixture
@@ -12,20 +10,3 @@ def webapp():
     we can use this object to test calls to a wsgi application
     """
     return TestApp(wsgi.application)
-
-
-@pytest.fixture
-def sample_notes(jm, sample_data, eleven_jobs_stored, test_user,
-                 failure_classifications, test_repository):
-    """provide 11 jobs with job notes."""
-
-    jobs = jm.get_job_list(0, 10)
-
-    for ds_job in jobs:
-        for fcid in [1, 2]:
-            job = Job.objects.get(project_specific_id=ds_job['id'],
-                                  repository=test_repository)
-            JobNote.objects.create(job=job,
-                                   failure_classification_id=fcid,
-                                   user=test_user,
-                                   text="you look like a man-o-lantern")

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -358,11 +358,11 @@ class JobsModel(TreeherderModelBase):
         note = JobNote.objects.filter(
             job__repository__name=self.project,
             job__project_specific_id=job_id).order_by('-created').first()
-
         if note:
             failure_classification_id = note.failure_classification.id
         else:
-            failure_classification_id = 0
+            failure_classification_id = FailureClassification.objects.values_list(
+                'id', flat=True).get(name='not classified')
 
         self.execute(
             proc='jobs.updates.update_last_job_classification',


### PR DESCRIPTION
We were always resetting the failure classification to an invalid value
when the last job note was deleted for a job, but we didn't notice it
before because we didn't have foreign key validation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2008)
<!-- Reviewable:end -->
