### PR TITLE
Bug 1347454 - Make prev/next keybindings match vi again.

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -517,11 +517,11 @@ treeherderApp.controller('MainCtrl', [
             [['j', 'shift+j'], function(ev) {
                 if (thTabs.selectedTab === "autoClassification") {
                     $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyChangeSelection,
-                                                       'previous',
+                                                       'next',
                                                        !ev.shiftKey));
                 } else {
                     $rootScope.$emit(thEvents.changeSelection,
-                                     'previous',
+                                     'next',
                                      thJobNavSelectors.UNCLASSIFIED_FAILURES);
                 }
             }],
@@ -530,11 +530,11 @@ treeherderApp.controller('MainCtrl', [
             [['k', 'shift+k'], function(ev) {
                 if (thTabs.selectedTab === "autoClassification") {
                     $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyChangeSelection,
-                                                       'next',
+                                                       'previous',
                                                        !ev.shiftKey));
                 } else {
                     $rootScope.$emit(thEvents.changeSelection,
-                                     'next',
+                                     'previous',
                                      thJobNavSelectors.UNCLASSIFIED_FAILURES);
                 }
             }],

--- a/ui/partials/main/thShortcutTable.html
+++ b/ui/partials/main/thShortcutTable.html
@@ -69,9 +69,9 @@
           <th colspan=2>Autoclassify Panel</th>
         </tr>
         <tr><td><kbd>j</kbd></td>
-          <td>Select previous failure</td></tr>
-        <tr><td><kbd>k</kbd></td>
           <td>Select next failure</td></tr>
+        <tr><td><kbd>k</kbd></td>
+          <td>Select previous failure</td></tr>
         <tr><td><kbd>a</kbd></td>
           <td>Add all subsequent lines to the selection</td></tr>
         <tr><td><kbd>0</kbd>-<kbd>9</kbd></td>


### PR DESCRIPTION
The autoclassify UI rewrite accidentially swapped the meaning of the
j and k keys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2255)
<!-- Reviewable:end -->
