### PR TITLE
Bug 1329040 - Remove dead Retrigger dropdown css

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -118,11 +118,6 @@ div#info-panel .info-panel-navbar .navbar-nav > li.active a:focus {
   color: #EEF0F2;
 }
 
-#retriggerLabel + ul.dropdown-menu > li > a:hover {
-  background-color: #f5f5f5 !important;
-  color: black !important;
-}
-
 #info-panel-content {
   position: relative; /* So we can absolutely position the loading overlay */
   height: 60%;

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -109,7 +109,8 @@
         </ul>
         <ul class="nav navbar-nav navbar-right">
           <li>
-            <button
+            <button id="actionbar-menu-btn"
+               title="Other job actions"
                class="dropdown-toggle"
                data-toggle="dropdown">
               <span class="fa fa-ellipsis-h" aria-hidden="true"></span>


### PR DESCRIPTION
This fixes Bugzilla bug [1329040](https://bugzilla.mozilla.org/show_bug.cgi?id=1329040).

This change
* removes some dead Retrigger css
* adds a unique selector id for the new Actionbar menu button for automated testing
* adds a tooltip for it so new users might be more comfortable clicking on the button

Tested on OSX 10.11.5:
Nightly **53.0a1 (2017-01-05) (64-bit)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2065)
<!-- Reviewable:end -->
