### PR TITLE
Bug 1336504 - Update whitenoise from 3.2.3 to 3.3.0

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -2,7 +2,7 @@
 
 gunicorn==19.6.0 --hash=sha256:723234ea1fa8dff370ab69830ba8bc37469a7cba13fd66055faeef24085e6530
 
-whitenoise==3.2.3 --hash=sha256:e76bf2d44158ed2e85c512cec1595b34680ea76337f77ea635da3668b852d7fd
+whitenoise==3.3.0 --hash=sha256:1d62a003a0ab747de96da45c831cbb512dcb7f69c1ef0bd20b1cd4ae45d8a0c4
 
 # Used by the Whitenoise CLI tool to provide Brotli-compressed versions of static files.
 Brotli==0.5.2 --hash=sha256:3411b9acd2a2056e55084acf7a6ab3e4a8540c2ef37a4435bca62644e8aaf50e


### PR DESCRIPTION
Notably this means long-lived static assets will be served with a `Cache-Control` header that now contains the new `immutable` directive, for improved browser caching behaviour. See:
https://bitsup.blogspot.co.uk/2016/05/cache-control-immutable.html
https://hacks.mozilla.org/2017/01/using-immutable-caching-to-speed-up-the-web/

Changes:
http://whitenoise.evans.io/en/stable/changelog.html#v3-3-0
https://github.com/evansd/whitenoise/compare/v3.2.3...v3.3.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2131)
<!-- Reviewable:end -->
