### PR TITLE
Bug 1295997 - Send the unstructured log size to New Relic as ints

### DIFF
--- a/treeherder/log_parser/artifactbuildercollection.py
+++ b/treeherder/log_parser/artifactbuildercollection.py
@@ -91,7 +91,7 @@ BuildbotPerformanceDataArtifactBuilder
             # Temporary annotation of log size to help set thresholds in bug 1295997.
             newrelic.agent.add_custom_parameter(
                 'unstructured_log_size',
-                response.headers.get('Content-Length', 'Unknown')
+                int(response.headers.get('Content-Length', -1))
             )
             newrelic.agent.add_custom_parameter(
                 'unstructured_log_encoding',


### PR DESCRIPTION
New Relic Insights doesn't coerce strings to integers, so doesn't allow the graphing of custom attributes sent as strings. HTTP headers are always exposed as strings, even for fields that are expected to represent numbers, so we must explicitly cast `Content-Length`.