### PR TITLE
Bug 1311974 - ResultSetViewSet.list "ValueError: invalid literal for int() with base 10: ..."

### DIFF
--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -284,6 +284,20 @@ def test_resultset_list_id_in(webapp, test_repository):
     assert resp.status_int == 400
 
 
+def test_resultset_list_bad_count(webapp, test_repository):
+    """
+    test for graceful error when passed an invalid count value
+    """
+    bad_count = "ZAP%n%s%n%s"
+
+    resp = webapp.get(
+            reverse("resultset-list", kwargs={"project": test_repository.name}),
+            params={'count': bad_count}, expect_errors=True)
+
+    assert resp.status_code == 400
+    assert resp.json == {'error': 'Valid count value required'}
+
+
 def test_resultset_author(webapp, test_repository):
     """
     test the author parameter

--- a/treeherder/webapp/api/resultset.py
+++ b/treeherder/webapp/api/resultset.py
@@ -138,7 +138,11 @@ class ResultSetViewSet(viewsets.ViewSet):
         if author:
             pushes = pushes.filter(author=author)
 
-        count = int(filter_params.get("count", 10))
+        try:
+            count = int(filter_params.get("count", 10))
+        except ValueError:
+            return Response({"error": "Valid count value required"},
+                            status=HTTP_400_BAD_REQUEST)
 
         if count > MAX_RESULTS_COUNT:
             msg = "Specified count exceeds api limit: {}".format(MAX_RESULTS_COUNT)


### PR DESCRIPTION
Resolved the bug to handle the case gracefully and throw HTTP 400. Also added test case for the same.
Bugzilla link - https://bugzilla.mozilla.org/show_bug.cgi?id=1311974.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2176)
<!-- Reviewable:end -->
