### PR TITLE
Bug 1378950 - Fix test_summary_performance_data non-determinism

### DIFF
--- a/tests/webapp/api/test_performance_data_api.py
+++ b/tests/webapp/api/test_performance_data_api.py
@@ -145,7 +145,7 @@ def test_summary_performance_data(webapp, test_repository,
 
     client = APIClient()
     resp = client.get(reverse('performance-signatures-list',
-                              kwargs={"project": test_repository.name}), fromat='json')
+                              kwargs={"project": test_repository.name}))
     assert resp.status_code == 200
 
     assert len(resp.data.keys()) == 2

--- a/tests/webapp/api/test_performance_data_api.py
+++ b/tests/webapp/api/test_performance_data_api.py
@@ -149,8 +149,8 @@ def test_summary_performance_data(webapp, test_repository,
     assert resp.status_code == 200
 
     assert len(resp.data.keys()) == 2
-    assert resp.data.keys() == [test_perf_signature.signature_hash,
-                                summary_signature_hash]
+    assert set(resp.data.keys()) == set([test_perf_signature.signature_hash,
+                                        summary_signature_hash])
 
     for signature in [summary_perf_signature, test_perf_signature]:
         expected = {


### PR DESCRIPTION
Previously it was dependant on the order of results returned by the API, when the backing DB query doesn't use an ORDER BY. This means that changes in the optimiser (eg upgrading to a different MySQL version) could cause the test to fail.

Also removes the typoed (and redundant) `format` parameter from the `APIClient` call.