### PR TITLE
Fixup message for no error lines.

### DIFF
--- a/ui/plugins/auto_classification/panel.html
+++ b/ui/plugins/auto_classification/panel.html
@@ -27,7 +27,7 @@
     </div>
   </div>
   <span ng-switch-when="ready">
-    <span ng-if="pendingLines().length == 0">No error lines reported</span>
+    <span ng-if="!errorLines || errorLines.length == 0">No error lines reported</span>
   </span>
   <span ng-switch-when="error">Error showing autoclassification data</span>
   <span ng-switch-default>Unexpected status {{ $ctrl.status }}</span>


### PR DESCRIPTION
This was displaying on fully verified jobs as well as jobs with no
error lines becase we used pendingLines rather than errorLines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2291)
<!-- Reviewable:end -->
