### PR TITLE
Remove .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,0 @@
-[run]
-branch = True
-
-[report]
-omit =
-  */migrations/*
-  treeherder/config/wsgi.py
-  treeherder/config/settings.py


### PR DESCRIPTION
Since it's not currently used, and at whatever point we add Python test coverage tracking, we'll likely need to overhaul it anyway.