### PR TITLE
Bug 1407906 - Make the filter by job field icon a toggle

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -581,11 +581,16 @@ treeherderApp.controller('MainCtrl', [
         $scope.fieldFilters = [];
         $scope.fieldChoices = thJobFilters.getFieldChoices();
 
-        $scope.startNewFieldFilter = function () {
-            $scope.newFieldFilter = { field: "", value: "" };
+        $scope.toggleFieldFilterVisibility = function () {
+            if ($scope.newFieldFilter === null) {
+                $scope.newFieldFilter = { field: "", value: "" };
+            }
+            $scope.isFieldFilterVisible = !$scope.isFieldFilterVisible;
         };
+
         $scope.cancelNewFieldFilter = function () {
             $scope.newFieldFilter = null;
+            $scope.isFieldFilterVisible = !$scope.isFieldFilterVisible;
         };
 
         // we have to set the field match type here so that the UI can either
@@ -623,8 +628,9 @@ treeherderApp.controller('MainCtrl', [
 
             thJobFilters.addFilter(field, value);
 
-            // Hide the new field filter form.
-            $scope.newFieldFilter = null;
+            // Clear the values and close the input form group
+            $scope.newFieldFilter = { field: "", value: "" };
+            $scope.isFieldFilterVisible = !$scope.isFieldFilterVisible;
         };
 
         $scope.fromChangeValue = function () {

--- a/ui/partials/main/thActiveFiltersBar.html
+++ b/ui/partials/main/thActiveFiltersBar.html
@@ -1,5 +1,5 @@
 <!-- Show this certain filters are active in Treeherder -->
-<div ng-if="newFieldFilter || filterBarFilters.length"
+<div ng-if="isFieldFilterVisible || filterBarFilters.length"
      class="alert-info active-filters-bar">
     <div ng-show="filterBarFilters.length" ng-cloak>
       <span class="active-filters-title">
@@ -20,7 +20,7 @@
           </span>
       </span>
     </div>
-    <div ng-if="newFieldFilter">
+    <div ng-if="isFieldFilterVisible">
       <form novalidate class="form-inline" role="form">
         <div class="form-group input-group-sm new-filter-input">
           <label class="sr-only" for="job-filter-field">Field</label>

--- a/ui/partials/main/thWatchedRepoNavPanel.html
+++ b/ui/partials/main/thWatchedRepoNavPanel.html
@@ -97,7 +97,7 @@
 
         <span>
           <span class="btn btn-view-nav btn-sm"
-                ng-click="startNewFieldFilter()"
+                ng-click="toggleFieldFilterVisibility()"
                 title="Filter by a job field">
             <i class="fa fa-filter" />
           </span>


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1407906](https://bugzilla.mozilla.org/show_bug.cgi?id=1407906)

This turns the Filter by a job field button, from an open-only behavior, to a toggle. Everything seems to work fine. I left the Cancel button in for now, so the user has that additional way of closing the input group.

Toggle Input Group Open:

![filtertogglestateopen](https://user-images.githubusercontent.com/3660661/31480500-1f9f1e62-aeec-11e7-971f-f7b055e34a41.jpg)

Toggle Input Group Closed:

![filtertogglestateclosed](https://user-images.githubusercontent.com/3660661/31480509-2cbf6340-aeec-11e7-81ab-3bc11bea90d3.jpg)


Tested on OSX 10.12.6:
Nightly **58.0a1 (2017-10-10) (64-bit)**