### PR TITLE
Bug 1401518 - Make Add new jobs menu require a decision task

### DIFF
--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -109,6 +109,46 @@ treeherderApp.controller('ResultSetCtrl', [
             $rootScope.selectedJob = job;
         };
 
+        $rootScope.$on(thEvents.applyNewJobs, function () {
+            $scope.getDecisionTaskVisibility();
+        });
+
+        $scope.getDecisionTaskVisibility = function () {
+            let dtId = ThResultSetStore.getGeckoDecisionTaskId($scope.repoName, $scope.resultset.id);
+            if (dtId.$$state.value === 'No decision task') {
+                $scope.isDecisionTaskVisible = false;
+            } else {
+                $scope.isDecisionTaskVisible = true;
+            }
+        };
+
+        $scope.addNewJobsMenuTitle = function () {
+            let title = "";
+
+            // Ensure resultset is available on initial page load
+            if (!$scope.resultset.id) {
+                // still loading
+                return undefined;
+            }
+
+            if (!$scope.user.loggedin) {
+                title = title.concat("must be logged in / ");
+            }
+
+            if (!$scope.isDecisionTaskVisible) {
+                title = title.concat("a decision task is required");
+            }
+
+            if (title === "") {
+                title = "Add new jobs to this push";
+            } else {
+                // Cut off trailing "/ " if one exists, capitalize first letter
+                title = title.replace(/\/ $/, "");
+                title = title.replace(/^./, l => l.toUpperCase());
+            }
+            return title;
+        };
+
         $scope.toggleRevisions = function () {
 
             ThResultSetStore.loadRevisions(

--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -11,18 +11,18 @@
   </button>
   <!-- Menu contents -->
   <ul class="dropdown-menu pull-right">
-    <li title="{{user.loggedin ? '' : 'Must be logged in'}}"
-        class="{{user.loggedin ? '' : 'disabled'}}">
-        <a target="_blank" data-ignore-job-clear-on-click
-           title="Add new jobs to this push"
+    <li><button target="_blank" data-ignore-job-clear-on-click
+           ng-attr-title="{{addNewJobsMenuTitle()}}"
+           ng-class="!user.loggedin || !isDecisionTaskVisible ? 'disabled' : ''"
+           ng-disabled="!user.loggedin || !isDecisionTaskVisible"
            href="" class="dropdown-item"
            ng-hide="resultset.isRunnableVisible"
-           ng-click="showRunnableJobs()">Add new jobs</a></li>
-    <li><a target="_blank" data-ignore-job-clear-on-click
-           title="Hide Runnable Jobs"
+           ng-click="showRunnableJobs()">Add new jobs</button></li>
+    <li><button target="_blank" data-ignore-job-clear-on-click
+           title="Hide new jobs from this push"
            href="" class="dropdown-item"
            ng-show="resultset.isRunnableVisible"
-           ng-click="deleteRunnableJobs()">Hide Runnable Jobs</a></li>
+           ng-click="deleteRunnableJobs()">Hide runnable jobs</button></li>
     <li><a target="_blank" data-ignore-job-clear-on-click class="dropdown-item"
            href="https://secure.pub.build.mozilla.org/buildapi/self-serve/{{::repoName}}/rev/{{::resultset.revision}}">BuildAPI</a></li>
     <li><a target="_blank" data-ignore-job-clear-on-click


### PR DESCRIPTION
This hopefully fixes Buzilla bug [1401518](https://bugzilla.mozilla.org/show_bug.cgi?id=1401518).

I tried fixing this a better way, per my later thread comment:

> Thinking about this further, I think it would be even better if we disable the menu, change the menu tooltip to "No decision task available" and prevent the user from selecting the menu to begin with.

Case 1: Logged in, decision task available (the 'all is well' scenario):

![proposedtestcase3](https://user-images.githubusercontent.com/3660661/34463351-fd2a23e8-ee26-11e7-8e29-e28c2685e504.jpg)

Case 2: Not logged in, no decision task available

![proposedtestcase2](https://user-images.githubusercontent.com/3660661/34463356-37da3af0-ee27-11e7-8069-965fc4fbe4ac.jpg)

Case 3: Logged in, no decision task available (I believe @whimboo's test case)

![proposedtestcase1](https://user-images.githubusercontent.com/3660661/34463360-53a57b46-ee27-11e7-9967-db2ef3030550.jpg)

Case 4: Not logged in, decision task available

![proposedtestcase5](https://user-images.githubusercontent.com/3660661/34463365-9488ee18-ee27-11e7-8e9e-57ab7960c029.jpg)

Everything seems fine in local testing, but I defer to the expert users to try it out locally. I left the original sticky `thNotify` encountered in the bug in the code, in case it gets hit by other workflows. I believe the case for **Hide Runnable Jobs** menu is unaffected by this change, and therefore doesn't require any modifications.

I'm listening to the `applyNewJobs` event, so the action menu-state in each resultset dropdown menu should update accordingly when we poll for new jobs and a missing decision task job appears.

The fix is based on my assumption that we expect every push to have a Gecko Decision task, and no push in any repo would be complete by not having one. Maybe that's an incorrect assumption, I defer to you guys.

Tested on OSX 10.12.6:
Nightly **59.0a1 (2017-12-30) (64-bit)**