### PR TITLE
Bug 1352244 - Fix queries for broken GraphQL objects

### DIFF
--- a/treeherder/webapp/graphql/schema.py
+++ b/treeherder/webapp/graphql/schema.py
@@ -61,22 +61,22 @@ class Query(graphene.ObjectType):
         return BuildPlatform.objects.all()
 
     def resolve_all_machine_platforms(self, args, context, info):
-        return BuildPlatform.objects.all()
+        return MachinePlatform.objects.all()
 
     def resolve_all_machines(self, args, context, info):
-        return BuildPlatform.objects.all()
+        return Machine.objects.all()
 
     def resolve_all_job_types(self, args, context, info):
-        return BuildPlatform.objects.all()
+        return JobType.objects.all()
 
     def resolve_all_products(self, args, context, info):
-        return BuildPlatform.objects.all()
+        return Product.objects.all()
 
     def resolve_all_failure_classifications(self, args, context, info):
-        return BuildPlatform.objects.all()
+        return FailureClassification.objects.all()
 
     def resolve_all_pushes(self, args, context, info):
-        return BuildPlatform.objects.all()
+        return Push.objects.all()
 
 
 schema = graphene.Schema(query=Query)


### PR DESCRIPTION
Only Jobs and BuildPlatform had the right ORM query matching their
Graph.  The rest were all BuildPlatform, which gave an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2305)
<!-- Reviewable:end -->
