### PR TITLE
Bug 1376517 - Make add-new-jobs errors sticky

### DIFF
--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -250,7 +250,7 @@ treeherderApp.controller('ResultSetCtrl', [
                         thNotify.send("Trigger request sent", "success");
                         ThResultSetStore.deleteRunnableJobs($scope.repoName, $scope.resultset);
                     }, function (e) {
-                        thNotify.send(ThTaskclusterErrors.format(e), 'danger');
+                        thNotify.send(ThTaskclusterErrors.format(e), 'danger', true);
                     });
                 });
             } else {


### PR DESCRIPTION
I believe this is the only place where taskcluster errors are not sticky currently.