### PR TITLE
Bug 1329685 - Do not run update_runnable_jobs in load_initial_data

### DIFF
--- a/treeherder/etl/runnable_jobs.py
+++ b/treeherder/etl/runnable_jobs.py
@@ -207,7 +207,15 @@ def _buildbot_runnable_jobs(project):
     return ret
 
 
+def _ensure_buildbot_data_is_loaded():
+    if not RunnableJob.objects.all():
+        RunnableJobsProcess().run()
+
+
 def list_runnable_jobs(project, decision_task_id=None):
+    # Bug 1329685 - This guarantees that calling list_runnable_jobs always returns the correct data
+    # even when running Treeherder for the first time
+    _ensure_buildbot_data_is_loaded()
     ret = _buildbot_runnable_jobs(project)
     ret = ret + _taskcluster_runnable_jobs(decision_task_id)
 

--- a/treeherder/model/management/commands/load_initial_data.py
+++ b/treeherder/model/management/commands/load_initial_data.py
@@ -12,5 +12,4 @@ class Command(BaseCommand):
                      'failure_classification',
                      'performance_framework',
                      'performance_bug_templates')
-        call_command('update_runnable_jobs')
         call_command('load_preseed')


### PR DESCRIPTION
Running update_runnable_jobs as part of load_initial_data causes a two
minutes increase when deploying Treeherder and when running vagrant
provision.

The commit that introduced the regression is this one:
https://github.com/mozilla/treeherder/pull/2072/commits/91f71e13d8bb3851776c2b77c6c387a07c81ec8b

Not having an up-to-date runnable jobs table causes not to have any data in
SETA's job priorities API for *Buildbot*. This does not affect TaskCluster
since the date is loaded on the fly.

The API that will have an empty list of builders:
http://localhost:8000/api/project/mozilla-inbound/seta/job-priorities/?build_system_type=buildbot

The slowest part of updating runnable jobs for Buildbot is when it runs for the first time.
The waiting happens after this line shows in the output:
> [treeherder.etl.runnable_jobs:117] Updating runnable jobs table with transformed allthethings.json data.

After that completes, you can reload the empty API and you can see that it works properly.

In any case, this is obviously not an issue in production (since the table is never empty), however, when working on your local
environment you start with an empty runnable jobs table.

This change ensures that we never return incomplete runnable jobs data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2082)
<!-- Reviewable:end -->
