### PR TITLE
Bug 1223883 - Fix pytest warnings("cannot collect test class 'TestFailureDetector' / 'TestApp' because it has a __init__ constructor")

### DIFF
--- a/tests/autoclassify/test_classify_failures.py
+++ b/tests/autoclassify/test_classify_failures.py
@@ -1,5 +1,5 @@
-from treeherder.autoclassify.detectors import (ManualDetector,
-                                               TestFailureDetector)
+from treeherder.autoclassify.detectors import TestFailureDetector as _TestFailureDetector
+from treeherder.autoclassify.detectors import ManualDetector
 from treeherder.autoclassify.matchers import (CrashSignatureMatcher,
                                               ElasticSearchTestMatcher,
                                               PreciseTestMatcher)
@@ -123,7 +123,7 @@ def test_autoclassified_after_manual_classification(test_user,
                                                     test_job_2,
                                                     text_log_errors_failure_lines,
                                                     failure_classifications):
-    register_detectors(ManualDetector, TestFailureDetector)
+    register_detectors(ManualDetector, _TestFailureDetector)
 
     lines = [(test_line, {})]
     test_error_lines, test_failure_lines = create_lines(test_job_2, lines)
@@ -152,7 +152,7 @@ def test_autoclassified_after_manual_classification(test_user,
 def test_autoclassified_no_update_after_manual_classification_1(test_job_2,
                                                                 test_user,
                                                                 failure_classifications):
-    register_detectors(ManualDetector, TestFailureDetector)
+    register_detectors(ManualDetector, _TestFailureDetector)
 
     # Line type won't be detected by the detectors we have registered
     lines = [(log_line, {})]
@@ -173,7 +173,7 @@ def test_autoclassified_no_update_after_manual_classification_1(test_job_2,
 
 def test_autoclassified_no_update_after_manual_classification_2(test_user, test_job_2,
                                                                 failure_classifications):
-    register_detectors(ManualDetector, TestFailureDetector)
+    register_detectors(ManualDetector, _TestFailureDetector)
 
     # Too many failure lines
     test_error_lines, test_failure_lines = create_lines(test_job_2,

--- a/tests/e2e/test_jobs_loaded.py
+++ b/tests/e2e/test_jobs_loaded.py
@@ -1,11 +1,11 @@
 from django.core.urlresolvers import reverse
-from webtest import TestApp
+from webtest import TestApp as _TestApp
 
 from treeherder.config.wsgi import application
 
 
 def test_pending_job_available(test_repository, pending_jobs_stored):
-    webapp = TestApp(application)
+    webapp = _TestApp(application)
     resp = webapp.get(
         reverse("jobs-list", kwargs={"project": test_repository.name})
     )
@@ -17,7 +17,7 @@ def test_pending_job_available(test_repository, pending_jobs_stored):
 
 
 def test_running_job_available(test_repository, running_jobs_stored):
-    webapp = TestApp(application)
+    webapp = _TestApp(application)
     resp = webapp.get(
         reverse("jobs-list", kwargs={"project": test_repository.name})
     )
@@ -29,7 +29,7 @@ def test_running_job_available(test_repository, running_jobs_stored):
 
 
 def test_completed_job_available(test_repository, completed_jobs_stored):
-    webapp = TestApp(application)
+    webapp = _TestApp(application)
     resp = webapp.get(
         reverse("jobs-list", kwargs={"project": test_repository.name})
     )
@@ -46,7 +46,7 @@ def test_pending_stored_to_running_loaded(test_repository, pending_jobs_stored,
     given a loaded pending job, if I store and load the same job with status running,
     the latter is shown in the jobs endpoint
     """
-    webapp = TestApp(application)
+    webapp = _TestApp(application)
     resp = webapp.get(
         reverse("jobs-list", kwargs={"project": test_repository.name})
     )
@@ -61,7 +61,7 @@ def test_finished_job_to_running(test_repository, completed_jobs_stored,
     """
     tests that a job finished cannot change state
     """
-    webapp = TestApp(application)
+    webapp = _TestApp(application)
     resp = webapp.get(
         reverse("jobs-list", kwargs={"project": test_repository.name})
     )
@@ -77,7 +77,7 @@ def test_running_job_to_pending(test_repository, running_jobs_stored,
     tests that a job transition from pending to running
     cannot happen
     """
-    webapp = TestApp(application)
+    webapp = _TestApp(application)
     resp = webapp.get(
         reverse("jobs-list", kwargs={"project": test_repository.name})
     )

--- a/tests/log_parser/test_store_failure_lines.py
+++ b/tests/log_parser/test_store_failure_lines.py
@@ -10,7 +10,7 @@ from treeherder.log_parser.failureline import (store_failure_lines,
 from treeherder.model.models import (FailureLine,
                                      Group,
                                      JobLog)
-from treeherder.model.search import TestFailureLine
+from treeherder.model.search import TestFailureLine as _TestFailureLine
 
 from ..sampledata import SampleData
 
@@ -190,7 +190,7 @@ def test_store_error_summary_elastic_search(activate_responses, test_repository,
 
     failure = FailureLine.objects.get(pk=1)
 
-    es_line = TestFailureLine.get(1, routing=failure.test)
+    es_line = _TestFailureLine.get(1, routing=failure.test)
     for prop in ["test", "subtest", "status", "expected"]:
         assert getattr(es_line, prop) == getattr(failure, prop)
     assert es_line.best_classification is None

--- a/tests/model/test_cycle_data.py
+++ b/tests/model/test_cycle_data.py
@@ -14,8 +14,8 @@ from treeherder.model.models import (FailureLine,
                                      JobType,
                                      Machine,
                                      Push)
-from treeherder.model.search import (TestFailureLine,
-                                     refresh_all)
+from treeherder.model.search import TestFailureLine as _TestFailureLine
+from treeherder.model.search import refresh_all
 from treeherder.perf.models import (PerformanceDatum,
                                     PerformanceSignature)
 
@@ -45,7 +45,7 @@ def test_cycle_all_data(test_repository, failure_classifications, sample_data,
     assert JobLog.objects.count() == 0
 
     # There should be nothing in elastic search after cycling
-    assert TestFailureLine.search().count() == 0
+    assert _TestFailureLine.search().count() == 0
 
 
 def test_cycle_all_but_one_job(test_repository, failure_classifications, sample_data,
@@ -96,7 +96,7 @@ def test_cycle_all_but_one_job(test_repository, failure_classifications, sample_
         assert (set(item.id for item in object_type.objects.all()) ==
                 set(item.id for item in objects))
 
-    assert set(int(item.meta.id) for item in TestFailureLine.search().execute()) == set(item.id for item in extra_objects["failure_lines"][1])
+    assert set(int(item.meta.id) for item in _TestFailureLine.search().execute()) == set(item.id for item in extra_objects["failure_lines"][1])
 
 
 def test_cycle_all_data_in_chunks(test_repository, failure_classifications, sample_data,
@@ -116,7 +116,7 @@ def test_cycle_all_data_in_chunks(test_repository, failure_classifications, samp
     create_failure_lines(Job.objects.get(id=1),
                          [(test_line, {})] * 7)
 
-    assert TestFailureLine.search().count() > 0
+    assert _TestFailureLine.search().count() > 0
 
     call_command('cycle_data', sleep_time=0, days=1, chunk_size=3)
     refresh_all()
@@ -125,7 +125,7 @@ def test_cycle_all_data_in_chunks(test_repository, failure_classifications, samp
     assert Job.objects.count() == 0
     assert FailureLine.objects.count() == 0
     assert JobDetail.objects.count() == 0
-    assert TestFailureLine.search().count() == 0
+    assert _TestFailureLine.search().count() == 0
 
 
 def test_cycle_job_model_reference_data(test_repository, failure_classifications,

--- a/tests/webapp/api/test_failureline.py
+++ b/tests/webapp/api/test_failureline.py
@@ -13,7 +13,7 @@ from treeherder.model.models import (BugJobMap,
                                      MatcherManager,
                                      TextLogError,
                                      TextLogErrorMetadata)
-from treeherder.model.search import TestFailureLine
+from treeherder.model.search import TestFailureLine as _TestFailureLine
 
 
 def test_get_failure_line(webapp, failure_lines):
@@ -72,7 +72,7 @@ def test_update_failure_line_verify(test_repository,
     assert error_line.metadata.best_classification == classified_failures[0]
     assert error_line.metadata.best_is_verified
 
-    es_line = TestFailureLine.get(failure_line.id, routing=failure_line.test)
+    es_line = _TestFailureLine.get(failure_line.id, routing=failure_line.test)
     assert es_line.best_classification == classified_failures[0].id
     assert es_line.best_is_verified
 

--- a/tests/webapp/api/test_text_log_error.py
+++ b/tests/webapp/api/test_text_log_error.py
@@ -14,7 +14,7 @@ from treeherder.model.models import (BugJobMap,
                                      MatcherManager,
                                      TextLogError,
                                      TextLogErrorMetadata)
-from treeherder.model.search import TestFailureLine
+from treeherder.model.search import TestFailureLine as _TestFailureLine
 
 
 def test_get_error(text_log_errors_failure_lines):
@@ -75,7 +75,7 @@ def test_update_error_verify(test_repository,
     assert error_line.metadata.best_classification == classified_failures[0]
     assert error_line.metadata.best_is_verified
 
-    es_line = TestFailureLine.get(failure_line.id, routing=failure_line.test)
+    es_line = _TestFailureLine.get(failure_line.id, routing=failure_line.test)
     assert es_line.best_classification == classified_failures[0].id
     assert es_line.best_is_verified
 
@@ -461,7 +461,7 @@ def test_update_error_verify_bug(test_repository,
     assert error_line.metadata.best_classification == classified_failures[0]
     assert error_line.metadata.best_is_verified
 
-    es_line = TestFailureLine.get(failure_line.id, routing=failure_line.test)
+    es_line = _TestFailureLine.get(failure_line.id, routing=failure_line.test)
     assert es_line.best_classification == classified_failures[0].id
     assert es_line.best_is_verified
 


### PR DESCRIPTION
Bugzilla Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1223883
