### PR TITLE
Bug 1343329 - Add push_id filtering support to the /jobdetail/ API

### DIFF
--- a/tests/webapp/api/test_job_details_api.py
+++ b/tests/webapp/api/test_job_details_api.py
@@ -38,12 +38,14 @@ def test_job_details(test_repository, failure_classifications,
     for (job_guid, params) in details.iteritems():
         if i < 3:
             repository = test_repository
+            push_id = 1
         else:
             # renumber last
             repository = test_repository2
+            push_id = 2
             i = 1
         print (i, repository)
-        job = create_generic_job(job_guid, repository, 1, i,
+        job = create_generic_job(job_guid, repository, push_id, i,
                                  generic_reference_data)
         JobDetail.objects.create(
             job=job, **params)
@@ -120,4 +122,15 @@ def test_job_details(test_repository, failure_classifications,
         'title': 'title',
         'url': None,
         'value': 'value1'
+    }]
+
+    # Should be able to filter by push_id
+    resp = webapp.get(reverse('jobdetail-list') + '?push_id=2')
+    assert resp.status_int == 200
+    assert resp.json['results'] == [{
+        'job_guid': 'ijkl',
+        'job_id': 3,
+        'title': 'title3',
+        'url': 'https://localhost/foo',
+        'value': 'value3'
     }]

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -642,12 +642,13 @@ class JobDetailViewSet(viewsets.ReadOnlyModelViewSet):
         job__guid = django_filters.CharFilter(name='job__guid')  # for backwards compat
         title = django_filters.CharFilter(name='title')
         value = django_filters.CharFilter(name='value')
+        push_id = django_filters.NumberFilter(name='job__push')
         repository = django_filters.CharFilter(name='job__repository__name')
 
         class Meta:
             model = JobDetail
             fields = ['job_id', 'job_guid', 'job__guid', 'job_id__in', 'title',
-                      'value', 'repository']
+                      'value', 'push_id', 'repository']
 
     filter_backends = [filters.DjangoFilterBackend]
     filter_class = JobDetailFilter
@@ -661,7 +662,7 @@ class JobDetailViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = JobDetailPagination
 
     # one of these is required
-    required_filters = ['job_guid', 'job__guid', 'job_id', 'job_id__in']
+    required_filters = ['job_guid', 'job__guid', 'job_id', 'job_id__in', 'push_id']
 
     def list(self, request):
         query_param_keys = request.query_params.keys()


### PR DESCRIPTION
This will allow the test-centric UI prototype to more easily fetch all "artifact uploaded" URLs associated with a single push.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2211)
<!-- Reviewable:end -->
