### PR TITLE
Bug 1319246 - Allow login with plain email from Auth0

### DIFF
--- a/tests/auth/test_backends.py
+++ b/tests/auth/test_backends.py
@@ -3,70 +3,128 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from taskcluster.sync import Auth
 
-from treeherder.auth.backends import (TaskclusterAuthBackend,
-                                      TaskclusterAuthenticationFailed)
+from treeherder.auth.backends import (NoEmailException,
+                                      TaskclusterAuthBackend)
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(('username', 'email', 'user', 'exp_exception'), [
-    ('dude', 'dude@lebowski.net', {"username": "dude", "email": "dude@lebowski.net"}, False),
-    ('thneed', 'dude@lebowski.net', {"username": "dude", "email": "dude@lebowski.net"}, False),
-    ('thneed', 'dood@lebowski.net', {"username": "dude", "email": "dude@lebowski.net"}, True)])
-def test_get_user(username, email, user, exp_exception):
-    test_user = User.objects.create(**user)
-    # create a user with duplicate email
-    User.objects.create(username="fleh", email=user["email"])
+@pytest.mark.parametrize(('username', 'email', 'scopes', 'user', 'exp_exception'), [
+    # user exists, has scope, exact match on username
+    ('mozilla-ldap/dude@lebowski.net',
+     'dude@lebowski.net',
+     ["assume:mozilla-user:dude@lebowski.net"],
+     {"username": "mozilla-ldap/dude@lebowski.net", "email": "dude@lebowski.net"},
+     False
+     ),
+    # user exists, wildcard scope, exact match on username
+    ('mozilla-ldap/dude@lebowski.net',
+     'dude@lebowski.net',
+     ["assume:mozilla-user:*"],
+     {"username": "mozilla-ldap/dude@lebowski.net", "email": "dude@lebowski.net"},
+     False
+     ),
+    # user exists, has scope, but username gets updated
+    ('mozilla-ldap/dude@lebowski.net',
+     'dude@lebowski.net',
+     ["assume:mozilla-user:dude@lebowski.net"],
+     {"username": "dude", "email": "dude@lebowski.net"},
+     False
+     ),
+    # user does not exist, raises exception
+    ('thneed',
+     'dood@lebowski.net',
+     ["assume:mozilla-user:dude@lebowski.net"],
+     None,
+     True
+     ),
+    # user does not have scope, raises exception
+    ('mozilla-ldap/dude@me.net',
+     'dude@lebowski.net',
+     ["assume:foo:bar"],
+     {"username": "dude", "email": "nope@lebowski.net"},
+     True
+     )])
+def test_find_user_by_email(username, email, scopes, user, exp_exception):
+    if user:
+        test_user = User.objects.create(**user)
+        # create a user with duplicate email
+        User.objects.create(username="fleh", email=user["email"])
 
     tca = TaskclusterAuthBackend()
     if exp_exception:
         with pytest.raises(ObjectDoesNotExist):
-            tca._get_user(email)
+            tca._find_user_by_email(email, username, scopes)
     else:
-        found_user = tca._get_user(email)
-        assert test_user == found_user
+        found_user = tca._find_user_by_email(email, username, scopes)
+        assert found_user.id == test_user.id
+        assert found_user.username == username
+        assert found_user.email == email
 
 
-@pytest.mark.parametrize(('result', 'exp_email', 'exp_exception'),
-                         [({'scopes': ['assume:mozilla-user:biped@mozilla.com',
-                                       'assume:mozillians-user:biped'],
-                            'clientId': 'mozilla-ldap/biped@mozilla.com'},
-                           'biped@mozilla.com',
-                           False),
-                          ({'scopes': ['assume:mozillians-user:biped'],
-                            'clientId': 'mozilla-ldap/biped@mozilla.com'},
-                           "biped@mozilla.com",
-                           False),
-                          # a Mozillians account without email in clientId
-                          ({'scopes': ["assume:mozillians-user:dude",
-                                       "assume:mozillians-unvouched",
-                                       "auth:create-client:email/dude@lebowski.rug/*",
-                                       "auth:delete-client:email/dude@lebowski.rug/*",
-                                       "auth:update-client:email/dude@lebowski.rug/*",
-                                       "auth:reset-access-token:email/dude@lebowski.rug/*"],
-                            'clientId': 'email/duderino'},
-                           None,
-                           True),
-                          ])
-def test_get_email(result, exp_email, exp_exception):
+@pytest.mark.parametrize(
+    ('client_id', 'exp_email', 'exp_exception'),
+    [('email/biped@mozilla.com', 'biped@mozilla.com', False),  # email clientId
+     ('mozilla-ldap/biped@mozilla.com', "biped@mozilla.com", False),  # ldap clientId
+     ('meh/duderino', None, True),  # invalid clientId, exception
+     ('email/', None, True),  # invalid clientId, exception
+     ('email/mozilla-ldap/foo@bar.com', None, True),  # invalid clientId, exception
+     ('email/foo@bar.com <fakeness>', None, True),  # invalid clientId, exception
+     ('meh/email/duderino@dude.net', None, True),  # invalid clientId, exception
+     ])
+def test_extract_email_from_clientid(client_id, exp_email, exp_exception):
     tca = TaskclusterAuthBackend()
     if exp_exception:
-        with pytest.raises(TaskclusterAuthenticationFailed):
-            tca._get_email(result)
+        with pytest.raises(NoEmailException):
+            tca._extract_email_from_clientid(client_id)
     else:
-        email = tca._get_email(result)
+        email = tca._extract_email_from_clientid(client_id)
         assert email == exp_email
 
 
 @pytest.mark.django_db
-def test_create_missing_user(monkeypatch):
+@pytest.mark.parametrize(
+    ('result', 'exp_username', 'email', 'exp_create_user'),
+    [({'status': 'auth-success',
+       'scopes': [],
+       'clientId': 'email/user@foo.com'},
+      'email/user@foo.com',
+      'user@foo.com',
+      True),
+     ({'status': 'auth-success',
+       'scopes': [],
+       'clientId': 'email/emailaddressexceeding30chars@foo.com'},
+      'email/emailaddressexceeding30chars@foo.com',
+      'emailaddressexceeding30chars@foo.com',
+      True),
+     ({'status': 'auth-success',
+       'scopes': ["assume:mozilla-user:foo@bar.net"],
+       'clientId': 'email/foo@bar.net'},
+      'email/foo@bar.net',
+      'foo@bar.net',
+      False),
+     ])
+def test_existing_email_create_user(test_user, monkeypatch, result,
+                                    exp_username, email, exp_create_user):
+    """
+    Test whether a user was created or not, despite an existing user with
+    a matching email.
 
+    If they log in with LDAP, and have the scope of mozilla-user, then we will
+    match to an existing user and migrate their ``username``.  But if they log
+    in with email only, then only return an existing user on an exact
+    ``username`` == ``clientId``.  Otherwise, create a new user with that
+    username.
+    """
     def authenticateHawk_mock(selfless, obj):
-        return {'status': 'auth-success',
-                'scopes': ['assume:mozilla-user:biped@mozilla.com',
-                           'assume:project:treeherder:*'],
-                'clientId': 'mozilla-ldap/biped@mozilla.com'}
-
+        return result
     monkeypatch.setattr(Auth, "authenticateHawk", authenticateHawk_mock)
+
+    existing_user = User.objects.create(username="mee", email=email)
+
     tca = TaskclusterAuthBackend()
     new_user = tca.authenticate(auth_header="meh", host="fleh", port=3)
-    assert new_user.email == "biped@mozilla.com"
+    assert new_user.username == exp_username
+    if exp_create_user:
+        assert new_user.id != existing_user.id
+    else:
+        assert new_user.id == existing_user.id

--- a/tests/auth/test_backends.py
+++ b/tests/auth/test_backends.py
@@ -34,16 +34,16 @@ def test_get_user(username, email, user, exp_exception):
                            False),
                           ({'scopes': ['assume:mozillians-user:biped'],
                             'clientId': 'mozilla-ldap/biped@mozilla.com'},
-                           None,
-                           True),
-                          # typical mozillians account logged in with Auth0
+                           "biped@mozilla.com",
+                           False),
+                          # a Mozillians account without email in clientId
                           ({'scopes': ["assume:mozillians-user:dude",
                                        "assume:mozillians-unvouched",
                                        "auth:create-client:email/dude@lebowski.rug/*",
                                        "auth:delete-client:email/dude@lebowski.rug/*",
                                        "auth:update-client:email/dude@lebowski.rug/*",
                                        "auth:reset-access-token:email/dude@lebowski.rug/*"],
-                            'clientId': 'email/dude@lebowski.rug'},
+                            'clientId': 'email/duderino'},
                            None,
                            True),
                           ])

--- a/tests/webapp/api/test_auth.py
+++ b/tests/webapp/api/test_auth.py
@@ -1,3 +1,4 @@
+import pytest
 from django.contrib.sessions.models import Session
 from django.core.urlresolvers import reverse
 from mohawk import Sender
@@ -103,11 +104,11 @@ def test_post_no_auth():
 
 # TC Auth Login and Logout Tests
 
-def test_login_and_logout(test_user, webapp, monkeypatch):
-
+def test_ldap_login_and_logout(test_user, webapp, monkeypatch):
+    """LDAP login user exists, has scope: find by email"""
     def mock_auth(selfless, payload):
         return {"status": "auth-success",
-                "clientId": "foo",
+                "clientId": "mozilla-ldap/user@foo.com",
                 "scopes": ["assume:mozilla-user:user@foo.com"]
                 }
     monkeypatch.setattr(Auth, 'authenticateHawk', mock_auth)
@@ -119,16 +120,108 @@ def test_login_and_logout(test_user, webapp, monkeypatch):
     session = Session.objects.get(session_key=session_key)
     session_data = session.get_decoded()
     user = User.objects.get(id=session_data.get('_auth_user_id'))
-    assert user == test_user
+    assert user.id == test_user.id
 
     webapp.get(reverse("auth-logout"), status=200)
     assert "sessionid" not in webapp.cookies
 
 
-def test_login_not_active(test_user, webapp, monkeypatch):
+def test_ldap_login_no_mozilla_user_scope(test_user, webapp, monkeypatch):
+    """
+    LDAP login, user exists, no scope: find by username.
+    also covers logging in by email
+    """
+    client_id = "mozilla-ldap/test@foo.com"
+    existing_user = User.objects.create(username=client_id, email="test@foo.com")
+
     def mock_auth(selfless, payload):
         return {"status": "auth-success",
-                "clientId": "foo",
+                "clientId": client_id,
+                "scopes": []
+                }
+    monkeypatch.setattr(Auth, 'authenticateHawk', mock_auth)
+
+    webapp.get(reverse("auth-login"), headers={"tcauth": "foo"}, status=200)
+
+    session_key = webapp.cookies["sessionid"]
+    session = Session.objects.get(session_key=session_key)
+    session_data = session.get_decoded()
+    user = User.objects.get(id=session_data.get('_auth_user_id'))
+    assert user.id == existing_user.id
+    assert user.username == client_id
+
+
+def test_ldap_login_no_mozilla_user_scope_create(test_user, webapp, monkeypatch):
+    """
+    LDAP login, user exists, no scope: find by username.
+    create because no username match
+    """
+    client_id = "mozilla-ldap/user@foo.com"
+
+    def mock_auth(selfless, payload):
+        return {"status": "auth-success",
+                "clientId": client_id,
+                "scopes": []
+                }
+    monkeypatch.setattr(Auth, 'authenticateHawk', mock_auth)
+
+    webapp.get(reverse("auth-login"), headers={"tcauth": "foo"}, status=200)
+
+    session_key = webapp.cookies["sessionid"]
+    session = Session.objects.get(session_key=session_key)
+    session_data = session.get_decoded()
+    user = User.objects.get(id=session_data.get('_auth_user_id'))
+    assert user.id != test_user.id
+    assert user.username == client_id
+
+
+@pytest.mark.django_db
+def test_login_email_user_doesnt_exist(test_user, webapp, monkeypatch):
+    """email login, user doesn't exist, create it"""
+    def mock_auth(selfless, payload):
+        return {"status": "auth-success",
+                "clientId": "email/user@foo.com",
+                "scopes": []
+                }
+    monkeypatch.setattr(Auth, 'authenticateHawk', mock_auth)
+
+    resp = webapp.get(reverse("auth-login"), headers={"tcauth": "foo"})
+    assert resp.json["username"] == "email/user@foo.com"
+
+
+@pytest.mark.django_db
+def test_login_no_email(test_user, webapp, monkeypatch):
+    """
+    When we move to clientId for display in the UI, we may decide users can
+    login without an email.  But for now, it's required.
+
+    Note: Need to have the ``test_user`` fixture in this test, even though we
+    don't use it directly.  If you don't, you will get a
+    TransactionManagementError.
+
+    I am MOSTLY certain this error happens because the model backend tries
+    to authenticate the user, but there are NO users at all, so it hits an
+    exception, which causes the TaskclusterAuthBackend to also fail because the
+    transaction has been compromised.
+
+    """
+    def mock_auth(selfless, payload):
+        return {"status": "auth-success",
+                "clientId": "foo/bar",
+                "scopes": ["assume:mozilla-user:meh"]
+                }
+    monkeypatch.setattr(Auth, 'authenticateHawk', mock_auth)
+
+    resp = webapp.get(reverse("auth-login"), headers={"tcauth": "foo"}, status=403)
+    assert resp.json["detail"] == "No email found in clientId: 'foo/bar'"
+
+
+@pytest.mark.django_db
+def test_login_not_active(test_user, webapp, monkeypatch):
+    """LDAP login, user not active"""
+    def mock_auth(selfless, payload):
+        return {"status": "auth-success",
+                "clientId": "email/user@foo.com",
                 "scopes": ["assume:mozilla-user:user@foo.com"]
                 }
     monkeypatch.setattr(Auth, 'authenticateHawk', mock_auth)
@@ -138,18 +231,6 @@ def test_login_not_active(test_user, webapp, monkeypatch):
 
     resp = webapp.get(reverse("auth-login"), headers={"tcauth": "foo"}, status=403)
     assert resp.json["detail"] == "This user has been disabled."
-
-
-def test_login_no_email(webapp, monkeypatch):
-    def mock_auth(selfless, payload):
-        return {"status": "auth-success",
-                "clientId": "foo",
-                "scopes": ["assume:mozilla-user:meh"]
-                }
-    monkeypatch.setattr(Auth, 'authenticateHawk', mock_auth)
-
-    resp = webapp.get(reverse("auth-login"), headers={"tcauth": "foo"}, status=403)
-    assert resp.json["detail"] == "Invalid email for clientId: 'foo'. Invalid value for scope 'assume:mozilla-user': 'meh'"
 
 
 def test_login_invalid(webapp, monkeypatch):

--- a/treeherder/auth/backends.py
+++ b/treeherder/auth/backends.py
@@ -50,12 +50,22 @@ class TaskclusterAuthBackend(object):
         For more info on scopes:
         https://docs.taskcluster.net/manual/3rdparty#authenticating-with-scopes
         """
+        # Try finding the email in the mozilla-user scope
         email = self._get_scope_value(result["scopes"], "assume:mozilla-user:")
 
         if email and re.search(r'.+@.+', email):
             return email
+        else:
+            # Try finding the email in the clientId.
+            match = re.search(
+                r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)",
+                result["clientId"])
+            if match:
+                return match.group(0)
+
+        # If we get here, we couldn't find a valid email.  So deny login.
         raise TaskclusterAuthenticationFailed(
-            "Invalid email for clientId: '{}'. Invalid value for scope 'assume:mozilla-user': '{}'".format(
+            "Unable to determine email for clientId: '{}'. Scope 'assume:mozilla-user': '{}'".format(
                 result["clientId"], email))
 
     def _get_user(self, email):

--- a/treeherder/auth/backends.py
+++ b/treeherder/auth/backends.py
@@ -1,5 +1,3 @@
-import base64
-import hashlib
 import logging
 import re
 
@@ -7,6 +5,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.reverse import reverse
 from taskcluster.sync import Auth
+from taskcluster.utils import scope_match
 
 try:
     from django.utils.encoding import smart_bytes
@@ -37,58 +36,50 @@ class TaskclusterAuthBackend(object):
          'expires': '2016-10-31T17:40:45.692Z'}
     """
 
-    def _get_scope_value(self, scopes, scope_prefix):
-        for scope in scopes:
-            if scope.startswith(scope_prefix):
-                return scope[len(scope_prefix):]
-        return None
-
-    def _get_email(self, result):
+    def _extract_email_from_clientid(self, client_id):
         """
-        Get the user's email from the mozilla-user scope
+        Extract the user's email from the client_id
 
-        For more info on scopes:
-        https://docs.taskcluster.net/manual/3rdparty#authenticating-with-scopes
+        The client_id MUST be in the form:
+            "email/<username>@<domain>"
+              or
+            "mozilla-ldap/<username>@<domain>"
         """
-        # Try finding the email in the mozilla-user scope
-        email = self._get_scope_value(result["scopes"], "assume:mozilla-user:")
 
-        if email and re.search(r'.+@.+', email):
-            return email
-        else:
-            # Try finding the email in the clientId.
+        if client_id.startswith("email/") or client_id.startswith("mozilla-ldap/"):
+            email = client_id.split("/", 1)[1]
+            # ensure what we find after the split is a valid email and ONLY
+            # a valid email
             match = re.search(
-                r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)",
-                result["clientId"])
+                r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)",
+                email)
             if match:
                 return match.group(0)
+        raise NoEmailException("No email found in clientId: '{}'".format(client_id))
 
-        # If we get here, we couldn't find a valid email.  So deny login.
-        raise TaskclusterAuthenticationFailed(
-            "Unable to determine email for clientId: '{}'. Scope 'assume:mozilla-user': '{}'".format(
-                result["clientId"], email))
-
-    def _get_user(self, email):
+    def _find_user_by_email(self, email, username, scopes):
         """
-        Try to find an exising user that matches the email.
-
-        TODO: Switch to using ``username`` instead of email once we are on
-        Django 1.10 in Bug 1311967.  will need to migrate existing hashed
-        usenames at that point.
-
+        Try to find an existing user that matches the email.
         """
 
-        # Since there is a unique index on username, but not on email,
-        # it is POSSIBLE there could be two users with the same email and
-        # different usernames.  Not very likely, but this is safer.
-        user = User.objects.filter(email=email)
+        if scope_match(scopes, [["assume:mozilla-user:{}".format(email)]]):
+            # Find the user by their email.
 
-        # if we didn't find any, then raise an exception so we create a new
-        # user
-        if not user:
-            raise ObjectDoesNotExist
+            # Since there is a unique index on username, but not on email,
+            # it is POSSIBLE there could be two users with the same email and
+            # different usernames.  Not very likely, but this is safer.
+            users = User.objects.filter(email=email)
 
-        return user.first()
+            # update the username
+            if users:
+                user = users.first()
+                user.username = username
+                user.save()
+                return user
+
+        # if we didn't find any, or the user doesn't have the proper scope,
+        # then raise an exception so we create a new user
+        raise ObjectDoesNotExist
 
     def authenticate(self, auth_header=None, host=None, port=None):
         if not auth_header:
@@ -109,32 +100,30 @@ class TaskclusterAuthBackend(object):
 
         if result["status"] != "auth-success":
             logger.warning("Error logging in: {}".format(result["message"]))
-            raise TaskclusterAuthenticationFailed(result["message"])
+            raise TaskclusterAuthException(result["message"])
 
-        # TODO: remove this size limit when we upgrade to django 1.10
-        # in Bug 1311967
-        email = self._get_email(result)
-        if len(email) <= 30:
-            username = email
-        else:
-            username = base64.urlsafe_b64encode(
-                hashlib.sha1(smart_bytes(email)).digest()
-                ).rstrip(b'=')[-30:]
+        client_id = result["clientId"]
+        email = self._extract_email_from_clientid(client_id)
 
+        # Look for an existing user in this order:
+        #
+        # 1. Matching username/clientId
+        # 2. Matching email.
+        # Otherwise, create it, as long as it has an email.
         try:
-            # Find the user by their email.
-            user = self._get_user(email)
-            user.username = username
+            return User.objects.get(username=client_id)
 
         except ObjectDoesNotExist:
-            # the user doesn't already exist, create it.
-            logger.warning("Creating new user: {}".format(username))
-            user = User(email=email,
-                        username=username,
-                        )
+            try:
+                # TODO: remove this once all users are converted to clientId
+                # as username.
+                return self._find_user_by_email(email, client_id, result["scopes"])
 
-        user.save()
-        return user
+            except ObjectDoesNotExist:
+                # the user doesn't already exist, create it.
+                logger.warning("Creating new user: {}".format(client_id))
+                return User.objects.create(email=email,
+                                           username=client_id)
 
     def get_user(self, user_id):
         try:
@@ -143,5 +132,9 @@ class TaskclusterAuthBackend(object):
             return None
 
 
-class TaskclusterAuthenticationFailed(Exception):
+class TaskclusterAuthException(Exception):
+    pass
+
+
+class NoEmailException(Exception):
     pass

--- a/treeherder/auth/backends.py
+++ b/treeherder/auth/backends.py
@@ -116,7 +116,7 @@ class TaskclusterAuthBackend(object):
         except ObjectDoesNotExist:
             try:
                 # TODO: remove this once all users are converted to clientId
-                # as username.
+                # as username.  Bug 1337987.
                 return self._find_user_by_email(email, client_id, result["scopes"])
 
             except ObjectDoesNotExist:


### PR DESCRIPTION
This allows users to use the Taskcluster Auth "Sign-in with Email" option.  If an email isn't found in the user's scope of "mozilla-user" then it will attempt to find an email in the ``clientId`` value of the result.  If it can't be found there, then deny login as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2011)
<!-- Reviewable:end -->
