### PR TITLE
Bug 1371820 - Automatically select 'fixed by commit' classification type in certain circumstances

### DIFF
--- a/tests/ui/unit/controllers/pinboard.tests.js
+++ b/tests/ui/unit/controllers/pinboard.tests.js
@@ -1,0 +1,41 @@
+'use strict';
+
+/* jasmine specs for controllers go here */
+
+describe('PinboardCtrl', function(){
+    var $httpBackend, controller, pinboardScope;
+
+    beforeEach(angular.mock.module('treeherder.app'));
+
+    beforeEach(inject(function ($injector, $rootScope, $controller) {
+        $httpBackend = $injector.get('$httpBackend');
+        jasmine.getJSONFixtures().fixturesPath='base/tests/ui/mock';
+
+        pinboardScope = $rootScope.$new();
+        $controller('PinboardCtrl', {
+          '$scope': pinboardScope,
+        });
+    }));
+
+    /*
+        Tests PinboardCtrl
+     */
+    it('should determine sha or commit url', function() {
+        // Blatantly not a sha or commit
+        var str = "banana";
+        expect(pinboardScope.isSHAorCommit(str)).toBe(false);
+        // This contains a legit 12-char SHA but includes a space
+        str = "c00b13480420 8c2652ebd4f45a1d37277c54e60b";
+        expect(pinboardScope.isSHAorCommit(str)).toBe(false);
+        // This is a valid commit URL
+        str = "https://hg.mozilla.org/integration/mozilla-inbound/rev/c00b134804208c2652ebd4f45a1d37277c54e60b";
+        expect(pinboardScope.isSHAorCommit(str)).toBe(true);
+        // Valid 40-char SHA
+        str = "c00b134804208c2652ebd4f45a1d37277c54e60b";
+        expect(pinboardScope.isSHAorCommit(str)).toBe(true);
+        // Valid 12-char SHA
+        str = "c00b13480420";
+        expect(pinboardScope.isSHAorCommit(str)).toBe(true);
+    });
+
+});

--- a/ui/partials/main/thPinboardPanel.html
+++ b/ui/partials/main/thPinboardPanel.html
@@ -55,6 +55,7 @@
                class="form-control add-classification-input"
                ng-model="classification.text"
                ng-click="allowKeys()"
+               ng-paste="pasteSHA($event)"
                placeholder="click to add comment"
                blur-this></input>
         <div ng-if="classification.failure_classification_id === 2">

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -132,6 +132,18 @@ treeherder.controller('PinboardCtrl', [
             }
         };
 
+        // If the pasted data is (or looks like) a 12 or 40 char SHA,
+        // or if the pasted data is an hg.m.o url, automatically select
+        // the "fixed by commit" classification type
+        $scope.pasteSHA = function (evt) {
+            var pastedData = evt.originalEvent.clipboardData.getData('text');
+            var re1 = pastedData.search(/^[0-9a-f]{12}$/) >= 0;
+            var re2 = pastedData.search(/^[0-9a-f]{40}$/) >= 0;
+            if (re1 || re2 || pastedData.includes("hg.mozilla.org")) {
+                $scope.classification.failure_classification_id = 2;
+            }
+        };
+
         $scope.retriggerAllPinnedJobs = function () {
             // pushing pinned jobs to a list.
             $scope.retriggerJob(_.values($scope.pinnedJobs));

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -132,14 +132,16 @@ treeherder.controller('PinboardCtrl', [
             }
         };
 
+        $scope.isSHAorCommit = function (str) {
+            return /^[a-f\d]{12,40}$/.test(str) || str.includes("hg.mozilla.org");
+        };
+
         // If the pasted data is (or looks like) a 12 or 40 char SHA,
         // or if the pasted data is an hg.m.o url, automatically select
         // the "fixed by commit" classification type
         $scope.pasteSHA = function (evt) {
             var pastedData = evt.originalEvent.clipboardData.getData('text');
-            var re1 = pastedData.search(/^[0-9a-f]{12}$/) >= 0;
-            var re2 = pastedData.search(/^[0-9a-f]{40}$/) >= 0;
-            if (re1 || re2 || pastedData.includes("hg.mozilla.org")) {
+            if ($scope.isSHAorCommit(pastedData)) {
                 $scope.classification.failure_classification_id = 2;
             }
         };


### PR DESCRIPTION
If a 12 or 40 char string consisting only of a-f,0-9 is pasted into the classification textbox, or if the pasted string contains 'hg.mozilla.org', automatically select the 'fixed by commit' classification type, to reduce the number of clicks needed to properly classify this failure.