### PR TITLE
Bug 1321920 - Switch the revision checker failure case from log() to debug()

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -73,7 +73,7 @@ treeherderApp.controller('MainCtrl', [
                 });
             }, revisionPollInterval);
         }, function(reason) {
-            $log.log(reason);
+            $log.debug(reason);
         });
 
         $rootScope.getWindowTitle = function() {


### PR DESCRIPTION
I think this should remove the spam when running locally. Unsure if I even need this, we could probably do nothing in the failure case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2019)
<!-- Reviewable:end -->
