### PR TITLE
Bug 1364031 - Fix failing displayNumber test

### DIFF
--- a/tests/ui/unit/filters.tests.js
+++ b/tests/ui/unit/filters.tests.js
@@ -237,9 +237,10 @@ describe('displayNumber filter', function() {
 
     it('returns expected values', function() {
         var displayPrecision = $filter('displayNumber');
+        const infinitySymbol = '\u221e';
         expect(displayPrecision('123.53222')).toEqual('123.53');
         expect(displayPrecision('123123123.53222')).toEqual('123,123,123.53');
-        expect(displayPrecision(1/0)).toEqual('Infinity');
+        expect(displayPrecision(1/0)).toEqual(infinitySymbol);
         expect(displayPrecision(Number.NaN)).toEqual('N/A');
     });
 });


### PR DESCRIPTION
Updates the test since after bug 1361835, an infinity result returns the infinity symbol rather than the string `Infinity`.