### PR TITLE
Bug 1065567 - Add ability to ingest Mercurial Pushes via Pulse

### DIFF
--- a/tests/sample_data/pulse_consumer/hg_push.json
+++ b/tests/sample_data/pulse_consumer/hg_push.json
@@ -1,0 +1,23 @@
+{
+    "payload": {
+      "pushlog_pushes": [
+        {
+          "time": 14698302460,
+          "push_full_json_url": "https://hg.mozilla.org/try/json-pushes?version=2&full=1&startID=136597&endID=136598",
+          "pushid": 136598,
+          "push_json_url": " https: //hg.mozilla.org/try/json-pushes?version=2&startID=136597&endID=136598",
+          "user": " james@hoppipolla.co.uk"
+        }
+      ],
+      "heads": [
+        "2f77bc4f354d9ba67ea5270b2fc789f4b0521287"
+      ],
+      "repo_url": "https://hg.mozilla.org/try",
+      "_meta": {
+        "sent": "2016-07-29T22:11:18.503365",
+        "routing_key": "try",
+        "serializer": "json",
+        "exchange": "exchange/hgpushes/v1"
+      }
+    }
+}

--- a/tests/sample_data/pulse_consumer/hg_push_commits.json
+++ b/tests/sample_data/pulse_consumer/hg_push_commits.json
@@ -1,0 +1,38 @@
+{
+  "lastpushid": 136598,
+  "pushes": {
+    "136598": {
+      "changesets": [
+        {
+          "author": "James Graham \u003cjames@hoppipolla.co.uk\u003e",
+          "branch": "default",
+          "desc": "Update web-platform-tests expected data to revision 6744ac43d76207bdd1ececa4b91c9bfeef3ad522\n\nMozReview-Commit-ID: DKYxwGwjqUu\n",
+          "files": [
+            "testing/web-platform/meta/2dcontext/shadows/2d.shadow.pattern.basic.html.ini",
+            "testing/web-platform/meta/IndexedDB/transaction-lifetime-empty.html.ini"
+          ],
+          "node": "16df582a3768ef56c1338b1c6b57d30820249a0d",
+          "parents": [
+            "ae327128aed16186be41d27e5cddb43f60133718"
+          ],
+          "tags": []
+        },
+        {
+          "author": "James Graham \u003cjames@hoppipolla.co.uk\u003e",
+          "branch": "default",
+          "desc": "try: -b do -p win32,win64,linux64,linux,macosx64 -u web-platform-tests[Ubuntu,10.8,10.10,10.10.5,Windows XP,Windows 7,Windows 8] -t none\n\nMozReview-Commit-ID: 83PbEOQP2Nc\n",
+          "files": [],
+          "node": "2f77bc4f354d9ba67ea5270b2fc789f4b0521287",
+          "parents": [
+            "16df582a3768ef56c1338b1c6b57d30820249a0d"
+          ],
+          "tags": [
+            "tip"
+          ]
+        }
+      ],
+      "date": 1469830246,
+      "user": "james@hoppipolla.co.uk"
+    }
+  }
+}

--- a/tests/sample_data/pulse_consumer/transformed_hg_push.json
+++ b/tests/sample_data/pulse_consumer/transformed_hg_push.json
@@ -1,0 +1,18 @@
+{
+  "author": "james@hoppipolla.co.uk",
+  "push_timestamp": 1469830246,
+  "revision": "2f77bc4f354d9ba67ea5270b2fc789f4b0521287",
+  "revision_hash": "88eecdab42c2070b361645c0533c04d6dedb3734",
+  "revisions": [
+    {
+      "author": "James Graham <james@hoppipolla.co.uk>",
+      "comment": "Update web-platform-tests expected data to revision 6744ac43d76207bdd1ececa4b91c9bfeef3ad522\n\nMozReview-Commit-ID: DKYxwGwjqUu\n",
+      "revision": "16df582a3768ef56c1338b1c6b57d30820249a0d"
+    },
+    {
+      "author": "James Graham <james@hoppipolla.co.uk>",
+      "comment": "try: -b do -p win32,win64,linux64,linux,macosx64 -u web-platform-tests[Ubuntu,10.8,10.10,10.10.5,Windows XP,Windows 7,Windows 8] -t none\n\nMozReview-Commit-ID: 83PbEOQP2Nc\n",
+      "revision": "2f77bc4f354d9ba67ea5270b2fc789f4b0521287"
+    }
+  ]
+}

--- a/tests/sampledata.py
+++ b/tests/sampledata.py
@@ -51,6 +51,14 @@ class SampleData(object):
                   os.path.dirname(__file__))) as f:
             self.transformed_github_pr = json.load(f)
 
+        with open("{0}/sample_data/pulse_consumer/hg_push.json".format(
+                  os.path.dirname(__file__))) as f:
+            self.hg_push = json.load(f)
+
+        with open("{0}/sample_data/pulse_consumer/transformed_hg_push.json".format(
+                  os.path.dirname(__file__))) as f:
+            self.transformed_hg_push = json.load(f)
+
         self.job_data = []
         self.resultset_data = []
 

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -548,6 +548,12 @@ PULSE_RESULTSET_SOURCES = env.json(
         #         '#'
         #     ],
         # },
+        # {
+        #     "exchange": "exchange/hgpushes/v1",
+        #     "routing_keys": [
+        #         "#"
+        #     ]
+        # },
         # ... other CI systems
     ])
 


### PR DESCRIPTION
This uses the same mechanism we use for ingesting GitHub pushes.  This adds an additional Transformer for HG pushes, and requires adding the Pulse exchange of ``exchange/hgpushes/v1`` to the existing PULSE_RESULTSET_SOURCES environment variable.