### PR TITLE
Bug 1343586 - Increase # of available colors for perf graphs

### DIFF
--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -8,7 +8,8 @@ perf.controller('GraphsCtrl', [
         $uibModal, thServiceDomain, $http, $q, $timeout, PhSeries,
         PhAlerts, ThRepositoryModel, ThResultSetModel,
         phTimeRanges, phDefaultTimeRangeValue) {
-        var availableColors = [ 'red', 'green', 'blue', 'orange', 'purple' ];
+        var availableColors = [ 'maroon', 'navy', 'pink', 'turquoise', 'brown',
+                                'red', 'green', 'blue', 'orange', 'purple' ];
 
         $scope.highlightedRevisions = [ undefined, undefined ];
         $scope.highlightAlerts = true;


### PR DESCRIPTION
It's not recommended, but also not unusual for people to have graphs with 6+ series in them. Let's try to handle this case a little better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2214)
<!-- Reviewable:end -->
