### PR TITLE
Bug 1428051 - Remove unused Angular DI parameters

### DIFF
--- a/ui/js/components/perf/compare.js
+++ b/ui/js/components/perf/compare.js
@@ -1,7 +1,7 @@
 'use strict';
 
 treeherder.component('phCompareTable', {
-    templateUrl: ['$element', '$attrs', function ($element, $attrs) {
+    templateUrl: ['$attrs', function ($attrs) {
         if ($attrs.type === 'trend') {
             return 'partials/perf/trendtable.html';
         }
@@ -18,7 +18,7 @@ treeherder.component('phCompareTable', {
         filterByFramework: '@',
         releaseBlockerCriteria: '@'
     },
-    controller: ['$element', '$attrs', function ($element, $attrs) {
+    controller: ['$attrs', function ($attrs) {
         var ctrl = this;
 
         if (!ctrl.baseTitle) {

--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -1,11 +1,11 @@
 "use strict";
 
 treeherder.controller('BugFilerCtrl', [
-    '$scope', '$rootScope', '$uibModalInstance', '$http', 'summary',
+    '$scope', '$uibModalInstance', '$http', 'summary',
     'search_terms', 'fullLog', 'parsedLog', 'reftest', 'selectedJob',
     'allFailures', 'crashSignatures', 'successCallback', 'thNotify',
     function BugFilerCtrl(
-        $scope, $rootScope, $uibModalInstance, $http, summary, search_terms,
+        $scope, $uibModalInstance, $http, summary, search_terms,
         fullLog, parsedLog, reftest, selectedJob, allFailures,
         crashSignatures, successCallback, thNotify) {
 

--- a/ui/js/controllers/filters.js
+++ b/ui/js/controllers/filters.js
@@ -1,11 +1,11 @@
 "use strict";
 
 treeherderApp.controller('JobFilterCtrl', [
-    '$scope', '$rootScope', '$route', '$routeParams', '$location', 'ThLog',
+    '$scope', '$rootScope',
     'thResultStatusList', 'thEvents', 'thJobFilters',
     'ThResultSetStore', 'thPinboard', 'thNotify', 'thFailureResults', 'thPinboardCountError',
     function JobFilterCtrl(
-        $scope, $rootScope, $route, $routeParams, $location, ThLog,
+        $scope, $rootScope,
         thResultStatusList, thEvents, thJobFilters,
         ThResultSetStore, thPinboard, thNotify, thFailureResults, thPinboardCountError) {
 

--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -1,14 +1,14 @@
 "use strict";
 
 treeherderApp.controller('JobsCtrl', [
-    '$scope', '$http', '$rootScope', '$routeParams', 'ThLog',
-    'thUrl', 'ThRepositoryModel', 'thDefaultRepo',
-    'ThResultSetStore', 'thResultStatusList', '$location', 'thEvents',
-    'ThJobModel', 'thNotify',
+    '$scope', '$rootScope', '$routeParams',
+    'thDefaultRepo',
+    'ThResultSetStore', '$location', 'thEvents',
+    'thNotify',
     function JobsCtrl(
-        $scope, $http, $rootScope, $routeParams, ThLog,
-        thUrl, ThRepositoryModel, thDefaultRepo,
-        ThResultSetStore, thResultStatusList, $location, thEvents, ThJobModel, thNotify) {
+        $scope, $rootScope, $routeParams,
+        thDefaultRepo,
+        ThResultSetStore, $location, thEvents, thNotify) {
 
         // load our initial set of resultsets
         // scope needs this function so it can be called directly by the user, too.
@@ -86,17 +86,17 @@ treeherderApp.controller('JobsCtrl', [
 
 
 treeherderApp.controller('ResultSetCtrl', [
-    '$scope', '$rootScope', '$http', 'ThLog', '$location',
-    'thUrl', 'thResultStatusInfo', 'thDateFormat',
-    'ThResultSetStore', 'thEvents', 'thJobFilters', 'thNotify',
+    '$scope', '$rootScope',
+    'thResultStatusInfo', 'thDateFormat',
+    'ThResultSetStore', 'thEvents', 'thNotify',
     'thBuildApi', 'thPinboard', 'ThResultSetModel', 'dateFilter',
-    'ThModelErrors', 'ThJobModel', 'ThTaskclusterErrors', '$uibModal', 'thPinboardCountError',
+    'ThModelErrors', 'ThTaskclusterErrors', '$uibModal', 'thPinboardCountError',
     function ResultSetCtrl(
-        $scope, $rootScope, $http, ThLog, $location,
-        thUrl, thResultStatusInfo, thDateFormat,
-        ThResultSetStore, thEvents, thJobFilters, thNotify,
+        $scope, $rootScope,
+        thResultStatusInfo, thDateFormat,
+        ThResultSetStore, thEvents, thNotify,
         thBuildApi, thPinboard, ThResultSetModel, dateFilter, ThModelErrors,
-        ThJobModel, ThTaskclusterErrors, $uibModal, thPinboardCountError) {
+        ThTaskclusterErrors, $uibModal, thPinboardCountError) {
 
         $scope.getCountClass = function (resultStatus) {
             return thResultStatusInfo(resultStatus).btnClass;

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -2,12 +2,12 @@
 
 logViewerApp.controller('LogviewerCtrl', [
     '$location', '$window', '$document', '$rootScope', '$scope',
-    '$timeout', '$resource', 'ThTextLogStepModel', 'ThJobDetailModel',
+    '$timeout', 'ThTextLogStepModel', 'ThJobDetailModel',
     'ThJobModel', 'thNotify', 'dateFilter', 'ThResultSetModel',
     'thDateFormat', 'thReftestStatus', 'thUrl',
     function Logviewer(
         $location, $window, $document, $rootScope, $scope,
-        $timeout, $resource, ThTextLogStepModel, ThJobDetailModel,
+        $timeout, ThTextLogStepModel, ThJobDetailModel,
         ThJobModel, thNotify, dateFilter, ThResultSetModel,
         thDateFormat, thReftestStatus, thUrl) {
 

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -1,16 +1,16 @@
 "use strict";
 
 treeherderApp.controller('MainCtrl', [
-    '$scope', '$rootScope', '$routeParams', '$location', '$timeout', '$q',
+    '$scope', '$rootScope', '$location', '$timeout', '$q',
     'ThLog', 'ThRepositoryModel', 'thPinboard', 'thTabs', '$document',
-    'thClassificationTypes', 'thEvents', '$interval', '$window', 'thNotify',
+    'thClassificationTypes', 'thEvents', '$interval', '$window',
     'thJobFilters', 'ThResultSetStore',
     'thDefaultRepo', 'thJobNavSelectors', 'thTitleSuffixLimit', '$http',
     '$httpParamSerializer',
     function MainController(
-        $scope, $rootScope, $routeParams, $location, $timeout, $q,
+        $scope, $rootScope, $location, $timeout, $q,
         ThLog, ThRepositoryModel, thPinboard, thTabs, $document,
-        thClassificationTypes, thEvents, $interval, $window, thNotify,
+        thClassificationTypes, thEvents, $interval, $window,
         thJobFilters, ThResultSetStore,
         thDefaultRepo, thJobNavSelectors, thTitleSuffixLimit, $http,
         $httpParamSerializer) {

--- a/ui/js/controllers/perf/alerts.js
+++ b/ui/js/controllers/perf/alerts.js
@@ -1,8 +1,8 @@
 "use strict";
 
 perf.factory('PhBugs', [
-    '$http', '$httpParamSerializer', '$templateRequest', '$interpolate', '$rootScope', 'dateFilter', 'thServiceDomain',
-    function ($http, $httpParamSerializer, $templateRequest, $interpolate, $rootScope, dateFilter, thServiceDomain) {
+    '$http', '$httpParamSerializer', '$interpolate', '$rootScope', 'dateFilter', 'thServiceDomain',
+    function ($http, $httpParamSerializer, $interpolate, $rootScope, dateFilter, thServiceDomain) {
         return {
             fileBug: function (alertSummary) {
                 $http.get(thServiceDomain + '/api/performance/bug-template/?framework=' + alertSummary.framework).then(function (response) {
@@ -64,10 +64,10 @@ perf.controller(
         }]);
 
 perf.controller(
-    'MarkDownstreamAlertsCtrl', ['$scope', '$uibModalInstance', '$http', '$q', 'alertSummary',
-        'allAlertSummaries', 'PhAlerts', 'phAlertStatusMap',
-        function ($scope, $uibModalInstance, $http, $q, alertSummary, allAlertSummaries,
-                 PhAlerts, phAlertStatusMap) {
+    'MarkDownstreamAlertsCtrl', ['$scope', '$uibModalInstance', '$q', 'alertSummary',
+        'allAlertSummaries', 'phAlertStatusMap',
+        function ($scope, $uibModalInstance, $q, alertSummary, allAlertSummaries,
+                 phAlertStatusMap) {
             $scope.title = "Mark alerts downstream";
             $scope.placeholder = "Alert #";
 
@@ -102,9 +102,9 @@ perf.controller(
         }]);
 
 perf.controller(
-    'ReassignAlertsCtrl', ['$scope', '$uibModalInstance', '$http', '$q', 'alertSummary',
-        'allAlertSummaries', 'PhAlerts', 'phAlertStatusMap',
-        function ($scope, $uibModalInstance, $http, $q, alertSummary, allAlertSummaries, PhAlerts, phAlertStatusMap) {
+    'ReassignAlertsCtrl', ['$scope', '$uibModalInstance', '$q', 'alertSummary',
+        'allAlertSummaries', 'phAlertStatusMap',
+        function ($scope, $uibModalInstance, $q, alertSummary, allAlertSummaries, phAlertStatusMap) {
 
             $scope.title = "Reassign alerts";
             $scope.placeholder = "Alert #";
@@ -142,17 +142,17 @@ perf.controller(
         }]);
 
 perf.controller('AlertsCtrl', [
-    '$state', '$stateParams', '$scope', '$rootScope', '$http', '$q', '$uibModal',
+    '$state', '$stateParams', '$scope', '$rootScope', '$q', '$uibModal',
     'thUrl', 'ThRepositoryModel', 'ThOptionCollectionModel',
     'ThResultSetModel',
-    'PhFramework', 'PhSeries', 'PhAlerts', 'PhBugs', 'phTimeRanges',
+    'PhFramework', 'PhAlerts', 'PhBugs', 'phTimeRanges',
     'phDefaultTimeRangeValue', 'phAlertSummaryStatusMap', 'phAlertStatusMap',
     'dateFilter', 'thDateFormat', 'clipboard', 'phTimeRangeValues',
-    function AlertsCtrl($state, $stateParams, $scope, $rootScope, $http, $q,
+    function AlertsCtrl($state, $stateParams, $scope, $rootScope, $q,
                         $uibModal,
                         thUrl, ThRepositoryModel,
                         ThOptionCollectionModel, ThResultSetModel,
-                        PhFramework, PhSeries, PhAlerts, PhBugs, phTimeRanges,
+                        PhFramework, PhAlerts, PhBugs, phTimeRanges,
                         phDefaultTimeRangeValue, phAlertSummaryStatusMap, phAlertStatusMap,
                         dateFilter, thDateFormat, clipboard, phTimeRangeValues) {
         $scope.alertSummaries = undefined;

--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -3,12 +3,11 @@
 perf.controller('CompareChooserCtrl', [
     '$state', '$stateParams', '$scope', '$q', 'ThRepositoryModel', 'ThResultSetModel',
     'phCompareDefaultNewRepo', 'phCompareDefaultOriginalRepo',
-    'thPerformanceBranches', 'localStorageService', 'compareBaseLineDefaultTimeRange',
+    'localStorageService', 'compareBaseLineDefaultTimeRange',
     function CompareChooserCtrl($state, $stateParams, $scope, $q,
                                 ThRepositoryModel, ThResultSetModel,
                                 phCompareDefaultNewRepo,
                                 phCompareDefaultOriginalRepo,
-                                thPerformanceBranches,
                                 localStorageService,
                                 compareBaseLineDefaultTimeRange) {
         ThRepositoryModel.get_list().success(function (projects) {
@@ -118,15 +117,13 @@ perf.controller('CompareChooserCtrl', [
     }]);
 
 perf.controller('CompareResultsCtrl', [
-    '$state', '$stateParams', '$scope', '$rootScope', '$location',
-    'thServiceDomain', 'ThRepositoryModel',
-    'ThResultSetModel', '$http', '$httpParamSerializer', '$q', '$timeout', 'PhFramework', 'PhSeries',
-    'math', 'phTimeRanges', 'PhCompare', 'compareBaseLineDefaultTimeRange',
+    '$state', '$stateParams', '$scope',
+    'ThRepositoryModel',
+    'ThResultSetModel', '$httpParamSerializer', '$q', 'PhFramework', 'PhSeries',
+    'phTimeRanges', 'PhCompare', 'compareBaseLineDefaultTimeRange',
     function CompareResultsCtrl($state, $stateParams, $scope,
-                                $rootScope, $location,
-                                thServiceDomain,
-                                ThRepositoryModel, ThResultSetModel, $http, $httpParamSerializer,
-                                $q, $timeout, PhFramework, PhSeries, math,
+                                ThRepositoryModel, ThResultSetModel, $httpParamSerializer,
+                                $q, PhFramework, PhSeries,
                                 phTimeRanges,
                                 PhCompare, compareBaseLineDefaultTimeRange) {
         function displayResults(rawResultsMap, newRawResultsMap) {
@@ -482,14 +479,13 @@ perf.controller('CompareResultsCtrl', [
     }]);
 
 perf.controller('CompareSubtestResultsCtrl', [
-    '$state', '$stateParams', '$scope', '$rootScope', '$location',
-    'thServiceDomain', 'ThRepositoryModel',
-    'ThResultSetModel', '$http', '$q', '$timeout', 'PhSeries', 'math',
+    '$state', '$stateParams', '$scope',
+    'ThRepositoryModel',
+    'ThResultSetModel', '$q', 'PhSeries',
     'PhCompare', 'phTimeRanges', 'compareBaseLineDefaultTimeRange', '$httpParamSerializer',
-    function CompareSubtestResultsCtrl($state, $stateParams, $scope, $rootScope,
-                                       $location, thServiceDomain,
+    function CompareSubtestResultsCtrl($state, $stateParams, $scope,
                                        ThRepositoryModel, ThResultSetModel,
-                                       $http, $q, $timeout, PhSeries, math,
+                                       $q, PhSeries,
                                        PhCompare, phTimeRanges, compareBaseLineDefaultTimeRange,
                                        $httpParamSerializer) {
          //TODO: duplicated from comparectrl

--- a/ui/js/controllers/perf/dashboard.js
+++ b/ui/js/controllers/perf/dashboard.js
@@ -3,10 +3,10 @@
 perf.value('defaultTimeRange', 86400 * 2);
 
 perf.controller('dashCtrl', [
-    '$state', '$stateParams', '$scope', '$rootScope', '$q', '$http', '$httpParamSerializer',
+    '$state', '$stateParams', '$scope', '$rootScope', '$q', '$httpParamSerializer',
     'ThRepositoryModel', 'ThResultSetModel', 'PhSeries', 'PhCompare',
     'thDefaultRepo', 'phTimeRanges', 'defaultTimeRange', 'phBlockers', 'phDashboardValues',
-    function dashCtrl($state, $stateParams, $scope, $rootScope, $q, $http, $httpParamSerializer,
+    function dashCtrl($state, $stateParams, $scope, $rootScope, $q, $httpParamSerializer,
                       ThRepositoryModel, ThResultSetModel, PhSeries, PhCompare,
                       thDefaultRepo, phTimeRanges,
                       defaultTimeRange, phBlockers, phDashboardValues) {
@@ -213,10 +213,10 @@ perf.controller('dashCtrl', [
 ]);
 
 perf.controller('dashSubtestCtrl', [
-    '$state', '$stateParams', '$scope', '$rootScope', '$q', '$http',
+    '$state', '$stateParams', '$scope', '$rootScope', '$q',
     'ThRepositoryModel', 'ThResultSetModel', 'PhSeries', 'PhCompare',
     'thDefaultRepo', 'phTimeRanges', 'defaultTimeRange', 'phDashboardValues',
-    function ($state, $stateParams, $scope, $rootScope, $q, $http,
+    function ($state, $stateParams, $scope, $rootScope, $q,
              ThRepositoryModel, ThResultSetModel, PhSeries, PhCompare,
              thDefaultRepo, phTimeRanges, defaultTimeRange,
              phDashboardValues) {

--- a/ui/js/controllers/perf/e10s-trend.js
+++ b/ui/js/controllers/perf/e10s-trend.js
@@ -5,13 +5,13 @@ perf.value('defaultNewDate', 0);
 perf.value('defaultSampleSize', 604800);
 
 perf.controller('e10sTrendCtrl', [
-    '$state', '$stateParams', '$scope', '$rootScope', '$q', '$http', '$httpParamSerializer',
-    'ThRepositoryModel', 'ThResultSetModel', 'PhSeries', 'PhCompare',
-    'thServiceDomain', 'thDefaultRepo', 'phTimeRanges', 'defaultSampleSize',
+    '$state', '$stateParams', '$scope', '$rootScope', '$q', '$httpParamSerializer',
+    'ThRepositoryModel', 'PhSeries', 'PhCompare',
+    'thDefaultRepo', 'phTimeRanges', 'defaultSampleSize',
     'phComparisonDate', 'defaultBaseDate', 'defaultNewDate', 'phBlockers',
-    function e10sTrendCtrl($state, $stateParams, $scope, $rootScope, $q, $http, $httpParamSerializer,
-                      ThRepositoryModel, ThResultSetModel, PhSeries, PhCompare,
-                      thServiceDomain, thDefaultRepo, phTimeRanges,
+    function e10sTrendCtrl($state, $stateParams, $scope, $rootScope, $q, $httpParamSerializer,
+                      ThRepositoryModel, PhSeries, PhCompare,
+                      thDefaultRepo, phTimeRanges,
                       defaultSampleSize, phComparisonDate, defaultBaseDate, defaultNewDate, phBlockers) {
 
         $scope.compareResults = {};
@@ -253,13 +253,13 @@ perf.controller('e10sTrendCtrl', [
 ]);
 
 perf.controller('e10sTrendSubtestCtrl', [
-    '$state', '$stateParams', '$scope', '$rootScope', '$q', '$http', '$httpParamSerializer',
-    'ThRepositoryModel', 'ThResultSetModel', 'PhSeries', 'PhCompare',
-    'thServiceDomain', 'thDefaultRepo', 'phTimeRanges', 'defaultSampleSize',
-    'phComparisonDate', 'defaultBaseDate', 'defaultNewDate', 'phBlockers',
-    function e10sTrendCtrl($state, $stateParams, $scope, $rootScope, $q, $http, $httpParamSerializer,
-                      ThRepositoryModel, ThResultSetModel, PhSeries, PhCompare,
-                      thServiceDomain, thDefaultRepo, phTimeRanges,
+    '$state', '$stateParams', '$scope', '$rootScope', '$q',
+    'ThRepositoryModel', 'PhSeries', 'PhCompare',
+    'thDefaultRepo', 'phTimeRanges', 'defaultSampleSize',
+    'phComparisonDate', 'defaultBaseDate', 'defaultNewDate',
+    function e10sTrendCtrl($state, $stateParams, $scope, $rootScope, $q,
+                      ThRepositoryModel, PhSeries, PhCompare,
+                      thDefaultRepo, phTimeRanges,
                       defaultSampleSize, phComparisonDate, defaultBaseDate, defaultNewDate) {
 
         var baseSignature = $stateParams.baseSignature;

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -1,11 +1,11 @@
 "use strict";
 
 perf.controller('GraphsCtrl', [
-    '$state', '$stateParams', '$scope', '$rootScope', '$location', '$uibModal',
-    '$window', 'thServiceDomain', '$http', '$q', '$timeout', 'PhSeries', 'PhAlerts',
+    '$state', '$stateParams', '$scope', '$rootScope', '$uibModal',
+    '$window', 'thServiceDomain', '$q', '$timeout', 'PhSeries', 'PhAlerts',
     'ThRepositoryModel', 'ThResultSetModel', 'phTimeRanges', 'phDefaultTimeRangeValue',
-    function GraphsCtrl($state, $stateParams, $scope, $rootScope, $location,
-        $uibModal, $window, thServiceDomain, $http, $q, $timeout, PhSeries,
+    function GraphsCtrl($state, $stateParams, $scope, $rootScope,
+        $uibModal, $window, thServiceDomain, $q, $timeout, PhSeries,
         PhAlerts, ThRepositoryModel, ThResultSetModel,
         phTimeRanges, phDefaultTimeRangeValue) {
         var availableColors = ['maroon', 'navy', 'pink', 'turquoise', 'brown',
@@ -876,11 +876,11 @@ perf.filter('testNameContainsWords', function () {
     };
 });
 
-perf.controller('TestChooserCtrl', ['$scope', '$uibModalInstance', '$http',
-    'projects', 'timeRange', 'thServiceDomain', 'thDefaultRepo', 'PhSeries',
+perf.controller('TestChooserCtrl', ['$scope', '$uibModalInstance',
+    'projects', 'timeRange', 'thDefaultRepo', 'PhSeries',
     'PhFramework', 'defaultFrameworkId', 'defaultProjectName', 'defaultPlatform',
     '$q', 'testsDisplayed', 'options', 'thPerformanceBranches', 'phDefaultFramework',
-    function ($scope, $uibModalInstance, $http, projects, timeRange, thServiceDomain,
+    function ($scope, $uibModalInstance, projects, timeRange,
         thDefaultRepo, PhSeries, PhFramework, defaultFrameworkId, defaultProjectName,
         defaultPlatform, $q, testsDisplayed, options, thPerformanceBranches,
         phDefaultFramework) {

--- a/ui/js/controllers/tcjobactions.js
+++ b/ui/js/controllers/tcjobactions.js
@@ -1,12 +1,12 @@
 "use strict";
 
 treeherder.controller('TCJobActionsCtrl', [
-    '$scope', '$http', '$uibModalInstance', 'ThResultSetStore',
-    'ThJobDetailModel', 'thTaskcluster', 'ThTaskclusterErrors',
+    '$scope', '$uibModalInstance', 'ThResultSetStore',
+    'thTaskcluster', 'ThTaskclusterErrors',
     'thNotify', 'job', 'repoName', 'resultsetId', 'tcactions',
     'jsyaml', 'Ajv', 'jsonSchemaDefaults',
-    function ($scope, $http, $uibModalInstance, ThResultSetStore,
-             ThJobDetailModel, thTaskcluster, ThTaskclusterErrors, thNotify,
+    function ($scope, $uibModalInstance, ThResultSetStore,
+             thTaskcluster, ThTaskclusterErrors, thNotify,
              job, repoName, resultsetId, tcactions, jsyaml, Ajv, jsonSchemaDefaults) {
         const ajv = new Ajv({ format: 'full', verbose: true, allErrors: true });
         let decisionTaskId;

--- a/ui/js/directives/treeherder/bottom_nav_panel.js
+++ b/ui/js/directives/treeherder/bottom_nav_panel.js
@@ -39,8 +39,8 @@ treeherder.directive('thRelatedBugQueued', function () {
 });
 
 treeherder.directive('thFailureClassification', [
-    '$parse', 'thClassificationTypes',
-    function ($parse, thClassificationTypes) {
+    'thClassificationTypes',
+    function (thClassificationTypes) {
         return {
             scope: {
                 failureId: "=",
@@ -63,7 +63,7 @@ treeherder.directive('thFailureClassification', [
     }]);
 
 treeherder.directive('thSimilarJobs', [
-    'ThJobModel', 'ThLog',
+    'ThJobModel',
     function (ThJobModel) {
         return {
             restrict: "E",

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -2,16 +2,16 @@
 
 /* Directives */
 treeherder.directive('thCloneJobs', [
-    '$rootScope', '$http', 'ThLog', 'thUrl', 'thCloneHtml',
+    '$rootScope', 'ThLog', 'thUrl', 'thCloneHtml',
     'thResultStatusInfo', 'thEvents', 'thAggregateIds',
     'thJobFilters', 'ThResultSetStore',
-    'ThJobModel', 'linkifyBugsFilter', 'thResultStatus', 'thPlatformName',
+    'ThJobModel', 'thResultStatus', 'thPlatformName',
     'thNotify', '$timeout', '$compile',
     function (
-        $rootScope, $http, ThLog, thUrl, thCloneHtml,
+        $rootScope, ThLog, thUrl, thCloneHtml,
         thResultStatusInfo, thEvents, thAggregateIds,
         thJobFilters, ThResultSetStore,
-        ThJobModel, linkifyBugsFilter, thResultStatus, thPlatformName,
+        ThJobModel, thResultStatus, thPlatformName,
         thNotify, $timeout, $compile) {
 
         var $log = new ThLog("thCloneJobs");

--- a/ui/js/directives/treeherder/top_nav_bar.js
+++ b/ui/js/directives/treeherder/top_nav_bar.js
@@ -79,8 +79,8 @@ treeherder.directive('thWatchedRepo', [
     }]);
 
 treeherder.directive('thWatchedRepoInfoDropDown', [
-    'ThLog', 'ThRepositoryModel', 'treeStatus',
-    function (ThLog, ThRepositoryModel, treeStatus) {
+    'ThRepositoryModel', 'treeStatus',
+    function (ThRepositoryModel, treeStatus) {
 
         return {
             restrict: "E",

--- a/ui/js/models/build_platform.js
+++ b/ui/js/models/build_platform.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('ThBuildPlatformModel', [
-    '$http', '$log', 'thUrl',
-    function ($http, $log, thUrl) {
+    '$http', 'thUrl',
+    function ($http, thUrl) {
 
         // ThBuildPlatform is the js counterpart of buildplatform
 

--- a/ui/js/models/classification.js
+++ b/ui/js/models/classification.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('ThJobClassificationModel', [
-    '$http', 'ThLog', 'thUrl',
-    function ($http, ThLog, thUrl) {
+    '$http', 'thUrl',
+    function ($http, thUrl) {
 
         // ThJobClassificationModel is the js counterpart of note
 

--- a/ui/js/models/classified_failure.js
+++ b/ui/js/models/classified_failure.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('ThClassifiedFailuresModel', [
-    '$http', '$q', 'ThLog', 'thUrl',
-    function ($http, $q, ThLog, thUrl) {
+    '$http', '$q', 'thUrl',
+    function ($http, $q, thUrl) {
 
         var ThClassifiedFailuresModel = function (data) {
             angular.extend(this, data);

--- a/ui/js/models/failure_lines.js
+++ b/ui/js/models/failure_lines.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('ThFailureLinesModel', [
-    '$http', '$q', 'ThLog', 'thUrl',
-    function ($http, $q, ThLog, thUrl) {
+    '$http', '$q', 'thUrl',
+    function ($http, $q, thUrl) {
 
         var ThFailureLinesModel = function (data) {
             angular.extend(this, data);

--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('ThJobModel', [
-    '$http', 'ThLog', 'thUrl', 'thPlatformName', '$q',
-    function ($http, ThLog, thUrl, thPlatformName, $q) {
+    '$http', 'thUrl', 'thPlatformName', '$q',
+    function ($http, thUrl, thPlatformName, $q) {
         // ThJobModel is the js counterpart of job
 
         var ThJobModel = function (data) {

--- a/ui/js/models/job_group.js
+++ b/ui/js/models/job_group.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('ThJobGroupModel', [
-    '$http', '$log', 'thUrl',
-    function ($http, $log, thUrl) {
+    '$http', 'thUrl',
+    function ($http, thUrl) {
 
         // ThJobGroupModel is the js counterpart of job_type
 

--- a/ui/js/models/job_log_url.js
+++ b/ui/js/models/job_log_url.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('ThJobLogUrlModel', [
-    '$http', '$log', 'thUrl',
-    function ($http, $log, thUrl) {
+    '$http', 'thUrl',
+    function ($http, thUrl) {
 
         // ThJobLogUrlModel is the js counterpart of job_type
 

--- a/ui/js/models/job_type.js
+++ b/ui/js/models/job_type.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('ThJobTypeModel', [
-    '$http', '$log', 'thUrl',
-    function ($http, $log, thUrl) {
+    '$http', 'thUrl',
+    function ($http, thUrl) {
 
         // ThJobTypeModel is the js counterpart of job_type
 

--- a/ui/js/models/matcher.js
+++ b/ui/js/models/matcher.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('ThMatcherModel', [
-    '$http', '$log', 'thUrl',
-    function ($http, $log, thUrl) {
+    '$http', 'thUrl',
+    function ($http, thUrl) {
 
         // ThJobTypeModel is the js counterpart of job_type
 

--- a/ui/js/models/option_collection.js
+++ b/ui/js/models/option_collection.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('ThOptionCollectionModel', [
-    '$http', '$log', 'thUrl',
-    function ($http, $log, thUrl) {
+    '$http', 'thUrl',
+    function ($http, thUrl) {
         var optionCollectionMap = {};
         var loadPromise = $http.get(
             thUrl.getRootUrl("/optioncollectionhash/")).then(

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -1,11 +1,11 @@
 'use strict';
 
-treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location',
-    '$q', '$interpolate', 'thUrl', 'thEvents', 'tcactions',
-    'thServiceDomain', 'ThLog', 'thNotify', 'ThJobModel', 'thTaskcluster', 'jsyaml',
-    function ($rootScope, $http, $location, $q, $interpolate, thUrl,
-        thEvents, tcactions, thServiceDomain, ThLog,
-        thNotify, ThJobModel, thTaskcluster, jsyaml) {
+treeherder.factory('ThResultSetModel', ['$http', '$location',
+    '$q', '$interpolate', 'thUrl', 'tcactions',
+    'thServiceDomain', 'ThLog', 'ThJobModel', 'thTaskcluster', 'jsyaml',
+    function ($http, $location, $q, $interpolate, thUrl,
+        tcactions, thServiceDomain, ThLog,
+        ThJobModel, thTaskcluster, jsyaml) {
 
         var $log = new ThLog("ThResultSetModel");
 

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -2,13 +2,13 @@
 
 treeherder.factory('ThResultSetStore', [
     '$rootScope', '$q', '$location', '$interval', 'thPlatformMap',
-    'ThResultSetModel', 'ThJobModel', 'ThJobDetailModel', 'thEvents',
+    'ThResultSetModel', 'ThJobModel', 'thEvents',
     'thResultStatusObject', 'thAggregateIds', 'ThLog', 'thNotify',
     'thJobFilters', 'thOptionOrder', 'ThRepositoryModel', '$timeout',
     'ThRunnableJobModel',
     function (
         $rootScope, $q, $location, $interval, thPlatformMap, ThResultSetModel,
-        ThJobModel, ThJobDetailModel, thEvents, thResultStatusObject, thAggregateIds,
+        ThJobModel, thEvents, thResultStatusObject, thAggregateIds,
         ThLog, thNotify, thJobFilters, thOptionOrder, ThRepositoryModel,
         $timeout, ThRunnableJobModel) {
 

--- a/ui/js/models/text_log_errors.js
+++ b/ui/js/models/text_log_errors.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('ThTextLogErrorsModel', [
-    '$http', '$q', 'ThLog', 'thUrl',
-    function ($http, $q, ThLog, thUrl) {
+    '$http', '$q', 'thUrl',
+    function ($http, $q, thUrl) {
 
         var ThTextLogErrorsModel = function (data) {
             if (data.metadata === null) {

--- a/ui/js/models/user.js
+++ b/ui/js/models/user.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('ThUserModel', [
-    '$http', '$log', 'thUrl', 'thNotify', '$q',
-    function ($http, $log, thUrl, thNotify, $q) {
+    '$http', 'thUrl', 'thNotify', '$q',
+    function ($http, thUrl, thNotify, $q) {
 
         // ThUserModel is the js counterpart of user
 

--- a/ui/js/services/buildapi.js
+++ b/ui/js/services/buildapi.js
@@ -1,8 +1,8 @@
 'use strict';
 
 treeherder.factory('thBuildApi', [
-    '$http', '$location', 'thUrl', 'ThLog', 'thNotify',
-    function ($http, $location, thUrl, ThLog, thNotify) {
+    '$http', 'thNotify',
+    function ($http, thNotify) {
 
         var selfServeUrl = "https://secure.pub.build.mozilla.org/buildapi/self-serve/";
 

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -20,13 +20,13 @@
  */
 treeherder.factory('thJobFilters', [
     'thResultStatusList', 'ThLog', '$rootScope', '$location',
-    'thNotify', 'thEvents', 'thFailureResults',
-    'thResultStatus', 'thClassificationTypes', 'ThRepositoryModel',
+    'thEvents', 'thFailureResults',
+    'thResultStatus', 'thClassificationTypes',
     'thPlatformName',
     function (
         thResultStatusList, ThLog, $rootScope, $location,
-        thNotify, thEvents, thFailureResults,
-        thResultStatus, thClassificationTypes, ThRepositoryModel,
+        thEvents, thFailureResults,
+        thResultStatus, thClassificationTypes,
         thPlatformName) {
 
         const $log = new ThLog("thJobFilters");

--- a/ui/js/services/pinboard.js
+++ b/ui/js/services/pinboard.js
@@ -1,10 +1,10 @@
 'use strict';
 
 treeherder.factory('thPinboard', [
-    '$http', 'thUrl', 'ThJobClassificationModel', '$rootScope', 'thEvents',
+    'ThJobClassificationModel', '$rootScope', 'thEvents',
     'ThBugJobMapModel', 'thNotify', 'ThModelErrors', 'ThLog', 'ThResultSetStore', 'thPinboardCountError',
     function (
-        $http, thUrl, ThJobClassificationModel, $rootScope, thEvents,
+        ThJobClassificationModel, $rootScope, thEvents,
         ThBugJobMapModel, thNotify, ThModelErrors, ThLog, ThResultSetStore, thPinboardCountError) {
 
         var $log = new ThLog("thPinboard");

--- a/ui/plugins/annotations/controller.js
+++ b/ui/plugins/annotations/controller.js
@@ -1,11 +1,11 @@
 "use strict";
 
 treeherder.controller('AnnotationsPluginCtrl', [
-    '$scope', '$rootScope', 'ThLog', 'ThJobClassificationModel', 'thNotify',
-    'thEvents', 'ThResultSetStore', 'ThBugJobMapModel', 'thTabs',
+    '$scope', '$rootScope', 'ThLog', 'thNotify',
+    'thEvents', 'ThResultSetStore', 'thTabs',
     function AnnotationsPluginCtrl(
-        $scope, $rootScope, ThLog, ThJobClassificationModel,
-        thNotify, thEvents, ThResultSetStore, ThBugJobMapModel, thTabs) {
+        $scope, $rootScope, ThLog, thNotify,
+        thEvents, ThResultSetStore, thTabs) {
 
         var $log = new ThLog(this.constructor.name);
 

--- a/ui/plugins/auto_classification/controller.js
+++ b/ui/plugins/auto_classification/controller.js
@@ -93,8 +93,8 @@ treeherder.factory('ThClassificationOption', ['thExtendProperties',
  * Non-editable best option controller
  */
 treeherder.controller('ThStaticClassificationOptionController', [
-    '$scope', 'highlightCommonTermsFilter', 'escapeHTMLFilter', 'thPinboard', 'thUrl', 'ThLog',
-    function ($scope, highlightCommonTerms, escapeHTML, thPinboard, thUrl, ThLog) {
+    '$scope', 'thPinboard', 'thUrl', 'ThLog',
+    function ($scope, thPinboard, thUrl, ThLog) {
         var ctrl = this;
 
         var log = new ThLog('ThStaticClassificationOptionController');
@@ -128,9 +128,9 @@ treeherder.component('thStaticClassificationOption', {
  * Editable option component controller
  */
 treeherder.controller('ThClassificationOptionController', [
-    '$scope', '$uibModal', 'highlightCommonTermsFilter', 'escapeHTMLFilter', 'thPinboard', 'thUrl',
+    '$scope', '$uibModal', 'thPinboard', 'thUrl',
     'thReftestStatus', 'ThLog',
-    function ($scope, $uibModal, highlightCommonTerms, escapeHTML, thPinboard, thUrl, thReftestStatus,
+    function ($scope, $uibModal, thPinboard, thUrl, thReftestStatus,
               ThLog) {
         var ctrl = this;
 
@@ -212,12 +212,10 @@ treeherder.component('thClassificationOption', {
  */
 treeherder.controller('ThErrorLineController', [
     '$scope', '$rootScope',
-    'highlightLogLineFilter', 'escapeHTMLFilter',
-    'thEvents', 'thValidBugNumber', 'thUrl', 'ThLog',
+    'thEvents', 'thUrl', 'ThLog',
     'ThClassificationOption', 'thStringOverlap',
     function ($scope, $rootScope,
-              highlightLogLine, escapeHTML,
-              thEvents, thValidBugNumber, thUrl, ThLog,
+              thEvents, thUrl, ThLog,
               ThClassificationOption, thStringOverlap) {
         var ctrl = this;
         var log = new ThLog('ThErrorLineController');
@@ -819,10 +817,10 @@ treeherder.component('thAutoclassifyToolbar', {
  * Main controller for the autoclassification panel.
  */
 treeherder.controller('ThAutoclassifyPanelController', [
-    '$scope', '$rootScope', '$q', '$timeout',
+    '$scope', '$rootScope', '$q',
     'ThLog', 'thEvents', 'thNotify', 'thJobNavSelectors', 'thPinboard',
     'thUrl', 'ThMatcherModel', 'ThTextLogErrorsModel', 'ThErrorLineData',
-    function ($scope, $rootScope, $q, $timeout,
+    function ($scope, $rootScope, $q,
              ThLog, thEvents, thNotify, thJobNavSelectors, thPinboard,
              thUrl, ThMatcherModel, ThTextLogErrorsModel, ThErrorLineData) {
 

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -5,7 +5,7 @@ treeherder.controller('PluginCtrl', [
     'thUrl', 'ThJobClassificationModel',
     'thClassificationTypes', 'ThJobModel', 'thEvents', 'dateFilter', 'thDateFormat',
     'numberFilter', 'ThBugJobMapModel', 'thResultStatus', 'thJobFilters',
-    'ThResultSetModel', 'ThLog', '$q', 'thPinboard',
+    'ThLog', '$q', 'thPinboard',
     'ThJobDetailModel', 'thBuildApi', 'thNotify', 'ThJobLogUrlModel', 'ThModelErrors', 'ThTaskclusterErrors',
     'thTabs', '$timeout', 'thReftestStatus', 'ThResultSetStore',
     'PhSeries', 'thServiceDomain', 'thTaskcluster', 'jsyaml', 'tcactions',
@@ -14,7 +14,7 @@ treeherder.controller('PluginCtrl', [
         thUrl, ThJobClassificationModel,
         thClassificationTypes, ThJobModel, thEvents, dateFilter, thDateFormat,
         numberFilter, ThBugJobMapModel, thResultStatus, thJobFilters,
-        ThResultSetModel, ThLog, $q, thPinboard,
+        ThLog, $q, thPinboard,
         ThJobDetailModel, thBuildApi, thNotify, ThJobLogUrlModel, ThModelErrors, ThTaskclusterErrors, thTabs,
         $timeout, thReftestStatus, ThResultSetStore, PhSeries,
         thServiceDomain, thTaskcluster, jsyaml, tcactions) {

--- a/ui/plugins/failure_summary/controller.js
+++ b/ui/plugins/failure_summary/controller.js
@@ -2,11 +2,11 @@
 
 treeherder.controller('BugsPluginCtrl', [
     '$scope', '$rootScope', 'ThLog', 'ThTextLogStepModel',
-    'ThBugSuggestionsModel', 'thPinboard', 'thEvents', '$q',
-    'thTabs', '$timeout', 'thUrl', '$uibModal', '$location',
+    'ThBugSuggestionsModel', 'thPinboard', 'thEvents',
+    'thTabs', 'thUrl', '$uibModal', '$location',
     function BugsPluginCtrl(
         $scope, $rootScope, ThLog, ThTextLogStepModel, ThBugSuggestionsModel,
-        thPinboard, thEvents, $q, thTabs, $timeout, thUrl, $uibModal, $location) {
+        thPinboard, thEvents, thTabs, thUrl, $uibModal, $location) {
 
         var $log = new ThLog(this.constructor.name);
 

--- a/ui/plugins/similar_jobs/controller.js
+++ b/ui/plugins/similar_jobs/controller.js
@@ -2,12 +2,12 @@
 
 treeherder.controller('SimilarJobsPluginCtrl', [
     '$scope', 'ThLog', 'ThJobModel', 'ThTextLogStepModel', 'thResultStatusInfo',
-    'thEvents', 'numberFilter', 'dateFilter', 'thClassificationTypes',
+    'numberFilter', 'dateFilter', 'thClassificationTypes',
     'thResultStatus', 'ThResultSetModel', 'thNotify',
     'thTabs',
     function SimilarJobsPluginCtrl(
         $scope, ThLog, ThJobModel, ThTextLogStepModel, thResultStatusInfo,
-        thEvents, numberFilter, dateFilter, thClassificationTypes,
+        numberFilter, dateFilter, thClassificationTypes,
         thResultStatus, ThResultSetModel, thNotify,
         thTabs) {
 


### PR DESCRIPTION
Found by adjusting the eslint `no-unused-vars` rule, changing the `args` preference from `after-used` to `all`:
https://eslint.org/docs/rules/no-unused-vars.html#options

That rule is too noisy to enable by default. Ideally we could use the AngularJS eslint plugin/config (which has specific rules for this), but it's not compatible with latest eslint:
https://github.com/Gillespie59/eslint-plugin-angular/issues/490

Unless these DI parameters can have side-effects I'm not aware of, this change should be reasonably safe, since eslint's `no-undef` rule will error if anything was removed that was being directly referenced.