### PR TITLE
Bug 1334654 - Use taskId + retryId as job_guid

### DIFF
--- a/treeherder/etl/job_loader.py
+++ b/treeherder/etl/job_loader.py
@@ -107,7 +107,7 @@ class JobLoader:
         We can rely on the structure of ``pulse_job`` because it will
         already have been validated against the JSON Schema at this point.
         """
-        job_guid = pulse_job["taskId"]
+        job_guid = '{}/{}'.format(pulse_job["taskId"], pulse_job["retryId"])
         x = {
             "job": {
                 "job_guid": job_guid,


### PR DESCRIPTION
See: https://github.com/taskcluster/taskcluster-treeherder/pull/34
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1323110#c7

@camd, with this in place, treeherder can in the future refactor to store taskId and retryId as separate properties...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2114)
<!-- Reviewable:end -->
