### PR TITLE
Bug 1330015 - Make "add additional jobs" option work again

### DIFF
--- a/tests/webapp/api/test_runnable_jobs_api.py
+++ b/tests/webapp/api/test_runnable_jobs_api.py
@@ -1,0 +1,48 @@
+from django.core.urlresolvers import reverse
+
+from treeherder.model.models import RunnableJob
+
+
+def test_runnable_jobs_api(webapp, test_job):
+    RunnableJob.objects.create(
+        build_platform=test_job.build_platform,
+        machine_platform=test_job.machine_platform,
+        job_type=test_job.job_type,
+        option_collection_hash=test_job.option_collection_hash,
+        ref_data_name=test_job.signature.name,
+        build_system_type=test_job.signature.build_system_type,
+        repository=test_job.repository)
+    url = reverse("runnable_jobs-list",
+                  kwargs={"project": test_job.repository.name})
+    resp = webapp.get(url).json
+    assert resp == {
+        'meta': {
+            'count': 1,
+            'offset': 0,
+            'repository': test_job.repository.name
+        },
+        'results': [{
+            'build_architecture': 'x86',
+            'build_os': 'b2g',
+            'build_platform': 'b2g-emu-jb',
+            'build_platform_id': 1,
+            'build_system_type': 'buildbot',
+            'job_coalesced_to_guid': None,
+            'job_group_description': '',
+            'job_group_id': 1,
+            'job_group_name': 'unknown',
+            'job_group_symbol': '?',
+            'job_type_description': '',
+            'job_type_id': 1,
+            'job_type_name': 'B2G Emulator Image Build',
+            'job_type_symbol': 'B',
+            'machine_platform_architecture': 'x86',
+            'machine_platform_id': 1,
+            'machine_platform_os': 'b2g',
+            'option_collection_hash': '32faaecac742100f7753f0c1d0aa0add01b4046b',
+            'platform': 'b2g-emu-jb',
+            'platform_option': 'debug',
+            'ref_data_name': 'b2g_mozilla-release_emulator-jb-debug_dep',
+            'result': 'runnable',
+            'state': 'runnable'}]
+    }

--- a/treeherder/etl/runnable_jobs.py
+++ b/treeherder/etl/runnable_jobs.py
@@ -153,7 +153,9 @@ def _taskcluster_runnable_jobs(decision_task_id):
                 'job_type_symbol': treeherder_options['symbol'],
                 'platform': treeherder_options.get('machine', {}).get('platform', ''),
                 'platform_option': platform_option,
-                'ref_data_name': label
+                'ref_data_name': label,
+                'state': 'runnable',
+                'result': 'runnable'
                 })
 
         return ret
@@ -196,6 +198,9 @@ def _buildbot_runnable_jobs(project):
             'ref_data_name': datum.ref_data_name,
             'build_system_type': datum.build_system_type,
             'platform_option': options,
+            'result': 'runnable',
+            'state': 'runnable',
+            'job_coalesced_to_guid': None
             })
 
     return ret


### PR DESCRIPTION
We need to set state/result of runnable jobs to "runnable" for this to work,
and that got broken accidentally. Add a unit test so that this doesn't happen
again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2076)
<!-- Reviewable:end -->
