### PR TITLE
Bug 1387487 - Reduce gunicorn maximum request time to 20 seconds

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: newrelic-admin run-program gunicorn treeherder.config.wsgi:application --timeout 29
+web: newrelic-admin run-program gunicorn treeherder.config.wsgi:application --timeout 20
 worker_beat: newrelic-admin run-program celery beat -A treeherder
 worker_pushlog: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q pushlog --concurrency=5
 worker_buildapi_pending: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q buildapi_pending --concurrency=5

--- a/bin/run_gunicorn
+++ b/bin/run_gunicorn
@@ -13,4 +13,4 @@ exec newrelic-admin run-program gunicorn -w $NUM_WORKERS \
     treeherder.config.wsgi:application \
     --keep-alive=3 \
     --log-level error \
-    --timeout=30
+    --timeout=20


### PR DESCRIPTION
To ensure that:
* the Heroku router's 30 second timeout doesn't beat gunicorn to it, given that routing time is included in Heroku's timing
* the app is more likely to remain responsive, when receiving many badly filtered API calls