### PR TITLE
Vagrant: Update shellcheck from 0.4.6 to 0.4.7

### DIFF
--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -20,7 +20,7 @@ GECKODRIVER_VERSION="0.19.1"
 PYTHON_VERSION="$(sed 's/python-//' runtime.txt)"
 PIP_VERSION="9.0.1"
 # Keep in sync with the version pre-installed on Travis.
-SHELLCHECK_VERSION="0.4.6"
+SHELLCHECK_VERSION="0.4.7"
 
 # Suppress prompts during apt-get invocations.
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Passes locally even given the newly added checks:
https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v047---2017-12-08