### PR TITLE
Bug 1366345 - Force the save() event to be emitted when ctrl-enter is used while manually entering bug numbers

### DIFF
--- a/ui/partials/main/thPinboardPanel.html
+++ b/ui/partials/main/thPinboardPanel.html
@@ -30,6 +30,7 @@
              class="add-related-bugs-input"
              ng-model="$parent.newEnteredBugNumber"
              placeholder="enter bug number"
+             ng-keypress="ctrlEnterSaves($event)"
              focus-me="focusInput">
     </form>
     <span ng-repeat="bug in relatedBugs">

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -92,7 +92,7 @@ treeherder.controller('PinboardCtrl', [
                     thNotify.send("Please enter a valid bug number", "danger");
                 }
             }
-            if (!$scope.canSaveClassifications()) {
+            if (!$scope.canSaveClassifications() && $scope.user.loggedin) {
                 thNotify.send("Please classify this failure before saving", "danger");
                 errorFree = false;
             }
@@ -250,6 +250,14 @@ treeherder.controller('PinboardCtrl', [
 
         $scope.completeClassification = function() {
             $rootScope.$broadcast('blur-this', "classification-comment");
+        };
+
+        // The manual bug entry input eats the global ctrl+enter save() shortcut.
+        // Force that event to be emitted so ctrl+enter saves the classification.
+        $scope.ctrlEnterSaves = function(ev) {
+            if (ev.ctrlKey && ev.keyCode === 13) {
+                $scope.$evalAsync($rootScope.$emit(thEvents.saveClassification));
+            }
         };
 
         $scope.saveEnteredBugNumber = function() {


### PR DESCRIPTION
Something is eating the event fired when ctrl-enter is pressed to save classifications if the manual bug number field is focused, making the user press ctrl-enter twice to save the classification.  This patch adds a keypress listener to the bug entry field which forces the save() function to get called when ctrl-enter is pressed.