### PR TITLE
Bug 1246196 - Speed up loading similar jobs

### DIFF
--- a/treeherder/model/migrations/0044_add_similar_job_indexes.py
+++ b/treeherder/model/migrations/0044_add_similar_job_indexes.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('model', '0043_bugscache_cleanup'),
+    ]
+
+    operations = [
+        migrations.AlterIndexTogether(
+            name='job',
+            index_together=set([('repository', 'option_collection_hash', 'job_type', 'start_time'), ('repository', 'job_type', 'start_time'), ('repository', 'build_platform', 'option_collection_hash', 'job_type', 'start_time'), ('repository', 'build_platform', 'job_type', 'start_time')]),
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -739,6 +739,15 @@ class Job(models.Model):
     class Meta:
         db_table = 'job'
         unique_together = ('repository', 'project_specific_id')
+        index_together = [
+            # these speed up the various permutations of the "similar jobs"
+            # queries
+            ('repository', 'job_type', 'start_time'),
+            ('repository', 'build_platform', 'job_type', 'start_time'),
+            ('repository', 'option_collection_hash', 'job_type', 'start_time'),
+            ('repository', 'build_platform', 'option_collection_hash',
+             'job_type', 'start_time'),
+        ]
 
     def __str__(self):
         return "{0} {1} {2} {3}".format(self.id, self.repository, self.guid,

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -563,11 +563,10 @@ class JobsViewSet(viewsets.ViewSet):
                              job_type_id=job.job_type_id,
                              repository=repository).exclude(
                                  id=job.id).select_related(
-                                     *self._default_select_related +
-                                     ['push__time'])).qs
+                                     *self._default_select_related)).qs
 
         # similar jobs we want in descending order from most recent
-        jobs = jobs.order_by('-push__time')
+        jobs = jobs.order_by('-start_time')
 
         response_body = self._get_job_list_response(jobs, offset, count,
                                                     return_type)


### PR DESCRIPTION
* Instead of ordering by push time (which is a foreign key), order by job
start time.
* Add composite indexes to speed up the query

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2015)
<!-- Reviewable:end -->
