### PR TITLE
Bug 1339157 - Remove the RTD copyright year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Treeherder'
-copyright = u'2016, Mozilla and other contributors'
+copyright = u'Mozilla and other contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
I noticed the Read The Docs copyright is out of date, so let's update it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2163)
<!-- Reviewable:end -->
