### PR TITLE
Move fxtest-library include into pipeline block

### DIFF
--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -1,5 +1,3 @@
-@Library('fxtest@1.9') _
-
 /** Desired capabilities */
 def capabilities = [
   browserName: 'Firefox',
@@ -9,6 +7,9 @@ def capabilities = [
 
 pipeline {
   agent any
+  libraries {
+    lib('fxtest@1.9')
+  }
   options {
     ansiColor('xterm')
     timestamps()


### PR DESCRIPTION
@edmorley @davehunt r?

This was suggested to us a while back by a core Jenkins project member, and nearly all other web-automation projects have it; just bringing this up to parity.

Full build output: https://gist.github.com/stephendonner/0ee5ee9ce654b9f7ad76c7c3df1b68d9 (usual intermittent failures)