### PR TITLE
Bug 1414312 - Fix perfherder textual alert summary copy function on recent Firefoxen

### DIFF
--- a/ui/js/models/perf/alerts.js
+++ b/ui/js/models/perf/alerts.js
@@ -92,8 +92,7 @@ treeherder.factory('PhAlerts', [
             // add summary header if getting text for clipboard only
             if (copySummary) {
                 var lastUpdated = new Date(this.last_updated);
-                resultStr += "== Change summary for alert #" + this.id +
-                             " (as of " + lastUpdated.toLocaleFormat("%B %d %Y %H:%M UTC") + ") ==\n";
+                resultStr += `== Change summary for alert #${this.id} (as of ${lastUpdated.toUTCString()}) ==\n`;
             }
             if (regressed.length > 0) {
                 // add a newline if we displayed the header


### PR DESCRIPTION
It used toLocaleFormat, which was never standard and seems to no longer be defined
in recent Firefox versions. Use toUTCString instead, which seems to be available
everywhere.