### PR TITLE
Bug 1353093 - Make migration 0008 a no-op

### DIFF
--- a/treeherder/model/migrations/0008_push_job_child_references.py
+++ b/treeherder/model/migrations/0008_push_job_child_references.py
@@ -13,14 +13,26 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterField(
-            model_name='job',
-            name='push',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='jobs', to='model.Push'),
+        migrations.RunSQL(
+            migrations.RunSQL.noop,
+            reverse_sql=migrations.RunSQL.noop,
+            state_operations=[
+                migrations.AlterField(
+                    model_name='job',
+                    name='push',
+                    field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='jobs', to='model.Push'),
+                ),
+            ],
         ),
-        migrations.AlterField(
-            model_name='jobdetail',
-            name='job',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='job_details', to='model.Job'),
+        migrations.RunSQL(
+            migrations.RunSQL.noop,
+            reverse_sql=migrations.RunSQL.noop,
+            state_operations=[
+                migrations.AlterField(
+                    model_name='jobdetail',
+                    name='job',
+                    field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='job_details', to='model.Job'),
+                ),
+            ],
         ),
     ]


### PR DESCRIPTION
Django bug https://code.djangoproject.com/ticket/28065 causes the
addition of ``related_name`` to create a migration that will drop and
re-add the foreign key.  However, this is a ``meta`` only change, so
no DB changes should be made and this ForeignKey drop and re-add
is super expensive.  I didn't notice this problem before I merged
commit d85b8f74d2bd63a7bd1de420aa15f422b360dbc8.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2334)
<!-- Reviewable:end -->
