### PR TITLE
Bug 1215102 - Adjust Celery settings to match CloudAMQP recommendations

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,15 +1,15 @@
 web: newrelic-admin run-program gunicorn treeherder.config.wsgi:application --timeout 29 --max-requests 150
-worker_beat: newrelic-admin run-program celery -A treeherder beat
-worker_pushlog: newrelic-admin run-program celery -A treeherder worker -Q pushlog --maxtasksperchild=500 --concurrency=5
-worker_buildapi_pending: newrelic-admin run-program celery -A treeherder worker -Q buildapi_pending --maxtasksperchild=20 --concurrency=5
-worker_buildapi_running: newrelic-admin run-program celery -A treeherder worker -Q buildapi_running --maxtasksperchild=20 --concurrency=5
-worker_buildapi_4hr: newrelic-admin run-program celery -A treeherder worker -Q buildapi_4hr --maxtasksperchild=20 --concurrency=1
-worker_store_pulse_jobs: newrelic-admin run-program celery -A treeherder worker -Q store_pulse_jobs --maxtasksperchild=20 --concurrency=3
-worker_store_pulse_resultsets: newrelic-admin run-program celery -A treeherder worker -Q store_pulse_resultsets --maxtasksperchild=20 --concurrency=3
+worker_beat: newrelic-admin run-program celery beat -A treeherder
+worker_pushlog: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q pushlog --maxtasksperchild=500 --concurrency=5
+worker_buildapi_pending: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q buildapi_pending --maxtasksperchild=20 --concurrency=5
+worker_buildapi_running: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q buildapi_running --maxtasksperchild=20 --concurrency=5
+worker_buildapi_4hr: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q buildapi_4hr --maxtasksperchild=20 --concurrency=1
+worker_store_pulse_jobs: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q store_pulse_jobs --maxtasksperchild=20 --concurrency=3
+worker_store_pulse_resultsets: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q store_pulse_resultsets --maxtasksperchild=20 --concurrency=3
 worker_read_pulse_jobs: newrelic-admin run-program ./manage.py read_pulse_jobs
 worker_read_pulse_resultsets: newrelic-admin run-program ./manage.py read_pulse_resultsets
-worker_default: newrelic-admin run-program celery -A treeherder worker -Q default,cycle_data,calculate_durations,fetch_bugs,detect_intermittents,fetch_allthethings,generate_perf_alerts,seta_analyze_failures --maxtasksperchild=50 --concurrency=3
-worker_hp: newrelic-admin run-program celery -A treeherder worker -Q classification_mirroring,publish_to_pulse --maxtasksperchild=50 --concurrency=1
-worker_log_parser: newrelic-admin run-program celery -A treeherder worker -Q log_parser,log_parser_fail,log_store_failure_lines,log_store_failure_lines_fail,log_crossreference_error_lines,log_crossreference_error_lines_fail,log_autoclassify,log_autoclassify_fail --maxtasksperchild=50 --concurrency=7
+worker_default: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q default,cycle_data,calculate_durations,fetch_bugs,detect_intermittents,fetch_allthethings,generate_perf_alerts,seta_analyze_failures --maxtasksperchild=50 --concurrency=3
+worker_hp: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q classification_mirroring,publish_to_pulse --maxtasksperchild=50 --concurrency=1
+worker_log_parser: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_parser,log_parser_fail,log_store_failure_lines,log_store_failure_lines_fail,log_crossreference_error_lines,log_crossreference_error_lines_fail,log_autoclassify,log_autoclassify_fail --maxtasksperchild=50 --concurrency=7
 
 release: ./bin/pre_deploy

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -266,6 +266,14 @@ BROKER_URL = env('BROKER_URL')
 if server_supports_tls(BROKER_URL):
     BROKER_USE_SSL = True
 
+# Recommended by CloudAMQP:
+# https://www.cloudamqp.com/docs/celery.html
+BROKER_HEARTBEAT = None
+BROKER_CONNECTION_TIMEOUT = 30
+CELERY_RESULT_BACKEND = None
+CELERY_SEND_EVENTS = False
+CELERY_EVENT_QUEUE_EXPIRES = 60
+
 CELERY_IGNORE_RESULT = True
 
 CELERY_ACCEPT_CONTENT = ['json']

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -257,6 +257,17 @@ CELERY_QUEUES = [
     Queue('seta_analyze_failures', Exchange('default'), routing_key='seta_analyze_failures'),
 ]
 
+# Celery broker setup
+BROKER_URL = env('BROKER_URL')
+
+# Force Celery to use TLS when appropriate (ie if not localhost),
+# rather than relying on `BROKER_URL` having `amqps://` or `?ssl=` set.
+# This is required since CloudAMQP's automatically defined URL uses neither.
+if server_supports_tls(BROKER_URL):
+    BROKER_USE_SSL = True
+
+CELERY_IGNORE_RESULT = True
+
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
@@ -587,15 +598,6 @@ CACHES = {
 
 KEY_PREFIX = TREEHERDER_MEMCACHED_KEY_PREFIX
 
-# Celery broker setup
-BROKER_URL = env('BROKER_URL')
-
-# Force Celery to use TLS when appropriate (ie if not localhost),
-# rather than relying on `BROKER_URL` having `amqps://` or `?ssl=` set.
-# This is required since CloudAMQP's automatically defined URL uses neither.
-if server_supports_tls(BROKER_URL):
-    BROKER_USE_SSL = True
-
 # This code handles the memcachier service on heroku.
 # TODO: Stop special-casing Heroku and use newer best practices from:
 # https://www.memcachier.com/documentation#django.
@@ -611,8 +613,6 @@ if env.bool('IS_HEROKU', default=False):
             "tcp_nodelay": True,
         },
     })
-
-CELERY_IGNORE_RESULT = True
 
 SWAGGER_SETTINGS = {
     'SECURITY_DEFINITIONS': {},


### PR DESCRIPTION
CloudAMQP recommend disabling events/heartbeats/gossip/mingle messages, in order to reduce unnecessary load on the rabbitmq server:
https://www.cloudamqp.com/docs/celery.html

For settings reference, see:
http://docs.celeryproject.org/en/3.1/configuration.html
http://docs.celeryproject.org/en/3.1/whatsnew-3.1.html#gossip-worker-worker-communication
http://docs.celeryproject.org/en/3.1/reference/celery.bin.worker.html#cmdoption-celery-worker--without-gossip

The Procfile is now becoming exceptionally verbose, however that's a problem to consider solving in another bug, perhaps via a runner script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2165)
<!-- Reviewable:end -->
