### PR TITLE
Bug 1265709 - Reference perf signatures by id instead of hash where possible

### DIFF
--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -39,7 +39,7 @@ class PerformanceSignatureSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PerformanceSignature
-        fields = ['framework_id', 'signature_hash', 'machine_platform',
+        fields = ['id', 'framework_id', 'signature_hash', 'machine_platform',
                   'suite', 'test', 'lower_is_better', 'has_subtests',
                   'option_collection_hash', 'extra_options']
 

--- a/ui/js/controllers/perf/dashboard.js
+++ b/ui/js/controllers/perf/dashboard.js
@@ -74,9 +74,9 @@ perf.controller('dashCtrl', [
                 // (so we can mash together pgo and opt)
                 $scope.testList = _.uniq(_.map(seriesToMeasure, 'testName'));
 
-                $q.all(_.chunk(seriesToMeasure, 20).map(function (seriesChunk) {
+                $q.all(_.chunk(seriesToMeasure, 40).map(function (seriesChunk) {
                     var params = {
-                        signatures: _.map(seriesChunk, 'signature'),
+                        signature_id: _.map(seriesChunk, 'id'),
                         framework: $scope.framework
                     };
                     if ($scope.revision) {
@@ -273,9 +273,9 @@ perf.controller('dashSubtestCtrl', [
                 $scope.testList = [summaryTestName];
                 $scope.titles[summaryTestName] = summaryTestName;
 
-                return $q.all(_.chunk(seriesList, 20).map(function (seriesChunk) {
+                return $q.all(_.chunk(seriesList, 40).map(function (seriesChunk) {
                     var params = {
-                        signatures: _.map(seriesChunk, 'signature'),
+                        signature_id: _.map(seriesChunk, 'id'),
                         framework: $scope.framework
                     };
                     if ($scope.revision) {

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -128,7 +128,7 @@ perf.controller('GraphsCtrl', [
                 if (alertSummary) {
                     alert = _.find(alertSummary.alerts,
                         function (alert) {
-                            return alert.series_signature.signature_hash === phSeries.signature;
+                            return alert.series_signature.id === phSeries.id;
                         });
                 }
                 $scope.tooltipContent = {
@@ -596,7 +596,7 @@ perf.controller('GraphsCtrl', [
 
         function getSeriesData(series) {
             return PhSeries.getSeriesData(series.projectName, { interval: $scope.myTimerange.value,
-                signatures: series.signature,
+                signature_id: series.id,
                 framework: series.frameworkId
             }).then(
                 function (seriesData) {
@@ -624,7 +624,7 @@ perf.controller('GraphsCtrl', [
                     series.relatedAlertSummaries = [];
                     var repo = _.find($rootScope.repos, { name: series.projectName });
                     return PhAlerts.getAlertSummaries({
-                        seriesSignature: series.signature,
+                        signatureId: series.id,
                         repository: repo.id }).then(function (data) {
                             series.relatedAlertSummaries = data.results;
                         });

--- a/ui/js/models/perf/alerts.js
+++ b/ui/js/models/perf/alerts.js
@@ -18,15 +18,14 @@ treeherder.factory('PhAlerts', [
         };
         Alert.prototype.getGraphsURL = function (timeRange, alertRepository,
                                                 performanceFrameworkId) {
-            var signature = this.series_signature.signature_hash;
-            var url = "#/graphs?timerange=" + timeRange +
-                "&series=[" + [alertRepository, signature, 1] + "]" +
-                "&selected=[" + [alertRepository, signature] + "]";
+            let url = `#/graphs?timerange=${timeRange}&series=${alertRepository},${this.series_signature.id},1`;
 
-            // for talos only, automatically add related branches
+            // for talos only, automatically add related branches (we take advantage of
+            // the otherwise rather useless signature hash to avoid having to fetch this
+            // information from the server)
             if (performanceFrameworkId === 1) {
                 const branches = (alertRepository === "mozilla-beta") ? ['mozilla-inbound'] : thPerformanceBranches.filter(branch => branch !== alertRepository);
-                url += branches.map(branch => `&series=[${branch},${signature},0]`).join("");
+                url += branches.map(branch => `&series=${branch},${this.series_signature.signature_hash},0`).join("");
             }
 
             return url;
@@ -261,9 +260,9 @@ treeherder.factory('PhAlerts', [
                     if (options && !_.isUndefined(options.frameworkFilter)) {
                         params[params.length] = ("framework=" + options.frameworkFilter);
                     }
-                    if (options && !_.isUndefined(options.seriesSignature)) {
-                        params[params.length] = ("alerts__series_signature__signature_hash=" +
-                                                 options.seriesSignature);
+                    if (options && !_.isUndefined(options.signatureId)) {
+                        params[params.length] = ("alerts__series_signature=" +
+                                                 options.signatureId);
                     }
                     if (options && !_.isUndefined(options.repository)) {
                         params[params.length] = ("repository=" +

--- a/ui/js/services/perf/compare.js
+++ b/ui/js/services/perf/compare.js
@@ -219,10 +219,10 @@ treeherder.factory('PhCompare', [
 
             getResultsMap: (projectName, seriesList, params) => {
                 let resultsMap = {};
-                return $q.all(_.chunk(seriesList, 20).map(
+                return $q.all(_.chunk(seriesList, 40).map(
                     seriesChunk => PhSeries.getSeriesData(
                         projectName, {
-                            signatures: _.map(seriesChunk, 'signature'),
+                            signature_id: _.map(seriesChunk, 'id'),
                             framework: _.uniq(_.map(seriesChunk, 'frameworkId')),
                             ...params
                         }).then((seriesData) => {


### PR DESCRIPTION
* Make the performance data api accept signature id as input
* Rewrite most of the frontend to use that API in preference to passing
  in signature hashes
* Correspondingly increase the chunks of comparison data we fetch
  at once