### PR TITLE
Bug 1391321 - Use taskcluster actions.json for all actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jquery": "3.2.1",
     "jquery.scrollto": "2.1.2",
     "js-yaml": "3.9.1",
-    "json-e": "2.1.1",
+    "json-e": "2.2.1",
     "json-schema-defaults": "0.3.0",
     "lodash": "4.17.4",
     "metrics-graphics": "2.11.0",

--- a/ui/entry-logviewer.js
+++ b/ui/entry-logviewer.js
@@ -32,6 +32,7 @@ require('./js/models/job_detail.js');
 require('./js/models/job.js');
 require('./js/models/runnable_job.js');
 require('./js/models/resultset.js');
+require('./js/services/tcactions.js');
 require('./js/models/text_log_step.js');
 require('./js/filters.js');
 require('./js/controllers/logviewer.js');

--- a/ui/entry-perf.js
+++ b/ui/entry-perf.js
@@ -42,6 +42,7 @@ require('./js/models/repository.js');
 require('./js/models/job.js');
 require('./js/models/runnable_job.js');
 require('./js/models/resultset.js');
+require('./js/services/tcactions.js');
 require('./js/models/user.js');
 require('./js/models/error.js');
 require('./js/perf.js');

--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -195,13 +195,22 @@ treeherderApp.controller('ResultSetCtrl', [
                 return;
             }
 
-            ThResultSetModel.triggerMissingJobs($scope.resultset.id, $scope.repoName).then(function () {
-                thNotify.send("Request sent to trigger missing jobs", "success");
-            }, function (e) {
-                thNotify.send(
-                    ThModelErrors.format(e, "The action 'trigger missing jobs' failed"),
-                    'danger', true
-                );
+            ThResultSetStore.getGeckoDecisionTaskId(
+                $scope.repoName,
+                $scope.resultset.id
+            ).then(function (decisionTaskID) {
+                ThResultSetModel.triggerMissingJobs(
+                    $scope.resultset.id,
+                    $scope.repoName,
+                    decisionTaskID
+                ).then(function () {
+                    thNotify.send("Request sent to trigger missing jobs", "success");
+                }, function (e) {
+                    thNotify.send(
+                        ThModelErrors.format(e, "The action 'trigger missing jobs' failed"),
+                        'danger', true
+                    );
+                });
             });
         };
 

--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -203,8 +203,8 @@ treeherderApp.controller('ResultSetCtrl', [
                     $scope.resultset.id,
                     $scope.repoName,
                     decisionTaskID
-                ).then(function () {
-                    thNotify.send("Request sent to trigger missing jobs", "success");
+                ).then(function (msg) {
+                    thNotify.send(msg, "success", true);
                 }, function (e) {
                     thNotify.send(
                         ThModelErrors.format(e, "The action 'trigger missing jobs' failed"),
@@ -234,7 +234,7 @@ treeherderApp.controller('ResultSetCtrl', [
                     times,
                     decisionTaskID
                 ).then(function (msg) {
-                    thNotify.send(msg, "success");
+                    thNotify.send(msg, "success", true);
                 }, function (e) {
                     thNotify.send(ThTaskclusterErrors.format(e), 'danger', true);
                 });
@@ -254,8 +254,8 @@ treeherderApp.controller('ResultSetCtrl', [
             if ($scope.user.loggedin) {
                 var buildernames = ThResultSetStore.getSelectedRunnableJobs($rootScope.repoName, $scope.resultset.id);
                 ThResultSetStore.getGeckoDecisionTaskId($rootScope.repoName, $scope.resultset.id).then(function (decisionTaskID) {
-                    ThResultSetModel.triggerNewJobs($scope.repoName, $scope.resultset.id, buildernames, decisionTaskID).then(function () {
-                        thNotify.send("Trigger request sent", "success");
+                    ThResultSetModel.triggerNewJobs($scope.repoName, $scope.resultset.id, buildernames, decisionTaskID).then(function (results) {
+                        thNotify.send(results[1], "success", true);
                         ThResultSetStore.deleteRunnableJobs($scope.repoName, $scope.resultset);
                     }, function (e) {
                         thNotify.send(ThTaskclusterErrors.format(e), 'danger', true);

--- a/ui/js/controllers/tcjobactions.js
+++ b/ui/js/controllers/tcjobactions.js
@@ -55,11 +55,13 @@ treeherder.controller('TCJobActionsCtrl', [
             }
         });
 
-        tcactions.load(repoName, resultsetId, job).then((results) => {
-            originalTask = results.originalTask;
-            $scope.actions = results.actions;
-            $scope.staticActionVariables = results.staticActionVariables;
-            $scope.input.selectedAction = $scope.actions[0];
-            $scope.updateSelectedAction();
+        ThResultSetStore.getGeckoDecisionTaskId(repoName, resultsetId).then((decisionTaskId) => {
+            tcactions.load(decisionTaskId, job).then((results) => {
+                originalTask = results.originalTask;
+                $scope.actions = results.actions;
+                $scope.staticActionVariables = results.staticActionVariables;
+                $scope.input.selectedAction = $scope.actions[0];
+                $scope.updateSelectedAction();
+            });
         });
     }]);

--- a/ui/js/controllers/tcjobactions.js
+++ b/ui/js/controllers/tcjobactions.js
@@ -29,15 +29,15 @@ treeherder.controller('TCJobActionsCtrl', [
             let tc = thTaskcluster.client();
 
             let actionTaskId = tc.slugid();
-            let actionTask = tcactions.render($scope.input.selectedAction.task, _.defaults({}, {
-                taskGroupId: originalTask.taskGroupId,
+            tcactions.submit({
+                action: $scope.input.selectedAction,
+                actionTaskId,
+                decisionTaskId: originalTask.taskGroupId,
                 taskId: job.taskcluster_metadata.task_id,
                 task: originalTask,
                 input: $scope.input.jsonPayload ? JSON.parse($scope.input.jsonPayload) : undefined,
-            }, $scope.staticActionVariables));
-
-            let queue = new tc.Queue();
-            queue.createTask(actionTaskId, actionTask).then(function () {
+                staticActionVariables: $scope.staticActionVariables,
+            }).then(function () {
                 $scope.$apply(thNotify.send("Custom action request sent successfully", 'success'));
                 $scope.triggering = false;
                 $uibModalInstance.close('request sent');

--- a/ui/js/controllers/tcjobactions.js
+++ b/ui/js/controllers/tcjobactions.js
@@ -3,10 +3,10 @@
 treeherder.controller('TCJobActionsCtrl', [
     '$scope', '$http', '$uibModalInstance', 'ThResultSetStore',
     'ThJobDetailModel', 'thTaskcluster', 'ThTaskclusterErrors',
-    'thNotify', 'job', 'repoName', 'resultsetId', 'actionsRender',
+    'thNotify', 'job', 'repoName', 'resultsetId', 'tcactions',
     function ($scope, $http, $uibModalInstance, ThResultSetStore,
              ThJobDetailModel, thTaskcluster, ThTaskclusterErrors, thNotify,
-             job, repoName, resultsetId, actionsRender) {
+             job, repoName, resultsetId, tcactions) {
         let jsonSchemaDefaults = require('json-schema-defaults');
         let originalTask;
         $scope.input = {};
@@ -29,7 +29,7 @@ treeherder.controller('TCJobActionsCtrl', [
             let tc = thTaskcluster.client();
 
             let actionTaskId = tc.slugid();
-            let actionTask = actionsRender($scope.input.selectedAction.task, _.defaults({}, {
+            let actionTask = tcactions.render($scope.input.selectedAction.task, _.defaults({}, {
                 taskGroupId: originalTask.taskGroupId,
                 taskId: job.taskcluster_metadata.task_id,
                 task: originalTask,
@@ -55,45 +55,11 @@ treeherder.controller('TCJobActionsCtrl', [
             }
         });
 
-        let decisionTask = ThResultSetStore.getGeckoDecisionJob(repoName, resultsetId);
-        if (decisionTask) {
-            let originalTaskId = job.taskcluster_metadata.task_id;
-            $http.get('https://queue.taskcluster.net/v1/task/' + originalTaskId).then(
-                function (response) {
-                    originalTask = response.data;
-                    ThJobDetailModel.getJobDetails({
-                        job_id: decisionTask.id,
-                        title: 'artifact uploaded',
-                        value: 'actions.json' }).then(function (details) {
-                            if (!details.length) {
-                                alert("Could not find actions.json");
-                                return;
-                            }
-
-                            let actionsUpload = details[0];
-                            return $http.get(actionsUpload.url).then(function (response) {
-                                if (response.data.version !== 1) {
-                                    alert("Wrong version of actions.json, can't continue");
-                                    return;
-                                }
-                                $scope.staticActionVariables = response.data.variables;
-                                // only display actions which should be displayed
-                                // in this task's context
-                                $scope.actions = response.data.actions.filter(function (action) {
-                                    return action.kind === 'task' && (
-                                        !action.context.length || _.some((action.context).map(function (actionContext) {
-                                            return !Object.keys(actionContext).length || _.every(_.map(actionContext, function (v, k) {
-                                                return (originalTask.tags[k] === v);
-                                            }));
-                                        })));
-                                });
-                                $scope.input.selectedAction = $scope.actions[0];
-                                $scope.updateSelectedAction();
-                            });
-                        });
-                });
-        } else {
-            alert("No decision task, can't find taskcluster actions");
-        }
-
+        tcactions.load(repoName, resultsetId, job).then((results) => {
+            originalTask = results.originalTask;
+            $scope.actions = results.actions;
+            $scope.staticActionVariables = results.staticActionVariables;
+            $scope.input.selectedAction = $scope.actions[0];
+            $scope.updateSelectedAction();
+        });
     }]);

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -202,7 +202,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
 
                         // In this case we have actions.json tasks
                         if (results) {
-                            const missingtask = _.find(results.actions, {name: 'run-missing-tests'});
+                            const missingtask = _.find(results.actions, { name: 'run-missing-tests' });
                             // We'll fall back to actions.yaml if this isn't true
                             if (missingtask) {
                                 return tcactions.submit({
@@ -231,7 +231,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
 
                         // In this case we have actions.json tasks
                         if (results) {
-                            const talostask = _.find(results.actions, {name: 'run-all-talos'});
+                            const talostask = _.find(results.actions, { name: 'run-all-talos' });
                             // We'll fall back to actions.yaml if this isn't true
                             if (talostask) {
                                 return tcactions.submit({
@@ -240,7 +240,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
                                     decisionTaskId,
                                     taskId: null,
                                     task: null,
-                                    input: {times},
+                                    input: { times },
                                     staticActionVariables: results.staticActionVariables,
                                 }).then(function () {
                                     return `Request sent to trigger all talos jobs ${times} time(s) via actions.json (${actionTaskId})`;
@@ -323,7 +323,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
 
                                 // In this case we have actions.json tasks
                                 if (results) {
-                                    const addjobstask = _.find(results.actions, {name: 'add-new-jobs'});
+                                    const addjobstask = _.find(results.actions, { name: 'add-new-jobs' });
                                     // We'll fall back to actions.yaml if this isn't true
                                     if (addjobstask) {
                                         return tcactions.submit({
@@ -332,7 +332,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
                                             decisionTaskId,
                                             taskId: null,
                                             task: null,
-                                            input: {tasks: tclabels},
+                                            input: { tasks: tclabels },
                                             staticActionVariables: results.staticActionVariables,
                                         }).then(() => `Request sent to trigger new jobs via actions.json (${actionTaskId})`);
                                     }

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -213,7 +213,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
                                     task: null,
                                     input: {},
                                     staticActionVariables: results.staticActionVariables,
-                                });
+                                }).then(() => `Request sent to trigger missing jobs via actions.json (${actionTaskId})`);
                             }
                         }
                     });
@@ -243,7 +243,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
                                     input: {times},
                                     staticActionVariables: results.staticActionVariables,
                                 }).then(function () {
-                                    return "Request sent to trigger all talos jobs " + times + " time(s)";
+                                    return `Request sent to trigger all talos jobs ${times} time(s) via actions.json (${actionTaskId})`;
                                 });
                             }
                         }
@@ -260,7 +260,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
                             });
                             let task = thTaskcluster.refreshTimestamps(jsyaml.safeLoad(action));
                             return queue.createTask(actionTaskId, task).then(function () {
-                                return "Request sent to trigger all talos jobs " + times + " time(s)";
+                                return `Request sent to trigger all talos jobs ${times} time(s) via actions.yml (${actionTaskId})` ;
                             });
                         });
                     });
@@ -306,7 +306,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
                             }
                             let bbdata = {
                                 requested_jobs: bbnames,
-                                decision_task_id: decisionTaskID
+                                decision_task_id: decisionTaskId
                             };
                             return $http.post(
                                 thUrl.getProjectUrl("/resultset/", repoName) + resultset_id + '/trigger_runnable_jobs/',
@@ -334,7 +334,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
                                             task: null,
                                             input: {tasks: tclabels},
                                             staticActionVariables: results.staticActionVariables,
-                                        });
+                                        }).then(() => `Request sent to trigger new jobs via actions.json (${actionTaskId})`);
                                     }
                                 }
 
@@ -349,7 +349,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
                                         action_args: `--decision-id ${decisionTaskId} --task-labels ${taskLabels}`,
                                     });
                                     let task = thTaskcluster.refreshTimestamps(jsyaml.safeLoad(action));
-                                    return queue.createTask(actionTaskId, task);
+                                    return queue.createTask(actionTaskId, task).then(() => `Request sent to trigger new jobs via actions.yml (${actionTaskId})`);
                                 });
                             });
                         }),

--- a/ui/js/services/tcactions.js
+++ b/ui/js/services/tcactions.js
@@ -1,8 +1,8 @@
 "use strict";
 
 treeherder.factory('tcactions', [
-    '$q', '$http', 'thTaskcluster',
-    function ($q, $http, thTaskcluster) {
+    '$q', '$http', 'thTaskcluster', 'thNotify',
+    function ($q, $http, thTaskcluster, thNotify) {
         const jsone = require('json-e');
         const tc = thTaskcluster.client();
         const queue = new tc.Queue();
@@ -29,7 +29,7 @@ treeherder.factory('tcactions', [
             },
             load: (decisionTaskID, job) => {
                 if (!decisionTaskID) {
-                    alert("No decision task, can't find taskcluster actions");
+                    thNotify.send("No decision task, can't find taskcluster actions", "danger", true);
                     return;
                 }
 
@@ -47,7 +47,7 @@ treeherder.factory('tcactions', [
                     }
 
                     if (response.data.version !== 1) {
-                        alert("Wrong version of actions.json, can't continue");
+                        thNotify.send("Wrong version of actions.json, can't continue", "danger", true);
                         return;
                     }
 

--- a/ui/js/services/tcactions.js
+++ b/ui/js/services/tcactions.js
@@ -9,6 +9,24 @@ treeherder.factory('tcactions', [
 
         return {
             render: (template, context) => jsone(template, context),
+            submit: ({action, actionTaskId, decisionTaskId, taskId,
+                      task, input, staticActionVariables}) => {
+
+                const actionTask = jsone(action.task, _.defaults({}, {
+                    taskGroupId: decisionTaskId,
+                    taskId,
+                    task,
+                    input,
+                }, staticActionVariables));
+
+                return queue.task(decisionTaskId).then((decisionTask) => {
+                    const submitQueue = new tc.Queue({
+                        authorizedScopes: decisionTask.scopes,
+                    });
+
+                    return submitQueue.createTask(actionTaskId, actionTask);
+                });
+            },
             load: (decisionTaskID, job) => {
                 if (!decisionTaskID) {
                     alert("No decision task, can't find taskcluster actions");

--- a/ui/js/services/tcactions.js
+++ b/ui/js/services/tcactions.js
@@ -9,8 +9,8 @@ treeherder.factory('tcactions', [
 
         return {
             render: (template, context) => jsone(template, context),
-            submit: ({action, actionTaskId, decisionTaskId, taskId,
-                      task, input, staticActionVariables}) => {
+            submit: ({ action, actionTaskId, decisionTaskId, taskId,
+                      task, input, staticActionVariables }) => {
 
                 const actionTask = jsone(action.task, _.defaults({}, {
                     taskGroupId: decisionTaskId,

--- a/ui/js/services/tcactions.js
+++ b/ui/js/services/tcactions.js
@@ -1,9 +1,54 @@
 "use strict";
 
-treeherder.factory('actionsRender', function () {
-    const jsone = require('json-e');
+treeherder.factory('tcactions', [
+    '$http', 'ThJobDetailModel', 'ThResultSetStore',
+    function ($http, ThJobDetailModel, ThResultSetStore) {
+        const jsone = require('json-e');
 
-    // this simply calls json-e at the moment, but exists as a service to allow
-    // addition of more context items later.
-    return (template, context) => jsone(template, context);
-});
+        return {
+            render: (template, context) => jsone(template, context),
+            load: (repoName, resultsetId, job) => {
+                let decisionTask = ThResultSetStore.getGeckoDecisionJob(repoName, resultsetId);
+
+                if (!decisionTask) {
+                    alert("No decision task, can't find taskcluster actions");
+                    return;
+                }
+
+                let originalTaskId = job.taskcluster_metadata.task_id;
+                return $http.get('https://queue.taskcluster.net/v1/task/' + originalTaskId).then(
+                    function (response) {
+                        const originalTask = response.data;
+                        return ThJobDetailModel.getJobDetails({
+                            job_id: decisionTask.id,
+                            title: 'artifact uploaded',
+                            value: 'actions.json'}).then(function (details) {
+                                if (!details.length) {
+                                    alert("Could not find actions.json");
+                                    return;
+                                }
+
+                                let actionsUpload = details[0];
+                                return $http.get(actionsUpload.url).then(function (response) {
+                                    if (response.data.version !== 1) {
+                                        alert("Wrong version of actions.json, can't continue");
+                                        return;
+                                    }
+                                    return {
+                                        originalTask,
+                                        staticActionVariables: response.data.variables,
+                                        actions: response.data.actions.filter(function (action) {
+                                            return action.kind === 'task' && (
+                                                !action.context.length || _.some((action.context).map(function (actionContext) {
+                                                    return !Object.keys(actionContext).length || _.every(_.map(actionContext, function (v, k) {
+                                                        return (originalTask.tags[k] === v);
+                                                    }));
+                                                })));
+                                        }),
+                                    };
+                                });
+                            });
+                    });
+            },
+        };
+    }]);

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -393,7 +393,7 @@ treeherder.controller('PluginCtrl', [
                             const tc = thTaskcluster.client();
                             const actionTaskId = tc.slugid();
                             if (results) {
-                                const backfilltask = _.find(results.actions, {name: 'backfill'});
+                                const backfilltask = _.find(results.actions, { name: 'backfill' });
                                 // We'll fall back to actions.yaml if this isn't true
                                 if (backfilltask) {
                                     return tcactions.submit({

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -386,7 +386,7 @@ treeherder.controller('PluginCtrl', [
             }
 
             if ($scope.job.build_system_type === 'taskcluster' || $scope.job.reason.startsWith('Created by BBB for task')) {
-                return ThResultSetStore.getGeckoDecisionTaskId(
+                ThResultSetStore.getGeckoDecisionTaskId(
                     $scope.repoName,
                     $scope.resultsetId).then(function (decisionTaskId) {
                         return tcactions.load(decisionTaskId).then((results) => {

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -405,7 +405,7 @@ treeherder.controller('PluginCtrl', [
                                         input: {},
                                         staticActionVariables: results.staticActionVariables,
                                     }).then(function () {
-                                        $scope.$apply(thNotify.send("Request sent to backfill jobs", 'success'));
+                                        $scope.$apply(thNotify.send(`Request sent to backfill job via actions.json (${actionTaskId})`, 'success', true));
                                     }, function (e) {
                                         // The full message is too large to fit in a Treeherder
                                         // notification box.
@@ -435,9 +435,10 @@ treeherder.controller('PluginCtrl', [
                                     action: 'backfill',
                                     action_args: '--project ' + $scope.repoName + ' --job ' + $scope.job.id,
                                 });
+
                                 let task = thTaskcluster.refreshTimestamps(jsyaml.safeLoad(action));
                                 queue.createTask(actionTaskId, task).then(function () {
-                                    $scope.$apply(thNotify.send("Request sent to backfill jobs", 'success'));
+                                    $scope.$apply(thNotify.send(`Request sent to backfill job via actions.yml (${actionTaskId})`, 'success', true));
                                 }, function (e) {
                                     // The full message is too large to fit in a Treeherder
                                     // notification box.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2496,10 +2496,6 @@ es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
     es6-iterator "2"
     es6-symbol "~3.1"
 
-es6-error@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.0.2.tgz#eec5c726eacef51b7f6b73c20db6e1b13b069c98"
-
 es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512"
@@ -3903,11 +3899,9 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
-json-e@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/json-e/-/json-e-2.1.1.tgz#f9769ec2e508622cf316b4418932248f4e0e0669"
-  dependencies:
-    es6-error "^4.0.1"
+json-e@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/json-e/-/json-e-2.2.1.tgz#b3df35d3046c588ae20a5c7515ca6c5dc3532f21"
 
 json-loader@^0.5.4:
   version "0.5.7"


### PR DESCRIPTION
This makes it so that if a push has an `actions.json` set of tasks, it will use that over `actions.yml` or pulse-actions when possible. This should prove to be more reliable and have the side benefit of being more secure with our new `authorizedScopes` usage.

*This PR will be easiest to review by going one commit at a time, each bit should be self-contained!*

I'm going to bug @djmitche first so we can make sure this makes sense from a tc perspective and then when we're happy, I'll assign a treeherder reviewer.