### PR TITLE
Bug 1416347 - Implement a solution for generating a noise metric when viewing perfherder compare

### DIFF
--- a/ui/js/components/perf/compare.js
+++ b/ui/js/components/perf/compare.js
@@ -43,7 +43,8 @@ treeherder.component('phCompareTable', {
         function shouldBeShown(result) {
             return (!ctrl.filterOptions.showOnlyImportant || result.isMeaningful) &&
                 (!ctrl.filterOptions.showOnlyConfident || result.isConfident) &&
-                (!ctrl.filterOptions.showOnlyBlockers || result.isBlocker);
+                (!ctrl.filterOptions.showOnlyBlockers || result.isBlocker) &&
+                (!ctrl.filterOptions.showOnlyNoise || result.isNoiseMetric);
         }
         function filterResult(results, key) {
             if (_.isUndefined(ctrl.filterOptions.filter)) {

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -26,13 +26,13 @@ perf.config(['$compileProvider', '$httpProvider', '$stateProvider', '$urlRouterP
             .state('compare', {
                 title: 'Compare',
                 templateUrl: 'partials/perf/comparectrl.html',
-                url: '/compare?originalProject&originalRevision?&newProject&newRevision&hideMinorChanges&framework&filter&showOnlyImportant&showOnlyConfident&selectedTimeRange?',
+                url: '/compare?originalProject&originalRevision?&newProject&newRevision&hideMinorChanges&framework&filter&showOnlyImportant&showOnlyConfident&selectedTimeRange&showOnlyNoise?',
                 controller: 'CompareResultsCtrl'
             })
             .state('comparesubtest', {
                 title: 'Compare - Subtests',
                 templateUrl: 'partials/perf/comparesubtestctrl.html',
-                url: '/comparesubtest?originalProject&originalRevision?&newProject&newRevision&originalSignature&newSignature&filter&showOnlyImportant&showOnlyConfident&framework&selectedTimeRange?',
+                url: '/comparesubtest?originalProject&originalRevision?&newProject&newRevision&originalSignature&newSignature&filter&showOnlyImportant&showOnlyConfident&framework&selectedTimeRange&showOnlyNoise?',
                 controller: 'CompareSubtestResultsCtrl'
             })
             .state('comparechooser', {

--- a/ui/js/services/perf/compare.js
+++ b/ui/js/services/perf/compare.js
@@ -75,14 +75,19 @@ treeherder.factory('PhCompare', [
                 }
 
                 // Some statistics for a single set of values
-                function analyzeSet(values) {
-                    var average = math.average(values),
-                        stddev = math.stddev(values, average);
+                function analyzeSet(values, testName) {
+                    if (testName === 'Noise Metric') {
+                        var average = Math.sqrt(_.sum(values.map(x => Math.pow(x, 2)))),
+                            stddev = 1;
+                    } else {
+                        var average = math.average(values),
+                            stddev = math.stddev(values, average);
+                    }
 
                     return {
                         average: average,
                         stddev: stddev,
-                        stddevPct: math.percentOf(stddev, average),
+                        stddevPct: Math.round(math.percentOf(stddev, average) * 100) / 100,
 
                         // We use slice to keep the original values at their original order
                         // in case the order is important elsewhere.
@@ -104,7 +109,7 @@ treeherder.factory('PhCompare', [
                 cmap.isEmpty = false;
 
                 if (hasOrig) {
-                    var orig = analyzeSet(originalData.values);
+                    var orig = analyzeSet(originalData.values, testName);
                     cmap.originalValue = orig.average;
                     cmap.originalRuns = orig.runs;
                     cmap.originalStddev = orig.stddev;
@@ -113,7 +118,7 @@ treeherder.factory('PhCompare', [
                     cmap.originalRuns = [];
                 }
                 if (hasNew) {
-                    var newd = analyzeSet(newData.values);
+                    var newd = analyzeSet(newData.values, testName);
                     cmap.newValue = newd.average;
                     cmap.newRuns = newd.runs;
                     cmap.newStddev = newd.stddev;
@@ -176,6 +181,7 @@ treeherder.factory('PhCompare', [
                                      abs_t_value >= T_VALUE_CARE_MIN));
                 cmap.needsMoreRuns = (cmap.isComplete && !cmap.isConfident &&
                                       cmap.originalRuns.length < 6);
+                cmap.isNoiseMetric = false;
 
                 return cmap;
             },

--- a/ui/partials/perf/comparectrl.html
+++ b/ui/partials/perf/comparectrl.html
@@ -14,6 +14,17 @@
         <strong>tests with no results:</strong>
         {{testNoResults}}
       </div>
+      <div class="alert alert-warning" role="alert" ng-if="testsTooVariable.length > 1 && filterOptions.showOnlyNoise">
+          <strong>Tests with too much noise to be considered in the noise metric:</strong>
+              <table>
+                  <tr ng-repeat="tname in testsTooVariable">
+                    <td>{{tname.platform}}</td>
+                    <td>{{tname.testname}}</td>
+                    <td>{{tname.baseStddev}}</td>
+                    <td>{{tname.newStddev}}</td>
+                  </tr>
+              </table>
+      </div>
       <div class="form-group" ng-if="!originalRevision">
         Time range to sample (before push):
         <select ng-model="selectedTimeRange"

--- a/ui/partials/perf/comparesubtestctrl.html
+++ b/ui/partials/perf/comparesubtestctrl.html
@@ -7,6 +7,16 @@
   <div id="error" ng-if="!dataLoading && errors.length">
     <compare-error errors="errors" original-revision="originalRevision" original-project="originalProject" new-revision="newRevision" new-project="newProject"></compare-error>
   </div>
+    <div class="alert alert-warning" role="alert" ng-if="testsTooVariable.length > 1 && filterOptions.showOnlyNoise">
+        <strong>Tests with too much noise to be considered in the noise metric:</strong>
+        <table>
+            <tr ng-repeat="tname in testsTooVariable">
+                <td>{{tname.testname}}</td>
+                <td>{{tname.baseStddev}}</td>
+                <td>{{tname.newStddev}}</td>
+            </tr>
+        </table>
+    </div>
   <div id="subtest-summary" ng-if="!dataLoading && !errors.length">
     <h1>{{subtestTitle}} subtest summary</h1>
     <revision-information original-project="originalProject" original-revision="originalRevision" original-result-set="originalResultSet" new-project="newProject" new-revision="newRevision" new-result-set="newResultSet" selected-time-range="selectedTimeRange"></revision-information>

--- a/ui/partials/perf/comparetable.html
+++ b/ui/partials/perf/comparetable.html
@@ -28,6 +28,14 @@
       Hide uncertain results
     </label>
   </div>
+    <div class="checkbox" uib-tooltip="Display Noise Metric to compare noisy tests at a platform level">
+        <label>
+            <input type="checkbox"
+                   ng-model="$ctrl.filterOptions.showOnlyNoise"
+                   ng-change="$ctrl.updateFilteredTestList()" />
+            Show Only Noise
+        </label>
+    </div>
   <div ng-if="$ctrl.releaseBlockerCriteria" class="checkbox">
     <label>
       <input type="checkbox"


### PR DESCRIPTION
this works for summary and subtest, probably has a lot of potential wins and logic to improve upon- for now I want to get a first attempt rolled out for easier comparison of new platforms.