### PR TITLE
Bug 1419923 - Pull unimplemented F1 key from shortcut table

### DIFF
--- a/ui/partials/main/thShortcutTable.html
+++ b/ui/partials/main/thShortcutTable.html
@@ -10,10 +10,6 @@
   </div>
   <div class="card-body panel-spacing">
     <table id="shortcuts">
-      <!-- Expose when onscreen help is complete - bug 1141569
-      <tr><td><kbd>F1</kbd></td>
-        <td>Display onscreen help</td></tr>
-      -->
       <tr>
         <th colspan=2>Jobs View</th>
       </tr>


### PR DESCRIPTION
This fixes Bugzilla bug [1419923](https://bugzilla.mozilla.org/show_bug.cgi?id=1419923).

This removes the unimplemented `F1` key placeholder in the shortcut table, since there are no future plans for inline UI help at this time as originally discussed in the Description of bug [1141569](https://bugzilla.mozilla.org/show_bug.cgi?id=1141569).

Tested on OSX 10.12.6:
Nightly **59.0a1 (2017-11-22) (64-bit)**