### PR TITLE
Bug 1378433 - Skip test_mysqlclient_tls_enforced() on Travis

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,3 +1,5 @@
+import os
+
 import MySQLdb
 import pytest
 import responses
@@ -10,6 +12,7 @@ from django.core.management import call_command
 from treeherder.etl.common import fetch_text
 
 
+@pytest.mark.xfail('TRAVIS' in os.environ, reason='bug 1378433', strict=True)
 def test_mysqlclient_tls_enforced():
     """
     Test that if a CA certificate is specified, the connection won't fall back to


### PR DESCRIPTION
Since unlike for Vagrant/Heroku, on Travis we have to upgrade from MySQL 5.6 to 5.7 and so there are still enough MySQL 5.6 remnants behind that cause the test to fail (eg libmysqlclient18, old libmysqlclient-dev header files etc). Multiple attempts have been made to clean them up to no avail, and since this will go away soon when we switch Travis to using Docker images (since they won't have an existing older MySQL version installed), it's not worth spending any more time on it.

We still have the custom Django system check that ensures that the libmysqlclient against which mysqlclient-python was built against is from MySQL >5.7.11.