### PR TITLE
Bug 1417666 - Improve field filter clearing workflows

### DIFF
--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -309,9 +309,20 @@ treeherder.factory('thJobFilters', [
             $location.search(_withPrefix(field), value);
         }
 
+        function clearAllFilters() {
+            removeAllFieldFilters();
+            removeClearableNonFieldFilters();
+        }
+
         function removeAllFieldFilters() {
             const locationSearch = $location.search();
             _stripFieldFilters(locationSearch);
+            $location.search(locationSearch);
+        }
+
+        function removeClearableNonFieldFilters() {
+            const locationSearch = $location.search();
+            _stripClearableFieldFilters(locationSearch);
             $location.search(locationSearch);
         }
 
@@ -473,9 +484,22 @@ treeherder.factory('thJobFilters', [
             return locationSearch;
         }
 
+        function _stripClearableFieldFilters(locationSearch) {
+            _.forEach(locationSearch, function (val, field) {
+                if (_isClearableFilter(field)) {
+                    delete locationSearch[field];
+                }
+            });
+            return locationSearch;
+        }
+
         function _isFieldFilter(field) {
             return field.startsWith(PREFIX) &&
                 !_.includes(['resultStatus', 'classifiedState'], _withoutPrefix(field));
+        }
+
+        function _isClearableFilter(field) {
+            return _.includes(NON_FIELD_FILTERS, field);
         }
 
         /**
@@ -573,6 +597,7 @@ treeherder.factory('thJobFilters', [
             replaceFilter: replaceFilter,
             removeAllFieldFilters: removeAllFieldFilters,
             resetNonFieldFilters: resetNonFieldFilters,
+            clearAllFilters: clearAllFilters,
             toggleFilters: toggleFilters,
             toggleResultStatuses: toggleResultStatuses,
             toggleInProgress: toggleInProgress,

--- a/ui/partials/main/thActiveFiltersBar.html
+++ b/ui/partials/main/thActiveFiltersBar.html
@@ -2,23 +2,27 @@
 <div ng-if="isFieldFilterVisible || filterBarFilters.length"
      class="alert-info active-filters-bar">
     <div ng-show="filterBarFilters.length" ng-cloak>
+      <span class="pointable"
+            title="Clear all of these filters"
+            ng-click="jobFilters.clearAllFilters()">
+        <i class="fa fa-times-circle"></i>
+      </span>
       <span class="active-filters-title">
-        <i class="fa fa-info-circle" aria-hidden="true"></i>
         <b>Active Filters</b>
       </span>
       <span ng-repeat="filter in filterBarFilters"
             class="filtersbar-filter">
+          <span class="pointable"
+                title="Clear filter: {{ filter.field }}"
+                ng-click="jobFilters.removeFilter(filter.key, filter.value)">
+            <i class="fa fa-times-circle"></i>
+          </span>
           <span title="Filter by {{ filter.field }}: {{ filter.value }}">
             <b>{{ filter.field }}:</b>
             <span ng-if="filter.field === 'failure_classification_id'"
                   ng-bind-html="getFilterValue(filter.field, filter.value)"></span>
             <span ng-if="filter.field === 'author'"> {{filter.value.split('@')[0] | limitTo: 20}}</span>
             <span ng-if="filter.field !== 'author' && filter.field !== 'failure_classification_id'"> {{filter.value | limitTo: 12}}</span>
-          </span>
-          <span class="pointable"
-                title="Click to clear filter: {{ filter.field }}"
-                ng-click="jobFilters.removeFilter(filter.key, filter.value)">
-            <i class="fa fa-times-circle"></i>
           </span>
       </span>
     </div>


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1417666](https://bugzilla.mozilla.org/show_bug.cgi?id=1417666).

This tweak adds the ability to clear all field filters in one click by hooking to the existing unused function `removeAllFieldFilters()`, and to clear field filters sequentially without having to mouse to arbitrary points on screen by placing the close icons at the front of each filter.

Current:
![current](https://user-images.githubusercontent.com/3660661/32861910-513cf856-ca24-11e7-8a8a-6efafe65b4c0.jpg)

Proposed:
![proposed](https://user-images.githubusercontent.com/3660661/32861916-571f72c6-ca24-11e7-969a-e57f7d6cce52.jpg)

Tested on OSX 10.12.6:
Nightly **59.0a1 (2017-11-15) (64-bit)**