### PR TITLE
Bug 1075222 - Don't allow orphan parens on new job rows

### DIFF
--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -5,6 +5,7 @@
 .job-group {
   margin: 0 -3px 0 3px;
   cursor: default;
+  display: inline-block;
 }
 
 .job-btn {
@@ -58,7 +59,7 @@
   content: "(";
 }
 
-.group-content::after {
+.group-content:last-child::after {
   content: ")";
 }
 


### PR DESCRIPTION
This doesn't just prevent parens but also keeps job groups together on a line.  It doesn't appear to have much effect on the overall vertical whitespace so seems like a tidy solution to me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2037)
<!-- Reviewable:end -->
