### PR TITLE
Bug 1215587 - Fix graphql query with job_group change

### DIFF
--- a/tests/webapp/graphql/test_helper.py
+++ b/tests/webapp/graphql/test_helper.py
@@ -23,10 +23,10 @@ def test_optimize(query_node, push_stored):
     qs = Push.objects.filter(revision=push_stored[0]["revision"])
     field_map = {
         "jobType": ("job_type", "select"),
-        "jobGroup": ("job_type__job_group", "select"),
+        "jobGroup": ("job_group", "select"),
         "failureClassification": ("failure_classification", "prefetch"),
     }
     qs = helpers.optimize(qs, query_node, field_map)
 
     assert ('failure_classification',) == qs._prefetch_related_lookups
-    assert {'job_type': {'job_group': {}}} == qs.query.select_related
+    assert {'job_type': {}, 'job_group': {}} == qs.query.select_related

--- a/tests/webapp/graphql/test_schema.py
+++ b/tests/webapp/graphql/test_schema.py
@@ -23,3 +23,81 @@ def test_graphql_options(webapp, eleven_jobs_stored, test_repository):
                     ]
                 }}
     assert expected == response_dict
+
+
+def test_graphql_push_with_jobs(webapp, sample_push, eleven_jobs_stored, test_repository):
+    """
+    Retrieve a GraphQL set of a push and its jobs.
+    """
+    query = """
+      query pushesQuery {{
+        allPushes(revision: "{revision}") {{
+            edges {{
+              node {{
+                revision
+                repository {{
+                  name
+                }}
+                jobs (tier_Lt: 3) {{
+                  edges {{
+                    node {{
+                      guid
+                      failureClassification {{
+                        name
+                      }}
+                      jobLog {{
+                        failureLine {{
+                          test
+                        }}
+                      }}
+                      jobType {{
+                        symbol
+                      }}
+                      jobGroup {{
+                        symbol
+                      }}
+                      optionCollectionHash
+                      buildPlatform {{
+                        platform
+                      }}
+                      textLogStep {{
+                        errors {{
+                          bugSuggestions
+                        }}
+                      }}
+                    }}
+                  }}
+                }}
+              }}
+            }}
+        }}
+      }}
+    """.format(revision=sample_push[0]["revision"])
+    url = "{}?{}".format(reverse("graphql"), 'query={}'.format(query))
+    resp = webapp.post(url)
+    assert resp.status_int == 200
+    response_dict = resp.json
+    expected = {'data': {'allPushes': {'edges': [{'node': {'jobs': {
+        'edges': [{'node': {'buildPlatform': {'platform': 'b2g-emu-jb'},
+                            'failureClassification': {
+                                'name': 'not classified'},
+                            'guid': 'f1c75261017c7c5ce3000931dce4c442fe0a1297',
+                            'jobGroup': {'symbol': '?'},
+                            'jobLog': [{'failureLine': []}],
+                            'jobType': {'symbol': 'B'},
+                            'optionCollectionHash':
+                                '32faaecac742100f7753f0c1d0aa0add01b4046b',
+                            'textLogStep': []}},
+                  {'node': {'buildPlatform': {'platform': 'b2g-emu-ics'},
+                            'failureClassification': {
+                                'name': 'not classified'},
+                            'guid': '3f317a2869250b7f85876ac0cdc885923897ded2',
+                            'jobGroup': {'symbol': '?'},
+                            'jobLog': [{'failureLine': []}],
+                            'jobType': {'symbol': 'B'},
+                            'optionCollectionHash':
+                                '32faaecac742100f7753f0c1d0aa0add01b4046b',
+                            'textLogStep': []}}]},
+        'repository': {'name': 'test_treeherder_jobs'},
+        'revision': '45f8637cb9f78f19cb8463ff174e81756805d8cf'}}]}}}
+    assert expected == response_dict

--- a/treeherder/webapp/graphql/schema.py
+++ b/treeherder/webapp/graphql/schema.py
@@ -128,7 +128,7 @@ class PushGraph(DjangoObjectType):
             "buildPlatform": ("build_platform", "select"),
             "jobLog": ("job_log", "prefetch"),
             "jobType": ("job_type", "select"),
-            "jobGroup": ("job_type__job_group", "select"),
+            "jobGroup": ("job_group", "select"),
             "failureClassification": ("failure_classification", "prefetch"),
             "failureLine": ("job_log__failure_line", "prefetch"),
             "group": ("job_log__failure_line__group", "prefetch"),


### PR DESCRIPTION
Ironically, my change to job_group broke the GraphQL query optimizations due to the ``select_related`` change required.  I didn't have a test for this workflow, so I added one.