### PR TITLE
Bug 1326314 - Improve Bugzilla component suggestions for services

### DIFF
--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -319,7 +319,7 @@ treeherder.value("thBugzillaProductObject", {
     "security":
         ["Core :: Security","Firefox :: Security"],
     "services":
-        ["Core :: Web Services"],
+        ["Firefox :: Sync","Core :: FxAccounts","Cloud Services :: Firefox: Common"],
     "startupcache":
         ["Core :: XPCOM"],
     "storage":


### PR DESCRIPTION
I noticed most recent Sync intermittents ended up in "Core :: Web Services". Most of the code in `services/` is Sync and FxA, so let's suggest those for intermittent failures instead. We'll triage bugs in those components weekly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2051)
<!-- Reviewable:end -->
