### PR TITLE
Bug 1416870 - Always use abbreviated mode for calculating performance test name

### DIFF
--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -143,7 +143,7 @@ perf.controller('CompareResultsCtrl', [
             $scope.testsTooVariable = [{ platform: "Platform", testname: "Testname", baseStddev: "Base Stddev", newStddev: "New Stddev" }];
 
             $scope.testList.forEach(function (testName) {
-                $scope.titles[testName] = testName.replace('summary ', '');
+                $scope.titles[testName] = testName;
                 $scope.platformList.forEach(function (platform) {
                     if (Object.keys($scope.oldStddevVariance).indexOf(platform) < 0) {
                         $scope.oldStddevVariance[platform] = { values: [], lowerIsBetter: true, frameworkID: $scope.filterOptions.framework.id };
@@ -176,8 +176,11 @@ perf.controller('CompareResultsCtrl', [
                     }
                     cmap.links = [];
 
+                    const hasSubtests = ((rawResultsMap[oldSig] && rawResultsMap[oldSig].hasSubtests) ||
+                                         (newRawResultsMap[newSig] && newRawResultsMap[newSig].hasSubtests));
+
                     if ($scope.originalRevision) {
-                        if (testName.indexOf("summary") > 0) {
+                        if (hasSubtests) {
                             var detailsLink = 'perf.html#/comparesubtest?';
                             detailsLink += $httpParamSerializer({
                                 originalProject: $scope.originalProject.name,
@@ -207,7 +210,7 @@ perf.controller('CompareResultsCtrl', [
                                 $scope.newResultSet])
                         });
                     } else {
-                        if (testName.indexOf("summary") > 0) {
+                        if (hasSubtests) {
                             var detailsLink = 'perf.html#/comparesubtest?';
                             detailsLink += $httpParamSerializer({
                                 originalProject: $scope.originalProject.name,
@@ -258,8 +261,7 @@ perf.controller('CompareResultsCtrl', [
             });
 
             // Remove the tests with no data, report them as well; not needed for subtests
-            $scope.testNoResults = _.difference($scope.testList, Object.keys($scope.compareResults))
-                .map(function (name) { return ' ' + name.replace(' summary', ''); }).sort().join();
+            $scope.testNoResults = _.difference($scope.testList, Object.keys($scope.compareResults)).sort().join();
             $scope.testList = Object.keys($scope.compareResults).sort().concat([noiseMetricTestName]);
             $scope.titles[noiseMetricTestName] = noiseMetricTestName;
         }
@@ -511,7 +513,7 @@ perf.controller('CompareSubtestResultsCtrl', [
             $scope.compareResults = {};
             $scope.titles = {};
 
-            var testName = $scope.testList[0].replace('summary ', '');
+            const testName = $scope.testList[0];
 
             $scope.titles[testName] = $scope.platformList[0] + ': ' + testName;
             $scope.compareResults[testName] = [];

--- a/ui/js/models/perf/alerts.js
+++ b/ui/js/models/perf/alerts.js
@@ -184,7 +184,7 @@ treeherder.factory('PhAlerts', [
             // add test info
             title += " " + _.uniq(
                 _.map(alertsInSummary, function (a) {
-                    return PhSeries.getTestName(a.series_signature, { abbreviate: true });
+                    return PhSeries.getTestName(a.series_signature);
                 })).sort().join(' / ');
             // add platform info
             title += " (" + _.uniq(

--- a/ui/js/models/perf/series.js
+++ b/ui/js/models/perf/series.js
@@ -2,16 +2,10 @@
 
 treeherder.factory('PhSeries', ['$http', 'thServiceDomain', 'ThOptionCollectionModel', '$q', function ($http, thServiceDomain, ThOptionCollectionModel, $q) {
 
-    var _getTestName = function (signatureProps, displayOptions) {
-        var suiteName = signatureProps.suite;
-        var testName = signatureProps.test;
-
-        if (!(displayOptions && displayOptions.abbreviate)) {
-            // "summary" may appear for non-abbreviated output
-            testName = testName || "summary";
-        }
-
-        return suiteName === testName ? suiteName : suiteName + " " + testName;
+    var _getTestName = function (signatureProps) {
+        // only return suite name if testname is identical, and handle
+        // undefined test name
+        return _.uniq(_.filter([signatureProps.suite, signatureProps.test])).join(" ");
     };
 
     var _getSeriesOptions = function (signatureProps, optionCollectionMap) {

--- a/ui/js/services/perf/compare.js
+++ b/ui/js/services/perf/compare.js
@@ -255,10 +255,7 @@ treeherder.factory('PhCompare', [
                                         const entry = _getResultMapEntry(datum);
                                         if (!entry[signatureHash]) {
                                             entry[signatureHash] = {
-                                                platform: signature.platform,
-                                                name: signature.name,
-                                                lowerIsBetter: signature.lowerIsBetter,
-                                                frameworkId: signature.frameworkId,
+                                                ...signature,
                                                 values: [datum.value]
                                             };
                                         } else {


### PR DESCRIPTION
This means we no longer display tests as being a "summary" in the
test chooser (you can generally figure that out by noticing that there
is no subtest specified).