### PR TITLE
Bug 1393550 - Add a Maintenance mode page

### DIFF
--- a/treeherder/config/urls.py
+++ b/treeherder/config/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import (include,
                               url)
 from django.contrib import admin
 from django.views.decorators.csrf import csrf_exempt
+from django.views.generic import TemplateView
 from rest_framework_swagger.views import get_swagger_view
 
 from treeherder.credentials.urls import urlpatterns as credentials_patterns
@@ -17,6 +18,10 @@ urlpatterns = [
    url(r'^admin/', include(admin.site.urls)),
    url(r'^docs/', get_swagger_view(title='Treeherder API')),
    url(r'^credentials/', include(credentials_patterns)),
+   url(r'^maintenance/',
+       TemplateView.as_view(template_name='maintenance_mode.html'),
+       name="maintenance"),
+
 ]
 
 if settings.DEBUG:

--- a/treeherder/templates/maintenance_mode.html
+++ b/treeherder/templates/maintenance_mode.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset=utf-8>
+    <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no"
+          name=viewport>
+    <title>Treeherder maintenance</title>
+    <link rel="shortcut icon" type="image/x-icon"
+          href="https://www.herokucdn.com/favicon.ico">
+    <style>html, body {
+        font-family: sans-serif;
+        -ms-text-size-adjust: 100%;
+        -webkit-text-size-adjust: 100%;
+        background-color: #F7F8FB;
+        height: 100%;
+        -webkit-font-smoothing: antialiased;
+    }
+
+    body {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .message__title {
+        font-size: 22px;
+        font-weight: 100;
+        margin-top: 15px;
+        color: #47494E;
+        margin-bottom: 8px;
+    }
+
+    p {
+        -webkit-margin-after: 0;
+        -webkit-margin-before: 0;
+        font-size: 15px;
+        color: #7F828B;
+        line-height: 21px;
+        margin-bottom: 4px;
+    }
+
+    </style>
+    <base target=_parent/>
+</head>
+<body>
+<div class=spacer></div>
+<div class=message>
+    <div class=message__title> Treeherder is Offline for maintenance</div>
+    <p> Please be patient while we do some work under the hood. </p>
+    <p> You can find more information at:</p>
+    <ul>
+        <li><a href="https://mozilla-releng.net/treestatus">TreeStatus</a></li>
+        <li><a href="irc://irc.mozilla.org/treeherder">#treeherder</a> channel on IRC</li>
+    </ul>
+    <p> Please check back later. </p>
+    <p>Best wishes,</p>
+    <p>&mdash; The Treeherder team</p></div>
+</body>
+</html>


### PR DESCRIPTION
This page will show when Treeherder is in Maintenance mode.  You must also add a config variable of MAINTENANCE_PAGE_URL=https://treeherder.allizom.org/maintenance/ to display it at the right time.