### PR TITLE
Bug 1320963 - Really fix regex for long max-age static assets

### DIFF
--- a/treeherder/config/whitenoise_custom.py
+++ b/treeherder/config/whitenoise_custom.py
@@ -13,7 +13,7 @@ class CustomWhiteNoise(WhiteNoiseMiddleware):
 
     # Matches grunt-cache-bust's style of hash filenames. eg:
     #   index.min-e10ba468ffc8816a.js
-    IMMUTABLE_FILE_RE = re.compile(r'\.min-[a-f0-9]{16,}\.(js|css)$')
+    IMMUTABLE_FILE_RE = re.compile(r'\.min\.[a-f0-9]{16,}\.(js|css)$')
     INDEX_NAME = 'index.html'
 
     def update_files_dictionary(self, *args):


### PR DESCRIPTION
The previous change adjusted the hash length, however the filenames also no longer use a hyphen as a separator, eg:
index.min.fe5b2cd9a306c9d1.css

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2134)
<!-- Reviewable:end -->
