### PR TITLE
Bug 1337987 - Remove login backend auth code that finds a user by email, rather than username

### DIFF
--- a/tests/auth/test_backends.py
+++ b/tests/auth/test_backends.py
@@ -7,60 +7,6 @@ from treeherder.auth.backends import (NoEmailException,
                                       TaskclusterAuthBackend)
 
 
-@pytest.mark.django_db
-@pytest.mark.parametrize(('username', 'email', 'scopes', 'user', 'exp_exception'), [
-    # user exists, has scope, exact match on username
-    ('mozilla-ldap/dude@lebowski.net',
-     'dude@lebowski.net',
-     ["assume:mozilla-user:dude@lebowski.net"],
-     {"username": "mozilla-ldap/dude@lebowski.net", "email": "dude@lebowski.net"},
-     False
-     ),
-    # user exists, wildcard scope, exact match on username
-    ('mozilla-ldap/dude@lebowski.net',
-     'dude@lebowski.net',
-     ["assume:mozilla-user:*"],
-     {"username": "mozilla-ldap/dude@lebowski.net", "email": "dude@lebowski.net"},
-     False
-     ),
-    # user exists, has scope, but username gets updated
-    ('mozilla-ldap/dude@lebowski.net',
-     'dude@lebowski.net',
-     ["assume:mozilla-user:dude@lebowski.net"],
-     {"username": "dude", "email": "dude@lebowski.net"},
-     False
-     ),
-    # user does not exist, raises exception
-    ('thneed',
-     'dood@lebowski.net',
-     ["assume:mozilla-user:dude@lebowski.net"],
-     None,
-     True
-     ),
-    # user does not have scope, raises exception
-    ('mozilla-ldap/dude@me.net',
-     'dude@lebowski.net',
-     ["assume:foo:bar"],
-     {"username": "dude", "email": "nope@lebowski.net"},
-     True
-     )])
-def test_find_user_by_email(username, email, scopes, user, exp_exception):
-    if user:
-        test_user = User.objects.create(**user)
-        # create a user with duplicate email
-        User.objects.create(username="fleh", email=user["email"])
-
-    tca = TaskclusterAuthBackend()
-    if exp_exception:
-        with pytest.raises(ObjectDoesNotExist):
-            tca._find_user_by_email(email, username, scopes)
-    else:
-        found_user = tca._find_user_by_email(email, username, scopes)
-        assert found_user.id == test_user.id
-        assert found_user.username == username
-        assert found_user.email == email
-
-
 @pytest.mark.parametrize(
     ('client_id', 'exp_email', 'exp_exception'),
     [('email/biped@mozilla.com', 'biped@mozilla.com', False),  # email clientId

--- a/tests/auth/test_backends.py
+++ b/tests/auth/test_backends.py
@@ -22,3 +22,50 @@ def test_extract_email_from_clientid(client_id, exp_email, exp_exception):
     else:
         email = tca._extract_email_from_clientid(client_id)
         assert email == exp_email
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ('result', 'exp_username', 'email', 'exp_create_user'),
+    [({'status': 'auth-success',
+       'scopes': [],
+       'clientId': 'email/user@foo.com'},
+      'email/user@foo.com',
+      'user@foo.com',
+      True),
+     ({'status': 'auth-success',
+       'scopes': [],
+       'clientId': 'email/emailaddressexceeding30chars@foo.com'},
+      'email/emailaddressexceeding30chars@foo.com',
+      'emailaddressexceeding30chars@foo.com',
+      True),
+     ({'status': 'auth-success',
+       'scopes': ["assume:mozilla-user:foo@bar.net"],
+       'clientId': 'email/foo@bar.net'},
+      'email/foo@bar.net',
+      'foo@bar.net',
+      False),
+     ])
+def test_existing_email_create_user(test_user, monkeypatch, result,
+                                    exp_username, email, exp_create_user):
+    """
+    Test whether a user was created or not, despite an existing user with
+    a matching email.
+
+    If they log in with email only, then only return an existing user on an exact
+    ``username`` == ``clientId``.  Otherwise, create a new user with that
+    username.
+    """
+    def authenticateHawk_mock(selfless, obj):
+        return result
+    monkeypatch.setattr(Auth, "authenticateHawk", authenticateHawk_mock)
+
+    existing_user = User.objects.create(username="email/foo@bar.net", email=email)
+
+    tca = TaskclusterAuthBackend()
+    new_user = tca.authenticate(auth_header="meh", host="fleh", port=3)
+    assert new_user.username == exp_username
+    if exp_create_user:
+        assert new_user.id != existing_user.id
+    else:
+        assert new_user.id == existing_user.id

--- a/tests/auth/test_backends.py
+++ b/tests/auth/test_backends.py
@@ -1,6 +1,5 @@
 import pytest
 from django.contrib.auth.models import User
-from django.core.exceptions import ObjectDoesNotExist
 from taskcluster import Auth
 
 from treeherder.auth.backends import (NoEmailException,

--- a/tests/auth/test_backends.py
+++ b/tests/auth/test_backends.py
@@ -1,6 +1,4 @@
 import pytest
-from django.contrib.auth.models import User
-from taskcluster import Auth
 
 from treeherder.auth.backends import (NoEmailException,
                                       TaskclusterAuthBackend)
@@ -24,52 +22,3 @@ def test_extract_email_from_clientid(client_id, exp_email, exp_exception):
     else:
         email = tca._extract_email_from_clientid(client_id)
         assert email == exp_email
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    ('result', 'exp_username', 'email', 'exp_create_user'),
-    [({'status': 'auth-success',
-       'scopes': [],
-       'clientId': 'email/user@foo.com'},
-      'email/user@foo.com',
-      'user@foo.com',
-      True),
-     ({'status': 'auth-success',
-       'scopes': [],
-       'clientId': 'email/emailaddressexceeding30chars@foo.com'},
-      'email/emailaddressexceeding30chars@foo.com',
-      'emailaddressexceeding30chars@foo.com',
-      True),
-     ({'status': 'auth-success',
-       'scopes': ["assume:mozilla-user:foo@bar.net"],
-       'clientId': 'email/foo@bar.net'},
-      'email/foo@bar.net',
-      'foo@bar.net',
-      False),
-     ])
-def test_existing_email_create_user(test_user, monkeypatch, result,
-                                    exp_username, email, exp_create_user):
-    """
-    Test whether a user was created or not, despite an existing user with
-    a matching email.
-
-    If they log in with LDAP, and have the scope of mozilla-user, then we will
-    match to an existing user and migrate their ``username``.  But if they log
-    in with email only, then only return an existing user on an exact
-    ``username`` == ``clientId``.  Otherwise, create a new user with that
-    username.
-    """
-    def authenticateHawk_mock(selfless, obj):
-        return result
-    monkeypatch.setattr(Auth, "authenticateHawk", authenticateHawk_mock)
-
-    existing_user = User.objects.create(username="mee", email=email)
-
-    tca = TaskclusterAuthBackend()
-    new_user = tca.authenticate(auth_header="meh", host="fleh", port=3)
-    assert new_user.username == exp_username
-    if exp_create_user:
-        assert new_user.id != existing_user.id
-    else:
-        assert new_user.id == existing_user.id

--- a/tests/auth/test_backends.py
+++ b/tests/auth/test_backends.py
@@ -1,4 +1,6 @@
 import pytest
+from django.contrib.auth.models import User
+from taskcluster import Auth
 
 from treeherder.auth.backends import (NoEmailException,
                                       TaskclusterAuthBackend)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -442,6 +442,21 @@ def test_user(request, transactional_db):
 
 
 @pytest.fixture
+def test_ldap_user(request, transactional_db):
+    # a user *without* sheriff/staff permissions
+    from django.contrib.auth.models import User
+    user = User.objects.create(username="mozilla-ldap/user@foo.com",
+                               email='user@foo.com',
+                               is_staff=False)
+
+    def fin():
+        user.delete()
+    request.addfinalizer(fin)
+
+    return user
+
+
+@pytest.fixture
 def test_sheriff(request, transactional_db):
     # a user *with* sheriff/staff permissions
     from django.contrib.auth.models import User

--- a/tests/webapp/api/test_auth.py
+++ b/tests/webapp/api/test_auth.py
@@ -104,6 +104,27 @@ def test_post_no_auth():
 
 # TC Auth Login and Logout Tests
 
+def test_ldap_login_and_logout(test_ldap_user, webapp, monkeypatch):
+    """LDAP login user exists, has scope: find by email"""
+    def mock_auth(selfless, payload):
+        return {"status": "auth-success",
+                "clientId": "mozilla-ldap/user@foo.com",
+                "scopes": ["assume:mozilla-user:user@foo.com"]
+                }
+    monkeypatch.setattr(Auth, 'authenticateHawk', mock_auth)
+
+    assert "sessionid" not in webapp.cookies
+
+    webapp.get(reverse("auth-login"), headers={"tcauth": "foo"}, status=200)
+    session_key = webapp.cookies["sessionid"]
+    session = Session.objects.get(session_key=session_key)
+    session_data = session.get_decoded()
+    user = User.objects.get(id=session_data.get('_auth_user_id'))
+    assert user.id == test_ldap_user.id
+
+    webapp.get(reverse("auth-logout"), status=200)
+    assert "sessionid" not in webapp.cookies
+
 
 def test_ldap_login_no_mozilla_user_scope(test_user, webapp, monkeypatch):
     """
@@ -196,17 +217,17 @@ def test_login_no_email(test_user, webapp, monkeypatch):
 
 
 @pytest.mark.django_db
-def test_login_not_active(test_user, webapp, monkeypatch):
+def test_login_not_active(test_ldap_user, webapp, monkeypatch):
     """LDAP login, user not active"""
     def mock_auth(selfless, payload):
         return {"status": "auth-success",
-                "clientId": "email/user@foo.com",
+                "clientId": "mozilla-ldap/user@foo.com",
                 "scopes": ["assume:mozilla-user:user@foo.com"]
                 }
     monkeypatch.setattr(Auth, 'authenticateHawk', mock_auth)
 
-    test_user.is_active = False
-    test_user.save()
+    test_ldap_user.is_active = False
+    test_ldap_user.save()
 
     resp = webapp.get(reverse("auth-login"), headers={"tcauth": "foo"}, status=403)
     assert resp.json["detail"] == "This user has been disabled."

--- a/tests/webapp/api/test_auth.py
+++ b/tests/webapp/api/test_auth.py
@@ -104,27 +104,6 @@ def test_post_no_auth():
 
 # TC Auth Login and Logout Tests
 
-def test_ldap_login_and_logout(test_user, webapp, monkeypatch):
-    """LDAP login user exists, has scope: find by email"""
-    def mock_auth(selfless, payload):
-        return {"status": "auth-success",
-                "clientId": "mozilla-ldap/user@foo.com",
-                "scopes": ["assume:mozilla-user:user@foo.com"]
-                }
-    monkeypatch.setattr(Auth, 'authenticateHawk', mock_auth)
-
-    assert "sessionid" not in webapp.cookies
-
-    webapp.get(reverse("auth-login"), headers={"tcauth": "foo"}, status=200)
-    session_key = webapp.cookies["sessionid"]
-    session = Session.objects.get(session_key=session_key)
-    session_data = session.get_decoded()
-    user = User.objects.get(id=session_data.get('_auth_user_id'))
-    assert user.id == test_user.id
-
-    webapp.get(reverse("auth-logout"), status=200)
-    assert "sessionid" not in webapp.cookies
-
 
 def test_ldap_login_no_mozilla_user_scope(test_user, webapp, monkeypatch):
     """

--- a/treeherder/auth/backends.py
+++ b/treeherder/auth/backends.py
@@ -74,10 +74,8 @@ class TaskclusterAuthBackend(object):
         client_id = result["clientId"]
         email = self._extract_email_from_clientid(client_id)
 
-        # Look for an existing user in this order:
-        #
-        # 1. Matching username/clientId
-        # Otherwise, create it, as long as it has an email.
+        # Look for an existing user by username/clientId
+        # If not found, create it, as long as it has an email.
         try:
             return User.objects.get(username=client_id)
 

--- a/treeherder/auth/backends.py
+++ b/treeherder/auth/backends.py
@@ -5,7 +5,6 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.reverse import reverse
 from taskcluster import Auth
-from taskcluster.utils import scopeMatch
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/auth/backends.py
+++ b/treeherder/auth/backends.py
@@ -77,7 +77,6 @@ class TaskclusterAuthBackend(object):
         # Look for an existing user in this order:
         #
         # 1. Matching username/clientId
-        # 2. Matching email.
         # Otherwise, create it, as long as it has an email.
         try:
             return User.objects.get(username=client_id)


### PR DESCRIPTION
```
def test_existing_email_create_user(test_user, monkeypatch, result,
                                    exp_username, email, exp_create_user): 
```
in [tests/auth/test_backends.py](https://github.com/mozilla/treeherder/blob/master/tests/auth/test_backends.py#L106) failing for exp_create_user = False