### PR TITLE
Bug 1377138 - Add Treeherder repository to Treeherder

### DIFF
--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -20,6 +20,7 @@ pipeline {
       "--color=yes " +
       "--driver=SauceLabs " +
       "--variables=capabilities.json"
+    PULSE = credentials('PULSE')
     SAUCELABS_API_KEY = credentials('SAUCELABS_API_KEY')
   }
   stages {
@@ -32,7 +33,8 @@ pipeline {
         always {
           archiveArtifacts 'tests/jenkins/results/*'
           junit 'tests/jenkins/results/*.xml'
-          submitToActiveData('tests/jenkins/results/py27.log')
+          submitToActiveData('tests/jenkins/results/py27_raw.txt')
+          submitToTreeherder('treeherder', 'e2e', 'End-to-end integration tests', 'tests/jenkins/results/*', 'tests/jenkins/results/py27_tbpl.txt')
           publishHTML(target: [
             allowMissing: false,
             alwaysLinkToLastBuild: true,

--- a/tests/jenkins/requirements.txt
+++ b/tests/jenkins/requirements.txt
@@ -1,7 +1,7 @@
 # pyup: ignore file
-mozlog==3.4
+mozlog==3.5
 PyPOM==1.1.1
-pytest==3.0.7
-pytest-metadata==1.3.0
-pytest-selenium==1.9.1
-pytest-xdist==1.15.0
+pytest==3.1.2
+pytest-metadata==1.5.0
+pytest-selenium==1.11.0
+pytest-xdist==1.18.0

--- a/tests/jenkins/tox.ini
+++ b/tests/jenkins/tox.ini
@@ -8,8 +8,9 @@ passenv = DISPLAY PYTEST_ADDOPTS PYTEST_BASE_URL SAUCELABS_API_KEY SAUCELABS_USE
 deps = -rrequirements.txt
 commands = pytest \
     --junit-xml=results/{envname}.xml \
-    --html=results/{envname}.html \
-    --log-raw=results/{envname}.log \
+    --html=results/{envname}.html --self-contained-html \
+    --log-raw=results/{envname}_raw.txt \
+    --log-tbpl=results/{envname}_tbpl.txt \
     {posargs}
 
 [pytest]

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1212,13 +1212,13 @@
     "model": "model.repository",
     "fields": {
         "dvcs_type": "git",
-        "name": "treeherder-tests",
-        "url": "https://github.com/mozilla/treeherder-tests",
+        "name": "treeherder",
+        "url": "https://github.com/mozilla/treeherder",
         "branch": "master",
         "active_status": "active",
-        "codebase": "treeherder-tests",
+        "codebase": "treeherder",
         "repository_group": 5,
-        "description": "Tests for Treeherder"
+        "description": "A system for managing CI data for Mozilla projects"
     }
 }
 ]


### PR DESCRIPTION
This renames the repository within the "qa automation tests" group in Treeherder from the original 'treeherder-tests' to simply 'treeherder'. This reflects the functional UI tests moving to the main repository. It also enabled submitting the results of these tests running in Jenkins to Treeherder, and updates the test dependencies to take advantage of the latest features from these packages.

Note that ultimately the tests in the 'jenkins' folder will be migrated into the 'selenium' folder, and will be executed in Travis CI. We may continue to run the tests in Jenkins and report results to ActiveData/Treeherder as a form of monitoring, much like we do today.

I ran an adhoc build from this branch, which can be seen here: https://fx-test-jenkins-dev.stage.mozaws.net:8443/job/treeherder.adhoc/30/ but will require VPN to see. Only the expected failures, but the upload attempts looked good.