### PR TITLE
Bug 1337726 - Disable E129 pyflakes lint.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,8 @@ exclude = .git,__pycache__,.vagrant,node_modules,treeherder/model/migrations,tre
 # https://github.com/PyCQA/pycodestyle/blob/2.2.0/pycodestyle.py#L72
 # Our additions...
 # E501: line too long
-ignore = E121,E123,E126,E226,E24,E704,W503,E501
+# E129: visually indented line with same indent as next logical line
+ignore = E121,E123,E126,E129,E226,E24,E704,W503,E501
 max-line-length = 140
 
 [flake8]
@@ -16,7 +17,7 @@ exclude = .git,__pycache__,.vagrant,node_modules,treeherder/model/migrations,tre
 # F401: module imported but unused
 # F403: 'from module import *' used; unable to detect undefined names
 # F405: name may be undefined, or defined from star imports: module
-ignore = E121,E123,E126,E226,E24,E704,W503,E501,F401,F403,F405
+ignore = E121,E123,E126,E129,E226,E24,E704,W503,E501,F401,F403,F405
 max-line-length = 140
 
 [isort]


### PR DESCRIPTION
This demands a weird style when using
```
if (something and
    something_else):
```

which is not really helpful to code readability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2149)
<!-- Reviewable:end -->
