### PR TITLE
Bug 1383085 - handle actions with no schema

### DIFF
--- a/ui/js/controllers/tcjobactions.js
+++ b/ui/js/controllers/tcjobactions.js
@@ -16,7 +16,11 @@ treeherder.controller('TCJobActionsCtrl', [
         };
 
         $scope.updateSelectedAction = function () {
-            $scope.input.jsonPayload = JSON.stringify(jsonSchemaDefaults($scope.input.selectedAction.schema), null, 4);
+            if ($scope.input.selectedAction.schema) {
+                $scope.input.jsonPayload = JSON.stringify(jsonSchemaDefaults($scope.input.selectedAction.schema), null, 4);
+            } else {
+                $scope.input.jsonPayload = undefined;
+            }
         };
 
         $scope.triggerAction = function () {
@@ -29,7 +33,7 @@ treeherder.controller('TCJobActionsCtrl', [
                 taskGroupId: originalTask.taskGroupId,
                 taskId: job.taskcluster_metadata.task_id,
                 task: originalTask,
-                input: JSON.parse($scope.input.jsonPayload),
+                input: $scope.input.jsonPayload ? JSON.parse($scope.input.jsonPayload) : undefined,
             }, $scope.staticActionVariables));
 
             let queue = new tc.Queue();

--- a/ui/partials/main/tcjobactions.html
+++ b/ui/partials/main/tcjobactions.html
@@ -12,7 +12,7 @@
     </select>
     <p id="selectedActionHelp" class="help-block">{{input.selectedAction.description}}</p>
   </div>
-  <div class="form-group">
+  <div class="form-group" ng-if="input.selectedAction.schema">
     <label>JSON Payload</label>
      <textarea ng-model="input.jsonPayload" class="form-control" rows="5" spellcheck=false/>
   </div>


### PR DESCRIPTION
When an action has no schema, this hides the JSON payload field and
doesn't try to JSON.parse it.

Note that this still fails for schema = {}, since json-schema-defaults
returns `undefined` for that value.