### PR TITLE
Bug 1329735 - New logviewer puts many entries in browsing history

### DIFF
--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -233,12 +233,12 @@ logViewerApp.controller('LogviewerCtrl', [
             const { lineNumber, highlightStart, highlightEnd } = data;
 
             if (highlightStart !== highlightEnd) {
-                $location.search('lineNumber', `${highlightStart}-${highlightEnd}`);
+                $location.search('lineNumber', `${highlightStart}-${highlightEnd}`).replace();
             }
             else if (highlightStart) {
-                $location.search('lineNumber', highlightStart);
+                $location.search('lineNumber', highlightStart).replace();
             } else {
-                $location.search('lineNumber', lineNumber);
+                $location.search('lineNumber', lineNumber).replace();
             }
         }
 


### PR DESCRIPTION
This bug required changes in both [taskcluster/unified-logviewer/pull/29](https://github.com/taskcluster/unified-logviewer/pull/29) and Treeherder repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2078)
<!-- Reviewable:end -->
