### PR TITLE
Bug 1419987 - Always use latest minor version of node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
     # Job 3: Nodejs UI tests
     - env: ui-tests
       language: node_js
-      node_js: "8.9.0"
+      node_js: "8"
       cache:
         directories:
           - node_modules
@@ -100,7 +100,7 @@ matrix:
           - ${HOME}/venv
           - node_modules
       install:
-        - nvm install 8.9.0
+        - nvm install 8
         - source ./bin/travis-setup.sh services python_env geckodriver js_env
       script:
         - yarn build

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   },
   "license": "MPL-2.0",
   "engines": {
-    "node": "8.9.0",
-    "yarn": "^1.2.1"
+    "node": "8.x",
+    "yarn": "1.x"
   },
   "dependencies": {
     "ajv": "5.2.3",


### PR DESCRIPTION
Since the node minor/patch versions are reliable enough that it's not worth the hassle of pinning to an exact version. This only affects Heroku/Travis, since Vagrant was already always using the latest 8 series release via the APT repo.

This effectively upgrades node on Heroku/Travis from 8.9.0 to 8.9.1, since it's the latest release at the moment:
https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.9.1

The yarn version specifier has been adjusted to use the `.x` format, which gives the same end result as the caret range, given Heroku doesn't cache binaries from one build to the next (only `node_modules`).