### PR TITLE
Bug 1340232 - Remove unused -webkit css from main page

### DIFF
--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -22,25 +22,13 @@ a:visited {
   color: purple;
 }
 
-input:focus::-webkit-input-placeholder {
-  color: transparent;
-}
-
-input:focus::-moz-placeholder {
-  color: transparent;
-}
-
 #global-container {
-  display: -webkit-flex;
   display: flex;
-  -webkit-flex-direction: column;
   flex-direction: column;
   height: 100%;
 }
 
 .th-global-content {
-  flex: 1; /* Not using auto because it causes unnecessary reflows, see bug 162725 */
-  -webkit-flex: auto;
   position: relative; /* Required to position inner content */
   overflow-y: auto;
 }

--- a/ui/css/treeherder-navbar-panels.css
+++ b/ui/css/treeherder-navbar-panels.css
@@ -24,8 +24,6 @@
 .th-option-group {
     margin-right: 5px;
     border: 1px solid #101010;
-    -moz-border-radius: 5px;
-    -webkit-border-radius: 5px;
     border-radius: 5px;
 }
 

--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -6,7 +6,6 @@
     background-color: #273038;
     margin-bottom: 0px;
     flex: none;
-    -webkit-flex: none;
 }
 
 #th-global-navbar-top {

--- a/ui/css/treeherder-resultsets.css
+++ b/ui/css/treeherder-resultsets.css
@@ -7,8 +7,6 @@
   padding: 2px 0px 0px 34px;
   white-space: nowrap;
   display: flex;
-  display: -webkit-flex;
-  -webkit-flex-flow: row wrap;
   flex-flow: row nowrap;
   align-items: center;
   justify-content: space-between;
@@ -16,8 +14,6 @@
 
 .result-set-left {
   display: flex;
-  display: -webkit-flex;
-  -webkit-flex-flow: row wrap;
   flex-flow: row wrap;
   flex: auto;
   align-items: center;
@@ -51,7 +47,6 @@
 
 .result-counts {
   flex: none;
-  -webkit-flex: none;
   padding-right: 10px;
 }
 


### PR DESCRIPTION
This removes unused `-webkit` properties from the main page, resultsets, and navbar, stemming from webkit browser evolution (eg. Chrome) which appears to now support their non -webkit equivalents.

Everything seems consistent in the branch vs current production in basic functionality at all browser sizes for the navbar menus, filter panel, resultsets, dropdowns, counters, info panel and pinboard integration testing.

Tested on OSX 10.11.5:
Nightly **54.0a1 (2017-02-19) (64-bit)**
Chrome Release **56.0.2924.87 (64-bit)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2197)
<!-- Reviewable:end -->
