### PR TITLE
Bug 1349405 - Delete .heroku/yarn/ during post_compile

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -35,5 +35,6 @@ set-env NEW_RELIC_PROCESS_HOST_DISPLAY_NAME '$DYNO'
 # required once `yarn run build` has run. The buildpack cache will still
 # contain them, so this doesn't slow down the next slug compile.
 rm -r .heroku/node/
+rm -r .heroku/yarn/
 rm -r .profile.d/nodejs.sh
 rm -r node_modules/


### PR DESCRIPTION
Since it avoids including 4500 unused files (28MB) in the slug, now that
we're using the yarn support added to newer versions of the nodejs
buildpack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2278)
<!-- Reviewable:end -->
