### PR TITLE
Make yarn default to saving non-tilde versions in package.json

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -8,3 +8,6 @@ ignore-engines true
 # on symlinks that won't exist elsewhere. This alternate config form is required due to:
 # https://github.com/yarnpkg/yarn/issues/4925
 --*.no-bin-links true
+
+# Default to saving the exact package version in package.json and not a tilde version range.
+save-exact true


### PR DESCRIPTION
Since otherwise it defaults to the tilde version ranges (eg `^1.2.3`), whereas we choose to use exact version numbers instead. This saves having to remember to pass `--exact` each time `yarn add` is used.