### PR TITLE
Improve range tests

### DIFF
--- a/tests/jenkins/pages/treeherder.py
+++ b/tests/jenkins/pages/treeherder.py
@@ -318,13 +318,19 @@ class TreeherderPage(Base):
             return self.find_element(*self._pin_all_jobs_locator).click()
 
         def set_as_bottom_of_range(self):
+            # TODO workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1411264
+            el = self.page.find_element(By.CSS_SELECTOR, 'body')
             self.find_element(*self._dropdown_toggle_locator).click()
             self.find_element(*self._set_bottom_of_range_locator).click()
+            self.wait.until(EC.staleness_of(el))
             self.page.wait_for_page_to_load()
 
         def set_as_top_of_range(self):
+            # TODO workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1411264
+            el = self.page.find_element(By.CSS_SELECTOR, 'body')
             self.find_element(*self._dropdown_toggle_locator).click()
             self.find_element(*self._set_top_of_range_locator).click()
+            self.wait.until(EC.staleness_of(el))
             self.page.wait_for_page_to_load()
 
         def view(self):

--- a/tests/jenkins/tests/test_range.py
+++ b/tests/jenkins/tests/test_range.py
@@ -6,17 +6,18 @@ from pages.treeherder import TreeherderPage
 @pytest.mark.nondestructive
 def test_set_as_top_of_range(base_url, selenium):
     page = TreeherderPage(selenium, base_url).open()
-    current_top_of_range = page.result_sets[0].datestamp
-    page.result_sets[1].set_as_top_of_range()
-    page.wait_for_page_to_load()
-    new_top_of_range = page.result_sets[0].datestamp
-    assert not new_top_of_range == current_top_of_range
+    result_sets = page.result_sets
+    datestamp = result_sets[1].datestamp
+    assert result_sets[0].datestamp != datestamp
+    result_sets[1].set_as_top_of_range()
+    assert page.result_sets[0].datestamp == datestamp
 
 
 @pytest.mark.nondestructive
 def test_set_as_bottom_of_range(base_url, selenium):
     page = TreeherderPage(selenium, base_url).open()
-    current_bottom_of_range = page.result_sets[9].datestamp
-    page.result_sets[0].set_as_bottom_of_range()
-    new_bottom_of_range = page.result_sets[0].datestamp
-    assert not new_bottom_of_range == current_bottom_of_range
+    result_sets = page.result_sets
+    datestamp = result_sets[-2].datestamp
+    assert result_sets[-1].datestamp != datestamp
+    page.result_sets[-2].set_as_bottom_of_range()
+    assert page.result_sets[-1].datestamp == datestamp


### PR DESCRIPTION
This improves the tests by working around bug 1411264 and picking result sets relative to the end of the list instead of assuming the number of result sets that exist.

@rbillings r?