### PR TITLE
Bug 1342828 - Detect mozmill builders that are split into chunks.

### DIFF
--- a/treeherder/etl/buildbot.py
+++ b/treeherder/etl/buildbot.py
@@ -639,7 +639,7 @@ JOB_NAME_BUILDERNAME = [
     {"regex": re.compile(r'instrumentation-background'), "name": "Android Instrumentation Background"},
     {"regex": re.compile(r'instrumentation-browser'), "name": "Android Instrumentation Browser"},
     {"regex": re.compile(r'xpcshell'), "name": "XPCShell"},
-    {"regex": re.compile(r'mozmill$'), "name": "Mozmill"},
+    {"regex": re.compile(r'mozmill'), "name": "Mozmill"},
     {"regex": re.compile(r'luciddream'), "name": "Luciddream"},
     {"regex": re.compile(r'media-tests'), "name": "Media Tests MSE Video Playback"},
     {"regex": re.compile(r'media-youtube-tests'), "name": "Media Tests MSE YouTube Playback"},


### PR DESCRIPTION
Thunderbird's mozmill builder was split into chunks in https://bugzilla.mozilla.org/show_bug.cgi?id=1342828 which leads to treeherder not being able to properly identify them. This teaches treeherder how to detect them again.