### PR TITLE
Bug 1350353 - Link error lines to the corresponding line in the logs.

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -465,7 +465,9 @@ treeherderApp.controller('MainCtrl', [
 
             // Shortcut: open the logviewer for the selected job
             ['l', function() {
-                if ($scope.selectedJob) {
+                if (thTabs.selectedTab === "autoClassification") {
+                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyOpenLogViewer));
+                } else if ($scope.selectedJob) {
                     $scope.$evalAsync($rootScope.$emit(thEvents.openLogviewer));
                 }
             }],

--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -28,8 +28,12 @@ treeherder.factory('thUrl', [
                     return result + k + '=' + v;
                 }, "");
             },
-            getLogViewerUrl: function(job_id) {
-                return "logviewer.html#?job_id=" + job_id + "&repo=" + $rootScope.repoName;
+            getLogViewerUrl: function(job_id, line_number) {
+                var rv = "logviewer.html#?job_id=" + job_id + "&repo=" + $rootScope.repoName;
+                if (line_number) {
+                    rv += "&lineNumber=" + line_number;
+                }
+                return rv;
             },
             getBugUrl: function(bug_id) {
                 return "https://bugzilla.mozilla.org/show_bug.cgi?id=" + bug_id;

--- a/ui/plugins/auto_classification/controller.js
+++ b/ui/plugins/auto_classification/controller.js
@@ -237,6 +237,7 @@ treeherder.controller('ThErrorLineController', [
          */
         function build() {
             line = $scope.line = ctrl.errorLine;
+            $scope.logUrl = thUrl.getLogViewerUrl(ctrl.thJob.id, line.data.line_number + 1);
             if (!line.verified) {
                 $scope.options = getOptions();
                 log.debug("options", $scope.options);
@@ -797,10 +798,10 @@ treeherder.component('thAutoclassifyToolbar', {
 treeherder.controller('ThAutoclassifyPanelController', [
     '$scope', '$rootScope', '$q', '$timeout',
     'ThLog', 'thEvents', 'thNotify', 'thJobNavSelectors', 'thPinboard',
-    'ThMatcherModel', 'ThTextLogErrorsModel', 'ThErrorLineData',
+    'thUrl', 'ThMatcherModel', 'ThTextLogErrorsModel', 'ThErrorLineData',
     function($scope, $rootScope, $q, $timeout,
              ThLog, thEvents, thNotify, thJobNavSelectors, thPinboard,
-             ThMatcherModel, ThTextLogErrorsModel, ThErrorLineData) {
+             thUrl, ThMatcherModel, ThTextLogErrorsModel, ThErrorLineData) {
 
         var ctrl = this;
 
@@ -1037,6 +1038,14 @@ treeherder.controller('ThAutoclassifyPanelController', [
             setEditable([lineId], editable);
         };
 
+        ctrl.onOpenLogViewer = function() {
+            var selected = $scope.selectedLines();
+            if (selected.length) {
+                var lineNumber = selected[0].data.line_number + 1;
+            }
+            window.open(thUrl.getLogViewerUrl(ctrl.thJob.id, lineNumber));
+        };
+
         function setEditable(lineIds, editable) {
             var f = editable ? (lineId) => ctrl.editableLineIds.add(lineId):
                     (lineId) => ctrl.editableLineIds.delete(lineId);
@@ -1229,6 +1238,9 @@ treeherder.controller('ThAutoclassifyPanelController', [
 
         $rootScope.$on(thEvents.autoclassifyToggleEdit,
                        () => ctrl.onToggleEditable());
+
+        $rootScope.$on(thEvents.autoclassifyOpenLogViewer,
+                       () => ctrl.onOpenLogViewer());
     }
 ]);
 

--- a/ui/plugins/auto_classification/errorLine.html
+++ b/ui/plugins/auto_classification/errorLine.html
@@ -45,9 +45,17 @@
       </span>
       application crashed [{{ ::failureLine.signature }}]
     </span>
+    <span>[<a title="Open the log viewer in a new window"
+       target="_blank"
+       href="{{ logUrl }}"
+       class="">log…</a>]</span>
   </div>
-  <div ng-if="!failureLine"
-       ng-bind-html="::searchLine | escapeHTML | highlightLogLine">
+  <div ng-if="!failureLine">
+    <span ng-bind-html="::searchLine | escapeHTML | highlightLogLine"></span>
+    <span>[<a title="Open the log viewer in a new window"
+       target="_blank"
+       href="{{ logUrl }}"
+       class="">log…</a>]</span>
   </div>
 
   <div ng-if="line.verified && !line.verifiedIgnore">


### PR DESCRIPTION
Also make the "l" shortcut open the log viewer on the first selected
line, if any.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2290)
<!-- Reviewable:end -->
