### PR TITLE
Bug 1344983 - Vagrant: Increase VM memory allocation from 2GB to 3GB

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |vb, override|
     override.vm.box = "ubuntu/trusty64"
     vb.name = "treeherder"
-    vb.memory = "2048"
+    vb.memory = "3072"
 
     puppet_provisioner(override)
   end
@@ -35,7 +35,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider "hyperv" do |hv, override|
     override.vm.box = "ericmann/trusty64"
     hv.vmname = "treeherder"
-    hv.memory = "2048"
+    hv.memory = "3072"
 
     # Hyper-V box doesn't have Puppet installed. So install it manually.
     override.vm.provision "install-puppet", type: "shell" do |s|


### PR DESCRIPTION
Since with the MySQL, Elasticsearch, rabbitmq-server and memcached services running there is only 640MB free, which is insufficient for building the UI using Webpack/Neutrino or when mass ingesting data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2230)
<!-- Reviewable:end -->
