### PR TITLE
Bug 1328173 - Switch test_no_missing_migrations to using check_changes

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -38,12 +38,7 @@ def test_mysqlclient_tls_enforced():
 @pytest.mark.django_db
 def test_no_missing_migrations():
     """Check no model changes have been made since the last `./manage.py makemigrations`."""
-    with pytest.raises(SystemExit) as e:
-        # Replace with `check_changes=True` once we're using Django 1.10:
-        # https://code.djangoproject.com/ticket/25604
-        # https://github.com/django/django/pull/5453
-        call_command('makemigrations', interactive=False, dry_run=True, exit_code=True)
-    assert str(e.value) == '1'
+    call_command('makemigrations', interactive=False, dry_run=True, check_changes=True)
 
 
 def test_memcached_setup():


### PR DESCRIPTION
Django 1.10 added a new check changes mode to the `makemigrations` command, which we can use to avoid the hack of checking that the exit code is 1 in the passing case:
https://docs.djangoproject.com/en/1.10/ref/django-admin/#cmdoption-makemigrations-check

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2070)
<!-- Reviewable:end -->
