### PR TITLE
Bug 1340132 - Reduce usage of --maxtasksperchild with celery

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,15 +1,15 @@
 web: newrelic-admin run-program gunicorn treeherder.config.wsgi:application --timeout 29
 worker_beat: newrelic-admin run-program celery beat -A treeherder
-worker_pushlog: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q pushlog --maxtasksperchild=500 --concurrency=5
-worker_buildapi_pending: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q buildapi_pending --maxtasksperchild=20 --concurrency=5
-worker_buildapi_running: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q buildapi_running --maxtasksperchild=20 --concurrency=5
-worker_buildapi_4hr: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q buildapi_4hr --maxtasksperchild=20 --concurrency=1
-worker_store_pulse_jobs: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q store_pulse_jobs --maxtasksperchild=20 --concurrency=3
-worker_store_pulse_resultsets: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q store_pulse_resultsets --maxtasksperchild=20 --concurrency=3
+worker_pushlog: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q pushlog --concurrency=5
+worker_buildapi_pending: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q buildapi_pending --concurrency=5
+worker_buildapi_running: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q buildapi_running --concurrency=5
+worker_buildapi_4hr: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q buildapi_4hr --concurrency=1
+worker_store_pulse_jobs: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q store_pulse_jobs --concurrency=3
+worker_store_pulse_resultsets: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q store_pulse_resultsets --concurrency=3
 worker_read_pulse_jobs: newrelic-admin run-program ./manage.py read_pulse_jobs
 worker_read_pulse_resultsets: newrelic-admin run-program ./manage.py read_pulse_resultsets
-worker_default: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q default,cycle_data,calculate_durations,fetch_bugs,fetch_allthethings,generate_perf_alerts,seta_analyze_failures --maxtasksperchild=50 --concurrency=3
-worker_hp: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q classification_mirroring,publish_to_pulse --maxtasksperchild=50 --concurrency=1
+worker_default: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q default,cycle_data,calculate_durations,fetch_bugs,fetch_allthethings,generate_perf_alerts,seta_analyze_failures --concurrency=3
+worker_hp: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q classification_mirroring,publish_to_pulse --concurrency=1
 worker_log_parser: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_parser,log_parser_fail,log_store_failure_lines,log_store_failure_lines_fail,log_crossreference_error_lines,log_crossreference_error_lines_fail,log_autoclassify,log_autoclassify_fail --maxtasksperchild=50 --concurrency=7
 
 release: ./bin/pre_deploy

--- a/bin/run_celery_worker
+++ b/bin/run_celery_worker
@@ -10,5 +10,4 @@ source /etc/profile.d/treeherder.sh
 
 exec newrelic-admin run-program celery -A treeherder worker -c 3 \
      -Q default,cycle_data,calculate_durations,fetch_bugs,fetch_allthethings,generate_perf_alerts,seta_analyze_failures \
-     -E --maxtasksperchild=500 \
-     -l INFO -n default.%h
+     -E -l INFO -n default.%h

--- a/bin/run_celery_worker_buildapi
+++ b/bin/run_celery_worker_buildapi
@@ -10,5 +10,5 @@ source /etc/profile.d/treeherder.sh
 
 exec newrelic-admin run-program celery -A treeherder worker -Q buildapi_pending,buildapi_running,buildapi_4hr,store_pulse_jobs,store_pulse_resultsets \
     --concurrency=5 -l INFO \
-    --maxtasksperchild=20 -n buildapi.%h
+    -n buildapi.%h
 

--- a/bin/run_celery_worker_hp
+++ b/bin/run_celery_worker_hp
@@ -9,5 +9,5 @@ PATH=$PROJECT_ROOT/venv/bin:$PATH
 source /etc/profile.d/treeherder.sh
 
 exec newrelic-admin run-program celery -A treeherder worker -c 1 \
-     -Q classification_mirroring,publish_to_pulse -E --maxtasksperchild=500 \
+     -Q classification_mirroring,publish_to_pulse -E \
      -l INFO -n hp.%h

--- a/bin/run_celery_worker_pushlog
+++ b/bin/run_celery_worker_pushlog
@@ -11,5 +11,5 @@ source /etc/profile.d/treeherder.sh
 exec newrelic-admin run-program celery -A treeherder worker \
     -Q pushlog \
     --concurrency=5 -l INFO \
-    --maxtasksperchild=500 -n pushlog.%h
+    -n pushlog.%h
 


### PR DESCRIPTION
Now we're no longer using datasource, the memory leaks previously seen have gone. As such there is no need to make the celery worker processes restart so frequently (they will now only be restarted at the daily Heroku dyno restart), which will improve performance.

In addition, this will reduce the number of transactions that don't get reported to New Relic (when the maxtasksperchild threshold is reached, the worker is forcibly killed before it can submit the New Relic payload).

The log parser tasks have been left unchanged for now, since they appear to still be leaking.