### PR TITLE
Bug 1081074 - Add "Set as Default" item to repo info dropdown

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -577,6 +577,7 @@ treeherderApp.controller('MainCtrl', [
             if (!defaulting && $scope.cachedReloadTriggerParams &&
                 !_.isEqual(newReloadTriggerParams, $scope.cachedReloadTriggerParams) &&
                 !$rootScope.skipNextPageReload) {
+                localStorage.setItem("defaultRepo", newReloadTriggerParams.repo);
 
                 $window.location.reload();
             } else {
@@ -648,4 +649,3 @@ treeherderApp.controller('MainCtrl', [
         };
     }
 ]);
-

--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -109,7 +109,7 @@ treeherder.value("thRepoGroupOrder", {
     "qa automation tests": 6
 });
 
-treeherder.value("thDefaultRepo", "mozilla-inbound");
+treeherder.value("thDefaultRepo", localStorage.getItem("defaultRepo") || "mozilla-inbound");
 
 treeherder.value("thDateFormat", "EEE MMM d, H:mm:ss");
 


### PR DESCRIPTION
<img width="507" alt="setasdefault" src="https://cloud.githubusercontent.com/assets/46655/21405169/50e90f36-c78a-11e6-81ae-d64b801588e4.png">

I see we have `localStorageService` in a few places but I don't see how it's available in `values.js`-- possible I could get some advice here?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2038)
<!-- Reviewable:end -->
