### PR TITLE
Bug 1345131 - Preparation for using pyup.io to manage Python dependencies

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,11 +7,11 @@ whitenoise==3.3.0 --hash=sha256:1d62a003a0ab747de96da45c831cbb512dcb7f69c1ef0bd2
 # Used by the Whitenoise CLI tool to provide Brotli-compressed versions of static files.
 Brotli==0.5.2 --hash=sha256:3411b9acd2a2056e55084acf7a6ab3e4a8540c2ef37a4435bca62644e8aaf50e
 
-Django==1.10.7 --hash=sha256:e68fd450154ad7ee2c88472bb812350490232462adc6e3c6bcb544abe5212134
+Django==1.10.7 --hash=sha256:e68fd450154ad7ee2c88472bb812350490232462adc6e3c6bcb544abe5212134  # pyup: <1.11 # Bug 1353561
 
-celery==3.1.24 --hash=sha256:25396191954521184cc15018f776a2a2278b04dd4213d94f795daef4b7961b4b
+celery==3.1.24 --hash=sha256:25396191954521184cc15018f776a2a2278b04dd4213d94f795daef4b7961b4b  # pyup: <4 # Bug 1337717
 
-kombu==3.0.37 --hash=sha256:7ceab743e3e974f3e5736082e8cc514c009e254e646d6167342e0e192aee81a6
+kombu==3.0.37 --hash=sha256:7ceab743e3e974f3e5736082e8cc514c009e254e646d6167342e0e192aee81a6  # pyup: <4 # Bug 1337717
 
 simplejson==3.10.0 --hash=sha256:953be622e88323c6f43fad61ffd05bebe73b9fd9863a46d68b052d2aa7d71ce2
 
@@ -21,11 +21,11 @@ newrelic==2.82.0.62 --hash=sha256:482bdb36a9858d4d2aaeec4e211bd5b318310b270aa021
 mysqlclient==1.3.9 --hash=sha256:990ccf1e1f15b9a291b811c993dc1c216566714bc14e6581b38665bd61c28c99
 
 # Required by celery
-billiard==3.3.0.23 --hash=sha256:692a2a5a55ee39a42bcb7557930e2541da85df9ea81c6e24827f63b80cd39d0b
+billiard==3.3.0.23 --hash=sha256:692a2a5a55ee39a42bcb7557930e2541da85df9ea81c6e24827f63b80cd39d0b  # pyup: <3.4 # Bug 1337717
 pytz==2016.10 --hash=sha256:a1ea35e87a63c7825846d5b5c81d23d668e8a102d3b1b465ce95afe1b3a2e065
 
 # Required by kombu
-amqp==1.4.9 --hash=sha256:e0ed0ce6b8ffe5690a2e856c7908dc557e0e605283d6885dd1361d79f2928908
+amqp==1.4.9 --hash=sha256:e0ed0ce6b8ffe5690a2e856c7908dc557e0e605283d6885dd1361d79f2928908  # pyup: <2 # Bug 1337717
 anyjson==0.3.3 --hash=sha256:37812d863c9ad3e35c0734c42e0bf0320ce8c3bed82cd20ad54cb34d158157ba
 
 # Required by mozlog
@@ -87,9 +87,9 @@ pylibmc==1.5.1 --hash=sha256:ecba261859c3e1ba3365389cb4f4dfffb7e02120a9f57a288ca
 
 django-pylibmc==0.6.1 --hash=sha256:9cffdee703aaf9ebc029d9dbdee8abdd0723564b95e4b2ac59e4a668b8e58f93
 
-elasticsearch==2.4.0 --hash=sha256:ede15c3573f46ea72c4d53ea7f11fe648c60d167d75d739e27f72d78a6d7f692
+elasticsearch==2.4.0 --hash=sha256:ede15c3573f46ea72c4d53ea7f11fe648c60d167d75d739e27f72d78a6d7f692  # pyup: >=2,<3 # Client has to match ES server version.
 
-elasticsearch-dsl==2.1.0 --hash=sha256:48f5869035e852f68bfaf1ba586becf4b109c661e7c054045395f554ac7566af
+elasticsearch-dsl==2.1.0 --hash=sha256:48f5869035e852f68bfaf1ba586becf4b109c661e7c054045395f554ac7566af  # pyup: >=2,<3 # Client has to match ES server version.
 
 # required by elasticsearch
 urllib3==1.20 --hash=sha256:b64c0faa183e9e9e76193146c4147e82a734982c6b6719dca851d6cc4ec90c01

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,3 +1,4 @@
+# pyup: ignore file
 # Packages that are shared between deployment and dev environments.
 
 gunicorn==19.6.0 --hash=sha256:723234ea1fa8dff370ab69830ba8bc37469a7cba13fd66055faeef24085e6530

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,7 +14,7 @@ responses==0.5.1 --hash=sha256:3a907f7aae2fd2286d06cfdf238957786c38bbcadc451adce
 
 django-extensions==1.7.5 --hash=sha256:9e0ee15e6e8f88888898092c814f547fb2fb72332dd7982d6605e740cc5a7bd5
 
-pytest-selenium==1.8.0 --hash=sha256:64ee80556502248d7cc4c827cae4b784a92843f1a2a39622d8205ab832365474
+pytest-selenium==1.9.1 --hash=sha256:d3533b244beaf64308e81eb158285cf071f3fcafed70c4184cfabae936055093
 
 # Required by django-extension's runserver_plus command.
 Werkzeug==0.11.15 --hash=sha256:c6f6f89124df0514d886782c658c3e12f2caaa94da34cee3fd82eebf4ebf052b
@@ -49,6 +49,7 @@ pytest-django==3.1.2 --hash=sha256:00995c2999b884a38ae9cd30a8c00ed32b3d38c104125
 
 # Required by pytest-selenium
 selenium==3.0.2 --hash=sha256:33be5a03d87bf0e6c7a57d3f9bba5314cc66ce4acd44f003465386af2f5a7b4f
-pytest-html==1.13.0 --hash=sha256:df423fb613e0e3e1f02b4a4f09e2a670f51f79051617c84545039ff817556bb8
-pytest-variables==1.4 --hash=sha256:bd2e152e64c8f670e7969c76219a7842cf8ede795703127981ed71af38cfe08a
-pytest-base-url==1.2.0 --hash=sha256:248dae2e3e7bb2c69d10101724b68fe756853e4ece4d9feb8bf09b38c027f65b
+pytest-html==1.14.2 --hash=sha256:899d59d3e70f141ebf93b25b31e9d7c0a18469259cec3edaa3686f1d85b06c13
+pytest-metadata==1.3.0 --hash=sha256:b8735ad24a4974b35ca2d37a443596a26e0986754b0841c46231f4a6f6fa92c9
+pytest-variables==1.5.1 --hash=sha256:8f2b7c16c54bfe93561c7a36a5e9d8780bdcd36e6e37d9f7b3b51b656449e2ea
+pytest-base-url==1.3.0 --hash=sha256:3e1d40d2826c2d848b31355502815250ad4035e5bfb4e3ad0405b2d6fad874f4


### PR DESCRIPTION
**1) Update pytest-\* packages**
Since the new pytest-html version now depends on pytest-metadata, and pyup doesn't yet handle adding new sub-dependencies as part of package updates (pyupio/pyup#209), so we have to do so manually. The other packages have to be updated at the same time, since pytest-html made breaking changes in a minor version.

https://github.com/pytest-dev/pytest-html/blob/master/CHANGES.rst
https://github.com/pytest-dev/pytest-html/compare/v1.13.0...v1.14.2

https://github.com/pytest-dev/pytest-variables/blob/master/CHANGES.rst
https://github.com/pytest-dev/pytest-variables/compare/v1.4...v1.5.1

https://github.com/pytest-dev/pytest-base-url/blob/master/CHANGES.rst
https://github.com/pytest-dev/pytest-base-url/compare/v1.2.0...v1.3.0

https://pytest-selenium.readthedocs.io/en/latest/news.html
https://github.com/pytest-dev/pytest-selenium/compare/v1.8.0...v1.9.1

**2) Add pyup version filters to requirements/common.txt**
This prevents pyup from trying to update these packages beyond the versions specified.

**3) Exclude requirements/common.txt from pyup temporarily**
This will allow us to have the combined initial PR from pyup for `dev.txt` and `docs.txt` first (since they are safer), and then later this annotation will be removed, causing pyup to open separate PRs for remaining package updates (so we can update the more risky common.txt packages a few at a time).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2324)
<!-- Reviewable:end -->
