### PR TITLE
Bug 1328294 - Correct select_related() usage inJobDetailViewSet

### DIFF
--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -599,8 +599,7 @@ class JobDetailViewSet(viewsets.ReadOnlyModelViewSet):
     Endpoint for retrieving metadata (e.g. links to artifacts, file sizes)
     associated with a particular job
     '''
-    queryset = JobDetail.objects.all().select_related('job__guid',
-                                                      'job__repository__name')
+    queryset = JobDetail.objects.all().select_related('job', 'job__repository')
     serializer_class = serializers.JobDetailSerializer
 
     class JobDetailFilter(filters.FilterSet):


### PR DESCRIPTION
The fields listed must be relational fields - `select_related()` does not control which fields are returned, just which tables are joined.

Under Django <=1.9 any non-relational fields are ignored, however under Django 1.10 these cause errors of form:
"FieldError: Non-relational field given in select_related: 'name'. Choices are: repository_group"

This change is a no-op in terms of generated SQL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2061)
<!-- Reviewable:end -->
