### PR TITLE
Bug 1242905 - Fix watch depth in react revisions

### DIFF
--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -457,7 +457,7 @@ treeherder.directive('thCloneJobs', [
                 var ulEl = element.find('.revision-list');
 
                 _.extend(scope, { repo: $rootScope.currentRepo });
-                var revisionList = $compile('<revisions resultset="resultset" repo="repo"></revisions>')(scope);
+                var revisionList = $compile('<revisions watch-depth="reference" resultset="resultset" repo="repo"></revisions>')(scope);
                 $(ulEl).replaceWith(revisionList);
 
             }


### PR DESCRIPTION
By default, ngReact watches component props using an expensive deep
$watch. This made the revision list react components noticeably slow
down the UI when clicking a job button. This commit changes the watch
depth for the revision list components to lighten the load.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2041)
<!-- Reviewable:end -->
