### PR TITLE
Bug 1340329 - Recognize gtest failure lines as errors

### DIFF
--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -363,6 +363,7 @@ class ErrorParser(ParserBase):
         "command timed out:",
         "wget: unable ",
         "TEST-VALGRIND-ERROR",
+        "[  FAILED  ] ",
     )
 
     RE_ERR_MATCH = re.compile((


### PR DESCRIPTION
This is pretty simple, though I don't know if there are reasons why this wouldn't work (such as running gtests with expected failures).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2185)
<!-- Reviewable:end -->
