### PR TITLE
Bug 1408954 - Use latest yarn on Heroku/Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,9 @@ matrix:
           - node_modules
       addons:
         firefox: latest
+      before_install:
+        # Use newer yarn than that pre-installed in the Travis image.
+        - curl -sSfL https://yarnpkg.com/latest.tar.gz | tar -xz --strip-components=1 -C "$HOME"
       install:
         # `--frozen-lockfile` will catch cases where people have forgotten to update `yarn.lock`.
         # `--no-bin-links` is only necessary on Windows hosts, but we include here to ensure
@@ -211,6 +214,8 @@ matrix:
         - source ~/venv/bin/activate
         - curl -sSfL https://github.com/mozilla/geckodriver/releases/download/v0.19.0/geckodriver-v0.19.0-linux64.tar.gz | tar -zxC $HOME/bin
         - nvm install 8.7.0
+        # Use newer yarn than that pre-installed in the Travis image.
+        - curl -sSfL https://yarnpkg.com/latest.tar.gz | tar -xz --strip-components=1 -C "$HOME"
       install:
         - pip install --disable-pip-version-check --require-hashes -r requirements/common.txt -r requirements/dev.txt
         - yarn install --frozen-lockfile --no-bin-links

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "license": "MPL-2.0",
   "engines": {
-    "node": "8.7.0"
+    "node": "8.7.0",
+    "yarn": "^1.2.1"
   },
   "dependencies": {
     "ajv": "^5.2.2",


### PR DESCRIPTION
For parity with Vagrant and to save the hassle of constantly updating.
Heroku uses the version from `package.json`.