### PR TITLE
Bug 1351408 - Skip unmatchable failure_line entries when trying to crossreference lines

### DIFF
--- a/tests/autoclassify/utils.py
+++ b/tests/autoclassify/utils.py
@@ -14,6 +14,7 @@ test_line = {"action": "test_result", "test": "test1", "subtest": "subtest1",
              "status": "FAIL", "expected": "PASS", "message": "message1"}
 log_line = {"action": "log", "level": "ERROR", "message": "message1"}
 crash_line = {"action": "crash", "signature": "signature", "test": "test1"}
+group_line = {"action": "test_groups"}
 
 
 def create_lines(test_job, lines):

--- a/treeherder/log_parser/crossreference.py
+++ b/treeherder/log_parser/crossreference.py
@@ -107,7 +107,9 @@ def structured_iterator(failure_lines):
     """
     to_regexp = ErrorSummaryReConvertor()
     for failure_line in failure_lines:
-        yield failure_line, to_regexp(failure_line)
+        regexp = to_regexp(failure_line)
+        if regexp:
+            yield failure_line, regexp
     while True:
         yield None, None
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2299)
<!-- Reviewable:end -->
