### PR TITLE
Bug 1347764 - Do a better job of selecting product/component in the bug filer

### DIFF
--- a/ui/plugins/failure_summary/main.html
+++ b/ui/plugins/failure_summary/main.html
@@ -5,7 +5,7 @@
             <div class="job-tabs-content">
                 <a class="btn btn-xs btn-default"
                    prevent-default-on-left-click
-                   ng-show="user.loggedin && (filerInAddress || user.is_staff)"
+                   ng-show="(filerInAddress || user.is_staff)"
                    ng-click="fileBug($index)"
                    title="file a bug for this failure">
                   <i class="fa fa-bug"></i>


### PR DESCRIPTION
This makes a few changes to how the bug filer works.

First, it tries to strip out some bits of the failure summary that just aren't useful (like full file paths leading up to the test failures, and some jetpack/xpcshell prefixes).

It then rearranges the findProduct function so that the manual productSearch is attempted first. This makes sure the other ways of showing products don't ever get shown when the manual productSearch is performed.

If the manualProduct search is not attempted (or if it finds 0 results), it moves on to some new things:

We fix up the failure path for videopuppeteer and web-platform-tests to try to find their moz.build info.

Once it's fixed up paths as needed, we search the moz.build metadata for the recommended product/component for the given path.

If no recommended product/component was found in the metadata (or if the metadata doesn't exist for a given path), we fall back to hardcoding some product/components. It's slightly smarter than it was previously, as we'll search within the failure path for a few job types.

If we still don't have any product/component pairs, we go back to the hardcoded suggestions based on the root of the file path.



The other change this makes is to drop the loggedIn requirement for showing the bug filer, because I'm tired of having to drop that to test things locally. It still requires the user to add the "&bugfiler" param.