### PR TITLE
Bug 1313221 - Disable the unused gaia and gaia-master repositories

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -538,7 +538,7 @@
         "name": "gaia",
         "url": "https://github.com/mozilla-b2g/gaia",
         "branch": "pull request",
-        "active_status": "active",
+        "active_status": "onhold",
         "codebase": "gaia",
         "repository_group": 3,
         "description": ""
@@ -578,7 +578,7 @@
         "name": "gaia-master",
         "url": "https://github.com/mozilla-b2g/gaia",
         "branch": "master",
-        "active_status": "active",
+        "active_status": "onhold",
         "codebase": "gaia",
         "repository_group": 4,
         "description": "Gaia master branch"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1313221

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2280)
<!-- Reviewable:end -->
