### PR TITLE
Bug 1348360 - Remove 'flake8: noqa' and fix linter errors in update_job_priority.py

### DIFF
--- a/treeherder/seta/update_job_priority.py
+++ b/treeherder/seta/update_job_priority.py
@@ -9,12 +9,8 @@ Known bug:
    the same set of jobs. Unfortunately, this is less than ideal if we want to make this
    work for project repositories.
 '''
-import copy
 import datetime
-import json
 import logging
-import os
-import time
 
 from treeherder.etl.seta import (parse_testtype,
                                  valid_platform)
@@ -50,6 +46,7 @@ def _unique_key(job):
     return unique_key(testtype=str(job['testtype']),
                       buildtype=str(job['platform_option']),
                       platform=str(job['platform']))
+
 
 def _sanitize_data(runnable_jobs_data):
     """We receive data from runnable jobs api and return the sanitized data that meets our needs.
@@ -101,6 +98,7 @@ def _sanitize_data(runnable_jobs_data):
 
     return sanitized_list
 
+
 def query_sanitized_data(repo_name='mozilla-inbound'):
     """Return sanitized jobs data based on runnable api. None if failed to obtain or no new data.
 
@@ -123,8 +121,10 @@ def query_sanitized_data(repo_name='mozilla-inbound'):
     runnable_jobs = RunnableJobsClient().query_runnable_jobs(repo_name)
     return _sanitize_data(runnable_jobs)
 
+
 def _two_weeks_from_now():
     return datetime.datetime.now() + datetime.timedelta(days=14)
+
 
 def _initialize_values():
     logger.info('Fetch all rows from the job priority table.')
@@ -140,6 +140,7 @@ def _initialize_values():
         # If information to determine job failures is available, the jobs will quickly be turned
         # into high value jobs.
         return jp_index, SETA_LOW_VALUE_PRIORITY, None
+
 
 def _update_table(data):
     """Add new jobs to the priority table and update the build system if required.
@@ -189,7 +190,7 @@ def _update_table(data):
                 failed_changes += 1
 
     logger.info('We have {} new jobs and {} updated jobs out of {} total jobs '
-                      'processed.'.format(new_jobs, updated_jobs, total_jobs))
+                'processed.'.format(new_jobs, updated_jobs, total_jobs))
 
     if failed_changes != 0:
         logger.warning('We have failed {} changes out of {} total jobs processed.'.format(

--- a/treeherder/seta/update_job_priority.py
+++ b/treeherder/seta/update_job_priority.py
@@ -116,7 +116,7 @@ def query_sanitized_data(repo_name='mozilla-inbound'):
         "data": {},
         "expires": "2017-10-06T18:30:18.428Z"
       }
-     [3] https://treeherder.mozilla.org/api/project/mozilla-inbound/runnable_jobs/?decision_task_id=Pp7ZxoH0SKyU6wnhX_Fp0g&format=json  # flake8: noqa
+     [3] https://treeherder.mozilla.org/api/project/mozilla-inbound/runnable_jobs/?decision_task_id=Pp7ZxoH0SKyU6wnhX_Fp0g&format=json
     """
     runnable_jobs = RunnableJobsClient().query_runnable_jobs(repo_name)
     return _sanitize_data(runnable_jobs)


### PR DESCRIPTION
These were hidden by the use of `# flake8: noqa`, which wasn't actually required on the line in question since line length checks are disabled, and in fact disabled flake8 for the entire file rather than just the one line.

```
treeherder/seta/update_job_priority.py:12:1: F401 'copy' imported but unused
treeherder/seta/update_job_priority.py:14:1: F401 'json' imported but unused
treeherder/seta/update_job_priority.py:16:1: F401 'os' imported but unused
treeherder/seta/update_job_priority.py:17:1: F401 'time' imported but unused
treeherder/seta/update_job_priority.py:54:1: E302 expected 2 blank lines, found 1
treeherder/seta/update_job_priority.py:104:1: E302 expected 2 blank lines, found 1
treeherder/seta/update_job_priority.py:126:1: E302 expected 2 blank lines, found 1
treeherder/seta/update_job_priority.py:129:1: E302 expected 2 blank lines, found 1
treeherder/seta/update_job_priority.py:144:1: E302 expected 2 blank lines, found 1
treeherder/seta/update_job_priority.py:192:23: E127 continuation line over-indented for visual indent
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2265)
<!-- Reviewable:end -->
