### PR TITLE
Bug 1367867 - Improve recognition of user Initial Labels

### DIFF
--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -220,16 +220,6 @@ a:visited {
   content: none;
 }
 
-.label-initials {
-  display: inline-block;
-  margin-right: 0.5em;
-  padding: 0.2em 0.3em;
-  width: 2.5em;
-  border: 1px solid #999999;
-  background-color: white;
-  color: #999999;
-}
-
 .label[href] {
   color: #fff;
 }

--- a/ui/css/treeherder-resultsets.css
+++ b/ui/css/treeherder-resultsets.css
@@ -135,8 +135,22 @@ fieldset[disabled] .btn-resultset:hover {
 
 .revision-holder {
   padding-left: 20px;
-  padding-right: 11px;
+  padding-right: 6px;
   display: inline-block;
+}
+
+.user-push-icon {
+  color: gray;
+}
+
+.user-push-initials {
+  display: inline-block;
+  min-width: 18px;
+  font-size: 8px;
+  font-style: italic;
+  font-weight: bold;
+  padding-left: 3px;
+  color: gray;
 }
 
 .revision-comment {

--- a/ui/js/filters.js
+++ b/ui/js/filters.js
@@ -99,12 +99,15 @@ treeherder.filter('initials', function() {
         var words = str.split(' ');
         var firstLetters = _.filter(_.map(words, function(word) { return word.replace(/[^A-Z]/gi, '')[0]; }));
         var initials = "";
+
         if (firstLetters.length === 1) {
             initials = firstLetters[0];
         } else if (firstLetters.length > 1) {
             initials = firstLetters[0] + firstLetters[firstLetters.length - 1];
         }
-        return '<span class="label label-initials">' + initials + '</span>';
+
+        return '<span class="user-push-icon"><i class="fa fa-user-o" aria-hidden="true"></i></span>' +
+               '<div class="icon-superscript user-push-initials">' + initials + '</div>';
     };
 });
 


### PR DESCRIPTION
This hopefully improves at-a-glance recognition of what the user labels are, in the revision list.

The computed difference between the old initial text and the new one is essentially unchanged (9px to 8px). I intentionally used superscript with the initials to differentiate them visually and to place them beside the 'head' of the user icon.

Current:
![currentuserlabel](https://cloud.githubusercontent.com/assets/3660661/26468369/256d1682-4164-11e7-8a25-d59d57a1c242.jpg)

Proposed:
![proposeduserlabel](https://cloud.githubusercontent.com/assets/3660661/26468374/2dd79c98-4164-11e7-81ea-c7c24c14d2c5.jpg)


Tested on OSX 10.12:
Nightly **55.0a1 (2017-05-01) (64-bit)**
Chrome Release **58.0.3029.110 (64-bit)**
