### PR TITLE
Bug 1345220 - Docs: Update read-only replica GRANTs for new tables

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -18,7 +18,9 @@ as of November 2016 (obviously you should replace `myuser` and
 .. code-block:: sql
 
     CREATE USER 'myuser' IDENTIFIED BY 'mysecurepassword';
+    # Whilst `password` is not used (and randomly generated), it's still safer to exclude it.
     GRANT SELECT (id, username, email) ON treeherder.auth_user to 'myuser' REQUIRE SSL;
+    # Tables containing no sensitive data.
     GRANT SELECT ON treeherder.bug_job_map to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.bugscache to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.build_platform to 'myuser' REQUIRE SSL;
@@ -55,7 +57,10 @@ as of November 2016 (obviously you should replace `myuser` and
     GRANT SELECT ON treeherder.repository_group to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.runnable_job to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.seta_jobpriority to 'myuser' REQUIRE SSL;
+    GRANT SELECT ON treeherder.taskcluster_metadata to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.text_log_error to 'myuser' REQUIRE SSL;
+    GRANT SELECT ON treeherder.text_log_error_match to 'myuser' REQUIRE SSL;
+    GRANT SELECT ON treeherder.text_log_error_metadata to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.text_log_step to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.text_log_summary to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.text_log_summary_line to 'myuser' REQUIRE SSL;
@@ -69,4 +74,4 @@ statements using the following SQL:
     SELECT CONCAT('GRANT SELECT ON ', table_schema, '.', table_name, ' to ''myuser'' REQUIRE SSL;') AS grant_stmt
     FROM information_schema.TABLES
     WHERE table_schema = 'treeherder'
-    AND table_name NOT REGEXP 'django_|auth_|credentials|corsheaders_';
+    AND table_name NOT REGEXP 'django_|auth_|credentials';


### PR DESCRIPTION
These were added by bug 1312575 and bug 1323110.

The table exclusion list has also been updated to remove the corsheader entry, since as of v2.0.0 it no longer creates any tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2234)
<!-- Reviewable:end -->
