### PR TITLE
Fix test_close_open_panels

### DIFF
--- a/tests/jenkins/pages/treeherder.py
+++ b/tests/jenkins/pages/treeherder.py
@@ -15,7 +15,6 @@ class TreeherderPage(Base):
     _clear_filter_locator = (By.ID, 'quick-filter-clear-button')
     _close_the_job_panel_locator = (By.CSS_SELECTOR, '.info-panel-navbar-controls > li:nth-child(2)')
     _filter_panel_all_failures_locator = (By.CSS_SELECTOR, '.pull-right input')
-    _filter_panel_body_locator = (By.CSS_SELECTOR, '.th-top-nav-options-panel')
     _filter_panel_busted_failures_locator = (By.ID, 'busted')
     _filter_panel_exception_failures_locator = (By.ID, 'exception')
     _filter_panel_locator = (By.CSS_SELECTOR, 'span.navbar-right > span:nth-child(4)')
@@ -66,11 +65,6 @@ class TreeherderPage(Base):
     @property
     def checkbox_testfailed_is_selected(self):
         return self.find_element(*self._filter_panel_testfailed_failures_locator).is_selected()
-
-    @property
-    def filter_panel_is_open(self):
-        el = self.find_element(*self._filter_panel_body_locator)
-        return el.is_displayed()
 
     @property
     def info_panel(self):

--- a/tests/jenkins/tests/test_keyboard_shortcuts.py
+++ b/tests/jenkins/tests/test_keyboard_shortcuts.py
@@ -4,21 +4,14 @@ from pages.treeherder import TreeherderPage
 
 
 def test_close_open_panels(base_url, selenium):
-    """Open Treeherder, verify shortcut: 'Esc' closes filter and job panel.
-    Open Treeherder page, open Filters panel, select random job, close all
-    panels using 'esc' button, verify if all panels are closed.
+    """Open Treeherder, verify shortcut: 'Esc' closes job panel.
+    Open Treeherder page, select random job, close all panels using 'esc'
+    button, verify if all panels are closed.
     """
     page = TreeherderPage(selenium, base_url).open()
-
-    page.click_on_filters_panel()
     page.select_random_job()
-
-    assert page.filter_panel_is_open
     assert page.info_panel.is_open
-
     page.close_all_panels()
-
-    assert not page.filter_panel_is_open
     assert not page.info_panel.is_open
 
 


### PR DESCRIPTION
The filters panel has been changed to a drop down, which is hidden once a job is selected. I've fixed the test by so that it only checks that the job details panel is closed when the keyboard shortcut is triggered.

@rbillings r?