### PR TITLE
Bug 1419966 - Angularize start/end query examples in the User Guide

### DIFF
--- a/ui/js/controllers/userguide.js
+++ b/ui/js/controllers/userguide.js
@@ -1,6 +1,16 @@
 "use strict";
 
-userguideApp.controller('UserguideCtrl',
-    function () {
+userguideApp.controller('UserguideCtrl', ['$scope',
+    function UserguideCtrl($scope) {
+
+        // Used for dynamic startdate, enddate param examples
+        let d = new Date();
+        let y = d.getFullYear();
+        let m = d.getMonth() + 1;
+        let sd = d.getDate() - 2;
+        let ed = d.getDate();
+
+        $scope.startDate = y + '-' + m + '-' + sd;
+        $scope.endDate = y + '-' + m + '-' + ed;
     }
-);
+]);

--- a/ui/userguide.html
+++ b/ui/userguide.html
@@ -432,13 +432,21 @@
                 </tr>
                 <tr>
                   <td><span class="queryparam">startdate</span></td>
-                  <td>Specify the earliest date in the push range.</td>
-                  <td><span class="queryparam">&startdate=2015-02-18</span></td>
+                  <td>
+                    <span>Specify the earliest</span>
+                    <span class="queryparam">YYYY-MM-DD</span>
+                    <span>date in the push range.</span>
+                  </td>
+                  <td><span class="queryparam">&startdate={{ startDate }}</span></td>
                 </tr>
                 <tr>
                   <td><span class="queryparam">enddate</span></td>
-                  <td>Specify the latest date in the push range.</td>
-                  <td><span class="queryparam">&enddate=2015-02-21</span></td>
+                  <td>
+                    <span>Specify the latest</span>
+                    <span class="queryparam">YYYY-MM-DD</span>
+                    <span>date in the push range.</span>
+                  </td>
+                  <td><span class="queryparam">&enddate={{ endDate }}</span></td>
                 </tr>
               </table>
             </div>


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1419966](https://bugzilla.mozilla.org/show_bug.cgi?id=1419966).

This provides a dynamic date example for the `&startdate` and `&enddate` query filters, so they never fall out of date or otherwise result in the users browser freezing trying to load a year's worth of pushes from a static start/end date example.

Visually the examples are unchanged, except I think they may print as D or M for single integer days, but in testing I think Treeherder handles those. I also added a YYYY-MM-DD cue in the description.

Proposed:
![proposed](https://user-images.githubusercontent.com/3660661/33153460-e10bfa3c-cfaf-11e7-825c-4670351a0e9c.jpg)

Tested on OSX 10.12.6:
Nightly **59.0a1 (2017-11-22) (64-bit)**