### PR TITLE
Bug 1351036 - Strip 'xpcshell-unpack.ini:' from failure paths in the bug filer

### DIFF
--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -89,6 +89,8 @@ treeherder.controller('BugFilerCtrl', [
             summary = summary.replace(re, "");
             re = /xpcshell-child-process.ini:/gi;
             summary = summary.replace(re, "");
+            re = /xpcshell-unpack.ini:/gi;
+            summary = summary.replace(re, "");
 
             summary = summary.split(" | ");
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2308)
<!-- Reviewable:end -->
