### PR TITLE
Bug 1352398 - use raw link to revisions instead of a revision number in the talos regression template

### DIFF
--- a/treeherder/perf/fixtures/performance_bug_templates.yaml
+++ b/treeherder/perf/fixtures/performance_bug_templates.yaml
@@ -7,7 +7,11 @@
     default_product: Firefox
     cc_list: jmaher@mozilla.com, rwood@mozilla.com, ionut.goldan@softvision.ro
     text: |
-      Talos has detected a Firefox performance regression from push {{ revision }}. As author of one of the patches included in that push, we need your help to address this regression.
+      Talos has detected a Firefox performance regression from push:
+
+      {{ revisionHref }}
+
+      As author of one of the patches included in that push, we need your help to address this regression.
 
       {{ alertSummary }}
 
@@ -31,7 +35,11 @@
     default_product: Firefox
     cc_list: jmaher@mozilla.com, rwood@mozilla.com, nfroyd@mozilla.com, ionut.goldan@softvision.ro
     text: |
-      We have detected a build metrics regression from push {{ revision }}. As author of one of the patches included in that push, we need your help to address this regression.
+      We have detected a build metrics regression from push:
+
+      {{ revisionHref }}
+
+      As author of one of the patches included in that push, we need your help to address this regression.
 
       {{ alertSummary }}
 
@@ -49,7 +57,11 @@
     default_product: Firefox
     cc_list: jmaher@mozilla.com, rwood@mozilla.com, bc@mozilla.com, ionut.goldan@softvision.ro
     text: |
-      We have detected an autophone (Android) regression from push {{ revision }}. As author of one of the patches included in that push, we need your help to address this regression.
+      We have detected an autophone (Android) regression from push:
+
+      {{ revisionHref }}
+
+      As author of one of the patches included in that push, we need your help to address this regression.
 
       {{ alertSummary }}
 

--- a/ui/js/controllers/perf/alerts.js
+++ b/ui/js/controllers/perf/alerts.js
@@ -1,14 +1,15 @@
 "use strict";
 
 perf.factory('PhBugs', [
-    '$http', '$httpParamSerializer', '$templateRequest', '$interpolate', 'dateFilter', 'thServiceDomain',
-    function($http, $httpParamSerializer, $templateRequest, $interpolate, dateFilter, thServiceDomain) {
+    '$http', '$httpParamSerializer', '$templateRequest', '$interpolate', '$rootScope', 'dateFilter', 'thServiceDomain',
+    function($http, $httpParamSerializer, $templateRequest, $interpolate, $rootScope, dateFilter, thServiceDomain) {
         return {
             fileTalosBug: function(alertSummary) {
                 $http.get(thServiceDomain + '/api/performance/bug-template/?framework=' + alertSummary.framework).then(function(response) {
                     var template = response.data[0];
+                    var repo = _.find($rootScope.repos,{ name: alertSummary.repository });
                     var compiledText = $interpolate(template.text)({
-                        revision: alertSummary.resultSetMetadata.revision,
+                        revisionHref: repo.getPushLogHref(alertSummary.resultSetMetadata.revision),
                         alertHref: window.location.origin + '/perf.html#/alerts?id=' +
                             alertSummary.id,
                         alertSummary: alertSummary.getTextualSummary()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2337)
<!-- Reviewable:end -->
