### PR TITLE
Bug 1344358 - Make perf regression detection work better w/ retriggers

### DIFF
--- a/tests/perfalert/test_analyze.py
+++ b/tests/perfalert/test_analyze.py
@@ -1,5 +1,6 @@
 import os
-import unittest
+
+import pytest
 
 from tests.sampledata import SampleData
 from treeherder.perfalert.perfalert import (Datum,
@@ -10,87 +11,80 @@ from treeherder.perfalert.perfalert import (Datum,
                                             linear_weights)
 
 
-class TestAnalyze(unittest.TestCase):
-
-    def test_analyze(self):
-        self.assertEqual(analyze([]),
-                         {"avg": 0.0, "n": 0, "variance": 0.0})
-        self.assertEqual(analyze([3.0]),
-                         {"avg": 3.0, "n": 1, "variance": 0.0})
-        self.assertEqual(analyze([1.0, 2.0, 3.0, 4.0]),
-                         {"avg": 2.5, "n": 4, "variance": 5.0/3.0})
-        self.assertEqual(analyze([1.0, 2.0, 3.0, 4.0], linear_weights),
-                         {"avg": 2.0, "n": 4, "variance": 2.0})
-
-    def test_weights(self):
-        self.assertEqual([default_weights(i, 5) for i in range(5)],
-                         [1.0, 1.0, 1.0, 1.0, 1.0])
-        self.assertEqual([linear_weights(i, 5) for i in range(5)],
-                         [1.0, 0.8, 0.6, 0.4, 0.2])
-
-    def test_calc_t(self):
-        self.assertEqual(calc_t([0.0, 0.0], [1.0, 2.0]), 3.0)
-        self.assertEqual(calc_t([0.0, 0.0], [0.0, 0.0]), 0.0)
-        self.assertEqual(calc_t([0.0, 0.0], [1.0, 1.0]), float('inf'))
+def test_analyze():
+    assert analyze([]) == {"avg": 0.0, "n": 0, "variance": 0.0}
+    assert analyze([3.0]) == {"avg": 3.0, "n": 1, "variance": 0.0}
+    assert analyze([1.0, 2.0, 3.0, 4.0]) == {"avg": 2.5, "n": 4,
+                                             "variance": 5.0/3.0}
+    assert analyze([1.0, 2.0, 3.0, 4.0], linear_weights) == {"avg": 2.0,
+                                                             "n": 4,
+                                                             "variance": 2.0}
 
 
-class TestAnalyzer(unittest.TestCase):
-
-    def test_detect_changes(self):
-        data = []
-
-        times = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-        values = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1,  1,  1,  1,  1,  1,  1]
-        for (t, v) in zip(times, values):
-            data.append(Datum(t, float(v)))
-
-        result = [(d.push_timestamp, d.state) for d in
-                  detect_changes(data, min_back_window=5, max_back_window=5,
-                                 fore_window=5, t_threshold=2)]
-        self.assertEqual(result, [
-            (1, 'good'),
-            (2, 'good'),
-            (3, 'good'),
-            (4, 'good'),
-            (5, 'good'),
-            (6, 'good'),
-            (7, 'good'),
-            (8, 'regression'),
-            (9, 'good'),
-            (10, 'good')])
-
-    def test_json_files(self):
-        self.check_json('runs1.json', [1365019665])
-        self.check_json('runs2.json', [1357704596, 1358971894, 1365014104])
-        self.check_json('runs3.json', [1335293827, 1338839958])
-        self.check_json('runs4.json', [1364922838])
-        self.check_json('runs5.json', [])
-        self.check_json('a11y.json', [1366197637, 1367799757])
-        self.check_json('tp5rss.json', [1372846906, 1373413365, 1373424974])
-
-    def check_json(self, filename, expected_timestamps):
-        """Parse JSON produced by http://graphs.mozilla.org/api/test/runs"""
-        # Configuration for Analyzer
-        FORE_WINDOW = 12
-        MIN_BACK_WINDOW = 12
-        MAX_BACK_WINDOW = 24
-        THRESHOLD = 7
-
-        payload = SampleData.get_perf_data(os.path.join('graphs', filename))
-        runs = payload['test_runs']
-        data = []
-        for r in runs:
-            data.append(Datum(r[2], r[3], testrun_id=r[0],
-                              revision_id=r[1][2]))
-
-        results = detect_changes(data, min_back_window=MIN_BACK_WINDOW,
-                                 max_back_window=MAX_BACK_WINDOW,
-                                 fore_window=FORE_WINDOW,
-                                 t_threshold=THRESHOLD)
-        regression_timestamps = [d.push_timestamp for d in results if
-                                 d.state == 'regression']
-        self.assertEqual(regression_timestamps, expected_timestamps)
+def test_weights():
+    assert [default_weights(i, 5) for i in range(5)] == [1.0, 1.0, 1.0, 1.0, 1.0]
+    assert [linear_weights(i, 5) for i in range(5)] == [1.0, 0.8, 0.6, 0.4, 0.2]
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_calc_t():
+    assert calc_t([0.0, 0.0], [1.0, 2.0]) == 3.0
+    assert calc_t([0.0, 0.0], [0.0, 0.0]) == 0.0
+    assert calc_t([0.0, 0.0], [1.0, 1.0]) == float('inf')
+
+
+def test_detect_changes():
+    data = []
+
+    times = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    values = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1,  1,  1,  1,  1,  1,  1]
+    for (t, v) in zip(times, values):
+        data.append(Datum(t, float(v)))
+
+    result = [(d.push_timestamp, d.state) for d in
+              detect_changes(data, min_back_window=5, max_back_window=5,
+                             fore_window=5, t_threshold=2)]
+    assert result == [
+        (1, 'good'),
+        (2, 'good'),
+        (3, 'good'),
+        (4, 'good'),
+        (5, 'good'),
+        (6, 'good'),
+        (7, 'good'),
+        (8, 'regression'),
+        (9, 'good'),
+        (10, 'good')
+    ]
+
+
+@pytest.mark.parametrize(("filename", "expected_timestamps"), [
+    ('runs1.json', [1365019665]),
+    ('runs2.json', [1357704596, 1358971894, 1365014104]),
+    ('runs3.json', [1335293827, 1338839958]),
+    ('runs4.json', [1364922838]),
+    ('runs5.json', []),
+    ('a11y.json', [1366197637, 1367799757]),
+    ('tp5rss.json', [1372846906, 1373413365, 1373424974])
+    ])
+def test_detect_changes_historical_data(filename, expected_timestamps):
+    """Parse JSON produced by http://graphs.mozilla.org/api/test/runs"""
+    # Configuration for Analyzer
+    FORE_WINDOW = 12
+    MIN_BACK_WINDOW = 12
+    MAX_BACK_WINDOW = 24
+    THRESHOLD = 7
+
+    payload = SampleData.get_perf_data(os.path.join('graphs', filename))
+    runs = payload['test_runs']
+    data = []
+    for r in runs:
+        data.append(Datum(r[2], r[3], testrun_id=r[0],
+                          revision_id=r[1][2]))
+
+    results = detect_changes(data, min_back_window=MIN_BACK_WINDOW,
+                             max_back_window=MAX_BACK_WINDOW,
+                             fore_window=FORE_WINDOW,
+                             t_threshold=THRESHOLD)
+    regression_timestamps = [d.push_timestamp for d in results if
+                             d.state == 'regression']
+    assert regression_timestamps == expected_timestamps

--- a/tests/perfalert/test_analyze.py
+++ b/tests/perfalert/test_analyze.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from tests.sampledata import SampleData
-from treeherder.perfalert.perfalert import (Datum,
+from treeherder.perfalert.perfalert import (RevisionDatum,
                                             analyze,
                                             calc_t,
                                             default_weights,
@@ -11,14 +11,26 @@ from treeherder.perfalert.perfalert import (Datum,
                                             linear_weights)
 
 
-def test_analyze():
-    assert analyze([]) == {"avg": 0.0, "n": 0, "variance": 0.0}
-    assert analyze([3.0]) == {"avg": 3.0, "n": 1, "variance": 0.0}
-    assert analyze([1.0, 2.0, 3.0, 4.0]) == {"avg": 2.5, "n": 4,
-                                             "variance": 5.0/3.0}
-    assert analyze([1.0, 2.0, 3.0, 4.0], linear_weights) == {"avg": 2.0,
-                                                             "n": 4,
-                                                             "variance": 2.0}
+@pytest.mark.parametrize(("revision_data", "weight_fn",
+                          "expected"), [
+    # common-cases (one revision, one value)
+    ([], default_weights, {"avg": 0.0, "n": 0, "variance": 0.0}),
+    ([[3.0]], default_weights, {"avg": 3.0, "n": 1, "variance": 0.0}),
+    ([[1.0], [2.0], [3.0], [4.0]], default_weights, {"avg": 2.5, "n": 4,
+                                                     "variance": 5.0/3.0}),
+    ([[1.0], [2.0], [3.0], [4.0]], linear_weights, {"avg": 2.0,
+                                                    "n": 4,
+                                                    "variance": 2.0}),
+    # trickier cases (multiple data per revision)
+    ([[1.0, 3.0], [4.0, 4.0]], default_weights, {"avg": 3.0, "n": 4,
+                                                 "variance": 2.0}),
+    ([[2.0, 3.0], [4.0, 4.0]], linear_weights, {"avg": 3.0, "n": 4,
+                                                "variance": 1.0}),
+    ])
+def test_analyze_fn(revision_data, weight_fn, expected):
+    data = [RevisionDatum(i, i, values) for (i, values) in zip(
+        range(len(revision_data)), revision_data)]
+    assert analyze(data, weight_fn) == expected
 
 
 def test_weights():
@@ -26,10 +38,14 @@ def test_weights():
     assert [linear_weights(i, 5) for i in range(5)] == [1.0, 0.8, 0.6, 0.4, 0.2]
 
 
-def test_calc_t():
-    assert calc_t([0.0, 0.0], [1.0, 2.0]) == 3.0
-    assert calc_t([0.0, 0.0], [0.0, 0.0]) == 0.0
-    assert calc_t([0.0, 0.0], [1.0, 1.0]) == float('inf')
+@pytest.mark.parametrize(("old_data", "new_data", "expected"), [
+    ([0.0, 0.0], [1.0, 2.0], 3.0),
+    ([0.0, 0.0], [0.0, 0.0], 0.0),
+    ([0.0, 0.0], [1.0, 1.0], float('inf'))
+    ])
+def test_calc_t(old_data, new_data, expected):
+    assert calc_t([RevisionDatum(0, 0, old_data)],
+                  [RevisionDatum(1, 1, new_data)]) == expected
 
 
 def test_detect_changes():
@@ -38,23 +54,46 @@ def test_detect_changes():
     times = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
     values = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1,  1,  1,  1,  1,  1,  1]
     for (t, v) in zip(times, values):
-        data.append(Datum(t, float(v)))
+        data.append(RevisionDatum(t, t, [float(v)]))
 
-    result = [(d.push_timestamp, d.state) for d in
+    result = [(d.push_timestamp, d.change_detected) for d in
               detect_changes(data, min_back_window=5, max_back_window=5,
                              fore_window=5, t_threshold=2)]
     assert result == [
-        (1, 'good'),
-        (2, 'good'),
-        (3, 'good'),
-        (4, 'good'),
-        (5, 'good'),
-        (6, 'good'),
-        (7, 'good'),
-        (8, 'regression'),
-        (9, 'good'),
-        (10, 'good')
+        (0, False),
+        (1, False),
+        (2, False),
+        (3, False),
+        (4, False),
+        (5, False),
+        (6, False),
+        (7, False),
+        (8, True),
+        (9, False),
+        (10, False),
+        (11, False),
+        (12, False),
+        (13, False),
+        (14, False),
+        (15, False)
     ]
+
+
+def test_detect_changes_few_revisions_many_values():
+    '''
+    Tests that we correctly detect a regression with
+    a small number of revisions but a large number of values
+    '''
+    data = [RevisionDatum(0, 0, [0]*50+[1]*30),
+            RevisionDatum(1, 1, [0]*10+[1]*30),
+            RevisionDatum(1, 1, [0]*10+[1]*30)]
+    result = [(d.push_timestamp, d.change_detected) for d in
+              detect_changes(data, min_back_window=5, max_back_window=10,
+                             fore_window=5, t_threshold=2)]
+
+    assert result == [(0, False),
+                      (1, True),
+                      (1, False)]
 
 
 @pytest.mark.parametrize(("filename", "expected_timestamps"), [
@@ -76,15 +115,13 @@ def test_detect_changes_historical_data(filename, expected_timestamps):
 
     payload = SampleData.get_perf_data(os.path.join('graphs', filename))
     runs = payload['test_runs']
-    data = []
-    for r in runs:
-        data.append(Datum(r[2], r[3], testrun_id=r[0],
-                          revision_id=r[1][2]))
+    data = [RevisionDatum(r[2], r[2], [r[3]]) for r in runs]
 
-    results = detect_changes(data, min_back_window=MIN_BACK_WINDOW,
+    results = detect_changes(data,
+                             min_back_window=MIN_BACK_WINDOW,
                              max_back_window=MAX_BACK_WINDOW,
                              fore_window=FORE_WINDOW,
                              t_threshold=THRESHOLD)
     regression_timestamps = [d.push_timestamp for d in results if
-                             d.state == 'regression']
+                             d.change_detected]
     assert regression_timestamps == expected_timestamps

--- a/tests/perfalert/test_create_alerts.py
+++ b/tests/perfalert/test_create_alerts.py
@@ -105,22 +105,24 @@ def test_detect_alerts_in_series_with_retriggers(
     # gracefully by generating a sequence where the regression
     # "appears" in the middle of a series with the same push
     # to make sure things are calculated correctly
+    # (in this case, we're moving from consistent 0.5 to a 0.5/1.0
+    # mix)
     base_time = time.time()  # generate it based off current time
-    for i in range(30):
-        _generate_performance_data(test_repository, test_perf_signature,
-                                   generic_reference_data,
-                                   base_time, 1, 0.5, 1)
     for i in range(20):
         _generate_performance_data(test_repository, test_perf_signature,
                                    generic_reference_data,
+                                   base_time, 1, 0.5, 1)
+    for i in range(5):
+        _generate_performance_data(test_repository, test_perf_signature,
+                                   generic_reference_data,
                                    base_time, 2, 0.5, 1)
-    for i in range(40):
+    for i in range(15):
         _generate_performance_data(test_repository, test_perf_signature,
                                    generic_reference_data,
                                    base_time, 2, 1.0, 1)
 
     generate_new_alerts_in_series(test_perf_signature)
-    _verify_alert(1, 2, 1, test_perf_signature, 0.5, 1.0, True,
+    _verify_alert(1, 2, 1, test_perf_signature, 0.5, 0.875, True,
                   PerformanceAlert.UNTRIAGED,
                   PerformanceAlertSummary.UNTRIAGED, None)
 

--- a/treeherder/perf/alerts.py
+++ b/treeherder/perf/alerts.py
@@ -9,7 +9,7 @@ from treeherder.perf.models import (PerformanceAlert,
                                     PerformanceAlertSummary,
                                     PerformanceDatum,
                                     PerformanceSignature)
-from treeherder.perfalert.perfalert import (Datum,
+from treeherder.perfalert.perfalert import (RevisionDatum,
                                             detect_changes)
 
 
@@ -49,8 +49,13 @@ def generate_new_alerts_in_series(signature):
         series = series.filter(
             push_timestamp__gt=latest_alert_timestamp[0])
 
-    data = [Datum(int(time.mktime(d.push_timestamp.timetuple())), d.value, testrun_id=d.push_id) for d in series]
-    prev = None
+    revision_data = {}
+    for d in series:
+        if not revision_data.get(d.push_id):
+            revision_data[d.push_id] = RevisionDatum(
+                int(time.mktime(d.push_timestamp.timetuple())),
+                d.push_id, [])
+        revision_data[d.push_id].values.append(d.value)
 
     min_back_window = signature.min_back_window
     if min_back_window is None:
@@ -65,19 +70,14 @@ def generate_new_alerts_in_series(signature):
     if alert_threshold is None:
         alert_threshold = settings.PERFHERDER_REGRESSION_THRESHOLD
 
-    analyzed_series = detect_changes(data, min_back_window=min_back_window,
+    analyzed_series = detect_changes(revision_data.values(),
+                                     min_back_window=min_back_window,
                                      max_back_window=max_back_window,
                                      fore_window=fore_window)
-    prev_testrun_id = None
+
     with transaction.atomic():
         for (prev, cur) in zip(analyzed_series, analyzed_series[1:]):
-            # we can have the same testrun id in a sequence if there are
-            # retriggers, so only set the prev_testrun_id if that isn't
-            # the case
-            if prev.testrun_id != cur.testrun_id:
-                prev_testrun_id = prev.testrun_id
-
-            if cur.state == 'regression' and prev_testrun_id:
+            if cur.change_detected:
                 prev_value = cur.historical_stats['avg']
                 new_value = cur.forward_stats['avg']
                 alert_properties = get_alert_properties(
@@ -95,8 +95,8 @@ def generate_new_alerts_in_series(signature):
                 summary, _ = PerformanceAlertSummary.objects.get_or_create(
                     repository=signature.repository,
                     framework=signature.framework,
-                    push_id=cur.testrun_id,
-                    prev_push_id=prev_testrun_id,
+                    push_id=cur.push_id,
+                    prev_push_id=prev.push_id,
                     defaults={
                         'manually_created': False,
                         'last_updated': datetime.datetime.utcfromtimestamp(

--- a/treeherder/perfalert/perfalert/__init__.py
+++ b/treeherder/perfalert/perfalert/__init__.py
@@ -1,4 +1,7 @@
-def analyze(data, weight_fn=None):
+import copy
+
+
+def analyze(revision_data, weight_fn=None):
     """Returns the average and sample variance (s**2) of a list of floats.
 
     `weight_fn` is a function that takes a list index and a window width, and
@@ -9,13 +12,27 @@ def analyze(data, weight_fn=None):
     if weight_fn is None:
         weight_fn = default_weights
 
-    n = len(data)
-    weights = [weight_fn(i, n) for i in range(n)]
-    weighted_sum = sum(data[i] * weights[i] for i in range(n))
-    weighted_avg = weighted_sum / sum(weights) if n > 0 else 0.0
+    # get a weighted average for the full set of data -- this is complicated
+    # by the fact that we might have multiple data points from each revision
+    # which we would want to weight equally -- do this by creating a set of
+    # weights only for each bucket containing (potentially) multiple results
+    # for each value
+    num_revisions = len(revision_data)
+    weights = [weight_fn(i, num_revisions) for i in range(num_revisions)]
+    weighted_sum = 0
+    sum_of_weights = 0
+    for i in range(num_revisions):
+        weighted_sum += sum(value * weights[i] for value in
+                            revision_data[i].values)
+        sum_of_weights += weights[i] * len(revision_data[i].values)
+    weighted_avg = weighted_sum / sum_of_weights if num_revisions > 0 else 0.0
 
-    variance = (sum(pow(d-weighted_avg, 2) for d in data) / (n-1)) if n > 1 else 0.0
-    return {"avg": weighted_avg, "n": n, "variance": variance}
+    # now that we have a weighted average, we can calculate the variance of the
+    # whole series
+    all_data = [v for datum in revision_data for v in datum.values]
+    variance = (sum(pow(d-weighted_avg, 2) for d in all_data) / (len(all_data)-1)) if len(all_data) > 1 else 0.0
+
+    return {"avg": weighted_avg, "n": len(all_data), "variance": variance}
 
 
 def default_weights(i, n):
@@ -36,7 +53,7 @@ def linear_weights(i, n):
 
 
 def calc_t(w1, w2, weight_fn=None):
-    """Perform a Students t-test on the two lists of data.
+    """Perform a Students t-test on the two sets of revision data.
 
     See the analyze() function for a description of the `weight_fn` argument.
     """
@@ -55,38 +72,37 @@ def calc_t(w1, w2, weight_fn=None):
     return delta_s / (((s1['variance'] / s1['n']) + (s2['variance'] / s2['n'])) ** 0.5)
 
 
-class Datum(object):
-    def __init__(self, push_timestamp, value, testrun_timestamp=None,
-                 testrun_id=None, revision_id=None, state='good'):
+class RevisionDatum(object):
+    '''
+    This class represents a specific revision and the set of values for it
+    '''
+    def __init__(self, push_timestamp, push_id, values):
+
         # Date code was pushed
         self.push_timestamp = push_timestamp
-        # Value of this point
-        self.value = value
 
-        # Which test run was this
-        self.testrun_id = testrun_id
-        # What revision this data is for
-        self.revision_id = revision_id
+        # What revision this data is for (usually, but not guaranteed
+        # to be increasing with push_timestamp)
+        self.push_id = push_id
+
+        # data values associated with this revision
+        self.values = copy.copy(values)
 
         # t-test score
         self.t = 0
-        # Whether a perf regression is found
-        self.state = state
+
+        # Whether a perf regression or improvement was found
+        self.change_detected = False
 
     def __cmp__(self, o):
-        # only compare value to make sorting deterministic
-        # in cases where we have multiple datapoints with
-        # the same push timestamp
-        return cmp(
-            (self.push_timestamp, self.testrun_id, self.value),
-            (o.push_timestamp, o.testrun_id, o.value),
-        )
+        return self.push_timestamp < o.push_timestamp
 
     def __repr__(self):
-        return "<%s: %s, %s, %.3f, %.3f, %s>" % (self.push_timestamp,
-                                                 self.revision_id,
-                                                 self.testrun_id, self.value,
-                                                 self.t, self.state)
+        values_str = '[ %s ]' % ', '.join(['%.3f' % value for value in
+                                          self.values])
+        return "<%s: %s, %s, %.3f, %s>" % (self.push_timestamp,
+                                           self.push_id, values_str,
+                                           self.t, self.change_detected)
 
 
 def detect_changes(data, min_back_window=12, max_back_window=24,
@@ -94,65 +110,69 @@ def detect_changes(data, min_back_window=12, max_back_window=24,
     # Use T-Tests
     # Analyze test data using T-Tests, comparing data[i-j:i] to data[i:i+k]
     data = sorted(data)
-    (j, k) = (min_back_window, fore_window)
-    good_data = []
 
-    num_points = len(data) - k + 1
     last_seen_regression = 0
-    for i in range(num_points):
+    for i in range(1, len(data)):
         di = data[i]
-        # if we haven't seen something that looks like a change in a
-        # while, incorporate some extra historical data into our t-test
-        # calculation
-        if last_seen_regression > min_back_window:
-            additional_back_window = min(last_seen_regression,
-                                         max_back_window - min_back_window)
-        else:
-            additional_back_window = 0
-        jw = [d.value for d in good_data[-1 * (j + additional_back_window):]]
-        kw = [d.value for d in data[i:i+k]]
 
-        # Reverse the backward data so that the current point is at the
-        # start of the window.
-        jw.reverse()
+        # keep on getting previous data until we've either got at least 12
+        # data points *or* we've hit the maximum back window
+        jw = []
+        di.amount_prev_data = 0
+        prev_indice = i - 1
+        while di.amount_prev_data < max_back_window and prev_indice >= 0 and (
+                (i - prev_indice) <= min(max(last_seen_regression,
+                                             min_back_window),
+                                         max_back_window)):
+            jw.append(data[prev_indice])
+            di.amount_prev_data += len(jw[-1].values)
+            prev_indice -= 1
+
+        # accumulate present + future data until we've got at least 12 values
+        kw = []
+        di.amount_next_data = 0
+        next_indice = i
+        while di.amount_next_data < fore_window and next_indice < len(data):
+            kw.append(data[next_indice])
+            di.amount_next_data += len(kw[-1].values)
+            next_indice += 1
 
         di.historical_stats = analyze(jw)
         di.forward_stats = analyze(kw)
 
-        if len(jw) >= min_back_window:
-            di.t = abs(calc_t(jw, kw, linear_weights))
-            # add additional historical data points next time if we
-            # haven't detected a likely regression
-            if di.t > t_threshold:
-                last_seen_regression = 0
-            else:
-                last_seen_regression += 1
+        di.t = abs(calc_t(jw, kw, linear_weights))
+        # add additional historical data points next time if we
+        # haven't detected a likely regression
+        if di.t > t_threshold:
+            last_seen_regression = 0
         else:
-            # Assume it's ok, we don't have enough data
-            di.t = 0
-
-        good_data.append(di)
+            last_seen_regression += 1
 
     # Now that the t-test scores are calculated, go back through the data to
     # find where changes most likely happened.
-    for i in range(1, len(good_data) - 1):
-        di = good_data[i]
+    for i in range(1, len(data)):
+        di = data[i]
+
+        # if we don't have enough data yet, skip for now (until more comes
+        # in)
+        if di.amount_prev_data < min_back_window or di.amount_next_data < fore_window:
+            continue
+
         if di.t <= t_threshold:
             continue
 
         # Check the adjacent points
-        prev = good_data[i-1]
+        prev = data[i-1]
         if prev.t > di.t:
             continue
-        next = good_data[i+1]
-        if next.t > di.t:
-            continue
+        # next may or may not exist if it's the last in the series
+        if (i+1) < len(data):
+            next = data[i+1]
+            if next.t > di.t:
+                continue
 
         # This datapoint has a t value higher than the threshold and higher
         # than either neighbor.  Mark it as the cause of a regression.
-        di.state = 'regression'
+        di.change_detected = True
 
-    # Return all but the first and last points whose scores we calculated,
-    # since we can only produce a final decision for a point whose scores
-    # were compared to both of its neighbors.
-    return data[1:num_points-1]
+    return data


### PR DESCRIPTION
Retriggering performance jobs to generate better performance numbers
is becoming increasingly common, but our old regression detection
code didn't really account for that case -- in particular, it
had a bug that would allow for a regression to be generated *inside*
the data for a particular revision (if there were enough).

This commit fixes that bug and also changes the behaviour of the
linear weighting function so that retriggers on a particular revision
will be weighted the same (rather than declining in importance)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2284)
<!-- Reviewable:end -->
