### PR TITLE
Bug 1408496 - Fix duplicate push Author filter bar values

### DIFF
--- a/ui/partials/main/thActiveFiltersBar.html
+++ b/ui/partials/main/thActiveFiltersBar.html
@@ -8,10 +8,11 @@
       </span>
       <span ng-repeat="filter in filterBarFilters"
             class="filtersbar-filter">
-          <span title="Filter by {{ filter.field}}: {{ filter.value }}"
-                ng-if="filter.field == 'author'"><b>{{ filter.field }}:</b> {{filter.value.split('@')[0] | limitTo: 20}}</span>
-          <span title="Filter by {{ filter.field}}: {{ filter.value }}"
-                ng-if="filter !== 'author'"><b>{{ filter.field }}:</b> {{filter.value | limitTo: 12}}</span>
+          <span title="Filter by {{ filter.field}}: {{ filter.value }}">
+            <b>{{ filter.field }}:</b>
+            <span ng-if="filter.field === 'author'"> {{filter.value.split('@')[0] | limitTo: 20}}</span>
+            <span ng-if="filter.field !== 'author'"> {{filter.value | limitTo: 12}}</span>
+          </span>
           <span class="pointable"
                 title="Click to clear {{ filter.field }}"
                 ng-click="jobFilters.removeFilter(filter.key, filter.value)">


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1408496](https://bugzilla.mozilla.org/show_bug.cgi?id=1408496)

This prevents double **author:** entries in the job filter bar. I also economized a bit while I was there so we only have one title property and one field label in the markup.

Current:

![current](https://user-images.githubusercontent.com/3660661/31561371-a444b4c6-b025-11e7-8cad-47927cd317b2.jpg)

Proposed:

![proposed](https://user-images.githubusercontent.com/3660661/31561386-aab939c6-b025-11e7-85c2-ec4f200511ad.jpg)

Tested on OSX 10.12.6:
Nightly **58.0a1 (2017-10-13) (64-bit)**