### PR TITLE
Bug 1389756 - README: Update/fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 treeherder
 ==================
 [![Build Status](https://travis-ci.org/mozilla/treeherder.png?branch=master)](https://travis-ci.org/mozilla/treeherder)
-[![Python Requirements Status](https://requires.io/github/mozilla/treeherder/requirements.svg?branch=master)](https://requires.io/github/mozilla/treeherder/requirements/?branch=master)
-[![Node Dependency Status](https://david-dm.org/mozilla/treeherder.svg)](https://david-dm.org/mozilla/treeherder)
-[![Node devDependency Status](https://david-dm.org/mozilla/treeherder/dev-status.svg)](https://david-dm.org/mozilla/treeherder#info=devDependencies)
-[![Documentation Status](http://readthedocs.org/projects/treeherder/badge/?version=latest)](https://treeherder.readthedocs.io/?badge=latest)
+[![Python Package Status](https://pyup.io/repos/github/mozilla/treeherder/shield.svg)](https://pyup.io/repos/github/mozilla/treeherder/)
+[![Node dependencies Status](https://david-dm.org/mozilla/treeherder/status.svg)](https://david-dm.org/mozilla/treeherder)
+[![Node devDependencies Status](https://david-dm.org/mozilla/treeherder/dev-status.svg)](https://david-dm.org/mozilla/treeherder?type=dev)
+[![Documentation Status](https://readthedocs.org/projects/treeherder/badge/?version=latest)](https://treeherder.readthedocs.io/?badge=latest)
 
 
 #### Description


### PR DESCRIPTION
* Switches the requires.io to pyup.io
* Uses the new form david-dm badge URL to fix deep linking
* Uses HTTPS for the read the docs badge