### PR TITLE
Further improvements to test_filter_jobs

### DIFF
--- a/tests/jenkins/pages/treeherder.py
+++ b/tests/jenkins/pages/treeherder.py
@@ -47,6 +47,11 @@ class TreeherderPage(Base):
         return self.find_element(*self._active_watched_repo_locator).text
 
     @property
+    def all_builds(self):
+        return list(itertools.chain.from_iterable(
+            r.builds for r in self.result_sets))
+
+    @property
     def all_emails(self):
         return list(itertools.chain.from_iterable([r.emails for r in self.result_sets]))
 

--- a/tests/jenkins/tests/test_filter_jobs.py
+++ b/tests/jenkins/tests/test_filter_jobs.py
@@ -3,24 +3,15 @@ import pytest
 from pages.treeherder import TreeherderPage
 
 
-def platforms(result_set):
-    parts = []
-    for build in result_set.builds:
-        parts.extend(build.platform_name.lower().split())
-    return set(parts)
-
-
-def linux_and_windows(result_set):
-    return {'linux', 'windows'}.issubset(platforms(result_set))
-
-
 @pytest.mark.nondestructive
 def test_filter_jobs(base_url, selenium):
     """Open resultset page and filter for platform"""
     page = TreeherderPage(selenium, base_url).open()
-    # select the first result set with linux and windows platforms
-    result_set = next(r for r in page.result_sets if linux_and_windows(r))
-    assert {'linux', 'windows'}.issubset(platforms(result_set))
+    platforms = [b.platform_name.lower() for b in page.all_builds]
+    assert any(p for p in platforms if 'linux' in p)
+    assert any(p for p in platforms if 'windows' in p)
+
     page.filter_by('linux')
-    assert 'linux' in platforms(result_set)
-    assert 'windows' not in platforms(result_set)
+    platforms = [b.platform_name.lower() for b in page.all_builds]
+    assert any(p for p in platforms if 'linux' in p)
+    assert not any(p for p in platforms if 'windows' in p)


### PR DESCRIPTION
I noticed we still had failures for this test, which *appear* to be related to the result sets refreshing on the page. This improvement looks across all builds and platforms rather than focusing on the first result set with the necessary platforms, and should be more stable.

@rbillings r?