### PR TITLE
Bug 1400416 - Don't strip showOnlyImportant=1 from perfherder URLs.

### DIFF
--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -412,7 +412,7 @@ perf.controller('CompareResultsCtrl', [
             var params = {
                 framework: $scope.filterOptions.framework.id,
                 filter: $scope.filterOptions.filter,
-                showOnlyImportant: $scope.filterOptions.showOnlyImportant ? undefined : 0,
+                showOnlyImportant: $scope.filterOptions.showOnlyImportant ? 1 : undefined,
                 showOnlyConfident: $scope.filterOptions.showOnlyConfident ? 1 : undefined
             };
 


### PR DESCRIPTION
The default value for showOnlyImportant is 0, but currently showOnlyImportant=1
is stripped from the URL, because it's assumed to be the default, while
showOnlyImportant=0 is occasionally added.