### PR TITLE
Bug 1336556 - followup to fix active-filters-bar

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -592,7 +592,7 @@ treeherderApp.controller('MainCtrl', [
 
         // query parameters that will be shown in activefiltersbar when set
         $scope.activeFiltersBarProperties = ['fromchange', 'tochange', 'author',
-            'nojobs', 'startdate', 'enddate', 'revisiolint'];
+            'nojobs', 'startdate', 'enddate', 'revision'];
 
         $scope.showActiveFiltersBar = function() {
             return $scope.search().fromchange || $scope.search().tochange ||


### PR DESCRIPTION
For some reason, the commit that updated lint messed this up:
https://github.com/mozilla/treeherder/commit/11ca87fb3444f87981a3c751bd195758183222b4#diff-84c67dfb34465e36f91640c8c95657c9L593

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2311)
<!-- Reviewable:end -->
