### PR TITLE
Bug 1330324 - Use MySQL READ-COMMITTED transaction isolation level

### DIFF
--- a/puppet/files/mysql/my.cnf
+++ b/puppet/files/mysql/my.cnf
@@ -20,3 +20,9 @@ slow_query_log="1"
 # original character with a U+FFFD replacement character.
 # See bug 1275425.
 sql_mode="NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES"
+
+# Django advises using READ-COMMITTED instead of REPEATABLE-READ:
+# https://docs.djangoproject.com/en/1.10/ref/models/querysets/#get-or-create
+# Unhelpfully MySQL uses a different (undocumented) variable name if set via config file:
+# https://bugs.mysql.com/bug.php?id=70008
+transaction-isolation=READ-COMMITTED


### PR DESCRIPTION
Since Django recommends it over REPEATABLE-READ:
https://docs.djangoproject.com/en/1.10/ref/models/querysets/#get-or-create
https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_tx_isolation

This will update Travis/Vagrant, a separate PR will be opened against the prod RDS Terraform configs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2173)
<!-- Reviewable:end -->
