### PR TITLE
Bug 1343932 - Update nodejs used on Heroku/Travis from 7.7.1 to 7.7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     - env: ui-tests
       sudo: false
       language: node_js
-      node_js: "7.7.1"
+      node_js: "7.7.2"
       cache:
         # Note: This won't re-use the same cache as the linters job,
         # since caches are tied to the language/version combination.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "MPL-2.0",
   "engines": {
-    "node": "7.7.1"
+    "node": "7.7.2"
   },
   "dependencies": {
     "babel-preset-es2015": "6.18.0",


### PR DESCRIPTION
Vagrant uses the latest 7.x.x release, which is now 7.7.2. To reduce
differences between environments whilst the Neutrino/webpack work is
stabilised, it makes sense to update Heroku/Travis again too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2241)
<!-- Reviewable:end -->
