### PR TITLE
Bug 1389536 - Fix Django 1.11 deprecation warnings for url and authenticate()

### DIFF
--- a/tests/auth/test_backends.py
+++ b/tests/auth/test_backends.py
@@ -1,5 +1,6 @@
 import pytest
 from django.contrib.auth.models import User
+from rest_framework.test import APIRequestFactory
 from taskcluster import Auth
 
 from treeherder.auth.backends import (NoEmailException,
@@ -61,11 +62,12 @@ def test_existing_email_create_user(test_user, monkeypatch, result,
     def authenticateHawk_mock(selfless, obj):
         return result
     monkeypatch.setattr(Auth, "authenticateHawk", authenticateHawk_mock)
+    factory = APIRequestFactory()
 
+    request = factory.get('/endpoint/', HTTP_TCAUTH='meh', host="fleh", port=3)
     existing_user = User.objects.create(username="email/foo@bar.net", email=email)
-
     tca = TaskclusterAuthBackend()
-    new_user = tca.authenticate(auth_header="meh", host="fleh", port=3)
+    new_user = tca.authenticate(request)
     assert new_user.username == exp_username
     if exp_create_user:
         assert new_user.id != existing_user.id

--- a/treeherder/auth/backends.py
+++ b/treeherder/auth/backends.py
@@ -50,7 +50,12 @@ class TaskclusterAuthBackend(object):
         raise NoEmailException(
             "No email found in clientId: '{}'".format(client_id))
 
-    def authenticate(self, auth_header=None, host=None, port=None):
+    def authenticate(self, request):
+
+        auth_header = request.META.get("HTTP_TCAUTH", None)
+        host = request.get_host().split(":")[0]
+        port = int(request.get_port())
+
         if not auth_header:
             # Doesn't have the right params for this backend.  So just
             # skip and let another backend have a try at it.

--- a/treeherder/config/urls.py
+++ b/treeherder/config/urls.py
@@ -14,7 +14,7 @@ admin.site.login_template = 'webapp/admin_login.html'
 urlpatterns = [
    url(r'^api/', include(api_urls)),
    url(r'^embed/', include(embed_urls)),
-   url(r'^admin/', include(admin.site.urls)),
+   url(r'^admin/', admin.site.urls),
    url(r'^docs/', get_swagger_view(title='Treeherder API')),
    url(r'^credentials/', include(credentials_patterns)),
 ]

--- a/treeherder/webapp/api/auth.py
+++ b/treeherder/webapp/api/auth.py
@@ -40,14 +40,9 @@ class TaskclusterAuthViewSet(viewsets.ViewSet):
         """
         Verify credentials with Taskcluster
         """
-        auth_header = request.META.get("HTTP_TCAUTH", None)
-        host = request.get_host().split(":")[0]
-        port = request.get_port()
-
         try:
-            user = authenticate(auth_header=auth_header,
-                                host=host,
-                                port=int(port))
+            user = authenticate(request)
+
             if not user:
                 raise AuthenticationFailed("User not authenticated.")
 


### PR DESCRIPTION
Bugzilla link: https://bugzilla.mozilla.org/show_bug.cgi?id=1389536