### PR TITLE
Bug 1335506 - Hide the trigger missing jobs button until it behaves

### DIFF
--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -27,7 +27,7 @@
            href="https://secure.pub.build.mozilla.org/buildapi/self-serve/{{::repoName}}/rev/{{::resultset.revision}}">BuildAPI</a></li>
     <li><a target="_blank" data-ignore-job-clear-on-click
            href=""
-           ng-show="user.is_staff"
+           ng-show="user.is_staff && false" <!-- Bug 1335310 tracks fixing the feature -->
            ng-click="triggerMissingJobs(resultset.revision)">Trigger missing jobs</a></li>
     <li><a target="_blank" data-ignore-job-clear-on-click
            href=""


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2121)
<!-- Reviewable:end -->
