### PR TITLE
Bug 1389538 - Fix django-rest-framework deprecation warnings about 'rest_framework.filters'

### DIFF
--- a/treeherder/webapp/api/classifiedfailure.py
+++ b/treeherder/webapp/api/classifiedfailure.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-import django_filters
+from django_filters import rest_framework as filters
 from rest_framework import viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response
@@ -15,7 +15,7 @@ from treeherder.webapp.api import (pagination,
 from treeherder.webapp.api.utils import as_dict
 
 
-class ClassifiedFailureFilter(django_filters.rest_framework.FilterSet):
+class ClassifiedFailureFilter(filters.FilterSet):
     class Meta(object):
         model = ClassifiedFailure
         fields = ["bug_number"]

--- a/treeherder/webapp/api/classifiedfailure.py
+++ b/treeherder/webapp/api/classifiedfailure.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-import rest_framework_filters as filters
+import django_filters
 from rest_framework import viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response
@@ -15,7 +15,7 @@ from treeherder.webapp.api import (pagination,
 from treeherder.webapp.api.utils import as_dict
 
 
-class ClassifiedFailureFilter(filters.FilterSet):
+class ClassifiedFailureFilter(django_filters.rest_framework.FilterSet):
     class Meta(object):
         model = ClassifiedFailure
         fields = ["bug_number"]

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -4,8 +4,7 @@ import django_filters
 from dateutil import parser
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models as django_models
-from rest_framework import (filters,
-                            viewsets)
+from rest_framework import viewsets
 from rest_framework.decorators import (detail_route,
                                        list_route)
 from rest_framework.exceptions import ParseError
@@ -602,7 +601,7 @@ class JobDetailViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = JobDetail.objects.all().select_related('job', 'job__repository')
     serializer_class = serializers.JobDetailSerializer
 
-    class JobDetailFilter(filters.FilterSet):
+    class JobDetailFilter(django_filters.rest_framework.FilterSet):
 
         class NumberInFilter(django_filters.filters.BaseInFilter,
                              django_filters.NumberFilter):
@@ -629,7 +628,7 @@ class JobDetailViewSet(viewsets.ReadOnlyModelViewSet):
             fields = ['job_id', 'job_guid', 'job__guid', 'job_id__in', 'title',
                       'value', 'push_id', 'repository']
 
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
     filter_class = JobDetailFilter
 
     # using a custom pagination size of 2000 to avoid breaking mozscreenshots

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -2,6 +2,7 @@ import datetime
 import time
 from collections import defaultdict
 
+import django_filters
 from django.conf import settings
 from rest_framework import (exceptions,
                             filters,
@@ -246,7 +247,7 @@ class PerformanceAlertSummaryViewSet(viewsets.ModelViewSet):
     permission_classes = (IsStaffOrReadOnly,)
 
     serializer_class = PerformanceAlertSummarySerializer
-    filter_backends = (filters.DjangoFilterBackend, filters.OrderingFilter)
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend, filters.OrderingFilter)
     filter_fields = ['id', 'status', 'framework', 'repository',
                      'alerts__series_signature__signature_hash']
     ordering = ('-last_updated', '-id')
@@ -273,7 +274,7 @@ class PerformanceAlertViewSet(viewsets.ModelViewSet):
     permission_classes = (IsStaffOrReadOnly,)
 
     serializer_class = PerformanceAlertSerializer
-    filter_backends = (filters.DjangoFilterBackend, filters.OrderingFilter)
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend, filters.OrderingFilter)
     filter_fields = ['id']
     ordering = ('-id')
 
@@ -341,5 +342,5 @@ class PerformanceAlertViewSet(viewsets.ModelViewSet):
 class PerformanceBugTemplateViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = PerformanceBugTemplate.objects.all()
     serializer_class = PerformanceBugTemplateSerializer
-    filter_backends = (filters.DjangoFilterBackend, filters.OrderingFilter)
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend, filters.OrderingFilter)
     filter_fields = ['framework']


### PR DESCRIPTION
The deprecation warnings don't show up now. :)