### PR TITLE
Bug 1378118 - Disable unused auto-loaded pytest plugins

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,5 +31,7 @@ known_first_party = tests
 testpaths = tests
 norecursedirs = __pycache__ jenkins ui
 DJANGO_SETTINGS_MODULE=tests.settings
+# Disable unused auto-loaded plugins.
+addopts = -p no:mozlog -p no:metadata -p no:html
 markers =
     slow: mark a test as slow.


### PR DESCRIPTION
This stops the broken mozlog plugin being loaded, which was preventing us updating to newer pytest. Other unused plugins have also been disabled, to avoid future issues and improve pytest load times.