### PR TITLE
Bug 1390573 - Clean up stale pyc files during Vagrant provision

### DIFF
--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -24,13 +24,16 @@ export DEBIAN_FRONTEND=noninteractive
 # Speeds up pip invocations and reduces output spam.
 export PIP_DISABLE_PIP_VERSION_CHECK='True'
 
+echo '-----> Performing cleanup'
+# Remove the old MySQL 5.6 PPA repository, if this is an existing Vagrant instance.
+sudo rm -f /etc/apt/sources.list.d/ondrej-ubuntu-mysql-5_6-xenial.list
+# Celery sometimes gets stuck and requires that celerybeat-schedule be deleted.
+rm -f celerybeat-schedule
+
 echo '-----> Configuring .profile and environment variables'
 ln -sf "$SRC_DIR/vagrant/.profile" "$HOME/.profile"
 sudo ln -sf "$SRC_DIR/vagrant/env.sh" /etc/profile.d/treeherder.sh
 . /etc/profile.d/treeherder.sh
-
-# Remove the old MySQL 5.6 PPA repository, if this is an existing Vagrant instance.
-sudo rm -f /etc/apt/sources.list.d/ondrej-ubuntu-mysql-5_6-xenial.list
 
 if [[ ! -f /etc/apt/sources.list.d/nodesource.list ]]; then
     echo '-----> Adding APT repository for Node.js'
@@ -113,9 +116,5 @@ while ! curl "$ELASTICSEARCH_URL" &> /dev/null; do sleep 1; done
 echo '-----> Running Django migrations and loading reference data'
 ./manage.py migrate --noinput
 ./manage.py load_initial_data
-
-echo '-----> Performing cleanup'
-# Celery sometimes gets stuck and requires that celerybeat-schedule be deleted.
-rm -f celerybeat-schedule || true
 
 echo '-----> Setup complete!'

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -27,6 +27,8 @@ export PIP_DISABLE_PIP_VERSION_CHECK='True'
 echo '-----> Performing cleanup'
 # Remove the old MySQL 5.6 PPA repository, if this is an existing Vagrant instance.
 sudo rm -f /etc/apt/sources.list.d/ondrej-ubuntu-mysql-5_6-xenial.list
+# Stale pyc files can cause pytest ImportMismatchError exceptions.
+find . -type f -name '*.pyc' -delete
 # Celery sometimes gets stuck and requires that celerybeat-schedule be deleted.
 rm -f celerybeat-schedule
 


### PR DESCRIPTION
**1) Move the cleanup step earlier in provision**
To reduce the risk that one of the commands we run is broken by things that need cleaning up (eg pyc files). An unnecessary `|| true` has also been removed from the moved `rm -f` command.

**2) Remove .pyc files during provision**
To prevent confusing pytest `ImportMismatchError` exceptions if the paths hardcoded in pyc files (which are git-ignored) leftover from the past, don't match the paths used now.