### PR TITLE
Bug 1343108 - Clean up obsolete $httpProvider defaults

### DIFF
--- a/ui/js/treeherder_app.js
+++ b/ui/js/treeherder_app.js
@@ -23,10 +23,6 @@ treeherderApp.config(['$compileProvider', '$routeProvider', '$httpProvider',
 
         localStorageServiceProvider.setPrefix("treeherder");
 
-        // avoid CORS issue when getting the logs from the ftp site
-        $httpProvider.defaults.useXDomain = true;
-        delete $httpProvider.defaults.headers.common['X-Requested-With'];
-
         $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
         $httpProvider.defaults.xsrfCookieName = 'csrftoken';
         $httpProvider.useApplyAsync(true);


### PR DESCRIPTION
`useXDomain` never actually did anything since the PR that proposed it was never merged:
https://github.com/angular/angular.js/issues/2956#issuecomment-19493940

And deleting the 'X-Requested-With' header isn't required as of Angular >1.1.x :
https://github.com/angular/angular.js/issues/11008
https://github.com/angular/angular.js/commit/3a75b1124d062f64093a90b26630938558909e8d

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2279)
<!-- Reviewable:end -->
