### PR TITLE
Bug 1408671 - Display job field filter classification by name not id

### DIFF
--- a/ui/partials/main/thActiveFiltersBar.html
+++ b/ui/partials/main/thActiveFiltersBar.html
@@ -8,13 +8,15 @@
       </span>
       <span ng-repeat="filter in filterBarFilters"
             class="filtersbar-filter">
-          <span title="Filter by {{ filter.field}}: {{ filter.value }}">
+          <span title="Filter by {{ filter.field }}: {{ filter.value }}">
             <b>{{ filter.field }}:</b>
+            <span ng-if="filter.field === 'failure_classification_id'"
+                  ng-bind-html="getFilterValue(filter.field, filter.value)"></span>
             <span ng-if="filter.field === 'author'"> {{filter.value.split('@')[0] | limitTo: 20}}</span>
-            <span ng-if="filter.field !== 'author'"> {{filter.value | limitTo: 12}}</span>
+            <span ng-if="filter.field !== 'author' && filter.field !== 'failure_classification_id'"> {{filter.value | limitTo: 12}}</span>
           </span>
           <span class="pointable"
-                title="Click to clear {{ filter.field }}"
+                title="Click to clear filter: {{ filter.field }}"
                 ng-click="jobFilters.removeFilter(filter.key, filter.value)">
             <i class="fa fa-times-circle"></i>
           </span>


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1408671](https://bugzilla.mozilla.org/show_bug.cgi?id=1408671).

This maps the 'id' of the failure_classification_type in the UI to its human readable string. Previously you'd just get the number passed from the filter value in the URL.

It turns out we have a dead/unused function `getFilterValue()` which does this conversion:
https://github.com/mozilla/treeherder/blob/6a7b7a3def3158f4ccbe9859c5496371a7d0bf84/ui/js/controllers/main.js#L604-L613

I assume it was legacy code for something else. Anyway let's give it new life and use that, instead of the convolutions of iterating through classification types for a match in jobFilters.js as was being done in the original PR https://github.com/mozilla/treeherder/pull/2922.

Before:

![before](https://user-images.githubusercontent.com/3660661/32532950-b0f6d7b2-c41b-11e7-8116-4f1d319a5460.jpg)

Proposed:

![proposed](https://user-images.githubusercontent.com/3660661/32532958-b9725f6a-c41b-11e7-9dd8-bf89d0ca172c.jpg)

I think all my test cases and workflows are fine, including page reloads. Feel free to have a bash at it and see if you can break it.

Tested on OSX 10.12.6:
Nightly **59.0a1 (2017-11-15) (64-bit)**