### PR TITLE
Add `###!!! ASSERTION` to list of error strings.

### DIFF
--- a/tests/log_parser/test_error_parser.py
+++ b/tests/log_parser/test_error_parser.py
@@ -22,6 +22,7 @@ ERROR_TEST_CASES = (
     "[taskcluster-vcs:error] Could not extract archive",
     "[test_linux.sh:error] could not download zip file",
     "14:15:32     INFO -  REFTEST ERROR | file:///Z:/task_1491573689/build/tests/reftest/tests/layout/reftests/w3c-css/submitted/text3/text-justify-inter-character-001.html | application timed out after 330 seconds with no output",
+    "18:14:37     INFO -  [3132] ###!!! ASSERTION: Table inline-size is less than the sum of its columns' min inline-sizes: '!(aISizeType == BTLS_FINAL_ISIZE && aISize < guess_min)', file /builds/slave/tb-c-cen-lx-d-0000000000000000/build/mozilla/layout/tables/BasicTableLayoutStrategy.cpp, line 811"
 )
 
 NON_ERROR_TEST_CASES = (

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -348,6 +348,7 @@ class ErrorParser(ParserBase):
         "Assertion failure:",
         "Assertion failed:",
         "###!!! ABORT:",
+        "###!!! ASSERTION:",
         "E/GeckoLinker",
         "SUMMARY: AddressSanitizer",
         "SUMMARY: LeakSanitizer",


### PR DESCRIPTION
This is currently occuring in the thunderbird mozmill tests. E.g.

https://treeherder.mozilla.org/logviewer.html#?job_id=108046858&repo=comm-central&lineNumber=52209