### PR TITLE
Bug 1338206 - Create new users via the create_user() helper

### DIFF
--- a/treeherder/auth/backends.py
+++ b/treeherder/auth/backends.py
@@ -122,8 +122,7 @@ class TaskclusterAuthBackend(object):
             except ObjectDoesNotExist:
                 # the user doesn't already exist, create it.
                 logger.warning("Creating new user: {}".format(client_id))
-                return User.objects.create(email=email,
-                                           username=client_id)
+                return User.objects.create_user(client_id, email=email)
 
     def get_user(self, user_id):
         try:


### PR DESCRIPTION
Since it's recommended over direct creation, by the Django docs:
https://docs.djangoproject.com/en/1.10/topics/auth/default/#topics-auth-creating-users

Specifically, the helper:
* normalises username/email
* sets an unusable password rather than a blank one (subtle security implications that are unlikely to affect us, but better to be safe)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2152)
<!-- Reviewable:end -->
