### PR TITLE
Bug 1407775 - Improve the layout and info in the job filters bar

### DIFF
--- a/ui/css/treeherder-navbar-panels.css
+++ b/ui/css/treeherder-navbar-panels.css
@@ -24,6 +24,19 @@
  *  Active Filters panel
  */
 .active-filters-bar {
-    padding: 0 15px 0 15px;
-    border: 1px solid transparent;
+    padding: 5px 25px 5px 30px;
+}
+
+.active-filters-title {
+    padding-right: 15px;
+}
+
+.filtersbar-filter {
+    font-size: 12px;
+    padding-right: 12px;
+    display: inline-block;
+}
+
+.new-filter-input {
+    margin-top: 5px;
 }

--- a/ui/partials/main/thActiveFiltersBar.html
+++ b/ui/partials/main/thActiveFiltersBar.html
@@ -1,20 +1,27 @@
 <!-- Show this certain filters are active in Treeherder -->
-<div class="alert-info active-filters-bar">
+<div ng-if="newFieldFilter || filterBarFilters.length"
+     class="alert-info active-filters-bar">
     <div ng-show="filterBarFilters.length" ng-cloak>
-      <i class="fa fa-info-circle" aria-hidden="true"></i>
-      <span><b>Active Filters</b></span>
-
-      <span ng-repeat="filter in filterBarFilters" class="btn btn-sm"
-            title="Click to clear the {{ filter.field }} filter"
-            ng-click="jobFilters.removeFilter(filter.key, filter.value)">
-          <span ng-if="filter.field == 'author'">{{ filter.field }}: {{filter.value.split('@')[0] | limitTo: 20}}</span>
-          <span ng-if="filter !== 'author'">{{ filter.field }}: {{filter.value | limitTo: 12}}</span>
-          <i class="fa fa-times-circle"></i>
+      <span class="active-filters-title">
+        <i class="fa fa-info-circle" aria-hidden="true"></i>
+        <b>Active Filters</b>
+      </span>
+      <span ng-repeat="filter in filterBarFilters"
+            class="filtersbar-filter">
+          <span title="Filter by {{ filter.field}}: {{ filter.value }}"
+                ng-if="filter.field == 'author'"><b>{{ filter.field }}:</b> {{filter.value.split('@')[0] | limitTo: 20}}</span>
+          <span title="Filter by {{ filter.field}}: {{ filter.value }}"
+                ng-if="filter !== 'author'"><b>{{ filter.field }}:</b> {{filter.value | limitTo: 12}}</span>
+          <span class="pointable"
+                title="Click to clear {{ filter.field }}"
+                ng-click="jobFilters.removeFilter(filter.key, filter.value)">
+            <i class="fa fa-times-circle"></i>
+          </span>
       </span>
     </div>
     <div ng-if="newFieldFilter">
       <form novalidate class="form-inline" role="form">
-        <div class="form-group input-group-sm">
+        <div class="form-group input-group-sm new-filter-input">
           <label class="sr-only" for="job-filter-field">Field</label>
           <select id="job-filter-field"
                   class="form-control"
@@ -32,7 +39,7 @@
                  ng-model="newFieldFilter.value"
                  id="job-filter-value"
                  type="text"
-                 placeholder="filter value">
+                 placeholder="enter filter value">
           <label class="sr-only" for="job-filter-choice-value">Value</label>
           <select ng-show="newFieldFilter.matchType==='choice'"
                   class="form-control"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,7 @@
 # yarn lockfile v1
 
 
-abbrev@1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
-
-abbrev@1.0.x:
+abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
@@ -134,13 +130,9 @@ angular-ui-router@0.4.2:
   dependencies:
     angular "^1.0.8"
 
-angular@1.5.11:
+angular@1.5.11, angular@^1.0.8:
   version "1.5.11"
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.5.11.tgz#8c5ba7386f15965c9acf3429f6881553aada30d6"
-
-angular@^1.0.8:
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/angular/-/angular-1.6.5.tgz#37f788eebec5ce2e3fa02b17bbcb2a231576a0d6"
 
 ansi-escapes@^1.1.0:
   version "1.4.0"
@@ -1578,15 +1570,15 @@ combined-stream@~0.0.4:
   dependencies:
     delayed-stream "0.0.5"
 
-commander@2, commander@2.11.x, commander@~2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
-
-commander@2.9.0:
+commander@2, commander@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+commander@2.11.x, commander@~2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -2335,16 +2327,9 @@ domutils@1.1:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5.1, domutils@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -2810,13 +2795,9 @@ express@^4.13.3:
     utils-merge "1.0.0"
     vary "~1.1.1"
 
-extend@3.0.0:
+extend@3.0.0, extend@^3.0.0, extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
-
-extend@^3.0.0, extend@~3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
 extglob@^0.3.1:
   version "0.3.2"
@@ -3442,11 +3423,7 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-iconv-lite@0.4, iconv-lite@~0.4.13:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
-
-iconv-lite@0.4.15:
+iconv-lite@0.4, iconv-lite@0.4.15, iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
@@ -4447,17 +4424,13 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@1.2.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1407775](https://bugzilla.mozilla.org/show_bug.cgi?id=1407775).

This improves a few layout things in the job filters bar:

- pass the full filter.value into a tooltip for long filters
- vertically align the title with adjacent spans, it was slightly out
- delete only on the font awesome icon, not the whole span
- align the contents with the related push block below it
- apply alternate bold/plain styling for each field/value pair for readability
- supporting tweaks as needed

Current:

![before](https://user-images.githubusercontent.com/3660661/31466409-0ec48268-aea5-11e7-8512-ea8ba8d2f106.jpg)

Proposed:

![after](https://user-images.githubusercontent.com/3660661/31466417-16d3cde2-aea5-11e7-8994-0fb927c5029a.jpg)

Tested on OSX 10.12.6:
Nightly **58.0a1 (2017-10-10) (64-bit)**