### PR TITLE
Bug 1414255 - Vagrant: Use alternative fix for shellcheck SC2164

### DIFF
--- a/vagrant/.profile
+++ b/vagrant/.profile
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# Make non-zero exit codes & other errors fatal.
-set -euo pipefail
-
 # Source .bashrc, since the default .profile we're replacing did so.
 # shellcheck source=/dev/null
 . "$HOME/.bashrc"
@@ -20,7 +17,7 @@ sudo iptables -t nat -A PREROUTING -i enp0s3 -p tcp -j DNAT --to 127.0.0.1
 
 PS1='\[\e[0;31m\]\u\[\e[m\] \[\e[1;34m\]\w\[\e[m\] \$ '
 echo "Type 'thelp' to see a list of Treeherder-specific helper aliases"
-cd "$HOME/treeherder"
+cd "$HOME/treeherder" || return 1
 
 # Helper aliases
 


### PR DESCRIPTION
Since the `.profile` script is sourced in the login shell, so using strict mode can cause the shell to exit and so `vagrant ssh` to not work. Instead we fix the SC2164 using the method here:
https://github.com/koalaman/shellcheck/wiki/SC2164