### PR TITLE
Bug 1347726 - Prevent prevent-default-on-left-click elements retaining focus

### DIFF
--- a/ui/js/directives/treeherder/main.js
+++ b/ui/js/directives/treeherder/main.js
@@ -85,6 +85,7 @@ treeherder.directive('preventDefaultOnLeftClick', [
                     if (event.which === 1) {
                         event.preventDefault();
                     }
+                    element.blur();
                 });
             }
         };


### PR DESCRIPTION
Elements like toolbar buttons can be clicked and then become
disabled. In this case they will eat keyboard shortcuts leading to
bugs. A simplisitic fix is just to ensure that those elements give up
focus after they are activated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2262)
<!-- Reviewable:end -->
