### PR TITLE
Bug 1081074 - Store and display watched repos in the nav panel

### DIFF
--- a/ui/js/directives/treeherder/top_nav_bar.js
+++ b/ui/js/directives/treeherder/top_nav_bar.js
@@ -14,8 +14,8 @@ treeherder.directive('thFilterCheckbox', [
     }]);
 
 treeherder.directive('thWatchedRepo', [
-    'ThLog',
-    function (ThLog) {
+    'ThLog', 'ThRepositoryModel',
+    function (ThLog, ThRepositoryModel) {
 
         var $log = new ThLog("thWatchedRepo");
 
@@ -56,6 +56,8 @@ treeherder.directive('thWatchedRepo', [
         return {
             restrict: "E",
             link: function(scope) {
+
+                scope.repoData = ThRepositoryModel.repos[scope.watchedRepo];
 
                 scope.updateTitleText = function() {
                     if (scope.repoData.treeStatus) {

--- a/ui/partials/main/thWatchedRepo.html
+++ b/ui/partials/main/thWatchedRepo.html
@@ -1,28 +1,28 @@
 <span class="btn-group">
   <button class="watched-repo-main-btn btn btn-sm {{btnClass}}"
-          ng-class="{'active': name===repoName}"
-          ng-click="changeRepo(name)"
+          ng-class="{'active': watchedRepo===repoName}"
+          ng-click="changeRepo(watchedRepo)"
           type="button"
           title="{{titleText|stripHtml}}">
-    <i class="fa {{statusIcon}} {{statusIconClass}} {{statusColor}}"></i> {{::name}}
+    <i class="fa {{statusIcon}} {{statusIconClass}} {{statusColor}}"></i> {{::watchedRepo}}
   </button>
   <button class="watched-repo-info-btn btn btn-sm {{btnClass}} dropdown-toggle"
-          ng-class="{'active': name===repoName}"
+          ng-class="{'active': watchedRepo===repoName}"
           ng-click="setDropDownPull($event)"
           type="button"
-          title="{{::name}} info"
+          title="{{::watchedRepo}} info"
           data-toggle="dropdown">
     <span class="fa fa-info-circle"></span>
   </button>
   <button class="watched-repo-unwatch-btn btn btn-sm {{btnClass}}"
-          ng-class="{'active': name===repoName}"
-          ng-click="repoModel.unwatchRepo(name)"
-          ng-hide="name===repoName"
-          title="unwatch {{::name}}">
+          ng-class="{'active': watchedRepo===repoName}"
+          ng-click="repoModel.unwatchRepo(watchedRepo)"
+          ng-hide="watchedRepo===repoName"
+          title="unwatch {{::watchedRepo}}">
     <span class="fa fa-times"></span>
   </button>
-  <th-watched-repo-info-drop-down name="{{::name}}"
-                                  reason="{{repoData.treeStatus.reason}}"
-                                  message_of_the_day="{{repoData.treeStatus.message_of_the_day}}">
+  <th-watched-repo-info-drop-down name="{{::watchedRepo}}"
+                                  reason="{{repos[watchedRepo].treeStatus.reason}}"
+                                  message_of_the_day="{{repos[watchedRepo].treeStatus.message_of_the_day}}">
   </th-watched-repo-info-drop-down>
 </span>

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -1,10 +1,12 @@
 <div id="watched-repo-navbar" class="th-context-navbar watched-repo-navbar clearfix">
-  <th-watched-repo ng-repeat="(name, repoData) in repoModel.watchedRepos"></th-watched-repo>
+
+  <th-watched-repo ng-repeat="watchedRepo in repoModel.watchedRepos"></th-watched-repo>
+
   <div class="navbar-right">
     <span>
       <form role="search" class="form-inline">
 
-        <span class="btn btn-sm btn-view-nav nav-menu-btn" 
+        <span class="btn btn-sm btn-view-nav nav-menu-btn"
               ng-show="serverChanged" ng-cloak
               ng-click="updateButtonClick()"
               id="revisionChangedLabel"
@@ -72,7 +74,7 @@
 
         <!-- Toggle Duplicate Jobs -->
         <span class="btn btn-view-nav btn-sm btn-toggle-duplicate-jobs"
-              tabindex="1" role="button" 
+              tabindex="1" role="button"
               title="{{ showDuplicateJobs ? 'Hide Duplicate Jobs' : 'Show Duplicate Jobs' }}"
               ng-click="groupState !== 'expanded' && toggleShowDuplicateJobs()"
               ng-disabled="groupState === 'expanded'"


### PR DESCRIPTION
Addresses @camd's comment here:  https://bugzilla.mozilla.org/show_bug.cgi?id=1081074#c9

The only item needing addressing is sort order; navbar items are output by `thWatchedRepoNavPanel.html`, via:

```
<th-watched-repo ng-repeat="(name, repoData) in repoModel.watchedRepos"></th-watched-repo>
```

I'll need to add something to reverse that object key order to put the most recently watched repos first (before a page refresh).  Working on that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2105)
<!-- Reviewable:end -->
