### PR TITLE
Bug 1417099 - Vagrant: Fix networking when using latest Bento images

### DIFF
--- a/vagrant/.profile
+++ b/vagrant/.profile
@@ -13,7 +13,10 @@
 # As such, it's just easier to re-run the commands on each login since they take <30ms.
 sudo sysctl -q -w net.ipv4.conf.all.route_localnet=1
 sudo iptables -t nat --flush
-sudo iptables -t nat -A PREROUTING -i enp0s3 -p tcp -j DNAT --to 127.0.0.1
+# Have to calculate the interface name dynamically, due to:
+# https://github.com/chef/bento/pull/900#issuecomment-344297489
+INTERFACE_NAME="$(sudo ip -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://')"
+sudo iptables -t nat -A PREROUTING -i "${INTERFACE_NAME}" -p tcp -j DNAT --to 127.0.0.1
 
 PS1='\[\e[0;31m\]\u\[\e[m\] \[\e[1;34m\]\w\[\e[m\] \$ '
 echo "Type 'thelp' to see a list of Treeherder-specific helper aliases"


### PR DESCRIPTION
The bento image has renamed the network interface from `enp0s3` back to `eth0`, effectively reverting the upstream Ubuntu 16.04 "predictable network interface names" feature. We now have to calculate the name dynamically, since we don't know which version of the bento image will be installed locally when people use the Treeherder Vagrant environment.

Tested by performing a `vagrant destroy -f && vagrant up && vagrant ssh`, then `./manage.py runserver` in the VM and confirming 127.0.0.1:8000 connects successfully from the host.