### PR TITLE
Bug 1340232 - Remove unused -webkit css from info-panel

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -4,10 +4,7 @@ div#info-panel {
   height: 35%;
   max-height: 75%;
   flex: none;
-  -webkit-flex: none;
-  display: -webkit-flex;
   display: flex;
-  -webkit-flex-flow: column;
   flex-flow: column;
 }
 
@@ -36,7 +33,6 @@ div#info-panel .navbar {
 div#info-panel-resizer {
   display: flex;
   flex: none;
-  -webkit-flex: none;
   background-color: #919dad;
   cursor: ns-resize;
   height: 2px;
@@ -131,18 +127,13 @@ div#info-panel .info-panel-navbar .navbar-nav > li.active a:focus {
   position: relative; /* So we can absolutely position the loading overlay */
   height: 60%;
   flex: auto;
-  -webkit-flex: auto;
-  display: -webkit-flex;
   display: flex;
-  -webkit-flex-flow: row;
   flex-flow: row;
 }
 
 #job-details-panel, #job-tabs-panel {
   background-color: #fff;
-  display: -webkit-flex;
   display: flex;
-  -webkit-flex-flow: column;
   flex-flow: column;
 }
 
@@ -271,7 +262,6 @@ div#info-panel .info-panel-navbar .navbar-nav > li.active a:focus {
 }
 
 #job-tabs-panel {
-  -webkit-flex: 1 6;
   flex: 1 6;
   padding: 0px;
   min-width: 565px;
@@ -279,31 +269,23 @@ div#info-panel .info-panel-navbar .navbar-nav > li.active a:focus {
 
 #job-tabs-pane {
   max-height: calc(100% - 33px);
-  -webkit-flex: 1;
   flex: 1;
-  display: -webkit-flex;
   display: flex;
   overflow: auto;
 }
 
 #job-tabs-pane > * {
-  -webkit-flex: 1;
   flex: 1;
-  display: -webkit-flex;
   display: flex;
 }
 
 #job-tabs-pane > * > * {
-  -webkit-flex: 1;
   flex: 1;
-  display: -webkit-flex;
   display: flex;
 }
 
 #job-tabs-pane > * > * > * {
-  -webkit-flex: 1;
   flex: 1;
-  display: -webkit-flex;
   display: flex;
 }
 
@@ -422,9 +404,7 @@ ul.failure-summary-list li .btn-xs {
 }
 
 .similar_jobs {
-  display: -webkit-flex;
   display: flex;
-  -webkit-flex-flow: row;
   flex-flow: row;
 }
 
@@ -433,7 +413,6 @@ div.similar_jobs .right_panel {
   margin-right: 1px;
   overflow-y: auto;
   flex: 1 1;
-  -webkit-flex: 1 1;
 }
 
 div.similar_jobs .right_panel form {
@@ -458,7 +437,6 @@ div.similar_jobs .right_panel .similar_job_detail table {
 div.similar_jobs .left_panel {
   overflow: auto;
   flex: 1 1;
-  -webkit-flex: 1 1;
 }
 
 div.similar_jobs .left_panel table {


### PR DESCRIPTION
This removes unused -webkit properties from the info-panel, stemming from webkit browser evolution (eg. Chrome) which appears to now support their non -webkit equivalents.

Everything seems consistent in this branch vs current production in basic info-panel functionality testing: scroll, job details, tab functionality, annotation, similar jobs, performance, resizing the info panel, changing the browser width, pinboard integration.

Tested on OSX 10.11.5:
Nightly **54.0a1 (2017-02-16) (64-bit)**
Chrome Release **Version 56.0.2924.87 (64-bit)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2189)
<!-- Reviewable:end -->
