### PR TITLE
Bug 1320136 - Clean up RunSQL and RunPython operations

### DIFF
--- a/treeherder/model/migrations/0001_initial.py
+++ b/treeherder/model/migrations/0001_initial.py
@@ -367,13 +367,19 @@ class Migration(migrations.Migration):
         migrations.RunSQL(
             sql='CREATE FULLTEXT INDEX `idx_crash_signature` on bugscache (`crash_signature`);',
             reverse_sql='ALTER TABLE bugscache DROP INDEX idx_crash_signature',
+            # Since this cancels out the RunSQL command marked as elidable in 0043_bugscache_cleanup.py.
+            elidable=True,
         ),
         migrations.RunSQL(
             sql='CREATE FULLTEXT INDEX `idx_keywords` on bugscache (`keywords`);',
             reverse_sql='ALTER TABLE bugscache DROP INDEX idx_keywords',
+            # Since this cancels out the RunSQL command marked as elidable in 0043_bugscache_cleanup.py.
+            elidable=True,
         ),
         migrations.RunSQL(
             sql='CREATE FULLTEXT INDEX `idx_all_full_text` on bugscache (`summary`, `crash_signature`, `keywords`);',
             reverse_sql='ALTER TABLE bugscache DROP INDEX idx_all_full_text',
+            # Since this cancels out the RunSQL command marked as elidable in 0043_bugscache_cleanup.py.
+            elidable=True,
         ),
     ]

--- a/treeherder/model/migrations/0015_auto_20160402_1345.py
+++ b/treeherder/model/migrations/0015_auto_20160402_1345.py
@@ -10,15 +10,5 @@ class Migration(migrations.Migration):
         ('model', '0014_auto_20160322_1130'),
     ]
 
-    operations = [
-        migrations.RunSQL(
-            """CREATE INDEX failure_line_test_idx ON failure_line
-            (test(50), subtest(25), status, expected);""",
-            """DROP INDEX failure_line_test_idx ON failure_line;""",
-            state_operations=[migrations.AlterIndexTogether(
-                name='failureline',
-                index_together=set([('job_guid', 'repository'),
-                                    ('test', 'subtest', 'status', 'expected')]),
-            )],
-        )
-    ]
+    # RunSQL command merged into the one in 0028_test_match_created_index.py.
+    operations = []

--- a/treeherder/model/migrations/0018_merge_duplicate_classifications.py
+++ b/treeherder/model/migrations/0018_merge_duplicate_classifications.py
@@ -44,5 +44,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(combine_classified_failures, noop)
+        # Marked as elidable since this migration is only required to fix existing
+        # bad data (which has already occurred on stage/prod) and so can be omitted
+        # when this migration is squashed in the future.
+        migrations.RunPython(combine_classified_failures, noop, elidable=True)
     ]

--- a/treeherder/model/migrations/0022_add_index_failureline_signature.py
+++ b/treeherder/model/migrations/0022_add_index_failureline_signature.py
@@ -11,10 +11,9 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # This has to be RawSQL because django doesn't have a syntax for creating
-        # prefix indicies
+        # Since Django doesn't natively support creating prefix indicies.
         migrations.RunSQL(
-            """CREATE INDEX failure_line_signature_idx ON failure_line
-            (signature(50));""",
-            """DROP INDEX failure_line_signature_idx ON failure_line;"""),
+            ['CREATE INDEX failure_line_signature_idx ON failure_line (signature(50));'],
+            reverse_sql=['DROP INDEX failure_line_signature_idx ON failure_line;'],
+        ),
     ]

--- a/treeherder/model/migrations/0027_failure_line_idx_signature_test.py
+++ b/treeherder/model/migrations/0027_failure_line_idx_signature_test.py
@@ -10,15 +10,5 @@ class Migration(migrations.Migration):
         ('model', '0026_failure_line_job_log_id'),
     ]
 
-    operations = [
-        migrations.RunSQL(
-            """CREATE INDEX failure_line_signature_test_idx ON failure_line
-            (signature(50), test(50));""",
-            """DROP INDEX failure_line_signature_test_idx ON failure_line;""",
-            state_operations=[migrations.AlterIndexTogether(
-                name='failureline',
-                index_together=set([('signature', 'test'),
-                                    ('job_guid', 'repository'),
-                                    ('test', 'subtest', 'status', 'expected')]))],
-        ),
-    ]
+    # RunSQL command merged into the one in 0028_test_match_created_index.py.
+    operations = []

--- a/treeherder/model/migrations/0028_test_match_created_index.py
+++ b/treeherder/model/migrations/0028_test_match_created_index.py
@@ -11,19 +11,16 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # Since Django doesn't natively support creating prefix indicies.
         migrations.RunSQL(
-            """
-            DROP INDEX failure_line_test_idx ON failure_line;
-            CREATE INDEX failure_line_test_idx ON failure_line (test(50), subtest(25), status, expected, created);
-            DROP INDEX failure_line_signature_test_idx ON failure_line;
-            CREATE INDEX failure_line_signature_test_idx ON failure_line (signature(25), test(50), created);
-            """,
-            """
-            DROP INDEX failure_line_test_idx ON failure_line;
-            CREATE INDEX failure_line_test_idx ON failure_line (test(50), subtest(25), status, expected);
-            DROP INDEX failure_line_signature_idx ON failure_line;
-            CREATE INDEX failure_line_signature_test_idx ON failure_line (signature(50), test);
-            """,
+            [
+                'CREATE INDEX failure_line_test_idx ON failure_line (test(50), subtest(25), status, expected, created);',
+                'CREATE INDEX failure_line_signature_test_idx ON failure_line (signature(25), test(50), created);',
+            ],
+            reverse_sql=[
+                'DROP INDEX failure_line_test_idx ON failure_line;',
+                'DROP INDEX failure_line_signature_test_idx ON failure_line;',
+            ],
             state_operations=[migrations.AlterIndexTogether(
                 name='failureline',
                 index_together=set([('test', 'subtest', 'status', 'expected', 'created'),

--- a/treeherder/model/migrations/0035_job_detail_field_lengths_decrease.py
+++ b/treeherder/model/migrations/0035_job_detail_field_lengths_decrease.py
@@ -15,7 +15,11 @@ class Migration(migrations.Migration):
         migrations.RunSQL(
             ("UPDATE job_detail SET "
              "  title = SUBSTRING(title, 1, 70), "
-             "  value = SUBSTRING(value, 1, 125)")
+             "  value = SUBSTRING(value, 1, 125)"),
+            # Marked as elidable since this migration is only required to fix existing
+            # bad data (which has already occurred on stage/prod) and so can be omitted
+            # when this migration is squashed in the future.
+            elidable=True,
         ),
         migrations.AlterField(
             model_name='jobdetail',

--- a/treeherder/model/migrations/0036_job_details_unique_together.py
+++ b/treeherder/model/migrations/0036_job_details_unique_together.py
@@ -11,16 +11,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunSQL(
-            # Using ALTER IGNORE so that it will automatically delete duplicates
-            ("ALTER IGNORE TABLE `job_detail` ADD CONSTRAINT "
-             "`job_detail_title_11a9e7f847f5214c_uniq` "
-             "UNIQUE (`title`, `value`, `job_id`);"),
-            state_operations=[
-                migrations.AlterUniqueTogether(
-                    name='jobdetail',
-                    unique_together=set([('title', 'value', 'job')]),
-                ),
-            ],
+        migrations.AlterUniqueTogether(
+            name='jobdetail',
+            unique_together=set([('title', 'value', 'job')]),
         ),
     ]

--- a/treeherder/model/migrations/0043_bugscache_cleanup.py
+++ b/treeherder/model/migrations/0043_bugscache_cleanup.py
@@ -31,13 +31,19 @@ class Migration(migrations.Migration):
         migrations.RunSQL(
             sql='ALTER TABLE bugscache DROP INDEX idx_crash_signature',
             reverse_sql='CREATE FULLTEXT INDEX `idx_crash_signature` on bugscache (`crash_signature`);',
+            # Since this cancels out the RunSQL command marked as elidable in 0001_initial.py.
+            elidable=True,
         ),
         migrations.RunSQL(
             sql='ALTER TABLE bugscache DROP INDEX idx_keywords',
             reverse_sql='CREATE FULLTEXT INDEX `idx_keywords` on bugscache (`keywords`);',
+            # Since this cancels out the RunSQL command marked as elidable in 0001_initial.py.
+            elidable=True,
         ),
         migrations.RunSQL(
             sql='ALTER TABLE bugscache DROP INDEX idx_all_full_text',
             reverse_sql='CREATE FULLTEXT INDEX `idx_all_full_text` on bugscache (`summary`, `crash_signature`, `keywords`);',
+            # Since this cancels out the RunSQL command marked as elidable in 0001_initial.py.
+            elidable=True,
         ),
     ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -1074,7 +1074,8 @@ class FailureLine(models.Model):
     status = models.CharField(max_length=7, choices=STATUS_CHOICES)
     expected = models.CharField(max_length=7, choices=STATUS_CHOICES, blank=True, null=True)
     message = models.TextField(blank=True, null=True)
-    signature = models.TextField(blank=True, null=True)  # Prefix index length 50
+    # We manually create a prefix index: signature(50)
+    signature = models.TextField(blank=True, null=True)
     level = models.CharField(max_length=8, choices=STATUS_CHOICES, blank=True, null=True)
     stack = models.TextField(blank=True, null=True)
     stackwalk_stdout = models.TextField(blank=True, null=True)

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -195,6 +195,7 @@ class Bugscache(models.Model):
     id = models.PositiveIntegerField(primary_key=True)
     status = models.CharField(max_length=64, db_index=True)
     resolution = models.CharField(max_length=64, blank=True, db_index=True)
+    # Is covered by a FULLTEXT index created via a migrations RunSQL operation.
     summary = models.CharField(max_length=255)
     crash_signature = models.TextField(blank=True)
     keywords = models.TextField(blank=True)
@@ -1102,8 +1103,9 @@ class FailureLine(models.Model):
         db_table = 'failure_line'
         index_together = (
             ('job_guid', 'repository'),
-            # The test and subtest indicies are length 50 and 25, respectively
+            # Prefix index: test(50), subtest(25), status, expected, created
             ('test', 'subtest', 'status', 'expected', 'created'),
+            # Prefix index: signature(25), test(50), created
             ('signature', 'test', 'created')
         )
         unique_together = (


### PR DESCRIPTION
Django's `squashmigrations` command cannot optimise past `RunSQL` or `RunPython` migration operations, since it cannot guarantee that the order of migration operations isn't important. However as of Django 1.10 these commands can be marked as `elidable`, if they are not required in the final migration (eg if they only manipulate legacy data and have already run in all necessary environments), which solves this problem.

This PR makes use of the new `elidable` feature along with a few other changes, to reduce the number of RunSQL operations that will block the optimisation of migrations when we use `squashmigrations` in a later PR.

See individual commits for more details.

A dump of the resultant schema before/after this PR shows no surprises (generated using `mysqldump -u root --no-data --compact treeherder`):
```diff
--- schema-before.sql   2017-01-16 20:20:01.844226800 +0000
+++ schema-after.sql    2017-01-16 20:19:13.524275100 +0000
@@ -369,17 +369,17 @@
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `job_detail` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `title` varchar(70) COLLATE utf8_bin DEFAULT NULL,
   `value` varchar(125) COLLATE utf8_bin NOT NULL,
   `url` varchar(512) COLLATE utf8_bin DEFAULT NULL,
   `job_id` bigint(20) NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `job_detail_title_11a9e7f847f5214c_uniq` (`title`,`value`,`job_id`),
+  UNIQUE KEY `job_detail_title_3ede20fe_uniq` (`title`,`value`,`job_id`),
   KEY `job_detail_job_id_4b64346c_fk_job_id` (`job_id`),
   CONSTRAINT `job_detail_job_id_4b64346c_fk_job_id` FOREIGN KEY (`job_id`) REFERENCES `job` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `job_duration` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2085)
<!-- Reviewable:end -->
