### PR TITLE
Bug 1335920 - Use JSON-e directly to parameterize action tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "jquery": "3.2.1",
     "jquery.scrollto": "2.1.2",
     "js-yaml": "3.8.4",
+    "json-e": "^2.1.1",
     "json-schema-defaults": "0.3.0",
     "lodash": "4.17.4",
     "mousetrap": "1.6.1",

--- a/ui/js/services/tcactions.js
+++ b/ui/js/services/tcactions.js
@@ -1,88 +1,9 @@
 "use strict";
 
 treeherder.factory('actionsRender', function () {
-    // Render string given context
-    let renderString = (value, context) => {
-        return value.replace(/\${([^}]+)}/g, (expr, key) => {
-            if (context[key] === undefined) {
-                throw new Error('Undefined variable referenced in: ' + expr);
-            }
-            if (!_.includes(['number', 'string'], typeof(context[key]))) {
-                throw new Error('Cannot interpolate variable in: ' + expr);
-            }
-            return context[key];
-        });
-    };
+    const jsone = require('json-e');
 
-    // Regular expression matching a timespan on the form:
-    // X days Y hours Z minutes
-    const timespanExpression = new RegExp([
-        '^(\\s*(-|\\+))?',
-        '(\\s*(\\d+)\\s*d(ays?)?)?',
-        '(\\s*(\\d+)\\s*h((ours?)|r)?)?',
-        '(\\s*(\\d+)\\s*min(utes?)?)?',
-        '\\s*$',
-    ].join(''), 'i');
-
-    // Render timespan fromNow as JSON timestamp
-    let fromNow = (timespan = '', reference = Date.now()) => {
-        let m = timespanExpression.exec(timespan);
-        if (!m) {
-            throw new Error('Invalid timespan expression: ' + timespan);
-        }
-        let neg = (m[2] === '-' ? - 1 : 1);
-        let days = parseInt(m[4] || 0);
-        let hours = parseInt(m[7] || 0);
-        let minutes = parseInt(m[11] || 0);
-        return new Date(
-            reference + neg * ((days * 24 + hours) * 60 + minutes) * 60 * 1000).toJSON();
-    };
-
-    // Render JSON template (can later be replaced with jsone)
-    let render = (template, context) => _.cloneDeepWith(template, value => {
-        if (typeof(value) === 'string') {
-            return renderString(value, context);
-        }
-        if (typeof(value) !== 'object' || value instanceof Array) {
-            return undefined; // Return undefined to apply recursively
-        }
-
-        // Replace {$eval: 'variable'} with variable
-        if (value['$eval']) {
-            if (typeof(value['$eval']) !== 'string') {
-                throw new Error('$eval cannot carry non-string expression');
-            }
-            if (context[value['$eval']] === undefined) {
-                throw new Error('Undefined variable in $eval: ' + value['$eval']);
-            }
-            return context[value['$eval']];
-        }
-
-        // Replace {$json: value} with JSON.stringify(value)
-        if (value['$json']) {
-            return JSON.stringify(render(value['$json'], context));
-        }
-
-        // Replace deprecated {$dumps: value} with JSON.stringify(value)
-        if (value['$dumps']) {
-            return JSON.stringify(render(value['$dumps'], context));
-        }
-
-        // Replace {$fromNow: 'timespan'} with a JSON timestamp
-        if (value['$fromNow'] !== undefined) {
-            let timespan = render(value['$fromNow'], context);
-            if (typeof(timespan) !== 'string') {
-                throw new Error('$fromNow must be given a timespan as string');
-            }
-            return fromNow(timespan);
-        }
-
-        // Apply string interpolation to keys, and recursively render all values
-        return _.reduce(value, (result, value, key) => {
-            result[renderString(key, context)] = render(value, context);
-            return result;
-        }, {});
-    });
-
-    return render;
+    // this simply calls json-e at the moment, but exists as a service to allow
+    // addition of more context items later.
+    return (template, context) => jsone(template, context);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2186,6 +2186,10 @@ es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
     es6-iterator "2"
     es6-symbol "~3.1"
 
+es6-error@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.0.2.tgz#eec5c726eacef51b7f6b73c20db6e1b13b069c98"
+
 es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512"
@@ -3548,6 +3552,12 @@ jsesc@^2.4.0:
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
+
+json-e@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/json-e/-/json-e-2.1.1.tgz#f9769ec2e508622cf316b4418932248f4e0e0669"
+  dependencies:
+    es6-error "^4.0.1"
 
 json-loader@^0.5.4:
   version "0.5.4"


### PR DESCRIPTION
This replaces the old, "fake" JSON-e with the real JSON-e library.

The library is packaged as a service since the action spec will
eventually specify additional context values, and we want to apply those
values universally.