### PR TITLE
Bug 1062463 - Correctly highlight/select jobs when adding to pinboard

### DIFF
--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -416,10 +416,8 @@ treeherder.directive('thCloneJobs', [
                         //Left mouse button pressed
                         if (ev.ctrlKey || ev.metaKey) {
                             _.bind(togglePinJobCb, this, ev, el, job)();
-                        } else {
-                            _.bind(clickJobCb, this, ev, el, job)();
                         }
-
+                        _.bind(clickJobCb, this, ev, el, job)();
                         break;
 
                     case 2:


### PR DESCRIPTION
**Fix for Treeherder Bug 1062463**
https://bugzilla.mozilla.org/show_bug.cgi?id=1062463

Bug summary: User can end up with multiple jobs selected using Ctrl/Cmd - click to pin. When a user pins a new job using cmd-click(mac) or ctrl-click(pc), that job will now be also selected/highlights and the previously selected/highlighted job will be deselected.

Please see link above for screenshots and more information.