### PR TITLE
Bug 1354135 - Don't skip the ingestion of artifacts for pending jobs

### DIFF
--- a/tests/etl/test_job_loader.py
+++ b/tests/etl/test_job_loader.py
@@ -105,8 +105,8 @@ def test_ingest_pending_pulse_job(pulse_jobs, result_set_stored,
     assert job.taskcluster_metadata.task_id == 'IYyscnNMTLuxzna7PNqUJQ'
 
     # should not have processed any log or details for pending jobs
-    assert JobLog.objects.count() == 0
-    assert JobDetail.objects.count() == 0
+    assert JobLog.objects.count() == 2
+    assert JobDetail.objects.count() == 2
 
 
 def test_ingest_pulse_jobs_bad_project(pulse_jobs, test_repository, result_set_stored,

--- a/treeherder/etl/jobs.py
+++ b/treeherder/etl/jobs.py
@@ -292,12 +292,6 @@ def _load_job(repository, job_datum, push_id, lower_tier_signatures):
         except IntegrityError:
             pass
 
-    # if the job was pending, there's nothing more to do here
-    # (pending jobs have no artifacts, and we would have just created
-    # it)
-    if state == 'pending':
-        return (job_guid, signature_hash)
-
     # Update job with any data that would have changed
     Job.objects.filter(id=job.id).update(
         guid=job_guid,


### PR DESCRIPTION
Since it's no longer true that they won't have artifacts.