### PR TITLE
Bug 1370279 - Prevent conflicts with jenkins pytest config & improve performance

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-DJANGO_SETTINGS_MODULE=tests.settings
-markers =
-    slow: mark a test as slow.

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,8 @@ force_grid_wrap = true
 line_length = 140
 # Remove when https://github.com/timothycrosley/isort/issues/297 fixed.
 known_first_party = tests
+
+[tool:pytest]
+DJANGO_SETTINGS_MODULE=tests.settings
+markers =
+    slow: mark a test as slow.

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,8 @@ line_length = 140
 known_first_party = tests
 
 [tool:pytest]
-norecursedirs = jenkins
+testpaths = tests
+norecursedirs = __pycache__ jenkins ui
 DJANGO_SETTINGS_MODULE=tests.settings
 markers =
     slow: mark a test as slow.

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ line_length = 140
 known_first_party = tests
 
 [tool:pytest]
+norecursedirs = jenkins
 DJANGO_SETTINGS_MODULE=tests.settings
 markers =
     slow: mark a test as slow.


### PR DESCRIPTION
**1) Move pytest configuration to setup.cfg**
Since it keeps everything test/lint/tool related in one place, so easier to keep ignore paths in sync and less repo clutter.

**2) Prevent conflicts with jenkins pytest configuration**
This fixes the `ConftestImportFailure` exception seen when trying to run pytest in Vagrant after bug 1286686 landed.

**3) Improve pytest test collection performance**
Before this change running pytest with no arguments took 51 seconds to just collect the list of tests to run (`pytest --collect-only`), since the entire source directory was scanned (including the 18,000 files in `node_modules`). Now it takes only 3.7 seconds.