### PR TITLE
Bug 1065567 - Decrease pushlog interval to 5 minutes

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -299,9 +299,9 @@ CELERYD_TASK_SOFT_TIME_LIMIT = 15 * 60
 CELERYD_TASK_TIME_LIMIT = CELERYD_TASK_SOFT_TIME_LIMIT + 30
 
 CELERYBEAT_SCHEDULE = {
-    'fetch-push-logs-every-minute': {
+    'fetch-push-logs-every-5-minutes': {
         'task': 'fetch-push-logs',
-        'schedule': timedelta(minutes=1),
+        'schedule': timedelta(minutes=5),
         'relative': True,
         'options': {
             "queue": "pushlog"

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -299,6 +299,7 @@ CELERYD_TASK_SOFT_TIME_LIMIT = 15 * 60
 CELERYD_TASK_TIME_LIMIT = CELERYD_TASK_SOFT_TIME_LIMIT + 30
 
 CELERYBEAT_SCHEDULE = {
+    # this is just a failsafe in case the Pulse ingestion misses something
     'fetch-push-logs-every-5-minutes': {
         'task': 'fetch-push-logs',
         'schedule': timedelta(minutes=5),


### PR DESCRIPTION
Now that we are also ingesting HG pushes via Pulse, this celery beat
fetch interval is just a failsafe.  So we can decrease the interval from
every minute to every 5 minutes.