### PR TITLE
Bug 1375712 - Return bug suggestions from graphql queries

### DIFF
--- a/treeherder/webapp/graphql/schema.py
+++ b/treeherder/webapp/graphql/schema.py
@@ -4,6 +4,7 @@ from graphene_django.types import DjangoObjectType
 
 from treeherder.model import error_summary
 from treeherder.model.models import *
+from treeherder.webapp.graphql.types import ObjectScalar
 
 
 class JobDetailGraph(DjangoObjectType):
@@ -169,30 +170,6 @@ class Query(graphene.ObjectType):
 
     def resolve_all_text_log_steps(self, args, context, info):
         return TextLogStep.objects.filter(**args)
-
-
-class ObjectScalar(graphene.types.scalars.Scalar):
-    """
-    Un-modeled Object Field for GraphQL data
-
-    This allows an object that's not covered by a model to be returned
-    as a field of a graph.
-    """
-
-    def __init__(self):
-        super(ObjectScalar, self).__init__()
-
-    @staticmethod
-    def serialize(dt):
-        return dt
-
-    @staticmethod
-    def parse_literal(node):
-        return node.value
-
-    @staticmethod
-    def parse_value(value):
-        return value
 
 
 schema = graphene.Schema(query=Query)

--- a/treeherder/webapp/graphql/types.py
+++ b/treeherder/webapp/graphql/types.py
@@ -1,0 +1,25 @@
+import graphene
+
+
+class ObjectScalar(graphene.types.scalars.Scalar):
+    """
+    Un-modeled Object Field for GraphQL data
+
+    This allows an object that's not covered by a model to be returned
+    as a field of a graph.
+    """
+
+    def __init__(self):
+        super(ObjectScalar, self).__init__()
+
+    @staticmethod
+    def serialize(dt):
+        return dt
+
+    @staticmethod
+    def parse_literal(node):
+        return node.value
+
+    @staticmethod
+    def parse_value(value):
+        return value


### PR DESCRIPTION
This GraphQL Schema addition is a little different in that we are enabling the return of an object that is not represented by a Django Model.  The Bug Suggestions is fetched from the cache and returned as an object.  So I've introduced a new ``ObjectScalar`` to represent a simple ``Object`` type to be returned.