### PR TITLE
Bug 1336476 - Set treeherder logging level to warning

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -179,7 +179,7 @@ LOGGING = {
         },
         'treeherder': {
             'handlers': ['console'],
-            'level': 'ERROR',
+            'level': 'WARNING',
         },
         'kombu': {
             'handlers': ['console'],


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2130)
<!-- Reviewable:end -->
