### PR TITLE
Bug 1423376 - Travis: Skip selenium tests if yarn build failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,8 +103,10 @@ matrix:
       install:
         - nvm install 8
         - source ./bin/travis-setup.sh services python_env geckodriver js_env
-      script:
+      before_script:
+        # Run in `before_script` to prevent the selenium tests from still being run if the UI build fails.
         - yarn build
+      script:
         - pytest tests/selenium/ --driver Firefox
 
 notifications:


### PR DESCRIPTION
By design, Travis runs all commands in `scripts` even if earlier ones fail. However in the case of the selenium tests, they are expected to fail if `yarn build` failed, so running them regardless only makes the log output harder to follow. Moving `yarn build` to `before_script` means the job will instead be aborted prior to running the tests.