### PR TITLE
Bug 1349617 - Handle process output lines in the log parser.

### DIFF
--- a/tests/model/test_error_summary.py
+++ b/tests/model/test_error_summary.py
@@ -53,6 +53,24 @@ PIPE_DELIMITED_LINE_TEST_CASES = (
             "| application crashed [@ jemalloc_crash]"
         ),
         'webgl-resize-test.html'
+    ),
+    (
+        (
+            "GECKO(1670) "
+            "| TEST-UNEXPECTED-FAIL "
+            "| /tests/dom/events/test/pointerevents/pointerevent_touch-action-table-test_touch-manual.html "
+            "| touch-action attribute test on the cell: assert_true: scroll received while shouldn't expected true got false"
+        ),
+        'pointerevent_touch-action-table-test_touch-manual.html'
+    ),
+    (
+        (
+            "PID 1670 "
+            "| TEST-UNEXPECTED-FAIL "
+            "| /tests/dom/events/test/pointerevents/pointerevent_touch-action-table-test_touch-manual.html "
+            "| touch-action attribute test on the cell: assert_true: scroll received while shouldn't expected true got false"
+        ),
+        'pointerevent_touch-action-table-test_touch-manual.html'
     )
 )
 

--- a/treeherder/model/error_summary.py
+++ b/treeherder/model/error_summary.py
@@ -16,6 +16,7 @@ MOZHARNESS_RE = re.compile(
     r'^\d+:\d+:\d+[ ]+(?:DEBUG|INFO|WARNING|ERROR|CRITICAL|FATAL) - [ ]?'
 )
 REFTEST_RE = re.compile("\s+[=!]=\s+.*")
+OUTPUT_RE = re.compile("^\s*(?:GECKO\(\d+\)|PID \d+)\s*$")
 
 
 def get_error_summary(job):
@@ -96,10 +97,12 @@ def get_error_search_term(error_line):
     search_term = None
 
     if len(tokens) >= 3:
+        # If this is process output then discard the token with the PID
+        if len(tokens) > 3 and OUTPUT_RE.match(tokens[0]):
+            tokens = tokens[1:]
         # it's in the "FAILURE-TYPE | testNameOrFilePath | message" type format.
         test_name_or_path = tokens[1]
         message = tokens[2]
-
         # Leak failure messages are of the form:
         # leakcheck | .*\d+ bytes leaked (Object-1, Object-2, Object-3, ...)
         match = LEAK_RE.search(message)


### PR DESCRIPTION
Process output lines start with a prefix like GECKO(1234) or PID 1234
and then a pipe. This is an extra pipe symbol compared to other lines,
so our code that splits on | and assumes specific data in specific
positions is broken. Try to detect the process output case and discard
the first token so that we have the same fields as other
pipe-delimited data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2289)
<!-- Reviewable:end -->
