### PR TITLE
Bug 1345512 - Remove unused css from Logviewer

### DIFF
--- a/ui/css/logviewer.css
+++ b/ui/css/logviewer.css
@@ -78,28 +78,6 @@ body {
     margin: 0em 0.6em 0em 0em;
 }
 
-.lv-line-text {
-    white-space: pre;
-}
-
-.lv-line-num {
-    white-space: pre;
-    float: left;
-    align-items: center;
-    border-right: solid thin #e6e6e6;
-    -moz-user-select: none;
-    -khtml-user-select: none;
-    -webkit-user-select: none;
-    -o-user-select: none;
-    color: rgba(0, 0, 0, 0.3);
-}
-
-.lv-line-num:hover {
-    color: black;
-    background-color: #F8EEC7;
-    cursor: pointer;
-}
-
 .lv-error-line {
     background-color: white;
     color: #333333;
@@ -135,16 +113,11 @@ body {
 }
 
 .run-data .break-word{
-    -ms-word-break: break-all;
     word-break: break-all;
-
-    /* Non standard for webkit */
-    word-break: break-word;
-
-    -webkit-hyphens: auto;
-    -moz-hyphens: auto;
+    word-break: break-word; /* Non standard for webkit */
     hyphens: auto;
 }
+
 .run-data .steps-data {
     margin-bottom: 10px;
     max-height: 210px;
@@ -162,7 +135,6 @@ div.lv-step {
 .lv-step {
     border-radius: 2px;
     overflow: hidden;
-    -webkit-user-select: text;
     -moz-user-select: text;
     -ms-user-select: text;
     -o-user-select: text;


### PR DESCRIPTION
This removes unused css from the Logviewer.

Everything seems consistent in the branch vs current production. It would be good for someone else to try it out on another platform for sanity. Where possible some -moz -webkit and -ms prefixed properties were removed, others needed to remain.

Tested on OSX 10.11.5:
Nightly **55.0a1 (2017-03-14) (64-bit)**
Chrome Release **56.0.2924.87 (64-bit)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2247)
<!-- Reviewable:end -->
