### PR TITLE
Bug 1346567 - Temporarily disable perfherder data cycling

### DIFF
--- a/tests/model/test_cycle_data.py
+++ b/tests/model/test_cycle_data.py
@@ -158,6 +158,7 @@ def test_cycle_job_model_reference_data(test_repository, failure_classifications
     assert Machine.objects.filter(id__in=original_machine_ids).count() == len(original_machine_ids)
 
 
+@pytest.mark.skip(reason="Perf data cycling temporarily disabled (bug 1346567)")
 def test_cycle_job_with_performance_data(test_repository, failure_classifications,
                                          test_job, mock_log_parser,
                                          test_perf_signature):
@@ -184,6 +185,7 @@ def test_cycle_job_with_performance_data(test_repository, failure_classification
     assert p.job is None
 
 
+@pytest.mark.skip(reason="Perf data cycling temporarily disabled (bug 1346567)")
 @pytest.mark.parametrize("test_repository_expire_data", [False, True])
 def test_cycle_performance_data(test_repository, push_stored,
                                 test_perf_signature,

--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -63,7 +63,10 @@ class Command(BaseCommand):
                                                 options['sleep_time'])
             self.debug("Deleted {} jobs from {}".format(rs_deleted,
                                                         repository.name))
-            if repository.expire_performance_data:
+
+            # TODO: Fix the performance issues and re-enable:
+            # https://bugzilla.mozilla.org/show_bug.cgi?id=1346567#c10
+            if False and repository.expire_performance_data:
                 PerformanceDatum.objects.cycle_data(repository,
                                                     cycle_interval,
                                                     options['chunk_size'],


### PR DESCRIPTION
Since it's timing out due to missing indexes, preventing the rest of the jobs data cycling from taking place (resulting in disk space usage alerts).