### PR TITLE
Bug 1378361 - Update Elasticsearch from 5.3.1 to 5.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
       services:
         - rabbitmq
       before_install:
-        - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.1.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
+        - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.0.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
         - sudo service elasticsearch restart
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
         - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
@@ -107,7 +107,7 @@ matrix:
       services:
         - rabbitmq
       before_install:
-        - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.1.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
+        - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.0.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
         - sudo service elasticsearch restart
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
         - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
@@ -137,7 +137,7 @@ matrix:
       services:
         - rabbitmq
       before_install:
-        - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.1.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
+        - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.0.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
         - sudo service elasticsearch restart
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
         - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
@@ -169,7 +169,7 @@ matrix:
       services:
         - rabbitmq
       before_install:
-        - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.1.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
+        - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.0.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
         - sudo service elasticsearch restart
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
         - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -15,7 +15,7 @@ PYTHON_DIR="$HOME/python"
 
 cd "$SRC_DIR"
 
-ELASTICSEARCH_VERSION="5.3.1"
+ELASTICSEARCH_VERSION="5.5.0"
 PYTHON_VERSION="$(cat runtime.txt | sed 's/python-//')"
 PIP_VERSION="9.0.1"
 


### PR DESCRIPTION
This updates the version used in Vagrant and on Travis to the latest
release. The Heroku addon version will be updated separately to match.

Changes between the two versions:
https://www.elastic.co/guide/en/elasticsearch/reference/5.5/release-notes-5.3.2.html
https://www.elastic.co/guide/en/elasticsearch/reference/5.5/release-notes-5.3.3.html
https://www.elastic.co/guide/en/elasticsearch/reference/5.5/release-notes-5.4.0.html
https://www.elastic.co/guide/en/elasticsearch/reference/5.5/release-notes-5.4.1.html
https://www.elastic.co/guide/en/elasticsearch/reference/5.5/release-notes-5.4.2.html
https://www.elastic.co/guide/en/elasticsearch/reference/5.5/release-notes-5.4.3.html
https://www.elastic.co/guide/en/elasticsearch/reference/5.5/release-notes-5.5.0.html