### PR TITLE
Bug 1392546 - Speed up MySQL I/O in Vagrant/Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,12 @@ matrix:
         - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.0.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
         - sudo service elasticsearch restart
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
+        # Using tmpfs to improve MySQL performance reduces pytest runtime by 30%.
+        - sudo mkdir /mnt/ramdisk
+        - sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
+        - sudo stop mysql
+        - sudo mv /var/lib/mysql /mnt/ramdisk
+        - sudo ln -s /mnt/ramdisk/mysql /var/lib/mysql
         - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
         - sudo -E apt-get -yqq update
         - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server libmysqlclient-dev
@@ -104,6 +110,12 @@ matrix:
         - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.0.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
         - sudo service elasticsearch restart
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
+        # Using tmpfs to improve MySQL performance reduces pytest runtime by 30%.
+        - sudo mkdir /mnt/ramdisk
+        - sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
+        - sudo stop mysql
+        - sudo mv /var/lib/mysql /mnt/ramdisk
+        - sudo ln -s /mnt/ramdisk/mysql /var/lib/mysql
         - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
         - sudo -E apt-get -yqq update
         - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server libmysqlclient-dev
@@ -131,6 +143,12 @@ matrix:
         - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.0.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
         - sudo service elasticsearch restart
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
+        # Using tmpfs to improve MySQL performance reduces pytest runtime by 30%.
+        - sudo mkdir /mnt/ramdisk
+        - sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
+        - sudo stop mysql
+        - sudo mv /var/lib/mysql /mnt/ramdisk
+        - sudo ln -s /mnt/ramdisk/mysql /var/lib/mysql
         - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
         - sudo -E apt-get -yqq update
         - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server libmysqlclient-dev
@@ -162,6 +180,12 @@ matrix:
         - curl -sSo ~/elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.0.deb && sudo dpkg -i --force-confold ~/elasticsearch.deb
         - sudo service elasticsearch restart
         - sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
+        # Using tmpfs to improve MySQL performance reduces pytest runtime by 30%.
+        - sudo mkdir /mnt/ramdisk
+        - sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
+        - sudo stop mysql
+        - sudo mv /var/lib/mysql /mnt/ramdisk
+        - sudo ln -s /mnt/ramdisk/mysql /var/lib/mysql
         - echo 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7' | sudo tee /etc/apt/sources.list.d/mysql.list > /dev/null
         - sudo -E apt-get -yqq update
         - sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server libmysqlclient-dev

--- a/vagrant/mysql.cnf
+++ b/vagrant/mysql.cnf
@@ -8,10 +8,6 @@
 character_set_server="utf8"
 collation_server="utf8_bin"
 
-log_output="FILE"
-long_query_time="2"
-slow_query_log="1"
-
 # Ensure operations involving astral characters fail loudly,
 # rather than mysql silently replacing each each byte of the
 # original character with a U+FFFD replacement character.

--- a/vagrant/mysql.cnf
+++ b/vagrant/mysql.cnf
@@ -19,3 +19,6 @@ sql_mode="NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES"
 # Unhelpfully MySQL uses a different (undocumented) variable name if set via config file:
 # https://bugs.mysql.com/bug.php?id=70008
 transaction-isolation=READ-COMMITTED
+
+# Vagrant/Travis only: Speed up I/O by reducing data-loss protection.
+innodb_flush_log_at_trx_commit="0"

--- a/vagrant/mysql.cnf
+++ b/vagrant/mysql.cnf
@@ -5,9 +5,6 @@
 # https://github.com/mozilla-platform-ops/devservices-aws/blob/master/treeherder/rds.tf
 
 [mysqld]
-# Allow connections from the Vagrant host and not just the loopback interface.
-bind-address="0.0.0.0"
-
 character_set_server="utf8"
 collation_server="utf8_bin"
 


### PR DESCRIPTION
Using a ramdisk on Travis halves the duration of the pytest command, which even when the Travis setup time is included still reduces Travis end to end time by 30%.

The use of `innodb_flush_log_at_trx_commit=0` in Vagrant reduces pytest time by 30%.

See individual commits for more details.