### PR TITLE
Bump shared-library version to 1.9

### DIFF
--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('fxtest@1.6') _
+@Library('fxtest@1.9') _
 
 /** Desired capabilities */
 def capabilities = [


### PR DESCRIPTION
@edmorley this is largely just to keep parity with web-automation suites' shared-library versions.

Full build output; intermittent, currently-known failures: https://fx-test-jenkins-dev.stage.mozaws.net:8443/job/treeherder.adhoc/49/console

https://gist.github.com/stephendonner/05664f681ff6768d5b83cac839d09376