### PR TITLE
Improve test_open_single_result by working around bug 1411264

### DIFF
--- a/tests/jenkins/pages/treeherder.py
+++ b/tests/jenkins/pages/treeherder.py
@@ -332,7 +332,10 @@ class TreeherderPage(Base):
             self.page.wait_for_page_to_load()
 
         def view(self):
+            # FIXME workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1411264
+            el = self.page.find_element(By.CSS_SELECTOR, 'body')
             self.find_element(*self._datestamp_locator).click()
+            self.wait.until(EC.staleness_of(el))
             self.page.wait_for_page_to_load()
 
         class Build(Region):

--- a/tests/jenkins/tests/test_view_single_result.py
+++ b/tests/jenkins/tests/test_view_single_result.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 
 from pages.treeherder import TreeherderPage
@@ -7,7 +9,8 @@ from pages.treeherder import TreeherderPage
 def test_open_single_result(base_url, selenium):
     page = TreeherderPage(selenium, base_url).open()
     assert len(page.result_sets) > 1
-    datestamp = page.result_sets[0].datestamp
-    page.result_sets[0].view()
+    result_set = random.choice(page.result_sets)
+    datestamp = result_set.datestamp
+    result_set.view()
     assert 1 == len(page.result_sets)
     assert datestamp == page.result_sets[0].datestamp


### PR DESCRIPTION
This works around bug 1411264, but also now picks a random result set instead of the first one every time.

@rbillings r?