### PR TITLE
Bug 1326207 - Replace Django system check hack with --fail-level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,11 +87,7 @@ matrix:
         # Several security features in settings.py (eg setting HSTS headers) are conditional on
         # 'https://' being in the site URL. In addition, we override the test environment's debug
         # value so the tests pass. The real environment variable will be checked during deployment.
-        # Replace grep with `--fail-level WARNING` once we're using Django 1.10, since in
-        # previous versions an exit code of 1 is hard-coded to only ERROR and above:
-        # https://github.com/django/django/commit/287532588941d2941e19c4cd069bcbd8af889203
-        # The pipefail ensures exceptions during the command still cause the step to fail.
-        - set -o pipefail; SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' ./manage.py check --deploy 2>&1 | awk '/^WARNINGS/{err=1} {print} END{exit err}'
+        - SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' ./manage.py check --deploy --fail-level WARNING
         - py.test tests/ --runslow --ignore=tests/e2e/ --ignore=tests/etl/ --ignore=tests/log_parser/ --ignore=tests/webapp/
 
     # Job 4: Python Tests Chunk B

--- a/bin/pre_deploy
+++ b/bin/pre_deploy
@@ -15,10 +15,7 @@ else
 fi
 
 echo "-----> PRE-DEPLOY: Running Django system checks..."
-# Replace awk with `--fail-level WARNING` once we're using Django 1.10, since in
-# previous versions an exit code of 1 is hard-coded to only ERROR and above:
-# https://github.com/django/django/commit/287532588941d2941e19c4cd069bcbd8af889203
-./manage.py check --deploy 2>&1 | awk '/^WARNINGS/{err=1} {print} END{exit err}'
+./manage.py check --deploy --fail-level WARNING
 
 echo "-----> PRE-DEPLOY: Running Django migration..."
 newrelic-admin run-program ./manage.py migrate --noinput

--- a/runtests.sh
+++ b/runtests.sh
@@ -12,11 +12,7 @@ isort --check-only --diff --quiet \
 
 echo "Running Django system checks"
 # See .travis.yml for explanation of the environment variable overriding.
-# Replace awk with `--fail-level WARNING` once we're using Django 1.10, since in
-# previous versions an exit code of 1 is hard-coded to only ERROR and above:
-# https://github.com/django/django/commit/287532588941d2941e19c4cd069bcbd8af889203
-SITE_URL="https://treeherder.dev" TREEHERDER_DEBUG="False" ./manage.py check --deploy 2>&1 \
- | awk '/^WARNINGS/{err=1} {print} END{exit err}' || { exit 1; }
+SITE_URL="https://treeherder.dev" TREEHERDER_DEBUG="False" ./manage.py check --deploy --fail-level WARNING || { exit 1; }
 
 echo "Running Python tests"
 py.test tests/


### PR DESCRIPTION
Django 1.10 added a new `--fail-level` option that allows overriding the default of only exiting 1 for ERROR and above, avoiding the need to rely on awk hacks:
https://docs.djangoproject.com/en/1.10/ref/django-admin/#check

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2069)
<!-- Reviewable:end -->
