### PR TITLE
Bug 1394593 - Fix Heroku deployments with latest Python buildpack

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -23,8 +23,6 @@ source $BIN_DIR/utils
 # Only variables that are rarely changed and not site-specific should
 # be set here. Set everything else using Heroku's CLI / dashboard.
 
-set-env IS_HEROKU 1
-
 # Override the hostname that is displayed in New Relic, so the Dyno name
 # (eg "web.1") is shown, rather than "Dynamic Hostname". $DYNO is quoted
 # so that it's expanded at runtime on each dyno, rather than now.

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -14,19 +14,15 @@ yarn build
 # collectstatic, and so does not affect files in the `dist/` directory.
 python -m whitenoise.compress dist
 
-# The post_compile script is run in a sub-shell, so we need to source the
-# buildpack's utils script again, so we can use set-env/set-default-env:
-# https://github.com/heroku/heroku-buildpack-python/blob/master/bin/utils
-source $BIN_DIR/utils
-
 # Add environment variables to the profile script run on Dyno startup.
+# https://devcenter.heroku.com/articles/dynos#the-profile-file
 # Only variables that are rarely changed and not site-specific should
 # be set here. Set everything else using Heroku's CLI / dashboard.
 
-# Override the hostname that is displayed in New Relic, so the Dyno name
-# (eg "web.1") is shown, rather than "Dynamic Hostname". $DYNO is quoted
-# so that it's expanded at runtime on each dyno, rather than now.
-set-env NEW_RELIC_PROCESS_HOST_DISPLAY_NAME '$DYNO'
+# Override the hostname displayed in New Relic, so the Dyno name (eg "web.1")
+# is shown, rather than "Dynamic Hostname". Single quotes are used to so that
+# `$DYNO` is expanded at app runtime, rather than now.
+echo 'export NEW_RELIC_PROCESS_HOST_DISPLAY_NAME="${DYNO}"' >> .profile
 
 # Remove nodejs files to reduce slug size (and avoid environment variable
 # pollution from the nodejs profile script), since they are no longer

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -631,7 +631,7 @@ KEY_PREFIX = TREEHERDER_MEMCACHED_KEY_PREFIX
 # This code handles the memcachier service on heroku.
 # TODO: Stop special-casing Heroku and use newer best practices from:
 # https://www.memcachier.com/documentation#django.
-if env.bool('IS_HEROKU', default=False):
+if 'DYNO' in env:
     # Prefs taken from:
     # https://github.com/rdegges/django-heroku-memcacheify/blob/v1.0.0/memcacheify.py#L30-L39
     CACHES['default'].update({


### PR DESCRIPTION
**1) Use 'DYNO' to check if running on Heroku**
On Heroku, the environment variable `DYNO` is always set in the environment. As such, we can just use that to determine whether code is being run on Heroku, rather than having to add our own environment variable.

**2) Use .profile instead of set-env**
`set-env` was renamed in the buildpack to `set_env`, breaking this script. Rather than just renaming our usage, it makes more sense to stop using what is really an internal buildpack API and instead use `.profile`:
https://devcenter.heroku.com/articles/dynos#the-profile-file