### PR TITLE
Remove workaround for Jenkins Issue 42771

### DIFF
--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -15,8 +15,11 @@ pipeline {
     timeout(time: 1, unit: 'HOURS')
   }
   environment {
-    /** See https://issues.jenkins-ci.org/browse/JENKINS-42771 - we'd like to expand this out into multi-line concatenations */
-    PYTEST_ADDOPTS = "--tb=short --color=yes --driver=SauceLabs --variables=capabilities.json"
+    PYTEST_ADDOPTS =
+      "--tb=short " +
+      "--color=yes " +
+      "--driver=SauceLabs " +
+      "--variables=capabilities.json"
     SAUCELABS_API_KEY = credentials('SAUCELABS_API_KEY')
   }
   stages {


### PR DESCRIPTION
We can safely revert the workaround, and remove the comment for https://issues.jenkins-ci.org/browse/JENKINS-42771, now that it's been fixed.

@davehunt @edmorley r?