### PR TITLE
Bug 1328908 - Fix postMessage error on log viewer pageload

### DIFF
--- a/ui/js/components/logviewer/logviewer.js
+++ b/ui/js/components/logviewer/logviewer.js
@@ -3,6 +3,7 @@
 treeherder.component('thLogViewer', {
     templateUrl: 'partials/logviewer/logviewer.html',
     controller: ($sce, $location, $element, $scope) => {
+        const unifiedLogviewerUrl = 'https://taskcluster.github.io/unified-logviewer/';
         const logParams = () => {
             const q = $location.search();
             let params = { lineHeight: 13 };
@@ -25,7 +26,7 @@ treeherder.component('thLogViewer', {
             const parent = $scope.$parent;
 
             if ($scope.$parent.rawLogURL) {
-                $element[0].childNodes[0].src = $sce.trustAsResourceUrl(`${parent.logBasePath}?url=${parent.rawLogURL}${logParams()}`);
+                $element[0].childNodes[0].src = $sce.trustAsResourceUrl(`${unifiedLogviewerUrl}?url=${parent.rawLogURL}${logParams()}`);
             }
         });
     }

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -13,7 +13,6 @@ logViewerApp.controller('LogviewerCtrl', [
 
         const query_string = $location.search();
         $scope.css = '';
-        $rootScope.logBasePath = 'https://taskcluster.github.io/unified-logviewer/';
         $rootScope.urlBasePath = $location.absUrl().split('logviewer')[0];
 
         if (query_string.repo !== "") {
@@ -45,7 +44,7 @@ logViewerApp.controller('LogviewerCtrl', [
             }
 
             updateQuery(values);
-            $document[0].getElementById('logview').contentWindow.postMessage(values, $rootScope.logBasePath);
+            $document[0].getElementById('logview').contentWindow.postMessage(values, "*");
         };
 
         $scope.hasFailedSteps = () => {


### PR DESCRIPTION
Fixes:
Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('https://taskcluster.github.io') does not match the recipient window's origin ('https://treeherder.mozilla.org').

We can't use the Treeherder base URL for the target origin, since otherwise once the iframe loads the target will change again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2063)
<!-- Reviewable:end -->
