### PR TITLE
Bug 1412792 - Update pyup ignore marker for graphene

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -313,7 +313,7 @@ iso8601==0.1.12 \
     --hash=sha256:bbbae5fb4a7abfe71d4688fd64bff70b91bbd74ef6a99d964bab18f7fdf286dd \
     --hash=sha256:49c4b20e1f38aa5cf109ddcd39647ac419f928512c869dc01d5c7098eddede82
 graphene==1.4.1 \
-    --hash=sha256:36134e026ec987514b240b57e3b6a995d6aed0fc5dece0567e77d5aed0ad0ece  # pyup: <2 # Bug 1412792
+    --hash=sha256:36134e026ec987514b240b57e3b6a995d6aed0fc5dece0567e77d5aed0ad0ece  # pyup: <1.4.2 # Bug 1412792
 
 enum34==1.1.6; python_version < '3' \
     --hash=sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79


### PR DESCRIPTION
Since 1.4.2 has too strict requirements, so we can't use it either.
(See #3060)