### PR TITLE
Bug 1339041 - Fix check on error code for Taskcluster expired creds

### DIFF
--- a/ui/js/models/error.js
+++ b/ui/js/models/error.js
@@ -42,7 +42,7 @@ treeherder.factory('ThTaskclusterErrors', ['localStorageService', function(local
         @param {Error} e error object from taskcluster client.
         */
         format: function(e) {
-            if (e.code === 'InsufficientScopes') {
+            if (e.code === 'AuthenticationFailed') {
                 let creds = localStorageService.get('taskcluster.credentials');
                 if (creds && creds.certificate && creds.certificate.expiry) {
                     let expires = new Date(creds.certificate.expiry);


### PR DESCRIPTION
This was the wrong error code and resulted in a confusing error message of `Taskcluster: ext.certificate.expiry < now`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2161)
<!-- Reviewable:end -->
