### PR TITLE
Bug 1340203 - Make some Django management commands report to New Relic

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -14,3 +14,9 @@ attributes.include = request.parameters.*
 # users to opt-out. See:
 # https://groups.google.com/forum/#!topic/mozilla.dev.webdev/ragGTzhyY2w
 browser_monitoring.enabled = false
+
+[import-hook:django]
+# The agent doesn't annotate Django management commands by default:
+# https://docs.newrelic.com/docs/agents/python-agent/supported-features/python-background-tasks#django
+# List finite-duration commands here to enable their annotation by the agent.
+instrumentation.scripts.django_admin = check migrate load_initial_data


### PR DESCRIPTION
The name of suitable (finite duration) management commands have to be defined in the New Relic config file, since Django management commands are not annotated by default:
https://docs.newrelic.com/docs/agents/python-agent/supported-features/python-background-tasks#django

We'll likely want to expand this list in the future, particularly if we switch from celery beat schedules and towards the Heroku scheduler in  bug 1176492 (since it will run management commands directly, outside of Celery).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2180)
<!-- Reviewable:end -->
