### PR TITLE
Bug 1333427 - Fix remaining "Empty string passed to getElementById()" warnings

### DIFF
--- a/ui/admin.html
+++ b/ui/admin.html
@@ -21,7 +21,7 @@
         <button id="th-logo"
                 title="Treeherder services" role="button"
                 class="btn btn-view-nav"
-                data-toggle="dropdown" data-target="#">Treeherder Admin
+                data-toggle="dropdown">Treeherder Admin
           <span class="fa fa-angle-down lightgray"></span>
         </button>
         <ul class="dropdown-menu" role="menu">
@@ -35,7 +35,7 @@
         <!-- Help Menu -->
         <span class="dropdown">
           <button id="helpLabel" title="Treeherder help" role="button"
-                  data-toggle="dropdown" data-target="#"
+                  data-toggle="dropdown"
                   class="btn btn-view-nav btn-right-navbar nav-help-btn">
             <span class="fa fa-question-circle lightgray nav-help-icon"></span>
             <span class="fa fa-angle-down lightgray"></span>

--- a/ui/failureviewer.html
+++ b/ui/failureviewer.html
@@ -22,7 +22,7 @@
           <li>
             <span class="dropdown">
               <button id="fv-logo" title="Treeherder services" role="button"
-                      data-toggle="dropdown" data-target="#">Failure Viewer
+                      data-toggle="dropdown">Failure Viewer
                 <span class="fa fa-angle-down"></span>
               </button>
               <ul class="dropdown-menu" role="menu" aria-labelledby="fv-logo">

--- a/ui/js/components/auth.js
+++ b/ui/js/components/auth.js
@@ -13,7 +13,7 @@ treeherder.component("login", {
         <span class="dropdown"
               ng-if="$ctrl.user.loggedin">
           <button id="logoutLabel" title="Logged in as: {{$ctrl.user.email}}" role="button"
-                  data-toggle="dropdown" data-target="#"
+                  data-toggle="dropdown"
                   class="btn btn-view-nav btn-right-navbar">
             <div class="nav-user-icon">
               <span class="fa fa-user pull-left"></span>

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -21,7 +21,7 @@
           <li>
             <span class="dropdown">
               <button id="lv-logo" title="Treeherder services" role="button"
-                      data-toggle="dropdown" data-target="#">Logviewer
+                      data-toggle="dropdown">Logviewer
                 <span class="fa fa-angle-down"></span>
               </button>
               <ul class="dropdown-menu" role="menu" aria-labelledby="lv-logo">

--- a/ui/partials/main/thGlobalTopNavPanel.html
+++ b/ui/partials/main/thGlobalTopNavPanel.html
@@ -4,7 +4,7 @@
     <!-- Logo Menu -->
     <span class="dropdown">
       <button id="th-logo" title="Treeherder services" role="button"
-              data-toggle="dropdown" data-target="#"
+              data-toggle="dropdown"
               class="btn btn-view-nav">Treeherder
         <span class="fa fa-angle-down lightgray"></span>
       </button>
@@ -24,7 +24,7 @@
       <!-- Infra Menu -->
       <span class="dropdown">
         <button id="infraLabel" title="Infrastructure status" role="button"
-                data-toggle="dropdown" data-target="#"
+                data-toggle="dropdown"
                 class="btn btn-view-nav btn-right-navbar nav-menu-btn">Infra
           <span class="fa fa-angle-down lightgray"></span>
         </button>
@@ -37,7 +37,7 @@
       <span ng-controller="RepositoryMenuCtrl" >
         <span th-checkbox-dropdown-container class="dropdown">
           <button id="repoLabel" title="Watch a repo" role="button"
-                  data-toggle="dropdown" data-target="#"
+                  data-toggle="dropdown"
                   class="btn btn-view-nav btn-right-navbar nav-menu-btn">Repos
             <span class="fa fa-angle-down lightgray"></span>
           </button>
@@ -68,7 +68,7 @@
       <!-- Help Menu -->
       <span class="dropdown">
         <button id="helpLabel" title="Treeherder help" role="button"
-                data-toggle="dropdown" data-target="#"
+                data-toggle="dropdown"
                 class="btn btn-view-nav btn-right-navbar nav-help-btn">
           <span class="fa fa-question-circle lightgray nav-help-icon"></span>
           <span class="fa fa-angle-down lightgray"></span>

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -34,7 +34,7 @@
         <span th-checkbox-dropdown-container class="dropdown">
           <span id="tierLabel" role="button"
                   title="Show/hide job tiers"
-                  data-toggle="dropdown" data-target="#"
+                  data-toggle="dropdown"
                   class="btn btn-view-nav btn-sm nav-menu-btn">Tiers
             <span class="fa fa-angle-down lightgray"></span>
           </span>

--- a/ui/perf.html
+++ b/ui/perf.html
@@ -21,7 +21,7 @@
         <button id="th-logo"
                 title="Treeherder services" role="button"
                 class="btn btn-view-nav"
-                data-toggle="dropdown" data-target="#">Perfherder
+                data-toggle="dropdown">Perfherder
           <span class="fa fa-angle-down lightgray"></span>
         </button>
         <ul class="dropdown-menu" role="menu" aria-labelledby="perf-logo">
@@ -34,7 +34,7 @@
       <!-- Dashboard Menu -->
       <span class="dropdown">
         <button id="dashboardLabel" title="Dashboard" role="button"
-                data-toggle="dropdown" data-target="#"
+                data-toggle="dropdown"
                 class="btn btn-view-nav">Dashboard
           <span class="fa fa-angle-down lightgray"></span>
         </button>
@@ -48,7 +48,7 @@
         <!-- Help Menu -->
         <span class="dropdown">
           <button id="helpLabel" title="Perfherder help" role="button"
-                  data-toggle="dropdown" data-target="#"
+                  data-toggle="dropdown"
                   class="btn btn-view-nav btn-right-navbar nav-help-btn">
             <span class="fa fa-question-circle lightgray nav-help-icon"></span>
             <span class="fa fa-angle-down lightgray"></span>


### PR DESCRIPTION
It turns out that adding a data-target property of '#' to a dropdown
is unnecessary and confuses bootstrap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2100)
<!-- Reviewable:end -->
