### PR TITLE
Bug 1419167 - Vagrant: Remove unnecessary MSYS SSH pre-requisite

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,6 @@ Prerequisites
 * If you are new to Mozilla or the A-Team, read the `A-Team Bootcamp`_.
 * Install Git_, Virtualbox_ and Vagrant_ (latest versions recommended).
 * Clone the `treeherder repo`_ from GitHub.
-* Windows only: Ensure MSYS ssh (ships with Git for Windows) is on the PATH, so Vagrant can find it (using PuTTY is more hassle).
 * Linux only: An nfsd server is required. You can install this on Ubuntu by running `apt-get install nfs-common nfs-kernel-server`
 
 Setting up Vagrant


### PR DESCRIPTION
Since recent Vagrant now bundles its own SSH client.