### PR TITLE
Bug 1403195 - Fix styling and mismatched tags in userguide.html

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -28,7 +28,7 @@
             <div id="th-global-content" class="th-global-content"
                  ng-click="clearJobOnClick($event)">
                 <span class="th-view-content" ng-cloak>
-                    <ng-view ></ng-view>
+                    <ng-view></ng-view>
                 </span>
             </div>
             <div ng-controller="PluginCtrl"

--- a/ui/userguide.html
+++ b/ui/userguide.html
@@ -140,19 +140,21 @@
             <div class="panel-body panel-spacing">
               <table id="shortcuts">
                 <tr>
-                  <td><span class="kbd">ctrl/cmd</span>+<span class="kbd">c</td>
+                  <td><kbd>ctrl/cmd</kbd><kbd>c</kbd></td>
                   <td>Copy job details
                     <img src="./img/logviewerIconHelp.svg" id="ug-logviewer-icon">
-                    </span> logviewer url on hover</td>
+                    logviewer url on hover
+                  </td>
                 </tr>
                 <tr>
-                  <td><span class="kbd">ctrl/cmd</span>+<span class="kbd">c</td>
+                  <td><kbd>ctrl/cmd</kbd><kbd>c</kbd></td>
                   <td>Copy job details
-                    <span id="ug-raw-log-icon" class="fa fa-file-text-o">
-                    </span> raw log url on hover</td>
+                    <span id="ug-raw-log-icon" class="fa fa-file-text-o"></span>
+                    raw log url on hover
+                  </td>
                 </tr>
                 <tr>
-                  <td><span class="kbd">ctrl/cmd</span>+<span class="kbd">c</td>
+                  <td><kbd>ctrl/cmd</kbd><kbd>c</kbd></td>
                   <td>Copy job details <span class="small"><label>Job:</label>
                     <span id="ug-job-name">name</span></span> as raw text on hover
                   </td>


### PR DESCRIPTION
The `class='kbd'` usages were missed from the changes in bug 1339508. 
The mismatched tags have been present since the original landing in bug 1139421.

**Before:**

![userguide-copyonhover-before](https://user-images.githubusercontent.com/501702/30868563-ef522626-a2d6-11e7-82a5-6dbbd4045aa1.png)

...plus validation errors.

**After:**

![userguide-copyonhover-after](https://user-images.githubusercontent.com/501702/30868570-f36844e8-a2d6-11e7-94c2-f8797d4a436e.png)

...with no validation errors.

Also removes a stray space from index.html.