### PR TITLE
Bug 1333396 - Add a dropdown list showing recent revisions while annotating jobs when using "fixed by commit" 

### DIFF
--- a/ui/partials/main/thPinboardPanel.html
+++ b/ui/partials/main/thPinboardPanel.html
@@ -56,6 +56,15 @@
                ng-click="allowKeys()"
                placeholder="click to add comment"
                blur-this></input>
+        <div ng-if="classification.failure_classification_id === 2">
+          <select id="recent-choice">
+            <option value="0" selected disabled>Choose a recent commit</option>
+            <option ng-repeat="tip in revisionList | limitTo:20"
+              ng-click="classification.text=tip.revision">
+              {{tip.revision | limitTo: 12}} {{tip.author}}
+            </option>
+          </select>
+        </div>
       </div>
     </form>
   </div>

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -20,6 +20,7 @@ treeherder.controller('PluginCtrl', [
         var $log = new ThLog("PluginCtrl");
 
         $scope.job = {};
+        $scope.revisionList = [];
 
         var reftestUrlRoot = "https://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl=";
 
@@ -333,8 +334,20 @@ treeherder.controller('PluginCtrl', [
         $scope.$watch('getCountPinnedJobs()', function(newVal, oldVal) {
             if (oldVal === 0 && newVal > 0) {
                 $scope.isPinboardVisible = true;
+                getRevisionTips($scope.repoName, $scope.revisionList);
             }
         });
+
+        var getRevisionTips = function(projectName, list) {
+            list.splice(0, list.length);
+            var rsArr = ThResultSetStore.getResultSetsArray(projectName);
+            _.forEach(rsArr, rs => {
+                list.push({
+                    revision: rs.revision,
+                    author: rs.author
+                });
+            });
+        };
 
         $scope.canCancel = function() {
             return $scope.job &&

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -244,6 +244,5 @@ treeherder.controller('PinboardCtrl', [
         $scope.classification = thPinboard.createNewClassification();
         $scope.pinnedJobs = thPinboard.pinnedJobs;
         $scope.relatedBugs = thPinboard.relatedBugs;
-
     }
 ]);


### PR DESCRIPTION
While annotating jobs for classification type "fixed by commit", a dropdown suggesting recent revisions added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2095)
<!-- Reviewable:end -->
