### PR TITLE
Bug 1416257 - Make it easier for contributors to set up a node environment

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -2,3 +2,9 @@
 # in package.json  is a great idea, in practice it causes unnecessary confusion/hassle for
 # contributors, since most node/yarn versions will work fine with Treeherder anyway.
 ignore-engines true
+
+# `--no-bin-links` is required when using Vagrant on Windows hosts (where symlinks aren't
+# allowed), and so we include here to ensure that the package.json scripts aren't relying
+# on symlinks that won't exist elsewhere. This alternate config form is required due to:
+# https://github.com/yarnpkg/yarn/issues/4925
+--*.no-bin-links true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,4 @@
+# Whilst in theory yarn's checking of the node/yarn version against the `engines` property
+# in package.json  is a great idea, in practice it causes unnecessary confusion/hassle for
+# contributors, since most node/yarn versions will work fine with Treeherder anyway.
+ignore-engines true

--- a/bin/travis-setup.sh
+++ b/bin/travis-setup.sh
@@ -66,9 +66,7 @@ setup_js_env() {
 
     echo '-----> Running yarn install'
     # `--frozen-lockfile` will catch cases where people have forgotten to update `yarn.lock`.
-    # `--no-bin-links` is only necessary on Windows hosts, but we include here to ensure
-    # that the package.json scripts aren't relying on symlinks that won't exist elsewhere.
-    yarn install --frozen-lockfile --no-bin-links
+    yarn install --frozen-lockfile
 }
 
 for task in "$@"; do

--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -136,11 +136,9 @@ Updating package.json
 ---------------------
 
 * Always use ``yarn`` to make changes, not ``npm``, so that ``yarn.lock`` remains in sync.
-* Add new packages using ``yarn add <PACKAGE> --no-bin-links`` (``yarn.lock`` will be automatically updated).
-* After changes to ``package.json`` use ``yarn install --no-bin-links`` to install them and automatically update ``yarn.lock``.
+* Add new packages using ``yarn add <PACKAGE>`` (``yarn.lock`` will be automatically updated).
+* After changes to ``package.json`` use ``yarn install`` to install them and automatically update ``yarn.lock``.
 * For more details see the `Yarn documentation`_.
-
-Note: To work around symlink issues for Windows hosts, use ``--no-bin-links`` with any command that adds/modifies packages. Whilst this is technically unnecessary with non-Windows hosts, it's still recommended since otherwise your local changes might inadvertently rely on ``node_modules/.bin/`` symlinks that won't exist in a newly created Vagrant environment. Unfortunately yarn doesn't yet support setting this option via the global yarn config, otherwise we could just enable it by default.
 
 .. _Yarn documentation: https://yarnpkg.com/en/docs/usage
 

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -9,7 +9,7 @@ production, a minified/built version of the UI (generated using webpack) is used
 
 To build the UI locally:
 
-* Install local dependencies by running ``yarn install --no-bin-links`` from the project root.
+* Install local dependencies by running ``yarn install`` from the project root.
 * Run ``yarn build`` to create the ``dist`` directory.
 
 Then start gunicorn/runserver as usual.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -72,7 +72,6 @@ Starting a local Treeherder instance
 
   .. code-block:: bash
 
-    vagrant ~/treeherder$ yarn install --no-bin-links
     vagrant ~/treeherder$ yarn start:local
 
   This will build the UI code in the ``dist/`` folder and keep watching for

--- a/docs/seta.rst
+++ b/docs/seta.rst
@@ -46,7 +46,6 @@ After you set up Treeherder, ssh (3 different tabs) into the provisioned VM and 
 -------
 .. code-block:: bash
 
-   yarn install --no-bin-links
    yarn start:local
 
 3rd tab

--- a/docs/ui/installation.rst
+++ b/docs/ui/installation.rst
@@ -9,7 +9,7 @@ see the Vagrant instructions.
 To get started:
 
 * Clone the `treeherder repo`_ from GitHub.
-* Install `Node.js`_ and Yarn_ if not present.
+* Install `Node.js`_ and Yarn_ (see `package.json`_ for known compatible versions, listed under `engines`).
 * Run ``yarn install --no-bin-links`` to install all dependencies.
 
 Running the standalone development server
@@ -125,7 +125,8 @@ The tests will perform an initial run and then re-execute each time a project fi
 .. _Karma: http://karma-runner.github.io/0.8/config/configuration-file.html
 .. _treeherder repo: https://github.com/mozilla/treeherder
 .. _Node.js: https://nodejs.org/en/download/current/
+.. _Yarn: https://yarnpkg.com/en/docs/install
+.. _package.json: https://github.com/mozilla/treeherder/blob/master/package.json
 .. _eslint: http://eslint.org
 .. _Jasmine: https://jasmine.github.io/
 .. _enzyme: http://airbnb.io/enzyme/
-.. _Yarn: https://yarnpkg.com/en/docs/install

--- a/docs/ui/installation.rst
+++ b/docs/ui/installation.rst
@@ -10,7 +10,7 @@ To get started:
 
 * Clone the `treeherder repo`_ from GitHub.
 * Install `Node.js`_ and Yarn_ (see `package.json`_ for known compatible versions, listed under `engines`).
-* Run ``yarn install --no-bin-links`` to install all dependencies.
+* Run ``yarn install`` to install all dependencies.
 
 Running the standalone development server
 -----------------------------------------
@@ -102,7 +102,7 @@ Running the unit tests
 
 The unit tests for the UI are run with Karma_ and Jasmine_. React components are tested with enzyme_. At this time, these tests cannot be run inside of a Vagrant VM. To run the tests:
 
-* If you haven't already done so, install local dependencies by running ``yarn install --no-bin-links`` from the project root.
+* If you haven't already done so, install local dependencies by running ``yarn install`` from the project root.
 * Then run the following command to execute the tests:
 
 .. code-block:: bash

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -117,11 +117,7 @@ curl -sSfL 'https://download.mozilla.org/?product=firefox-beta-latest&lang=en-US
 echo '-----> Running yarn install'
 # We have to use `--no-bin-links` to work around symlink issues with Windows hosts.
 # TODO: Switch the flag to a global yarn pref once yarn adds support.
-# The node version isn't pinned in Vagrant (unlike Heroku/Travis) so we have to use
-# --ignore-engines to prevent failures when there's a new release. This will be fixed
-# as part of the move to a Docker based development environment, where the non-APT approach
-# is much simpler.
-yarn install --no-bin-links --ignore-engines
+yarn install --no-bin-links
 
 if [[ "$(shellcheck --version 2>&1)" != *"version: ${SHELLCHECK_VERSION}"* ]]; then
     echo '-----> Installing shellcheck'

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -115,9 +115,7 @@ echo '-----> Installing Firefox'
 curl -sSfL 'https://download.mozilla.org/?product=firefox-beta-latest&lang=en-US&os=linux64' | sudo tar -jxC "${HOME}"
 
 echo '-----> Running yarn install'
-# We have to use `--no-bin-links` to work around symlink issues with Windows hosts.
-# TODO: Switch the flag to a global yarn pref once yarn adds support.
-yarn install --no-bin-links
+yarn install
 
 if [[ "$(shellcheck --version 2>&1)" != *"version: ${SHELLCHECK_VERSION}"* ]]; then
     echo '-----> Installing shellcheck'


### PR DESCRIPTION
**1) Docs: Remove unnecessary `yarn install` steps**
The vagrant provision runs `yarn install`, so it isn't necessary to do so again before running `yarn start`.

**2) Docs: Clarify which node/yarn version should be used**
Since for people installing node/yarn on their own (outside the Vagrant environment) it can be confusing to work out which version is appropriate, given node always has both an LTS and current release.

**3) Disable yarn strict engines mode using .yarnrc**
As of yarn 1.0+ if the version of node or yarn doesn't match that specified in `package.json`, yarn commands will fail to run and complain about incompatible versions. Unfortunately the error message doesn't really make it clear that the user has the wrong version installed, and instead gives the impression something is broken with Treeherder. In addition, much of the time the exact version isn't important, so the user doesn't need to go to the trouble of changing their node installation.

As such, we just disable the yarn engines check for now.

**4) Bug 1418956 - Set yarn's no-bin-links option via .yarnrc**
To save having to pass it each time when using `yarn {install,add}`.



