### PR TITLE
Docs: `yarn run foo` -> `yarn foo`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
         - sh -e /etc/init.d/xvfb start
       script:
         - yarn test
-        - yarn run build
+        - yarn build
 
     # Job 3: Python Tests Chunk A
     - env: python-tests-main
@@ -194,7 +194,7 @@ matrix:
         - "sh -e /etc/init.d/xvfb start"
         - sleep 3 # give xvfb some time to start
       script:
-        - yarn run build
+        - yarn build
         - py.test tests/selenium/ --runselenium --driver Firefox
 
 notifications:

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -6,7 +6,7 @@ echo $SOURCE_VERSION > ui/revision.txt
 
 # Create a `dist/` directory containing built/minified versions of the `ui/` assets.
 # Uses the node binaries/packages installed by the nodejs buildpack previously.
-yarn run build
+yarn build
 
 # Generate gzipped versions of files that would benefit from compression, that
 # WhiteNoise can then serve in preference to the originals. This is required
@@ -32,7 +32,7 @@ set-env NEW_RELIC_PROCESS_HOST_DISPLAY_NAME '$DYNO'
 
 # Remove nodejs files to reduce slug size (and avoid environment variable
 # pollution from the nodejs profile script), since they are no longer
-# required once `yarn run build` has run. The buildpack cache will still
+# required once `yarn build` has run. The buildpack cache will still
 # contain them, so this doesn't slow down the next slug compile.
 rm -r .heroku/node/
 rm -r .heroku/yarn/

--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -120,7 +120,7 @@ To do this:
 
      git checkout (your feature branch)
      git checkout -b gh-pages
-     SERVICE_DOMAIN=https://treeherder.mozilla.org yarn run build
+     SERVICE_DOMAIN=https://treeherder.mozilla.org yarn build
      git add -f dist/
      git commit -m "Add dist directory containing built UI"
 

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -10,6 +10,6 @@ production, a minified/built version of the UI (generated using webpack) is used
 To build the UI locally:
 
 * Install local dependencies by running ``yarn install --no-bin-links`` from the project root.
-* Run ``yarn run build`` to create the ``dist`` directory.
+* Run ``yarn build`` to create the ``dist`` directory.
 
 Then start gunicorn/runserver as usual.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -73,7 +73,7 @@ Starting a local Treeherder instance
   .. code-block:: bash
 
     vagrant ~/treeherder$ yarn install --no-bin-links
-    vagrant ~/treeherder$ yarn run start:local
+    vagrant ~/treeherder$ yarn start:local
 
   This will build the UI code in the ``dist/`` folder and keep watching for
   new changes (See the :doc:`UI installation section <ui/installation>` for more ways to work with the UI code).

--- a/docs/ui/installation.rst
+++ b/docs/ui/installation.rst
@@ -22,7 +22,7 @@ production site. You do not need to set up the Vagrant VM, but login will be una
 
   .. code-block:: bash
 
-     $ yarn run start
+     $ yarn start
 
 * The server will perform an initial build and then watch for new changes. Once the server is running, you can navigate to: `<http://localhost:5000>`_ to see the UI.
 
@@ -30,13 +30,13 @@ production site. You do not need to set up the Vagrant VM, but login will be una
 
   .. code-block:: bash
 
-     $ yarn run start:stage
+     $ yarn start:stage
 
   If you need to serve data from another domain, type:
 
   .. code-block:: bash
 
-    $ SERVICE_DOMAIN=<url> yarn run start
+    $ SERVICE_DOMAIN=<url> yarn start
 
   This will run the unminified UI using ``<url>`` as the service domain.
 
@@ -58,7 +58,7 @@ installation instructions, then follow these steps:
 
   .. code-block:: bash
 
-    vagrant ~/treeherder$ yarn run start:local
+    vagrant ~/treeherder$ yarn start:local
 
 This will watch UI files for changes and build an unminified version in the ``dist/`` directory.
 Note that this process is a little slower than using the regular development server, so you may
@@ -78,7 +78,7 @@ If you would like to view the minified production version of the UI with Vagrant
 
  .. code-block:: bash
 
-    $ yarn run build
+    $ yarn build
 
 Once the build is complete, the minified version of the UI will now be accessible at http://localhost:8000.
 
@@ -95,7 +95,7 @@ To run eslint by itself, you may run the lint task:
 
   .. code-block:: bash
 
-     $ yarn run lint
+     $ yarn lint
 
 Running the unit tests
 ======================
@@ -107,7 +107,7 @@ The unit tests for the UI are run with Karma_ and Jasmine_. React components are
 
 .. code-block:: bash
 
-    $ yarn run test
+    $ yarn test
 
 After the tests have finished, you can find a coverage report in the `coverage/` directory.
 
@@ -118,7 +118,7 @@ automatically when files change. To do this, you may run the following command:
 
 .. code-block:: bash
 
-    $ yarn run test:watch
+    $ yarn test:watch
 
 The tests will perform an initial run and then re-execute each time a project file is changed.
 


### PR DESCRIPTION
The run is redundant.