### PR TITLE
Bug 1286686 - Initial move of Treeherder-Tests into /selenium folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ matrix:
         # 'https://' being in the site URL. In addition, we override the test environment's debug
         # value so the tests pass. The real environment variable will be checked during deployment.
         - SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' ./manage.py check --deploy --fail-level WARNING
-        - py.test tests/ --runslow --ignore=tests/e2e/ --ignore=tests/etl/ --ignore=tests/log_parser/ --ignore=tests/webapp/ --ignore=tests/selenium/
+        - py.test tests/ --runslow --ignore=tests/e2e/ --ignore=tests/etl/ --ignore=tests/log_parser/ --ignore=tests/webapp/ --ignore=tests/selenium/ --ignore=tests/jenkins/
 
     # Job 4: Python Tests Chunk B
     - env: python-tests-e2e-etl-logparser

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pycodestyle]
-exclude = .git,__pycache__,.vagrant,node_modules
+exclude = .git,__pycache__,.vagrant,node_modules,tests/jenkins
 # E121,E123,E126,E226,E24,E704,W503: Ignored in default pycodestyle config:
 # https://github.com/PyCQA/pycodestyle/blob/2.2.0/pycodestyle.py#L72
 # Our additions...
@@ -12,7 +12,7 @@ max-line-length = 140
 # flake8 is a combination of pyflakes & pycodestyle.
 # Unfortunately we have to mostly duplicate the above, since some tools use
 # pycodestyle's config (eg autopep8) so we can't just define everything under [flake8].
-exclude = .git,__pycache__,.vagrant,node_modules
+exclude = .git,__pycache__,.vagrant,node_modules,tests/jenkins
 # The ignore list for pycodestyle above, plus our own PyFlakes additions:
 # F403: 'from module import *' used; unable to detect undefined names
 # F405: name may be undefined, or defined from star imports: module
@@ -20,7 +20,7 @@ ignore = E121,E123,E126,E129,E226,E24,E704,W503,E501,F403,F405
 max-line-length = 140
 
 [isort]
-skip = .git,__pycache__,.vagrant,node_modules,migrations
+skip = .git,__pycache__,.vagrant,node_modules,migrations,tests/jenkins
 multi_line_output = 1
 force_grid_wrap = true
 line_length = 140

--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -1,0 +1,57 @@
+@Library('fxtest@1.3') _
+
+/** Desired capabilities */
+def capabilities = [
+  browserName: 'Firefox',
+  version: '47.0',
+  platform: 'Windows 10'
+]
+
+pipeline {
+  agent any
+  options {
+    ansiColor('xterm')
+    timestamps()
+    timeout(time: 1, unit: 'HOURS')
+  }
+  environment {
+    /** See https://issues.jenkins-ci.org/browse/JENKINS-42771 - we'd like to expand this out into multi-line concatenations */
+    PYTEST_ADDOPTS = "--tb=short --color=yes --driver=SauceLabs --variables=capabilities.json"
+    SAUCELABS_API_KEY = credentials('SAUCELABS_API_KEY')
+  }
+  stages {
+    stage('Test') {
+      steps {
+        writeCapabilities(capabilities, 'capabilities.json')
+        sh "tox -e py27"
+      }
+      post {
+        always {
+          archiveArtifacts 'results/*'
+          junit 'results/*.xml'
+          submitToActiveData('results/py27.log')
+          publishHTML(target: [
+            allowMissing: false,
+            alwaysLinkToLastBuild: true,
+            keepAll: true,
+            reportDir: 'results',
+            reportFiles: "py27.html",
+            reportName: 'HTML Report'])
+        }
+      }
+    }
+  }
+  post {
+    failure {
+      mail(
+        body: "${BUILD_URL}",
+        from: "firefox-test-engineering@mozilla.com",
+        replyTo: "firefox-test-engineering@mozilla.com",
+        subject: "Build failed in Jenkins: ${JOB_NAME} #${BUILD_NUMBER}",
+        to: "fte-ci@mozilla.com")
+    }
+    changed {
+      ircNotification()
+    }
+  }
+}

--- a/tests/jenkins/expected.py
+++ b/tests/jenkins/expected.py
@@ -1,0 +1,14 @@
+class window_with_title(object):
+    """An expectation for checking that a window exists with the specified title.
+
+    :returns: window handle if window exists, False otherwise
+    """
+
+    def __init__(self, title):
+        self.title = title
+
+    def __call__(self, selenium):
+        for w in selenium.window_handles:
+            selenium.switch_to.window(w)
+            if self.title in selenium.title:
+                return w

--- a/tests/jenkins/pages/base.py
+++ b/tests/jenkins/pages/base.py
@@ -1,0 +1,19 @@
+from pypom import Page, Region
+from selenium.webdriver.common.by import By
+
+
+class Base(Page):
+
+    @property
+    def header(self):
+        return self.Header(self)
+
+    class Header(Region):
+
+        _root_locator = (By.ID, 'th-global-navbar')
+        _dropdown_menu_switch_page_locator = (By.CSS_SELECTOR, '.open ul > li a')
+        _dropdown_menu_locator = (By.ID, 'th-logo')
+
+        def switch_page_using_dropdown(self):
+            self.find_element(*self._dropdown_menu_locator).click()
+            self.find_element(*self._dropdown_menu_switch_page_locator).click()

--- a/tests/jenkins/pages/perfherder.py
+++ b/tests/jenkins/pages/perfherder.py
@@ -1,0 +1,22 @@
+from selenium.webdriver.common.by import By
+
+from pages.base import Base
+
+
+class PerfherderPage(Base):
+
+    _graph_chooser_locator = (By.ID, 'graph-chooser')
+
+    def wait_for_page_to_load(self):
+        self.wait.until(lambda s: self.is_graph_chooser_displayed)
+        return self
+
+    @property
+    def is_graph_chooser_displayed(self):
+        return self.is_element_displayed(*self._graph_chooser_locator)
+
+    def open_treeherder_page(self):
+        self.header.switch_page_using_dropdown()
+
+        from treeherder import TreeherderPage
+        return TreeherderPage(self.selenium, self.base_url).wait_for_page_to_load()

--- a/tests/jenkins/pages/run.sh
+++ b/tests/jenkins/pages/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+
+source ./venv_modules/bin/activate
+firefox-ui-functional tests/test_tp.py --binary firefox/FirefoxNightly.app/Contents/MacOS/firefox-bin -v

--- a/tests/jenkins/pages/treeherder.py
+++ b/tests/jenkins/pages/treeherder.py
@@ -1,0 +1,467 @@
+import itertools
+import random
+
+from pypom import Page, Region
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.keys import Keys
+
+from pages.base import Base
+
+
+class TreeherderPage(Base):
+
+    _active_watched_repo_locator = (By.CSS_SELECTOR, '#watched-repo-navbar button.active')
+    _clear_filter_locator = (By.ID, 'quick-filter-clear-button')
+    _close_the_job_panel_locator = (By.CSS_SELECTOR, '.info-panel-navbar-controls > li:nth-child(2)')
+    _filter_panel_all_failures_locator = (By.CSS_SELECTOR, '.pull-right input')
+    _filter_panel_body_locator = (By.CSS_SELECTOR, '.th-top-nav-options-panel')
+    _filter_panel_busted_failures_locator = (By.ID, 'busted')
+    _filter_panel_exception_failures_locator = (By.ID, 'exception')
+    _filter_panel_locator = (By.CSS_SELECTOR, 'span.navbar-right > span:nth-child(4)')
+    _filter_panel_reset_locator = (By.CSS_SELECTOR, '.pull-right span:nth-child(3)')
+    _filter_panel_testfailed_failures_locator = (By.ID, 'testfailed')
+    _info_panel_content_locator = (By.ID, 'info-panel-content')
+    _mozilla_central_repo_locator = (By.CSS_SELECTOR, '#th-global-navbar-top a[href*="mozilla-central"]')
+    _nav_filter_coalesced_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title=coalesced]')
+    _nav_filter_failures_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title=failures]')
+    _nav_filter_inprogress_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title*=progress]')
+    _nav_filter_retry_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title=retry]')
+    _nav_filter_successes_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title=success]')
+    _nav_filter_usercancel_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title=usercancel]')
+    _next_ten_locator = (By.CSS_SELECTOR, 'div.btn:nth-child(1)')
+    _next_twenty_locator = (By.CSS_SELECTOR, 'div.btn:nth-child(2)')
+    _next_fifty_locator = (By.CSS_SELECTOR, 'div.btn:nth-child(3)')
+    _quick_filter_locator = (By.ID, 'quick-filter')
+    _repos_menu_locator = (By.ID, 'repoLabel')
+    _result_sets_locator = (By.CSS_SELECTOR, '.result-set:not(.row)')
+    _unchecked_repos_links_locator = (By.CSS_SELECTOR, '#repoLabel + .dropdown-menu .dropdown-checkbox:not([checked]) + .dropdown-link')
+    _unclassified_failure_count_locator = (By.ID, 'unclassified-failure-count')
+    _unclassified_failure_filter_locator = (By.CSS_SELECTOR, '.btn-unclassified-failures')
+
+    def wait_for_page_to_load(self):
+        self.wait.until(lambda s: len(self.result_sets) >= 1)
+        return self
+
+    @property
+    def active_watched_repo(self):
+        return self.find_element(*self._active_watched_repo_locator).text
+
+    @property
+    def all_emails(self):
+        return list(itertools.chain.from_iterable([r.emails for r in self.result_sets]))
+
+    @property
+    def all_jobs(self):
+        return list(itertools.chain.from_iterable([r.jobs for r in self.result_sets]))
+
+    @property
+    def checkbox_busted_is_selected(self):
+        return self.find_element(*self._filter_panel_busted_failures_locator).is_selected()
+
+    @property
+    def checkbox_exception_is_selected(self):
+        return self.find_element(*self._filter_panel_exception_failures_locator).is_selected()
+
+    @property
+    def checkbox_testfailed_is_selected(self):
+        return self.find_element(*self._filter_panel_testfailed_failures_locator).is_selected()
+
+    @property
+    def filter_panel_is_open(self):
+        el = self.find_element(*self._filter_panel_body_locator)
+        return el.is_displayed()
+
+    @property
+    def info_panel(self):
+        return self.InfoPanel(self)
+
+    @property
+    def nav_filter_coalesced_is_selected(self):
+        el = self.find_element(*self._nav_filter_coalesced_locator)
+        return ('fa-dot-circle-o' in el.get_attribute('class'))
+
+    @property
+    def nav_filter_failures_is_selected(self):
+        el = self.find_element(*self._nav_filter_failures_locator)
+        return ('fa-dot-circle-o' in el.get_attribute('class'))
+
+    @property
+    def nav_filter_in_progress_is_selected(self):
+        el = self.find_element(*self._nav_filter_inprogress_locator)
+        return ('fa-dot-circle-o' in el.get_attribute('class'))
+
+    @property
+    def nav_filter_retry_is_selected(self):
+        el = self.find_element(*self._nav_filter_retry_locator)
+        return ('fa-dot-circle-o' in el.get_attribute('class'))
+
+    @property
+    def nav_filter_success_is_selected(self):
+        el = self.find_element(*self._nav_filter_successes_locator)
+        return ('fa-dot-circle-o' in el.get_attribute('class'))
+
+    @property
+    def nav_filter_usercancel_is_selected(self):
+        el = self.find_element(*self._nav_filter_usercancel_locator)
+        return ('fa-dot-circle-o' in el.get_attribute('class'))
+
+    @property
+    def pinboard(self):
+        return self.Pinboard(self)
+
+    @property
+    def random_email_name(self):
+        random_email_name = random.choice(self.all_emails)
+        return random_email_name.get_name
+
+    @property
+    def result_sets(self):
+        return [self.ResultSet(self, el) for el in self.find_elements(*self._result_sets_locator)]
+
+    @property
+    def search_term(self):
+        el = self.find_element(*self._quick_filter_locator)
+        return el.get_attribute('value')
+
+    @property
+    def unchecked_repos(self):
+        return self.find_elements(*self._unchecked_repos_links_locator)
+
+    @property
+    def unclassified_failure_count(self):
+        return int(self.find_element(*self._unclassified_failure_count_locator).text)
+
+    def clear_filter(self, method='pointer'):
+        if method == 'pointer':
+            self.selenium.find_element(*self._clear_filter_locator).click()
+        elif method == 'keyboard':
+            self.find_element(By.CSS_SELECTOR, 'body').send_keys(
+                Keys.CONTROL + Keys.SHIFT + 'f')
+        else:
+            raise Exception('Unsupported method: {}'.format(method))
+
+    def click_on_filters_panel(self):
+        self.find_element(*self._filter_panel_locator).click()
+
+    def click_on_active_watched_repo(self):
+        self.find_element(*self._active_watched_repo_locator).click()
+        self.wait_for_page_to_load()
+
+    def close_the_job_panel(self):
+        self.find_element(*self._close_the_job_panel_locator).click()
+
+    def close_all_panels(self):
+        self.find_element(By.CSS_SELECTOR, 'body').send_keys(Keys.ESCAPE)
+
+    def deselect_all_failures(self):
+        """Filters Panel must be opened"""
+        self.find_element(*self._filter_panel_all_failures_locator).click()
+
+    def deselect_busted_failures(self):
+        """Filters Panel must be opened"""
+        self.find_element(*self._filter_panel_busted_failures_locator).click()
+
+    def deselect_exception_failures(self):
+        """Filters Panel must be opened"""
+        self.find_element(*self._filter_panel_exception_failures_locator).click()
+
+    def deselect_testfailed_failures(self):
+        """Filters Panel must be opened"""
+        self.find_element(*self._filter_panel_testfailed_failures_locator).click()
+
+    def filter_by(self, term, method='pointer'):
+        if method == 'pointer':
+            el = self.selenium.find_element(*self._quick_filter_locator)
+            el.send_keys(term)
+            el.send_keys(Keys.RETURN)
+            self.wait.until(lambda s: self.result_sets)
+        elif method == 'keyboard':
+            self.find_element(By.CSS_SELECTOR, 'body').send_keys(
+                'f' + term + Keys.RETURN)
+        else:
+            raise Exception('Unsupported method: {}'.format(method))
+
+    def filter_job_coalesced(self):
+        self.find_element(*self._nav_filter_coalesced_locator).click()
+
+    def filter_job_failures(self):
+        self.find_element(*self._nav_filter_failures_locator).click()
+
+    def filter_job_in_progress(self):
+        self.find_element(*self._nav_filter_inprogress_locator).click()
+
+    def filter_job_retries(self):
+        self.find_element(*self._nav_filter_retry_locator).click()
+
+    def filter_job_successes(self):
+        self.find_element(*self._nav_filter_successes_locator).click()
+
+    def filter_job_usercancel(self):
+        self.find_element(*self._nav_filter_usercancel_locator).click()
+
+    def filter_unclassified_jobs(self):
+        self.find_element(*self._unclassified_failure_filter_locator).click()
+
+    def get_next_ten_results(self):
+        self.find_element(*self._next_ten_locator).click()
+        self.wait.until(lambda s: len(self.result_sets) == 20)
+
+    def get_next_twenty_results(self):
+        self.find_element(*self._next_twenty_locator).click()
+        self.wait.until(lambda s: len(self.result_sets) == 30)
+
+    def get_next_fifty_results(self):
+        self.find_element(*self._next_fifty_locator).click()
+        self.wait.until(lambda s: len(self.result_sets) == 60)
+
+    def open_next_unclassified_failure(self):
+        el = self.find_element(*self._result_sets_locator)
+        self.wait.until(EC.visibility_of(el))
+        el.send_keys('n')
+        self.wait.until(lambda s: self.info_panel.job_details.job_result_status)
+
+    def open_perfherder_page(self):
+        self.header.switch_page_using_dropdown()
+
+        from perfherder import PerfherderPage
+        return PerfherderPage(self.selenium, self.base_url).wait_for_page_to_load()
+
+    def open_repos_menu(self):
+        self.find_element(*self._repos_menu_locator).click()
+
+    def pin_using_spacebar(self):
+        el = self.find_element(*self._result_sets_locator)
+        self.wait.until(EC.visibility_of(el))
+        el.send_keys(Keys.SPACE)
+        self.wait.until(lambda _: self.pinboard.is_pinboard_open)
+
+    def reset_filters(self):
+        """Filters Panel must be opened"""
+        self.find_element(*self._filter_panel_reset_locator).click()
+
+    def select_busted_failures(self):
+        """Filters Panel must be opened"""
+        self.find_element(*self._filter_panel_busted_failures_locator).click()
+
+    def select_exception_failures(self):
+        """Filters Panel must be opened"""
+        self.find_element(*self._filter_panel_exception_failures_locator).click()
+
+    def select_mozilla_central_repo(self):
+        # Fix me: https://github.com/mozilla/treeherder-tests/issues/43
+        self.open_repos_menu()
+        self.find_element(*self._mozilla_central_repo_locator).click()
+        self.wait_for_page_to_load()
+
+    def select_next_job(self):
+        self.find_element(By.CSS_SELECTOR, 'body').send_keys(Keys.ARROW_RIGHT)
+
+    def select_previous_job(self):
+        self.find_element(By.CSS_SELECTOR, 'body').send_keys(Keys.ARROW_LEFT)
+
+    def select_random_email(self):
+        random_email = random.choice(self.all_emails)
+        random_email.click()
+        self.wait_for_page_to_load()
+
+    def select_random_job(self):
+        random_job = random.choice(self.all_jobs)
+        random_job.click()
+
+    def select_random_repo(self):
+        self.open_repos_menu()
+        repo = random.choice(self.unchecked_repos)
+        repo_name = repo.text
+        repo.click()
+        self.wait.until(lambda s: self._active_watched_repo_locator == repo_name)
+        return repo_name
+
+    def select_testfailed_failures(self):
+        """Filters Panel must be opened"""
+        self.find_element(*self._filter_panel_testfailed_failures_locator).click()
+
+    class ResultSet(Region):
+
+        _datestamp_locator = (By.CSS_SELECTOR, '.result-set-title-left > span a')
+        _dropdown_toggle_locator = (By.CLASS_NAME, 'dropdown-toggle')
+        _email_locator = (By.CSS_SELECTOR, '.result-set-title-left > th-author > span > a')
+        _expanded_group_content_locator = (By.CSS_SELECTOR, '.group-job-list[style="display: inline;"]')
+        _group_content_locator = (By.CSS_SELECTOR, 'span.group-count-list .btn')
+        _jobs_locator = (By.CSS_SELECTOR, '.job-btn.filter-shown')
+        _pin_all_jobs_locator = (By.CLASS_NAME, 'pin-all-jobs-btn')
+        _platform_locator = (By.CLASS_NAME, 'platform')
+        _set_bottom_of_range_locator = (By.CSS_SELECTOR, '.open ul > li:nth-child(8) > a')
+        _set_top_of_range_locator = (By.CSS_SELECTOR, '.open ul > li:nth-child(7) > a')
+
+        @property
+        def builds(self):
+            return [self.Build(self.page, root=el) for el in self.find_elements(*self._platform_locator)]
+
+        @property
+        def datestamp(self):
+            return self.find_element(*self._datestamp_locator).text
+
+        @property
+        def emails(self):
+            return [self.Email(self.page, root=el) for el in self.find_elements(*self._email_locator)]
+
+        @property
+        def email_name(self):
+            return self.find_element(*self._email_locator).text
+
+        @property
+        def find_expanded_group_content(self):
+            return self.is_element_displayed(*self._expanded_group_content_locator)
+
+        @property
+        def jobs(self):
+            return [self.Job(self.page, root=el) for el in self.find_elements(*self._jobs_locator)]
+
+        def expand_group_count(self):
+            self.find_element(*self._group_content_locator).click()
+            self.wait.until(lambda s: self.is_element_displayed(*self._expanded_group_content_locator))
+
+        def pin_all_jobs(self):
+            return self.find_element(*self._pin_all_jobs_locator).click()
+
+        def set_as_bottom_of_range(self):
+            self.find_element(*self._dropdown_toggle_locator).click()
+            self.find_element(*self._set_bottom_of_range_locator).click()
+            self.page.wait_for_page_to_load()
+
+        def set_as_top_of_range(self):
+            self.find_element(*self._dropdown_toggle_locator).click()
+            self.find_element(*self._set_top_of_range_locator).click()
+            self.page.wait_for_page_to_load()
+
+        def view(self):
+            self.find_element(*self._datestamp_locator).click()
+            self.page.wait_for_page_to_load()
+
+        class Build(Region):
+
+            _platform_name_locator = (By.CSS_SELECTOR, 'td:nth-child(1) > span:nth-child(1)')
+
+            @property
+            def platform_name(self):
+                return self.find_element(*self._platform_name_locator).text
+
+        class Email(Region):
+
+            @property
+            def get_name(self):
+                return self.root.text
+
+            def click(self):
+                self.root.click()
+
+        class Job(Region):
+
+            @property
+            def selected(self):
+                return 'selected-job' in self.root.get_attribute('class')
+
+            @property
+            def symbol(self):
+                return self.root.text
+
+            @property
+            def title(self):
+                return self.root.get_attribute('title')
+
+            def click(self):
+                self.root.click()
+                self.wait.until(lambda _: self.page.info_panel.job_details.job_result_status)
+
+    class InfoPanel(Region):
+
+        _root_locator = (By.ID, 'info-panel-content')
+
+        @property
+        def is_open(self):
+            return self.root.is_displayed()
+
+        @property
+        def job_details(self):
+            return self.JobDetails(self.page)
+
+        class JobDetails(Region):
+
+            _root_locator = (By.ID, 'job-details-panel')
+            _job_keyword_locator = (By.CSS_SELECTOR, '#job-details-pane > ul > li > a:nth-last-child(1)')
+            _job_result_status_locator = (By.CSS_SELECTOR, '#result-status-pane > div:nth-child(1) > span:nth-child(2)')
+            _logviewer_button_locator = (By.ID, 'logviewer-btn')
+            _pin_job_locator = (By.ID, 'pin-job-btn')
+
+            @property
+            def job_keyword_name(self):
+                return self.find_element(*self._job_keyword_locator).text
+
+            @property
+            def job_result_status(self):
+                return self.find_element(*self._job_result_status_locator).text
+
+            def filter_by_job_keyword(self):
+                self.find_element(*self._job_keyword_locator).click()
+
+            def open_logviewer(self):
+                self.root.send_keys('l')
+                window_handles = self.selenium.window_handles
+                for handle in window_handles:
+                    self.selenium.switch_to.window(handle)
+                return LogviewerPage(self.selenium, self.page.base_url).wait_for_page_to_load()
+
+            def pin_job(self):
+                el = self.find_element(*self._job_keyword_locator)
+                self.wait.until(EC.visibility_of(el))
+                self.find_element(*self._pin_job_locator).click()
+
+    class Pinboard(Region):
+
+        _root_locator = (By.ID, 'pinboard-panel')
+        _clear_all_menu_locator = (By.CSS_SELECTOR, '#pinboard-controls .dropdown-menu li:nth-child(5) a')
+        _jobs_locator = (By.CLASS_NAME, 'pinned-job')
+        _open_save_menu_locator = (By.CSS_SELECTOR, '#pinboard-controls .save-btn-dropdown')
+        _pinboard_remove_job_locator = (By.CSS_SELECTOR, '#pinned-job-list .pinned-job-close-btn')
+
+        @property
+        def is_pinboard_open(self):
+            return self.root.is_displayed()
+
+        @property
+        def jobs(self):
+            return [self.Job(self.page, el) for el in self.find_elements(*self._jobs_locator)]
+
+        @property
+        def selected_job(self):
+            return next(j for j in self.jobs if j.is_selected)
+
+        def clear_pinboard(self):
+            el = self.find_element(*self._open_save_menu_locator)
+            el.click()
+            self.wait.until(lambda _: el.get_attribute('aria-expanded') == 'true')
+            self.find_element(*self._clear_all_menu_locator).click()
+
+        class Job(Region):
+
+            @property
+            def is_selected(self):
+                return 'selected-job' in self.root.get_attribute('class')
+
+            @property
+            def symbol(self):
+                return self.root.text
+
+
+class LogviewerPage(Page):
+
+    _job_header_locator = (By.CSS_SELECTOR, 'div.job-header')
+
+    def wait_for_page_to_load(self):
+        self.wait.until(lambda s: self.is_job_status_visible)
+        return self
+
+    @property
+    def is_job_status_visible(self):
+        return self.is_element_displayed(*self._job_header_locator)

--- a/tests/jenkins/requirements.txt
+++ b/tests/jenkins/requirements.txt
@@ -1,0 +1,7 @@
+# pyup: ignore file
+mozlog==3.4
+PyPOM==1.1.1
+pytest==3.0.7
+pytest-metadata==1.3.0
+pytest-selenium==1.9.1
+pytest-xdist==1.15.0

--- a/tests/jenkins/tests/conftest.py
+++ b/tests/jenkins/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.fixture(scope='session')
+def session_capabilities(session_capabilities):
+    session_capabilities.setdefault('tags', []).append('treeherder')
+    return session_capabilities
+
+
+@pytest.fixture
+def selenium(selenium):
+    selenium.maximize_window()
+    return selenium

--- a/tests/jenkins/tests/test_expanding_group_count.py
+++ b/tests/jenkins/tests/test_expanding_group_count.py
@@ -1,0 +1,13 @@
+import pytest
+
+from pages.treeherder import TreeherderPage
+
+
+@pytest.mark.nondestructive
+def test_expanding_group_count(base_url, selenium):
+    page = TreeherderPage(selenium, base_url).open()
+    assert len(page.result_sets) > 1
+    assert not page.result_sets[0].find_expanded_group_content
+
+    page.result_sets[0].expand_group_count()
+    assert page.result_sets[0].find_expanded_group_content

--- a/tests/jenkins/tests/test_filter_job_by_email.py
+++ b/tests/jenkins/tests/test_filter_job_by_email.py
@@ -1,0 +1,29 @@
+import pytest
+
+from pages.treeherder import TreeherderPage
+
+
+@pytest.mark.nondestructive
+def test_filter_by_email(base_url, selenium):
+    """Open Treeherder page, select and filter by random email,
+    verify if filtered emails have the same email address"""
+    page = TreeherderPage(selenium, base_url).open()
+    page.select_random_email()
+
+    filtered_emails_name = page.result_sets[0].email_name
+    random_email_name = page.random_email_name
+
+    assert filtered_emails_name == random_email_name
+
+
+@pytest.mark.nondestructive
+def test_remove_email_address_filter(base_url, selenium):
+    """Open Treeherder page, select and filter by random email,
+    remove email address filter, verify that job list display all authors"""
+    page = TreeherderPage(selenium, base_url).open()
+    page.select_random_email()
+
+    page.click_on_active_watched_repo()
+    all_emails = [email.get_name for email in page.all_emails]
+
+    assert len(set(all_emails)) > 1

--- a/tests/jenkins/tests/test_filter_job_by_keywords.py
+++ b/tests/jenkins/tests/test_filter_job_by_keywords.py
@@ -1,0 +1,17 @@
+import pytest
+
+from pages.treeherder import TreeherderPage
+
+
+@pytest.mark.nondestructive
+def test_filter_by_job_keyword(base_url, selenium):
+    """Open Treeherder page, select random job, click on the job keyword,
+    verify if filtered jobs have the same platform name"""
+    page = TreeherderPage(selenium, base_url).open()
+    page.select_random_job()
+
+    page.info_panel.job_details.filter_by_job_keyword()
+    keyword = page.info_panel.job_details.job_keyword_name
+
+    page.select_random_job()
+    assert keyword in page.info_panel.job_details.job_keyword_name

--- a/tests/jenkins/tests/test_filter_jobs.py
+++ b/tests/jenkins/tests/test_filter_jobs.py
@@ -1,0 +1,18 @@
+import pytest
+
+from pages.treeherder import TreeherderPage
+
+
+@pytest.mark.nondestructive
+def test_filter_jobs(base_url, selenium):
+    """Open resultset page and filter for platform"""
+    page = TreeherderPage(selenium, base_url).open()
+    platform = u'Linux'
+
+    page.filter_by(platform)
+    assert platform in page.result_sets[0].builds[0].platform_name
+
+    page.clear_filter()
+    platform2 = u'Windows'
+    page.filter_by(platform2)
+    assert platform not in page.result_sets[0].builds[0].platform_name

--- a/tests/jenkins/tests/test_filter_panel.py
+++ b/tests/jenkins/tests/test_filter_panel.py
@@ -1,0 +1,59 @@
+import pytest
+
+from pages.treeherder import TreeherderPage
+
+
+@pytest.mark.nondestructive
+def test_filter_by_test_status(base_url, selenium):
+    """Open Treeherder page, open Filters Panel, select one filter,
+    verify results"""
+    page = TreeherderPage(selenium, base_url).open()
+    page.filter_unclassified_jobs()
+    page.click_on_filters_panel()
+
+    # Test 'testfailed' unclassified failures
+    page.deselect_busted_failures()
+    page.deselect_exception_failures()
+    if len(page.all_jobs) > 0:
+        page.open_next_unclassified_failure()
+        assert 'testfailed' == page.info_panel.job_details.job_result_status
+
+    # Test 'busted' unclassified failures
+    page.select_busted_failures()
+    page.deselect_testfailed_failures()
+    if len(page.all_jobs) > 0:
+        page.close_the_job_panel()
+        page.open_next_unclassified_failure()
+        assert 'busted' == page.info_panel.job_details.job_result_status
+
+    # Test 'exception' unclassified failures
+    page.select_exception_failures()
+    page.deselect_busted_failures()
+    if len(page.all_jobs) > 0:
+        page.close_the_job_panel()
+        page.open_next_unclassified_failure()
+        assert 'exception' == page.info_panel.job_details.job_result_status
+
+
+@pytest.mark.nondestructive
+def test_filter_panel_reset_button(base_url, selenium):
+    """Open Treeherder page, open Filters Panel, disable all failures,
+    check that all checkboxes are not selected, check that there
+    are no failures, click reset button and verify that default checkboxes
+    are selected"""
+    page = TreeherderPage(selenium, base_url).open()
+    all_jobs = len(page.all_jobs)
+
+    page.click_on_filters_panel()
+    page.deselect_all_failures()
+    assert not page.checkbox_testfailed_is_selected
+    assert not page.checkbox_busted_is_selected
+    assert not page.checkbox_exception_is_selected
+
+    filtered_jobs = len(page.all_jobs)
+    assert not all_jobs == filtered_jobs
+
+    page.reset_filters()
+    assert page.checkbox_testfailed_is_selected
+    assert page.checkbox_busted_is_selected
+    assert page.checkbox_exception_is_selected

--- a/tests/jenkins/tests/test_get_next_results.py
+++ b/tests/jenkins/tests/test_get_next_results.py
@@ -1,0 +1,20 @@
+import pytest
+
+from pages.treeherder import TreeherderPage
+
+
+@pytest.mark.nondestructive
+def test_get_next_results(base_url, selenium):
+    page = TreeherderPage(selenium, base_url).open()
+    assert len(page.result_sets) == 10
+
+    page.get_next_ten_results()
+    assert len(page.result_sets) == 20
+
+    page = TreeherderPage(selenium, base_url).open()
+    page.get_next_twenty_results()
+    assert len(page.result_sets) == 30
+
+    page = TreeherderPage(selenium, base_url).open()
+    page.get_next_fifty_results()
+    assert len(page.result_sets) == 60

--- a/tests/jenkins/tests/test_keyboard_shortcuts.py
+++ b/tests/jenkins/tests/test_keyboard_shortcuts.py
@@ -1,0 +1,95 @@
+import random
+
+from pages.treeherder import TreeherderPage
+
+
+def test_close_open_panels(base_url, selenium):
+    """Open Treeherder, verify shortcut: 'Esc' closes filter and job panel.
+    Open Treeherder page, open Filters panel, select random job, close all
+    panels using 'esc' button, verify if all panels are closed.
+    """
+    page = TreeherderPage(selenium, base_url).open()
+
+    page.click_on_filters_panel()
+    page.select_random_job()
+
+    assert page.filter_panel_is_open
+    assert page.info_panel.is_open
+
+    page.close_all_panels()
+
+    assert not page.filter_panel_is_open
+    assert not page.info_panel.is_open
+
+
+def test_enter_quick_filter_shortcut(base_url, selenium):
+    """Open Treeherder, verify shortcut: 'f' moves cursor to filter search box.
+    Open Treeherder page, verify if search box is empty, enter search box
+    filter using 'f' shortcut, type 'debug', verify if filter box contains
+    word 'debug'.
+    """
+    page = TreeherderPage(selenium, base_url).open()
+    assert page.search_term == ''
+
+    page.filter_by('debug', method='keyboard')
+    assert page.search_term == 'debug'
+
+
+def test_clear_the_quick_filter_shortcut(base_url, selenium):
+    """Open Treeherder, verify shortcut: CTRL + SHIFT + 'f' clears the filter search box.
+    Open Treeherder page, filter by 'debug', verify if filter box contains the
+    word 'debug', clear the quick filter using CTRL + SHIFT + f shortcut,
+    verify if search box is empty.
+    """
+    page = TreeherderPage(selenium, base_url).open()
+
+    page.filter_by('debug')
+
+    page.clear_filter(method='keyboard')
+    assert page.search_term == ''
+
+
+def test_next_job_shortcut(base_url, selenium):
+    """Open Treeherder, verify shortcut: 'Right Arrow' opens next job.
+    Open Treeherder page, select random job and get the keyword name, select next job
+    using Right Arrow shortcut, verify job keywords match."""
+
+    page = TreeherderPage(selenium, base_url).open()
+    all_jobs = page.all_jobs[:-1]
+
+    # Check number of jobs
+    random_index = random.randint(0, len(all_jobs))
+    jobs = all_jobs[random_index:(random_index + 2)]
+
+    # Select random job and job next to it
+    jobs[0].click()
+    assert jobs[0].selected
+    assert not jobs[1].selected
+
+    page.select_next_job()
+
+    assert jobs[1].selected
+    assert not jobs[0].selected
+
+
+def test_previous_job_shortcut(base_url, selenium):
+    """Open Treeherder, verify shortcut: 'Left Arrow' opens previous job.
+    Open Treeherder page, select random job and get the keyword name, select previous job
+    using Left Arrow shortcut, verify job keywords match."""
+
+    page = TreeherderPage(selenium, base_url).open()
+    all_jobs = page.all_jobs[:-1]
+
+    # Check number of jobs
+    random_index = random.randint(0, len(all_jobs))
+    jobs = all_jobs[random_index:(random_index + 2)]
+
+    # Select random job and previous job
+    jobs[1].click()
+    assert jobs[1].selected
+    assert not jobs[0].selected
+
+    page.select_previous_job()
+
+    assert jobs[0].selected
+    assert not jobs[1].selected

--- a/tests/jenkins/tests/test_keyword.py
+++ b/tests/jenkins/tests/test_keyword.py
@@ -1,0 +1,18 @@
+import pytest
+
+from pages.treeherder import TreeherderPage
+
+
+@pytest.mark.nondestructive
+def test_filter_by_job_keyword(base_url, selenium):
+    """Open Treeherder page, select random job, click on the job keyword,
+    verify if filtered jobs have the same platform name"""
+    page = TreeherderPage(selenium, base_url).open()
+    page.select_random_job()
+
+    page.job_details.filter_by_job_keyword()
+    keyword = page.job_details.job_keyword_name
+    print keyword
+
+    page.select_random_job()
+    assert keyword in page.job_details.job_keyword_name

--- a/tests/jenkins/tests/test_load_page_results.py
+++ b/tests/jenkins/tests/test_load_page_results.py
@@ -1,0 +1,19 @@
+import pytest
+
+from pages.treeherder import TreeherderPage
+
+
+@pytest.mark.nondestructive
+def test_load_next_results(base_url, selenium):
+    page = TreeherderPage(selenium, base_url).open()
+    assert len(page.result_sets) == 10
+
+    page.get_next_ten_results()
+    assert len(page.result_sets) == 20
+
+    page.get_next_twenty_results()
+    page.wait_for_page_to_load()
+    assert len(page.result_sets) == 40
+
+    page.get_next_fifty_results()
+    assert len(page.result_sets) == 90

--- a/tests/jenkins/tests/test_pin_job.py
+++ b/tests/jenkins/tests/test_pin_job.py
@@ -1,0 +1,41 @@
+from pages.treeherder import TreeherderPage
+
+
+def test_pin_job(base_url, selenium):
+    """Open treeherder page, select first job and pin it"""
+    page = TreeherderPage(selenium, base_url).open()
+    job = page.result_sets[0].jobs[0]
+    job.click()
+    assert 0 == len(page.pinboard.jobs)
+    page.pin_using_spacebar()
+    assert 1 == len(page.pinboard.jobs)
+    assert job.symbol == page.pinboard.selected_job.symbol
+
+
+def test_pin_job_from_job_details(base_url, selenium):
+    """Open treeherder page, select first job, pin it by the pin icon"""
+    page = TreeherderPage(selenium, base_url).open()
+    job = page.result_sets[0].jobs[0]
+    job.click()
+    assert 0 == len(page.pinboard.jobs)
+    page.info_panel.job_details.pin_job()
+    assert 1 == len(page.pinboard.jobs)
+    assert job.symbol == page.pinboard.selected_job.symbol
+
+
+def test_clear_pinboard(base_url, selenium):
+    """Open treeherder page, pin a job and then clear the pinboard"""
+    page = TreeherderPage(selenium, base_url).open()
+    page.result_sets[0].jobs[0].click()
+    page.pin_using_spacebar()
+    assert 1 == len(page.pinboard.jobs)
+    page.pinboard.clear_pinboard()
+    assert page.pinboard.is_pinboard_open
+    assert 0 == len(page.pinboard.jobs)
+
+
+def test_pin_all_jobs(base_url, selenium):
+    """Open treeherder page, pin all jobs, confirm no more than 500 pins in pinboard"""
+    page = TreeherderPage(selenium, base_url).open()
+    page.result_sets[0].pin_all_jobs()
+    assert 0 < len(page.pinboard.jobs) <= 500

--- a/tests/jenkins/tests/test_range.py
+++ b/tests/jenkins/tests/test_range.py
@@ -1,0 +1,22 @@
+import pytest
+
+from pages.treeherder import TreeherderPage
+
+
+@pytest.mark.nondestructive
+def test_set_as_top_of_range(base_url, selenium):
+    page = TreeherderPage(selenium, base_url).open()
+    current_top_of_range = page.result_sets[0].datestamp
+    page.result_sets[1].set_as_top_of_range()
+    page.wait_for_page_to_load()
+    new_top_of_range = page.result_sets[0].datestamp
+    assert not new_top_of_range == current_top_of_range
+
+
+@pytest.mark.nondestructive
+def test_set_as_bottom_of_range(base_url, selenium):
+    page = TreeherderPage(selenium, base_url).open()
+    current_bottom_of_range = page.result_sets[9].datestamp
+    page.result_sets[0].set_as_bottom_of_range()
+    new_bottom_of_range = page.result_sets[0].datestamp
+    assert not new_bottom_of_range == current_bottom_of_range

--- a/tests/jenkins/tests/test_status_results.py
+++ b/tests/jenkins/tests/test_status_results.py
@@ -1,0 +1,84 @@
+import pytest
+import random
+
+from pages.treeherder import TreeherderPage
+
+
+@pytest.mark.nondestructive
+def test_default_status(base_url, selenium):
+    """Open resultset page and verify default job status buttons in the nav."""
+    page = TreeherderPage(selenium, base_url).open()
+    assert page.nav_filter_failures_is_selected
+    assert page.nav_filter_success_is_selected
+    assert page.nav_filter_retry_is_selected
+    assert page.nav_filter_usercancel_is_selected
+    assert not page.nav_filter_coalesced_is_selected
+    assert page.nav_filter_in_progress_is_selected
+
+
+@pytest.mark.nondestructive
+def test_status_results_failures(base_url, selenium):
+    """Open resultset page and verify job failure filter displays correctly."""
+    page = TreeherderPage(selenium, base_url).open()
+    page.filter_job_successes()
+    page.filter_job_retries()
+    page.filter_job_usercancel()
+    page.filter_job_in_progress()
+
+    all_jobs = page.all_jobs
+    job = random.choice(all_jobs)
+    unclassified = ['testfailed', 'exception', 'busted']
+    assert any(status in job.title for status in unclassified)
+
+
+@pytest.mark.nondestructive
+def test_status_results_success(base_url, selenium):
+    """Open resultset page and verify job status success filter displays correctly."""
+    page = TreeherderPage(selenium, base_url).open()
+    page.filter_job_failures()
+    page.filter_job_retries()
+    page.filter_job_usercancel()
+    page.filter_job_in_progress()
+
+    assert all(map(lambda job: 'success' in job.title, page.all_jobs))
+
+
+@pytest.mark.nondestructive
+def test_status_results_retry(base_url, selenium):
+    """Open resultset page and verify job status retry filter displays correctly."""
+    page = TreeherderPage(selenium, base_url).open()
+    page.filter_job_failures()
+    page.filter_job_successes()
+    page.filter_job_usercancel()
+    page.filter_job_in_progress()
+
+    assert all(map(lambda job: 'retry' in job.title, page.all_jobs))
+
+
+@pytest.mark.nondestructive
+def test_status_results_coalesced(base_url, selenium):
+    """Open resultset page and verify job status coalesced filter displays correctly."""
+    page = TreeherderPage(selenium, base_url).open()
+    page.filter_job_failures()
+    page.filter_job_successes()
+    page.filter_job_retries()
+    page.filter_job_usercancel()
+    page.filter_job_coalesced()
+    page.filter_job_in_progress()
+
+    assert all(map(lambda job: 'coalesced' in job.title, page.all_jobs))
+
+
+@pytest.mark.nondestructive
+def test_status_results_in_progress(base_url, selenium):
+    """Open resultset page and verify job status in progress filter displays correctly."""
+    page = TreeherderPage(selenium, base_url).open()
+    page.filter_job_failures()
+    page.filter_job_successes()
+    page.filter_job_retries()
+    page.filter_job_usercancel()
+
+    all_jobs = page.all_jobs
+    job = random.choice(all_jobs)
+    runnable = ['running', 'pending']
+    assert any(status in job.title for status in runnable)

--- a/tests/jenkins/tests/test_switch_repo.py
+++ b/tests/jenkins/tests/test_switch_repo.py
@@ -1,0 +1,12 @@
+import pytest
+
+from pages.treeherder import TreeherderPage
+
+
+@pytest.mark.nondestructive
+def test_switch_repo(base_url, selenium):
+    """Switch to new active watched repo"""
+    page = TreeherderPage(selenium, base_url).open()
+    assert 'mozilla-inbound' == page.active_watched_repo
+    page.select_mozilla_central_repo()
+    assert 'mozilla-central' == page.active_watched_repo

--- a/tests/jenkins/tests/test_treeherder_menu.py
+++ b/tests/jenkins/tests/test_treeherder_menu.py
@@ -1,0 +1,16 @@
+import pytest
+
+from pages.treeherder import TreeherderPage
+
+
+@pytest.mark.nondestructive
+def test_treeherder_dropdown(base_url, selenium):
+    """Switch between Treeherder and Perfherder using header dropdown"""
+    treeherder_page = TreeherderPage(selenium, base_url).open()
+
+    # Switch to Perfherder page
+    perfherder_page = treeherder_page.open_perfherder_page()
+    assert perfherder_page.is_graph_chooser_displayed
+
+    # Return to Treeherder page
+    treeherder_page = perfherder_page.open_treeherder_page()

--- a/tests/jenkins/tests/test_unclassified_job.py
+++ b/tests/jenkins/tests/test_unclassified_job.py
@@ -1,0 +1,38 @@
+import pytest
+import random
+
+from pages.treeherder import TreeherderPage
+
+
+@pytest.mark.nondestructive
+def test_unclassified_failure(base_url, selenium):
+    """Open resultset page and search for next unclassified failure"""
+    page = TreeherderPage(selenium, base_url).open()
+    assert page.unclassified_failure_count > 0
+    page.open_next_unclassified_failure()
+    teststatus = page.info_panel.job_details.job_result_status
+    assert teststatus in ['busted', 'testfailed', 'exception']
+
+
+@pytest.mark.nondestructive
+def test_open_unclassified_failure_log(base_url, selenium):
+    """Open the job log and verify there is content"""
+    treeherder_page = TreeherderPage(selenium, base_url).open()
+    assert treeherder_page.unclassified_failure_count > 0
+    treeherder_page.open_next_unclassified_failure()
+    logviewer_page = treeherder_page.info_panel.job_details.open_logviewer()
+    assert logviewer_page.is_job_status_visible
+
+
+@pytest.mark.nondestructive
+def test_view_unclassified_jobs(base_url, selenium):
+    page = TreeherderPage(selenium, base_url).open()
+    all_jobs = page.all_jobs
+
+    page.filter_unclassified_jobs()
+    filtered_jobs = page.all_jobs
+    assert not all_jobs == filtered_jobs
+
+    job = random.choice(filtered_jobs)
+    unclassified = ['testfailed', 'busted', 'exception']
+    assert any(status in job.title for status in unclassified)

--- a/tests/jenkins/tests/test_view_single_result.py
+++ b/tests/jenkins/tests/test_view_single_result.py
@@ -1,0 +1,13 @@
+import pytest
+
+from pages.treeherder import TreeherderPage
+
+
+@pytest.mark.nondestructive
+def test_open_single_result(base_url, selenium):
+    page = TreeherderPage(selenium, base_url).open()
+    assert len(page.result_sets) > 1
+    datestamp = page.result_sets[0].datestamp
+    page.result_sets[0].view()
+    assert 1 == len(page.result_sets)
+    assert datestamp == page.result_sets[0].datestamp

--- a/tests/jenkins/tox.ini
+++ b/tests/jenkins/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+skipsdist = true
+envlist = py27
+
+[testenv]
+passenv = DISPLAY PYTEST_ADDOPTS PYTEST_BASE_URL SAUCELABS_API_KEY SAUCELABS_USERNAME \
+    JENKINS_URL JOB_NAME BUILD_NUMBER
+deps = -rrequirements.txt
+commands = pytest \
+    --junit-xml=results/{envname}.xml \
+    --html=results/{envname}.html \
+    --log-raw=results/{envname}.log \
+    {posargs}
+
+[pytest]
+addopts = -n=auto --verbose -r=a --driver=Firefox
+testpaths = tests
+xfail_strict = true
+base_url = https://treeherder.allizom.org
+sensitive_url = mozilla\.org


### PR DESCRIPTION
Moving the contents of the Treeherder-Tests repo into the /selenium folder. Tests will not run automatically, as Travis will need to be set up. This is just to get the content into the primary repo going forward so that the Treeherder-Tests repo can be decommissioned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2302)
<!-- Reviewable:end -->
