### PR TITLE
Bug 1419994 - Fix failure Summary pin icon width

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -406,10 +406,6 @@ ul.failure-summary-list li .btn-xs {
   color: purple;
 }
 
-.failure-summary-bugs button {
-  padding: 2px 3px 1px 3px;
-}
-
 /* We override global anchor color to replicate TBPL here */
 .show-hide-more {
   padding: 0 0 0 37px;


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1419994](https://bugzilla.mozilla.org/show_bug.cgi?id=1419994).

This returns the pin icon in the Failure Summary tab to its former approximate width, and also so it matches the same dimensions as its sibling in the Failure Classification tab.

We still need the `failure-summary-bug` tags in the markup for other formatting, but it appears we can pull this css target without affecting anything else (that I can find).

Current:
![current](https://user-images.githubusercontent.com/3660661/33289131-8eca5d3c-d38c-11e7-893e-0f0d0f777931.jpg)

Proposed:
![proposed](https://user-images.githubusercontent.com/3660661/33289170-b249f830-d38c-11e7-914a-59b84f0e0016.jpg)

Tested on OSX 10.12.6:
Nightly **59.0a1 (2017-11-27) (64-bit)**
