### PR TITLE
Bug 1340232 - Return flex property for small push reflows

### DIFF
--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -29,6 +29,7 @@ a:visited {
 }
 
 .th-global-content {
+  flex: 1;
   position: relative; /* Required to position inner content */
   overflow-y: auto;
 }


### PR DESCRIPTION
As part of PR https://github.com/mozilla/treeherder/pull/2197 we removed this flex property since its antecedent bugs were fixed. But it turns out we still need it for small pushes containing small numbers of jobs, so the info-panel doesn't consume more than its usual vertical space.

Tested on OSX 10.11.5:
Nightly **54.0a1 (2017-02-23) (64-bit)**
Chrome Release **56.0.2924.87 (64-bit)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2205)
<!-- Reviewable:end -->
