### PR TITLE
Bug 1340232 - Remove unused -webkit css in the pinboard

### DIFF
--- a/ui/css/treeherder-pinboard.css
+++ b/ui/css/treeherder-pinboard.css
@@ -18,15 +18,9 @@
 
 .pin-count-pulse {
   animation: pin-count-pulse 0.4s;
-  -webkit-animation: pin-count-pulse 0.4s;
 }
 
 @keyframes pin-count-pulse {
-  0%, 100% { transform: scale(1); }
-  50% { transform: scale(3); }
-}
-
-@-webkit-keyframes pin-count-pulse {
   0%, 100% { transform: scale(1); }
   50% { transform: scale(3); }
 }
@@ -53,11 +47,8 @@
   background-color: #e6eef5;
   color: #252c33;
   flex: auto;
-  -webkit-flex: auto;
   display: flex;
-  display: -webkit-flex;
   flex-flow: row;
-  -webkit-flex-flow: row;
 }
 
 #pinboard-panel .header {
@@ -72,7 +63,6 @@
 #pinned-job-list {
   position: relative;
   flex: auto;
-  -webkit-flex: auto;
   margin: 7px 7px 10px;
 }
 
@@ -108,7 +98,6 @@
   position: relative;
   width: 200px;
   flex: none;
-  -webkit-flex: none;
   margin: 7px 7px 10px;
 }
 
@@ -151,24 +140,12 @@
   text-decoration: underline;
 }
 
-/* Spin button suppression on chrome (bug 1045611) */
-#pinboard-related-bugs form input[type=number]::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* Spin button suppression on firefox (bug 1045611) */
-#pinboard-related-bugs form input[type=number] {
-  -moz-appearance: textfield;
-}
-
 /*
  * Classification container
  */
 
 #pinboard-classification {
   flex: none;
-  -webkit-flex: none;
   width: 185px;
   padding: 5px;
 }
@@ -199,7 +176,6 @@
 
 #pinboard-controls {
   flex: none;
-  -webkit-flex: none;
   height: 43px;
   margin: 20px;
 }


### PR DESCRIPTION
This removes unused `-webkit` properties from the pinboard, stemming from webkit browser evolution (eg. Chrome) which appears to now support their non -webkit equivalents.

Everything seems consistent in the branch vs current production in basic pinboard functionality testing: pinning, unpinning, bug numbers, classifications, pinning many jobs, resizing the pinboard, changing the browser width, etc.

Tested on OSX 10.11.5:
Nightly **54.0a1 (2017-02-13) (64-bit)**
Chrome Release **56.0.2924.87 (64-bit)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2182)
<!-- Reviewable:end -->
