### PR TITLE
Bug 1413156 - Remove lodash forEach usage for arrays

### DIFF
--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -77,7 +77,7 @@ treeherderApp.controller('JobsCtrl', [
         }
 
         $rootScope.$on(thEvents.toggleAllRevisions, function (ev, expand) {
-            _.forEach($scope.result_sets, function (rs) {
+            $scope.result_sets.forEach(function (rs) {
                 $rootScope.$emit(thEvents.toggleRevisions, rs, expand);
             });
         });

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -257,7 +257,7 @@ treeherderApp.controller('MainCtrl', [
             // If any tier has changed, update the tier menu check boxes and
             // throw an event.
             var changed = false;
-            _.forEach(thJobFilters.tiers, function (tier) {
+            thJobFilters.tiers.forEach(function (tier) {
                 var isShowing = $scope.isTierShowing(tier);
                 if (isShowing !== $scope.tiers[tier]) {
                     $scope.tiers[tier] = isShowing;

--- a/ui/js/controllers/perf/alerts.js
+++ b/ui/js/controllers/perf/alerts.js
@@ -175,8 +175,8 @@ perf.controller('AlertsCtrl', [
         };
 
         function updateAlertVisibility() {
-            _.forEach($scope.alertSummaries, function (alertSummary) {
-                _.forEach(alertSummary.alerts, function (alert) {
+            $scope.alertSummaries.forEach(function (alertSummary) {
+                alertSummary.alerts.forEach(function (alert) {
                     // only show alert if it passes all filter criteria
                     // also hide downstream alerts that are not directly related
                     // to this summary (FIXME: maybe show something underneath
@@ -381,7 +381,7 @@ perf.controller('AlertsCtrl', [
             }).then(
                 function () {
                     // update the alert summaries appropriately
-                    _.forEach(summariesToUpdate, function (alertSummary) {
+                    summariesToUpdate.forEach(function (alertSummary) {
                         updateAlertSummary(alertSummary);
                     });
                 });
@@ -402,8 +402,7 @@ perf.controller('AlertsCtrl', [
                 _.defaults(resultSetToSummaryMap,
                            _.set({}, alertSummary.repository, {}));
 
-                _.forEach(
-                    [alertSummary.push_id, alertSummary.prev_push_id],
+                [alertSummary.push_id, alertSummary.prev_push_id].forEach(
                     function (resultSetId) {
                         // skip nulls
                         if (resultSetId === null) return;
@@ -429,7 +428,7 @@ perf.controller('AlertsCtrl', [
                                     function (t) {
                                         return ((Date.now() / 1000.0) - resultSet.push_timestamp) < t;
                                     }));
-                                _.forEach(resultSetToSummaryMap[repo][resultSet.id],
+                                resultSetToSummaryMap[repo][resultSet.id].forEach(
                                           function (summary) {
                                               if (summary.push_id === resultSet.id) {
                                                   summary.resultSetMetadata = resultSet;
@@ -443,7 +442,7 @@ perf.controller('AlertsCtrl', [
             })).then(function () {
                 // for all complete summaries, fill in job and pushlog links
                 // and downstream summaries
-                _.forEach(alertSummaries, function (summary) {
+                alertSummaries.forEach(function (summary) {
                     var repo = _.find($rootScope.repos,
                                       { name: summary.repository });
 

--- a/ui/js/controllers/perf/dashboard.js
+++ b/ui/js/controllers/perf/dashboard.js
@@ -303,7 +303,7 @@ perf.controller('dashSubtestCtrl', [
                                              function (results) {
                                                  return results.name;
                                              });
-                    _.forEach(subtestNames, function (subtestName) {
+                    subtestNames.forEach(function (subtestName) {
                         var baseSig = _.find(Object.keys(resultsMap.base), function (sig) {
                             return resultsMap.base[sig].name === subtestName;
                         });

--- a/ui/js/controllers/perf/e10s-trend.js
+++ b/ui/js/controllers/perf/e10s-trend.js
@@ -360,7 +360,7 @@ perf.controller('e10sTrendSubtestCtrl', [
                                              function (results) {
                                                  return results.name;
                                              });
-                    _.forEach(subtestNames, function (subtestName) {
+                    subtestNames.forEach(function (subtestName) {
                         var baseSig = _.find(Object.keys(resultsMap.base), function (sig) {
                             return resultsMap.base[sig].name === subtestName;
                         });

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -253,7 +253,7 @@ perf.controller('GraphsCtrl', [
             $scope.seriesList.forEach(function (series, i) {
                 if (series.visible && series.highlightedPoints &&
                     series.highlightedPoints.length) {
-                    _.forEach(series.highlightedPoints, function (highlightedPoint) {
+                    series.highlightedPoints.forEach(function (highlightedPoint) {
                         $scope.plot.highlight(i, highlightedPoint);
                     });
                 }
@@ -414,9 +414,9 @@ perf.controller('GraphsCtrl', [
             }
 
             if ($scope.highlightAlerts) {
-                _.forEach($scope.seriesList, function (series) {
+                $scope.seriesList.forEach(function (series) {
                     if (series.visible) {
-                        _.forEach(series.relatedAlertSummaries, function (alertSummary) {
+                        series.relatedAlertSummaries.forEach(function (alertSummary) {
                             addHighlightedDatapoint(series, alertSummary.push_id);
                         });
                     }
@@ -1106,7 +1106,7 @@ perf.controller('TestChooserCtrl', ['$scope', '$uibModalInstance', '$http',
                                     { platform: $scope.selectedPlatform }), 'name');
                                 // filter out tests which are already displayed or are
                                 // already selected
-                                _.forEach(_.union(testsDisplayed, $scope.testsToAdd),
+                                _.union(testsDisplayed, $scope.testsToAdd).forEach(
                                     function (test) {
                                         _.remove($scope.unselectedTestList, {
                                             projectName: test.projectName,

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -318,7 +318,7 @@ treeherder.directive('thCloneJobs', [
             var lastJobSelected = ThResultSetStore.getSelectedJob($rootScope.repoName);
             var typeSymbolCounts = _.countBy(jgObj.jobs, "job_type_symbol");
 
-            _.forEach(jgObj.jobs, function (job) {
+            jgObj.jobs.forEach(function (job) {
 
                 // Set the resultState
                 var resultStatus = thResultStatus(job);
@@ -356,7 +356,7 @@ treeherder.directive('thCloneJobs', [
                 }
             });
 
-            _.forEach(stateCounts, function (countInfo) {
+            stateCounts.forEach(function (countInfo) {
                 if (countInfo.count === 1) {
                     // if there is only 1 job for this status, then just add
                     // the job, rather than the count

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -356,7 +356,7 @@ treeherder.directive('thCloneJobs', [
                 }
             });
 
-            stateCounts.forEach(function (countInfo) {
+            _.forEach(stateCounts, function (countInfo) {
                 if (countInfo.count === 1) {
                     // if there is only 1 job for this status, then just add
                     // the job, rather than the count

--- a/ui/js/models/perf/alerts.js
+++ b/ui/js/models/perf/alerts.js
@@ -54,7 +54,7 @@ treeherder.factory('PhAlerts', [
                              '/api/performance/alert/' + this.id + '/',
                              modification);
         };
-        phAlertStatusMap.forEach(function (status) {
+        _.forEach(phAlertStatusMap, function (status) {
             Alert.prototype['is' + _.capitalize(status.text)] = function () {
                 return this.status === status.id;
             };
@@ -64,7 +64,7 @@ treeherder.factory('PhAlerts', [
             _.assign(this, alertSummaryData);
             this._initializeAlerts(optionCollectionMap);
         };
-        phAlertSummaryStatusMap.forEach(function (status) {
+        _.forEach(phAlertSummaryStatusMap, function (status) {
             AlertSummary.prototype['is' + _.capitalize(status.text)] = function () {
                 return this.status === status.id;
             };

--- a/ui/js/models/perf/alerts.js
+++ b/ui/js/models/perf/alerts.js
@@ -54,7 +54,7 @@ treeherder.factory('PhAlerts', [
                              '/api/performance/alert/' + this.id + '/',
                              modification);
         };
-        _.forEach(phAlertStatusMap, function (status) {
+        phAlertStatusMap.forEach(function (status) {
             Alert.prototype['is' + _.capitalize(status.text)] = function () {
                 return this.status === status.id;
             };
@@ -64,7 +64,7 @@ treeherder.factory('PhAlerts', [
             _.assign(this, alertSummaryData);
             this._initializeAlerts(optionCollectionMap);
         };
-        _.forEach(phAlertSummaryStatusMap, function (status) {
+        phAlertSummaryStatusMap.forEach(function (status) {
             AlertSummary.prototype['is' + _.capitalize(status.text)] = function () {
                 return this.status === status.id;
             };

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -285,7 +285,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
                     let tclabels = [];
                     let bbnames = [];
 
-                    _.forEach(buildernames, function (name) {
+                    buildernames.forEach(function (name) {
                         // The following has 3 cases that it accounts for
                         // 1. The name is a buildbot buildername not scheduled through bbb, in which case we pass it on
                         // 2. The name is a taskcluster task label, in which case we pass it on

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -717,7 +717,7 @@ treeherder.factory('ThResultSetStore', [
 
             var platformData = {};
 
-            _.forEach(jobList, function (job) {
+            jobList.forEach(function (job) {
                 aggregateJobPlatform(repoName, job, platformData);
             });
 

--- a/ui/js/services/classifications.js
+++ b/ui/js/services/classifications.js
@@ -28,7 +28,7 @@ treeherder.factory('thClassificationTypes', [
         var load = function () {
             return $http.get(thUrl.getRootUrl("/failureclassification/"), { cache: true })
                 .success(function (data) {
-                    _.forEach(data, addClassification);
+                    data.forEach(addClassification);
                 });
         };
 

--- a/ui/js/services/pinboard.js
+++ b/ui/js/services/pinboard.js
@@ -38,7 +38,7 @@ treeherder.factory('thPinboard', [
         };
 
         var saveBugs = function (job) {
-            relatedBugs.forEach(function (bug) {
+            Object.entries(relatedBugs).forEach(function ([key, bug]) {
                 var bjm = new ThBugJobMapModel({
                     bug_id: bug.id,
                     job_id: job.id,

--- a/ui/js/services/pinboard.js
+++ b/ui/js/services/pinboard.js
@@ -38,7 +38,7 @@ treeherder.factory('thPinboard', [
         };
 
         var saveBugs = function (job) {
-            _.forEach(relatedBugs, function (bug) {
+            relatedBugs.forEach(function (bug) {
                 var bjm = new ThBugJobMapModel({
                     bug_id: bug.id,
                     job_id: job.id,
@@ -77,7 +77,7 @@ treeherder.factory('thPinboard', [
             },
 
             pinJobs: function (jobsToPin) {
-                _.forEach(jobsToPin, api.pinJob);
+                jobsToPin.forEach(api.pinJob);
             },
 
             unPinJob: function (id) {

--- a/ui/js/services/pinboard.js
+++ b/ui/js/services/pinboard.js
@@ -38,7 +38,7 @@ treeherder.factory('thPinboard', [
         };
 
         var saveBugs = function (job) {
-            Object.entries(relatedBugs).forEach(function ([key, bug]) {
+            Object.entries(relatedBugs).forEach(function ([, bug]) {
                 var bjm = new ThBugJobMapModel({
                     bug_id: bug.id,
                     job_id: job.id,

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -209,7 +209,7 @@ treeherder.controller('PluginCtrl', [
                                 seriesList = seriesList.concat(newSeriesList);
                             });
                         })).then(function () {
-                            _.forEach(seriesList, function (series) {
+                            seriesList.forEach(function (series) {
                                 // skip series which are subtests of another series
                                 if (series.parentSignature) {
                                     return;
@@ -319,7 +319,7 @@ treeherder.controller('PluginCtrl', [
         var getRevisionTips = function (projectName, list) {
             list.splice(0, list.length);
             var rsArr = ThResultSetStore.getResultSetsArray(projectName);
-            _.forEach(rsArr, (rs) => {
+            rsArr.forEach((rs) => {
                 list.push({
                     revision: rs.revision,
                     author: rs.author,


### PR DESCRIPTION
I looked around for usages of _.forEach and found several places where it could be replaced trivially. Unfortunately I could not remove it entirely because it is used on both arrays and objects.