### PR TITLE
Bug 1360305 - Make hovering over very old performance data work as expected

### DIFF
--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -214,11 +214,12 @@ class PerformanceDatumViewSet(viewsets.ViewSet):
 
         ret = defaultdict(list)
         values_list = datums.values_list(
-            'signature_id', 'signature__signature_hash', 'job_id', 'push_id',
+            'id', 'signature_id', 'signature__signature_hash', 'job_id', 'push_id',
             'push_timestamp', 'value')
-        for (signature_id, signature_hash, job_id, push_id,
+        for (id, signature_id, signature_hash, job_id, push_id,
              push_timestamp, value) in values_list:
             ret[signature_hash].append({
+                'id': id,
                 'signature_id': signature_id,
                 'job_id': job_id,
                 'push_id': push_id,

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -57,7 +57,8 @@ perf.controller('GraphsCtrl', [
                 frameworkId: flotItem.series.thSeries.frameworkId,
                 resultSetId: resultSetId,
                 flotDataOffset: (flotItem.dataIndex -
-                    flotItem.series.resultSetData.indexOf(resultSetId)),
+                                 flotItem.series.resultSetData.indexOf(resultSetId)),
+                id: flotItem.series.idData[flotItem.dataIndex],
                 jobId: flotItem.series.jobIdData[flotItem.dataIndex]
             };
         }
@@ -91,8 +92,8 @@ perf.controller('GraphsCtrl', [
 
                 // we need the flot data for calculating values/deltas and to know where
                 // on the graph to position the tooltip
-                var flotIndex = phSeries.flotSeries.jobIdData.indexOf(
-                    dataPoint.jobId);
+                var flotIndex = phSeries.flotSeries.idData.indexOf(
+                    dataPoint.id);
                 var flotData = {
                     series: _.find($scope.plot.getData(), function(fs) {
                         return fs.thSeries.projectName === dataPoint.projectName &&
@@ -253,8 +254,8 @@ perf.controller('GraphsCtrl', [
                             s.signature === $scope.selectedDataPoint.signature;
                     });
                 var selectedSeries = $scope.seriesList[selectedSeriesIndex];
-                var flotDataPoint = selectedSeries.flotSeries.jobIdData.indexOf(
-                    $scope.selectedDataPoint.jobId);
+                var flotDataPoint = selectedSeries.flotSeries.idData.indexOf(
+                    $scope.selectedDataPoint.id);
                 flotDataPoint = flotDataPoint ? flotDataPoint : selectedSeries.flotSeries.resultSetData.indexOf(
                     $scope.selectedDataPoint.resultSetId);
                 $scope.plot.highlight(selectedSeriesIndex, flotDataPoint);
@@ -570,7 +571,7 @@ perf.controller('GraphsCtrl', [
                     return ($scope.selectedDataPoint) ? "[" + [$scope.selectedDataPoint.projectName,
                         $scope.selectedDataPoint.signature,
                         $scope.selectedDataPoint.resultSetId,
-                        $scope.selectedDataPoint.jobId,
+                        $scope.selectedDataPoint.id,
                         $scope.selectedDataPoint.frameworkId]
                         + "]" : undefined;
                 })()
@@ -607,8 +608,8 @@ perf.controller('GraphsCtrl', [
                             seriesData[series.signature],
                             'push_id'),
                         thSeries: jQuery.extend({}, series),
-                        jobIdData: _.map(seriesData[series.signature],
-                            'job_id')
+                        jobIdData: _.map(seriesData[series.signature], 'job_id'),
+                        idData: _.map(seriesData[series.signature], 'id')
                     };
                 }).then(function() {
                     series.relatedAlertSummaries = [];
@@ -794,7 +795,7 @@ perf.controller('GraphsCtrl', [
                     projectName: tooltipArray[0],
                     signature: tooltipArray[1],
                     resultSetId: parseInt(tooltipArray[2]),
-                    jobId: parseInt(tooltipArray[3]),
+                    id: parseInt(tooltipArray[3]),
                     frameworkId: parseInt(tooltipArray[4]) || 1
                 };
                 $scope.selectedDataPoint = (tooltipString) ? tooltip : null;

--- a/ui/partials/perf/graphsctrl.html
+++ b/ui/partials/perf/graphsctrl.html
@@ -74,8 +74,7 @@
             {{tooltipContent.revision| limitTo: 12}}
           </a>
           <span ng-show="tooltipContent.prevRevision && tooltipContent.revision">
-            (<a id="tt-cset" ng-href="{{tooltipContent.revision | getRevisionUrl:tooltipContent.project.name}}&selectedJob={{tooltipContent.jobId}}&group_state=expanded" target="_blank">job</a>,
-            <a ng-href="#/comparesubtest?originalProject={{tooltipContent.project.name}}&newProject={{tooltipContent.project.name}}&originalRevision={{tooltipContent.prevRevision}}&newRevision={{tooltipContent.revision}}&originalSignature={{selectedDataPoint.signature}}&newSignature={{selectedDataPoint.signature}}&framework={{selectedDataPoint.frameworkId}}" target="_blank">compare</a>)
+            (<span ng-if="tooltipContent.jobId"><a id="tt-cset" ng-href="{{tooltipContent.revision | getRevisionUrl:tooltipContent.project.name}}&selectedJob={{tooltipContent.jobId}}&group_state=expanded" target="_blank">job</a>, </span><a ng-href="#/comparesubtest?originalProject={{tooltipContent.project.name}}&newProject={{tooltipContent.project.name}}&originalRevision={{tooltipContent.prevRevision}}&newRevision={{tooltipContent.revision}}&originalSignature={{selectedDataPoint.signature}}&newSignature={{selectedDataPoint.signature}}&framework={{selectedDataPoint.frameworkId}}" target="_blank">compare</a>)
           </span>
         </p>
         <p ng-if="tooltipContent.alertSummary">


### PR DESCRIPTION
We don't have job information for data > 4 months old (per Treeherder's job
expiry policy), but we can at least let the user hover over it as they
expect.