### PR TITLE
Bug 1408784 - Upgrade to Angular UI-Router 1.0

### DIFF
--- a/neutrino-custom/base.js
+++ b/neutrino-custom/base.js
@@ -33,13 +33,13 @@ module.exports = neutrino => {
     if (process.env.NODE_ENV !== 'test') {
         // Include files from node_modules in the separate, more-cacheable vendor chunk:
         const jsDeps = [
+            '@uirouter/angularjs',
             'angular',
             'angular-local-storage',
             'angular-resource',
             'angular-route',
             'angular-sanitize',
             'angular-toarrayfilter',
-            'angular-ui-router',
             'angular1-ui-bootstrap4',
             'bootstrap/dist/js/bootstrap',
             'hawk',

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "yarn": "1.x"
   },
   "dependencies": {
+    "@uirouter/angularjs": "1.0.12",
     "ajv": "5.5.2",
     "angular": "1.5.11",
     "angular-clipboard": "1.6.2",
@@ -20,7 +21,6 @@
     "angular-route": "1.5.11",
     "angular-sanitize": "1.5.11",
     "angular-toarrayfilter": "1.0.3",
-    "angular-ui-router": "0.4.3",
     "angular1-ui-bootstrap4": "2.4.22",
     "bootstrap": "4.0.0-beta.2",
     "deepmerge": "1.5.2",

--- a/ui/entry-perf.js
+++ b/ui/entry-perf.js
@@ -17,7 +17,10 @@ require('metrics-graphics/dist/metricsgraphics.css');
 // Vendor JS
 require('angular');
 require('angular-resource');
-require('angular-ui-router');
+require('@uirouter/angularjs');
+// Enable the $stateChange event polyfill so $stateChangeSuccess still works:
+// https://ui-router.github.io/guide/ng1/migrate-to-1_0#state-change-events
+require('@uirouter/angularjs/release/stateEvents.js');
 require('angular-sanitize');
 require('angular-local-storage');
 require('mousetrap');

--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -1,3 +1,5 @@
 "use strict";
 
-module.exports = angular.module("perf", ['ui.router', 'ui.bootstrap', 'treeherder', 'angular-clipboard']);
+// ui.router.state.events polyfills the legacy ui-router $stateChange events:
+// https://ui-router.github.io/guide/ng1/migrate-to-1_0#state-change-events
+module.exports = angular.module("perf", ['ui.router', 'ui.router.state.events', 'ui.bootstrap', 'treeherder', 'angular-clipboard']);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,16 @@
   version "8.5.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.2.tgz#83b8103fa9a2c2e83d78f701a9aa7c9539739aa5"
 
+"@uirouter/angularjs@1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@uirouter/angularjs/-/angularjs-1.0.12.tgz#b2275b7e33e0024a485f96568a18d350539880f3"
+  dependencies:
+    "@uirouter/core" "5.0.13"
+
+"@uirouter/core@5.0.13":
+  version "5.0.13"
+  resolved "https://registry.yarnpkg.com/@uirouter/core/-/core-5.0.13.tgz#e1b31626c393cbdd82651755ff1ce3fc55163fd0"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -136,12 +146,6 @@ angular-toarrayfilter@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/angular-toarrayfilter/-/angular-toarrayfilter-1.0.3.tgz#0741279050b67e67746d918ab6b74befdf051652"
 
-angular-ui-router@0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/angular-ui-router/-/angular-ui-router-0.4.3.tgz#6c29546fe50b8d2f74614dcb8660d6fc40d6e167"
-  dependencies:
-    angular "^1.0.8"
-
 angular1-ui-bootstrap4@2.4.22:
   version "2.4.22"
   resolved "https://registry.yarnpkg.com/angular1-ui-bootstrap4/-/angular1-ui-bootstrap4-2.4.22.tgz#378697405c957b96f947f42322f36660cd3fc88d"
@@ -149,10 +153,6 @@ angular1-ui-bootstrap4@2.4.22:
 angular@1.5.11:
   version "1.5.11"
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.5.11.tgz#8c5ba7386f15965c9acf3429f6881553aada30d6"
-
-angular@^1.0.8:
-  version "1.6.8"
-  resolved "https://registry.yarnpkg.com/angular/-/angular-1.6.8.tgz#5be378a58be91a5489e78b59c4518cd9fd273ffb"
 
 ansi-escapes@^1.1.0:
   version "1.4.0"


### PR DESCRIPTION
Notably:
* the package name has changed
* it no longer has an incorrect direct dependency on angularjs, which was causing v1.6 to be pulled in alongside the main v1.5 instance (it now uses a peer dependency instead).
* state change events (such as `$stateChangeSuccess`) were removed, so have been reinstated via the `ui.router.state.events` polyfill, since it's easier than trying to refactor to use the new transitions API (especially since much of this code might disappear once we switch more things to React).

See:
https://ui-router.github.io/guide/ng1/migrate-to-1_0