### PR TITLE
Bug 1288028 - Reduce latency of runnable jobs API

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -425,8 +425,8 @@ BUILDAPI_PENDING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson
 BUILDAPI_RUNNING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-running.js"
 BUILDAPI_BUILDS4H_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-4hr.js.gz"
 ALLTHETHINGS_URL = "https://secure.pub.build.mozilla.org/builddata/reports/allthethings.json"
-TASKCLUSTER_TASKGRAPH_URL = 'https://public-artifacts.taskcluster.net/{task_id}/0/public/full-task-graph.json'
 TASKCLUSTER_INDEX_URL = 'https://index.taskcluster.net/v1/task/gecko.v2.%s.latest.firefox.decision'
+TASKCLUSTER_RUNNABLE_JOBS_URL = 'https://public-artifacts.taskcluster.net/{task_id}/0/public/runnable-jobs.json.gz'
 
 # the amount of time we cache bug suggestion lookups (to speed up loading the bug
 # suggestions or autoclassify panels for recently finished jobs)

--- a/treeherder/etl/runnable_jobs.py
+++ b/treeherder/etl/runnable_jobs.py
@@ -127,7 +127,7 @@ def _taskcluster_runnable_jobs(project, decision_task_id):
     if not decision_task_id:
         return ret
 
-    tc_graph_url = settings.TASKCLUSTER_TASKGRAPH_URL.format(task_id=decision_task_id)
+    tc_graph_url = settings.TASKCLUSTER_RUNNABLE_JOBS_URL.format(task_id=decision_task_id)
     validate = URLValidator()
     try:
         validate(tc_graph_url)
@@ -141,30 +141,19 @@ def _taskcluster_runnable_jobs(project, decision_task_id):
         return []
 
     for label, node in tc_graph.iteritems():
-        if not ('extra' in node['task'] and 'treeherder' in node['task']['extra']):
-            # some tasks don't have the treeherder information we need
-            # to be able to display them (and are not intended to be
-            # displayed). skip.
-            continue
-
-        treeherder_options = node['task']['extra']['treeherder']
-        task_metadata = node['task']['metadata']
-        platform_option = ' '.join(treeherder_options.get('collection', {}).keys())
-
         ret.append({
-            'build_platform': treeherder_options.get('machine', {}).get('platform', ''),
+            'build_platform': node.get('platform', ''),
             'build_system_type': 'taskcluster',
-            'job_group_name': treeherder_options.get('groupName', ''),
-            'job_group_symbol': treeherder_options.get('groupSymbol', ''),
-            'job_type_description': task_metadata['description'],
-            'job_type_name': task_metadata['name'],
-            'job_type_symbol': treeherder_options['symbol'],
-            'platform': treeherder_options.get('machine', {}).get('platform', ''),
-            'platform_option': platform_option,
+            'job_group_name': node.get('groupName', ''),
+            'job_group_symbol': node.get('groupSymbol', ''),
+            'job_type_name': label,
+            'job_type_symbol': node['symbol'],
+            'platform': node.get('platform'),
+            'platform_option': ' '.join(node.get('collection', {}).keys()),
             'ref_data_name': label,
             'state': 'runnable',
             'result': 'runnable',
-            })
+        })
 
     return ret
 

--- a/treeherder/etl/runnable_jobs.py
+++ b/treeherder/etl/runnable_jobs.py
@@ -131,7 +131,9 @@ def _taskcluster_runnable_jobs(project, decision_task_id):
     validate = URLValidator()
     try:
         validate(tc_graph_url)
-        tc_graph = fetch_json(tc_graph_url)
+        # `force_gzip_encoding` works around Taskcluster not setting `Content-Encoding: gzip`:
+        # https://bugzilla.mozilla.org/show_bug.cgi?id=1423215
+        tc_graph = fetch_json(tc_graph_url, force_gzip_decompression=True)
     except ValidationError:
         logger.warning('Failed to validate {}'.format(tc_graph_url))
         return []


### PR DESCRIPTION
The runnable jobs API now fetches runnable-jobs.json if available and fallsback to
full-task-graph.json.

The new file is less than a tenth of the original file and contains the minimum
amount of data required for the endpoint.

You can test this locally with:
http://localhost:8000/api/project/try/runnable_jobs/?format=json&decision_task_id=DAKx7zD0RkWwa4dFs03kgA

You can check the new file in here:
https://public-artifacts.taskcluster.net/DAKx7zD0RkWwa4dFs03kgA/0/public/runnable-jobs.json

How can I run the tests for this? I would like to add a new test case.