### PR TITLE
Revert "Bug 1408671 - Display job field filter classification by name not id (#2922)"

### DIFF
--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -407,25 +407,15 @@ treeherder.factory('thJobFilters', [
          */
         function getFieldFiltersArray() {
             const fieldFilters = [];
-            const clopt = thClassificationTypes.classificationOptions;
 
             _.each($location.search(), function (values, fieldName) {
                 if (_isFieldFilter(fieldName)) {
                     const valArr = _toArray(values);
                     _.each(valArr, function (val) {
-                        let text = '';
-                        if (_withoutPrefix(fieldName) === 'failure_classification_id') {
-                            clopt.forEach(function (el) {
-                                if (el.id.toString() === val) {
-                                    text = el.name;
-                                }
-                            });
-                        }
                         if (fieldName !== QS_SEARCH_STR) {
                             fieldFilters.push({
                                 field: _withoutPrefix(fieldName),
                                 value: val,
-                                text: text,
                                 key: fieldName
                             });
                         }

--- a/ui/partials/main/thActiveFiltersBar.html
+++ b/ui/partials/main/thActiveFiltersBar.html
@@ -10,9 +10,8 @@
             class="filtersbar-filter">
           <span title="Filter by {{ filter.field}}: {{ filter.value }}">
             <b>{{ filter.field }}:</b>
-            <span ng-if="filter.field === 'failure_classification_id'">{{ filter.text }}</span>
             <span ng-if="filter.field === 'author'"> {{filter.value.split('@')[0] | limitTo: 20}}</span>
-            <span ng-if="filter.field !== 'author' && filter.field !== 'failure_classification_id'"> {{filter.value | limitTo: 12}}</span>
+            <span ng-if="filter.field !== 'author'"> {{filter.value | limitTo: 12}}</span>
           </span>
           <span class="pointable"
                 title="Click to clear {{ filter.field }}"


### PR DESCRIPTION
Still some issues with reload, so I've opened a PR for @camd or @edmorley to revert my change, in case that helps save them a minute or two.

This reverts commit 94739118f9f746ee7fd2c47af22896539d71cf17.