### PR TITLE
Bug 1351907 - Improve yarn script compatibility with Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,12 +56,12 @@
     "react-addons-test-utils": "15.3.2"
   },
   "scripts": {
-    "build": "./node_modules/neutrino/bin/neutrino build --presets ./neutrino-custom/production.js",
-    "lint": "./node_modules/eslint/bin/eslint.js --ext .js,.jsx ui/",
-    "start": "./node_modules/neutrino/bin/neutrino start --presets ./neutrino-custom/development.js",
-    "start:local": "./node_modules/neutrino/bin/neutrino start --presets ./neutrino-custom/local-watch.js",
-    "start:stage": "SERVICE_DOMAIN=https://treeherder.allizom.org ./node_modules/neutrino/bin/neutrino start --presets ./neutrino-custom/development.js",
-    "test": "./node_modules/neutrino/bin/neutrino test --presets ./neutrino-custom/test.js",
-    "test:watch": "./node_modules/neutrino/bin/neutrino test --watch --presets ./neutrino-custom/test.js"
+    "build": "node ./node_modules/neutrino/bin/neutrino build --presets ./neutrino-custom/production.js",
+    "lint": "node ./node_modules/eslint/bin/eslint.js --ext .js,.jsx ui/",
+    "start": "node ./node_modules/neutrino/bin/neutrino start --presets ./neutrino-custom/development.js",
+    "start:local": "node ./node_modules/neutrino/bin/neutrino start --presets ./neutrino-custom/local-watch.js",
+    "start:stage": "SERVICE_DOMAIN=https://treeherder.allizom.org node ./node_modules/neutrino/bin/neutrino start --presets ./neutrino-custom/development.js",
+    "test": "node ./node_modules/neutrino/bin/neutrino test --presets ./neutrino-custom/test.js",
+    "test:watch": "node ./node_modules/neutrino/bin/neutrino test --watch --presets ./neutrino-custom/test.js"
   }
 }


### PR DESCRIPTION
Typically the `package.json` commands call scripts that exist in the top-level `node_modules/.bin/` directory, which are (a) already on `PATH` when invoked by yarn, and (b) on Windows have `.cmd` script shims that work around Windows' lack of shebang support.

However due to symlinks being problematic inside Virtualbox, we have to use `--no-bin-links` with `yarn install`, which means the top-level `.bin/` directory doesn't exist. As such, the `<package>/bin/` scripts have to be used directly, which require prefixing with `node` to work around lack of shebang support on Windows.

See:
https://shapeshed.com/writing-cross-platform-node/#scripts-in-package-json

Note that even with these changes, the `start:stage` command will not work due to the environment variable prefix. This will be solved by the switch to newer Neutrino, which supports setting environment variables using the `--options` command line parameter instead.