### PR TITLE
Improve test_filter_jobs

### DIFF
--- a/tests/jenkins/pages/treeherder.py
+++ b/tests/jenkins/pages/treeherder.py
@@ -296,7 +296,7 @@ class TreeherderPage(Base):
 
         @property
         def builds(self):
-            return [self.Build(self.page, root=el) for el in self.find_elements(*self._platform_locator)]
+            return [self.Build(self.page, root=el) for el in self.find_elements(*self._platform_locator) if el.is_displayed()]
 
         @property
         def datestamp(self):

--- a/tests/jenkins/tests/test_filter_jobs.py
+++ b/tests/jenkins/tests/test_filter_jobs.py
@@ -3,16 +3,24 @@ import pytest
 from pages.treeherder import TreeherderPage
 
 
+def platforms(result_set):
+    parts = []
+    for build in result_set.builds:
+        parts.extend(build.platform_name.lower().split())
+    return set(parts)
+
+
+def linux_and_windows(result_set):
+    return {'linux', 'windows'}.issubset(platforms(result_set))
+
+
 @pytest.mark.nondestructive
 def test_filter_jobs(base_url, selenium):
     """Open resultset page and filter for platform"""
     page = TreeherderPage(selenium, base_url).open()
-    platform = u'Linux'
-
-    page.filter_by(platform)
-    assert platform in page.result_sets[0].builds[0].platform_name
-
-    page.clear_filter()
-    platform2 = u'Windows'
-    page.filter_by(platform2)
-    assert platform not in page.result_sets[0].builds[0].platform_name
+    # select the first result set with linux and windows platforms
+    result_set = next(r for r in page.result_sets if linux_and_windows(r))
+    assert {'linux', 'windows'}.issubset(platforms(result_set))
+    page.filter_by('linux')
+    assert 'linux' in platforms(result_set)
+    assert 'windows' not in platforms(result_set)


### PR DESCRIPTION
This improves test_filter_jobs, which fails when the first result set doesn't include builds with windows or linux platforms. This happens when the gecko decision task is running, and before the additional builds are added. This patch changes the test to select the first result set with the required platforms. It also makes sure that only displayed builds are returned from the page object.

@rbillings r?