### PR TITLE
Bug 1207460 - Add actionbar button color

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -93,7 +93,8 @@ div#info-panel .info-panel-navbar > ul.tab-headers > li {
   white-space: nowrap;
 }
 
-.info-panel-navbar .navbar-nav > li > a {
+.info-panel-navbar .navbar-nav > li > a,
+.info-panel-navbar .navbar-nav > li > button {
   color: #9FA3A5;
 }
 


### PR DESCRIPTION
This is a supplemental tweak omitted from PR https://github.com/mozilla/treeherder/pull/1992.

We add a suitable btn line so we get dark buttons in the action bar for both retrigger and backfill. Illustrating the logged out, non-hover appearance, below.

Current:
![before](https://cloud.githubusercontent.com/assets/3660661/20773642/c802656a-b720-11e6-9010-b4f99fc095b5.jpg)

Proposed:
![proposed](https://cloud.githubusercontent.com/assets/3660661/20773646/ce22d93e-b720-11e6-8bde-0e2881928afb.jpg)

Tested on OSX 10.11.5:
Nightly **53.0a1 (2016-11-29) (64-bit)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2010)
<!-- Reviewable:end -->
