### PR TITLE
Bug 1409381 - Fix thNotify when last param is omitted

### DIFF
--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -131,7 +131,7 @@ treeherder.factory('thNotify', [
              *   url -- Location the link should point to if exists
              */
             send: function (message, severity, opts) {
-                if (!_.isPlainObject(opts)) {
+                if (opts !== undefined && !_.isPlainObject(opts)) {
                     throw new Error('Must pass an object as last argument to thNotify.send!');
                 }
                 $log.debug("received message", message);


### PR DESCRIPTION
Now it is checking for ``undefined`` when the last param
was omitted and assigns it an empty object value.