### PR TITLE
Bug 1343624 - Vagrant: Install nodejs and yarn during provision

### DIFF
--- a/puppet/manifests/classes/init.pp
+++ b/puppet/manifests/classes/init.pp
@@ -7,10 +7,34 @@ class init {
         creates => "/etc/apt/sources.list.d/fkrull-deadsnakes-python2_7-trusty.list",
     }
 
+    exec { "add_nodejs_signing_key":
+        command => "curl -sSf https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key --keyring /etc/apt/trusted.gpg.d/nodesource.gpg add -",
+        creates => "/etc/apt/trusted.gpg.d/nodesource.gpg",
+    }
+
+    exec { "add_nodejs_repository":
+        command => "echo 'deb https://deb.nodesource.com/node_7.x trusty main' | sudo tee /etc/apt/sources.list.d/nodesource.list",
+        creates => "/etc/apt/sources.list.d/nodesource.list",
+    }
+
+    exec { "add_yarn_signing_key":
+        command => "curl -sSf https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key --keyring /etc/apt/trusted.gpg.d/yarn.gpg add -",
+        creates => "/etc/apt/trusted.gpg.d/yarn.gpg",
+    }
+
+    exec { "add_yarn_repository":
+        command => "echo 'deb https://dl.yarnpkg.com/debian/ stable main' | sudo tee /etc/apt/sources.list.d/yarn.list",
+        creates => "/etc/apt/sources.list.d/yarn.list",
+    }
+
     exec { "update_apt":
         command => "sudo apt-get update",
         require => [
             Exec["add_python27_ppa"],
+            Exec["add_nodejs_signing_key"],
+            Exec["add_nodejs_repository"],
+            Exec["add_yarn_signing_key"],
+            Exec["add_yarn_repository"],
         ]
     }
 }

--- a/puppet/manifests/classes/nodejs.pp
+++ b/puppet/manifests/classes/nodejs.pp
@@ -1,0 +1,18 @@
+class nodejs {
+
+  package { 'nodejs':
+    # Heroku/Travis pin to a specific point release, but that's not possible
+    # with apt-get due to https://github.com/nodesource/distributions/issues/33,
+    # and using the .deb has it's own set of issues, so let's not bother for now.
+    # In this case `latest` means latest 7.x.x release, and should be fairly safe.
+    ensure => latest,
+  }
+
+  package { 'yarn':
+    # Not pinning to a specific version for parity with Travis, and since yarn
+    # is rapidly releasing so would require continually incrementing.
+    ensure  => latest,
+    require => Package['nodejs'],
+  }
+
+}

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -21,7 +21,8 @@ class vagrant {
         init: before => Class["mysql"];
         mysql: before  => Class["elasticsearch"];
         elasticsearch: before  => Class["python"];
-        python: before => Class["varnish"];
+        python: before => Class["nodejs"];
+        nodejs: before => Class["varnish"];
         varnish: before => Class["treeherder"];
         treeherder: before => Class["rabbitmq"];
         rabbitmq: before => Class["dev"];


### PR DESCRIPTION
Since once we switch to Neutrino/webpack all UI and full-stack
development will require building the UI using nodejs.

Uses the steps here:
https://github.com/nodesource/distributions#manual-installation
https://yarnpkg.com/en/docs/install#linux-tab

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2239)
<!-- Reviewable:end -->
