### PR TITLE
Bug 1340590 - Catch when referer headers aren't sent and warn user

### DIFF
--- a/ui/js/models/error.js
+++ b/ui/js/models/error.js
@@ -20,7 +20,11 @@ treeherder.factory('ThModelErrors', [function() {
         format: function(e, message) {
             // If we failed to authenticate for some reason return a nicer error message.
             if (e.status === 401 || e.status === 403) {
-                return AUTH_ERROR_MSG;
+                if (e.detail === "CSRF Failed: Referer checking failed - no Referer.") {
+                    return e.detail;
+                } else {
+                    return AUTH_ERROR_MSG;
+                }
             }
 
             // If there is nothing in the server message use the HTTP response status.


### PR DESCRIPTION
Assuming the error message string never changes, this would work, I think. Testing locally in vagrant lets retriggers succeed even with referers blocked (Something special about localhost, maybe?).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2204)
<!-- Reviewable:end -->
