### PR TITLE
Bug 1421107 - Stop perf tab wrapping at narrower widths

### DIFF
--- a/ui/css/treeherder-info-panel.css
+++ b/ui/css/treeherder-info-panel.css
@@ -108,6 +108,11 @@ div#info-panel .info-panel-navbar > ul.tab-headers > li {
   min-width: 550px;
 }
 
+.perf-job-selected {
+  /* An override to optimize all other non-perf jobs at 550px */
+  min-width: 646px !important;
+}
+
 .info-panel-navbar-controls {
   flex-wrap: nowrap;
 }

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -150,7 +150,8 @@
   <div id="job-tabs-panel">
     <div id="job-tabs-navbar">
       <nav class="info-panel-navbar info-panel-navbar-tabs">
-        <ul class="nav navbar-nav tab-headers">
+        <ul class="nav navbar-nav tab-headers"
+            ng-class="{'perf-job-selected': tabService.tabs.perfDetails.enabled}">
           <li ng-repeat="tabName in tabService.tabOrder"
               ng-if="tabService.tabs[tabName].enabled"
               ng-class="{'active': tabService.selectedTab == tabName}">


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1421107](https://bugzilla.mozilla.org/show_bug.cgi?id=1421107).

This returns functionality lost in Treeherder which prevents the performance tab from wrapping at smaller browser widths if a Perf job is selected.

Current (tab incorrectly wrapping):

![current](https://user-images.githubusercontent.com/3660661/33518630-fd7cbc16-d765-11e7-983e-4274ab236d8b.jpg)

Proposed:

![proposed](https://user-images.githubusercontent.com/3660661/33518632-036a93c8-d766-11e7-838a-743b2fe20607.jpg)

I applied the `min-width` to the `ul` which was the most direct element, rather than multiple parents higher in `job-tabs-panel` which was done in the original implementation in https://github.com/mozilla/treeherder/pull/1002.

Everything seems fine in local testing on OSX selecting both Perf and non-Perf jobs.

Tested on OSX 10.12.6:
Nightly **59.0a1 (2017-12-02) (64-bit)**