### PR TITLE
Fix test failure list index out of range

### DIFF
--- a/tests/jenkins/pages/treeherder.py
+++ b/tests/jenkins/pages/treeherder.py
@@ -40,7 +40,7 @@ class TreeherderPage(Base):
     _unclassified_failure_filter_locator = (By.CSS_SELECTOR, '.btn-unclassified-failures')
 
     def wait_for_page_to_load(self):
-        self.wait.until(lambda s: len(self.result_sets) >= 1)
+        self.wait.until(lambda s: len(self.all_jobs) >= 1)
         return self
 
     @property


### PR DESCRIPTION
Many of the current Jenkins test failures are due to a "list index out of range" error caused by the browser closing prior to loading the data. This change should fix that.