### PR TITLE
Bug 1326250 - Fix TypeError in PerformanceParser error logging

### DIFF
--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -494,9 +494,8 @@ class PerformanceParser(ParserBase):
             except ValueError:
                 logger.warning("Unable to parse Perfherder data from line: %s",
                                line)
-            except jsonschema.ValidationError:
+            except jsonschema.ValidationError as e:
                 logger.warning("Perfherder line '%s' does not comply with "
-                               "json schema: %s", line)
-            # don't mark as complete, in case there are multiple performance
-            # artifacts
-            # self.complete = True
+                               "json schema: %s", line, e.message)
+
+            # Don't mark the parser as complete, in case there are multiple performance artifacts.


### PR DESCRIPTION
Previously schema violations would result in:
`TypeError: not enough arguments for format string`

See [bug 1326250 comment 1](https://bugzilla.mozilla.org/show_bug.cgi?id=1326250#c1) for why this didn't cause the test to fail. Other than parsing all test stdout/stderr, I'm not sure there is an easy way to make a test for it.

The exception `message` property is used instead of the `str` representation, since the latter results in pages of log output rather than just the human readable message:
https://github.com/Julian/jsonschema/blob/v2.6.0/jsonschema/exceptions.py#L59-L88
https://python-jsonschema.readthedocs.io/en/v2.6.0/errors/#jsonschema.exceptions.ValidationError.message