### PR TITLE
Bug 1372581 - Handle latin characters in commit author names

### DIFF
--- a/tests/sample_data/pulse_consumer/github_push_commits.json
+++ b/tests/sample_data/pulse_consumer/github_push_commits.json
@@ -73,8 +73,8 @@
     "sha": "ef46fa00eb0919e92f11ffdfe6a6926541ab409c",
     "commit": {
       "author": {
-        "name": "Roy C",
-        "email": "crosscent@gmail.com",
+        "name": "Fausto Núñez Alberro",
+        "email": "fausto.nunez@outlook.com",
         "date": "2016-07-28T16:59:27Z"
       },
       "committer": {

--- a/tests/sample_data/pulse_consumer/transformed_gh_push.json
+++ b/tests/sample_data/pulse_consumer/transformed_gh_push.json
@@ -5,7 +5,7 @@
                {"author": "KWierso <kwierso@users.noreply.github.com>",
                 "comment": "Bug 1287911 - Add the ability to tag revisions with metadata (#1706) r=camd\n\n* Bug 1287911 - Add the ability to tag revisions with metadata\r\n\r\n* Bug 1287911 - Make backout commit text be red in the list of revisions",
                 "revision": "09ef55394535acd453eb7728ef8981a96aa0aef6"},
-               {"author": "Roy C <crosscent@gmail.com>",
+               {"author": "Fausto Núñez Alberro <fausto.nunez@outlook.com>",
                 "comment": "Bug 1288530 - Update classifier unconditionally, and move classifier tooltip in AlertView (#1742)",
                 "revision": "ef46fa00eb0919e92f11ffdfe6a6926541ab409c"},
                {"author": "KWierso <kwierso@users.noreply.github.com>",

--- a/treeherder/etl/resultset_loader.py
+++ b/treeherder/etl/resultset_loader.py
@@ -104,7 +104,7 @@ class GithubTransformer:
         for commit in commits:
             revisions.append({
                 "comment": commit["commit"]["message"],
-                "author": "{} <{}>".format(
+                "author": u"{} <{}>".format(
                     commit["commit"]["author"]["name"],
                     commit["commit"]["author"]["email"]),
                 "revision": commit["sha"]


### PR DESCRIPTION
We use python .format() to concatenate the commit author’s name and
email address.  But if it has extended characters, it can’t go into a String.
So this makes sure to put those fields into a Unicode field to preserve them.

The original error should have been raised (or not caught) but instead I was allowing the code to continue until it threw the ``AttributeError`` later due to calling ``.get()`` on a null object.