### PR TITLE
Bug 1409778 - Simplify Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,10 +5,6 @@
     ":prNotPending",
     ":unpublishSafe"
   ],
-  "group": {
-    "commitMessage": "Update {{groupName}} packages",
-    "prTitle": "Update {{groupName}} packages"
-  },
   "ignoreDeps": [
     "deepmerge",
     "neutrino",


### PR DESCRIPTION
Now that the group package PR title and commit messages have been adjusted upstream, our config no longer needs to override them. See:
https://github.com/renovateapp/renovate/commit/1e4bebe627d8fe55328b4ac9546cf92e295b7b90

[skip ci]