### PR TITLE
Bug 1387147 - Return a 400 for JobDetail bad params instead of 500

### DIFF
--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -611,7 +611,7 @@ class JobDetailViewSet(viewsets.ReadOnlyModelViewSet):
             # See https://github.com/carltongibson/django-filter/issues/755
             def filter(self, qs, value):
                 if value in django_filters.constants.EMPTY_VALUES:
-                    raise ValueError("Invalid filter on empty value: {}".format(value))
+                    raise ParseError("Invalid filter on empty value: {}".format(value))
 
                 return django_filters.Filter.filter(self, qs, value)
 


### PR DESCRIPTION
If an invalid param value, such as ``job_id__id=‘’`` is passed in, we
will return a 400 response instead of a 500.