### PR TITLE
Docs - README.md - tweaks (ToC, separators)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-treeherder
+TreeHerder
 ==================
 [![Build Status](https://travis-ci.org/mozilla/treeherder.png?branch=master)](https://travis-ci.org/mozilla/treeherder)
 [![Python Package Status](https://pyup.io/repos/github/mozilla/treeherder/shield.svg)](https://pyup.io/repos/github/mozilla/treeherder/)
@@ -6,22 +6,28 @@ treeherder
 [![Node devDependencies Status](https://david-dm.org/mozilla/treeherder/dev-status.svg)](https://david-dm.org/mozilla/treeherder?type=dev)
 [![Documentation Status](https://readthedocs.org/projects/treeherder/badge/?version=latest)](https://treeherder.readthedocs.io/?badge=latest)
 
+Table of Contents (ToC)
+=======================
 
-#### Description
+* [Description](#description)
+* [Instances](#instances)
+* [Installation](#installation)
+* [Links](#links)
+
+## Description
 [Treeherder](https://treeherder.mozilla.org) is a reporting dashboard for Mozilla checkins. It allows users to see the results of automatic builds and their respective tests. The Treeherder service manages the etl layer for data ingestion, web services, and the data model behind Treeherder.
 
-
-#### Instances
+### Instances
 Treeherder exists on two instances, [stage](https://treeherder.allizom.org) for pre-deployment validation, and [production](https://treeherder.mozilla.org) for actual use.
 
+---
 
-#### Installation
+## Installation
 The steps to run Treeherder are provided [here](https://treeherder.readthedocs.io/installation.html).
 
 The steps to run only the UI are provided [here](https://treeherder.readthedocs.io/ui/installation.html).
 
-
-#### Links
+### Links
 
 Visit our project tracking Wiki at:
 https://wiki.mozilla.org/EngineeringProductivity/Projects/Treeherder
@@ -30,3 +36,7 @@ Visit our **readthedocs** page for other setup and configuration at:
 https://treeherder.readthedocs.io/
 
 File any bugs you may encounter [here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&component=Treeherder).
+
+---
+
+<img src="https://avatars2.githubusercontent.com/u/131524?s=200&v=4" width="50"></img>


### PR DESCRIPTION
## Docs - README.md - tweaks (ToC, separators)

**the current PR does basically aim at adding the following tweaks to the README.md file:**
- *ToC - table of contents*
- *separators*
- *thumbnail logo*
- *reviewing document hierarchical tree*

---

**motivaton for such:**
- *improving overall document accessebility*

---

<img src="https://avatars2.githubusercontent.com/u/131524?s=200&v=4" width="50"></img> <img src="https://avatars1.githubusercontent.com/u/7303598?s=460&v=4" width="50"></img>