### PR TITLE
Bug 1363467 - Allow 'less than' filtering on the Tier field in GraphQL

### DIFF
--- a/treeherder/webapp/graphql/schema.py
+++ b/treeherder/webapp/graphql/schema.py
@@ -17,7 +17,10 @@ class JobDetailGraph(DjangoObjectType):
 class JobGraph(DjangoObjectType):
     class Meta:
         model = Job
-        filter_fields = ('result', 'tier')
+        filter_fields = {
+            'result': ['exact'],
+            'tier': ['exact', 'lt'],
+        }
         interfaces = (graphene.relay.Node, )
 
     job_details = DjangoFilterConnectionField(JobDetailGraph)


### PR DESCRIPTION
This allows GraphQL queries to avoid downloading Tier-3 jobs.