### PR TITLE
Bug 1323559 - Travis: Switch to the newer Ubuntu Trusty images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 env:
   global:
     # Ensure the vendored libmysqlclient library can be found at run-time.
@@ -56,7 +57,6 @@ matrix:
     - env: python-tests-main
       # TODO: Investigate switching back to the container infra, by setting `sudo: false`.
       sudo: required
-      dist: trusty
       language: python
       python: "2.7.12"
       cache:
@@ -96,7 +96,6 @@ matrix:
     - env: python-tests-e2e-etl-logparser
       # TODO: Investigate switching back to the container infra, by setting `sudo: false`.
       sudo: required
-      dist: trusty
       language: python
       python: "2.7.12"
       cache:
@@ -126,7 +125,6 @@ matrix:
     - env: python-tests-webapp
       # TODO: Investigate switching back to the container infra, by setting `sudo: false`.
       sudo: required
-      dist: trusty
       language: python
       python: "2.7.12"
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,6 @@ matrix:
       before_install:
         - curl -sSo ~/elasticsearch.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.5/elasticsearch-2.3.5.deb && sudo dpkg -i ~/elasticsearch.deb
         - sudo service elasticsearch start
-        - while ! curl localhost:9200 &>/dev/null; do sleep 1; done
         - sudo cp puppet/files/mysql/my.cnf /etc/mysql/conf.d/treeherder.cnf
         - sudo service mysql restart
         # Create a clean virtualenv rather than using the one given to us,
@@ -80,6 +79,8 @@ matrix:
         - mysql -u root -e 'create database test_treeherder;'
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
+      before_script:
+        - while ! curl localhost:9200 &>/dev/null; do sleep 1; done
       script:
         # Several security features in settings.py (eg setting HSTS headers) are conditional on
         # 'https://' being in the site URL. In addition, we override the test environment's debug
@@ -105,7 +106,6 @@ matrix:
       before_install:
         - curl -sSo ~/elasticsearch.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.5/elasticsearch-2.3.5.deb && sudo dpkg -i ~/elasticsearch.deb
         - sudo service elasticsearch start
-        - while ! curl localhost:9200 &>/dev/null; do sleep 1; done
         - sudo cp puppet/files/mysql/my.cnf /etc/mysql/conf.d/treeherder.cnf
         - sudo service mysql restart
         # Create a clean virtualenv rather than using the one given to us,
@@ -116,6 +116,8 @@ matrix:
         - ./bin/vendor-libmysqlclient.sh ~/venv
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
+      before_script:
+        - while ! curl localhost:9200 &>/dev/null; do sleep 1; done
       script:
         - py.test tests/e2e/ tests/etl/ tests/log_parser/ --runslow
 
@@ -133,7 +135,6 @@ matrix:
       before_install:
         - curl -sSo ~/elasticsearch.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.5/elasticsearch-2.3.5.deb && sudo dpkg -i ~/elasticsearch.deb
         - sudo service elasticsearch start
-        - while ! curl localhost:9200 &>/dev/null; do sleep 1; done
         - sudo cp puppet/files/mysql/my.cnf /etc/mysql/conf.d/treeherder.cnf
         - sudo service mysql restart
         # Create a clean virtualenv rather than using the one given to us,
@@ -144,6 +145,8 @@ matrix:
         - ./bin/vendor-libmysqlclient.sh ~/venv
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
+      before_script:
+        - while ! curl localhost:9200 &>/dev/null; do sleep 1; done
       script:
         - py.test tests/webapp/ --runslow
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-group: deprecated # work around travis issue with trusty image https://github.com/travis-ci/travis-ci/issues/6928
 env:
   global:
     # Ensure the vendored libmysqlclient library can be found at run-time.
@@ -55,8 +54,7 @@ matrix:
 
     # Job 3: Python Tests Chunk A
     - env: python-tests-main
-      # Once mysql 5.6 is available on the container infra, we should switch back
-      # to it for its faster boot time, by setting `sudo: false`.
+      # TODO: Investigate switching back to the container infra, by setting `sudo: false`.
       sudo: required
       dist: trusty
       language: python
@@ -64,13 +62,6 @@ matrix:
       cache:
         directories:
           - ~/venv
-      addons:
-        apt:
-          packages:
-            # Install mysql 5.6 since the default is v5.5.
-            - mysql-server-5.6
-            - mysql-client-core-5.6
-            - mysql-client-5.6
       services:
         - rabbitmq
         - memcached
@@ -103,8 +94,7 @@ matrix:
 
     # Job 4: Python Tests Chunk B
     - env: python-tests-e2e-etl-logparser
-      # Once mysql 5.6 is available on the container infra, we should switch back
-      # to it for its faster boot time, by setting `sudo: false`.
+      # TODO: Investigate switching back to the container infra, by setting `sudo: false`.
       sudo: required
       dist: trusty
       language: python
@@ -112,13 +102,6 @@ matrix:
       cache:
         directories:
           - ~/venv
-      addons:
-        apt:
-          packages:
-            # Install mysql 5.6 since the default is v5.5.
-            - mysql-server-5.6
-            - mysql-client-core-5.6
-            - mysql-client-5.6
       services:
         - rabbitmq
         - memcached
@@ -141,8 +124,7 @@ matrix:
 
     # Job 5: Python Tests Chunk C
     - env: python-tests-webapp
-      # Once mysql 5.6 is available on the container infra, we should switch back
-      # to it for its faster boot time, by setting `sudo: false`.
+      # TODO: Investigate switching back to the container infra, by setting `sudo: false`.
       sudo: required
       dist: trusty
       language: python
@@ -150,13 +132,6 @@ matrix:
       cache:
         directories:
           - ~/venv
-      addons:
-        apt:
-          packages:
-            # Install mysql 5.6 since the default is v5.5.
-            - mysql-server-5.6
-            - mysql-client-core-5.6
-            - mysql-client-5.6
       services:
         - rabbitmq
         - memcached

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,6 @@ matrix:
           - ~/venv
       services:
         - rabbitmq
-        - memcached
       before_install:
         - curl -sSo ~/elasticsearch.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.5/elasticsearch-2.3.5.deb && sudo dpkg -i ~/elasticsearch.deb
         - sudo service elasticsearch start
@@ -103,7 +102,6 @@ matrix:
           - ~/venv
       services:
         - rabbitmq
-        - memcached
       before_install:
         - curl -sSo ~/elasticsearch.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.5/elasticsearch-2.3.5.deb && sudo dpkg -i ~/elasticsearch.deb
         - sudo service elasticsearch start
@@ -132,7 +130,6 @@ matrix:
           - ~/venv
       services:
         - rabbitmq
-        - memcached
       before_install:
         - curl -sSo ~/elasticsearch.deb https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.5/elasticsearch-2.3.5.deb && sudo dpkg -i ~/elasticsearch.deb
         - sudo service elasticsearch start


### PR DESCRIPTION
**1) Switch to the newer sudo-enabled image**
The image has received several updates, including now defaulting to mysql-server 5.6:
https://docs.travis-ci.com/user/build-environment-updates/2016-12-01/
...which means we can skip the 20-25s install of mysql-server-5.6.

The issue with Java on the newer image has now been fixed, so we no longer need to remain on the older (`group: deprecated`) release.

**2) Switch the container builds to the new Trusty beta**
Travis have just announced a beta for container-based Ubuntu Trusty builds:
https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/

This means the linter runs can now run on the same version of Ubuntu used by the other tests and production. This also reduces runtime since Travis can skip the glibc patching step required on the older image.

**3) Don't try to start memcached since already running**
The service is running by default, so no need to get Travis to start it, particularly since Travis adds a `sleep` between each service:
https://github.com/travis-ci/travis-build/blob/00982bc7404175a5ae500c5ba6651527515d4d40/lib/travis/build/appliances/services.rb#L30

**4) Move the Elasticsearch readiness check later**
The Elasticsearch background process takes up to 8 seconds to start but isn't required until the tests run, so needn't block the other setup tasks from running in parallel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2026)
<!-- Reviewable:end -->
