### PR TITLE
Bug 1348375 - Re-add wildcard imports in treeherder.etl.tasks

### DIFF
--- a/treeherder/etl/tasks/__init__.py
+++ b/treeherder/etl/tasks/__init__.py
@@ -1,0 +1,5 @@
+# Used by Celery for task auto-discovery.
+from .buildapi_tasks import *  # noqa
+from .pulse_tasks import *  # noqa
+from .classification_mirroring_tasks import *  # noqa
+from .tasks import *  # noqa


### PR DESCRIPTION
Since it turns out Celery uses them during task auto-discovery.

This partially reverts commit 63372232164bf09ae4378e07e196c407a0b29229.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2276)
<!-- Reviewable:end -->
