### PR TITLE
Bug 1317275 - Run pip check on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
       script:
+        - pip check
         - python lints/queuelint.py
         - flake8 --show-source
         - isort --check-only --diff --quiet

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+echo "Running pip check"
+pip check || { exit 1; }
+
 echo "Checking CELERY_QUEUES matches Procfile"
 ./lints/queuelint.py || { exit 1; }
 


### PR DESCRIPTION
Verifies installed packages have compatible dependencies, to help prevent issues like bug 1324707.
This will also reduce the time taken to review pyup bot PRs.

Example output if errors found:
```
Running pip check
celery 3.1.25 has requirement kombu<3.1,>=3.0.37, but you have kombu 4.1.0.
```