### PR TITLE
Get runnable jobs from current decision task on every project.

### DIFF
--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -331,9 +331,6 @@ treeherder.factory('ThResultSetStore', [
 
         var addRunnableJobs = function (repoName, resultSet) {
             getGeckoDecisionTaskId(repoName, resultSet.id).then(function (decisionTaskId) {
-                if (repoName !== "try") {
-                    decisionTaskId = "";
-                }
                 return ThRunnableJobModel.get_list(repoName, { decision_task_id: decisionTaskId }).then(function (jobList) {
                     var id = resultSet.id;
                     _.each(jobList, function (job) {


### PR DESCRIPTION
It [looks](https://github.com/mozilla/treeherder/pull/2057/files#diff-9da180a71af78c18a9d5089198b6099fL356) like it was meant to be temporary.