### PR TITLE
Bug 1365567 - Heroku: Don't vendor libmysqlclient on Heroku-16

### DIFF
--- a/bin/pre_compile
+++ b/bin/pre_compile
@@ -4,6 +4,11 @@
 # Make non-zero exit codes & other errors fatal.
 set -euo pipefail
 
+if [[ "$STACK" == "heroku-16" ]]; then
+    # Skip vendoring libmysqlclient on Heroku-16 since it's already new enough.
+    exit 0
+fi
+
 VENDOR_DIR="$BUILD_DIR/.heroku/vendor"
 
 mkdir -p "$VENDOR_DIR"


### PR DESCRIPTION
Since the OS package present in the Heroku-16 image is now new enough (v5.7.x) that it's not affected by [the MITM issue](https://github.com/heroku/stack-images/pull/38). See:
https://devcenter.heroku.com/articles/stack-packages