### PR TITLE
Bug 1308549 - Switch to soft Celery time limits to allow reporting to New Relic

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -266,6 +266,12 @@ CELERY_DEFAULT_QUEUE = 'default'
 CELERY_DEFAULT_EXCHANGE_TYPE = 'direct'
 CELERY_DEFAULT_ROUTING_KEY = 'default'
 
+# Default celery time limits in seconds. The gap between the soft and hard time limit
+# is to give the New Relic agent time to report the `SoftTimeLimitExceeded` exception.
+# NB: The per-task `soft_time_limit` must always be lower than `CELERYD_TASK_TIME_LIMIT`.
+CELERYD_TASK_SOFT_TIME_LIMIT = 15 * 60
+CELERYD_TASK_TIME_LIMIT = CELERYD_TASK_SOFT_TIME_LIMIT + 30
+
 CELERYBEAT_SCHEDULE = {
     'fetch-push-logs-every-minute': {
         'task': 'fetch-push-logs',

--- a/treeherder/etl/tasks/buildapi_tasks.py
+++ b/treeherder/etl/tasks/buildapi_tasks.py
@@ -12,7 +12,7 @@ from treeherder.etl.runnable_jobs import RunnableJobsProcess
 from treeherder.model.models import Repository
 
 
-@task(name='fetch-buildapi-pending', time_limit=10 * 60)
+@task(name='fetch-buildapi-pending', soft_time_limit=10 * 60)
 def fetch_buildapi_pending():
     """
     Fetches the buildapi pending jobs api and load them
@@ -20,7 +20,7 @@ def fetch_buildapi_pending():
     PendingJobsProcess().run()
 
 
-@task(name='fetch-buildapi-running', time_limit=10 * 60)
+@task(name='fetch-buildapi-running', soft_time_limit=10 * 60)
 def fetch_buildapi_running():
     """
     Fetches the buildapi running jobs api and load them
@@ -28,7 +28,7 @@ def fetch_buildapi_running():
     RunningJobsProcess().run()
 
 
-@task(name='fetch-buildapi-build4h', time_limit=10 * 60)
+@task(name='fetch-buildapi-build4h', soft_time_limit=10 * 60)
 def fetch_buildapi_build4h():
     """
     Fetches the buildapi running jobs api and load them
@@ -36,7 +36,7 @@ def fetch_buildapi_build4h():
     Builds4hJobsProcess().run()
 
 
-@task(name='fetch-allthethings', time_limit=15 * 60)
+@task(name='fetch-allthethings', soft_time_limit=15 * 60)
 def fetch_allthethings():
     """
     Fetches possible jobs from allthethings and load them
@@ -57,7 +57,7 @@ def fetch_push_logs():
         )
 
 
-@task(name='fetch-hg-push-logs', time_limit=10 * 60)
+@task(name='fetch-hg-push-logs', soft_time_limit=10 * 60)
 def fetch_hg_push_log(repo_name, repo_url):
     """
     Run a HgPushlog etl process

--- a/treeherder/etl/tasks/classification_mirroring_tasks.py
+++ b/treeherder/etl/tasks/classification_mirroring_tasks.py
@@ -4,7 +4,7 @@ from treeherder.etl.classification_mirroring import ElasticsearchDocRequest
 from treeherder.workers.task import retryable_task
 
 
-@retryable_task(name="submit-elasticsearch-doc", max_retries=10, time_limit=30)
+@retryable_task(name="submit-elasticsearch-doc", max_retries=10, soft_time_limit=30)
 def submit_elasticsearch_doc(project, job_id, bug_id, classification_timestamp, who):
     """
     Mirror the classification to Elasticsearch using a post request, until

--- a/treeherder/etl/tasks/tasks.py
+++ b/treeherder/etl/tasks/tasks.py
@@ -6,7 +6,7 @@ from celery import task
 from treeherder.etl.bugzilla import BzApiBugProcess
 
 
-@task(name='fetch-bugs', time_limit=10 * 60)
+@task(name='fetch-bugs', soft_time_limit=10 * 60)
 def fetch_bugs():
     """
     Run a BzApiBug process

--- a/treeherder/seta/tasks.py
+++ b/treeherder/seta/tasks.py
@@ -2,7 +2,7 @@ from treeherder.seta.analyze_failures import AnalyzeFailures
 from treeherder.workers.task import retryable_task
 
 
-@retryable_task(name='seta-analyze-failures', max_retries=3, time_limit=5*60)
+@retryable_task(name='seta-analyze-failures', max_retries=3, soft_time_limit=5*60)
 def seta_analyze_failures():
     '''We analyze all starred test failures from the last four months which were fixed by a commit.'''
     AnalyzeFailures().run()


### PR DESCRIPTION
**1) Switch Celery per-task time_limits to soft_time_limits**
Since the hard time limits prevent the New Relic Python agent from reporting the timeout exception:
http://docs.celeryproject.org/en/3.1/userguide/workers.html#time-limits

**2) Set default Celery soft and hard time limits**
Since otherwise if either is not set on an individual task, it can run forever (or at least until the dyno is restarted, every 24 hours):
http://docs.celeryproject.org/en/3.1/configuration.html#celeryd-task-time-limit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2155)
<!-- Reviewable:end -->
