### PR TITLE
Bug 1285007 - Make Taskcluster options more discoverable

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -104,6 +104,10 @@ div#info-panel .info-panel-navbar > ul.tab-headers > li {
   color: #D3D8DA;
 }
 
+.info-panel-navbar .actionbar-nav {
+  flex: auto;
+}
+
 div#info-panel .info-panel-navbar .navbar-nav > li.active a,
 div#info-panel .info-panel-navbar .navbar-nav > li.active a:hover,
 div#info-panel .info-panel-navbar .navbar-nav > li.active a:focus {

--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -99,7 +99,10 @@ div#info-panel .info-panel-navbar > ul.tab-headers > li {
 }
 
 .info-panel-navbar .navbar-nav > li > a:hover,
-.info-panel-navbar .navbar-nav > li > a:focus {
+.info-panel-navbar .navbar-nav > li > a:focus,
+.info-panel-navbar .navbar-nav > li > button:hover,
+.info-panel-navbar .navbar-nav > li > button:focus
+{
   background-color: #1E252B;
   color: #D3D8DA;
 }
@@ -164,8 +167,8 @@ div#info-panel .info-panel-navbar .navbar-nav > li.active a:focus {
  */
 
 #job-details-panel {
-  width: 252px;
-  min-width: 252px;
+  width: 260px;
+  min-width: 260px;
 }
 
 #job-details-panel .content-spacer {

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -167,6 +167,19 @@ treeherder.controller('PluginCtrl', [
                     // the second result comes from the job detail promise
                     $scope.job_details = results[1];
 
+                    // parse out some specific taskcluster options for display
+                    // in the action menu (if they exist)
+                    $scope.taskclusterOptions = [];
+                    $scope.job_details.forEach((line) => {
+                        if (line.value === "Inspect Task" ||
+                            line.value === "One Click Loaner") {
+                            $scope.taskclusterOptions.push({
+                                title: line.value,
+                                url: line.url
+                            });
+                        }
+                    });
+
                     // incorporate the buildername into the job details if this is a buildbot job
                     // (i.e. it has a buildbot request id)
                     var buildbotRequestIdDetail = _.find($scope.job_details,

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -110,17 +110,17 @@
         <ul class="nav navbar-nav navbar-right">
           <li>
             <button
-               class="dropdown-toggle icon-blue"
+               class="dropdown-toggle"
                data-toggle="dropdown">
               <span class="fa fa-ellipsis-h" aria-hidden="true"></span>
             </button>
-            <ul class="dropdown-menu">
+            <ul class="dropdown-menu actionbar-menu" role="menu">
               <li class="{{ canBackfill() ? '' : 'disabled' }}">
                 <a ng-attr-title="{{ backfillButtonTitle() }}"
                    ng-click="!canBackfill() || backfillJob()">Backfill</a>
               </li>
               <li ng-repeat="taskclusterOption in taskclusterOptions">
-                <a href="{{taskclusterOption.url}}">{{taskclusterOption.title}}</a>
+                <a target="_blank" href="{{taskclusterOption.url}}">{{taskclusterOption.title}}</a>
               </li>
             </ul>
           </li>

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -90,15 +90,6 @@
               <span class="fa fa-repeat"></span>
             </button>
           </li>
-          <li>
-            <button id="backfill-btn" href=""
-               ng-attr-title="{{backfillButtonTitle()}}"
-               ng-class="canBackfill() ? 'icon-cyan' : 'disabled'"
-               ng-disabled="!canBackfill()"
-               ng-click="backfillJob()">
-              <span class="fa fa-arrow-down"></span>
-            </button>
-          </li>
           <li ng-if="isReftest()" ng-repeat="job_log_url in job_log_urls">
             <a title="Launch the Reftest Analyser in a new window"
                target="_blank"
@@ -114,6 +105,24 @@
                ng-click="cancelJob()">
               <span class="fa fa-times-circle cancel-job-icon"></span>
             </a>
+          </li>
+        </ul>
+        <ul class="nav navbar-nav navbar-right">
+          <li>
+            <button
+               class="dropdown-toggle icon-blue"
+               data-toggle="dropdown">
+              <span class="fa fa-ellipsis-h" aria-hidden="true"></span>
+            </button>
+            <ul class="dropdown-menu">
+              <li class="{{ canBackfill() ? '' : 'disabled' }}">
+                <a ng-attr-title="{{ backfillButtonTitle() }}"
+                   ng-click="!canBackfill() || backfillJob()">Backfill</a>
+              </li>
+              <li ng-repeat="taskclusterOption in taskclusterOptions">
+                <a href="{{taskclusterOption.url}}">{{taskclusterOption.title}}</a>
+              </li>
+            </ul>
           </li>
         </ul>
       </nav>
@@ -217,10 +226,6 @@
         <li class="small" ng-if="!job_log_urls.length">
           <label>Log parsing status:</label>
           <span>No logs</span>
-        </li>
-        <li class="small" ng-repeat="line in job_details" ng-if="line.value == 'Inspect Task'">
-          <label>Taskcluster:</label>
-          <span><a href="{{line.url}}" target="_blank">{{line.value}}</a></span>
         </li>
       </ul>
 


### PR DESCRIPTION
Create an per-job "extras" job button in Treeherder and put "backfill"
and the current set of taskcluster options (one click loaner, inspect task)
in there, if they exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2052)
<!-- Reviewable:end -->
