### PR TITLE
Improve pin job tests

### DIFF
--- a/tests/jenkins/pages/treeherder.py
+++ b/tests/jenkins/pages/treeherder.py
@@ -228,9 +228,7 @@ class TreeherderPage(Base):
         self.find_element(*self._repos_menu_locator).click()
 
     def pin_using_spacebar(self):
-        el = self.find_element(*self._result_sets_locator)
-        self.wait.until(EC.visibility_of(el))
-        el.send_keys(Keys.SPACE)
+        self.find_element(By.CSS_SELECTOR, 'body').send_keys(Keys.SPACE)
         self.wait.until(lambda _: self.pinboard.is_pinboard_open)
 
     def reset_filters(self):

--- a/tests/jenkins/tests/test_pin_job.py
+++ b/tests/jenkins/tests/test_pin_job.py
@@ -1,10 +1,12 @@
+import random
+
 from pages.treeherder import TreeherderPage
 
 
 def test_pin_job(base_url, selenium):
     """Open treeherder page, select first job and pin it"""
     page = TreeherderPage(selenium, base_url).open()
-    job = page.result_sets[0].jobs[0]
+    job = random.choice(page.all_jobs)
     job.click()
     assert 0 == len(page.pinboard.jobs)
     page.pin_using_spacebar()
@@ -15,7 +17,7 @@ def test_pin_job(base_url, selenium):
 def test_pin_job_from_job_details(base_url, selenium):
     """Open treeherder page, select first job, pin it by the pin icon"""
     page = TreeherderPage(selenium, base_url).open()
-    job = page.result_sets[0].jobs[0]
+    job = random.choice(page.all_jobs)
     job.click()
     assert 0 == len(page.pinboard.jobs)
     page.info_panel.job_details.pin_job()
@@ -26,7 +28,7 @@ def test_pin_job_from_job_details(base_url, selenium):
 def test_clear_pinboard(base_url, selenium):
     """Open treeherder page, pin a job and then clear the pinboard"""
     page = TreeherderPage(selenium, base_url).open()
-    page.result_sets[0].jobs[0].click()
+    random.choice(page.all_jobs).click()
     page.pin_using_spacebar()
     assert 1 == len(page.pinboard.jobs)
     page.pinboard.clear_pinboard()
@@ -37,5 +39,6 @@ def test_clear_pinboard(base_url, selenium):
 def test_pin_all_jobs(base_url, selenium):
     """Open treeherder page, pin all jobs, confirm no more than 500 pins in pinboard"""
     page = TreeherderPage(selenium, base_url).open()
-    page.result_sets[0].pin_all_jobs()
-    assert 0 < len(page.pinboard.jobs) <= 500
+    result_set = next(r for r in page.result_sets if len(r.jobs) > 1)
+    result_set.pin_all_jobs()
+    assert len(result_set.jobs) <= len(page.pinboard.jobs) < 500


### PR DESCRIPTION
This improves the pin job tests by using a random job instead of assuming a suitable job exists in the first result set.

@rbillings r?