### PR TITLE
Bug 1407807 - Remove Tier as a choice from the job filter field dropdown

### DIFF
--- a/ui/partials/main/thActiveFiltersBar.html
+++ b/ui/partials/main/thActiveFiltersBar.html
@@ -31,6 +31,7 @@
                   required>
             <option value="" disabled selected>select filter field</option>
             <option ng-repeat="(field, obj) in fieldChoices"
+                    ng-if="obj.name !== 'tier'"
                     value="{{::field}}">{{::obj.name}}</option>
           </select>
           <label class="sr-only" for="job-filter-value">Value</label>


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1407807](https://bugzilla.mozilla.org/show_bug.cgi?id=1407807)

This suppresses the Tier field as a choice in the job filter field dropdown list. It's a one off, so the more generalized solution of adding a new display field to all 11 of the `FIELD_CHOICES` object elements in jobFilters.js may not be needed, at least for now.

Proposed (excluding Tier):

![proposed](https://user-images.githubusercontent.com/3660661/31557276-0e0d23f8-b016-11e7-8936-a0f5efae3e80.jpg)

Tested on OSX 10.12.6:
Nightly **58.0a1 (2017-10-13) (64-bit)**