### PR TITLE
Bug 1356719 - Strip out 'REFTEST ' from unexpected reftest passes

### DIFF
--- a/tests/ui/unit/controllers/bugfiler.tests.js
+++ b/tests/ui/unit/controllers/bugfiler.tests.js
@@ -194,6 +194,16 @@ describe('BugFilerCtrl', function(){
         expect(summary[0][0]).toBe("layout/reftests/css-display/display-contents-style-inheritance-1.html == layout/reftests/css-display/display-contents-style-inheritance-1-ref.html");
         expect(summary[0][1]).toBe("image comparison, max difference: 255, number of differing pixels: 699");
         expect(summary[1]).toBe("display-contents-style-inheritance-1.html");
+
+        // Test parsing reftest unexpected pass
+        summary = "REFTEST TEST-UNEXPECTED-PASS | file:///home/worker/workspace/build/tests/reftest/tests/layout/" +
+                  "reftests/backgrounds/vector/empty/wide--cover--width.html == file:///home/worker/workspace/" +
+                  "build/tests/reftest/tests/layout/reftests/backgrounds/vector/empty/ref-wide-lime.html | image comparison";
+        summary = bugFilerScope.parseSummary(summary);
+        expect(summary[0][0]).toBe("TEST-UNEXPECTED-PASS");
+        expect(summary[0][1]).toBe("backgrounds/vector/empty/wide--cover--width.html == backgrounds/vector/empty/ref-wide-lime.html");
+        expect(summary[0][2]).toBe("image comparison");
+        expect(summary[1]).toBe("display-contents-style-inheritance-1.html");
     });
 
 });

--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -53,6 +53,11 @@ treeherder.controller('BugFilerCtrl', [
                         allFailures[i].shift();
                     }
                 }
+
+                if (allFailures[i][0].search("REFTEST TEST-UNEXPECTED-PASS") >= 0) {
+                    allFailures[i][0] = allFailures[i][0].replace("REFTEST ", "");
+                }
+
                 if (i !== 0) {
                     thisFailure += "\n";
                 }
@@ -94,6 +99,11 @@ treeherder.controller('BugFilerCtrl', [
                 if (summary[0].search($scope.omittedLeads[i]) >= 0 && summary.length > 1) {
                     summary.shift();
                 }
+            }
+
+            // We don't want to include "REFTEST" when it's an unexpected pass
+            if (summary[0].search("REFTEST TEST-UNEXPECTED-PASS") >= 0) {
+                summary[0] = summary[0].replace("REFTEST ", "");
             }
 
             $uibModalInstance.possibleFilename = summary[0].split("==")[0].split("/").pop().trim();

--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -54,9 +54,7 @@ treeherder.controller('BugFilerCtrl', [
                     }
                 }
 
-                if (allFailures[i][0].search("REFTEST TEST-UNEXPECTED-PASS") >= 0) {
-                    allFailures[i][0] = allFailures[i][0].replace("REFTEST ", "");
-                }
+                allFailures[i][0] = allFailures[i][0].replace("REFTEST TEST-UNEXPECTED-PASS", "TEST-UNEXPECTED-PASS");
 
                 if (i !== 0) {
                     thisFailure += "\n";
@@ -102,9 +100,7 @@ treeherder.controller('BugFilerCtrl', [
             }
 
             // We don't want to include "REFTEST" when it's an unexpected pass
-            if (summary[0].search("REFTEST TEST-UNEXPECTED-PASS") >= 0) {
-                summary[0] = summary[0].replace("REFTEST ", "");
-            }
+            summary[0] = summary[0].replace("REFTEST TEST-UNEXPECTED-PASS", "TEST-UNEXPECTED-PASS");
 
             $uibModalInstance.possibleFilename = summary[0].split("==")[0].split("/").pop().trim();
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2343)
<!-- Reviewable:end -->
