### PR TITLE
Bug 1115608 - Set Django DB connection charset to utf8mb4

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -578,12 +578,15 @@ DATABASES = {
 for alias in DATABASES:
     # Persist database connections for 5 minutes, to avoid expensive reconnects.
     DATABASES[alias]['CONN_MAX_AGE'] = 300
+    DATABASES[alias]['OPTIONS'] = {
+        # Override Django's default connection charset of 'utf8', otherwise it's
+        # still not possible to insert non-BMP unicode into utf8mb4 tables.
+        'charset': 'utf8mb4',
+    }
     if DATABASES[alias]['HOST'] != 'localhost':
         # Use TLS when connecting to RDS.
-        DATABASES[alias]['OPTIONS'] = {
-            'ssl': {
-                'ca': 'deployment/aws/combined-ca-bundle.pem',
-            },
+        DATABASES[alias]['OPTIONS']['ssl'] = {
+            'ca': 'deployment/aws/combined-ca-bundle.pem',
         }
 
 # TREEHERDER_MEMCACHED is a string of comma-separated address:port pairs


### PR DESCRIPTION
This allows non-BMP unicode values to be sent by the client to MySQL server, to allow insertion into tables that have been converted to utf8mb4 (currently only the `commit` table).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2212)
<!-- Reviewable:end -->
