### PR TITLE
Bug 1336270 - Add missing 'load static' to credentials self-serve pages

### DIFF
--- a/treeherder/credentials/templates/credentials/base.html
+++ b/treeherder/credentials/templates/credentials/base.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+{% load static %}<!DOCTYPE html>
 <html lang="en">
 <head>
         <meta charset="utf-8">


### PR DESCRIPTION
In order to use the `static` statement later in the file, the static tag first has to be loaded:
https://docs.djangoproject.com/en/1.10/ref/templates/builtins/#std:templatetag-static

This was previously achieved via `load staticfiles` (deprecated form), but that was accidentally removed in bug 1273034 (https://github.com/mozilla/treeherder/commit/ba8165c23934f65df3bbd809f75af94e77a2a258#diff-305591ed7394d1ff36503ffa74c7b32cL1), resulting in HTTP 500s when the credentials self-serve pages were accessed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2127)
<!-- Reviewable:end -->
