### PR TITLE
Bug 1401233 - Improve the notification dropdown with a few tweaks

### DIFF
--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -380,18 +380,29 @@ fieldset[disabled] .btn-view-nav-closed.active {
 }
 
 #notification-dropdown {
-  width: 25em;
+  min-width: 25em;
   max-height: 20em;
   overflow-y: scroll;
+  padding-left: 20px;
+  padding-right: 14px;
+  white-space: nowrap;
 }
 
-#notification-dropdown .dropdown-header .label {
-  cursor: pointer;
+#notification-dropdown .dropdown-header {
+  padding-left: 0px;
+  padding-bottom: 4px;
 }
 
-#notification-dropdown li a {
+.notification-dropdown-line {
+  padding-top: 3px;
+  padding-bottom: 3px;
   overflow-x: hidden;
   text-overflow: ellipsis;
+}
+
+.notification-dropdown-btn {
+  margin-left: 4px;
+  font-size: 10px;
 }
 
 .dropdown.open > #repo-dropdown {

--- a/ui/partials/main/thGlobalTopNavPanel.html
+++ b/ui/partials/main/thGlobalTopNavPanel.html
@@ -24,13 +24,15 @@
         <ul id="notification-dropdown" class="dropdown-menu" role="menu" aria-labelledby="notificationLabel">
           <li role="presentation" class="dropdown-header" title="Notifications">
             Recent notifications
-            <span class="label label-default" ng-show="notifications().length" ng-click="clear()">Clear all</span>
+            <button class="btn btn-xs btn-default notification-dropdown-btn" title="Clear all notifications"
+                  ng-show="notifications().length" ng-click="clear()">Clear all</button>
           </li>
           <li ng-show="!notifications().length">
-            <a class="text-muted">No recent notifications</a>
+            <span>No recent notifications</span>
           </li>
-          <li ng-repeat="notification in notifications()" ng-switch on="notification.severity">
-            <a target="_blank" ng-href="{{notification.url}}" title="{{::notification.message}} {{::notification.linkText}}">
+          <li class="notification-dropdown-line" ng-repeat="notification in notifications()"
+              ng-switch on="notification.severity">
+            <span title="{{::notification.message}} {{::notification.linkText}}">
               <span ng-switch-when="danger" class="fa fa-ban text-danger"></span>
               <span ng-switch-when="warning" class="fa fa-warning text-warning"></span>
               <span ng-switch-when="info" class="fa fa-info-circle text-info"></span>
@@ -38,9 +40,9 @@
               <span ng-switch-default></span>
               <small class="text-muted">{{::notification.created | date:'short'}}</small>
               {{::notification.message}}
-              <u>{{::notification.linkText}}</u>
-              <span ng-if="notification.url" class="fa fa-link text-muted"></span>
-            </a>
+              <a ng-if="true" target="_blank"
+                 ng-href="{{notification.url}}">{{::notification.linkText}}</a>
+            </span>
           </li>
         </ul>
       </span>


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1401233](https://bugzilla.mozilla.org/show_bug.cgi?id=1401233).

This prevents typical notifications from being unreadable because they overflow the fixed width property on the dropdown.

Current:
![current](https://user-images.githubusercontent.com/3660661/30601288-92a21b86-9d2f-11e7-9186-467a2677dfe3.jpg)

Proposed:
![proposed](https://user-images.githubusercontent.com/3660661/30601299-99ebe836-9d2f-11e7-9dfb-69daf2f7f741.jpg)

Tested on OSX 10.12.6:
Nightly **57.0a1 (2017-09-16) (64-bit)**
Chrome Release **61.0.3163.91 (Official Build) (64-bit)**