### PR TITLE
Fix test_filter_panel_reset_button

### DIFF
--- a/tests/jenkins/pages/treeherder.py
+++ b/tests/jenkins/pages/treeherder.py
@@ -14,11 +14,10 @@ class TreeherderPage(Base):
     _active_watched_repo_locator = (By.CSS_SELECTOR, '#watched-repo-navbar button.active')
     _clear_filter_locator = (By.ID, 'quick-filter-clear-button')
     _close_the_job_panel_locator = (By.CSS_SELECTOR, '.info-panel-navbar-controls > li:nth-child(2)')
-    _filter_panel_all_failures_locator = (By.CSS_SELECTOR, '.pull-right input')
     _filter_panel_busted_failures_locator = (By.ID, 'busted')
     _filter_panel_exception_failures_locator = (By.ID, 'exception')
     _filter_panel_locator = (By.CSS_SELECTOR, 'span.navbar-right > span:nth-child(4)')
-    _filter_panel_reset_locator = (By.CSS_SELECTOR, '.pull-right span:nth-child(3)')
+    _filter_panel_reset_locator = (By.CSS_SELECTOR, '#filter-dropdown > li:last-child')
     _filter_panel_testfailed_failures_locator = (By.ID, 'testfailed')
     _info_panel_content_locator = (By.ID, 'info-panel-content')
     _mozilla_central_repo_locator = (By.CSS_SELECTOR, '#th-global-navbar-top a[href*="mozilla-central"]')
@@ -147,10 +146,6 @@ class TreeherderPage(Base):
 
     def close_all_panels(self):
         self.find_element(By.CSS_SELECTOR, 'body').send_keys(Keys.ESCAPE)
-
-    def deselect_all_failures(self):
-        """Filters Panel must be opened"""
-        self.find_element(*self._filter_panel_all_failures_locator).click()
 
     def deselect_busted_failures(self):
         """Filters Panel must be opened"""
@@ -349,6 +344,11 @@ class TreeherderPage(Base):
                 self.root.click()
 
         class Job(Region):
+
+            @property
+            def in_progress(self):
+                classes = self.root.get_attribute('class').split()
+                return any(c in ('btn-dkgray', 'btn-ltgray') for c in classes)
 
             @property
             def selected(self):

--- a/tests/jenkins/tests/test_filter_panel.py
+++ b/tests/jenkins/tests/test_filter_panel.py
@@ -42,23 +42,14 @@ def test_filter_by_test_status(base_url, selenium):
 
 @pytest.mark.nondestructive
 def test_filter_panel_reset_button(base_url, selenium):
-    """Open Treeherder page, open Filters Panel, disable all failures,
-    check that all checkboxes are not selected, check that there
-    are no failures, click reset button and verify that default checkboxes
-    are selected"""
+    """Open Treeherder page, hide jobs in progress, reset filters button and
+    verify in progress jobs are displayed"""
     page = TreeherderPage(selenium, base_url).open()
-    all_jobs = len(page.all_jobs)
-
+    assert any(j for j in page.all_jobs if j.in_progress)
+    page.filter_job_in_progress()
+    assert not page.nav_filter_in_progress_is_selected
+    assert not any(j for j in page.all_jobs if j.in_progress)
     page.click_on_filters_panel()
-    page.deselect_all_failures()
-    assert not page.checkbox_testfailed_is_selected
-    assert not page.checkbox_busted_is_selected
-    assert not page.checkbox_exception_is_selected
-
-    filtered_jobs = len(page.all_jobs)
-    assert not all_jobs == filtered_jobs
-
     page.reset_filters()
-    assert page.checkbox_testfailed_is_selected
-    assert page.checkbox_busted_is_selected
-    assert page.checkbox_exception_is_selected
+    assert page.nav_filter_in_progress_is_selected
+    assert any(j for j in page.all_jobs if j.in_progress)


### PR DESCRIPTION
This test is failing because of the recent filter panel changes. There's no longer a checkbox to hide all failures, so I've switched to using the navigation filters. I've also added checks to ensure that there are jobs of the specified type (switched to in progress as they are more abundant), and that there are none when they're hidden by the filter.

@rbillings r?