### PR TITLE
Bug 1329685 - Stop calling update_runnable_jobs during load_initial_data

### DIFF
--- a/treeherder/model/management/commands/load_initial_data.py
+++ b/treeherder/model/management/commands/load_initial_data.py
@@ -12,5 +12,4 @@ class Command(BaseCommand):
                      'failure_classification',
                      'performance_framework',
                      'performance_bug_templates')
-        call_command('update_runnable_jobs')
         call_command('load_preseed')


### PR DESCRIPTION
Since it increases the runtime of `load_initial_data` from 2 seconds to 2 minutes 30 seconds, which delays both Vagrant provisions and prod deploys.

This was added recently in bug 1328618, however another solution will have to be found to improve the local development workflow instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2098)
<!-- Reviewable:end -->
