### PR TITLE
Bug 1345131 - Enable pyup.io for requirements/common.txt

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,4 +1,3 @@
-# pyup: ignore file
 # Packages that are shared between deployment and dev environments.
 
 gunicorn==19.6.0 --hash=sha256:723234ea1fa8dff370ab69830ba8bc37469a7cba13fd66055faeef24085e6530


### PR DESCRIPTION
Now that the initial PR is out of the way, subsequent PRs will be one
package per PR, which is what we want for the more risky common.txt
updates (mass updating the dev dependencies was safe and so not worth
the additional spam of one PR per package).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder/2368)
<!-- Reviewable:end -->
