### PR TITLE
Bug 1364894 - Lint fixes to prepare for Neutrino v7's updated eslint

### DIFF
--- a/ui/entry-failureviewer.js
+++ b/ui/entry-failureviewer.js
@@ -1,4 +1,5 @@
 'use strict';
+
 // Webpack entry point for failurereviewer.html
 // Scripts and styles included here are automatically included on the page at build time
 

--- a/ui/entry-index.js
+++ b/ui/entry-index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 // Webpack entry point for index.html
 // Scripts and styles included here are automatically included on the page at build time
 require('./js/config');

--- a/ui/entry-logviewer.js
+++ b/ui/entry-logviewer.js
@@ -1,4 +1,5 @@
 'use strict';
+
 // Webpack entry point for logviewer.html
 // Scripts and styles included here are automatically included on the page at build time
 require('./js/config');

--- a/ui/entry-perf.js
+++ b/ui/entry-perf.js
@@ -1,4 +1,5 @@
 'use strict';
+
 // Webpack entry point for perf.html
 // Scripts and styles included here are automatically included on the page at build time
 

--- a/ui/entry-userguide.js
+++ b/ui/entry-userguide.js
@@ -1,4 +1,5 @@
 'use strict';
+
 // Webpack entry point for userguide.html
 // Scripts and styles included here are automatically included on the page at build time
 

--- a/ui/js/cache-templates.js
+++ b/ui/js/cache-templates.js
@@ -1,4 +1,5 @@
 'use strict';
+
 // This is a run block which, when used on an angular module, loads all
 // of the partials in /ui/partials and /ui/plugins into the Angular
 // template cache. This means that ng-includes and templateUrls will not

--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -246,7 +246,7 @@ treeherder.controller('BugFilerCtrl', [
                                             addProduct(suggested[0] + " :: " + suggested[1]);
                                         }
                                         // Only get rid of the throbber when all of these searches have completed
-                                        resultsCount = resultsCount - 1;
+                                        resultsCount -= 1;
                                         if (resultsCount === 0) {
                                             $scope.searching = false;
                                             injectProducts(failurePath);

--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -19,8 +19,8 @@ treeherderApp.controller('JobsCtrl', [
                 $location.search('revision', null);
                 $location.search('tochange', revision);
             }
-            ThResultSetStore.fetchResultSets($scope.repoName, count, keepFilters).
-                then(function () {
+            ThResultSetStore.fetchResultSets($scope.repoName, count, keepFilters)
+                .then(function () {
 
                     // since we fetched more resultsets, we need to persist the
                     // resultset state in the URL.

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -111,7 +111,7 @@ logViewerApp.controller('LogviewerCtrl', [
                 project_specific_id: $scope.job_id
             }).then(function (jobList) {
                 if (jobList.length > 0) {
-                    $scope.job_id = jobList[0]['id'];
+                    $scope.job_id = jobList[0].id;
                 }
                 ThJobModel.get($scope.repoName, $scope.job_id).then((job) => {
                     // set the title of the browser window/tab

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -182,7 +182,7 @@ logViewerApp.controller('LogviewerCtrl', [
 
                 // load the first failure step line else load the head
                 if (allErrors.length) {
-                    $scope.css = $scope.css + errorLinesCss(allErrors);
+                    $scope.css += errorLinesCss(allErrors);
 
                     if (!q.lineNumber) {
                         $scope.logPostMessage({ lineNumber: allErrors[0].line_number + 1, customStyle: $scope.css });
@@ -263,7 +263,7 @@ logViewerApp.controller('LogviewerCtrl', [
                 if (!workerReady) {
                     workerReady = true;
 
-                    $scope.css = $scope.css + logCss();
+                    $scope.css += logCss();
                     $scope.logPostMessage({ customStyle: $scope.css });
                 }
 

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -248,8 +248,7 @@ logViewerApp.controller('LogviewerCtrl', [
 
             if (highlightStart !== highlightEnd) {
                 $location.search('lineNumber', `${highlightStart}-${highlightEnd}`).replace();
-            }
-            else if (highlightStart) {
+            } else if (highlightStart) {
                 $location.search('lineNumber', highlightStart).replace();
             } else {
                 $location.search('lineNumber', lineNumber).replace();

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -90,7 +90,7 @@ treeherderApp.controller('MainCtrl', [
             // repoName is undefined for the first few title update attempts, show something sensible
             var title = "[" + ufc + "] " + ($rootScope.repoName ? $rootScope.repoName : "Treeherder");
 
-            if (params["revision"]) {
+            if (params.revision) {
                 var desc = getSingleRevisionTitleString();
                 var revtitle = desc[0] ? ": " + desc[0] : "";
                 var percentage = desc[1] ? desc[1] + "% - " : "";
@@ -630,13 +630,13 @@ treeherderApp.controller('MainCtrl', [
 
         $scope.fromChangeValue = function () {
             let url = window.location.href;
-            url = url.replace("&fromchange=" + $location.search()["fromchange"], "");
+            url = url.replace("&fromchange=" + $location.search().fromchange, "");
             return url;
         };
 
         $scope.toChangeValue = function () {
             let url = window.location.href;
-            url = url.replace("&tochange=" + $location.search()["tochange"], "");
+            url = url.replace("&tochange=" + $location.search().tochange, "");
             return url;
         };
 

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -574,7 +574,7 @@ treeherderApp.controller('MainCtrl', [
         };
 
         $scope.getFiltersForBar = function () {
-            return [ ...thJobFilters.getNonFieldFiltersArray(), ...thJobFilters.getFieldFiltersArray() ];
+            return [...thJobFilters.getNonFieldFiltersArray(), ...thJobFilters.getFieldFiltersArray()];
         };
 
         // field filters

--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -247,8 +247,10 @@ perf.controller('CompareResultsCtrl', [
 
                 PhSeries.getSeriesList(
                     $scope.originalProject.name,
-                    { interval: timeRange, subtests: 0,
-                        framework: $scope.filterOptions.framework.id
+                    {
+                        interval: timeRange,
+                        subtests: 0,
+                        framework: $scope.filterOptions.framework.id,
                     }).then(
                         function (originalSeriesList) {
                             $scope.platformList = _.uniq(
@@ -271,8 +273,11 @@ perf.controller('CompareResultsCtrl', [
 
                             PhSeries.getSeriesList(
                                 $scope.newProject.name,
-                                { interval: timeRange, subtests: 0,
-                                    framework: $scope.filterOptions.framework.id }).then(
+                                {
+                                    interval: timeRange,
+                                    subtests: 0,
+                                    framework: $scope.filterOptions.framework.id,
+                                }).then(
                                     function (newSeriesList) {
                                         $scope.platformList = _.union(
                                             $scope.platformList,
@@ -307,22 +312,28 @@ perf.controller('CompareResultsCtrl', [
                 }).then(function (resultsMap) {
                     var originalResultsMap = resultsMap;
                     PhSeries.getSeriesList(
-                        $scope.newProject.name, {
-                            interval: $scope.selectedTimeRange.value, subtests: 0,
-                            framework: $scope.filterOptions.framework.id }).then(
-                                function (newSeriesList) {
-                                    $scope.platformList = _.union($scope.platformList,
-                                        _.uniq(_.map(newSeriesList, 'platform')));
-                                    $scope.testList = _.union($scope.testList,
-                                        _.uniq(_.map(newSeriesList, 'name')));
-                                    return PhCompare.getResultsMap($scope.newProject.name,
+                        $scope.newProject.name,
+                        {
+                            interval: $scope.selectedTimeRange.value,
+                            subtests: 0,
+                            framework: $scope.filterOptions.framework.id,
+                        }).then(function (newSeriesList) {
+                            $scope.platformList = _.union(
+                                $scope.platformList,
+                                _.uniq(_.map(newSeriesList, 'platform'))
+                            );
+                            $scope.testList = _.union(
+                                $scope.testList,
+                                _.uniq(_.map(newSeriesList, 'name'))
+                            );
+                            return PhCompare.getResultsMap($scope.newProject.name,
                                                             newSeriesList,
                                                             { pushIDs: [$scope.newResultSet.id] });
-                                }).then(function (resultMaps) {
-                                    var newResultsMap = resultMaps[$scope.newResultSet.id];
-                                    $scope.dataLoading = false;
-                                    displayResults(originalResultsMap, newResultsMap);
-                                });
+                        }).then(function (resultMaps) {
+                            var newResultsMap = resultMaps[$scope.newResultSet.id];
+                            $scope.dataLoading = false;
+                            displayResults(originalResultsMap, newResultsMap);
+                        });
                 });
             }
         }

--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -103,8 +103,7 @@ perf.controller('CompareChooserCtrl', [
                                 newProject: $scope.newProject.name,
                                 newRevision: $scope.newRevision
                             });
-                        }
-                        else {
+                        } else {
                             $state.go('compare', {
                                 originalProject: $scope.originalProject.name,
                                 newProject: $scope.newProject.name,
@@ -135,8 +134,7 @@ perf.controller('CompareResultsCtrl', [
             $scope.titles = {};
             if ($scope.originalRevision) {
                 window.document.title = `Comparison between ${$scope.originalRevision} (${$scope.originalProject.name}) and ${$scope.newRevision} (${$scope.newProject.name})`;
-            }
-            else {
+            } else {
                 window.document.title = `Comparison between ${$scope.originalProject.name} and ${$scope.newRevision} (${$scope.newProject.name})`;
             }
 
@@ -188,9 +186,7 @@ perf.controller('CompareResultsCtrl', [
                             }), [$scope.originalResultSet,
                                 $scope.newResultSet])
                         });
-                    }
-
-                    else {
+                    } else {
                         if (testName.indexOf("summary") > 0) {
                             var detailsLink = 'perf.html#/comparesubtest?';
                             detailsLink += $httpParamSerializer({
@@ -293,8 +289,7 @@ perf.controller('CompareResultsCtrl', [
                                         displayResults(originalResultsMap, resultMaps[$scope.newResultSet.id]);
                                     });
                         });
-            }
-            else {
+            } else {
                 // using a range of data for baseline comparison
                 var originalSeriesList;
                 originalSeriesList = PhSeries.getSeriesList($scope.originalProject.name, {
@@ -420,8 +415,7 @@ perf.controller('CompareResultsCtrl', [
             if ($stateParams.originalRevision) {
                 $scope.originalRevision = $stateParams.originalRevision;
                 verifyPromises.push(verifyRevision($scope.originalProject, $scope.originalRevision, "original"));
-            }
-            else {
+            } else {
                 $scope.timeRanges = phTimeRanges;
                 $scope.selectedTimeRange = _.find($scope.timeRanges, {
                     value: ($stateParams.selectedTimeRange) ? parseInt($stateParams.selectedTimeRange) : compareBaseLineDefaultTimeRange
@@ -545,9 +539,7 @@ perf.controller('CompareSubtestResultsCtrl', [
                             })
                         });
                     }
-                }
-
-                else {
+                } else {
                     cmap.links = [{
                         title: 'graph',
                         href: PhCompare.getGraphsLink(_.map(_.uniq([
@@ -598,8 +590,7 @@ perf.controller('CompareSubtestResultsCtrl', [
             if ($stateParams.originalRevision) {
                 $scope.originalRevision = $stateParams.originalRevision;
                 verifyPromises.push(verifyRevision($scope.originalProject, $scope.originalRevision, "original"));
-            }
-            else {
+            } else {
                 $scope.timeRanges = phTimeRanges;
                 $scope.selectedTimeRange = _.find($scope.timeRanges, {
                     value: ($stateParams.selectedTimeRange) ? parseInt($stateParams.selectedTimeRange) : compareBaseLineDefaultTimeRange
@@ -736,14 +727,12 @@ perf.controller('CompareSubtestResultsCtrl', [
                                 $scope.dataLoading = false;
                                 displayResults(originalSeriesMap, newSeriesMap);
                             });
-                        }
-                        else {
+                        } else {
                             $scope.dataLoading = false;
                             displayResults(originalSeriesMap, {});
                         }
                     });
-                }
-                else {
+                } else {
                     $q.all([
                         PhSeries.getSeriesList(
                             $scope.originalProject.name, {
@@ -799,8 +788,7 @@ perf.controller('CompareSubtestResultsCtrl', [
                                     $scope.dataLoading = false;
                                     displayResults(originalSeriesMap, newSeriesMap);
                                 });
-                            }
-                            else {
+                            } else {
                                 $scope.dataLoading = false;
                                 displayResults(originalSeriesMap, {});
                             }

--- a/ui/js/controllers/perf/dashboard.js
+++ b/ui/js/controllers/perf/dashboard.js
@@ -150,7 +150,8 @@ perf.controller('dashCtrl', [
                                         $scope.compareResults[testName].push(cmap);
                                     }
                                 }
-                            } });
+                            }
+                        });
                     });
                 });
             });

--- a/ui/js/controllers/perf/dashboard.js
+++ b/ui/js/controllers/perf/dashboard.js
@@ -104,19 +104,19 @@ perf.controller('dashCtrl', [
                     $scope.testList.forEach(function (testName) {
                         $scope.titles[testName] = testName;
                         $scope.platformList.forEach(function (platform) {
-                            var baseSig = _.find(Object.keys(resultsMap['base']), function (sig) {
-                                return resultsMap['base'][sig].name === testName &&
-                                    resultsMap['base'][sig].platform === platform;
+                            var baseSig = _.find(Object.keys(resultsMap.base), function (sig) {
+                                return resultsMap.base[sig].name === testName &&
+                                    resultsMap.base[sig].platform === platform;
                             });
-                            var variantSig = _.find(Object.keys(resultsMap['variant']), function (sig) {
-                                return resultsMap['variant'][sig].name === testName &&
-                                    resultsMap['variant'][sig].platform === platform;
+                            var variantSig = _.find(Object.keys(resultsMap.variant), function (sig) {
+                                return resultsMap.variant[sig].name === testName &&
+                                    resultsMap.variant[sig].platform === platform;
                             });
                             if (variantSig && baseSig) {
                                 var cmap = PhCompare.getCounterMap(
-                                    testName, resultsMap['base'][baseSig],
-                                    resultsMap['variant'][variantSig], phBlockers);
-                                cmap.name = platform + ' ' + resultsMap['base'][baseSig].option;
+                                    testName, resultsMap.base[baseSig],
+                                    resultsMap.variant[variantSig], phBlockers);
+                                cmap.name = platform + ' ' + resultsMap.base[baseSig].option;
                                 cmap.links = [{
                                     title: 'graph',
                                     href: PhCompare.getGraphsLink(
@@ -128,7 +128,7 @@ perf.controller('dashCtrl', [
                                             };
                                         }))
                                 }];
-                                if (resultsMap['base'][baseSig].hasSubTests) {
+                                if (resultsMap.base[baseSig].hasSubTests) {
                                     var params = {
                                         topic: $stateParams.topic,
                                         baseSignature: baseSig,
@@ -299,21 +299,21 @@ perf.controller('dashSubtestCtrl', [
                         });
                 })).then(function () {
                     $scope.dataLoading = false;
-                    var subtestNames = _.map(resultsMap['base'],
+                    var subtestNames = _.map(resultsMap.base,
                                              function (results) {
                                                  return results.name;
                                              });
                     _.forEach(subtestNames, function (subtestName) {
-                        var baseSig = _.find(Object.keys(resultsMap['base']), function (sig) {
-                            return resultsMap['base'][sig].name === subtestName;
+                        var baseSig = _.find(Object.keys(resultsMap.base), function (sig) {
+                            return resultsMap.base[sig].name === subtestName;
                         });
-                        var variantSig = _.find(Object.keys(resultsMap['variant']), function (sig) {
-                            return resultsMap['variant'][sig].name === subtestName;
+                        var variantSig = _.find(Object.keys(resultsMap.variant), function (sig) {
+                            return resultsMap.variant[sig].name === subtestName;
                         });
                         if (variantSig && baseSig) {
                             var cmap = PhCompare.getCounterMap(
-                                subtestName, resultsMap['base'][baseSig],
-                                resultsMap['variant'][variantSig]);
+                                subtestName, resultsMap.base[baseSig],
+                                resultsMap.variant[variantSig]);
                             cmap.name = subtestName;
                             cmap.links = [{
                                 title: 'graph',

--- a/ui/js/controllers/perf/dashboard.js
+++ b/ui/js/controllers/perf/dashboard.js
@@ -255,13 +255,13 @@ perf.controller('dashSubtestCtrl', [
                     $scope.selectedRepo.name, $scope.revision).then(function (resultSets) {
                         resultSetId = resultSets[0].id;
                         return PhSeries.getSeriesList($scope.selectedRepo.name, {
-                            parent_signature: [ baseSignature, variantSignature ],
+                            parent_signature: [baseSignature, variantSignature],
                             framework: $scope.framework
                         });
                     });
             } else {
                 getSeriesList = PhSeries.getSeriesList($scope.selectedRepo.name, {
-                    parent_signature: [ baseSignature, variantSignature ],
+                    parent_signature: [baseSignature, variantSignature],
                     framework: $scope.framework
                 });
             }

--- a/ui/js/controllers/perf/e10s-trend.js
+++ b/ui/js/controllers/perf/e10s-trend.js
@@ -41,7 +41,7 @@ perf.controller('e10sTrendCtrl', [
                 baseResults[baseTestName].forEach(function (baseResult) {
                     if (newResults[baseTestName]) {
                         var newResult = newResults[baseTestName];
-                        newResult = _.find(newResult, function (obj) { return obj.name === baseResult['name']; });
+                        newResult = _.find(newResult, function (obj) { return obj.name === baseResult.name; });
                         if (match) {
                             var trendResult = PhCompare.getTrendMap(baseTestName, baseResult, newResult);
                             if (!$scope.compareResults[baseTestName]) {
@@ -111,19 +111,19 @@ perf.controller('e10sTrendCtrl', [
                     testList.forEach(function (testName) {
                         $scope.titles[testName] = testName;
                         platformList.forEach(function (platform) {
-                            var baseSig = _.find(Object.keys(resultsMap['base']), function (sig) {
-                                return resultsMap['base'][sig].name === testName &&
-                                    resultsMap['base'][sig].platform === platform;
+                            var baseSig = _.find(Object.keys(resultsMap.base), function (sig) {
+                                return resultsMap.base[sig].name === testName &&
+                                    resultsMap.base[sig].platform === platform;
                             });
-                            var e10sSig = _.find(Object.keys(resultsMap['e10s']), function (sig) {
-                                return resultsMap['e10s'][sig].name === testName &&
-                                    resultsMap['e10s'][sig].platform === platform;
+                            var e10sSig = _.find(Object.keys(resultsMap.e10s), function (sig) {
+                                return resultsMap.e10s[sig].name === testName &&
+                                    resultsMap.e10s[sig].platform === platform;
                             });
                             if (e10sSig && baseSig) {
                                 var cmap = PhCompare.getCounterMap(
-                                    testName, resultsMap['base'][baseSig],
-                                    resultsMap['e10s'][e10sSig], phBlockers);
-                                cmap.name = platform + ' ' + resultsMap['base'][baseSig].option;
+                                    testName, resultsMap.base[baseSig],
+                                    resultsMap.e10s[e10sSig], phBlockers);
+                                cmap.name = platform + ' ' + resultsMap.base[baseSig].option;
                                 cmap.links = [{
                                     title: 'graph',
                                     href: PhCompare.getGraphsLink(
@@ -135,7 +135,7 @@ perf.controller('e10sTrendCtrl', [
                                             };
                                         }))
                                 }];
-                                if (resultsMap['base'][baseSig].hasSubTests) {
+                                if (resultsMap.base[baseSig].hasSubTests) {
                                     var params = {
                                         repo: $scope.selectedRepo.name,
                                         basedate: $scope.selectedBaseDate.value,
@@ -292,7 +292,7 @@ perf.controller('e10sTrendSubtestCtrl', [
                 baseResults[baseTestName].forEach(function (baseResult) {
                     if (newResults[baseTestName]) {
                         var newResult = newResults[baseTestName];
-                        newResult = _.find(newResult, function (obj) { return obj.name === baseResult['name']; });
+                        newResult = _.find(newResult, function (obj) { return obj.name === baseResult.name; });
                         if (match) {
                             var trendResult = PhCompare.getTrendMap(baseTestName, baseResult, newResult);
                             if (!$scope.compareResults[baseTestName]) {
@@ -356,21 +356,21 @@ perf.controller('e10sTrendSubtestCtrl', [
                         });
                     });
                 })).then(function () {
-                    var subtestNames = _.map(resultsMap['base'],
+                    var subtestNames = _.map(resultsMap.base,
                                              function (results) {
                                                  return results.name;
                                              });
                     _.forEach(subtestNames, function (subtestName) {
-                        var baseSig = _.find(Object.keys(resultsMap['base']), function (sig) {
-                            return resultsMap['base'][sig].name === subtestName;
+                        var baseSig = _.find(Object.keys(resultsMap.base), function (sig) {
+                            return resultsMap.base[sig].name === subtestName;
                         });
-                        var e10sSig = _.find(Object.keys(resultsMap['e10s']), function (sig) {
-                            return resultsMap['e10s'][sig].name === subtestName;
+                        var e10sSig = _.find(Object.keys(resultsMap.e10s), function (sig) {
+                            return resultsMap.e10s[sig].name === subtestName;
                         });
                         if (e10sSig && baseSig) {
                             var cmap = PhCompare.getCounterMap(
-                                subtestName, resultsMap['base'][baseSig],
-                                resultsMap['e10s'][e10sSig]);
+                                subtestName, resultsMap.base[baseSig],
+                                resultsMap.e10s[e10sSig]);
                             cmap.name = subtestName;
                             cmap.links = [{
                                 title: 'graph',

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -11,7 +11,7 @@ perf.controller('GraphsCtrl', [
         var availableColors = ['maroon', 'navy', 'pink', 'turquoise', 'brown',
             'red', 'green', 'blue', 'orange', 'purple'];
 
-        $scope.highlightedRevisions = [ undefined, undefined ];
+        $scope.highlightedRevisions = [undefined, undefined];
         $scope.highlightAlerts = true;
         $scope.loadingGraphs = false;
 

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -773,7 +773,7 @@ perf.controller('GraphsCtrl', [
                     $scope.highlightAlerts = parseInt($stateParams.highlightAlerts);
                 }
                 if ($stateParams.highlightedRevisions) {
-                    if (typeof($stateParams.highlightedRevisions) === 'string') {
+                    if (typeof ($stateParams.highlightedRevisions) === 'string') {
                         $scope.highlightedRevisions = [$stateParams.highlightedRevisions];
                     } else {
                         $scope.highlightedRevisions = $stateParams.highlightedRevisions;

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -626,8 +626,7 @@ perf.controller('GraphsCtrl', [
                 let params = { framework: partialSeries.frameworkId };
                 if (partialSeries.id) {
                     params.id = partialSeries.id;
-                }
-                else {
+                } else {
                     params.signature = partialSeries.signature;
                 }
                 return PhSeries.getSeriesList(

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -198,12 +198,23 @@ perf.controller('GraphsCtrl', [
                     // get new tip position after transform
                     tipPosition = getTipPosition(tip, x, y, 10);
                     if (tip.css('visibility') === 'hidden') {
-                        tip.css({ opacity: 0, visibility: 'visible', left: tipPosition.left,
-                            top: tipPosition.top + 10 });
-                        tip.animate({ opacity: 1, left: tipPosition.left,
-                            top: tipPosition.top }, 250);
+                        tip.css({
+                            opacity: 0,
+                            visibility: 'visible',
+                            left: tipPosition.left,
+                            top: tipPosition.top + 10,
+                        });
+                        tip.animate({
+                            opacity: 1,
+                            left: tipPosition.left,
+                            top: tipPosition.top
+                        }, 250);
                     } else {
-                        tip.css({ opacity: 1, left: tipPosition.left, top: tipPosition.top });
+                        tip.css({
+                            opacity: 1,
+                            left: tipPosition.left,
+                            top: tipPosition.top,
+                        });
                     }
                 });
             }, 250);
@@ -1086,7 +1097,8 @@ perf.controller('TestChooserCtrl', ['$scope', '$uibModalInstance', '$http',
                     }
                     PhSeries.getSeriesList(
                         $scope.selectedProject.name,
-                        { interval: $scope.timeRange, platform: $scope.selectedPlatform,
+                        { interval: $scope.timeRange,
+                            platform: $scope.selectedPlatform,
                             framework: $scope.selectedFramework.id,
                             subtests: $scope.includeSubtests ? 1 : 0 }).then(function (seriesList) {
                                 $scope.unselectedTestList = _.sortBy(

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -575,7 +575,7 @@ perf.controller('GraphsCtrl', [
                     }
                     $scope.zoom = [];
                     return $scope.zoom;
-                })(),
+                }()),
                 selected: (function () {
                     return ($scope.selectedDataPoint) ? "[" + [$scope.selectedDataPoint.projectName,
                         $scope.selectedDataPoint.signature,
@@ -583,7 +583,7 @@ perf.controller('GraphsCtrl', [
                         $scope.selectedDataPoint.id,
                         $scope.selectedDataPoint.frameworkId]
                         + "]" : undefined;
-                })()
+                }())
             }, {
                 location: true,
                 inherit: true,

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -259,7 +259,7 @@ perf.controller('GraphsCtrl', [
                 var selectedSeries = $scope.seriesList[selectedSeriesIndex];
                 var flotDataPoint = selectedSeries.flotSeries.idData.indexOf(
                     $scope.selectedDataPoint.id);
-                flotDataPoint = flotDataPoint ? flotDataPoint : selectedSeries.flotSeries.resultSetData.indexOf(
+                flotDataPoint = flotDataPoint || selectedSeries.flotSeries.resultSetData.indexOf(
                     $scope.selectedDataPoint.resultSetId);
                 $scope.plot.highlight(selectedSeriesIndex, flotDataPoint);
             }
@@ -893,7 +893,7 @@ perf.controller('TestChooserCtrl', ['$scope', '$uibModalInstance', '$http',
         $scope.timeRange = timeRange;
         $scope.projects = projects;
         $scope.selectedProject = _.find(projects, {
-            name: defaultProjectName ? defaultProjectName : thDefaultRepo
+            name: defaultProjectName || thDefaultRepo
         });
         $scope.includeSubtests = false;
         $scope.loadingTestData = false;

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -143,7 +143,7 @@ perf.controller('GraphsCtrl', [
                     deltaValue: dv.toFixed(1),
                     deltaPercentValue: (100 * dvp).toFixed(1),
                     date: $.plot.formatDate(new Date(t), '%a %b %d, %H:%M:%S'),
-                    retriggers: (retriggerNum['retrigger'] - 1),
+                    retriggers: (retriggerNum.retrigger - 1),
                     alertSummary: alertSummary,
                     revisionInfoAvailable: true,
                     alert: alert
@@ -336,27 +336,27 @@ perf.controller('GraphsCtrl', [
 
         function zoomGraph() {
             // If either x or y exists then there is zoom set in the variable
-            if ($scope.zoom['x']) {
+            if ($scope.zoom.x) {
                 if (_.find($scope.seriesList, function (series) { return series.visible; })) {
                     $.each($scope.plot.getXAxes(), function (_, axis) {
                         var opts = axis.options;
-                        opts.min = $scope.zoom['x'][0];
-                        opts.max = $scope.zoom['x'][1];
+                        opts.min = $scope.zoom.x[0];
+                        opts.max = $scope.zoom.x[1];
                     });
                     $.each($scope.plot.getYAxes(), function (_, axis) {
                         var opts = axis.options;
-                        opts.min = $scope.zoom['y'][0];
-                        opts.max = $scope.zoom['y'][1];
+                        opts.min = $scope.zoom.y[0];
+                        opts.max = $scope.zoom.y[1];
                     });
                     $scope.plot.setupGrid();
                     $scope.overviewPlot.setSelection({
                         xaxis: {
-                            from: $scope.zoom['x'][0],
-                            to: $scope.zoom['x'][1]
+                            from: $scope.zoom.x[0],
+                            to: $scope.zoom.x[1]
                         },
                         yaxis: {
-                            from: $scope.zoom['y'][0],
-                            to: $scope.zoom['y'][1]
+                            from: $scope.zoom.y[0],
+                            to: $scope.zoom.y[1]
                         }
                     }, true);
                     $scope.overviewPlot.draw();
@@ -558,8 +558,8 @@ perf.controller('GraphsCtrl', [
                     if ((typeof $scope.zoom.x !== "undefined")
                         && (typeof $scope.zoom.y !== "undefined")
                         && ($scope.zoom.x !== 0 && $scope.zoom.y !== 0)) {
-                        var modifiedZoom = ("[" + ($scope.zoom['x'].toString()
-                                + ',' + $scope.zoom['y'].toString()) + "]").replace(/[\[\{\}\]"]+/g, '');
+                        var modifiedZoom = ("[" + ($scope.zoom.x.toString()
+                                + ',' + $scope.zoom.y.toString()) + "]").replace(/[\[\{\}\]"]+/g, '');
                         return modifiedZoom;
                     }
                     $scope.zoom = [];

--- a/ui/js/controllers/settings.js
+++ b/ui/js/controllers/settings.js
@@ -1,4 +1,5 @@
 "use strict";
+
 treeherderApp.controller('SettingsCtrl',
     function SheriffController() {
     }

--- a/ui/js/controllers/userguide.js
+++ b/ui/js/controllers/userguide.js
@@ -1,6 +1,6 @@
 "use strict";
 
 userguideApp.controller('UserguideCtrl',
-	function () {
-}
+    function () {
+    }
 );

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -729,7 +729,7 @@ treeherder.directive('thCloneJobs', [
                     if (orderedPlatforms[p] === platformName) {
                         //Target row for appending should be one less
                         //than the position of the platform name
-                        $(tableRows[ p - 1 ]).after(rowEl);
+                        $(tableRows[p - 1]).after(rowEl);
                         break;
                     }
                 }

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -982,7 +982,8 @@ treeherder.directive('thCloneJobs', [
                 //Add platforms
                 rowHtml += platformInterpolator(
                     {
-                        name: thPlatformName(platform.name), option: platform.option,
+                        name: thPlatformName(platform.name),
+                        option: platform.option,
                         id: thAggregateIds.getPlatformRowId(
                             resultset.id,
                             platform.name,

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -269,7 +269,7 @@ treeherder.directive('thCloneJobs', [
             jobStatus.title = getHoverText(job);
             jobStatus.extraClasses = "";
             jobStatus.extraClasses += job.visible ? " filter-shown" : "";
-            if ( !_.isEmpty(lastJobSelected.job) &&
+            if (!_.isEmpty(lastJobSelected.job) &&
                 (lastJobSelected.job.id === job.id)) {
                 jobStatus.extraClasses += " " + largeBtnCls + " " + selectedBtnCls;
             } else {
@@ -710,17 +710,17 @@ treeherder.directive('thCloneJobs', [
                 //Rows already exist, insert the new one in
                 //alphabetical order
                 var orderedPlatforms = [];
-                orderedPlatforms.push( platformName );
+                orderedPlatforms.push(platformName);
 
                 var td, platformSpan, spanPlatformName, r, p;
 
                 //Generate a list of platform names that have
                 //been added to the html table, use this for sorting
                 for (r=0; r<tableRows.length; r++) {
-                    td = $( tableRows[r] ).find('td');
-                    platformSpan = $( td[0] ).find('span');
+                    td = $(tableRows[r]).find('td');
+                    platformSpan = $(td[0]).find('span');
                     spanPlatformName = $(platformSpan).text();
-                    orderedPlatforms.push( spanPlatformName );
+                    orderedPlatforms.push(spanPlatformName);
                 }
 
                 orderedPlatforms.sort();
@@ -778,7 +778,7 @@ treeherder.directive('thCloneJobs', [
 
                     rowEl.append(platformTdEl);
 
-                    jobTdEl = $( thCloneHtml.get('jobTdClone').text );
+                    jobTdEl = $(thCloneHtml.get('jobTdClone').text);
 
                     renderJobTableRow(rowEl, jobTdEl, value.jobGroups);
 

--- a/ui/js/filters.js
+++ b/ui/js/filters.js
@@ -195,5 +195,5 @@ treeherder.filter('absoluteValue', function () {
 
 treeherder.filter('abbreviatedNumber', ['numeral', function (numeral) {
     return input =>
-        (input.toString().length <= 5) ? input : numeral(input).format('0.0a');
+        ((input.toString().length <= 5) ? input : numeral(input).format('0.0a'));
 }]);

--- a/ui/js/filters.js
+++ b/ui/js/filters.js
@@ -71,10 +71,10 @@ treeherder.filter('linkifyBugs', function () {
         // Settings
         var bug_title = 'bugzilla.mozilla.org';
         var bug_url = '<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=$1" ' +
-            'data-bugid="$1" ' + 'title="' + bug_title + '">$1</a>';
+            'data-bugid="$1" title="' + bug_title + '">$1</a>';
         var pr_title = 'github.com';
         var pr_url = '<a href="https://github.com/mozilla-b2g/gaia/pull/$1" ' +
-            'data-prid="$1" ' + 'title="' + pr_title + '">$1</a>';
+            'data-prid="$1" title="' + pr_title + '">$1</a>';
 
         if (bug_matches) {
             // Separate passes to preserve prefix

--- a/ui/js/filters.js
+++ b/ui/js/filters.js
@@ -145,12 +145,12 @@ treeherder.filter('highlightCommonTerms', function () {
 treeherder.filter('escapeHTML', function () {
     return function (text) {
         if (text) {
-            return text.
-                replace(/&/g, '&amp;').
-                replace(/</g, '&lt;').
-                replace(/>/g, '&gt;').
-                replace(/'/g, '&#39;').
-                replace(/"/g, '&quot;');
+            return text
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/'/g, '&#39;')
+                .replace(/"/g, '&quot;');
         }
         return '';
     };

--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -63,8 +63,8 @@ treeherder.factory('ThJobModel', [
             return $http.get(uri, {
                 params: options,
                 timeout: timeout
-            }).
-                then(function (response) {
+            })
+                .then(function (response) {
                     var item_list;
                     var next_pages_jobs = [];
                     // if the number of elements returned equals the page size, fetch the next pages

--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -14,7 +14,7 @@ treeherder.factory('ThJobModel', [
         ThJobModel.prototype.running_time_remaining = function () {
             var timestampNow = new Date().getTime()/1000;
             var current_duration = timestampNow - parseInt(this.start_timestamp);
-            return Math.round( (parseInt(this.running_eta) - current_duration) / 60);
+            return Math.round((parseInt(this.running_eta) - current_duration) / 60);
         };
 
         ThJobModel.prototype.get_average_duration = function () {

--- a/ui/js/models/job_group.js
+++ b/ui/js/models/job_group.js
@@ -23,8 +23,8 @@ treeherder.factory('ThJobGroupModel', [
             return $http.get(ThJobGroupModel.get_uri(), {
                 cache: true,
                 params: options
-            }).
-                then(function (response) {
+            })
+                .then(function (response) {
                     var item_list = [];
                     angular.forEach(response.data, function (elem) {
                         item_list.push(new ThJobGroupModel(elem));

--- a/ui/js/models/job_type.js
+++ b/ui/js/models/job_type.js
@@ -23,8 +23,8 @@ treeherder.factory('ThJobTypeModel', [
             return $http.get(ThJobTypeModel.get_uri(), {
                 cache: true,
                 params: options
-            }).
-                then(function (response) {
+            })
+                .then(function (response) {
                     var item_list = [];
                     angular.forEach(response.data, function (elem) {
                         item_list.push(new ThJobTypeModel(elem));

--- a/ui/js/models/perf/alerts.js
+++ b/ui/js/models/perf/alerts.js
@@ -75,10 +75,12 @@ treeherder.factory('PhAlerts', [
         AlertSummary.prototype.getTextualSummary = function (copySummary) {
             var resultStr = "";
             var improved = _.sortBy(_.filter(this.alerts, function (alert) {
-                return !alert.is_regression && alert.visible; }),
+                return !alert.is_regression && alert.visible;
+            }),
             'amount_pct').reverse();
             var regressed = _.sortBy(_.filter(this.alerts, function (alert) {
-                return alert.is_regression && alert.visible && !alert.isInvalid(); }),
+                return alert.is_regression && alert.visible && !alert.isInvalid();
+            }),
             'amount_pct').reverse();
 
             var formatAlert = function (alert, alertList) {

--- a/ui/js/models/perf/series.js
+++ b/ui/js/models/perf/series.js
@@ -6,7 +6,7 @@ treeherder.factory('PhSeries', ['$http', 'thServiceDomain', 'ThOptionCollectionM
         var suiteName = signatureProps.suite;
         var testName = signatureProps.test;
 
-        if (! (displayOptions && displayOptions.abbreviate)) {
+        if (!(displayOptions && displayOptions.abbreviate)) {
             // "summary" may appear for non-abbreviated output
             testName = testName || "summary";
         }

--- a/ui/js/models/perf/series.js
+++ b/ui/js/models/perf/series.js
@@ -15,7 +15,7 @@ treeherder.factory('PhSeries', ['$http', 'thServiceDomain', 'ThOptionCollectionM
     };
 
     var _getSeriesOptions = function (signatureProps, optionCollectionMap) {
-        var options = [ optionCollectionMap[signatureProps.option_collection_hash] ];
+        var options = [optionCollectionMap[signatureProps.option_collection_hash]];
         if (signatureProps.extra_options) {
             options = options.concat(signatureProps.extra_options);
         }

--- a/ui/js/models/perf/series.js
+++ b/ui/js/models/perf/series.js
@@ -40,14 +40,14 @@ treeherder.factory('PhSeries', ['$http', 'thServiceDomain', 'ThOptionCollectionM
         var options = _getSeriesOptions(signatureProps, optionCollectionMap);
 
         return {
-            id: signatureProps['id'],
+            id: signatureProps.id,
             name: _getSeriesName(signatureProps, optionCollectionMap),
             testName: _getTestName(signatureProps), // unadorned with platform/option info
-            suite: signatureProps['suite'],
-            test: signatureProps['test'] || null,
+            suite: signatureProps.suite,
+            test: signatureProps.test || null,
             signature: signature,
-            hasSubtests: signatureProps['has_subtests'] || false,
-            parentSignature: signatureProps['parent_signature'] || null,
+            hasSubtests: signatureProps.has_subtests || false,
+            parentSignature: signatureProps.parent_signature || null,
             projectName: projectName,
             platform: platform,
             options: options,

--- a/ui/js/models/repository.js
+++ b/ui/js/models/repository.js
@@ -128,14 +128,14 @@ treeherder.factory('ThRepositoryModel', [
                             getPushLogHref: function (arg) {
                                 if (this.dvcs_type === 'git') {
                                     // if git, assume github
-                                    if (typeof(arg) === 'string') {
+                                    if (typeof (arg) === 'string') {
                                         return this.getRevisionHref(arg);
                                     } else if (arg && arg.from && arg.to) {
                                         return this.url + '/compare/' + arg.from + '...' +
                                             arg.to;
                                     }
                                 } else if (this.dvcs_type === 'hg') {
-                                    if (typeof(arg) === 'string') {
+                                    if (typeof (arg) === 'string') {
                                         return this.pushlogURL + '?changeset=' + arg;
                                     } else if (arg && arg.from && arg.to) {
                                         return this.pushlogURL + '?fromchange=' +

--- a/ui/js/models/repository.js
+++ b/ui/js/models/repository.js
@@ -102,8 +102,8 @@ treeherder.factory('ThRepositoryModel', [
                 $interval(updateTreeStatus, 2 * 60 * 1000);
 
                 // return the promise of getting the repos
-                return get_list().
-                    success(function (data) {
+                return get_list()
+                    .success(function (data) {
                         // FIXME: only supporting github + hg for now for pushlog
                         // + revision info (we also assume dvcs_type git===github)
                         function Repo(props) {

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -260,7 +260,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
                             });
                             let task = thTaskcluster.refreshTimestamps(jsyaml.safeLoad(action));
                             return queue.createTask(actionTaskId, task).then(function () {
-                                return `Request sent to trigger all talos jobs ${times} time(s) via actions.yml (${actionTaskId})` ;
+                                return `Request sent to trigger all talos jobs ${times} time(s) via actions.yml (${actionTaskId})`;
                             });
                         });
                     });

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -870,8 +870,8 @@ treeherder.factory('ThResultSetStore', [
             if (rs && rs.revisions.length === 0) {
                 $log.debug("loadRevisions: check out to load revisions", rs, repoName);
                 // these revisions have never been loaded; do so now.
-                return ThResultSetModel.get(rs.revisions_uri).
-                    success(function (data) {
+                return ThResultSetModel.get(rs.revisions_uri)
+                    .success(function (data) {
 
                         if (rs.revisions.length === 0) {
                             Array.prototype.push.apply(rs.revisions, data);

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -661,7 +661,7 @@ treeherder.factory('ThResultSetStore', [
             platformName = job.platform;
             platformOption = job.platform_option;
 
-            if (_.isEmpty(repositories[repoName].rsMap[ resultsetId ])) {
+            if (_.isEmpty(repositories[repoName].rsMap[resultsetId])) {
                 //We don't have this resultset
                 return;
             }

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -10,57 +10,67 @@ perf.config(['$compileProvider', '$httpProvider', '$stateProvider', '$urlRouterP
         $httpProvider.defaults.xsrfCookieName = 'csrftoken';
         $httpProvider.useApplyAsync(true);
 
-        $stateProvider.state('alerts', {
-            title: 'Alerts',
-            templateUrl: 'partials/perf/alertsctrl.html',
-            url: '/alerts?id&status&framework&filter&hideImprovements&hideDwnToInv&page',
-            controller: 'AlertsCtrl'
-        }).state('graphs', {
-            title: 'Graphs',
-            templateUrl: 'partials/perf/graphsctrl.html',
-            url: '/graphs?timerange&series&highlightedRevisions&highlightAlerts&zoom&selected',
-            controller: 'GraphsCtrl'
-        }).state('compare', {
-            title: 'Compare',
-            templateUrl: 'partials/perf/comparectrl.html',
-            url: '/compare?originalProject&originalRevision?&newProject&newRevision&hideMinorChanges&framework&filter&showOnlyImportant&showOnlyConfident&selectedTimeRange?',
-            controller: 'CompareResultsCtrl'
-        }).state('comparesubtest', {
-            title: 'Compare - Subtests',
-            templateUrl: 'partials/perf/comparesubtestctrl.html',
-            url: '/comparesubtest?originalProject&originalRevision?&newProject&newRevision&originalSignature&newSignature&filter&showOnlyImportant&showOnlyConfident&framework&selectedTimeRange?',
-            controller: 'CompareSubtestResultsCtrl'
-        }).state('comparechooser', {
-            title: 'Compare Chooser',
-            templateUrl: 'partials/perf/comparechooserctrl.html',
-            url: '/comparechooser?originalProject&originalRevision&newProject&newRevision',
-            controller: 'CompareChooserCtrl'
-        }).state('e10s_trend', {
-            title: 'e10s Trend Dashboard',
-            templateUrl: 'partials/perf/e10s-trend.html',
-            url: '/e10s-trend?filter&showOnlyImportant&showOnlyConfident&showOnlyBlockers&repo&basedate&newdate&timerange&revision',
-            controller: 'e10sTrendCtrl'
-        }).state('e10s_trendsubtest', {
-            title: 'e10s Trend Dashboard - subtests',
-            templateUrl: 'partials/perf/e10s-trend-subtest.html',
-            url: '/e10s_trendsubtest?filter&showOnlyImportant&showOnlyConfident&showOnlyBlockers&repo&basedate&newdate&timerange&revision&baseSignature&e10sSignature',
-            controller: 'e10sTrendSubtestCtrl'
-        }).state('dashboard', {
-            title: 'Perfherder Dashboard',
-            templateUrl: 'partials/perf/dashboard.html',
-            url: '/dashboard?topic&filter&showOnlyImportant&showOnlyConfident&showOnlyBlockers&repo&timerange&revision',
-            controller: 'dashCtrl'
-        }).state('dashboardsubtest', {
-            title: 'Perfherder Dashboard - Subtests',
-            templateUrl: 'partials/perf/dashboardsubtest.html',
-            url: '/dashboardsubtest?topic&filter&showOnlyImportant&showOnlyConfident&baseSignature&variantSignature&repo&timerange&revision',
-            controller: 'dashSubtestCtrl'
-        }).state('comparesubtestdistribution', {
-            title: 'Compare Subtest Distribution',
-            templateUrl: 'partials/perf/comparesubtestdistribution.html',
-            url: '/comparesubtestdistribution?originalProject&newProject&originalRevision&newRevision&originalSubtestSignature?newSubtestSignature',
-            controller: 'CompareSubtestDistributionCtrl'
-        });
+        $stateProvider
+            .state('alerts', {
+                title: 'Alerts',
+                templateUrl: 'partials/perf/alertsctrl.html',
+                url: '/alerts?id&status&framework&filter&hideImprovements&hideDwnToInv&page',
+                controller: 'AlertsCtrl'
+            })
+            .state('graphs', {
+                title: 'Graphs',
+                templateUrl: 'partials/perf/graphsctrl.html',
+                url: '/graphs?timerange&series&highlightedRevisions&highlightAlerts&zoom&selected',
+                controller: 'GraphsCtrl'
+            })
+            .state('compare', {
+                title: 'Compare',
+                templateUrl: 'partials/perf/comparectrl.html',
+                url: '/compare?originalProject&originalRevision?&newProject&newRevision&hideMinorChanges&framework&filter&showOnlyImportant&showOnlyConfident&selectedTimeRange?',
+                controller: 'CompareResultsCtrl'
+            })
+            .state('comparesubtest', {
+                title: 'Compare - Subtests',
+                templateUrl: 'partials/perf/comparesubtestctrl.html',
+                url: '/comparesubtest?originalProject&originalRevision?&newProject&newRevision&originalSignature&newSignature&filter&showOnlyImportant&showOnlyConfident&framework&selectedTimeRange?',
+                controller: 'CompareSubtestResultsCtrl'
+            })
+            .state('comparechooser', {
+                title: 'Compare Chooser',
+                templateUrl: 'partials/perf/comparechooserctrl.html',
+                url: '/comparechooser?originalProject&originalRevision&newProject&newRevision',
+                controller: 'CompareChooserCtrl'
+            })
+            .state('e10s_trend', {
+                title: 'e10s Trend Dashboard',
+                templateUrl: 'partials/perf/e10s-trend.html',
+                url: '/e10s-trend?filter&showOnlyImportant&showOnlyConfident&showOnlyBlockers&repo&basedate&newdate&timerange&revision',
+                controller: 'e10sTrendCtrl'
+            })
+            .state('e10s_trendsubtest', {
+                title: 'e10s Trend Dashboard - subtests',
+                templateUrl: 'partials/perf/e10s-trend-subtest.html',
+                url: '/e10s_trendsubtest?filter&showOnlyImportant&showOnlyConfident&showOnlyBlockers&repo&basedate&newdate&timerange&revision&baseSignature&e10sSignature',
+                controller: 'e10sTrendSubtestCtrl'
+            })
+            .state('dashboard', {
+                title: 'Perfherder Dashboard',
+                templateUrl: 'partials/perf/dashboard.html',
+                url: '/dashboard?topic&filter&showOnlyImportant&showOnlyConfident&showOnlyBlockers&repo&timerange&revision',
+                controller: 'dashCtrl'
+            })
+            .state('dashboardsubtest', {
+                title: 'Perfherder Dashboard - Subtests',
+                templateUrl: 'partials/perf/dashboardsubtest.html',
+                url: '/dashboardsubtest?topic&filter&showOnlyImportant&showOnlyConfident&baseSignature&variantSignature&repo&timerange&revision',
+                controller: 'dashSubtestCtrl'
+            })
+            .state('comparesubtestdistribution', {
+                title: 'Compare Subtest Distribution',
+                templateUrl: 'partials/perf/comparesubtestdistribution.html',
+                url: '/comparesubtestdistribution?originalProject&newProject&originalRevision&newRevision&originalSubtestSignature?newSubtestSignature',
+                controller: 'CompareSubtestDistributionCtrl'
+            });
         $urlRouterProvider.otherwise('/graphs');
     }]).run(['$rootScope', '$state', '$stateParams', function ($rootScope, $state, $stateParams) {
         $rootScope.$state = $state;

--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -127,7 +127,7 @@ treeherder.provider('thResultStatusInfo', function () {
             // handle if a job is classified
             var classificationId = parseInt(failure_classification_id, 10);
             if (classificationId > 1) {
-                resultStatusInfo.btnClass = resultStatusInfo.btnClass + "-classified";
+                resultStatusInfo.btnClass += "-classified";
                 // autoclassification-only case
                 if (classificationId === 7) {
                     resultStatusInfo.btnClass += " autoclassified";

--- a/ui/js/services/buildapi.js
+++ b/ui/js/services/buildapi.js
@@ -46,11 +46,11 @@ treeherder.factory('thBuildApi', [
                         "Content-Type": "application/x-www-form-urlencoded"
                     },
                     withCredentials: true
-                }).
-                    success(function (data, status) {
+                })
+                    .success(function (data, status) {
                         notify(status, "cancel");
-                    }).
-                    error(function (data, status) {
+                    })
+                    .error(function (data, status) {
                         notify(status, "cancel");
                     });
             },
@@ -64,11 +64,11 @@ treeherder.factory('thBuildApi', [
                     },
                     withCredentials: true
 
-                }).
-                    success(function (data, status) {
+                })
+                    .success(function (data, status) {
                         notify(status, "cancel all jobs");
-                    }).
-                    error(function (data, status) {
+                    })
+                    .error(function (data, status) {
                         notify(status, "cancel all jobs");
                     });
             }

--- a/ui/js/services/classifications.js
+++ b/ui/js/services/classifications.js
@@ -26,8 +26,8 @@ treeherder.factory('thClassificationTypes', [
         };
 
         var load = function () {
-            return $http.get(thUrl.getRootUrl("/failureclassification/"), { cache: true }).
-                success(function (data) {
+            return $http.get(thUrl.getRootUrl("/failureclassification/"), { cache: true })
+                .success(function (data) {
                     _.forEach(data, addClassification);
                 });
         };

--- a/ui/js/services/classifications.js
+++ b/ui/js/services/classifications.js
@@ -8,13 +8,13 @@ treeherder.factory('thClassificationTypes', [
         var classificationOptions = [];
 
         var classificationColors = {
-            1: "",                 // not classified
-            2: "label-info",       // expected fail",
-            3: "label-success",    // fixed by backout",
-            4: "label-warning",    // intermittent",
-            5: "label-default",    // infra",
-            6: "label-danger",     // intermittent needs filing",
-            7: "label-warning"     // autoclassified intermittent
+            1: "", // not classified
+            2: "label-info", // expected fail",
+            3: "label-success", // fixed by backout",
+            4: "label-warning", // intermittent",
+            5: "label-default", // infra",
+            6: "label-danger", // intermittent needs filing",
+            7: "label-warning" // autoclassified intermittent
         };
 
         var addClassification = function (cl) {

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -427,7 +427,7 @@ treeherder.factory('thJobFilters', [
 
         function getNonFieldFiltersArray() {
             return Object.entries($location.search()).reduce((acc, [key, value]) => (
-                NON_FIELD_FILTERS.includes(key) ? [ ...acc, { field: key, key, value } ]: acc
+                NON_FIELD_FILTERS.includes(key) ? [...acc, { field: key, key, value }]: acc
             ), []);
         }
 

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -62,7 +62,7 @@ treeherder.factory('thJobFilters', [
         // job field.
         const MATCH_TYPE = {
             exactstr: 'exactstr',
-            substr: 'substr',       // returns true if any values match the substring
+            substr: 'substr', // returns true if any values match the substring
             searchStr: 'searchStr', // returns true only if ALL the values match the substring
             choice: 'choice'
         };

--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -159,7 +159,7 @@ treeherder.factory('thNotify', [
              * Delete the first non-sticky element from the notifications queue
              */
             shift: function () {
-                for (var i=0;i<thNotify.notifications.length; i++) {
+                for (var i=0; i<thNotify.notifications.length; i++) {
                     if (!thNotify.notifications[i].sticky) {
                         thNotify.remove(i);
                         return;

--- a/ui/js/services/perf/compare.js
+++ b/ui/js/services/perf/compare.js
@@ -300,8 +300,7 @@ treeherder.factory('PhCompare', [
                                                   resultSet.push_timestamp) < t;
                                       });
                               }));
-                    }
-                    else {
+                    } else {
                         graphsLink += '&timerange=' + timeRange;
                     }
                 }

--- a/ui/js/services/perf/compare.js
+++ b/ui/js/services/perf/compare.js
@@ -281,7 +281,7 @@ treeherder.factory('PhCompare', [
                         return [
                             series.projectName,
                             series.signature, 1,
-                            series.frameworkId ];
+                            series.frameworkId];
                     }),
                     highlightedRevisions: _.map(resultSets, function (resultSet) {
                         return resultSet.revision.slice(0, 12);

--- a/ui/js/services/pinboard.js
+++ b/ui/js/services/pinboard.js
@@ -23,8 +23,8 @@ treeherder.factory('thPinboard', [
                 ThResultSetStore.updateUnclassifiedFailureMap($rootScope.repoName, job);
 
                 classification.job_id = job.id;
-                classification.create().
-                    success(function () {
+                classification.create()
+                    .success(function () {
                         thNotify.send("Classification saved for " + job.platform + " " + job.job_type_name, "success");
                     }).error(function (data) {
                         var message = "Error saving classification for " + job.platform + " " + job.job_type_name;
@@ -44,8 +44,8 @@ treeherder.factory('thPinboard', [
                     job_id: job.id,
                     type: 'annotation'
                 });
-                bjm.create().
-                    success(function () {
+                bjm.create()
+                    .success(function () {
                         thNotify.send("Bug association saved for " + job.platform + " " + job.job_type_name, "success");
                     }).error(function (data) {
                         var message = "Error saving bug association for " + job.platform + " " + job.job_type_name;

--- a/ui/js/treeherder_app.js
+++ b/ui/js/treeherder_app.js
@@ -28,23 +28,23 @@ treeherderApp.config(['$compileProvider', '$routeProvider', '$httpProvider',
         $httpProvider.defaults.xsrfCookieName = 'csrftoken';
         $httpProvider.useApplyAsync(true);
 
-        $routeProvider.
-        when('/jobs', {
-            controller: 'JobsCtrl',
-            templateUrl: 'partials/main/jobs.html',
-            // see controllers/filters.js ``skipNextSearchChangeReload`` for
-            // why we set this to false.
-            reloadOnSearch: false
-        }).
-        when('/jobs/:tree', {
-            controller: 'JobsCtrl',
-            templateUrl: 'partials/main/jobs.html',
-            reloadOnSearch: false
-        }).
-        when('/login', {
-            template: '<login-callback/>'
-        }).
-        otherwise({ redirectTo: '/jobs' });
+        $routeProvider
+            .when('/jobs', {
+                controller: 'JobsCtrl',
+                templateUrl: 'partials/main/jobs.html',
+                // see controllers/filters.js ``skipNextSearchChangeReload`` for
+                // why we set this to false.
+                reloadOnSearch: false
+            })
+            .when('/jobs/:tree', {
+                controller: 'JobsCtrl',
+                templateUrl: 'partials/main/jobs.html',
+                reloadOnSearch: false
+            })
+            .when('/login', {
+                template: '<login-callback/>'
+            })
+            .otherwise({ redirectTo: '/jobs' });
     }]).run(require('./cache-templates'));
 
 module.exports = treeherderApp;

--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -187,7 +187,7 @@ treeherder.value("phTimeRanges", [
       { value: 2592000, text: "Last 30 days" },
       { value: 5184000, text: "Last 60 days" },
       { value: 7776000, text: "Last 90 days" },
-      { value: 31536000, text: "Last year" } ]);
+      { value: 31536000, text: "Last year" }]);
 
 treeherder.value("phDefaultTimeRangeValue", 1209600);
 

--- a/ui/plugins/auto_classification/controller.js
+++ b/ui/plugins/auto_classification/controller.js
@@ -369,7 +369,7 @@ treeherder.controller('ThErrorLineController', [
             var bugSuggestionOptions = bugSuggestions
                     .filter(bug => !autoclassifiedBugs.has(bug.id))
                     .map(bugSuggestion => new ThClassificationOption("unstructuredBug",
-                                                                       line.id + "-" + "ub-" + bugSuggestion.id,
+                                                                       line.id + "-ub-" + bugSuggestion.id,
                                                                        null,
                                                                        bugSuggestion.id,
                                                                        bugSuggestion.summary,

--- a/ui/plugins/auto_classification/controller.js
+++ b/ui/plugins/auto_classification/controller.js
@@ -176,7 +176,7 @@ treeherder.controller('ThClassificationOptionController', [
                     search_terms: () => ctrl.errorLine.data.bug_suggestions.search_terms,
                     fullLog: () => logUrl,
                     parsedLog: () => location.origin + "/" + thUrl.getLogViewerUrl(ctrl.thJob.id),
-                    reftest: () => thReftestStatus(ctrl.thJob) ? reftestUrlRoot + logUrl + "&only_show_unexpected=1" : "",
+                    reftest: () => (thReftestStatus(ctrl.thJob) ? reftestUrlRoot + logUrl + "&only_show_unexpected=1" : ""),
                     selectedJob: () => ctrl.thJob,
                     allFailures: () => [ctrl.errorLine.data.bug_suggestions.search.split(" | ")],
                     crashSignatures: () => crashSignatures,
@@ -1099,7 +1099,7 @@ treeherder.controller('ThAutoclassifyPanelController', [
 
             var minIndex = selectable.length ?
                     selectableIndexes
-                    .reduce((min, idx) => idx < min ? idx : min, $scope.errorLines.length) :
+                    .reduce((min, idx) => (idx < min ? idx : min), $scope.errorLines.length) :
                 null;
 
             var selected = $scope.selectedLines();

--- a/ui/plugins/auto_classification/controller.js
+++ b/ui/plugins/auto_classification/controller.js
@@ -678,8 +678,7 @@ treeherder.controller('ThErrorLineController', [
 
             if (!ctrl.canClassify) {
                 $scope.status = 'classification-disabled';
-            }
-            else if (line.verified) {
+            } else if (line.verified) {
                 $scope.status = 'verified';
             } else if (option.type === 'ignore') {
                 $scope.status = 'unverified-ignore';
@@ -877,8 +876,7 @@ treeherder.controller('ThAutoclassifyPanelController', [
         function build() {
             if (ctrl.thJob.state === "pending" || ctrl.thJob.state === "running") {
                 ctrl.loadStatus = "job_pending";
-            }
-            else if (!ctrl.logsParsed || ctrl.autoclassifyStatus === "pending") {
+            } else if (!ctrl.logsParsed || ctrl.autoclassifyStatus === "pending") {
                 ctrl.loadStatus = "pending";
             } else if (ctrl.logParsingFailed) {
                 ctrl.loadStatus = "failed";
@@ -963,7 +961,8 @@ treeherder.controller('ThAutoclassifyPanelController', [
             linesById = lines
                 .reduce((byId, line) => {
                     byId.set(line.id, new ThErrorLineData(line));
-                    return byId; }, linesById);
+                    return byId;
+                }, linesById);
             $scope.errorLines = Array.from(linesById.values());
             // Resort the lines to allow for in-place updates
             $scope.errorLines.sort((a, b) => a.data.id - b.data.id);

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -220,7 +220,7 @@ treeherder.controller('PluginCtrl', [
                                         series.frameworkId
                                     ] + ']&selected=[' + [
                                         $scope.repoName, series.signature,
-                                        $scope.job['result_set_id'], $scope.job['id']
+                                        $scope.job.result_set_id, $scope.job.id
                                     ] + ']',
                                     value: performanceData[series.signature][0].value,
                                     title: series.name

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -211,8 +211,9 @@ treeherder.controller('PluginCtrl', [
                         })).then(function () {
                             _.forEach(seriesList, function (series) {
                                 // skip series which are subtests of another series
-                                if (series.parentSignature)
-                                    { return; }
+                                if (series.parentSignature) {
+                                    return;
+                                }
                                 var detail = {
                                     url: thServiceDomain + '/perf.html#/graphs?series=[' + [
                                         $scope.repoName, series.signature, 1,

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -46,9 +46,9 @@ treeherder.controller('PinboardCtrl', [
         };
 
         $scope.pulsePinCount = function () {
-            $( ".pin-count-group" ).addClass( "pin-count-pulse" );
+            $(".pin-count-group").addClass("pin-count-pulse");
             $timeout(function () {
-                $( ".pin-count-group" ).removeClass( "pin-count-pulse" );
+                $(".pin-count-group").removeClass("pin-count-pulse");
             }, 700);
         };
 


### PR DESCRIPTION
Moving from Neutrino v4 to v7 brings with it an upgrade of ESLint from v3 to v4. This means both new ESLint rules and changes to existing rules to make them more strict. In addition, as part of the Netrino v7 migration, I'm switching us to using the AirBnb config as a base, rather than our current custom (and much smaller) set of enabled rules. (Even if we don't 100% agree with every AirBnB style choice, I think sticking to a standard makes it much easier for contributors.)

As such, we need to make a number of lint fixes as part of the Neutrino migration - which I've split out to a separate PR for easier review. 

The vast majority of the fixes here were created by using the automatic `--fix` option and then if needed, tweaking the formatting slightly. See each commit message for links to the ESLint/AirBnb style guide docs for that rule.

Note: I've not made any changes to the rule configs in this PR since I'd only have to rewrite them again in the main Neutrino v7 PR shortly, which will be enabling them a different way (via airbnb base).