### PR TITLE
Switch to using Marionette/geckodriver

### DIFF
--- a/tests/jenkins/tests/conftest.py
+++ b/tests/jenkins/tests/conftest.py
@@ -1,6 +1,14 @@
 import pytest
 
 
+@pytest.fixture
+def capabilities(request, capabilities):
+    driver = request.config.getoption('driver')
+    if capabilities.get('browserName', driver).lower() == 'firefox':
+        capabilities['marionette'] = True
+    return capabilities
+
+    
 @pytest.fixture(scope='session')
 def session_capabilities(session_capabilities):
     session_capabilities.setdefault('tags', []).append('treeherder')

--- a/tests/jenkins/tests/conftest.py
+++ b/tests/jenkins/tests/conftest.py
@@ -8,10 +8,11 @@ def capabilities(request, capabilities):
         capabilities['marionette'] = True
     return capabilities
 
-    
+
 @pytest.fixture(scope='session')
-def session_capabilities(session_capabilities):
-    session_capabilities.setdefault('tags', []).append('treeherder')
+def session_capabilities(pytestconfig, session_capabilities):
+    if pytestconfig.getoption('driver') == 'SauceLabs':
+        session_capabilities.setdefault('tags', []).append('treeherder')
     return session_capabilities
 
 


### PR DESCRIPTION
@davehunt thoughts?

Ad-hoc run is here: https://fx-test-jenkins-dev.stage.mozaws.net:8443/job/treeherder.adhoc/37/

Raw output: https://gist.github.com/stephendonner/ee5d4ee702c23d6ab56c3415f4834379

Some notes of my own:
1) you'll probably want us to remove the selenium.window.maximize() code, right?  If not here, then in a follow-up patch
2) re: docs - I was surprised to re-discover that we didn't move any of the README content over, when this was migrated from the treeherder-tests repo in https://github.com/mozilla/treeherder/commit/1d1f651ce4103d82b4e7f839cffd815c349b8935; so, should we put in something a la https://github.com/mozilla-services/socorro/blob/ea37047733100340ff775a8346c48c105a576399/e2e-tests/README.md albeit less verbose?