### PR TITLE
Bug 1351092 - Add link to the test-centric UI from resultsets

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -28,6 +28,8 @@ treeherderApp.controller('MainCtrl', [
         $rootScope.serverChanged = false;
         $rootScope.serverChangedDelayed = false;
 
+        $scope.testBasedUIHost = 'https://treeherder-manifest.herokuapp.com/';
+
         // Ensure user is available on initial page load
         $rootScope.user = {};
 

--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -40,6 +40,6 @@
            href="{{fromChangeValue()}}&fromchange={{resultset.revision}}" prevent-default-on-left-click
            ng-click="setLocationSearchParam('fromchange', resultset.revision)">Set as bottom of range</a></li>
     <li><a target="_blank" title="Prototype of a Treeherder UI centered on tests, rather than jobs"
-           href="{{testBasedUIHost}}?repo={{repoName}}&revision={{resultset.revision}}"><strong>ALPHA:</strong> Test-Centric UI</a></li>
+           href="{{testBasedUIHost}}?repo={{repoName}}&revision={{resultset.revision}}"><strong>Experimental:</strong> Test-Centric UI</a></li>
   </ul>
 </span>

--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -39,5 +39,7 @@
     <li><a target="_blank"
            href="{{fromChangeValue()}}&fromchange={{resultset.revision}}" prevent-default-on-left-click
            ng-click="setLocationSearchParam('fromchange', resultset.revision)">Set as bottom of range</a></li>
+    <li><a target="_blank" title="Prototype of a Treeherder UI centered on tests, rather than jobs"
+           href="{{testBasedUIHost}}?repo={{repoName}}&revision={{resultset.revision}}"><strong>ALPHA:</strong> Test-Centric UI</a></li>
   </ul>
 </span>


### PR DESCRIPTION
This links to our prototype running on Heroku.  I know it's hard-coded to the domain for now, which isn't ideal.  But that will be ripped out anyway once we merge this into Treeherder proper.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2296)
<!-- Reviewable:end -->
