### PR TITLE
Bug 1328710 - Set the sandbox attribute for the iframe used in the log viewer to improve security

### DIFF
--- a/ui/partials/logviewer/logviewer.html
+++ b/ui/partials/logviewer/logviewer.html
@@ -1,3 +1,4 @@
 <iframe
     id="logview"
-    frameBorder="0" />
+    frameBorder="0"
+    sandbox= "allow-scripts allow-same-origin" />


### PR DESCRIPTION
Trying to contribute to a FOSS project at Mozilla for the first time, and it seems this one is just about adding a sandbox attribute, so I thought I would try it out.
It appears that the only permissions needed in order for the iframe to show is allow-scripts and allow-same-origin.