### PR TITLE
Bug 1349283 - Update job status after saving final line in autoclassify panel

### DIFF
--- a/ui/plugins/auto_classification/controller.js
+++ b/ui/plugins/auto_classification/controller.js
@@ -938,10 +938,7 @@ treeherder.controller('ThAutoclassifyPanelController', [
         ctrl.onSaveAll = function() {
             save($scope.pendingLines())
                 .then(() => {
-                    var jobs = {};
-                    jobs[ctrl.thJob.id] = ctrl.thJob;
-                    // Emit this event to get the main UI to update
-                    $rootScope.$emit(thEvents.autoclassifyVerified, {jobs: jobs});
+                    signalFullyClassified();
                 });
             ctrl.selectedLineIds.clear();
         };
@@ -950,8 +947,23 @@ treeherder.controller('ThAutoclassifyPanelController', [
          * Save all selected lines
          */
         ctrl.onSave = function() {
-            save($scope.selectedLines());
+            save($scope.selectedLines())
+            .then(() => {
+                if ($scope.pendingLines().length === 0) {
+                    signalFullyClassified();
+                }
+            });
         };
+
+        /**
+         * Emit an event indicating that the job has been fully classified
+         */
+        function signalFullyClassified() {
+            var jobs = {};
+            jobs[ctrl.thJob.id] = ctrl.thJob;
+            // Emit this event to get the main UI to update
+            $rootScope.$emit(thEvents.autoclassifyVerified, {jobs: jobs});
+        }
 
         /**
          * Ignore selected lines


### PR DESCRIPTION
Emit the event that causes the job status to update after saving and
ending up with 0 pending lines, as well as after save all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2277)
<!-- Reviewable:end -->
