### PR TITLE
Bug 1322158 - Slide info panel onscreen during initial job selection

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -11,6 +11,15 @@ div#info-panel {
   flex-flow: column;
 }
 
+.info-panel-slide {
+  animation: info-panel-slide 0.4s;
+}
+
+@keyframes info-panel-slide {
+  0% { transform: translateY(100%); }
+  100% { transform: translateY(0%); }
+}
+
 div#info-panel .navbar {
   border-radius: 0px;
   border-style: solid;

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -523,6 +523,7 @@ treeherder.controller('PluginCtrl', [
 
         var selectJobAndRender = function(job) {
             $scope.jobLoadedPromise = selectJob(job);
+            $('#info-panel').addClass('info-panel-slide');
             $scope.jobLoadedPromise.then(function() {
                 thTabs.showTab(thTabs.selectedTab, job.id);
             });


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1322158](https://bugzilla.mozilla.org/show_bug.cgi?id=1322158).

This improves the UX of the info panel during initial job selection, by sliding onscreen, rather than it just popping onscreen as it currently does. Doing so:

* reduces the current jarring UX where it just appears
* provides more clarity it sits atop the job tables
* provides an additional visual cue it's movable and can be adjusted

Everything seems fine in local testing so far: `esc` to clear the selection, re-selection, page re-load with a job selected, pinboard open and closed, info panel resized and reopened. We still preserve the current 35% height for the panel.

Tested on OSX 10.11.5:
Nightly **53.0a1 (2016-12-02) (64-bit)**
Chrome Release **54.0.2840.98 (64-bit)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2020)
<!-- Reviewable:end -->
