### PR TITLE
Bug 1384255 - Improve the documentation of cache-template.js

### DIFF
--- a/ui/js/cache-templates.js
+++ b/ui/js/cache-templates.js
@@ -3,7 +3,14 @@
 // This is a run block which, when used on an angular module, loads all
 // of the partials in /ui/partials and /ui/plugins into the Angular
 // template cache. This means that ng-includes and templateUrls will not
-// actually need to request a partial file at any point.
+// actually need to request a partial file at any point. See:
+// https://github.com/dmachat/angular-webpack-cookbook/wiki/Angular-Template-Cache
+
+// TODO: See if there's a way to avoid adding all partials to every page, that
+// importantly also works for ng-includes. Perhaps one of these would work:
+//  - https://github.com/teux/ng-cache-loader
+//  - https://github.com/WearyMonkey/ngtemplate-loader
+//  - https://github.com/EJIqpEP/angular-templatecache-loader
 module.exports = ['$templateCache', ($templateCache) => {
     const partialsReq = require.context('../partials', true, /\.(tmpl|html)$/);
     partialsReq.keys().forEach((template) => {


### PR DESCRIPTION
Since:
(a) the reason for it / where the implementation comes from was unclear
(b) it turns out we're including partials in every page's bundle which we really should fix as part of bug 1384255 