### PR TITLE
Bug 1364888 - Upgrade to AngularJS 1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "ajv": "5.5.2",
-    "angular": "1.5.11",
+    "angular": "1.6.8",
     "angular-clipboard": "1.6.2",
     "angular-local-storage": "0.7.1",
     "angular-marked": "1.2.2",
-    "angular-resource": "1.5.11",
-    "angular-route": "1.5.11",
-    "angular-sanitize": "1.5.11",
+    "angular-resource": "1.6.8",
+    "angular-route": "1.6.8",
+    "angular-sanitize": "1.6.8",
     "angular-toarrayfilter": "1.0.3",
     "angular-ui-router": "0.4.3",
     "angular1-ui-bootstrap4": "2.4.22",
@@ -57,7 +57,7 @@
     "taskcluster-client": "2.5.4"
   },
   "devDependencies": {
-    "angular-mocks": "1.5.11",
+    "angular-mocks": "1.6.8",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
     "jasmine-core": "2.8.0",

--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -11,7 +11,7 @@ perf.controller('CompareChooserCtrl', [
                                 thPerformanceBranches,
                                 localStorageService,
                                 compareBaseLineDefaultTimeRange) {
-        ThRepositoryModel.get_list().success(function (projects) {
+        ThRepositoryModel.get_list().then(({ data: projects }) => {
             $scope.projects = projects;
             $scope.originalTipList = [];
             $scope.newTipList = [];

--- a/ui/js/failureviewer.js
+++ b/ui/js/failureviewer.js
@@ -2,9 +2,14 @@
 
 var failureViewerApp = angular.module('failureviewer', ['treeherder']);
 
-failureViewerApp.config(['$compileProvider', function ($compileProvider) {
+failureViewerApp.config(['$compileProvider', '$locationProvider',
+        function ($compileProvider, $locationProvider) {
     // Disable debug data, as recommended by https://docs.angularjs.org/guide/production
     $compileProvider.debugInfoEnabled(false);
+
+    // Revert to the legacy Angular <=1.5 URL hash prefix to save breaking existing links:
+    // https://docs.angularjs.org/guide/migration#commit-aa077e8
+    $locationProvider.hashPrefix('');
 }]).run(require('./cache-templates'));
 
 module.exports = failureViewerApp;

--- a/ui/js/logviewer.js
+++ b/ui/js/logviewer.js
@@ -2,10 +2,14 @@
 
 var logViewerApp = angular.module('logviewer', ['treeherder']);
 
-logViewerApp.config(['$compileProvider', '$resourceProvider',
-    function ($compileProvider, $resourceProvider) {
+logViewerApp.config(['$compileProvider', '$locationProvider', '$resourceProvider',
+    function ($compileProvider, $locationProvider, $resourceProvider) {
         // Disable debug data, as recommended by https://docs.angularjs.org/guide/production
         $compileProvider.debugInfoEnabled(false);
+
+        // Revert to the legacy Angular <=1.5 URL hash prefix to save breaking existing links:
+        // https://docs.angularjs.org/guide/migration#commit-aa077e8
+        $locationProvider.hashPrefix('');
 
         // Don't strip trailing slashes from calculated URLs
         $resourceProvider.defaults.stripTrailingSlashes = false;

--- a/ui/js/models/repository.js
+++ b/ui/js/models/repository.js
@@ -103,7 +103,7 @@ treeherder.factory('ThRepositoryModel', [
 
                 // return the promise of getting the repos
                 return get_list()
-                    .success(function (data) {
+                    .then(({ data }) => {
                         // FIXME: only supporting github + hg for now for pushlog
                         // + revision info (we also assume dvcs_type git===github)
                         function Repo(props) {

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -865,7 +865,7 @@ treeherder.factory('ThResultSetStore', [
                 $log.debug("loadRevisions: check out to load revisions", rs, repoName);
                 // these revisions have never been loaded; do so now.
                 return ThResultSetModel.get(rs.revisions_uri)
-                    .success(function (data) {
+                    .then(({ data }) => {
 
                         if (rs.revisions.length === 0) {
                             Array.prototype.push.apply(rs.revisions, data);

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -1,10 +1,14 @@
 "use strict";
 
 // configure the router here, after we have defined all the controllers etc
-perf.config(['$compileProvider', '$httpProvider', '$stateProvider', '$urlRouterProvider',
-    function ($compileProvider, $httpProvider, $stateProvider, $urlRouterProvider) {
+perf.config(['$compileProvider', '$locationProvider', '$httpProvider', '$stateProvider', '$urlRouterProvider',
+    function ($compileProvider, $locationProvider, $httpProvider, $stateProvider, $urlRouterProvider) {
         // Disable debug data, as recommended by https://docs.angularjs.org/guide/production
         $compileProvider.debugInfoEnabled(false);
+
+        // Revert to the legacy Angular <=1.5 URL hash prefix to save breaking existing links:
+        // https://docs.angularjs.org/guide/migration#commit-aa077e8
+        $locationProvider.hashPrefix('');
 
         $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
         $httpProvider.defaults.xsrfCookieName = 'csrftoken';

--- a/ui/js/services/buildapi.js
+++ b/ui/js/services/buildapi.js
@@ -47,10 +47,10 @@ treeherder.factory('thBuildApi', [
                     },
                     withCredentials: true
                 })
-                    .success(function (data, status) {
+                    .then(({ status }) => {
                         notify(status, "cancel");
                     })
-                    .error(function (data, status) {
+                    .catch(({ status }) => {
                         notify(status, "cancel");
                     });
             },
@@ -65,10 +65,10 @@ treeherder.factory('thBuildApi', [
                     withCredentials: true
 
                 })
-                    .success(function (data, status) {
+                    .then(({ status }) => {
                         notify(status, "cancel all jobs");
                     })
-                    .error(function (data, status) {
+                    .catch(({ status }) => {
                         notify(status, "cancel all jobs");
                     });
             }

--- a/ui/js/services/classifications.js
+++ b/ui/js/services/classifications.js
@@ -27,7 +27,7 @@ treeherder.factory('thClassificationTypes', [
 
         var load = function () {
             return $http.get(thUrl.getRootUrl("/failureclassification/"), { cache: true })
-                .success(function (data) {
+                .then(({ data }) => {
                     data.forEach(addClassification);
                 });
         };

--- a/ui/js/services/pinboard.js
+++ b/ui/js/services/pinboard.js
@@ -24,15 +24,15 @@ treeherder.factory('thPinboard', [
 
                 classification.job_id = job.id;
                 classification.create()
-                    .success(function () {
+                    .then(() => {
                         thNotify.send("Classification saved for " + job.platform + " " + job.job_type_name, "success");
-                    }).error(function (data) {
+                    }).catch((response) => {
                         var message = "Error saving classification for " + job.platform + " " + job.job_type_name;
                         thNotify.send(
-                            ThModelErrors.format(data, message),
+                            ThModelErrors.format(response, message),
                             "danger"
                         );
-                        $log.debug("classification failed", data);
+                        $log.debug("classification failed", response);
                     });
             }
         };
@@ -45,12 +45,12 @@ treeherder.factory('thPinboard', [
                     type: 'annotation'
                 });
                 bjm.create()
-                    .success(function () {
+                    .then(() => {
                         thNotify.send("Bug association saved for " + job.platform + " " + job.job_type_name, "success");
-                    }).error(function (data) {
+                    }).catch((response) => {
                         var message = "Error saving bug association for " + job.platform + " " + job.job_type_name;
                         thNotify.send(
-                            ThModelErrors.format(data, message),
+                            ThModelErrors.format(response, message),
                             "danger"
                         );
                     });

--- a/ui/js/treeherder_app.js
+++ b/ui/js/treeherder_app.js
@@ -5,12 +5,16 @@ var treeherderApp = angular.module('treeherder.app',
         'mc.resizer', 'angular-toArrayFilter', 'react',
         'hc.marked']);
 
-treeherderApp.config(['$compileProvider', '$routeProvider', '$httpProvider',
+treeherderApp.config(['$compileProvider', '$locationProvider', '$routeProvider', '$httpProvider',
     '$logProvider', '$resourceProvider', 'localStorageServiceProvider',
-    function ($compileProvider, $routeProvider, $httpProvider, $logProvider,
+    function ($compileProvider, $locationProvider, $routeProvider, $httpProvider, $logProvider,
              $resourceProvider, localStorageServiceProvider) {
         // Disable debug data, as recommended by https://docs.angularjs.org/guide/production
         $compileProvider.debugInfoEnabled(false);
+
+        // Revert to the legacy Angular <=1.5 URL hash prefix to save breaking existing links:
+        // https://docs.angularjs.org/guide/migration#commit-aa077e8
+        $locationProvider.hashPrefix('');
 
         // Don't strip trailing slashes from calculated URLs
         $resourceProvider.defaults.stripTrailingSlashes = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -116,21 +116,21 @@ angular-marked@1.2.2:
   dependencies:
     marked "^0.3.3"
 
-angular-mocks@1.5.11:
-  version "1.5.11"
-  resolved "https://registry.yarnpkg.com/angular-mocks/-/angular-mocks-1.5.11.tgz#a0e1dd0ea55fd77ee7a757d75536c5e964c86f81"
+angular-mocks@1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/angular-mocks/-/angular-mocks-1.6.8.tgz#ba2120057b4edaa56492d8789ddfbc8f18afa3c5"
 
-angular-resource@1.5.11:
-  version "1.5.11"
-  resolved "https://registry.yarnpkg.com/angular-resource/-/angular-resource-1.5.11.tgz#d93ea619184a2e0ee3ae338265758363172929f0"
+angular-resource@1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/angular-resource/-/angular-resource-1.6.8.tgz#cc2172f8ec4a3a8340c43c600a5fed543e4168af"
 
-angular-route@1.5.11:
-  version "1.5.11"
-  resolved "https://registry.yarnpkg.com/angular-route/-/angular-route-1.5.11.tgz#49614f3a167f54291e449fe8ba05d39c58924b83"
+angular-route@1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/angular-route/-/angular-route-1.6.8.tgz#82ace773e7b232bf77768370760244a8caab5d36"
 
-angular-sanitize@1.5.11:
-  version "1.5.11"
-  resolved "https://registry.yarnpkg.com/angular-sanitize/-/angular-sanitize-1.5.11.tgz#ebfb3f343e543f9b2ef050fb4c2e9ee048d1772f"
+angular-sanitize@1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/angular-sanitize/-/angular-sanitize-1.6.8.tgz#68175a1a5853a6439fffcb251a88a538a44a8e70"
 
 angular-toarrayfilter@1.0.3:
   version "1.0.3"
@@ -146,11 +146,7 @@ angular1-ui-bootstrap4@2.4.22:
   version "2.4.22"
   resolved "https://registry.yarnpkg.com/angular1-ui-bootstrap4/-/angular1-ui-bootstrap4-2.4.22.tgz#378697405c957b96f947f42322f36660cd3fc88d"
 
-angular@1.5.11:
-  version "1.5.11"
-  resolved "https://registry.yarnpkg.com/angular/-/angular-1.5.11.tgz#8c5ba7386f15965c9acf3429f6881553aada30d6"
-
-angular@^1.0.8:
+angular@1.6.8, angular@^1.0.8:
   version "1.6.8"
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.6.8.tgz#5be378a58be91a5489e78b59c4518cd9fd273ffb"
 


### PR DESCRIPTION
**1) Stop using deprecated $http callback methods**
Angular v1.4.4 deprecated `$http`'s `.success()` and `.error()` callbacks in favour of `.then()` and `.catch()`. The deprecated forms are finally removed in Angular 1.6, so we need to stop using them:
https://docs.angularjs.org/guide/migration#-http-

**2) Update from AngularJS 1.5 to 1.6**
...and fix the only other breaking change that affects us - the `hashPrefix` change - which we revert by manually setting it back to the empty string, so that existing URLs still work:
https://docs.angularjs.org/guide/migration#commit-aa077e8

For more details, see:
https://docs.angularjs.org/guide/migration#migrating-from-1-5-to-1-6
https://github.com/angular/angular.js/blob/master/CHANGELOG.md#160-rainbow-tsunami-2016-12-08

Closes #3044.