### PR TITLE
Improve tests that get the next results

### DIFF
--- a/tests/jenkins/pages/treeherder.py
+++ b/tests/jenkins/pages/treeherder.py
@@ -29,9 +29,9 @@ class TreeherderPage(Base):
     _nav_filter_retry_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title=retry]')
     _nav_filter_successes_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title=success]')
     _nav_filter_usercancel_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title=usercancel]')
-    _next_ten_locator = (By.CSS_SELECTOR, 'div.btn:nth-child(1)')
-    _next_twenty_locator = (By.CSS_SELECTOR, 'div.btn:nth-child(2)')
-    _next_fifty_locator = (By.CSS_SELECTOR, 'div.btn:nth-child(3)')
+    _get_next_10_locator = (By.CSS_SELECTOR, 'div.btn:nth-child(1)')
+    _get_next_20_locator = (By.CSS_SELECTOR, 'div.btn:nth-child(2)')
+    _get_next_50_locator = (By.CSS_SELECTOR, 'div.btn:nth-child(3)')
     _quick_filter_locator = (By.ID, 'quick-filter')
     _repos_menu_locator = (By.ID, 'repoLabel')
     _result_sets_locator = (By.CSS_SELECTOR, '.result-set:not(.row)')
@@ -203,17 +203,20 @@ class TreeherderPage(Base):
     def filter_unclassified_jobs(self):
         self.find_element(*self._unclassified_failure_filter_locator).click()
 
-    def get_next_ten_results(self):
-        self.find_element(*self._next_ten_locator).click()
-        self.wait.until(lambda s: len(self.result_sets) == 20)
+    def _get_next(self, count):
+        before = len(self.result_sets)
+        locator = getattr(self, '_get_next_{}_locator'.format(count))
+        self.find_element(*locator).click()
+        self.wait.until(lambda s: len(self.result_sets) == before + count)
 
-    def get_next_twenty_results(self):
-        self.find_element(*self._next_twenty_locator).click()
-        self.wait.until(lambda s: len(self.result_sets) == 30)
+    def get_next_10(self):
+        self._get_next(10)
 
-    def get_next_fifty_results(self):
-        self.find_element(*self._next_fifty_locator).click()
-        self.wait.until(lambda s: len(self.result_sets) == 60)
+    def get_next_20(self):
+        self._get_next(20)
+
+    def get_next_50(self):
+        self._get_next(50)
 
     def open_next_unclassified_failure(self):
         el = self.find_element(*self._result_sets_locator)

--- a/tests/jenkins/tests/test_get_next_results.py
+++ b/tests/jenkins/tests/test_get_next_results.py
@@ -4,17 +4,9 @@ from pages.treeherder import TreeherderPage
 
 
 @pytest.mark.nondestructive
-def test_get_next_results(base_url, selenium):
+@pytest.mark.parametrize('count', ((10), (20), (50)))
+def test_get_next_results(base_url, selenium, count):
     page = TreeherderPage(selenium, base_url).open()
     assert len(page.result_sets) == 10
-
-    page.get_next_ten_results()
-    assert len(page.result_sets) == 20
-
-    page = TreeherderPage(selenium, base_url).open()
-    page.get_next_twenty_results()
-    assert len(page.result_sets) == 30
-
-    page = TreeherderPage(selenium, base_url).open()
-    page.get_next_fifty_results()
-    assert len(page.result_sets) == 60
+    getattr(page, 'get_next_{}'.format(count))()
+    assert len(page.result_sets) == 10 + count

--- a/tests/jenkins/tests/test_load_page_results.py
+++ b/tests/jenkins/tests/test_load_page_results.py
@@ -8,12 +8,12 @@ def test_load_next_results(base_url, selenium):
     page = TreeherderPage(selenium, base_url).open()
     assert len(page.result_sets) == 10
 
-    page.get_next_ten_results()
+    page.get_next_10()
     assert len(page.result_sets) == 20
 
-    page.get_next_twenty_results()
+    page.get_next_20()
     page.wait_for_page_to_load()
     assert len(page.result_sets) == 40
 
-    page.get_next_fifty_results()
+    page.get_next_50()
     assert len(page.result_sets) == 90


### PR DESCRIPTION
This improves the two tests that get next results by waiting for the number of results to increase by the specified value. I have also removed some duplication, and parameterised one test to improve overall runtime when distributing tests across multiple processes. Currently, test_load_next_results is failing because it's waiting for the wrong number of results.