### PR TITLE
Bug 1311980 - Gracefully handle invalid job_id in BugJobMapViewSet.list

### DIFF
--- a/tests/webapp/api/test_bug_job_map_api.py
+++ b/tests/webapp/api/test_bug_job_map_api.py
@@ -148,3 +148,17 @@ def test_bug_job_map_delete(webapp, eleven_jobs_stored, test_repository,
         content = json.loads(resp.content)
         assert content == {"message": "Bug job map deleted"}
         assert BugJobMap.objects.count() == 0
+
+
+def test_bug_job_map_bad_job_id(webapp, test_repository):
+    """
+    test we have graceful error when we pass an invalid job_id
+    """
+    bad_job_id = "aaaa"
+
+    resp = webapp.get(
+            reverse("bug-job-map-list", kwargs={"project": test_repository.name}),
+            params={'job_id': bad_job_id}, expect_errors=True)
+
+    assert resp.status_code == 400
+    assert resp.json == {'message': 'Valid job_id required'}

--- a/treeherder/webapp/api/bug.py
+++ b/treeherder/webapp/api/bug.py
@@ -55,7 +55,11 @@ class BugJobMapViewSet(viewsets.ViewSet):
             return Response("Object not found", status=HTTP_404_NOT_FOUND)
 
     def list(self, request, project):
-        job_ids = map(int, request.query_params.getlist('job_id'))
+        try:
+            job_ids = map(int, request.query_params.getlist('job_id'))
+        except ValueError:
+            return Response({"message": "Valid job_id required"},
+                            status=400)
         if not job_ids:
             return Response({"message": "At least one job_id is required"},
                             status=400)


### PR DESCRIPTION
The value error is now handled gracefully with HTTP 400.
Bugzilla link: https://bugzilla.mozilla.org/show_bug.cgi?id=1311980

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2142)
<!-- Reviewable:end -->
