### PR TITLE
Actually require jsonSchemaDefaults where it's used

### DIFF
--- a/ui/entry-index.js
+++ b/ui/entry-index.js
@@ -33,7 +33,6 @@ require('js-yaml');
 require('react-dom');
 require('ngreact');
 require('jquery.scrollto');
-require('json-schema-defaults');
 require('./vendor/resizer.js');
 
 // Treeherder JS

--- a/ui/js/controllers/tcjobactions.js
+++ b/ui/js/controllers/tcjobactions.js
@@ -7,6 +7,7 @@ treeherder.controller('TCJobActionsCtrl', [
     function ($scope, $http, $uibModalInstance, ThResultSetStore,
              ThJobDetailModel, thTaskcluster, ThTaskclusterErrors, thNotify,
              job, repoName, resultsetId, actionsRender) {
+        let jsonSchemaDefaults = require('json-schema-defaults');
         let originalTask;
         $scope.input = {};
 


### PR DESCRIPTION
This used to be vendored, but vendored in such a way that it defined a
global named `jsonSchemaDefaults`.  Just requiring it in the entrypoint
does not have the same effect. So, require it where it's used like a
normal JS module.