### PR TITLE
Bug 1321910 - Fix backfill title console error on page load

### DIFF
--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -390,6 +390,12 @@ treeherder.controller('PluginCtrl', [
         $scope.backfillButtonTitle = function() {
             var title = "";
 
+            // Ensure currentRepo is available on initial page load
+            if (!$scope.currentRepo) {
+                // still loading
+                return undefined;
+            }
+
             if (!$scope.user.loggedin) {
                 title = title.concat("must be logged in to backfill a job / ");
             }


### PR DESCRIPTION
This tweak hopefully fixes Bugzilla bug [1321910](https://bugzilla.mozilla.org/show_bug.cgi?id=1321910).

I believe `backfillButtonTitle()` asks for the `$scope.currentRepo` object in the markup before it's defined during page load. So we'll declare them first in the function, and let Treeherder reset it again during the rest of the load process.

I think this will quiet down the console errors which were occurring. Perhaps there is a better or more economical way to do it. I'll dig around but leave this up for a review in the meantime.

Tested on OSX 10.11.5:
Nightly **53.0a1 (2016-12-02) (64-bit)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2018)
<!-- Reviewable:end -->
