### PR TITLE
Bug 1174777 - Hitting 'back' on a Compare result should preserve project/revision values

### DIFF
--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -3,30 +3,35 @@
 perf.controller('CompareChooserCtrl', [
     '$state', '$stateParams', '$scope', 'ThRepositoryModel', 'ThResultSetModel',
     'phCompareDefaultNewRepo', 'phCompareDefaultOriginalRepo', 'JsonPushes',
-    'thPerformanceBranches',
+    'thPerformanceBranches','localStorageService',
     function CompareChooserCtrl($state, $stateParams, $scope,
                                 ThRepositoryModel, ThResultSetModel,
                                 phCompareDefaultNewRepo,
                                 phCompareDefaultOriginalRepo,
-                                JsonPushes, thPerformanceBranches) {
+                                JsonPushes, thPerformanceBranches,
+                                localStorageService) {
         ThRepositoryModel.get_list().success(function(projects) {
             $scope.projects = projects;
             $scope.originalTipList = [];
             $scope.newTipList = [];
 
+            var getParameter = function(paramName, defaultValue) {
+                if ($stateParams[paramName])
+                    return $stateParams[paramName];
+                else if (localStorageService.get(paramName))
+                    return localStorageService.get(paramName);
+                return defaultValue;
+            };
+
             $scope.originalProject = _.findWhere(projects, {
-                name: ($stateParams.originalProject ?
-                       $stateParams.originalProject : phCompareDefaultOriginalRepo)
+                name: getParameter('originalProject', phCompareDefaultOriginalRepo)
             }) || projects[0];
             $scope.newProject = _.findWhere(projects, {
-                name: ($stateParams.newProject ?
-                       $stateParams.newProject : phCompareDefaultNewRepo)
+                name: getParameter('newProject', phCompareDefaultNewRepo)
             }) || projects[0];
 
-            $scope.originalRevision = ($stateParams.originalRevision ?
-                                       $stateParams.originalRevision : '');
-            $scope.newRevision = ($stateParams.newRevision ?
-                                  $stateParams.newRevision : '');
+            $scope.originalRevision = getParameter('originalRevision', '');
+            $scope.newRevision = getParameter('newRevision', '');
 
             var getRevisionTips = function(projectName, list) {
                 // due to we push the revision data into list,
@@ -127,6 +132,10 @@ perf.controller('CompareChooserCtrl', [
 
                 ThResultSetModel.getResultSetsFromRevision($scope.newProject.name, $scope.newRevision).then(
                     function () {
+                        localStorageService.set('originalProject', $scope.originalProject.name, "sessionStorage");
+                        localStorageService.set('originalRevision', $scope.originalRevision, "sessionStorage");
+                        localStorageService.set('newProject', $scope.newProject.name, "sessionStorage");
+                        localStorageService.set('newRevision', $scope.newRevision, "sessionStorage");
                         $scope.newRevisionError = undefined;
                         if ($scope.originalRevisionError === undefined && $scope.newRevisionError === undefined) {
                             $state.go('compare', {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2224)
<!-- Reviewable:end -->
