### PR TITLE
Bug 1330773 - Rename the fetch-allthethings and AllthethingsTransformerMixin task to something that mentions RunnableJobs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -8,7 +8,7 @@ worker_store_pulse_jobs: newrelic-admin run-program celery worker -A treeherder 
 worker_store_pulse_resultsets: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q store_pulse_resultsets --concurrency=3
 worker_read_pulse_jobs: newrelic-admin run-program ./manage.py read_pulse_jobs
 worker_read_pulse_pushes: newrelic-admin run-program ./manage.py read_pulse_pushes
-worker_default: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q default,cycle_data,calculate_durations,fetch_bugs,fetch_allthethings,generate_perf_alerts,seta_analyze_failures --concurrency=3
+worker_default: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q default,cycle_data,calculate_durations,fetch_bugs,fetch_runnablejobs,generate_perf_alerts,seta_analyze_failures --concurrency=3
 worker_hp: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q classification_mirroring,publish_to_pulse --concurrency=1
 worker_log_parser: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_parser,log_parser_fail,log_store_failure_lines,log_store_failure_lines_fail,log_crossreference_error_lines,log_crossreference_error_lines_fail,log_autoclassify,log_autoclassify_fail --maxtasksperchild=50 --concurrency=7
 

--- a/bin/run_celery_worker
+++ b/bin/run_celery_worker
@@ -6,5 +6,5 @@ cd $SRC_DIR
 source /etc/profile.d/treeherder.sh
 
 exec newrelic-admin run-program celery -A treeherder worker -c 3 \
-     -Q default,cycle_data,calculate_durations,fetch_bugs,fetch_allthethings,generate_perf_alerts,seta_analyze_failures \
+     -Q default,cycle_data,calculate_durations,fetch_bugs,fetch_runnablejobs,generate_perf_alerts,seta_analyze_failures \
      -E -l INFO -n default.%h

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -254,7 +254,7 @@ CELERY_QUEUES = [
     Queue('buildapi_pending', Exchange('default'), routing_key='buildapi_pending'),
     Queue('buildapi_running', Exchange('default'), routing_key='buildapi_running'),
     Queue('buildapi_4hr', Exchange('default'), routing_key='buildapi_4hr'),
-    Queue('fetch_allthethings', Exchange('default'), routing_key='fetch_allthethings'),
+    Queue('fetch_runnablejobs', Exchange('default'), routing_key='fetch_runnablejobs'),
     Queue('cycle_data', Exchange('default'), routing_key='cycle_data'),
     Queue('calculate_durations', Exchange('default'), routing_key='calculate_durations'),
     Queue('fetch_bugs', Exchange('default'), routing_key='fetch_bugs'),
@@ -332,12 +332,12 @@ CELERYBEAT_SCHEDULE = {
             "queue": "buildapi_4hr"
         }
     },
-    'fetch-allthethings-every-day': {
-        'task': 'fetch-allthethings',
+    'fetch-runnablejobs-every-day': {
+        'task': 'fetch-runnablejobs',
         'schedule': timedelta(hours=4),
         'relative': True,
         'options': {
-            'queue': "fetch_allthethings"
+            'queue': "fetch_runnablejobs"
         }
     },
     'cycle-data-every-day': {

--- a/treeherder/etl/runnable_jobs.py
+++ b/treeherder/etl/runnable_jobs.py
@@ -23,7 +23,7 @@ from treeherder.model.models import (BuildPlatform,
 logger = logging.getLogger(__name__)
 
 
-class AllthethingsTransformerMixin:
+class RunnableJobsTransformerMixin:
 
     def transform(self, extracted_content):
         logger.info('About to import allthethings.json builder data.')
@@ -40,7 +40,7 @@ class AllthethingsTransformerMixin:
         return jobs_per_branch
 
 
-class RunnableJobsProcess(AllthethingsTransformerMixin):
+class RunnableJobsProcess(RunnableJobsTransformerMixin):
 
     # XXX: Copied from refdata.py. What is the best place for this?
     def get_option_collection_hash(self, options):

--- a/treeherder/etl/tasks/buildapi_tasks.py
+++ b/treeherder/etl/tasks/buildapi_tasks.py
@@ -36,10 +36,10 @@ def fetch_buildapi_build4h():
     Builds4hJobsProcess().run()
 
 
-@task(name='fetch-allthethings', soft_time_limit=15 * 60)
-def fetch_allthethings():
+@task(name='fetch-runnablejobs', soft_time_limit=15 * 60)
+def fetch_runnablejobs():
     """
-    Fetches possible jobs from allthethings and load them
+    Fetches possible jobs from allthethings.json and load them
     """
     RunnableJobsProcess().run()
 


### PR DESCRIPTION
Bugzilla link: https://bugzilla.mozilla.org/show_bug.cgi?id=1330773

For the fetch_allthethings task: In treeherder/Procfile and /treeherder/bin/run_celery_worker, I wasn't really sure of what it does, so I didn't rename it for now.

Could you explain me the purpose of these files and hence, if it has to be renamed as well?