### PR TITLE
Bug 1340123 - Stop using --max-requests with gunicorn

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: newrelic-admin run-program gunicorn treeherder.config.wsgi:application --timeout 29 --max-requests 150
+web: newrelic-admin run-program gunicorn treeherder.config.wsgi:application --timeout 29
 worker_beat: newrelic-admin run-program celery beat -A treeherder
 worker_pushlog: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q pushlog --maxtasksperchild=500 --concurrency=5
 worker_buildapi_pending: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q buildapi_pending --maxtasksperchild=20 --concurrency=5

--- a/bin/run_gunicorn
+++ b/bin/run_gunicorn
@@ -13,7 +13,6 @@ source /etc/profile.d/treeherder.sh
 NUM_WORKERS=5
 
 exec newrelic-admin run-program gunicorn -w $NUM_WORKERS \
-    --max-requests=150 \
     treeherder.config.wsgi:application \
     --keep-alive=3 \
     --log-level error \


### PR DESCRIPTION
Since hopefully now we're no longer using datasource, the leaks should have gone. The gunicorn processes will now only be restarted at the daily Heroku dyno restart, rather than multiple times per minute, improving performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2177)
<!-- Reviewable:end -->
