### PR TITLE
Bug 1356047 - Allow csrf_exempt on graphql endpoints

### DIFF
--- a/treeherder/config/urls.py
+++ b/treeherder/config/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.conf.urls import (include,
                               url)
 from django.contrib import admin
+from django.views.decorators.csrf import csrf_exempt
 from rest_framework_swagger.views import get_swagger_view
 
 from treeherder.credentials.urls import urlpatterns as credentials_patterns
@@ -28,5 +29,5 @@ if settings.GRAPHQL:
     from graphene_django.views import GraphQLView
     from treeherder.webapp.graphql.schema import schema
     urlpatterns += [
-        url(r'^graphql', GraphQLView.as_view(graphiql=True, schema=schema)),
+        url(r'^graphql', csrf_exempt(GraphQLView.as_view(graphiql=True, schema=schema))),
     ]


### PR DESCRIPTION
This is necessary to allow the TestGroup UI to access these GraphQL endpoints from a separate domain.  The client library we are using is Apollo, which uses a POST, even for read-only requests.  It is easier to ease the CSRF protections here than to get Apollo to support GET requests at this time.  We'll likely move to GET requests at a later time.

Disabling CSRF protections on these endpoints is safe because they are all read-only.  If we create "mutations" for these endpoints which allow writes, we'll need to re-visit the use of this exemption.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2340)
<!-- Reviewable:end -->
