### PR TITLE
Bug 1349932 - Be more conservative showing Failure Classification lines.

### DIFF
--- a/ui/plugins/auto_classification/controller.js
+++ b/ui/plugins/auto_classification/controller.js
@@ -832,6 +832,7 @@ treeherder.controller('ThAutoclassifyPanelController', [
          * Update the panel for a new job selection
          */
         function jobChanged() {
+            ctrl.loadStatus = "loading";
             linesById = new Map();
             ctrl.selectedLineIds = new Set();
             ctrl.editableLineIds = new Set();
@@ -879,7 +880,6 @@ treeherder.controller('ThAutoclassifyPanelController', [
                      bugNumber: null,
                      type: null}));
             requestPromise = null;
-            ctrl.loadStatus = "ready";
             // Store the autoclassify status so that we only retry
             // the load when moving from 'cross_referenced' to 'autoclassified'
             autoclassifyStatusOnLoad = ctrl.autoclassifyStatus;
@@ -898,6 +898,7 @@ treeherder.controller('ThAutoclassifyPanelController', [
                         }
                     });
             }
+            $scope.$evalAsync(() => {ctrl.loadStatus = "ready";});
         }
 
         /**

--- a/ui/plugins/auto_classification/panel.html
+++ b/ui/plugins/auto_classification/panel.html
@@ -24,12 +24,15 @@
       <span class="fa fa-spinner fa-pulse th-spinner-lg"></span>
     </div>
   </div>
-  <span ng-switch-when="ready"></span>
+  <span ng-switch-when="ready">
+    <span ng-if="pendingLines().length == 0">No error lines reported</span>
+  </span>
   <span ng-switch-when="error">Error showing autoclassification data</span>
   <span ng-switch-default>Unexpected status {{ $ctrl.status }}</span>
 </div>
 
 <th-autoclassify-errors
+   ng-hidden="$ctrl.loadStatus !== 'ready'"
    load-status="$ctrl.loadStatus"
    error-matchers="errorMatchers"
    th-job="$ctrl.thJob"


### PR DESCRIPTION
When moving between jobs it was possible to see significant lag in the
UI, with the spinner disappearing, but the panel showing stale
data. Try to show the spinner earlier and hide it later so that it is
displayed until the latest data is available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2287)
<!-- Reviewable:end -->
