### PR TITLE
Bug 1390517 - Speed up the Travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
 
     # Job 2: Nodejs UI tests
     - env: ui-tests
-      sudo: false
+      sudo: required
       language: node_js
       node_js: "7.10.0"
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -192,7 +192,6 @@ matrix:
         - while ! curl "$ELASTICSEARCH_URL" &> /dev/null; do sleep 1; done
         - "export DISPLAY=:99.0"
         - "sh -e /etc/init.d/xvfb start"
-        - sleep 3 # give xvfb some time to start
       script:
         - yarn build
         - py.test tests/selenium/ --runselenium --driver Firefox

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,10 +89,10 @@ matrix:
         # 'https://' being in the site URL. In addition, we override the test environment's debug
         # value so the tests pass. The real environment variable will be checked during deployment.
         - SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' ./manage.py check --deploy --fail-level WARNING
-        - py.test tests/ --runslow --ignore=tests/e2e/ --ignore=tests/etl/ --ignore=tests/log_parser/ --ignore=tests/webapp/ --ignore=tests/selenium/ --ignore=tests/jenkins/
+        - pytest tests/ --runslow --ignore=tests/etl/ --ignore=tests/log_parser/ --ignore=tests/webapp/api/ --ignore=tests/selenium/ --ignore=tests/jenkins/
 
     # Job 4: Python Tests Chunk B
-    - env: python-tests-e2e-etl-logparser
+    - env: python-tests-etl-logparser
       language: python
       python: "2.7.13"
       cache:
@@ -116,10 +116,10 @@ matrix:
       before_script:
         - while ! curl "$ELASTICSEARCH_URL" &> /dev/null; do sleep 1; done
       script:
-        - py.test tests/e2e/ tests/etl/ tests/log_parser/ --runslow
+        - pytest tests/etl/ tests/log_parser/ --runslow
 
     # Job 5: Python Tests Chunk C
-    - env: python-tests-webapp
+    - env: python-tests-rest-api
       language: python
       python: "2.7.13"
       cache:
@@ -143,7 +143,7 @@ matrix:
       before_script:
         - while ! curl "$ELASTICSEARCH_URL" &> /dev/null; do sleep 1; done
       script:
-        - py.test tests/webapp/ --runslow
+        - pytest tests/webapp/api/ --runslow
 
     # Job 6: Python Tests - Selenium integration
     - env: python-tests-selenium

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 dist: trusty
+# The fully visualised "sudo" GCE environments are faster for longer running jobs.
+sudo: required
 # Use the latest Travis images since they are more up to date than the stable release.
 group: edge
 env:
@@ -9,7 +11,6 @@ env:
     - TREEHERDER_DJANGO_SECRET_KEY='secretkey-of-at-50-characters-to-pass-check-deploy'
 matrix:
   include:
-    # Each entry here creates another sub-job.
 
     # Job 1: Linters
     - env: python-linters
@@ -34,7 +35,6 @@ matrix:
 
     # Job 2: Nodejs UI tests
     - env: ui-tests
-      sudo: required
       language: node_js
       node_js: "7.10.0"
       cache:
@@ -60,8 +60,6 @@ matrix:
 
     # Job 3: Python Tests Chunk A
     - env: python-tests-main
-      # TODO: Investigate switching back to the container infra, by setting `sudo: false`.
-      sudo: required
       language: python
       python: "2.7.13"
       cache:
@@ -95,8 +93,6 @@ matrix:
 
     # Job 4: Python Tests Chunk B
     - env: python-tests-e2e-etl-logparser
-      # TODO: Investigate switching back to the container infra, by setting `sudo: false`.
-      sudo: required
       language: python
       python: "2.7.13"
       cache:
@@ -124,8 +120,6 @@ matrix:
 
     # Job 5: Python Tests Chunk C
     - env: python-tests-webapp
-      # TODO: Investigate switching back to the container infra, by setting `sudo: false`.
-      sudo: required
       language: python
       python: "2.7.13"
       cache:
@@ -153,8 +147,6 @@ matrix:
 
     # Job 6: Python Tests - Selenium integration
     - env: python-tests-selenium
-      # TODO: Investigate switching back to the container infra, by setting `sudo: false`.
-      sudo: required
       language: python
       python: "2.7.13"
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -162,6 +162,7 @@ matrix:
       cache:
         directories:
           - ~/venv
+          - node_modules
       addons:
         # Not using `latest` since the test run frequently times out with Firefox 55.
         firefox: "54.0.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 dist: trusty
+# Use the latest Travis images since they are more up to date than the stable release.
+group: edge
 env:
   global:
     - BROKER_URL='amqp://guest:guest@localhost:5672//'
@@ -43,10 +45,6 @@ matrix:
       addons:
         # Not using `latest` since the test run frequently times out with Firefox 55.
         firefox: "54.0.1"
-      before_install:
-        # Required due to: https://github.com/travis-ci/travis-ci/issues/7951
-        - curl -sSfL https://yarnpkg.com/install.sh | bash
-        - export PATH=$HOME/.yarn/bin:$PATH
       install:
         # `--frozen-lockfile` will catch cases where people have forgotten to update `yarn.lock`.
         # `--no-bin-links` is only necessary on Windows hosts, but we include here to ensure
@@ -179,13 +177,8 @@ matrix:
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
-        - mkdir -p $HOME/bin
         - curl -sSfL https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz | tar -zxC $HOME/bin
         - nvm install 7.10.0
-        # Required until Travis makes yarn available in the base image,
-        # since it only installs it for `language: nodejs` currently.
-        - curl -sSfL https://yarnpkg.com/install.sh | bash
-        - export PATH=$HOME/.yarn/bin:$PATH
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
         - yarn install --frozen-lockfile --no-bin-links

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
-        - pip install --disable-pip-version-check --upgrade pip==9.0.1
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
       script:
@@ -83,7 +82,6 @@ matrix:
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
-        - pip install --disable-pip-version-check --upgrade pip==9.0.1
         # Create the test database for `manage.py check --deploy`.
         - mysql -u root -e 'create database test_treeherder;'
       install:
@@ -119,7 +117,6 @@ matrix:
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
-        - pip install --disable-pip-version-check --upgrade pip==9.0.1
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
       before_script:
@@ -149,7 +146,6 @@ matrix:
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
-        - pip install --disable-pip-version-check --upgrade pip==9.0.1
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
       before_script:
@@ -182,7 +178,6 @@ matrix:
         # to work around: https://github.com/travis-ci/travis-ci/issues/4873
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
-        - pip install --disable-pip-version-check --upgrade pip==9.0.1
         - mkdir -p $HOME/bin
         - curl -sSfL https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz | tar -zxC $HOME/bin
         - nvm install 7.10.0


### PR DESCRIPTION
Previously the Travis run took anywhere from 8 to 15 minutes (wall time) to complete, which both holds up merging of PRs and also Heroku deployments (since the latter isn't triggered until the additional Travis run on master completes).

The long pole (and also the cause of the large variance) was the Javascript UI tests job, which was being run on the slower Travis container infrastructure. For longer running jobs, the boot time penalty of the fully virtualised GCE infrastructure is far outweighed by the faster CPU/more RAM.

After these changes, the Travis end-to-end time is now consistently in the 4m40s-5m50s range.

For more details see the individual commit messages.