### PR TITLE
Bug 1373376 - Remove broken webpack-md5-hash configuration

### DIFF
--- a/neutrino-custom/base.js
+++ b/neutrino-custom/base.js
@@ -4,7 +4,6 @@ const webpack = require('webpack');
 const lintPreset = require('./lint');
 const reactPreset = require('neutrino-preset-react');
 const HtmlPlugin = require('html-webpack-plugin');
-const Md5HashPlugin = require('webpack-md5-hash');
 
 const CWD = process.cwd();
 const SRC = path.join(CWD, 'src'); // neutrino's default source directory
@@ -42,11 +41,6 @@ module.exports = neutrino => {
         jsDeps.map(dep =>
             neutrino.config.entry('vendor').add(dep)
         );
-
-        // Ensure chunkhashes for unchanged chunks don't change -- this allows the bundled vendor
-        // file to keep its hash and stay cached in the user's browser when it hasn't been updated.
-        neutrino.config.output.chunkFilename('[chunkhash].[id].chunk.js');
-        neutrino.config.plugin('hash').use(Md5HashPlugin);
     }
 
     // Neutrino looks for the entry at src/index.js by default; Delete this and add the index in ui/:

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "raw-loader": "0.5.1",
     "react": "15.3.2",
     "react-dom": "15.3.2",
-    "taskcluster-client": "2.3.0",
-    "webpack-md5-hash": "0.0.5"
+    "taskcluster-client": "2.3.0"
   },
   "devDependencies": {
     "angular-mocks": "1.5.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,10 +1329,6 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-charenc@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-
 cheerio@^0.22.0:
   version "0.22.0"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
@@ -1666,10 +1662,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-crypt@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
 cryptiles@0.2.x:
   version "0.2.2"
@@ -3218,7 +3210,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5, is-buffer@~1.1.1:
+is-buffer@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
 
@@ -3942,14 +3934,6 @@ map-obj@^1.0.0, map-obj@^1.0.1:
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
-
-md5@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
-  dependencies:
-    charenc "~0.0.1"
-    crypt "~0.0.1"
-    is-buffer "~1.1.1"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -6186,12 +6170,6 @@ webpack-dev-server@^2.4.1:
     supports-color "^3.1.1"
     webpack-dev-middleware "^1.10.2"
     yargs "^6.0.0"
-
-webpack-md5-hash@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/webpack-md5-hash/-/webpack-md5-hash-0.0.5.tgz#d9f1899ead664459dd8b6b0c926ac71cfbd7bc7a"
-  dependencies:
-    md5 "^2.0.0"
 
 webpack-sources@^0.1.4:
   version "0.1.5"


### PR DESCRIPTION
The webpack-md5-hash plugin attempts to make the generated hashes less susceptible to churn when chunks haven't actually changed. However it requires careful use and clearly wasn't set up correctly, since the manifest file hashes were always the same regardless of content, causing stale files and runtime errors in production.

Once Neutrino v6 is released, we can use its new in-built support for caching to save having to implement this ourselves.