### PR TITLE
Bug 1378935 - Replace deprecated scope_match with scopeMatch

### DIFF
--- a/treeherder/auth/backends.py
+++ b/treeherder/auth/backends.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.reverse import reverse
 from taskcluster import Auth
-from taskcluster.utils import scope_match
+from taskcluster.utils import scopeMatch
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ class TaskclusterAuthBackend(object):
         Try to find an existing user that matches the email.
         """
 
-        if scope_match(scopes, [["assume:mozilla-user:{}".format(email)]]):
+        if scopeMatch(scopes, [["assume:mozilla-user:{}".format(email)]]):
             # Find the user by their email.
 
             # Since there is a unique index on username, but not on email,


### PR DESCRIPTION
Replace all instances of `scope_match` with `scopeMatch` as the former is deprecated according to a warning outputed after testing in Vagrant. Only instances were found in `treeherder/auth/backends.py`.