### PR TITLE
Update to Firefox 57

### DIFF
--- a/tests/jenkins/Jenkinsfile
+++ b/tests/jenkins/Jenkinsfile
@@ -1,7 +1,7 @@
 /** Desired capabilities */
 def capabilities = [
   browserName: 'Firefox',
-  version: '56.0',
+  version: '57',
   platform: 'Windows 10'
 ]
 


### PR DESCRIPTION
@edmorley r? 

Suggested temp fix/workaround from Sauce Labs, for a working Firefox 57 instance; I'll definitely circle back and fix to "57.0" once their permanent fix is live.

Ad-hoc build results here, comparable with master: https://gist.github.com/stephendonner/e79e12e778b90977ddb08fbd0e598b62