### PR TITLE
Bug 1347278 - Disable Successful Step checkbox for TaskCluster jobs

### DIFF
--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -133,6 +133,9 @@ logViewerApp.controller('LogviewerCtrl', [
                         {label: 'End', value: dateFilter(job.end_timestamp * 1000, thDateFormat)}
                     ];
 
+                    // Test to disable successful steps checkbox on taskcluster jobs
+                    $scope.isTaskClusterLog = (job.build_system_type === 'taskcluster');
+
                     // Test to expose the reftest button in the logviewer actionbar
                     $scope.isReftest = () => {
                         if (job.job_group_name) {

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -72,7 +72,9 @@
             <div id="lv-successful-steps">
               <input type="checkbox"
                      ng-model="showSuccessful"
-                     ng-change="toggleSuccessfulSteps()" />
+                     ng-change="toggleSuccessfulSteps()"
+                     ng-disabled="isTaskClusterLog"
+                     ng-attr-title="{{isTaskClusterLog ? 'Not available on TaskCluster jobs' : ''}}"/>
               <span>show successful steps</span>
             </div>
           </li>


### PR DESCRIPTION
This fixes Bugzilla bug [1347278](https://bugzilla.mozilla.org/show_bug.cgi?id=1347278).

This adds a conditional title, and disables the cursor on the 'show successful steps' checkbox for any TaskCluster job, since step parsing isn't yet supported from TaskCluster.

Proposed (cursor not shown here):

![disablesuccessstepstc](https://cloud.githubusercontent.com/assets/3660661/23922694/be32616a-08d9-11e7-907b-678c7bd3381a.jpg)

I also experimented with hiding the container entirely for TaskCluster jobs, but it seemed to make a lot more sense to tell the user why it's not available, rather than have them think it's missing. There was also a lot of angular template bouncing around when hiding, which would have been undesirable.

Tested on OSX 10.11.5:
Nightly **55.0a1 (2017-03-14) (64-bit)**
Chrome Release **56.0.2924.87 (64-bit)**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2253)
<!-- Reviewable:end -->
