### PR TITLE
Bug 1350384 - [Follow Up] Remove redundant dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "angular-ui-bootstrap": "1.3.3",
     "angular-ui-router": "0.4.2",
     "bootstrap": "3.3.7",
-    "d3": "^4.9.1",
     "deepmerge": "1.3.2",
     "font-awesome": "4.7.0",
     "hawk": "6.0.1",

--- a/ui/entry-perf.js
+++ b/ui/entry-perf.js
@@ -23,7 +23,6 @@ require('mousetrap');
 require('bootstrap/dist/js/bootstrap');
 require('angular-ui-bootstrap');
 require('numeral');
-require('metrics-graphics');
 require('./vendor/angular-clipboard.js');
 // The jquery flot package does not seem to be updated on npm, so we use a local version:
 require('./vendor/jquery.flot.js');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1979,7 +1979,7 @@ d3-zoom@1.2.0:
     d3-selection "1"
     d3-transition "1"
 
-d3@^4, d3@^4.9.1:
+d3@^4:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/d3/-/d3-4.9.1.tgz#f860be9252261a3c14eea64b1d2590d14f4db838"
   dependencies:


### PR DESCRIPTION
metrics-graphics is built over d3. So there is no need to add its pacakage separately.
Direct include of metrics-graphics is redundant with the angular fixture.