### PR TITLE
Bug 1376166 - Add/change Snippets Service repo and GitHub account in Treeherder

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1170,11 +1170,11 @@
     "model": "model.repository",
     "fields": {
         "dvcs_type": "git",
-        "name": "snippets-tests",
-        "url": "https://github.com/mozilla/snippets-tests",
+        "name": "snippets-service",
+        "url": "https://github.com/mozmar/snippets-service",
         "branch": "master",
         "active_status": "active",
-        "codebase": "snippets-tests",
+        "codebase": "snippets-service",
         "repository_group": 5,
         "description": "Tests for Snippets"
     }

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1176,7 +1176,7 @@
         "active_status": "active",
         "codebase": "snippets-service",
         "repository_group": 5,
-        "description": "Tests for Snippets"
+        "description": "Snippets Service"
     }
 },
 {


### PR DESCRIPTION
Hopefully this addresses both bug 1376166 as well as https://github.com/mozilla/snippets-tests/pull/115#issuecomment-310631998

/cc @davehunt @glogiotatidis