### PR TITLE
Update pytest to 3.3.0

### DIFF
--- a/tests/jenkins/requirements.txt
+++ b/tests/jenkins/requirements.txt
@@ -1,7 +1,7 @@
 # pyup: ignore file
 mozlog==3.5
 PyPOM==1.2.0
-pytest==3.2.2
+pytest==3.3.0
 pytest-metadata==1.5.1
 pytest-selenium==1.11.2
 pytest-xdist==1.20.1


### PR DESCRIPTION
Not sure if you want this, @edmorley - same failures as on master, but it seems there's some extra debug spew on failures, since pytest 3.3.0.

At least it doesn't seem affected by https://github.com/pytest-dev/pytest/issues/2956

Full console log: https://pastebin.com/eWEU8qk5

/cc @davehunt 