### PR TITLE
Bug 1399281 - Update nodejs from 8.4.0 to 8.5.0 and use --ignore-engines with yarn install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
     # Job 3: Nodejs UI tests
     - env: ui-tests
       language: node_js
-      node_js: "8.4.0"
+      node_js: "8.5.0"
       cache:
         # Note: This won't re-use the same cache as the linters job,
         # since caches are tied to the language/version combination.
@@ -210,7 +210,7 @@ matrix:
         - if [[ ! -f ~/venv/bin/activate ]]; then virtualenv -p python ~/venv; fi
         - source ~/venv/bin/activate
         - curl -sSfL https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz | tar -zxC $HOME/bin
-        - nvm install 8.4.0
+        - nvm install 8.5.0
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
         - yarn install --frozen-lockfile --no-bin-links

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "MPL-2.0",
   "engines": {
-    "node": "8.4.0"
+    "node": "8.5.0"
   },
   "dependencies": {
     "angular": "1.5.11",

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -103,7 +103,11 @@ pip install --require-hashes -r requirements/common.txt -r requirements/dev.txt 
 echo '-----> Running yarn install'
 # We have to use `--no-bin-links` to work around symlink issues with Windows hosts.
 # TODO: Switch the flag to a global yarn pref once yarn adds support.
-yarn install --no-bin-links
+# The node version isn't pinned in Vagrant (unlike Heroku/Travis) so we have to use
+# --ignore-engines to prevent failures when there's a new release. This will be fixed
+# as part of the move to a Docker based development environment, where the non-APT approach
+# is much simpler.
+yarn install --no-bin-links --ignore-engines
 
 echo '-----> Initialising MySQL database'
 # Re-enable blank password root logins, which are disabled by default in MySQL 5.7.


### PR DESCRIPTION
**1) Update nodejs from 8.4.0 to 8.5.0**
https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.5.0

**2) Vagrant: Use --ignore-engines with yarn install**
To prevent errors when Vagrant provisioning after a new nodejs version is released, due to version mismatch between package.json (used by Heroku) and the APT package used by Vagrant. The other option is pinning the version in Vagrant too, however we might as well wait until the Docker based development environment where state management/invalidation is simpler.