### PR TITLE
Bug 1347946 - Add pinboard integration to the Failure Classification panel

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -659,6 +659,10 @@ th-classification-option input {
   vertical-align: middle;
 }
 
+th-classification-option button.btn-xs, th-static-classification-option button.btn-xs {
+  font-size: 8px;
+}
+
 th-error-actions {
   padding: 4px 4px 4px 4px;
   text-align: center;

--- a/ui/js/services/pinboard.js
+++ b/ui/js/services/pinboard.js
@@ -166,6 +166,10 @@ treeherder.factory('thPinboard', [
                 return api.maxNumPinned - api.count.numPinnedJobs;
             },
 
+            isPinned: function(job) {
+                return pinnedJobs.hasOwnProperty(job.id);
+            },
+
             pinnedJobs: pinnedJobs,
             relatedBugs: relatedBugs,
             count: {

--- a/ui/plugins/auto_classification/controller.js
+++ b/ui/plugins/auto_classification/controller.js
@@ -93,13 +93,14 @@ treeherder.factory('ThClassificationOption', ['thExtendProperties',
  * Non-editable best option controller
  */
 treeherder.controller('ThStaticClassificationOptionController', [
-    '$scope', 'highlightCommonTermsFilter', 'escapeHTMLFilter', 'thUrl', 'ThLog',
-    function ($scope, highlightCommonTerms, escapeHTML, thUrl, ThLog) {
+    '$scope', 'highlightCommonTermsFilter', 'escapeHTMLFilter', 'thPinboard', 'thUrl', 'ThLog',
+    function ($scope, highlightCommonTerms, escapeHTML, thPinboard, thUrl, ThLog) {
         var ctrl = this;
 
         var log = new ThLog('ThStaticClassificationOptionController');
 
         $scope.getBugUrl = thUrl.getBugUrl;
+        $scope.thPinboard = thPinboard;
 
         ctrl.$onChanges = (changes) => {
             log.debug('$onChanges', ctrl, changes);
@@ -113,10 +114,12 @@ treeherder.component('thStaticClassificationOption', {
     templateUrl: 'plugins/auto_classification/staticOption.html',
     controller: 'ThStaticClassificationOptionController',
     bindings: {
+        thJob: '<',
         errorLine: '<',
         optionData: '<',
         selectedOption: '<',
         numOptions: '<',
+        canClassify:  '<',
         onExpandOptions: '&'
     }
 });
@@ -125,15 +128,16 @@ treeherder.component('thStaticClassificationOption', {
  * Editable option component controller
  */
 treeherder.controller('ThClassificationOptionController', [
-    '$scope', '$uibModal', 'highlightCommonTermsFilter', 'escapeHTMLFilter', 'thUrl',
+    '$scope', '$uibModal', 'highlightCommonTermsFilter', 'escapeHTMLFilter', 'thPinboard', 'thUrl',
     'thReftestStatus', 'ThLog',
-    function ($scope, $uibModal, highlightCommonTerms, escapeHTML, thUrl, thReftestStatus,
+    function ($scope, $uibModal, highlightCommonTerms, escapeHTML, thPinboard, thUrl, thReftestStatus,
               ThLog) {
         var ctrl = this;
 
         var log = new ThLog('ThClassificationOptionController');
 
         $scope.getBugUrl = thUrl.getBugUrl;
+        $scope.thPinboard = thPinboard;
 
         ctrl.$onChanges = (changes) => {
             log.debug('$onChanges', ctrl, changes);
@@ -782,7 +786,8 @@ treeherder.component('thAutoclassifyToolbar', {
         onIgnore: '&',
         onSave: '&',
         onSaveAll: '&',
-        onEdit: '&'
+        onEdit: '&',
+        onPin: '&'
     }
 });
 
@@ -791,10 +796,10 @@ treeherder.component('thAutoclassifyToolbar', {
  */
 treeherder.controller('ThAutoclassifyPanelController', [
     '$scope', '$rootScope', '$q', '$timeout',
-    'ThLog', 'thEvents', 'thNotify', 'thJobNavSelectors',
+    'ThLog', 'thEvents', 'thNotify', 'thJobNavSelectors', 'thPinboard',
     'ThMatcherModel', 'ThTextLogErrorsModel', 'ThErrorLineData',
     function($scope, $rootScope, $q, $timeout,
-             ThLog, thEvents, thNotify, thJobNavSelectors,
+             ThLog, thEvents, thNotify, thJobNavSelectors, thPinboard,
              ThMatcherModel, ThTextLogErrorsModel, ThErrorLineData) {
 
         var ctrl = this;
@@ -971,6 +976,15 @@ treeherder.controller('ThAutoclassifyPanelController', [
          */
         ctrl.onIgnore = function() {
             $rootScope.$emit(thEvents.autoclassifyIgnore);
+        };
+
+        /**
+         * Pin selected job to the pinboard
+         */
+
+        ctrl.onPin = function() {
+            //TODO: consider whether this should add bugs or mark all lines as ignored
+            thPinboard.pinJob(ctrl.thJob);
         };
 
         /**

--- a/ui/plugins/auto_classification/errorLine.html
+++ b/ui/plugins/auto_classification/errorLine.html
@@ -112,10 +112,12 @@
 
   <div ng-if="!line.verified && !$ctrl.isEditable && $ctrl.canClassify">
     <th-static-classification-option
+       th-job="$ctrl.thJob"
        error-line="line"
        option-data="currentOption"
        selected-option="selectedOption"
        num-options="options.length"
+       can-classify="$ctrl.canClassify"
        on-expand-options="editableChanged(true)">
     </th-static-classification-option>
   </div>

--- a/ui/plugins/auto_classification/option.html
+++ b/ui/plugins/auto_classification/option.html
@@ -16,6 +16,12 @@
          ng-if="!(option.type == 'classifiedFailure' && !option.bugNumber)"
          ng-hide="!$ctrl.canClassify"/>
   <span class="line-option-text" ng-if="option.bugNumber">
+    <button ng-if="!$ctrl.canClassify || thPinboard.isPinned($ctrl.thJob)"
+            class="btn btn-xs btn-default"
+            ng-click="thPinboard.addBug({id: option.bugNumber}, $ctrl.thJob)"
+            title="add to list of bugs to associate with all pinned jobs">
+      <i class="glyphicon glyphicon-pushpin"></i>
+    </button>
     <span ng-if="option.bugResolution" class="classification-bug-resolution">[{{ option.bugResolution }}]</span>
     <a href="{{ ::getBugUrl(option.bugNumber) }}"
        target="_blank">{{::option.bugNumber}} -

--- a/ui/plugins/auto_classification/panel.html
+++ b/ui/plugins/auto_classification/panel.html
@@ -9,6 +9,7 @@
    can-save="canSave(selectedLines())"
    can-save-all="canSave(pendingLines())"
    can-classify="canClassify"
+   on-pin="$ctrl.onPin()"
    on-ignore="$ctrl.onIgnore()"
    on-edit="$ctrl.onToggleEditable()"
    on-save="$ctrl.onSave()"

--- a/ui/plugins/auto_classification/staticOption.html
+++ b/ui/plugins/auto_classification/staticOption.html
@@ -7,6 +7,12 @@
 </div>
 
 <span class="line-option-text" ng-if="option.bugNumber">
+  <button ng-if="!$ctrl.canClassify || thPinboard.isPinned($ctrl.thJob)"
+          class="btn btn-xs btn-default"
+          ng-click="thPinboard.addBug({id: option.bugNumber}, $ctrl.thJob)"
+          title="add to list of bugs to associate with all pinned jobs">
+    <i class="glyphicon glyphicon-pushpin"></i>
+  </button>
   <span ng-if="option.bugResolution" class="classification-bug-resolution">[{{ option.bugResolution }}]</span>
   <a href="{{ ::getBugUrl(option.bugNumber) }}"
      target="_blank">{{::option.bugNumber}} -

--- a/ui/plugins/auto_classification/toolbar.html
+++ b/ui/plugins/auto_classification/toolbar.html
@@ -5,6 +5,11 @@
     </div>
 
     <button class="btn btn-view-nav btn-sm nav-menu-btn"
+            title="Pin job for bustage"
+            ng-click="$ctrl.onPin()"
+            prevent-default-on-left-click>Bustage</button>
+
+    <button class="btn btn-view-nav btn-sm nav-menu-btn"
             title="{{ buttonTitle($ctrl.hasSelection, 'Edit selected lines', 'Nothing selected') }}"
             ng-disabled="!($ctrl.hasSelection && $ctrl.canClassify)"
             ng-click="$ctrl.onEdit()"


### PR DESCRIPTION
Currently non-sheriffs cannot classify through the Failure
Classification panel. It turns out that there are a few peoeple who
want to do that. The simplest approach is to add the pinboard icons
analogous to the old UI so that they can mark jobs as classified but
not affect the autoclassification data. For sheriffs the pinboard is
also important for non-intermittents, so add a bustage button to the
toolbar and show the pinboard icons when the job is pinned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2288)
<!-- Reviewable:end -->
