### PR TITLE
Bug 1404076 - Make link to test-based ui more prominent

### DIFF
--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -25,6 +25,10 @@
     </span>
     <th-result-counts class="result-counts"></th-result-counts>
     <span class="result-set-buttons">
+      <a class="btn btn-sm btn-resultset test-view-btn"
+         href="{{testBasedUIHost}}?repo={{repoName}}&revision={{resultset.revision}}"
+         target="_blank"
+         title="View details on failed test results for this push">View Tests</a>
       <button class="btn btn-sm btn-resultset cancel-all-jobs-btn"
             ng-attr-title="{{getCancelJobsTitle()}}"
             ng-show="currentRepo.is_try_repo || user.is_staff"

--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -39,8 +39,6 @@
            href=""
            ng-click="customPushAction()"
            title="View/Edit/Submit Action tasks for this push">Custom Push Action...</a></li>
-    <li><a target="_blank" title="Prototype of a Treeherder UI centered on tests, rather than jobs"
-           href="{{testBasedUIHost}}?repo={{repoName}}&revision={{resultset.revision}}"><strong>Experimental:</strong> Test-Centric UI</a></li>
     <li><a target="_blank"
            href="{{toChangeValue()}}&tochange={{resultset.revision}}" prevent-default-on-left-click
            ng-click="setLocationSearchParam('tochange', resultset.revision)">Set as top of range</a></li>


### PR DESCRIPTION
This addresses [Bug 1404076](https://bugzilla.mozilla.org/show_bug.cgi?id=1404076)

Moves the link to the Test-based UI show on the Push status bar rather than in the action menu.  Text styling matches "Add new jobs".

![screenshot 2017-09-28 12 53 41](https://user-images.githubusercontent.com/419924/30987583-63dc257a-a44c-11e7-929c-d725354b2974.png)
