### PR TITLE
bug 1393277 - use --option=arg rather than --option arg

### DIFF
--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -256,7 +256,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
                             let template = $interpolate(action);
                             action = template({
                                 action: 'add-talos',
-                                action_args: '--decision-task-id ' + decisionTaskId + ' --times ' + times,
+                                action_args: '--decision-task-id=' + decisionTaskId + ' --times=' + times,
                             });
                             let task = thTaskcluster.refreshTimestamps(jsyaml.safeLoad(action));
                             return queue.createTask(actionTaskId, task).then(function () {
@@ -346,7 +346,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
                                     let taskLabels = tclabels.join(',');
                                     action = template({
                                         action: 'add-tasks',
-                                        action_args: `--decision-id ${decisionTaskId} --task-labels ${taskLabels}`,
+                                        action_args: `--decision-id=${decisionTaskId} --task-labels=${taskLabels}`,
                                     });
                                     let task = thTaskcluster.refreshTimestamps(jsyaml.safeLoad(action));
                                     return queue.createTask(actionTaskId, task).then(() => `Request sent to trigger new jobs via actions.yml (${actionTaskId})`);

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -433,7 +433,7 @@ treeherder.controller('PluginCtrl', [
                                 let template = $interpolate(action);
                                 action = template({
                                     action: 'backfill',
-                                    action_args: '--project ' + $scope.repoName + ' --job ' + $scope.job.id,
+                                    action_args: '--project=' + $scope.repoName + ' --job=' + $scope.job.id,
                                 });
 
                                 let task = thTaskcluster.refreshTimestamps(jsyaml.safeLoad(action));


### PR DESCRIPTION
We currently use `--option=arg` in the decision task [1], but
`--option arg` in treeherder actions. These are essentially equivalent.
In scriptworkers' chain of trust verification, we verify the
action or decision task's command is allowlisted. To do so, we ignore
options [2]. By specifying them as `--option=arg`, we're able to skip
verifying args as well as options.

We have plans to make this better, but until then, let's use
`--option=arg`.

[1] https://hg.mozilla.org/mozilla-central/file/ab2d700fda2b/.taskcluster.yml#l111
[2] https://github.com/mozilla-releng/scriptworker/blob/8437d4cd38abe30bcfd4f8ff4dc40615481fd490/scriptworker/cot/verify.py#L903