### PR TITLE
Bug 1362812 - Consider wpt reftests to be reftests.

### DIFF
--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -299,7 +299,8 @@ treeherder.provider('thReftestStatus', function() {
     this.$get = function() {
         return function(job) {
             if (job.job_group_name) {
-                return (job.job_group_name.toLowerCase().indexOf('reftest') !== -1);
+                return (job.job_group_name.toLowerCase().indexOf('reftest') !== -1 ||
+                        job.job_type_name.toLowerCase().indexOf('reftest') !== -1);
             }
         };
     };


### PR DESCRIPTION
These aren't in the "reftest" job group but do have "reftest" in the
job title. This change is required to ensure that they get the reftest
analyzer links.