### PR TITLE
Bug 1364030 - Update to neutrino-preset-karma 4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "karma-coverage-istanbul-reporter": "1.2.1",
     "karma-firefox-launcher": "1.0.1",
     "karma-jasmine": "1.1.0",
-    "neutrino-preset-karma": "4.2.0",
+    "neutrino-preset-karma": "4.2.1",
     "react-addons-test-utils": "15.3.2"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4133,9 +4133,9 @@ neutrino-lint-base@4.3.1:
     eslint-plugin-import "^2.2.0"
     lodash.clonedeep "^4.5.0"
 
-neutrino-preset-karma@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/neutrino-preset-karma/-/neutrino-preset-karma-4.2.0.tgz#54661206aaddd84f5fabba5a986b8848072d4cc4"
+neutrino-preset-karma@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/neutrino-preset-karma/-/neutrino-preset-karma-4.2.1.tgz#78c5a75ea1a13e16fb49ff5bdf7b541295d82b36"
   dependencies:
     karma "^1.5.0"
     karma-chrome-launcher "^2.0.0"


### PR DESCRIPTION
To pick up the fix for failing JS tests not making the Travis run fail (mozilla-neutrino/neutrino-dev#268).