### PR TITLE
Bug 1340232 - Remove unused -webkit css from perf

### DIFF
--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -1,12 +1,7 @@
 .blink {
 animation: blink 1s ease-in-out infinite alternate;
--webkit-animation: blink 1s ease-in-out infinite alternate;
 }
 @keyframes blink {
-from { opacity: 1; }
-to { opacity: 0; }
-}
-@-webkit-keyframes blink {
 from { opacity: 1; }
 to { opacity: 0; }
 }
@@ -74,8 +69,7 @@ to { opacity: 0; }
     display: block;
     background: rgba(0,0,0,.75);
     color: #fff;
-    -moz-border-radius: 5px;
-    -webkit-border-radius: 5px;
+    border-radius: 5px;
     padding: 10px 15px;
 }
 #graph-tooltip.locked .body {


### PR DESCRIPTION
This removes unused -webkit properties from Perf, stemming from webkit browser evolution (eg. Chrome) which appears to now support their non -webkit equivalents.

Everything seems consistent in the branch vs current production, with the blink behavior during test data load, and the tooltip radius on both browsers.

Tested on OSX 10.11.5:
Nightly **54.0a1 (2017-03-03) (64-bit)**
Chrome Release **56.0.2924.87 (64-bit)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2235)
<!-- Reviewable:end -->
