### PR TITLE
Bug 1324707 - Update django-rest-framework and friends for Django 1.10 compatibility

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -35,7 +35,7 @@ jsonschema==2.5.1 --hash=sha256:71e7b3bcf9fca408bcb65bb60892f375d3abdd2e4f296eee
 
 djangorestframework==3.5.3 --hash=sha256:f446041a944723e14502a0a5880d0bc74a499ac1075781177f2fa6d7fe7b415d
 
-django-rest-swagger==0.3.10 --hash=sha256:3dd8d3bd23ba2a04b9208f2b52ba4c9854c2a9f07aba29df19f40f514ea612e9
+django-rest-swagger==2.1.0 --hash=sha256:70f681bcccc75f5095104973e7ab47af3a979110202593c28c937f6dd6a04100
 
 django-cors-headers==1.2.2 --hash=sha256:c4ef22ce8734bb88cee381dcbb04dcca05bcdaffb09367a504bd388d2a6872aa
 
@@ -52,10 +52,12 @@ https://github.com/jeads/datasource/archive/v0.11.0.tar.gz#egg=datasource==0.11.
 functools32==3.2.3-2 --hash=sha256:89d824aa6c358c421a234d7f9ee0bd75933a67c29588ce50aaa3acdf4d403fa0
 
 # Required by django-rest-swagger
-Unipath==1.1 --hash=sha256:e6257e508d8abbfb6ddd8ec357e33589f1f48b1599127f23b017124d90b0fff7
+coreapi==2.1.1 --hash=sha256:59acf691c93ee267e9f60e75a0118d29ad46f30e779eadd6780bd61a0185091b
+openapi-codec==1.2.1 --hash=sha256:d8a04fe409ddf1bd58e27e247390dd3ac4090dbfd1eb63e7afa9c990feb86692
 
-# Required by django-rest-swagger
-PyYAML==3.12 --hash=sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab
+# Required by coreapi
+itypes==1.1.0 --hash=sha256:c6e77bb9fd68a4bfeb9d958fea421802282451a25bac4913ec94db82a899c073
+uritemplate==3.0.0 --hash=sha256:1b9c467a940ce9fb9f50df819e8ddd14696f89b9a8cc87ac77952ba416e0a8fd
 
 requests==2.11.1 --hash=sha256:545c4855cd9d7c12671444326337013766f4eea6068c3f0307fb2dc2696d580e
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -33,7 +33,7 @@ blessings==1.6 --hash=sha256:edc5713061f10966048bf6b40d9a514b381e0ba849c64e034c4
 
 jsonschema==2.5.1 --hash=sha256:71e7b3bcf9fca408bcb65bb60892f375d3abdd2e4f296eeeb8fe0bbbfcde598e
 
-djangorestframework==3.3.3 --hash=sha256:4f47056ad798103fc9fb049dff8a67a91963bd215d31bad12ad72b891559ab16
+djangorestframework==3.5.3 --hash=sha256:f446041a944723e14502a0a5880d0bc74a499ac1075781177f2fa6d7fe7b415d
 
 django-rest-swagger==0.3.10 --hash=sha256:3dd8d3bd23ba2a04b9208f2b52ba4c9854c2a9f07aba29df19f40f514ea612e9
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -78,9 +78,10 @@ python-dateutil==2.5.3 --hash=sha256:598499a75be2e5e18a66f12c00dd47a069de24794ef
 
 requests-hawk==1.0.0 --hash=sha256:c2626ab31ebef0c81b97781c44c2275bfcc6d8e8520fc4ced495f0f386f8fe26
 
+# djangorestframework-filters doesn't yet support django-filter 1.x.
 django-filter==0.15.3 --hash=sha256:2588847e33437d467c58b4acddcda7efc156f62b7006f9f7ad7d1ae6b5cba820
 
-djangorestframework-filters==0.9.0 --hash=sha256:eddd632c31f56f0944689185ea7b00d5c073bc4f676d47acdb2d1a3ae81eeea8
+djangorestframework-filters==0.9.1 --hash=sha256:7c5acca9c6e1391c151901ce385fad8b13317fb7abd5bc6290296b793e50594f
 
 pylibmc==1.5.1 --hash=sha256:ecba261859c3e1ba3365389cb4f4dfffb7e02120a9f57a288cacf2f42c45cdd6
 

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -603,7 +603,11 @@ if env.bool('IS_HEROKU', default=False):
 
 CELERY_IGNORE_RESULT = True
 
-SWAGGER_SETTINGS = {"enabled_methods": ['get', ]}
+SWAGGER_SETTINGS = {
+    'SECURITY_DEFINITIONS': {},
+    'SUPPORTED_SUBMIT_METHODS': ['get'],
+    'USE_SESSION_AUTH': False,
+}
 
 HAWK_CREDENTIALS_LOOKUP = 'treeherder.webapp.api.auth.hawk_lookup'
 

--- a/treeherder/config/urls.py
+++ b/treeherder/config/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.conf.urls import (include,
                               url)
 from django.contrib import admin
+from rest_framework_swagger.views import get_swagger_view
 
 from treeherder.credentials.urls import urlpatterns as credentials_patterns
 from treeherder.embed import urls as embed_urls
@@ -13,7 +14,7 @@ urlpatterns = [
    url(r'^api/', include(api_urls)),
    url(r'^embed/', include(embed_urls)),
    url(r'^admin/', include(admin.site.urls)),
-   url(r'^docs/', include('rest_framework_swagger.urls')),
+   url(r'^docs/', get_swagger_view(title='Treeherder API')),
    url(r'^credentials/', include(credentials_patterns)),
 ]
 

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -39,6 +39,7 @@ class JobExclusionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.JobExclusion
+        fields = '__all__'
 
     # We need to override .create and .update because ModelSerializer raises an error
     # if it finds nested resources. A JSONField instance is either a dict or a list
@@ -59,6 +60,7 @@ class ExclusionProfileSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.ExclusionProfile
+        fields = '__all__'
 
 
 class RepositoryGroupSerializer(serializers.ModelSerializer):
@@ -73,24 +75,28 @@ class RepositorySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Repository
+        fields = '__all__'
 
 
 class ProductSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Product
+        fields = '__all__'
 
 
 class BuildPlatformSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.BuildPlatform
+        fields = '__all__'
 
 
 class MachinePlatformSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.MachinePlatform
+        fields = '__all__'
 
 
 class JobSerializer(serializers.ModelSerializer):
@@ -137,42 +143,49 @@ class JobSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Job
+        fields = '__all__'
 
 
 class JobGroupSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.JobGroup
+        fields = '__all__'
 
 
 class JobTypeSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.JobType
+        fields = '__all__'
 
 
 class MachineSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Machine
+        fields = '__all__'
 
 
 class FailureClassificationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.FailureClassification
+        fields = '__all__'
 
 
 class BugscacheSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Bugscache
+        fields = '__all__'
 
 
 class MatcherSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Matcher
+        fields = '__all__'
 
 
 class ClassifiedFailureSerializer(serializers.ModelSerializer):
@@ -227,6 +240,7 @@ class TextLogSummaryLineSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.TextLogSummaryLine
+        fields = '__all__'
 
 
 class TextLogSummarySerializer(serializers.ModelSerializer):
@@ -234,6 +248,7 @@ class TextLogSummarySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.TextLogSummary
+        fields = '__all__'
 
 
 class JobDetailSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
**1) Add an explicit `fields` option to all ModelSerializers**
Since in django-rest-framework 3.5.0+ each `ModelSerializer` must include either a `fields` option or an `exclude` option:
http://www.django-rest-framework.org/topics/3.4-announcement/#use-fields-or-exclude-on-serializer-classes

@wlach / @camd - whilst this change is a no-op compared to current behaviour, do any of these look like they should actually exclude some fields rather than returning all of them?

**2) Update djangorestframework from 3.3.3 to 3.5.3**
http://www.django-rest-framework.org/topics/3.4-announcement/
http://www.django-rest-framework.org/topics/3.5-announcement/
http://www.django-rest-framework.org/topics/release-notes/#35x-series
https://github.com/tomchristie/django-rest-framework/compare/3.3.3...3.5.3

**3) Update django-rest-swagger from 0.3.10 to 2.1.0**
http://marcgibbons.github.io/django-rest-swagger/#changes-in-20
https://github.com/marcgibbons/django-rest-swagger/blob/master/CHANGELOG.md
https://github.com/marcgibbons/django-rest-swagger/compare/0.3.10...2.1.0

Uses the new URLs setup described at:
http://marcgibbons.github.io/django-rest-swagger/#quick-start

And the new format settings dict:
http://marcgibbons.github.io/django-rest-swagger/settings/

**4) Update djangorestframework-filters from 0.9.0 to 0.9.1**
https://github.com/philipn/django-rest-framework-filters/blob/master/CHANGELOG.rst#v091
https://github.com/philipn/django-rest-framework-filters/compare/v0.9.0...v0.9.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2048)
<!-- Reviewable:end -->
