### PR TITLE
Bug 1378433 - Update to MySQL 5.7 in Vagrant/Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 dist: trusty
 env:
   global:
-    # Ensure the vendored libmysqlclient library can be found at run-time.
-    - LD_LIBRARY_PATH="$HOME/venv/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
     - BROKER_URL='amqp://guest:guest@localhost:5672//'
     - DATABASE_URL='mysql://root@localhost/test_treeherder'
     - ELASTICSEARCH_URL='http://127.0.0.1:9200'
@@ -78,13 +76,12 @@ matrix:
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
         - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
         - sudo -E apt-get -yqq update
-        - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server
+        - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server libmysqlclient-dev
         # Create a clean virtualenv rather than using the one given to us,
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
         - pip install --disable-pip-version-check --upgrade pip==9.0.1
-        - ./bin/vendor-libmysqlclient.sh ~/venv
         # Create the test database for `manage.py check --deploy`.
         - mysql -u root -e 'create database test_treeherder;'
       install:
@@ -115,13 +112,12 @@ matrix:
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
         - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
         - sudo -E apt-get -yqq update
-        - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server
+        - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server libmysqlclient-dev
         # Create a clean virtualenv rather than using the one given to us,
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
         - pip install --disable-pip-version-check --upgrade pip==9.0.1
-        - ./bin/vendor-libmysqlclient.sh ~/venv
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
       before_script:
@@ -146,13 +142,12 @@ matrix:
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
         - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
         - sudo -E apt-get -yqq update
-        - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server
+        - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server libmysqlclient-dev
         # Create a clean virtualenv rather than using the one given to us,
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
         - pip install --disable-pip-version-check --upgrade pip==9.0.1
-        - ./bin/vendor-libmysqlclient.sh ~/venv
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
       before_script:
@@ -179,13 +174,12 @@ matrix:
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
         - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
         - sudo -E apt-get -yqq update
-        - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server
+        - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server libmysqlclient-dev
         # Create a clean virtualenv rather than using the one given to us,
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
         - pip install --disable-pip-version-check --upgrade pip==9.0.1
-        - ./bin/vendor-libmysqlclient.sh ~/venv
         - mkdir -p $HOME/bin
         - curl -sSfL https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz | tar -zxC $HOME/bin
         - nvm install 7.10.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,9 @@ matrix:
         - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.1.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
         - sudo service elasticsearch restart
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
-        - sudo service mysql restart
+        - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
+        - sudo -E apt-get -yqq update
+        - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server
         # Create a clean virtualenv rather than using the one given to us,
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
@@ -111,7 +113,9 @@ matrix:
         - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.1.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
         - sudo service elasticsearch restart
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
-        - sudo service mysql restart
+        - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
+        - sudo -E apt-get -yqq update
+        - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server
         # Create a clean virtualenv rather than using the one given to us,
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
@@ -140,7 +144,9 @@ matrix:
         - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.1.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
         - sudo service elasticsearch restart
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
-        - sudo service mysql restart
+        - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
+        - sudo -E apt-get -yqq update
+        - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server
         # Create a clean virtualenv rather than using the one given to us,
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
@@ -171,7 +177,9 @@ matrix:
         - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.1.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
         - sudo service elasticsearch restart
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
-        - sudo service mysql restart
+        - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
+        - sudo -E apt-get -yqq update
+        - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server
         # Create a clean virtualenv rather than using the one given to us,
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi

--- a/vagrant/env.sh
+++ b/vagrant/env.sh
@@ -1,6 +1,4 @@
 export PATH="/home/vagrant/python/bin:$PATH"
-# Ensure the vendored libmysqlclient library can be found at run-time.
-export LD_LIBRARY_PATH="/home/vagrant/python/lib/x86_64-linux-gnu"
 
 export ENABLE_LOCAL_SETTINGS_FILE='True'
 export BROKER_URL='amqp://guest:guest@localhost//'

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -48,11 +48,13 @@ echo '-----> Installing/updating APT packages'
 sudo -E apt-get -yqq update
 # g++ is required by Brotli
 # libmemcached-dev and zlib1g-dev are required by pylibmc
+# libmysqlclient-dev is required by mysqlclient
 # openjdk-8-jre-headless is required by Elasticsearch
 sudo -E apt-get -yqq install --no-install-recommends \
     g++ \
     git \
     libmemcached-dev \
+    libmysqlclient-dev \
     memcached \
     mysql-server-5.7 \
     nodejs \
@@ -91,8 +93,6 @@ if [[ "$($PYTHON_DIR/bin/pip --version 2>&1)" != *"$PIP_VERSION"* ]]; then
     echo "-----> Installing pip"
     curl -sSf https://bootstrap.pypa.io/get-pip.py | python - "pip==$PIP_VERSION"
 fi
-
-./bin/vendor-libmysqlclient.sh "$PYTHON_DIR"
 
 echo '-----> Running pip install'
 pip install --require-hashes -r requirements/common.txt -r requirements/dev.txt | sed -e '/^Requirement already satisfied:/d'


### PR DESCRIPTION
**1) Update to MySQL 5.7 in Vagrant/Travis**
The Vagrant environment is running Ubuntu 16.04, which has a native mysql-server-5.7 package available, so doesn't need a custom APT repository to be set.

Travis is still on Ubuntu 14.04 (since they don't offer an Ubuntu 16.04 image yet), so has to use the upstream mysql.com repository instead.

In the future I'll be switching both Travis and local development to use the same Docker images to avoid these kind of differences.

After this lands, we'll want to open a PR against the Terraform configs to switch the treeherder-dev RDS instance to MySQL 5.7, before doing the same for stage/prod.

**2) Stop vendoring libmysqlclient in Vagrant/Travis**
Now that we're using MySQL 5.7 server, there is no longer a conflict between our desired choice of client library (which had to be 5.7 to avoid security vulnerabilities) and the server version.

The library is still vendored on Heroku for now (in `bin/pre_compile`), but that can stop too, once we switch to the Heroku-16 stack which is based on Ubuntu 16.04 (bug 1365567).