### PR TITLE
Bug 1336276 - Update newrelic from 2.78.0.57 to 2.82.0.62

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -15,7 +15,7 @@ kombu==3.0.37 --hash=sha256:7ceab743e3e974f3e5736082e8cc514c009e254e646d6167342e
 
 simplejson==3.10.0 --hash=sha256:953be622e88323c6f43fad61ffd05bebe73b9fd9863a46d68b052d2aa7d71ce2
 
-newrelic==2.78.0.57 --hash=sha256:2191b7699e14a07efa5d9221270eb29bdf6cce643aa56cff08546ecb3f729be6
+newrelic==2.82.0.62 --hash=sha256:482bdb36a9858d4d2aaeec4e211bd5b318310b270aa0211adc8e481e8ca235ec
 
 # Required by Django
 mysqlclient==1.3.9 --hash=sha256:990ccf1e1f15b9a291b811c993dc1c216566714bc14e6581b38665bd61c28c99


### PR DESCRIPTION
Notably this fixes the reporting of exceptions that occur outside of a view handler (which previously did not show up in APM at all).

https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-282062
https://github.com/edmorley/newrelic-python-agent/compare/v2.78.0.57...v2.82.0.62

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2261)
<!-- Reviewable:end -->
