### PR TITLE
Remove unused dependencies thServiceDomain, thResultStatusObject

### DIFF
--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -87,13 +87,13 @@ treeherderApp.controller('JobsCtrl', [
 
 treeherderApp.controller('ResultSetCtrl', [
     '$scope', '$rootScope', '$http', 'ThLog', '$location',
-    'thUrl', 'thServiceDomain', 'thResultStatusInfo', 'thDateFormat',
+    'thUrl', 'thResultStatusInfo', 'thDateFormat',
     'ThResultSetStore', 'thEvents', 'thJobFilters', 'thNotify',
     'thBuildApi', 'thPinboard', 'ThResultSetModel', 'dateFilter',
     'ThModelErrors', 'ThJobModel', 'ThTaskclusterErrors', '$uibModal', 'thPinboardCountError',
     function ResultSetCtrl(
         $scope, $rootScope, $http, ThLog, $location,
-        thUrl, thServiceDomain, thResultStatusInfo, thDateFormat,
+        thUrl, thResultStatusInfo, thDateFormat,
         ThResultSetStore, thEvents, thJobFilters, thNotify,
         thBuildApi, thPinboard, ThResultSetModel, dateFilter, ThModelErrors,
         ThJobModel, ThTaskclusterErrors, $uibModal, thPinboardCountError) {

--- a/ui/js/controllers/perf/dashboard.js
+++ b/ui/js/controllers/perf/dashboard.js
@@ -4,11 +4,11 @@ perf.value('defaultTimeRange', 86400 * 2);
 
 perf.controller('dashCtrl', [
     '$state', '$stateParams', '$scope', '$rootScope', '$q', '$http', '$httpParamSerializer',
-    'ThRepositoryModel', 'ThResultSetModel', 'PhSeries', 'PhCompare', 'thServiceDomain',
+    'ThRepositoryModel', 'ThResultSetModel', 'PhSeries', 'PhCompare',
     'thDefaultRepo', 'phTimeRanges', 'defaultTimeRange', 'phBlockers', 'phDashboardValues',
     function dashCtrl($state, $stateParams, $scope, $rootScope, $q, $http, $httpParamSerializer,
                       ThRepositoryModel, ThResultSetModel, PhSeries, PhCompare,
-                      thServiceDomain, thDefaultRepo, phTimeRanges,
+                      thDefaultRepo, phTimeRanges,
                       defaultTimeRange, phBlockers, phDashboardValues) {
 
         $scope.dataLoading = true;
@@ -214,11 +214,11 @@ perf.controller('dashCtrl', [
 
 perf.controller('dashSubtestCtrl', [
     '$state', '$stateParams', '$scope', '$rootScope', '$q', '$http',
-    'ThRepositoryModel', 'ThResultSetModel', 'PhSeries', 'PhCompare', 'thServiceDomain',
+    'ThRepositoryModel', 'ThResultSetModel', 'PhSeries', 'PhCompare',
     'thDefaultRepo', 'phTimeRanges', 'defaultTimeRange', 'phDashboardValues',
     function ($state, $stateParams, $scope, $rootScope, $q, $http,
              ThRepositoryModel, ThResultSetModel, PhSeries, PhCompare,
-             thServiceDomain, thDefaultRepo, phTimeRanges, defaultTimeRange,
+             thDefaultRepo, phTimeRanges, defaultTimeRange,
              phDashboardValues) {
 
         var baseSignature = $stateParams.baseSignature;

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -3,14 +3,14 @@
 /* Directives */
 treeherder.directive('thCloneJobs', [
     '$rootScope', '$http', 'ThLog', 'thUrl', 'thCloneHtml',
-    'thServiceDomain', 'thResultStatusInfo', 'thEvents', 'thAggregateIds',
-    'thJobFilters', 'thResultStatusObject', 'ThResultSetStore',
+    'thResultStatusInfo', 'thEvents', 'thAggregateIds',
+    'thJobFilters', 'ThResultSetStore',
     'ThJobModel', 'linkifyBugsFilter', 'thResultStatus', 'thPlatformName',
     'thNotify', '$timeout', '$compile',
     function (
         $rootScope, $http, ThLog, thUrl, thCloneHtml,
-        thServiceDomain, thResultStatusInfo, thEvents, thAggregateIds,
-        thJobFilters, thResultStatusObject, ThResultSetStore,
+        thResultStatusInfo, thEvents, thAggregateIds,
+        thJobFilters, ThResultSetStore,
         ThJobModel, linkifyBugsFilter, thResultStatus, thPlatformName,
         thNotify, $timeout, $compile) {
 

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -1,10 +1,10 @@
 'use strict';
 
 treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
-    '$q', '$interpolate', 'thUrl', 'thResultStatusObject', 'thEvents', 'tcactions',
+    '$q', '$interpolate', 'thUrl', 'thEvents', 'tcactions',
     'thServiceDomain', 'ThLog', 'thNotify', 'ThJobModel', 'thTaskcluster', 'jsyaml',
     function ($rootScope, $http, $location, $q, $interpolate, thUrl,
-        thResultStatusObject, thEvents, tcactions, thServiceDomain, ThLog,
+        thEvents, tcactions, thServiceDomain, ThLog,
         thNotify, ThJobModel, thTaskcluster, jsyaml) {
 
         var $log = new ThLog("ThResultSetModel");

--- a/ui/js/services/buildapi.js
+++ b/ui/js/services/buildapi.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('thBuildApi', [
-    '$http', '$location', 'thUrl', 'thServiceDomain', 'ThLog', 'thNotify',
-    function ($http, $location, thUrl, thServiceDomain, ThLog, thNotify) {
+    '$http', '$location', 'thUrl', 'ThLog', 'thNotify',
+    function ($http, $location, thUrl, ThLog, thNotify) {
 
         var selfServeUrl = "https://secure.pub.build.mozilla.org/buildapi/self-serve/";
 


### PR DESCRIPTION
In my travels I noticed at least two unused dependencies in various controllers, so I thought I'd open a PR to remove them. I don't know if this is best practice or not or they should be left in for future hypothetical use. I defer to you guys.

I ran the unit tests locally and all 45 tests passed with these changes.