### PR TITLE
Bug 1376506 - Make job row contents flush left like they used to be

### DIFF
--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -53,14 +53,12 @@
 
 .group-content {
   margin: 0 0;
-  white-space: nowrap;
-  
+  white-space: nowrap;  
 }
 
 .group-content::before {
   content: "(";
   padding-left: 1px;
-
 }
 
 .group-content::after {

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -63,7 +63,7 @@
 
 .group-content::after {
   content: ")";
-  margin-left: =-1;
+  margin-left: -1px;
 }
 
 .group-job-list {

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -3,7 +3,7 @@
  */
 
 .job-group {
-  margin 0;
+  margin: 0;
   cursor: default;
 }
 

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -143,7 +143,7 @@
 .group-btn.btn-ltblue-count,
 .group-btn.btn-yellow-count,
 .group-btn.btn-pink-count {
-  margin: 0 -5px 0 -1px;
+  margin: 0 -4px 0 -1px;
 }
 
 .job-btn.btn-red,

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -3,7 +3,7 @@
  */
 
 .job-group {
-  margin: 0 -3px 0 3px;
+  margin: 0 0;
   cursor: default;
 }
 
@@ -38,11 +38,12 @@
 
 .group-symbol {
   background: transparent;
-  padding: 0px;
+  padding: 0 0 0 2px;
   border: 0px;
   vertical-align: 0;
   line-height: 1.32;
   cursor: pointer;
+  margin-right: -3px;
 }
 
 .group-symbol:hover {
@@ -51,19 +52,25 @@
 }
 
 .group-content {
-  margin-left: -3px;
+  margin: 0 0;
+  white-space: nowrap;
+  
 }
 
 .group-content::before {
   content: "(";
+  padding-left: 1px;
+
 }
 
 .group-content::after {
   content: ")";
+  margin-left: =-1;
 }
 
 .group-job-list {
   margin-left: -3px;
+  white-space: normal;
 }
 
 .runnable-job-btn {

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -3,7 +3,7 @@
  */
 
 .job-group {
-  margin: 0 0;
+  margin 0;
   cursor: default;
 }
 
@@ -52,7 +52,7 @@
 }
 
 .group-content {
-  margin: 0 0;
+  margin: 0;
   white-space: nowrap;  
 }
 


### PR DESCRIPTION
**Fix for Treeherder Bug 1376506**
https://bugzilla.mozilla.org/show_bug.cgi?id=1376506
Bug Summary: the jobs section text was not left aligned. 

Please see link above for screenshots and more information.