### PR TITLE
Bug 1176412 - Heroku: Remove New Relic host display name workaround

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -14,16 +14,6 @@ yarn build
 # collectstatic, and so does not affect files in the `dist/` directory.
 python -m whitenoise.compress dist
 
-# Add environment variables to the profile script run on Dyno startup.
-# https://devcenter.heroku.com/articles/dynos#the-profile-file
-# Only variables that are rarely changed and not site-specific should
-# be set here. Set everything else using Heroku's CLI / dashboard.
-
-# Override the hostname displayed in New Relic, so the Dyno name (eg "web.1")
-# is shown, rather than "Dynamic Hostname". Single quotes are used to so that
-# `$DYNO` is expanded at app runtime, rather than now.
-echo 'export NEW_RELIC_PROCESS_HOST_DISPLAY_NAME="${DYNO}"' >> .profile
-
 # Remove nodejs files to reduce slug size (and avoid environment variable
 # pollution from the nodejs profile script), since they are no longer
 # required once `yarn build` has run. The buildpack cache will still


### PR DESCRIPTION
Previously New Relic displayed the hostname for each dyno as "Dynamic Hostname", due to the randomly generated Heroku hostnames. As such, we had to set a manual display name to identify the dyno type reported for each transaction. This was only partly useful, since New Relic doesn't use it in all places of their UI.

However the New Relic Python agent 2.96.0.80 release has now added official support for Heroku dyno names, making this workaround unnecessary:
https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-252040
https://github.com/edmorley/newrelic-python-agent/commit/d2c4aa097e18da56f6d2d21879796f7ef796f05a#diff-a57cabe85e94b1050fb4ff1749effcf5R335