### PR TITLE
Wait for the status filters to be applied during tests

### DIFF
--- a/tests/jenkins/tests/test_status_results.py
+++ b/tests/jenkins/tests/test_status_results.py
@@ -23,7 +23,7 @@ def test_status_results_failures(base_url, selenium):
     page.filter_job_retries()
     page.filter_job_usercancel()
     page.filter_job_in_progress()
-    assert 0 < len(page.all_jobs) == len(page.all_failed_jobs)
+    page.wait.until(lambda _: 0 < len(page.all_jobs) == len(page.all_failed_jobs))
 
 
 @pytest.mark.nondestructive
@@ -34,7 +34,7 @@ def test_status_results_success(base_url, selenium):
     page.filter_job_retries()
     page.filter_job_usercancel()
     page.filter_job_in_progress()
-    assert 0 < len(page.all_jobs) == len(page.all_successful_jobs)
+    page.wait.until(lambda _: 0 < len(page.all_jobs) == len(page.all_successful_jobs))
 
 
 @pytest.mark.nondestructive
@@ -45,7 +45,7 @@ def test_status_results_retry(base_url, selenium):
     page.filter_job_successes()
     page.filter_job_usercancel()
     page.filter_job_in_progress()
-    assert 0 < len(page.all_jobs) == len(page.all_restarted_jobs)
+    page.wait.until(lambda _: 0 < len(page.all_jobs) == len(page.all_restarted_jobs))
 
 
 @pytest.mark.nondestructive
@@ -59,7 +59,7 @@ def test_status_results_superseded(base_url, selenium):
     page.filter_job_usercancel()
     page.filter_job_superseded()
     page.filter_job_in_progress()
-    assert 0 < len(page.all_jobs) == len(page.all_superseded_jobs)
+    page.wait.until(lambda _: 0 < len(page.all_jobs) == len(page.all_superseded_jobs))
 
 
 @pytest.mark.nondestructive
@@ -70,4 +70,4 @@ def test_status_results_in_progress(base_url, selenium):
     page.filter_job_successes()
     page.filter_job_retries()
     page.filter_job_usercancel()
-    assert 0 < len(page.all_jobs) == len(page.all_in_progress_jobs)
+    page.wait.until(lambda _: 0 < len(page.all_jobs) == len(page.all_in_progress_jobs))


### PR DESCRIPTION
It may be coincidence but since https://github.com/mozilla/treeherder/commit/51dc3cc938234c441c6b95a9715ac0daf5f03f9c I've seen an increase in failures for the tests exercising the status filters. It seems that every so often the filter takes a little longer than expected to apply. I have fixed this in the tests by introducing a wait instead of relying on the timing of the test when it immediately checks the results after applying the filter.