### PR TITLE
Bug 1418286 - Fix bolding of common terms in bug suggestions on Windows

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -1,3 +1,7 @@
+strong {
+  font-weight: bold;
+}
+
 div#info-panel {
   background-color: #AAAAAA;
   font-size: 12px;


### PR DESCRIPTION
Windows can show double-bolding with "font-weight: bolder".  But our
logic for highlighting common terms sometimes adds nested ``<strong>``
elements due to substrings.  This makes them all just "bold" regardless
of how much they're nested.