### PR TITLE
Fix test_open_single_result by avoiding result sets with no jobs

### DIFF
--- a/tests/jenkins/tests/test_view_single_result.py
+++ b/tests/jenkins/tests/test_view_single_result.py
@@ -9,7 +9,7 @@ from pages.treeherder import TreeherderPage
 def test_open_single_result(base_url, selenium):
     page = TreeherderPage(selenium, base_url).open()
     assert len(page.result_sets) > 1
-    result_set = random.choice(page.result_sets)
+    result_set = random.choice([r for r in page.result_sets if r.jobs])
     datestamp = result_set.datestamp
     result_set.view()
     assert 1 == len(page.result_sets)


### PR DESCRIPTION
After clicking a result set, we wait for there to be at least one job displayed so that we are confident that the page has loaded enough to continue with the tests. This change ensures we only attempt to view a result set that has at least one job associated.

@rbillings r?