### PR TITLE
Bug 1353203 - Generalize the reftest failure path stripping to hopefully catch all variations

### DIFF
--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -73,15 +73,11 @@ treeherder.controller('BugFilerCtrl', [
          */
         $uibModalInstance.parseSummary = function(summary) {
             // Strip out some extra stuff at the start of some failure paths
-            var re = /file:\/\/\/home\/worker\/workspace\/build\/tests\/reftest\/tests\//gi;
+            var re = /file:\/\/\/.*?\/build\/tests\/reftest\/tests\//gi;
             summary = summary.replace(re, "");
             re = /\/home\/worker\/workspace\/build\/src\//gi;
             summary = summary.replace(re, "");
             re = /\/home\/worker\/checkouts\/gecko\//gi;
-            summary = summary.replace(re, "");
-            re = /file:\/\/\/builds\/slave\/test\/build\/tests\/reftest\/tests\//gi;
-            summary = summary.replace(re, "");
-            re = /file:\/\/\/c:\/slave\/test\/build\/tests\/reftest\/tests\//gi;
             summary = summary.replace(re, "");
             re = /http:\/\/([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+):([0-9]+)\/tests\//gi;
             summary = summary.replace(re, "");


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2315)
<!-- Reviewable:end -->
