### PR TITLE
Bug 1348013 - Don't show a logs parsing message when the job is incomplete

### DIFF
--- a/ui/plugins/auto_classification/controller.js
+++ b/ui/plugins/auto_classification/controller.js
@@ -844,7 +844,10 @@ treeherder.controller('ThAutoclassifyPanelController', [
          * (Re)build all the panel contents with fresh data
          */
         function build() {
-            if (!ctrl.logsParsed || ctrl.autoclassifyStatus === "pending") {
+            if (ctrl.thJob.state === "pending" || ctrl.thJob.state === "running") {
+                ctrl.loadStatus = "job_pending";
+            }
+            else if (!ctrl.logsParsed || ctrl.autoclassifyStatus === "pending") {
                 ctrl.loadStatus = "pending";
             } else if (ctrl.logParsingFailed) {
                 ctrl.loadStatus = "failed";

--- a/ui/plugins/auto_classification/panel.html
+++ b/ui/plugins/auto_classification/panel.html
@@ -16,6 +16,7 @@
    ></th-autoclassify-toolbar>
 
 <div ng-switch="$ctrl.loadStatus">
+  <span ng-switch-when="job_pending">Job not complete, please wait</span>
   <span ng-switch-when="pending">Logs not fully parsed, please wait</span>
   <span ng-switch-when="failed">Log parsing failed</span>
   <span ng-switch-when="no_logs">No errors logged</span>


### PR DESCRIPTION
Before a job is complete we should show a message indicating that
rather than one claiming that the logs are not fully parsed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2286)
<!-- Reviewable:end -->
