### PR TITLE
Bug 1337970 - Unescape commit message tooltips

### DIFF
--- a/ui/js/reactrevisions.js
+++ b/ui/js/reactrevisions.js
@@ -67,7 +67,7 @@ var revisionItemComponent = React.createClass({
                     dangerouslySetInnerHTML: initialsHTML
                 }),
                 React.DOM.span(
-                    { title: escapedComment },
+                    { title: _.unescape(escapedComment) },
                     React.DOM.span(
                         { className: 'revision-comment' },
                         React.DOM.em({ dangerouslySetInnerHTML: escapedCommentHTML })


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2148)
<!-- Reviewable:end -->
