### PR TITLE
Bug 1333604 - Allow specific treeherder instance to be used in backfill

### DIFF
--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -419,10 +419,15 @@ treeherder.controller('PluginCtrl', [
                                     }
                                     $http.get(url).then(function(resp) {
                                         let action = resp.data;
+                                        let action_args = $interpolate('--project "{{project}}" --job "{{job}}" --treeherder-url "{{th}}"')({
+                                            project: $scope.repoName,
+                                            job: $scope.job.id,
+                                            th: (thServiceDomain || 'https://treeherder.mozilla.org') + '/api'
+                                        });
                                         let template = $interpolate(action);
                                         action = template({
                                             action: 'backfill',
-                                            action_args: '--project ' + $scope.repoName + ' --job ' + $scope.job.id,
+                                            action_args: action_args
                                         });
                                         let task = refreshTimestamps(jsyaml.safeLoad(action));
                                         let taskId = thTaskcluster.slugid();


### PR DESCRIPTION
As it stands, backfilling will not work in stage. This should fix that as soon as https://reviewboard.mozilla.org/r/107310/ lands. I'll assign this review to someone as soon as that gets try results back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2108)
<!-- Reviewable:end -->
