### PR TITLE
Bug 1361424 - Add GraphQL support for failure lines

### DIFF
--- a/treeherder/webapp/graphql/schema.py
+++ b/treeherder/webapp/graphql/schema.py
@@ -51,6 +51,16 @@ class JobGroupGraph(DjangoObjectType):
         model = JobGroup
 
 
+class JobLogGraph(DjangoObjectType):
+    class Meta:
+        model = JobLog
+
+
+class FailureLineGraph(DjangoObjectType):
+    class Meta:
+        model = FailureLine
+
+
 class ProductGraph(DjangoObjectType):
     class Meta:
         model = Product


### PR DESCRIPTION
This allows you to query for the FailureLine entries for jobs.  So it doesn't need a direct accessor.  This just allows them to be fields of ``Job`` queries.