### PR TITLE
Vagrant: Remove redundant environment variables

### DIFF
--- a/vagrant/env.sh
+++ b/vagrant/env.sh
@@ -2,7 +2,6 @@
 
 export PATH="${HOME}/firefox:${HOME}/python/bin:${PATH}"
 
-export ENABLE_LOCAL_SETTINGS_FILE='True'
 export BROKER_URL='amqp://guest:guest@localhost//'
 export DATABASE_URL='mysql://root@localhost/treeherder'
 export ELASTICSEARCH_URL='http://localhost:9200'
@@ -12,7 +11,6 @@ export ENABLE_DEBUG_TOOLBAR='True'
 export TREEHERDER_DJANGO_SECRET_KEY='secret-key-of-at-least-50-characters-to-pass-check-deploy'
 export NEW_RELIC_CONFIG_FILE='newrelic.ini'
 export NEW_RELIC_DEVELOPER_MODE='True'
-export GRAPHQL='True'
 
 # Enable Firefox headless mode, avoiding the need for xvfb.
 export MOZ_HEADLESS=1


### PR DESCRIPTION
* `ENABLE_LOCAL_SETTINGS_FILE` is no longer references anywhere.
* `GRAPHQL` now defaults to `True`, so doesn't need to be overridden.