### PR TITLE
Bug 1329992 - Fix resultset status endpoint

### DIFF
--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -141,9 +141,9 @@ class Push(models.Model):
         total_num_coalesced = 0
         for (state, result, total, num_coalesced) in jobs.values_list(
                 'state', 'result').annotate(
-                    total=Count('result'),
-                    num_coalesced=Count(Case(When(
-                        coalesced_to_guid__isnull=False, then=1)))):
+                    total=Count('result')).annotate(
+                        num_coalesced=Count(Case(When(
+                            coalesced_to_guid__isnull=False, then=1)))):
             total_num_coalesced += num_coalesced
             if state == 'completed':
                 status_dict[result] = total - num_coalesced


### PR DESCRIPTION
The way we were using Django's "annotate" function with values_list
resulted in non-deterministic output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2079)
<!-- Reviewable:end -->
