### PR TITLE
Increase timeout to 20 seconds for UI tests

### DIFF
--- a/tests/jenkins/pages/base.py
+++ b/tests/jenkins/pages/base.py
@@ -4,6 +4,9 @@ from selenium.webdriver.common.by import By
 
 class Base(Page):
 
+    def __init__(self, driver, base_url=None, timeout=20, **url_kwargs):
+        super(Base, self).__init__(driver, base_url, timeout, **url_kwargs)
+
     @property
     def header(self):
         return self.Header(self)


### PR DESCRIPTION
Looking at the recent UI test failures, it appears that the initial page load often takes more than 10 seconds to display jobs. There are three options to resolve this:

1. Increase the timeout (this patch)
2. Improve the performance of the application
3. Automatically rerun the test

As we're planning to move these tests to run on Travis, where we will have control over the number of results and jobs, and performance/latency will be less of a concern, I have opted for increasing the timeout.

@rbillings, @edmorley r?