### PR TITLE
Bug 1422208 - Stop the watched repo dropdown clipping off screen

### DIFF
--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -133,6 +133,8 @@ login {
 }
 
 .watched-repo-info-btn {
+    padding-left: 6px;
+    padding-right: 9px;
     border-right: 0;
 }
 

--- a/ui/partials/main/thWatchedRepo.html
+++ b/ui/partials/main/thWatchedRepo.html
@@ -18,7 +18,7 @@
           ng-class="{'active': watchedRepo===repoName}"
           ng-click="repoModel.unwatchRepo(watchedRepo)"
           ng-hide="watchedRepo===repoName"
-          title="unwatch {{::watchedRepo}}">
+          title="Unwatch {{::watchedRepo}}">
     <span class="fa fa-times"></span>
   </button>
   <th-watched-repo-info-drop-down name="{{::watchedRepo}}"

--- a/ui/partials/main/thWatchedRepoInfoDropDown.html
+++ b/ui/partials/main/thWatchedRepoInfoDropDown.html
@@ -1,4 +1,4 @@
-<ul class="dropdown-menu nav-dropdown-menu-right" role="menu">
+<ul class="dropdown-menu" role="menu">
   <li ng-show="reason" class="watched-repo-dropdown-item">
     <span ng-bind-html="reason|linkifyBugs"></span>
   </li>


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1422208](https://bugzilla.mozilla.org/show_bug.cgi?id=1422208).

This prevents the watched repo dropdown menu from clipping off screen when the first listed repo name is short (eg. 'Ash').

Current (clipped):
![current](https://user-images.githubusercontent.com/3660661/33908852-b8de8018-df57-11e7-977d-32f55cd667f5.jpg)

Proposed:
![proposed](https://user-images.githubusercontent.com/3660661/33908885-d393346c-df57-11e7-8a63-a926f62d8ec6.jpg)

Other menus:
![othermenus](https://user-images.githubusercontent.com/3660661/33908920-eee27aa2-df57-11e7-97ae-8eff8c44d355.jpg)

It seemed to be the least invasive way to fix the issue. For repos 'two' and 'three' in the row per above, the drop down now lies flush left with its parent repo container. Which seems to make the most sense.

I also tightened up the spacing between the info button and its repo name, so they look paired with each other. And I capitalized 'Unwatch repo'.

Tested on OSX 10.12.6:
Nightly **59.0a1 (2017-12-12) (64-bit)**