### PR TITLE
Bug 1385467 - Build a form from a json-schema for custom actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "angular-resource": "1.5.11",
     "angular-route": "1.5.11",
     "angular-sanitize": "1.5.11",
+    "angular-schema-form": "^0.8.13",
+    "angular-schema-form-bootstrap": "^0.2.0",
     "angular-toarrayfilter": "1.0.2",
     "angular-ui-bootstrap": "1.3.3",
     "angular-ui-router": "0.4.2",

--- a/tests/ui/unit/init.js
+++ b/tests/ui/unit/init.js
@@ -18,6 +18,8 @@ require('angular-sanitize');
 require('angular-cookies');
 require('angular-local-storage');
 require('angular-toarrayfilter');
+require('angular-schema-form');
+require('angular-schema-form-bootstrap');
 require('mousetrap');
 require('js-yaml');
 require('ngreact');

--- a/ui/entry-index.js
+++ b/ui/entry-index.js
@@ -26,6 +26,8 @@ require('angular-cookies');
 require('angular-sanitize');
 require('angular-toarrayfilter');
 require('angular-local-storage');
+require('angular-schema-form');
+require('angular-schema-form-bootstrap');
 require('bootstrap/dist/js/bootstrap');
 require('angular-ui-bootstrap');
 require('mousetrap');

--- a/ui/js/controllers/tcjobactions.js
+++ b/ui/js/controllers/tcjobactions.js
@@ -7,7 +7,6 @@ treeherder.controller('TCJobActionsCtrl', [
     function ($scope, $http, $uibModalInstance, ThResultSetStore,
              ThJobDetailModel, thTaskcluster, ThTaskclusterErrors, thNotify,
              job, repoName, resultsetId, actionsRender) {
-        let jsonSchemaDefaults = require('json-schema-defaults');
         let originalTask;
         $scope.input = {};
 
@@ -16,7 +15,8 @@ treeherder.controller('TCJobActionsCtrl', [
         };
 
         $scope.updateSelectedAction = function () {
-            $scope.input.jsonPayload = JSON.stringify(jsonSchemaDefaults($scope.input.selectedAction.schema), null, 4);
+            $scope.actionSchema = $scope.input.selectedAction.schema;
+            $scope.actionModel = {};
         };
 
         $scope.triggerAction = function () {
@@ -29,7 +29,7 @@ treeherder.controller('TCJobActionsCtrl', [
                 taskGroupId: originalTask.taskGroupId,
                 taskId: job.taskcluster_metadata.task_id,
                 task: originalTask,
-                input: JSON.parse($scope.input.jsonPayload),
+                input: $scope.model,
             }, $scope.staticActionVariables));
 
             let queue = new tc.Queue();

--- a/ui/js/treeherder.js
+++ b/ui/js/treeherder.js
@@ -2,4 +2,4 @@
 
 /*exported treeherder*/
 module.exports = angular.module('treeherder',
-    ['ngResource', 'ngSanitize', 'ngCookies', 'LocalStorageModule']);
+    ['ngResource', 'ngSanitize', 'ngCookies', 'LocalStorageModule', 'schemaForm']);

--- a/ui/partials/main/tcjobactions.html
+++ b/ui/partials/main/tcjobactions.html
@@ -12,11 +12,9 @@
     </select>
     <p id="selectedActionHelp" class="help-block">{{input.selectedAction.description}}</p>
   </div>
-  <div class="form-group">
-    <label>JSON Payload</label>
-     <textarea ng-model="input.jsonPayload" class="form-control" rows="5" spellcheck=false/>
+  <div ng-if="actionSchema" class="form-group">
+    <form sf-schema="actionSchema" sf-form="actionForm" sf-model="actionModel"></form>
   </div>
-  {{input.selectedAction.jsonPayload}}
 </div>
 <div class="modal-footer">
   <button ng-if="user.loggedin" class="btn btn-primary" ng-click="triggerAction()" ng-attr-title="{{user.loggedin ? 'Trigger this action' : 'Not logged in'}}" ng-disabled="triggering">

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,6 +101,23 @@ angular-sanitize@1.5.11:
   version "1.5.11"
   resolved "https://registry.yarnpkg.com/angular-sanitize/-/angular-sanitize-1.5.11.tgz#ebfb3f343e543f9b2ef050fb4c2e9ee048d1772f"
 
+"angular-sanitize@>= 1.2":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/angular-sanitize/-/angular-sanitize-1.6.5.tgz#b5625a817afad2ba58c333e98eef169a1c6f517a"
+
+angular-schema-form-bootstrap@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/angular-schema-form-bootstrap/-/angular-schema-form-bootstrap-0.2.0.tgz#7465db99e4a8bc7fa86c1385a510552384e27ace"
+
+angular-schema-form@^0.8.13:
+  version "0.8.13"
+  resolved "https://registry.yarnpkg.com/angular-schema-form/-/angular-schema-form-0.8.13.tgz#90bbe2a90664d083da3dc1271f890a94be7d140f"
+  dependencies:
+    angular ">= 1.2"
+    angular-sanitize ">= 1.2"
+    objectpath "^1.2.1"
+    tv4 "~1.0.15"
+
 angular-toarrayfilter@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/angular-toarrayfilter/-/angular-toarrayfilter-1.0.2.tgz#a81dcb0c9f3c39985f8fd4424dbe1dbea84771c4"
@@ -118,6 +135,10 @@ angular-ui-router@0.4.2:
 angular@1.5.11, angular@^1.0.8:
   version "1.5.11"
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.5.11.tgz#8c5ba7386f15965c9acf3429f6881553aada30d6"
+
+"angular@>= 1.2":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/angular/-/angular-1.6.5.tgz#37f788eebec5ce2e3fa02b17bbcb2a231576a0d6"
 
 ansi-escapes@^1.1.0:
   version "1.4.0"
@@ -4618,6 +4639,10 @@ object.values@^1.0.3:
     function-bind "^1.1.0"
     has "^1.0.1"
 
+objectpath@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/objectpath/-/objectpath-1.2.1.tgz#c87433bdd352aea014e4f9c0b52d70a42652052e"
+
 obuf@^1.0.0, obuf@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.1.tgz#104124b6c602c6796881a042541d36db43a5264e"
@@ -6175,6 +6200,10 @@ tunnel-agent@^0.6.0:
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
   dependencies:
     safe-buffer "^5.0.1"
+
+tv4@~1.0.15:
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/tv4/-/tv4-1.0.18.tgz#7397769f00358e33bf528dc5c8764c61b6de8245"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
Select a task on treeherder => click the triple dots in the bottom navigation => click on "Custom Actions...".  Some actions require a schema and presently you have to manually fill out the json-schema. It would be better if we had a form.

![screen shot 2017-07-28 at 5 30 57 pm](https://user-images.githubusercontent.com/3766511/28738858-11bb9752-73c4-11e7-9911-6ab56a1761fd.png)

This pull-request uses the library [angular-schema-form](https://github.com/json-schema-form/angular-schema-form) to build a form from a json-schema.

<img width="893" alt="screen shot 2017-07-28 at 6 33 49 pm" src="https://user-images.githubusercontent.com/3766511/28738859-11bd6f64-73c4-11e7-8b54-991aad24f7ae.png">
