### PR TITLE
Bug 1354438 - Give the Bug Filer control of its own API URL

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -13,8 +13,8 @@ PULSE_URI = BROKER_URL
 PULSE_EXCHANGE_NAMESPACE = 'test'
 
 # Set a fake api key for testing bug filing
-BZ_API_KEY = "12345helloworld"
-BZ_API_URL = "https://thisisnotbugzilla.org"
+BUGFILER_API_KEY = "12345helloworld"
+BUGFILER_API_URL = "https://thisisnotbugzilla.org"
 
 # ELASTIC SEARCH
 # Prefix indices used in tests to avoid clobbering data

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -438,8 +438,13 @@ PARSER_MAX_STEP_ERROR_LINES = 100
 PARSER_MAX_SUMMARY_LINES = 200
 FAILURE_LINES_CUTOFF = 35
 
+# BZ_API_URL is used to fetch bug suggestions from bugzilla
+# BUGFILER_API_URL is used when filing bugs
+# these are no longer necessarily the same so stage treeherder can submit
+# to stage bmo, while suggestions can still be fetched from prod bmo
 BZ_API_URL = "https://bugzilla.mozilla.org"
-BZ_API_KEY = env("BUGZILLA_API_KEY", default=None)
+BUGFILER_API_URL = env("BUGZILLA_API_URL", default=BZ_API_URL)
+BUGFILER_API_KEY = env("BUGZILLA_API_KEY", default=None)
 
 ORANGEFACTOR_SUBMISSION_URL = "https://brasstacks.mozilla.com/orangefactor/api/saveclassification"
 ORANGEFACTOR_HAWK_ID = "treeherder"

--- a/treeherder/webapp/api/bugzilla.py
+++ b/treeherder/webapp/api/bugzilla.py
@@ -15,8 +15,8 @@ class BugzillaViewSet(viewsets.ViewSet):
         """
         Create a bugzilla bug with passed params
         """
-        if settings.BZ_API_KEY is None:
-            return Response({"failure": "Bugzilla API key not defined. This shouldn't happen."},
+        if settings.BUGFILER_API_KEY is None:
+            return Response({"failure": "Bugzilla API key not set!"},
                             status=HTTP_400_BAD_REQUEST)
 
         params = request.data
@@ -24,9 +24,9 @@ class BugzillaViewSet(viewsets.ViewSet):
             request.user.email.replace('@', " [at] "),
             params.get("comment", "")
         )
-        url = settings.BZ_API_URL + "/rest/bug"
+        url = settings.BUGFILER_API_URL + "/rest/bug"
         headers = {
-            'x-bugzilla-api-key': settings.BZ_API_KEY,
+            'x-bugzilla-api-key': settings.BUGFILER_API_KEY,
             'Accept': 'application/json'
         }
         data = {


### PR DESCRIPTION
BZ_API_URL currently is used for both the bug filer and fetching bug suggestions through the rest of Treeherder. At the moment, both of them point to production bmo's API. Bug suggestions coming from the bugzilla instance that actually has most of the intermittent bugs filed makes sense. Filing bugs from staging Treeherder's bug filer into production bmo makes less sense, so this patch lets you specify a different API URL.

If the new environmental variable isn't present, the bug filer will still default to production bmo, so this should be deployable without any configuration changes, and everything should still just work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2328)
<!-- Reviewable:end -->
