### PR TITLE
Bug 1342269 - Fix shortcut table

### DIFF
--- a/ui/partials/main/thShortcutTable.html
+++ b/ui/partials/main/thShortcutTable.html
@@ -30,7 +30,7 @@
           <td>Select previous job</td></tr>
         <tr><td><kbd>&rarr;</kbd></td>
           <td>Select next job</td></tr>
-        <tr><td<kbd>k</kbd> or <kbd>p</kbd></td>
+        <tr><td><kbd>k</kbd> or <kbd>p</kbd></td>
           <td>Select previous unclassified failure</td></tr>
         <tr><td><kbd>j</kbd> or <kbd>n</kbd></td>
           <td>Select next unclassified failure</td></tr>


### PR DESCRIPTION
This fixes the recent layout break of the shortcut table. I also re-ordered the next/previous shortcuts where 'next' is read first in the list; which seems to make sense since by default this is the likely direction the user navigates.

Before:
![before](https://cloud.githubusercontent.com/assets/3660661/23284170/16b3bdb6-f9f8-11e6-9798-fd672a1d2970.jpg)

Fixed:
![after](https://cloud.githubusercontent.com/assets/3660661/23284178/2785d9f8-f9f8-11e6-8bad-49359c5b1281.jpg)

Tested on OSX 10.11.5:
Nightly **54.0a1 (2017-02-19) (64-bit)**
Chrome Release **56.0.2924.87 (64-bit)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2198)
<!-- Reviewable:end -->
