### PR TITLE
Bug 1373245 - Send database ID annotations to New Relic as strings

### DIFF
--- a/treeherder/autoclassify/tasks.py
+++ b/treeherder/autoclassify/tasks.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 @retryable_task(name='autoclassify', max_retries=10)
 def autoclassify(job_id):
-    newrelic.agent.add_custom_parameter("job_id", job_id)
+    newrelic.agent.add_custom_parameter("job_id", str(job_id))
     logger.info('Running autoclassify')
     job = Job.objects.select_related("repository").get(id=job_id)
     match_errors(job)

--- a/treeherder/etl/tasks/classification_mirroring_tasks.py
+++ b/treeherder/etl/tasks/classification_mirroring_tasks.py
@@ -11,8 +11,8 @@ def submit_elasticsearch_doc(project, job_id, bug_id, classification_timestamp, 
     OrangeFactor is rewritten to use Treeherder's API directly.
     """
     newrelic.agent.add_custom_parameter("project", project)
-    newrelic.agent.add_custom_parameter("job_id", job_id)
-    newrelic.agent.add_custom_parameter("bug_id", bug_id)
+    newrelic.agent.add_custom_parameter("job_id", str(job_id))
+    newrelic.agent.add_custom_parameter("bug_id", str(bug_id))
     req = ElasticsearchDocRequest(project, job_id, bug_id, classification_timestamp, who)
     req.generate_request_body()
     req.send_request()

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -36,11 +36,11 @@ def if_not_parsed(f):
 
 @retryable_task(name='log-parser', max_retries=10)
 def parse_logs(job_id, job_log_ids, priority):
+    newrelic.agent.add_custom_parameter("job_id", str(job_id))
+
     job = Job.objects.get(id=job_id)
     job_logs = JobLog.objects.filter(id__in=job_log_ids,
                                      job=job)
-
-    newrelic.agent.add_custom_parameter("job_id", job.id)
 
     if len(job_log_ids) != len(job_logs):
         logger.warning("Failed to load all expected job ids: %s" % ", ".join(job_log_ids))

--- a/treeherder/model/tasks.py
+++ b/treeherder/model/tasks.py
@@ -67,16 +67,16 @@ def publish_job_action(project, action, job_id, requester):
     :param job_id str: The job id the action was requested for.
     :param requester str: The email address associated with the request.
     """
-    job = Job.objects.get(id=job_id)
-
     newrelic.agent.add_custom_parameter("project", project)
     newrelic.agent.add_custom_parameter("action", action)
-    newrelic.agent.add_custom_parameter("job_id", job.id)
+    newrelic.agent.add_custom_parameter("job_id", str(job_id))
     newrelic.agent.add_custom_parameter("requester", requester)
+
     publisher = pulse_connection.get_publisher()
     if not publisher:
         return
 
+    job = Job.objects.get(id=job_id)
     publisher.job_action(
         version=1,
         build_system_type=job.signature.build_system_type,
@@ -94,8 +94,9 @@ def publish_job_action(project, action, job_id, requester):
 def publish_resultset_action(project, action, resultset_id, requester, times=1):
     newrelic.agent.add_custom_parameter("project", project)
     newrelic.agent.add_custom_parameter("action", action)
-    newrelic.agent.add_custom_parameter("resultset_id", resultset_id)
+    newrelic.agent.add_custom_parameter("resultset_id", str(resultset_id))
     newrelic.agent.add_custom_parameter("requester", requester)
+
     publisher = pulse_connection.get_publisher()
     if not publisher:
         return
@@ -114,11 +115,13 @@ def publish_resultset_action(project, action, resultset_id, requester, times=1):
 def publish_resultset_runnable_job_action(project, resultset_id, requester,
                                           requested_jobs, decision_task_id):
     newrelic.agent.add_custom_parameter("project", project)
-    newrelic.agent.add_custom_parameter("resultset_id", resultset_id)
+    newrelic.agent.add_custom_parameter("resultset_id", str(resultset_id))
     newrelic.agent.add_custom_parameter("requester", requester)
+
     publisher = pulse_connection.get_publisher()
     if not publisher:
         return
+
     timestamp = str(time.time())
     publisher.resultset_runnable_job_action(
         version=1,

--- a/treeherder/perf/tasks.py
+++ b/treeherder/perf/tasks.py
@@ -7,6 +7,6 @@ from treeherder.perf.models import PerformanceSignature
 
 @task(name='generate-alerts')
 def generate_alerts(signature_id):
-    newrelic.agent.add_custom_parameter("signature_id", signature_id)
+    newrelic.agent.add_custom_parameter("signature_id", str(signature_id))
     signature = PerformanceSignature.objects.get(id=signature_id)
     generate_new_alerts_in_series(signature)


### PR DESCRIPTION
Since if they are left as integers New Relic treats them as fields that can be graphed.