### PR TITLE
Bug 1400576 - Improve the expand/collapse job group markup

### DIFF
--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -16,7 +16,7 @@
 
         <!--Unclassified Failures Button-->
         <span class="btn btn-sm"
-              title="Loaded failures / Toggle filtering for unclassified failures"
+              title="Loaded failures / toggle filtering for unclassified failures"
               tabindex="0" role="button"
               ng-class="{'btn-unclassified-failures': getAllUnclassifiedFailureCount(repoName),
                          'btn-view-nav': getAllUnclassifiedFailureCount(repoName)===0}"
@@ -62,7 +62,7 @@
         <!-- Toggle Duplicate Jobs -->
         <span class="btn btn-view-nav btn-sm btn-toggle-duplicate-jobs"
               tabindex="1" role="button"
-              title="{{ showDuplicateJobs ? 'Hide Duplicate Jobs' : 'Show Duplicate Jobs' }}"
+              title="{{ showDuplicateJobs ? 'Hide duplicate jobs' : 'Show duplicate jobs' }}"
               ng-click="groupState !== 'expanded' && toggleShowDuplicateJobs()"
               ng-disabled="groupState === 'expanded'"
               ng-class="{ 'strikethrough': !showDuplicateJobs }">
@@ -83,13 +83,10 @@
           <!--Toggle Group State Button-->
           <span class="btn btn-view-nav btn-sm btn-toggle-group-state"
                 tabindex="0" role="button"
+                title="{{ groupState === 'collapsed' ? 'Expand job groups' : 'Collapse job groups' }}"
                 ng-click="toggleGroupState()">(
-            <span ng-if="groupState === 'collapsed'"
-                  class="group-state-nav-icon"
-                  title="Expand job groups">+</span>
-            <span ng-if="groupState !== 'collapsed'"
-                  class="group-state-nav-icon"
-                  title="Collapse job groups">-</span>
+            <span class="group-state-nav-icon">
+              {{ groupState === 'collapsed' ? "+" : "-" }}</span>
           )</span>
         </span>
 


### PR DESCRIPTION
This fixes Bugzilla bug [1400576](https://bugzilla.mozilla.org/show_bug.cgi?id=1400576).

This economizes the markup a bit, and ensures the tooltip will appear when hovering over the entire region of the expand/collapse job group button, not just hovering over the small area where the +/- text exists.

![jobgroupsbuttontooltip](https://user-images.githubusercontent.com/3660661/30513935-47b0dce0-9ada-11e7-9cec-36b2f390b598.jpg)

A couple of minor 'Sentence case' tweaks were included in nearby tooltips given we seem to use that style everywhere. I defer to you guys if they make sense.

Tested on OSX 10.12.6:
Nightly **57.0a1 (2017-09-05) (64-bit)**
Chrome Release **60.0.3112.113 (Official Build) (64-bit)**