### PR TITLE
Bug 1348375 - Re-enable flake8 "F401: module imported but unused"

### DIFF
--- a/docs/code_style.rst
+++ b/docs/code_style.rst
@@ -23,8 +23,8 @@ In addition:
 
   .. code-block:: python
 
-     from treeherder.client import (HawkAuth,
-                                    TreeherderClient)
+     from django.db import (models,
+                            transaction)
 
 The quickest way to correct import style locally is to let isort make the changes for you - see :ref:`running the tests <running-tests>`.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,9 @@ max-line-length = 140
 # pycodestyle's config (eg autopep8) so we can't just define everything under [flake8].
 exclude = .git,__pycache__,.vagrant,node_modules
 # The ignore list for pycodestyle above, plus our own PyFlakes additions:
-# F401: module imported but unused
 # F403: 'from module import *' used; unable to detect undefined names
 # F405: name may be undefined, or defined from star imports: module
-ignore = E121,E123,E126,E129,E226,E24,E704,W503,E501,F401,F403,F405
+ignore = E121,E123,E126,E129,E226,E24,E704,W503,E501,F403,F405
 max-line-length = 140
 
 [isort]

--- a/tests/autoclassify/test_classify_failures.py
+++ b/tests/autoclassify/test_classify_failures.py
@@ -9,8 +9,7 @@ from treeherder.model.models import (BugJobMap,
                                      FailureMatch,
                                      JobNote,
                                      TextLogError,
-                                     TextLogErrorMatch,
-                                     TextLogErrorMetadata)
+                                     TextLogErrorMatch)
 
 from .utils import (crash_line,
                     create_lines,

--- a/tests/client/test_perfherder_client.py
+++ b/tests/client/test_perfherder_client.py
@@ -2,7 +2,7 @@ import unittest
 
 import responses
 
-from treeherder.client import PerfherderClient
+from treeherder.client.thclient import PerfherderClient
 
 
 class PerfherderClientTest(unittest.TestCase):

--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -7,15 +7,15 @@ import unittest
 import responses
 from requests_hawk import HawkAuth
 
-from treeherder.client import (TreeherderArtifact,
-                               TreeherderArtifactCollection,
-                               TreeherderClient,
-                               TreeherderClientError,
-                               TreeherderJob,
-                               TreeherderJobCollection,
-                               TreeherderResultSet,
-                               TreeherderResultSetCollection,
-                               TreeherderRevision)
+from treeherder.client.thclient import (TreeherderArtifact,
+                                        TreeherderArtifactCollection,
+                                        TreeherderClient,
+                                        TreeherderClientError,
+                                        TreeherderJob,
+                                        TreeherderJobCollection,
+                                        TreeherderResultSet,
+                                        TreeherderResultSetCollection,
+                                        TreeherderRevision)
 
 
 class DataSetup(unittest.TestCase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from requests import Request
 from requests_hawk import HawkAuth
 from webtest.app import TestApp
 
-from treeherder.client import TreeherderClient
+from treeherder.client.thclient import TreeherderClient
 from treeherder.config.wsgi import application
 from treeherder.etl.jobs import store_job_data
 from treeherder.etl.resultset import store_result_set_data

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -6,7 +6,7 @@ from django.template import (Context,
                              Template)
 
 from tests import test_utils
-from treeherder.client import TreeherderJobCollection
+from treeherder.client.thclient import TreeherderJobCollection
 
 base_dir = os.path.dirname(__file__)
 

--- a/tests/etl/test_job_loader.py
+++ b/tests/etl/test_job_loader.py
@@ -8,7 +8,6 @@ from treeherder.model.models import (Job,
                                      JobDetail,
                                      JobLog,
                                      Push,
-                                     Repository,
                                      TaskclusterMetadata)
 
 

--- a/tests/model/test_classified_failure.py
+++ b/tests/model/test_classified_failure.py
@@ -4,7 +4,6 @@ from tests.autoclassify.utils import (create_failure_lines,
                                       create_text_log_errors,
                                       test_line)
 from treeherder.model.models import (ClassifiedFailure,
-                                     FailureLine,
                                      FailureMatch)
 
 

--- a/tests/perfalert/test_analyze.py
+++ b/tests/perfalert/test_analyze.py
@@ -2,12 +2,12 @@ import os
 import unittest
 
 from tests.sampledata import SampleData
-from treeherder.perfalert import (Datum,
-                                  analyze,
-                                  calc_t,
-                                  default_weights,
-                                  detect_changes,
-                                  linear_weights)
+from treeherder.perfalert.perfalert import (Datum,
+                                            analyze,
+                                            calc_t,
+                                            default_weights,
+                                            detect_changes,
+                                            linear_weights)
 
 
 class TestAnalyze(unittest.TestCase):

--- a/tests/seta/conftest.py
+++ b/tests/seta/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-from django.utils import timezone
 
 from treeherder.model.models import (Job,
                                      JobNote)

--- a/tests/seta/test_job_priorities.py
+++ b/tests/seta/test_job_priorities.py
@@ -5,7 +5,6 @@ from mock import patch
 
 from treeherder.seta.job_priorities import (SetaError,
                                             seta_job_scheduling)
-from treeherder.seta.settings import SETA_LOW_VALUE_PRIORITY
 
 
 @pytest.mark.django_db()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import datetime
 import json
 
 from tests.sampledata import SampleData
-from treeherder.client import TreeherderClient
+from treeherder.client.thclient import TreeherderClient
 from treeherder.etl.jobs import store_job_data
 from treeherder.etl.resultset import store_result_set_data
 from treeherder.model import models

--- a/tests/webapp/api/test_resultset_api.py
+++ b/tests/webapp/api/test_resultset_api.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 from rest_framework.test import APIClient
 
 from tests import test_utils
-from treeherder.client import TreeherderResultSetCollection
+from treeherder.client.thclient import TreeherderResultSetCollection
 from treeherder.etl.resultset import store_result_set_data
 from treeherder.model.models import (FailureClassification,
                                      Job,

--- a/tests/webapp/api/test_text_log_summary_lines.py
+++ b/tests/webapp/api/test_text_log_summary_lines.py
@@ -4,7 +4,6 @@ from rest_framework.test import APIClient
 from treeherder.model.models import (BugJobMap,
                                      FailureLine,
                                      JobNote,
-                                     TextLogError,
                                      TextLogErrorMetadata,
                                      TextLogSummary)
 

--- a/treeherder/auth/backends.py
+++ b/treeherder/auth/backends.py
@@ -7,13 +7,7 @@ from rest_framework.reverse import reverse
 from taskcluster.sync import Auth
 from taskcluster.utils import scope_match
 
-try:
-    from django.utils.encoding import smart_bytes
-except ImportError:
-    from django.utils.encoding import smart_str as smart_bytes
-
 logger = logging.getLogger(__name__)
-
 
 CLIENT_ID_RE = re.compile(
     r"^(?:email|mozilla-ldap)/([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.["

--- a/treeherder/autoclassify/tasks.py
+++ b/treeherder/autoclassify/tasks.py
@@ -1,9 +1,7 @@
 import logging
 
 import newrelic.agent
-from django.conf import settings
 
-from treeherder import celery_app
 from treeherder.autoclassify.autoclassify import match_errors
 from treeherder.model.models import Job
 from treeherder.workers.task import retryable_task

--- a/treeherder/client/__init__.py
+++ b/treeherder/client/__init__.py
@@ -1,1 +1,0 @@
-from .thclient import *

--- a/treeherder/client/thclient/__init__.py
+++ b/treeherder/client/thclient/__init__.py
@@ -1,2 +1,2 @@
-from .client import *
-from .perfherder import *
+from .client import *  # noqa
+from .perfherder import *  # noqa

--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -7,7 +7,7 @@ import simplejson as json
 from django.conf import settings
 from django.core.cache import cache
 
-from treeherder.client import TreeherderJobCollection
+from treeherder.client.thclient import TreeherderJobCollection
 from treeherder.etl import (buildbot,
                             common)
 from treeherder.etl.jobs import store_job_data

--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -5,7 +5,7 @@ import newrelic.agent
 import requests
 from django.core.cache import cache
 
-from treeherder.client import TreeherderResultSetCollection
+from treeherder.client.thclient import TreeherderResultSetCollection
 from treeherder.etl.common import (CollectionNotStoredException,
                                    fetch_json,
                                    generate_revision_hash)

--- a/treeherder/etl/tasks/__init__.py
+++ b/treeherder/etl/tasks/__init__.py
@@ -1,4 +1,0 @@
-from .buildapi_tasks import *
-from .pulse_tasks import *
-from .classification_mirroring_tasks import *
-from .tasks import *

--- a/treeherder/model/management/commands/import_reference_data.py
+++ b/treeherder/model/management/commands/import_reference_data.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from treeherder.client import TreeherderClient
+from treeherder.client.thclient import TreeherderClient
 from treeherder.model.models import (BuildPlatform,
                                      FailureClassification,
                                      JobGroup,

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -929,7 +929,7 @@ class BugJobMap(models.Model):
     def save(self, *args, **kwargs):
         super(BugJobMap, self).save(*args, **kwargs)
 
-        from treeherder.etl.tasks import submit_elasticsearch_doc
+        from treeherder.etl.tasks.classification_mirroring_tasks import submit_elasticsearch_doc
 
         if settings.ORANGEFACTOR_HAWK_KEY:
             if self.job.state == "completed":

--- a/treeherder/perf/alerts.py
+++ b/treeherder/perf/alerts.py
@@ -9,8 +9,8 @@ from treeherder.perf.models import (PerformanceAlert,
                                     PerformanceAlertSummary,
                                     PerformanceDatum,
                                     PerformanceSignature)
-from treeherder.perfalert import (Datum,
-                                  detect_changes)
+from treeherder.perfalert.perfalert import (Datum,
+                                            detect_changes)
 
 
 def get_alert_properties(prev_value, new_value, lower_is_better):

--- a/treeherder/perf/management/commands/import_perf_data.py
+++ b/treeherder/perf/management/commands/import_perf_data.py
@@ -6,8 +6,8 @@ from django.core.management.base import (BaseCommand,
 from django.db import (IntegrityError,
                        transaction)
 
-from treeherder.client import (PerfherderClient,
-                               PerformanceTimeInterval)
+from treeherder.client.thclient import (PerfherderClient,
+                                        PerformanceTimeInterval)
 from treeherder.model.models import (MachinePlatform,
                                      OptionCollection,
                                      Repository)

--- a/treeherder/perf/management/commands/test_analyze_perf.py
+++ b/treeherder/perf/management/commands/test_analyze_perf.py
@@ -4,8 +4,8 @@ from django.core.management.base import (BaseCommand,
 
 from treeherder.client.thclient import (PerfherderClient,
                                         PerformanceTimeInterval)
-from treeherder.perfalert import (Datum,
-                                  detect_changes)
+from treeherder.perfalert.perfalert import (Datum,
+                                            detect_changes)
 
 
 class Command(BaseCommand):

--- a/treeherder/perf/management/commands/test_analyze_perf.py
+++ b/treeherder/perf/management/commands/test_analyze_perf.py
@@ -2,8 +2,8 @@ from django.conf import settings
 from django.core.management.base import (BaseCommand,
                                          CommandError)
 
-from treeherder.client import (PerfherderClient,
-                               PerformanceTimeInterval)
+from treeherder.client.thclient import (PerfherderClient,
+                                        PerformanceTimeInterval)
 from treeherder.perfalert import (Datum,
                                   detect_changes)
 

--- a/treeherder/perfalert/__init__.py
+++ b/treeherder/perfalert/__init__.py
@@ -1,1 +1,0 @@
-from .perfalert import *

--- a/treeherder/seta/analyze_failures.py
+++ b/treeherder/seta/analyze_failures.py
@@ -5,8 +5,7 @@ from datetime import timedelta
 from django.utils import timezone
 
 from treeherder.etl.seta import (is_job_blacklisted,
-                                 parse_testtype,
-                                 valid_platform)
+                                 parse_testtype)
 from treeherder.model import models
 from treeherder.seta.common import unique_key
 from treeherder.seta.high_value_jobs import get_high_value_jobs

--- a/treeherder/seta/job_priorities.py
+++ b/treeherder/seta/job_priorities.py
@@ -7,7 +7,6 @@ from treeherder.etl.runnable_jobs import list_runnable_jobs
 from treeherder.etl.seta import (is_job_blacklisted,
                                  parse_testtype,
                                  valid_platform)
-from treeherder.model.models import Repository
 from treeherder.seta.common import unique_key
 from treeherder.seta.models import JobPriority
 from treeherder.seta.settings import (SETA_LOW_VALUE_PRIORITY,

--- a/treeherder/seta/migrations/0001_squashed_0002_remove_task_request_and_jp_timeout.py
+++ b/treeherder/seta/migrations/0001_squashed_0002_remove_task_request_and_jp_timeout.py
@@ -10,7 +10,6 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('model', '0001_squashed_0053_add_job_platform_option_push_index'),
     ]
 
     operations = [

--- a/treeherder/seta/models.py
+++ b/treeherder/seta/models.py
@@ -4,7 +4,6 @@ from django.db import models
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 
-from treeherder.model.models import Repository
 from treeherder.seta.common import unique_key
 from treeherder.seta.settings import SETA_LOW_VALUE_PRIORITY
 


### PR DESCRIPTION
As part of the flake8/pyflakes update recently, the `F401: module imported but unused` rule was disabled, since it appeared to be a new noisy rule. However it in fact was just an updated existing rule, that catches a few more cases that we care less about (it's more fussy about wildcard imports, even though they should be covered separately by F403).

As such, some valid unused imports have since snuck in.

This PR cleans those up and then re-enables this rule after fixing the extra wildcard import errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2269)
<!-- Reviewable:end -->
