### PR TITLE
Bug 1408671 - Display job field filter classification by name not id

### DIFF
--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -407,15 +407,25 @@ treeherder.factory('thJobFilters', [
          */
         function getFieldFiltersArray() {
             const fieldFilters = [];
+            const clopt = thClassificationTypes.classificationOptions;
 
             _.each($location.search(), function (values, fieldName) {
                 if (_isFieldFilter(fieldName)) {
-                    const valArr = _toArray(values);
+                    var valArr = _toArray(values);
                     _.each(valArr, function (val) {
+                        var text = '';
+                        if (_withoutPrefix(fieldName) === 'failure_classification_id') {
+                            for (var i = 0; i < clopt.length; i++) {
+                                if (clopt[i]['id'].toString() === val) {
+                                    text = clopt[i]['name'];
+                                }
+                            }
+                        }
                         if (fieldName !== QS_SEARCH_STR) {
                             fieldFilters.push({
                                 field: _withoutPrefix(fieldName),
                                 value: val,
+                                text: text,
                                 key: fieldName
                             });
                         }

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -411,15 +411,15 @@ treeherder.factory('thJobFilters', [
 
             _.each($location.search(), function (values, fieldName) {
                 if (_isFieldFilter(fieldName)) {
-                    var valArr = _toArray(values);
+                    const valArr = _toArray(values);
                     _.each(valArr, function (val) {
-                        var text = '';
+                        let text = '';
                         if (_withoutPrefix(fieldName) === 'failure_classification_id') {
-                            for (var i = 0; i < clopt.length; i++) {
-                                if (clopt[i]['id'].toString() === val) {
-                                    text = clopt[i]['name'];
+                            clopt.forEach(function (el) {
+                                if (el.id.toString() === val) {
+                                    text = el.name;
                                 }
-                            }
+                            });
                         }
                         if (fieldName !== QS_SEARCH_STR) {
                             fieldFilters.push({

--- a/ui/partials/main/thActiveFiltersBar.html
+++ b/ui/partials/main/thActiveFiltersBar.html
@@ -10,8 +10,9 @@
             class="filtersbar-filter">
           <span title="Filter by {{ filter.field}}: {{ filter.value }}">
             <b>{{ filter.field }}:</b>
+            <span ng-if="filter.field === 'failure_classification_id'">{{ filter.text }}</span>
             <span ng-if="filter.field === 'author'"> {{filter.value.split('@')[0] | limitTo: 20}}</span>
-            <span ng-if="filter.field !== 'author'"> {{filter.value | limitTo: 12}}</span>
+            <span ng-if="filter.field !== 'author' && filter.field !== 'failure_classification_id'"> {{filter.value | limitTo: 12}}</span>
           </span>
           <span class="pointable"
                 title="Click to clear {{ filter.field }}"


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1408671](https://bugzilla.mozilla.org/show_bug.cgi?id=1408671).

This maps the 'id' of the failure_classification_type in the UI to its human readable string. Previously you'd just get the number passed from the filter value in the URL.

Before:

![before](https://user-images.githubusercontent.com/3660661/32532950-b0f6d7b2-c41b-11e7-8116-4f1d319a5460.jpg)

Proposed:

![proposed](https://user-images.githubusercontent.com/3660661/32532958-b9725f6a-c41b-11e7-9dd8-bf89d0ca172c.jpg)

I still have a bit more testing to do, so marking as DNM for now. I'll update and assign this for review when I'm satisfied all my test cases and workflows are fine.

Tested on OSX 10.12.6:
Nightly **58.0a1 (2017-11-07) (64-bit)**