### PR TITLE
Bug 1413156 - refactor _.filter to es6 array.filter

### DIFF
--- a/ui/js/components/perf/compare.js
+++ b/ui/js/components/perf/compare.js
@@ -49,7 +49,7 @@ treeherder.component('phCompareTable', {
             if (_.isUndefined(ctrl.filterOptions.filter)) {
                 return results;
             }
-            return _.filter(results, function (result) {
+            return results.filter((result) => {
                 var testCondition = `${key} ${($attrs.type === 'trend') ? result.trendResult.name : result.name}`;
                 return _.every(ctrl.filterOptions.filter.split(' '), function (matchText) {
                     if ($attrs.type === 'trend') {

--- a/ui/js/controllers/perf/alerts.js
+++ b/ui/js/controllers/perf/alerts.js
@@ -212,7 +212,7 @@ perf.controller('AlertsCtrl', [
                     $scope.selectNoneOrSelectAll(alertSummary);
                 }
             });
-            $scope.numFilteredAlertSummaries = _.filter($scope.alertSummaries, { anyVisible: false }).length;
+            $scope.numFilteredAlertSummaries = $scope.alertSummaries.filter(summary => !summary.anyVisible).length;
 
         }
 
@@ -368,7 +368,7 @@ perf.controller('AlertsCtrl', [
             // We need to update not only the summary when resetting the alert,
             // but other summaries affected by the change
             var summariesToUpdate = [alertSummary].concat(_.flatten(_.map(
-                _.filter(alertSummary.alerts, { selected: true }),
+                alertSummary.alerts.filter(alert => alert.selected),
                 function (alert) {
                     return _.find($scope.alertSummaries, function (alertSummary) {
                         return alertSummary.id === alert.related_summary_id;

--- a/ui/js/controllers/perf/dashboard.js
+++ b/ui/js/controllers/perf/dashboard.js
@@ -62,9 +62,7 @@ perf.controller('dashCtrl', [
                     interval: $scope.selectedTimeRange.value,
                     subtests: 0,
                     framework: $scope.framework }).then(function (seriesList) {
-                        return _.filter(seriesList, function (series) {
-                            return filterSeriesByTopic(series);
-                        });
+                        return seriesList.filter(series => filterSeriesByTopic(series));
                     });
             }
 

--- a/ui/js/controllers/perf/e10s-trend.js
+++ b/ui/js/controllers/perf/e10s-trend.js
@@ -75,11 +75,11 @@ perf.controller('e10sTrendCtrl', [
                     base: {}
                 };
 
-                var seriesToMeasure = _.filter(seriesList, function (series) {
-                    return series.options.indexOf('pgo') >= 0 ||
+                var seriesToMeasure = seriesList.filter(series =>
+                    series.options.indexOf('pgo') >= 0 ||
                         (series.platform === 'osx-10-10' &&
-                         series.options.indexOf('opt') >= 0);
-                });
+                            series.options.indexOf('opt') >= 0)
+                );
 
                 platformList = _.uniq(_.map(seriesToMeasure, 'platform'));
                 // we just use the unadorned suite name to distinguish tests in this view
@@ -328,11 +328,11 @@ perf.controller('e10sTrendSubtestCtrl', [
                 var summaryTestName = seriesList[0].platform + ": " + seriesList[0].suite;
                 $scope.titles[summaryTestName] = summaryTestName;
 
-                var seriesToMeasure = _.filter(seriesList, function (series) {
-                    return series.options.indexOf('pgo') >= 0 ||
+                var seriesToMeasure = seriesList.filter(series =>
+                    series.options.indexOf('pgo') >= 0 ||
                         (series.platform === 'osx-10-10' &&
-                         series.options.indexOf('opt') >= 0);
-                });
+                         series.options.indexOf('opt') >= 0)
+                );
 
                 $q.all(_.chunk(seriesToMeasure, 20).map(function (seriesChunk) {
                     var params = {

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -559,7 +559,7 @@ perf.controller('GraphsCtrl', [
                 series: $scope.seriesList.map(series => `${series.projectName},${series.id},${series.visible ? 1 : 0},${series.frameworkId}`),
                 timerange: ($scope.myTimerange.value !== phDefaultTimeRangeValue) ?
                     $scope.myTimerange.value : undefined,
-                highlightedRevisions: $scope.highlightedRevision.filter(highlight => highlight && highlight.length >= 12),
+                highlightedRevisions: $scope.highlightedRevisions.filter(highlight => highlight && highlight.length >= 12),
                 highlightAlerts: !$scope.highlightAlerts ? 0 : undefined,
                 zoom: (function () {
                     if ((typeof $scope.zoom.x !== "undefined")

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -559,11 +559,7 @@ perf.controller('GraphsCtrl', [
                 series: $scope.seriesList.map(series => `${series.projectName},${series.id},${series.visible ? 1 : 0},${series.frameworkId}`),
                 timerange: ($scope.myTimerange.value !== phDefaultTimeRangeValue) ?
                     $scope.myTimerange.value : undefined,
-                highlightedRevisions: _.filter($scope.highlightedRevisions,
-                    function (highlight) {
-                        return (highlight &&
-                            highlight.length >= 12);
-                    }),
+                highlightedRevisions: $scope.highlightedRevision.filter(highlight => highlight && highlight.length >= 12),
                 highlightAlerts: !$scope.highlightAlerts ? 0 : undefined,
                 zoom: (function () {
                     if ((typeof $scope.zoom.x !== "undefined")
@@ -885,11 +881,9 @@ perf.filter('testNameContainsWords', function () {
         }
 
         var filters = textFilter.split(/\s+/);
-        return _.filter(tests, function (test) {
-            return _.every(filters, function (filter) {
-                return test.name.toLowerCase().indexOf(filter) !== -1;
-            });
-        });
+        return tests.filter(test => _.every(filters, function (filter) {
+            return test.name.toLowerCase().indexOf(filter) !== -1;
+        }));
     };
 });
 
@@ -978,14 +972,14 @@ perf.controller('TestChooserCtrl', ['$scope', '$uibModalInstance', '$http',
                     interval: $scope.timeRange,
                     framework: originalSeries.frameworkId
                 }).then(function (seriesList) {
-                    $scope.testsToAdd = _.clone(_.filter(seriesList, function (series) {
-                        return series.platform !== originalSeries.platform &&
-                            series.name === originalSeries.name &&
-                            !_.some(testsDisplayed, {
-                                projectName: series.projectName,
-                                signature: series.signature
-                            });
-                    }));
+                    $scope.testsToAdd = _.clone(seriesList.filter(series =>
+                        series.platform !== originalSeries.platform &&
+                        series.name === originalSeries.name &&
+                        !_.some(testsDisplayed, {
+                            projectName: series.projectName,
+                            signature: series.signature
+                        })
+                    ));
                 }).then(function () {
                     // resolve the testsToAdd's length after every thing was done
                     // so we don't need timeout here
@@ -1014,12 +1008,10 @@ perf.controller('TestChooserCtrl', ['$scope', '$uibModalInstance', '$http',
                 seriesList = _.flatten(seriesList);
 
                 // filter out tests which are already displayed
-                $scope.testsToAdd = _.filter(seriesList, function (series) {
-                    return !_.some(testsDisplayed, {
-                        projectName: series.projectName,
-                        signature: series.signature
-                    });
-                });
+                $scope.testsToAdd = seriesList.filter(series => !_.some(testsDisplayed, {
+                    projectName: series.projectName,
+                    signature: series.signature
+                }));
             }).then(function () {
                 loadingExtraDataPromise.resolve($scope.testsToAdd.length);
             });
@@ -1031,11 +1023,11 @@ perf.controller('TestChooserCtrl', ['$scope', '$uibModalInstance', '$http',
                     interval: $scope.timeRange,
                     framework: originalSeries.frameworkId
                 }).then(function (seriesList) {
-                    $scope.testsToAdd = _.clone(_.filter(seriesList, function (series) {
-                        return series.platform === originalSeries.platform &&
-                            series.testName === originalSeries.testName &&
-                            series.name !== originalSeries.name;
-                    }));
+                    $scope.testsToAdd = _.clone(seriesList.filter(series =>
+                        series.platform === originalSeries.platform &&
+                        series.testName === originalSeries.testName &&
+                        series.name !== originalSeries.name
+                    ));
                 }).then(function () {
                     // resolve the testsToAdd's length after every thing was done
                     // so we don't need timeout here
@@ -1102,8 +1094,9 @@ perf.controller('TestChooserCtrl', ['$scope', '$uibModalInstance', '$http',
                             framework: $scope.selectedFramework.id,
                             subtests: $scope.includeSubtests ? 1 : 0 }).then(function (seriesList) {
                                 $scope.unselectedTestList = _.sortBy(
-                                    _.filter(seriesList,
-                                    { platform: $scope.selectedPlatform }), 'name');
+                                    seriesList.filter(series => series.platform === $scope.selectedPlatform),
+                                    'name'
+                                );
                                 // filter out tests which are already displayed or are
                                 // already selected
                                 _.forEach(_.union(testsDisplayed, $scope.testsToAdd),

--- a/ui/js/filters.js
+++ b/ui/js/filters.js
@@ -97,7 +97,10 @@ treeherder.filter('initials', function () {
     return function (input) {
         var str = input || '';
         var words = str.split(' ');
-        var firstLetters = _.filter(_.map(words, function (word) { return word.replace(/[^A-Z]/gi, '')[0]; }));
+        var firstLetters = _.map(
+            words,
+            word => word.replace(/[^A-Z]/gi, '')[0]
+        ).filter(firstLetter => typeof firstLetter !== 'undefined');
         var initials = "";
 
         if (firstLetters.length === 1) {

--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -31,21 +31,21 @@ treeherder.factory('ThJobModel', [
                 this.job_group_symbol;
             symbolInfo += "(" + this.job_type_symbol + ")";
 
-            return _.filter([
+            return [
                 thPlatformName(this.platform),
                 this.platform_option,
                 (this.job_group_name === 'unknown') ? undefined : this.job_group_name,
                 this.job_type_name,
                 symbolInfo
-            ]).join(' ');
+            ].filter(item => typeof item !== 'undefined').join(' ');
         };
 
         ThJobModel.prototype.get_search_str = function () {
-            return _.filter([
+            return [
                 this.get_title(),
                 this.ref_data_name,
                 (this.signature !== this.ref_data_name) ? this.signature : undefined
-            ]).join(' ');
+            ].filter(item => typeof item !== 'undefined').join(' ');
         };
 
         ThJobModel.get_uri = function (repoName) { return thUrl.getProjectUrl("/jobs/", repoName); };

--- a/ui/js/models/perf/alerts.js
+++ b/ui/js/models/perf/alerts.js
@@ -74,14 +74,14 @@ treeherder.factory('PhAlerts', [
         });
         AlertSummary.prototype.getTextualSummary = function (copySummary) {
             var resultStr = "";
-            var improved = _.sortBy(_.filter(this.alerts, function (alert) {
-                return !alert.is_regression && alert.visible;
-            }),
-            'amount_pct').reverse();
-            var regressed = _.sortBy(_.filter(this.alerts, function (alert) {
-                return alert.is_regression && alert.visible && !alert.isInvalid();
-            }),
-            'amount_pct').reverse();
+            var improved = _.sortBy(
+                this.alerts.filter(alert => !alert.is_regression && alert.visible),
+                'amount_pct'
+            ).reverse();
+            var regressed = _.sortBy(
+                this.alerts.filter(alert => alert.is_regression && alert.visible && !alert.isInvalid()),
+                'amount_pct'
+            ).reverse();
 
             var formatAlert = function (alert, alertList) {
                 return _.padStart(alert.amount_pct.toFixed(0), 3) + "%  " +
@@ -162,17 +162,17 @@ treeherder.factory('PhAlerts', [
 
             // we should never include downstream alerts in the description
             var alertSummary = this;
-            var alertsInSummary = _.filter(this.alerts, function (alert) {
-                return (alert.status !== phAlertStatusMap.DOWNSTREAM.id ||
-                        alert.summary_id === alertSummary.id);
-            });
+            var alertsInSummary = this.alerts.filter(alert =>
+                (alert.status !== phAlertStatusMap.DOWNSTREAM.id ||
+                        alert.summary_id === alertSummary.id)
+            );
 
             // figure out if there are any regressions -- if there are,
             // the summary should only incorporate those. if there
             // aren't, then use all of them (that aren't downstream,
             // see above)
             if (_.some(_.map(alertsInSummary, 'is_regression'))) {
-                alertsInSummary = _.filter(alertsInSummary, 'is_regression');
+                alertsInSummary = alertsInSummary.filter(alert => alert.is_regression);
             }
 
             if (alertsInSummary.length > 1) {
@@ -206,7 +206,7 @@ treeherder.factory('PhAlerts', [
         AlertSummary.prototype.modifySelectedAlerts = function (modification) {
             this.allSelected = false;
 
-            return $q.all(_.filter(this.alerts, { selected: true }).map(
+            return $q.all(this.alerts.filter(alert => alert.selected).map(
                 function (selectedAlert) {
                     selectedAlert.selected = false;
                     return selectedAlert.modify(modification);

--- a/ui/js/models/repository.js
+++ b/ui/js/models/repository.js
@@ -298,7 +298,7 @@ treeherder.factory('ThRepositoryModel', [
 
             // filter out non-watched and unsupported repos to prevent repeatedly
             // hitting an endpoint we know will never work.
-            repoNames = _.filter(repoNames, function (repo) {
+            repoNames = repoNames.filter((repo) => {
                 if (_.includes(watchedRepos, repo) && repos[repo].treeStatus.status !== 'unsupported') {
                     return repo;
                 }

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -197,9 +197,7 @@ treeherder.factory('ThResultSetStore', [
                     // get the new job ids
                     var jobIds = _.map(jobList, 'id');
                     // remove the elements that need to be updated
-                    resultSet.jobList = _.filter(resultSet.jobList, function (job) {
-                        return _.indexOf(jobIds, job.id) === -1;
-                    });
+                    resultSet.jobList = resultSet.jobList.filter(job => _.indexOf(jobIds, job.id) === -1);
                     resultSet.jobList = resultSet.jobList.concat(jobList);
                 } else {
                     resultSet.jobList = jobList;

--- a/ui/js/services/jsonpushes.js
+++ b/ui/js/services/jsonpushes.js
@@ -67,7 +67,7 @@ treeherder.service('JsonPushes', ['$http', '$q', function ($http, $q) {
             });
             return $q.all(promises).then(
                 function (results) {
-                    results = _.filter(results);
+                    results = results.filter(result => typeof result !== 'undefined');
                     if (results.length === 0) {
                         // nothing found - try with the parent of the parent
                         setTimeout(function () {


### PR DESCRIPTION
Just wanted to see if this is the type of refactor you were looking for.
I kept it to _.filter; do you want a new PR for each function replacement?

I am also slightly concerned about any lodash-specific "iterables". I assumed these
iterables were only arrays. I didn't run into any errors while testing and running
the unit tests. 

"""
Remove existing lodash filter function and replace with
es6's array.filter(). Some whitespace changes were
made for clarity or because the linter got upset.
"""