### PR TITLE
Bug 1245389 - Add offset to log line number

### DIFF
--- a/ui/js/components/logviewer/logviewer.js
+++ b/ui/js/components/logviewer/logviewer.js
@@ -2,7 +2,7 @@
 
 treeherder.component('thLogViewer', {
     templateUrl: 'partials/logviewer/logviewer.html',
-    controller: ($sce, $location, $element, $scope) => {
+    controller: ($sce, $location, $element, $scope, $rootScope) => {
         const unifiedLogviewerUrl = 'https://taskcluster.github.io/unified-logviewer/';
         const logParams = () => {
             const q = $location.search();
@@ -11,7 +11,7 @@ treeherder.component('thLogViewer', {
             if (q.lineNumber) {
                 const lines = q.lineNumber.toString().split('-');
 
-                params.lineNumber = lines[0];
+                params.lineNumber = lines[0] - $rootScope.logOffset;
                 params.highlightStart = lines[0];
                 params.highlightEnd = lines.length === 2 ? lines[1] : lines[0];
             }

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -14,6 +14,7 @@ logViewerApp.controller('LogviewerCtrl', [
         const query_string = $location.search();
         $scope.css = '';
         $rootScope.urlBasePath = $location.absUrl().split('logviewer')[0];
+        $rootScope.logOffset = 7;
 
         if (query_string.repo !== "") {
             $rootScope.repoName = query_string.repo;
@@ -44,6 +45,12 @@ logViewerApp.controller('LogviewerCtrl', [
             }
 
             updateQuery(values);
+
+            // Add offset to lineNumber to see above the failure line
+            if (lineNumber) {
+                values.lineNumber -= $rootScope.logOffset;
+            }
+
             $document[0].getElementById('logview').contentWindow.postMessage(values, "*");
         };
 


### PR DESCRIPTION
Currently if you click on a failure, the viewer would put the red failure line on the very top of the log area, which is less optimal since some log above the failure line could usually be useful. This
PR adds an offset to a line number so that users can see the log above a failure line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2087)
<!-- Reviewable:end -->
