### PR TITLE
Bug 1045609 - Fix replacing filter values on non-field filters

### DIFF
--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -270,7 +270,8 @@ treeherder.factory('thJobFilters', [
             const oldQsVal = _getFiltersOrDefaults(field);
             let newQsVal = null;
 
-            if (oldQsVal) {
+            // All filters support multiple values except NON_FIELD_FILTERS.
+            if (oldQsVal && !NON_FIELD_FILTERS.includes(field)) {
                 // set the value to an array
                 newQsVal = _toArray(oldQsVal);
                 newQsVal.push(value);


### PR DESCRIPTION
This fixes if you set ``fromchange`` for two different pushes.  It makes sure to replace the value, rather than setting it to multiple values.