### PR TITLE
Bug 1335920 - support both $dumps and $json

### DIFF
--- a/ui/js/services/tcactions.js
+++ b/ui/js/services/tcactions.js
@@ -58,7 +58,12 @@ treeherder.factory('actionsRender', function () {
             return context[value['$eval']];
         }
 
-        // Replace {$dumps: value} with JSON.stringify(value)
+        // Replace {$json: value} with JSON.stringify(value)
+        if (value['$json']) {
+            return JSON.stringify(render(value['$json'], context));
+        }
+
+        // Replace deprecated {$dumps: value} with JSON.stringify(value)
         if (value['$dumps']) {
             return JSON.stringify(render(value['$dumps'], context));
         }


### PR DESCRIPTION
JSON-e defines `{$json: ..}`, and that's what the actions documentation
says, but Treeherder has been expecting `$dumps`, and the current
`action.json` files use `$dumps`.  So this is the first step toward
migrating to the JSON-e standard: make TH accept both.  Once this is
deployed, we can switch the in-tree code to generate `$json`.  A little
while later, we can switch TH to use JSON-e instead.

Custom actions have been broken for a few months now (from March 1 until #2619 is deployed) so I am not much more worried than that about breaking things.