### PR TITLE
Minor capitalization fixes for perfherder replicate views/links

### DIFF
--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -592,7 +592,7 @@ perf.controller('CompareSubtestResultsCtrl', [
                     //replicate distribution is added only for talos
                     if ($scope.filterOptions.framework === '1') {
                         cmap.links.push({
-                            title: 'replicate',
+                            title: 'replicates',
                             href: 'perf.html#/comparesubtestdistribution?' + $httpParamSerializer({
                                 originalProject: $scope.originalProject.name,
                                 newProject: $scope.newProject.name,
@@ -909,7 +909,7 @@ perf.controller('CompareSubtestDistributionCtrl', ['$scope', '$stateParams', '$q
                             "value": value
                         }));
                         metricsgraphics.data_graphic({
-                            title: `${target} Replicates over ${numRuns} run${(numRuns > 1) ? 's' : ''}`,
+                            title: `${target} replicates over ${numRuns} run${(numRuns > 1) ? 's' : ''}`,
                             chart_type: "bar",
                             data: replicateValues,
                             y_accessor: "value",


### PR DESCRIPTION
* Replicate link should be "replicates" (not "replicate")
* Title for graphs should not be lowercase except for first word