### PR TITLE
Bug 1414667 - Travis: Test using Firefox beta instead of stable

### DIFF
--- a/bin/travis-setup.sh
+++ b/bin/travis-setup.sh
@@ -56,7 +56,7 @@ setup_geckodriver() {
 
 setup_js_env() {
     echo '-----> Installing Firefox'
-    curl -sSfL 'https://download.mozilla.org/?product=firefox-latest&lang=en-US&os=linux64' | tar -jxC "${HOME}"
+    curl -sSfL 'https://download.mozilla.org/?product=firefox-beta-latest&lang=en-US&os=linux64' | tar -jxC "${HOME}"
     export PATH="${HOME}/firefox:${PATH}"
     # Enable Firefox headless mode, avoiding the need for xvfb.
     export MOZ_HEADLESS=1


### PR DESCRIPTION
Since it reduces the intermittent failure rate in bug 1401048 and is also likely more representative of what people are using to access Treeherder in production (whilst still being more stable than Nightly).