### PR TITLE
Bug 1315941 - Change the order of filters being applied to fix linkified classification comments

### DIFF
--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -138,7 +138,7 @@
              href="{{ getBugUrl(bug.bug_id) }}"
              title="View bug {{bug.bug_id}}"><em> {{bug.bug_id}}</em></a>
         </li>
-        <li ng-if="classifications[0].text.length > 0"><em ng-bind-html="classifications[0].text|linkifyClassifications:repoName|linkifyURLs"></em></li>
+        <li ng-if="classifications[0].text.length > 0"><em ng-bind-html="classifications[0].text|linkifyURLs|linkifyClassifications:repoName"></em></li>
         <li class="revision-comment">
           {{classifications[0].created|date:'EEE MMM d, H:mm:ss'}}</li>
         <li class="revision-comment">


### PR DESCRIPTION
I think the order of these two filters should be reversed, so that URLs get linkified before attempting to linkify SHA-like classification comments. Otherwise, SHAs get linkified, then the linkified SHAs get further linkified, causing the problem described in the bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2122)
<!-- Reviewable:end -->
