### PR TITLE
Bug 1340265 - Make the revisions use the full 40-char SHA

### DIFF
--- a/ui/css/treeherder-resultsets.css
+++ b/ui/css/treeherder-resultsets.css
@@ -137,6 +137,10 @@ fieldset[disabled] .btn-resultset:hover {
   padding-left: 20px;
   padding-right: 11px;
   display: inline-block;
+  width: 100px;
+  text-overflow: clip;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .revision-comment {

--- a/ui/js/reactrevisions.jsx
+++ b/ui/js/reactrevisions.jsx
@@ -37,7 +37,7 @@ const RevisionItem = (props) => {
                 <a title={`Open revision ${props.revision.revision} on ${props.repo.url}`}
                    href={props.repo.getRevisionHref(props.revision.revision)}
                    data-ignore-job-clear-on-click>
-                    {props.revision.revision.substring(0, 12)}
+                    {props.revision.revision}
                 </a>
             </span>
             <span title={`${name}: ${email}`}


### PR DESCRIPTION
This makes the revision shown in the treeherder UI copy the full 40-char SHA when double-clicked. 

It does something weird with the alignment of the committer initials and the commit message, though.... If I change it from "overflow: hidden;" to "overflow: -moz-hidden-unscrollable;" it seems to line up correctly, but that's suggested only for internal bits of Firefox, and obviously doesn't work in other browsers. I haven't had a chance to play around to try to adjust the alignment manually to fix it. (I might need to wrap the non-SHA parts of the line in a different container so I can push them around separately?)

Anyway, posting this now as a checkpoint of where I am now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2192)
<!-- Reviewable:end -->
