### PR TITLE
Bug 1164891 - [Follow Up] Remove directly included numeral library

### DIFF
--- a/ui/entry-perf.js
+++ b/ui/entry-perf.js
@@ -22,7 +22,6 @@ require('angular-local-storage');
 require('mousetrap');
 require('bootstrap/dist/js/bootstrap');
 require('angular-ui-bootstrap');
-require('numeral');
 require('metrics-graphics');
 require('./vendor/angular-clipboard.js');
 // The jquery flot package does not seem to be updated on npm, so we use a local version:


### PR DESCRIPTION
Since numeral is being included using an angular fixture it is not required to add
it in entry-perf.js