### PR TITLE
Bug 1372372 - Capitalize all user initials in revision list

### DIFF
--- a/ui/js/reactrevisions.jsx
+++ b/ui/js/reactrevisions.jsx
@@ -18,7 +18,9 @@ const RevisionItem = (props) => {
     let email, name, userTokens, escapedComment, escapedCommentHTML, initialsHTML, tags;
 
     userTokens = props.revision.author.split(/[<>]+/);
-    name = userTokens[0].trim();
+    name = userTokens[0].trim().replace(/\w\S*/g,
+                                        txt => txt.charAt(0).toUpperCase() + txt.substr(1));
+
     if (userTokens.length > 1) email = userTokens[1];
     initialsHTML = { __html: props.initialsFilter(name) };
 


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1372372](https://bugzilla.mozilla.org/show_bug.cgi?id=1372372).

This capitalizes all revision initials, so in scenarios like Sotaro Ikeda where they have just registered their name as 'sotaro' - at least we have a properly capitalized, more visible initial.

Before (note tiny lowercase 's' superscript to the user icon):

![before](https://user-images.githubusercontent.com/3660661/27055447-83f98c44-4f92-11e7-85b6-04a281c7e8d6.jpg)

Proposed (capitalized):
![proposed](https://user-images.githubusercontent.com/3660661/27055462-8e7290ee-4f92-11e7-8444-2ef700674a53.jpg)

The change only alters the first letter, so intercap cases like 'VanderMeulen' will be preserved :)

Tested on OSX 10.11.5
Nightly **55.0a1 (2017-06-12) (64-bit)**

