### PR TITLE
Bug 1343002 - Make add-jobs go direct to tc for tc jobs

### DIFF
--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -256,9 +256,7 @@ treeherderApp.controller('ResultSetCtrl', [
                         thNotify.send("Trigger request sent", "success");
                         ThResultSetStore.deleteRunnableJobs($scope.repoName, $scope.resultset);
                     }, function(e) {
-                        // Generic error eg. the user doesn't have permission
-                        thNotify.send(
-                            ThModelErrors.format(e, "Unable to send trigger"), 'danger');
+                        thNotify.send(ThTaskclusterErrors.format(e), 'danger');
                     });
                 });
             } else {


### PR DESCRIPTION
This makes add-new-jobs go direct to the taskcluster queue as well. I think this should be the last thing that pulse_actions handles for taskcluster, so we can remove scopes for tc from pulse_actions after that.

pulse_actions still handles bb-specific stuff though, so this logic passes on bb jobs to it the same as before.

I've tested this locally to the best of my ability on some of my own try pushes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2208)
<!-- Reviewable:end -->
