### PR TITLE
Improve test_expanding_group_count

### DIFF
--- a/tests/jenkins/tests/test_expanding_group_count.py
+++ b/tests/jenkins/tests/test_expanding_group_count.py
@@ -1,3 +1,5 @@
+import itertools
+
 import pytest
 
 from pages.treeherder import TreeherderPage
@@ -6,7 +8,9 @@ from pages.treeherder import TreeherderPage
 @pytest.mark.nondestructive
 def test_expanding_group_count(base_url, selenium):
     page = TreeherderPage(selenium, base_url).open()
-    group = next(g for g in page.result_sets[0].job_groups if not g.expanded)
+    all_groups = list(itertools.chain.from_iterable(
+        r.job_groups for r in page.result_sets))
+    group = next(g for g in all_groups if not g.expanded)
     jobs = group.jobs
     group.expand()
     assert len(group.jobs) > len(jobs)


### PR DESCRIPTION
I noticed a failure due to the first result set not having a job group to expand. This changes the test to target the first collapsed job group across all displayed result sets.

@rbillings r?