### PR TITLE
Bug 1321895 - Fix exception when cancelling a job

### DIFF
--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -261,7 +261,8 @@ class JobsModel(TreeherderModelBase):
 
         # Notify the build systems which created these jobs...
         for job in Job.objects.filter(push_id=push_id).exclude(state='completed'):
-            self._job_action_event(job.id, 'cancel', requester)
+            self._job_action_event(job.project_specific_id, 'cancel',
+                                   requester)
 
         # Mark pending jobs as cancelled to work around buildbot not including
         # cancelled jobs in builds-4hr if they never started running.


### PR DESCRIPTION
We still need to pass in old-style job id's for this, until the supporting
code is rewritten.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2016)
<!-- Reviewable:end -->
