### PR TITLE
Bug 1351644 - Add repositories for Firefox Test Engineering automated tests

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1132,5 +1132,19 @@
         "repository_group": 5,
         "description": "Firefox Account Page Object Model"
     }
+},
+{
+    "pk": 89,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "go-bouncer",
+        "url": "https://github.com/mozilla-services/go-bouncer",
+        "branch": "master",
+        "active_status": "active",
+        "codebase": "go-bouncer",
+        "repository_group": 5,
+        "description": "Go version of the redirector portion of bouncer"
+    }
 }
 ]

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1118,5 +1118,19 @@
         "repository_group": 5,
         "description": "Tests for Add-ons"
     }
+},
+{
+    "pk": 88,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "fxapom",
+        "url": "https://github.com/mozilla/fxapom",
+        "branch": "master",
+        "active_status": "active",
+        "codebase": "fxapom",
+        "repository_group": 5,
+        "description": "Firefox Account Page Object Model"
+    }
 }
 ]

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1104,5 +1104,19 @@
         "repository_group": 7,
         "description": "GPU renderer for Servo"
     }
+},
+{
+    "pk": 87,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "addon-tests",
+        "url": "https://github.com/mozilla/Addon-Tests",
+        "branch": "master",
+        "active_status": "active",
+        "codebase": "addon-tests",
+        "repository_group": 5,
+        "description": "Tests for Add-ons"
+    }
 }
 ]

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1174,5 +1174,19 @@
         "repository_group": 5,
         "description": "Tests for Snippets"
     }
+},
+{
+    "pk": 92,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "socorro",
+        "url": "https://github.com/mozilla/socorro",
+        "branch": "master",
+        "active_status": "active",
+        "codebase": "socorro",
+        "repository_group": 5,
+        "description": "Server for collecting, processing, and displaying crash reports from clients using the Breakpad libraries"
+    }
 }
 ]

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1146,5 +1146,19 @@
         "repository_group": 5,
         "description": "Go version of the redirector portion of bouncer"
     }
+},
+{
+    "pk": 90,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "mozillians-tests",
+        "url": "https://github.com/mozilla/mozillians-tests",
+        "branch": "master",
+        "active_status": "active",
+        "codebase": "mozillians-tests",
+        "repository_group": 5,
+        "description": "Tests for Mozillians"
+    }
 }
 ]

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1188,5 +1188,19 @@
         "repository_group": 5,
         "description": "Server for collecting, processing, and displaying crash reports from clients using the Breakpad libraries"
     }
+},
+{
+    "pk": 93,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "stubattribution-tests",
+        "url": "https://github.com/mozilla/stubattribution-tests",
+        "branch": "master",
+        "active_status": "active",
+        "codebase": "stubattribution-tests",
+        "repository_group": 5,
+        "description": "Tests for the stub attribution service"
+    }
 }
 ]

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1160,5 +1160,19 @@
         "repository_group": 5,
         "description": "Tests for Mozillians"
     }
+},
+{
+    "pk": 91,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "snippets-tests",
+        "url": "https://github.com/mozilla/snippets-tests",
+        "branch": "master",
+        "active_status": "active",
+        "codebase": "snippets-tests",
+        "repository_group": 5,
+        "description": "Tests for Snippets"
+    }
 }
 ]

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1202,5 +1202,19 @@
         "repository_group": 5,
         "description": "Tests for the stub attribution service"
     }
+},
+{
+    "pk": 94,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "treeherder-tests",
+        "url": "https://github.com/mozilla/treeherder-tests",
+        "branch": "master",
+        "active_status": "active",
+        "codebase": "treeherder-tests",
+        "repository_group": 5,
+        "description": "Tests for Treeherder"
+    }
 }
 ]


### PR DESCRIPTION
This adds the various repositories with automated tests currently being run in our Jenkins instance, in preparation for publishing test results to Treeherder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2301)
<!-- Reviewable:end -->
