### PR TITLE
Bug 1333422 - Remove useless resize-watching code from ui

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -165,17 +165,6 @@ treeherderApp.controller('MainCtrl', [
 
         $scope.repoModel = ThRepositoryModel;
 
-        $scope.getTopNavBarHeight = function() {
-            return $("#th-global-top-nav-panel").find("#top-nav-main-panel").height();
-        };
-
-        // adjust the body padding so we can see all the job/resultset data
-        // if the top navbar height has changed due to window width changes
-        // or adding enough watched repos to wrap.
-        $rootScope.$watch($scope.getTopNavBarHeight, function(newValue) {
-            $("body").css("padding-top", newValue);
-        });
-
         /**
          * The watched repos in the nav bar can be either on the left or the
          * right side of the screen and the drop-down menu may get cut off


### PR DESCRIPTION
We have some code which tries to get the size of a non-existent "top navbar"
to adjust the size of the resultset/jobs view. I think this dates way back
to 2014, before I added flexbox-- the code is harmless (since it does
nothing), but causes a confusing console error ("Empty string passed to
getElementById"). Let's remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2099)
<!-- Reviewable:end -->
