### PR TITLE
Bug 1413156 - fix linter "array-callback-return" error

### DIFF
--- a/ui/js/models/repository.js
+++ b/ui/js/models/repository.js
@@ -298,11 +298,7 @@ treeherder.factory('ThRepositoryModel', [
 
             // filter out non-watched and unsupported repos to prevent repeatedly
             // hitting an endpoint we know will never work.
-            repoNames = repoNames.filter((repo) => {
-                if (_.includes(watchedRepos, repo) && repos[repo].treeStatus.status !== 'unsupported') {
-                    return repo;
-                }
-            });
+            repoNames = repoNames.filter(repo => _.includes(watchedRepos, repo) && repos[repo].treeStatus.status !== 'unsupported');
             var newStatuses = {};
 
             var getStatus = function (repo) {


### PR DESCRIPTION
Some new linter rules added after 4ca94fca62f2564729ff4db88d821b5fd556a3b1
was merged failed a line of code that had an implicit return value
of `undefined`.

I don't have any linter errors on my end of things (branching off master). This is a shorter way of writing that function that will never have an implicit return value. I'm not quite sure why `return repo` was used since the predicate function passed to both `Array.filter()` and `_.filter()` expects a bool return value.