### PR TITLE
Bug 1304062 - Remove prefix index on failure_line.signature

### DIFF
--- a/treeherder/model/migrations/0001_squashed_0053_add_job_platform_option_push_index.py
+++ b/treeherder/model/migrations/0001_squashed_0053_add_job_platform_option_push_index.py
@@ -720,11 +720,6 @@ class Migration(migrations.Migration):
             ['CREATE FULLTEXT INDEX idx_summary ON bugscache (summary);'],
             reverse_sql=['ALTER TABLE bugscache DROP INDEX idx_summary;'],
         ),
-        # Since Django doesn't natively support creating prefix indicies.
-        migrations.RunSQL(
-            ['CREATE INDEX failure_line_signature_idx ON failure_line (signature(50));'],
-            reverse_sql=['DROP INDEX failure_line_signature_idx ON failure_line;'],
-        ),
         # Since Django doesn't natively support creating composite prefix indicies.
         migrations.RunSQL(
             [

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -1075,7 +1075,6 @@ class FailureLine(models.Model):
     status = models.CharField(max_length=7, choices=STATUS_CHOICES)
     expected = models.CharField(max_length=7, choices=STATUS_CHOICES, blank=True, null=True)
     message = models.TextField(blank=True, null=True)
-    # We manually create a prefix index: signature(50)
     signature = models.TextField(blank=True, null=True)
     level = models.CharField(max_length=8, choices=STATUS_CHOICES, blank=True, null=True)
     stack = models.TextField(blank=True, null=True)


### PR DESCRIPTION
Since it overlaps with the composite index, and the additional length isn't required (50 characters vs 25).

The RunSQL operation is being removed from the existing migrations file (rather than adding a new RunSQL operation that reverts it), since the index is missing on prod, so any attempts to remove it would error. This means that existing Vagrant environments will have an extra index until the environment is recreated, however it's unlike to have an impact on reproducibility of prod issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2125)
<!-- Reviewable:end -->
