### PR TITLE
Bug 1389572 - Travis: Speed up yarn and Elasticsearch setup

### DIFF
--- a/bin/travis-setup.sh
+++ b/bin/travis-setup.sh
@@ -9,10 +9,15 @@ export ELASTICSEARCH_URL='http://127.0.0.1:9200'
 export TREEHERDER_DJANGO_SECRET_KEY='secretkey-of-at-50-characters-to-pass-check-deploy'
 
 setup_services() {
-    echo '-----> Installing Elasticsearch'
-    curl -sSfo /tmp/elasticsearch.deb 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.0.deb'
-    sudo dpkg -i --force-confold /tmp/elasticsearch.deb
-    sudo service elasticsearch restart
+    ELASTICSEARCH_VERSION="5.5.0"
+    if [[ "$(dpkg-query --show --showformat='${Version}' elasticsearch 2>&1)" != "$ELASTICSEARCH_VERSION" ]]; then
+        echo '-----> Installing Elasticsearch'
+        curl -sSfo /tmp/elasticsearch.deb "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.deb"
+        sudo dpkg -i --force-confold /tmp/elasticsearch.deb
+        sudo service elasticsearch restart
+    else
+        sudo service elasticsearch start
+    fi
 
     # Using tmpfs for the MySQL data directory reduces pytest runtime by 30%.
     echo '-----> Creating RAM disk for MySQL'

--- a/bin/travis-setup.sh
+++ b/bin/travis-setup.sh
@@ -61,9 +61,6 @@ setup_js_env() {
     # Enable Firefox headless mode, avoiding the need for xvfb.
     export MOZ_HEADLESS=1
 
-    echo '-----> Installing yarn'
-    curl -sSfL 'https://yarnpkg.com/latest.tar.gz' | tar -xz --strip-components=1 -C "${HOME}"
-
     echo '-----> Running yarn install'
     # `--frozen-lockfile` will catch cases where people have forgotten to update `yarn.lock`.
     yarn install --frozen-lockfile


### PR DESCRIPTION
**1) Don't install custom yarn**
Since I've adjusted the Travis images to always use the latest yarn at the time the images are created, so it's not worth installing the latest version at every runtime.

**2) Skip Elasticsearch install if version matches**
Since I've updated the Travis images so that the pre-installed version of Elasticsearch matches the one we're looking for, meaning the download/install can be skipped, saving time.