### PR TITLE
Bug 1289824 - Add add-all-talos support for tc

### DIFF
--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -90,13 +90,13 @@ treeherderApp.controller('ResultSetCtrl', [
     'thUrl', 'thServiceDomain', 'thResultStatusInfo', 'thDateFormat',
     'ThResultSetStore', 'thEvents', 'thJobFilters', 'thNotify',
     'thBuildApi', 'thPinboard', 'ThResultSetModel', 'dateFilter',
-    'ThModelErrors', 'ThJobModel',
+    'ThModelErrors', 'ThJobModel', 'ThTaskclusterErrors',
     function ResultSetCtrl(
         $scope, $rootScope, $http, ThLog, $location,
         thUrl, thServiceDomain, thResultStatusInfo, thDateFormat,
         ThResultSetStore, thEvents, thJobFilters, thNotify,
         thBuildApi, thPinboard, ThResultSetModel, dateFilter, ThModelErrors,
-        ThJobModel) {
+        ThJobModel, ThTaskclusterErrors) {
 
         $scope.getCountClass = function(resultStatus) {
             return thResultStatusInfo(resultStatus).btnClass;
@@ -222,13 +222,20 @@ treeherderApp.controller('ResultSetCtrl', [
                 times = window.prompt("We only allow instances of each talos job to be between 1 to 6 times. Enter again", 6);
             }
 
-            ThResultSetModel.triggerAllTalosJobs($scope.resultset.id, $scope.repoName, times).then(function() {
-                thNotify.send("Request sent to trigger all talos jobs " + times + " time(s)", "success");
-            }, function(e) {
-                thNotify.send(
-                    ThModelErrors.format(e, "The action 'trigger all talos jobs' failed"),
-                    'danger', true
-                );
+            ThResultSetStore.getGeckoDecisionTaskID(
+                $scope.repoName,
+                $scope.resultset.id
+            ).then(function(decisionTaskID) {
+                ThResultSetModel.triggerAllTalosJobs(
+                    $scope.resultset.id,
+                    $scope.repoName,
+                    times,
+                    decisionTaskID
+                ).then(function(msg) {
+                    thNotify.send(msg, "success");
+                }, function(e) {
+                    thNotify.send(ThTaskclusterErrors.format(e), 'danger', true);
+                });
             });
         };
 

--- a/ui/js/services/taskcluster.js
+++ b/ui/js/services/taskcluster.js
@@ -8,6 +8,26 @@ treeherder.factory('thTaskcluster', ['$window', '$rootScope', 'localStorageServi
                 credentials: localStorageService.get('taskcluster.credentials') || {},
             });
         });
-        return client;
+
+        return {
+            client: function() { return client; },
+            refreshTimestamps: function(task) {
+                // Take a taskcluster task and make all of the timestamps
+                // new again. This is pretty much lifted verbatim from
+                // mozilla_ci_tools which is used by pulse_actions.
+                // We need to do this because action tasks are created with
+                // timestamps for expires/created/deadline that are based
+                // on the time of the original decision task creation. We must
+                // update to the current time, or Taskcluster will reject the
+                // task upon creation.
+                task.expires = client.fromNow('366 days');
+                task.created = client.fromNow(0);
+                task.deadline = client.fromNow('1 day');
+                _.map(task.payload.artifacts, function(artifact) {
+                    artifact.expires = client.fromNow('365 days');
+                });
+                return task;
+            },
+        };
     }
 ]);


### PR DESCRIPTION
This contains a good number of changes from #2057 but adds some refactoring for re-use of certain components for the add-talos support. As I understand it, what we want to do for add-all-talos is to still send a pulse message for pulse_actions to act on in order to add buildbot talos jobs, and then submit an action task to tc for the tc based ones. This PR is dependent on https://reviewboard.mozilla.org/r/103910/ getting merged first before it can work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2092)
<!-- Reviewable:end -->
