### PR TITLE
Bug 1330157 - Ensure runnable jobs always have a null coalesced value

### DIFF
--- a/treeherder/etl/runnable_jobs.py
+++ b/treeherder/etl/runnable_jobs.py
@@ -155,7 +155,8 @@ def _taskcluster_runnable_jobs(decision_task_id):
                 'platform_option': platform_option,
                 'ref_data_name': label,
                 'state': 'runnable',
-                'result': 'runnable'
+                'result': 'runnable',
+                'job_coalesced_to_guid': None
                 })
 
         return ret


### PR DESCRIPTION
Runnable jobs from taskcluster were missing their ``job_coalesced_to_guid`` value.  In the UI, if this field is not present AND set to null, it defaults to coalesced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2077)
<!-- Reviewable:end -->
