### PR TITLE
Bug 1341776 - Change the buildbot symbol for mochitest a11y to match taskcluster's symbol

### DIFF
--- a/tests/etl/test_buildbot.py
+++ b/tests/etl/test_buildbot.py
@@ -82,7 +82,7 @@ buildernames = [
       'name': {'group_name': 'Mochitest',
                'group_symbol': 'M',
                'name': 'Mochitest a11y',
-               'job_symbol': 'a'},
+               'job_symbol': 'a11y'},
       'platform': {'arch': 'x86',
                    'os': 'win',
                    'os_platform': 'windowsxp'}}),

--- a/treeherder/etl/buildbot.py
+++ b/treeherder/etl/buildbot.py
@@ -959,7 +959,7 @@ SYMBOLS = {
     "Mochitest WebGL": "gl",
     "Mochitest Jetpack": "JP",
     "Mochitest Metro Browser Chrome": "mc",
-    "Mochitest a11y": "a",
+    "Mochitest a11y": "a11y",
     "Mochitest Other": "oth",
     "Mochitest e10s": "M-e10s",
     "Mochitest e10s Browser Chrome": "bc",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2194)
<!-- Reviewable:end -->
