### PR TITLE
Bug 1421111 - Use double digit hours in UI datetimes

### DIFF
--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -178,7 +178,7 @@ treeherder.value("thRepoGroupOrder", {
 
 treeherder.value("thDefaultRepo", "mozilla-inbound");
 
-treeherder.value("thDateFormat", "EEE MMM d, H:mm:ss");
+treeherder.value("thDateFormat", "EEE MMM d, HH:mm:ss");
 
 treeherder.value("phCompareDefaultOriginalRepo", "mozilla-central");
 


### PR DESCRIPTION
This changes the times shown in the UI to be padded with a leading zero if the hour is only a single digit (ie between midnight and 10am). This fixes the test failure in `test_open_single_result()`, since that expects the hour to use padding.