### PR TITLE
Bug 1168117 - Remove support for defining the API URL via local.conf.js

### DIFF
--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -120,10 +120,9 @@ To do this:
 
      git checkout (your feature branch)
      git checkout -b gh-pages
-     cp ui/js/config/sample.local.conf.js ui/js/config/local.conf.js
-     yarn run build
-     git add -f ui/js/config/local.conf.js dist/
-     git commit -m "Add temp config file and dist directory to make the UI use prod's API"
+     SERVICE_DOMAIN=https://treeherder.mozilla.org yarn run build
+     git add -f dist/
+     git commit -m "Add dist directory containing built UI"
 
 * Push the ``gh-pages`` branch to your Treeherder fork.
 

--- a/docs/ui/installation.rst
+++ b/docs/ui/installation.rst
@@ -82,13 +82,6 @@ If you would like to view the minified production version of the UI with Vagrant
 
 Once the build is complete, the minified version of the UI will now be accessible at http://localhost:8000.
 
-Configuration
-=============
-
-Please note that if ``ui/js/config/local.conf.js`` exists, the above configuration will be overwritten by the ``thServiceDomain`` defined in that config file.
-
-If you wish to run the full treeherder Vagrant project (service + UI), remember to remove local.conf.js or else change ``thServiceDomain`` within it to refer to ``vagrant``, so the UI will use the local Vagrant service API.
-
 Validating JavaScript
 =====================
 

--- a/neutrino-custom/lint.js
+++ b/neutrino-custom/lint.js
@@ -85,7 +85,7 @@ module.exports = neutrino => {
                 globals: ['angular', '$', '_', 'treeherder', 'perf',
                     'treeherderApp', 'failureViewerApp', 'logViewerApp',
                     'userguideApp', 'admin', 'Mousetrap', 'jQuery', 'React',
-                    'hawk', 'jsonSchemaDefaults'
+                    'hawk', 'jsonSchemaDefaults', 'SERVICE_DOMAIN'
                 ]
             }
         }));

--- a/neutrino-custom/production.js
+++ b/neutrino-custom/production.js
@@ -19,7 +19,7 @@ module.exports = neutrino => {
         }
     ));
 
-    // Define the service domain globally so that window.thServiceDomain can be set:
+    // Define the service domain globally for the thServiceDomain provider:
     neutrino.config.plugin('define')
         .use(webpack.DefinePlugin, {
             SERVICE_DOMAIN: JSON.stringify(SERVICE_DOMAIN)

--- a/tests/ui/unit/init.js
+++ b/tests/ui/unit/init.js
@@ -9,8 +9,6 @@ window.jQuery = require('jquery');
 window._ = require('lodash');
 window.angular = require('angular');
 window.React = require('react');
-window.SERVICE_DOMAIN = '';
-window.thServiceDomain = '';
 require('react-dom');
 require('../vendor/jasmine-jquery.js');
 require('angular-mocks');

--- a/ui/js/config/index.js
+++ b/ui/js/config/index.js
@@ -1,12 +1,4 @@
-/* global SERVICE_DOMAIN */
 'use strict';
-
-// The treeherder API endpoint is set via window.thServiceDomain.
-// The SERVICE_DOMAIN global is set by webpack's DefinePlugin based on the SERVICE_DOMAIN environment variable.
-// Use it to set window.thServiceDomain if possible:
-if (!_.isEmpty(SERVICE_DOMAIN)) {
-    window.thServiceDomain = SERVICE_DOMAIN;
-}
 
 // Check for a config file and use it if available
 try {

--- a/ui/js/config/sample.local.conf.js
+++ b/ui/js/config/sample.local.conf.js
@@ -1,12 +1,5 @@
 'use strict';
 
-/* window.thServiceDomain holds a reference to a back-end service
- * used to retrieve job result data. Valid settings are  */
-var production = "https://treeherder.mozilla.org";
-
-// Set the service
-window.thServiceDomain = production;
-
 //treeherder.config(['$logProvider', 'ThLogConfigProvider',
 //    function($logProvider, ThLogConfigProvider) {
 //

--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -2,7 +2,8 @@
 
 treeherder.provider('thServiceDomain', function() {
     this.$get = function() {
-        return (window.thServiceDomain) ? window.thServiceDomain : "";
+        // The SERVICE_DOMAIN global is set by webpack's DefinePlugin.
+        return (typeof SERVICE_DOMAIN !== 'undefined') ? SERVICE_DOMAIN : "";
     };
 });
 


### PR DESCRIPTION
Previously a forgotten-about `local.conf.js` (which is git-ignored) would override the URL passed by the `SERVICE_URL` environment variable.

With webpack and environment variables, there is no need to use a local config file to control the API URL, so we can now remove this footgun.