### PR TITLE
Bug 1340554 - Switch away from deprecated Elasticsearch count API

### DIFF
--- a/tests/model/test_cycle_data.py
+++ b/tests/model/test_cycle_data.py
@@ -45,7 +45,7 @@ def test_cycle_all_data(test_repository, failure_classifications, sample_data,
     assert JobLog.objects.count() == 0
 
     # There should be nothing in elastic search after cycling
-    assert TestFailureLine.search().params(search_type="count").execute().hits.total == 0
+    assert TestFailureLine.search().count() == 0
 
 
 def test_cycle_all_but_one_job(test_repository, failure_classifications, sample_data,
@@ -116,7 +116,7 @@ def test_cycle_all_data_in_chunks(test_repository, failure_classifications, samp
     create_failure_lines(Job.objects.get(id=1),
                          [(test_line, {})] * 7)
 
-    assert TestFailureLine.search().params(search_type="count").execute().hits.total > 0
+    assert TestFailureLine.search().count() > 0
 
     call_command('cycle_data', sleep_time=0, days=1, chunk_size=3)
     refresh_all()
@@ -125,7 +125,7 @@ def test_cycle_all_data_in_chunks(test_repository, failure_classifications, samp
     assert Job.objects.count() == 0
     assert FailureLine.objects.count() == 0
     assert JobDetail.objects.count() == 0
-    assert TestFailureLine.search().params(search_type="count").execute().hits.total == 0
+    assert TestFailureLine.search().count() == 0
 
 
 def test_cycle_job_model_reference_data(test_repository, failure_classifications,

--- a/treeherder/model/management/commands/es_import_failure_lines.py
+++ b/treeherder/model/management/commands/es_import_failure_lines.py
@@ -65,8 +65,8 @@ existing data is considered for matching failure lines."""
             bulk_insert(es_lines)
             min_id = rows[len(rows) - 1]["id"]
             time.sleep(options['sleep'])
-        s = Search(doc_type=TestFailureLine).params(search_type="count")
-        self.stdout.write("Index contains %i documents" % s.execute().hits.total)
+        count = Search(doc_type=TestFailureLine).count()
+        self.stdout.write("Index contains %i documents" % count)
 
 
 def failure_line_from_value(line):


### PR DESCRIPTION
The count `search_type` was deprecated in Elasticsearch 2.0.0 and has been removed entirely in version 5+:
https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_50_search_changes.html

This switches to the `.count()` API instead:
https://elasticsearch-dsl.readthedocs.io/en/latest/api.html#elasticsearch_dsl.Search.count

This can be landed prior to the ES 5.x upgrade, since it's supported by the ES 2.x API too.