### PR TITLE
Bug 1336575 - Remove unused pinboard class

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -51,7 +51,6 @@
             <div ng-controller="PluginCtrl"
                  id="info-panel"
                  ng-show="selectedJob"
-                 ng-class="{'with-pinboard':isPinboardVisible}"
                  ng-include src="'plugins/pluginpanel.html'">
             </div>
         </div>


### PR DESCRIPTION
This removes what appears to be an unused `ng-class` from the markup. The info panel and pinboard appear to behave fine without it.

Tested on OSX 10.11.5:
Nightly **54.0a1 (2017-02-03) (64-bit)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2132)
<!-- Reviewable:end -->
