### PR TITLE
Bug 1394779 - Fix backfilling with actions.json tasks

### DIFF
--- a/ui/js/controllers/tcjobactions.js
+++ b/ui/js/controllers/tcjobactions.js
@@ -8,6 +8,8 @@ treeherder.controller('TCJobActionsCtrl', [
              ThJobDetailModel, thTaskcluster, ThTaskclusterErrors, thNotify,
              job, repoName, resultsetId, tcactions) {
         let jsonSchemaDefaults = require('json-schema-defaults');
+        let decisionTaskId;
+        let originalTaskId;
         let originalTask;
         $scope.input = {};
 
@@ -32,8 +34,8 @@ treeherder.controller('TCJobActionsCtrl', [
             tcactions.submit({
                 action: $scope.input.selectedAction,
                 actionTaskId,
-                decisionTaskId: originalTask.taskGroupId,
-                taskId: job.taskcluster_metadata.task_id,
+                decisionTaskId,
+                taskId: originalTaskId,
                 task: originalTask,
                 input: $scope.input.jsonPayload ? JSON.parse($scope.input.jsonPayload) : undefined,
                 staticActionVariables: $scope.staticActionVariables,
@@ -55,9 +57,11 @@ treeherder.controller('TCJobActionsCtrl', [
             }
         });
 
-        ThResultSetStore.getGeckoDecisionTaskId(repoName, resultsetId).then((decisionTaskId) => {
+        ThResultSetStore.getGeckoDecisionTaskId(repoName, resultsetId).then((dtId) => {
+            decisionTaskId = dtId;
             tcactions.load(decisionTaskId, job).then((results) => {
                 originalTask = results.originalTask;
+                originalTaskId = results.originalTaskId;
                 $scope.actions = results.actions;
                 $scope.staticActionVariables = results.staticActionVariables;
                 $scope.input.selectedAction = $scope.actions[0];

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -389,7 +389,7 @@ treeherder.controller('PluginCtrl', [
                 ThResultSetStore.getGeckoDecisionTaskId(
                     $scope.repoName,
                     $scope.resultsetId).then(function (decisionTaskId) {
-                        return tcactions.load(decisionTaskId).then((results) => {
+                        return tcactions.load(decisionTaskId, $scope.job).then((results) => {
                             const tc = thTaskcluster.client();
                             const actionTaskId = tc.slugid();
                             if (results) {
@@ -400,8 +400,8 @@ treeherder.controller('PluginCtrl', [
                                         action: backfilltask,
                                         actionTaskId,
                                         decisionTaskId,
-                                        taskId: null,
-                                        task: null,
+                                        taskId: results.originalTaskId,
+                                        task: results.originalTask,
                                         input: {},
                                         staticActionVariables: results.staticActionVariables,
                                     }).then(function () {


### PR DESCRIPTION
I think I forgot this the original time around. This should make backfilling work again with bbb jobs and with tc. It would be nice if this could land in production without a long wait in stage, but is not 🔥*the-world-is-ending*🔥 urgent!

I've tried this out as much as I can from my development install. Unfortunately backfilling is hard to try out for real.