### PR TITLE
Bug 1311967 - Update to Django 1.10

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ whitenoise==3.2.2 --hash=sha256:90a576ecb938cfef3fd1dba0c82d10e8e9ff0acb6079d7ed
 # Used by the Whitenoise CLI tool to provide Brotli-compressed versions of static files.
 Brotli==0.5.2 --hash=sha256:3411b9acd2a2056e55084acf7a6ab3e4a8540c2ef37a4435bca62644e8aaf50e
 
-Django==1.9.12 --hash=sha256:a59f85a2b007145006915f6134ec3b9c09e68e4377e0a6fd3529d6c56d6aeb04
+Django==1.10.5 --hash=sha256:4541a60834f28f308ee7b6e96400feca905fb0de473eb9dad6847e98a36d86d4
 
 celery==3.1.24 --hash=sha256:25396191954521184cc15018f776a2a2278b04dd4213d94f795daef4b7961b4b
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -47,6 +47,7 @@ def test_mysqlclient_tls_enforced():
     assert "SSL connection error" in str(e.value)
 
 
+@pytest.mark.django_db
 def test_no_missing_migrations():
     """Check no model changes have been made since the last `./manage.py makemigrations`."""
     with pytest.raises(SystemExit) as e:


### PR DESCRIPTION
Now that the Django 1.10 compatibility changes have landed via the [deps of bug 1311967](https://bugzilla.mozilla.org/showdependencytree.cgi?id=1311967&maxdepth=1&hide_resolved=0), we're ready to proceed.

**1) Mark test_no_missing_migrations as requiring DB access**
In Django 1.10 the makemigrations command now requires the database (see https://code.djangoproject.com/ticket/25850), so this test must now have the `django_db` annotation.

**2) Update Django from 1.9.12 to 1.10.5**
https://docs.djangoproject.com/en/1.10/releases/1.10/
https://docs.djangoproject.com/en/1.10/releases/1.10.1/
https://docs.djangoproject.com/en/1.10/releases/1.10.2/
https://docs.djangoproject.com/en/1.10/releases/1.10.3/
https://docs.djangoproject.com/en/1.10/releases/1.10.4/
https://docs.djangoproject.com/en/1.10/releases/1.10.5/
https://github.com/django/django/compare/1.9.12...1.10.5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2053)
<!-- Reviewable:end -->
