### PR TITLE
Bug 1359626 - Strip out more xpcshell prefixes from the path

### DIFF
--- a/tests/ui/unit/controllers/bugfiler.tests.js
+++ b/tests/ui/unit/controllers/bugfiler.tests.js
@@ -177,6 +177,18 @@ describe('BugFilerCtrl', function(){
         expect(summary[0][1]).toBe("application crashed [@ mozalloc_abort(char const*)]");
         expect(summary[1]).toBe("test_rename_objectStore_errors.js");
 
+        summary = "xpcshell-unpack.ini:dom/indexedDB/test/unit/test_rename_objectStore_errors.js | application crashed [@ mozalloc_abort(char const*)]";
+        summary = bugFilerScope.parseSummary(summary);
+        expect(summary[0][0]).toBe("dom/indexedDB/test/unit/test_rename_objectStore_errors.js");
+        expect(summary[0][1]).toBe("application crashed [@ mozalloc_abort(char const*)]");
+        expect(summary[1]).toBe("test_rename_objectStore_errors.js");
+
+        summary = "xpcshell.ini:dom/indexedDB/test/unit/test_rename_objectStore_errors.js | application crashed [@ mozalloc_abort(char const*)]";
+        summary = bugFilerScope.parseSummary(summary);
+        expect(summary[0][0]).toBe("dom/indexedDB/test/unit/test_rename_objectStore_errors.js");
+        expect(summary[0][1]).toBe("application crashed [@ mozalloc_abort(char const*)]");
+        expect(summary[1]).toBe("test_rename_objectStore_errors.js");
+
         // Test parsing Windows reftests on C drive
         summary = "file:///C:/slave/test/build/tests/reftest/tests/layout/reftests/w3c-css/submitted/variables/variable-supports-12.html | application timed out after 330 seconds with no output";
         summary = bugFilerScope.parseSummary(summary);

--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -107,9 +107,7 @@ treeherder.controller('BugFilerCtrl', [
             summary = summary.replace(re, "");
             re = /jetpack-package\//gi;
             summary = summary.replace(re, "");
-            re = /xpcshell-child-process.ini:/gi;
-            summary = summary.replace(re, "");
-            re = /xpcshell-unpack.ini:/gi;
+            re = /xpcshell([-a-zA-Z]+)?.ini:/gi;
             summary = summary.replace(re, "");
             summary = summary.replace("/_mozilla/", "mozilla/tests/");
             // We don't want to include "REFTEST" when it's an unexpected pass


### PR DESCRIPTION
Tired of manually adding these every single time I find a new prefix. This should stop them all, assuming they match the `xpcshell-FOO-BAR.ini:" format.