### PR TITLE
bug 1353376 - enable holly branch for macosx on tc scheduling testing

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -355,7 +355,7 @@
         "dvcs_type": "hg",
         "name": "holly",
         "url": "https://hg.mozilla.org/projects/holly",
-        "active_status": "onhold",
+        "active_status": "active",
         "codebase": "gecko",
         "repository_group": 6,
         "description": ""


### PR DESCRIPTION
enable holly branch for testing

Turn off buildbot macosx64 opt builds scheduling 
https://bugzilla.mozilla.org/show_bug.cgi?id=1353376