### PR TITLE
Bug 1320805 - Create per-project exclusion lists on-demand

### DIFF
--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -200,8 +200,6 @@ def test_job_list_excluded(webapp, eleven_jobs_stored, sample_data,
         author=test_sheriff,
     )
     exclusion_profile.exclusions.add(job_exclusion)
-
-    # save populates the flat exclusions
     exclusion_profile.save()
 
     resp = webapp.get(reverse(

--- a/treeherder/model/migrations/0046_remove_flat_exclusion_column.py
+++ b/treeherder/model/migrations/0046_remove_flat_exclusion_column.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0045_add_similar_job_indexes'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='exclusionprofile',
+            name='flat_exclusion',
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -542,7 +542,6 @@ class ExclusionProfile(models.Model):
     name = models.CharField(max_length=255, unique=True)
     is_default = models.BooleanField(default=False, db_index=True)
     exclusions = models.ManyToManyField(JobExclusion, related_name="profiles")
-    flat_exclusion = JSONField(blank=True, default={})
     author = models.ForeignKey(User, related_name="exclusion_profiles_authored", db_index=True)
     modified = models.DateTimeField(auto_now=True)
 

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -56,7 +56,6 @@ class JobExclusionSerializer(serializers.ModelSerializer):
 
 
 class ExclusionProfileSerializer(serializers.ModelSerializer):
-    flat_exclusion = NoOpSerializer(read_only=True)
 
     class Meta:
         model = models.ExclusionProfile


### PR DESCRIPTION
The way we had written things, a "flat exclusion" information (which
is essentially just a cache) had to be rewritten for *every* repository
on submission of a new job, even though the new job would apply to
only one repository. Let's fix this by just calculating this information
on demand (most of the time this should be very fast, as we already
store the final data in memcache)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2009)
<!-- Reviewable:end -->
