### PR TITLE
Bug 1384955 - Add Create Task to job action menu

### DIFF
--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -124,6 +124,9 @@
                 <a target="_blank" href="{{ getInspectTaskUrl(job.taskcluster_metadata.task_id) }}">Inspect Task</a>
               </li>
               <li>
+                <a target="_blank" href="{{ getInspectTaskUrl(job.taskcluster_metadata.task_id) }}/create">Edit and Retrigger</a>
+              </li>
+              <li>
                 <a target="_blank" href="https://tools.taskcluster.net/one-click-loaner/#{{job.taskcluster_metadata.task_id}}">One Click Loaner</a>
               </li>
               <li ng-if-end>


### PR DESCRIPTION
This hopefully fixes Bug [1384955](https://bugzilla.mozilla.org/show_bug.cgi?id=1384955).

I've named it Create Task. Since that is the page you land on, in TaskCluster. In my opinion, if the menu name gets changed, it should also change on the TaskCluster page so they are the same.

Proposed:

![proposed](https://user-images.githubusercontent.com/3660661/28974942-393fa38a-7906-11e7-8962-34a04c70cf97.jpg)

Tested on OSX 10.11.5:
Nightly **57.0a1 (2017-08-03) (64-bit)**
Chrome Release **59.0.3071.115 (Official Build) (64-bit)**