### PR TITLE
Make log parser custom parameters less variable.

### DIFF
--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -19,7 +19,6 @@ def if_not_parsed(f):
     """Decorator that ensures that log parsing task has not already run
     """
     def inner(job_log):
-        newrelic.agent.add_custom_parameter("job_log_id", job_log.id)
         newrelic.agent.add_custom_parameter("job_log_%s_url" % job_log.name, job_log.url)
 
         logger.debug("parser_task for %s" % job_log.id)

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -19,8 +19,8 @@ def if_not_parsed(f):
     """Decorator that ensures that log parsing task has not already run
     """
     def inner(job_log):
-        newrelic.agent.add_custom_parameter("job_log_%i_name" % job_log.id, job_log.name)
-        newrelic.agent.add_custom_parameter("job_log_%i_url" % job_log.id, job_log.url)
+        newrelic.agent.add_custom_parameter("job_log_id", job_log.id)
+        newrelic.agent.add_custom_parameter("job_log_%s_url" % job_log.name, job_log.url)
 
         logger.debug("parser_task for %s" % job_log.id)
         if job_log.status == JobLog.PARSED:


### PR DESCRIPTION
Having ids in the custom parameter names doesn't play too well with new
relic insights.