### PR TITLE
Bug 1409679 - On-demand bug suggestion fetch in test-view

### DIFF
--- a/ui/partials/main/jobs.html
+++ b/ui/partials/main/jobs.html
@@ -25,12 +25,10 @@
     </span>
     <th-result-counts class="result-counts"></th-result-counts>
     <span class="result-set-buttons">
-      <!--- https://bugzilla.mozilla.org/show_bug.cgi?id=1409679
       <a class="btn btn-sm btn-resultset test-view-btn"
          href="/testview.html?repo={{repoName}}&revision={{resultset.revision}}"
          target="_blank"
          title="View details on failed test results for this push">View Tests</a>
-      -->
       <button class="btn btn-sm btn-resultset cancel-all-jobs-btn"
             ng-attr-title="{{getCancelJobsTitle()}}"
             ng-show="currentRepo.is_try_repo || user.is_staff"

--- a/ui/test-view/redux/configureStore.js
+++ b/ui/test-view/redux/configureStore.js
@@ -104,7 +104,7 @@ async function fetchTests(store, fetchParams) {
   // Disable initial fetch of all bug suggestions due to bug:
   // https://bugzilla.mozilla.org/show_bug.cgi?id=1409679
   // store.dispatch(groupsStore.actions.fetchBugs(payload.rowData));
-  
+
   // We use most of the counts from the push status, but ``failed`` will be a count of
   // the "test failures" rather than jobs.  So we walk each group(manifest) and count
   // the failed tests.

--- a/ui/test-view/redux/configureStore.js
+++ b/ui/test-view/redux/configureStore.js
@@ -100,7 +100,11 @@ async function fetchTests(store, fetchParams) {
     type: groupsStore.types.RENDER_TESTS,
     payload,
   });
-  store.dispatch(groupsStore.actions.fetchBugs(payload.rowData));
+
+  // Disable initial fetch of all bug suggestions due to bug:
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1409679
+  // store.dispatch(groupsStore.actions.fetchBugs(payload.rowData));
+  
   // We use most of the counts from the push status, but ``failed`` will be a count of
   // the "test failures" rather than jobs.  So we walk each group(manifest) and count
   // the failed tests.
@@ -266,6 +270,37 @@ function stripHost(urlStr) {
   }
 }
 
+async function fetchBugsSingleTest(store, { test, bugSuggestions, url }) {
+
+  const testMap = test.jobs.reduce((gacc, job) => {
+    const bsUrl = url + groupsStore.getBugSuggestionQuery(job.guid);
+    gacc = { ...gacc, [bsUrl]: gacc[bsUrl] ? [ ...gacc[bsUrl], test] : [test] };
+    return gacc;
+  }, {});
+
+  // Do a request for each url in the keys of the testMap.  Using them as keys eliminates
+  // duplicate requests since multiple tests can be in the same job.
+  const responses = await Promise.all(Object.keys(testMap).map(url => fetch(`${SERVICE_DOMAIN}${url}`)));
+  const respData = await Promise.all(responses.map(promise => promise.json()));
+  const updatedBugSuggestions = {
+    ...bugSuggestions,
+    ...respData.reduce((bsAcc, data, idx) => {
+      testMap[stripHost(responses[idx].url)].forEach((test) => {
+        test.bugs = { ...test.bugs, ...extractBugSuggestions(data, test.name) };
+        bsAcc = { ...bsAcc, [`${test.jobGroup}-${test.name}`]: test.bugs };
+      });
+      return bsAcc;
+    }, {})
+  };
+
+  store.dispatch({
+    type: groupsStore.types.RENDER_BUGS,
+    payload: {
+      bugSuggestions: updatedBugSuggestions,
+    }
+  });
+}
+
 async function fetchBugs(store, { rowData, url }) {
   // map of tests to urls
   const testMap = Object.entries(rowData).reduce((gacc, [ , tests ]) => {
@@ -356,6 +391,9 @@ const testDataMiddleware = store => next => (action) => {
       return next(consumed);
     case groupsStore.types.FETCH_BUGS:
       fetchBugs(store, { ...action.meta });
+      return next(consumed);
+    case groupsStore.types.FETCH_BUGS_SINGLE_TEST:
+      fetchBugsSingleTest(store, { ...action.meta });
       return next(consumed);
     case groupsStore.types.TOGGLE_EXPANDED:
       toggleExpanded(store, { ...action.meta });

--- a/ui/test-view/redux/modules/groups.js
+++ b/ui/test-view/redux/modules/groups.js
@@ -6,6 +6,7 @@ export const types = {
   STORE_OPTIONS: 'STORE_OPTIONS',
   FETCH_COUNTS: 'FETCH_COUNTS',
   FETCH_BUGS: 'FETCH_BUGS',
+  FETCH_BUGS_SINGLE_TEST: 'FETCH_BUGS_SINGLE_TEST',
   RENDER_COUNTS: 'RENDER_COUNTS',
   TOGGLE_EXPANDED: 'TOGGLE_EXPANDED',
   RENDER_EXPANDED: 'RENDER_EXPANDED',
@@ -129,6 +130,16 @@ export const actions = {
       url: `/graphql?query=`,
       method: 'GET',
       rowData,
+    },
+  }),
+  fetchBugsSingleTest: (test, bugSuggestions) => ({
+    type: types.FETCH_BUGS_SINGLE_TEST,
+    meta: {
+      type: 'api',
+      url: `/graphql?query=`,
+      method: 'GET',
+      test,
+      bugSuggestions,
     },
   }),
   filterTests: (filter, groups, options, hideClassified) => ({

--- a/ui/test-view/ui/Test.js
+++ b/ui/test-view/ui/Test.js
@@ -23,6 +23,10 @@ class BugCountComponent extends React.Component {
   }
 
   onClick() {
+    store.dispatch(actions.groups.fetchBugsSingleTest(
+      this.props.test,
+      this.props.bugSuggestions
+    ));
     store.dispatch(actions.groups.toggleExpanded(
       Boolean(!this.props.expanded[this.props.testName]),
       this.props.testName,
@@ -34,7 +38,7 @@ class BugCountComponent extends React.Component {
     return (
       <td className="bug-count"
           onClick={this.onClick}>
-        {this.props.test.bugs === undefined ? <Icon name="spinner" spin /> : (
+        {this.props.test.bugs === undefined ? <Icon name="minus" title="Click to expand and fetch bugs"/> : (
           Object.keys(this.props.test.bugs).length > 0 ? Object.keys(this.props.test.bugs).length : (
             <Badge size="sm" color='danger' style={{ fontWeight: 400, fontSize: '.8rem', margin: '0 .5rem' }}>0</Badge>
           )
@@ -79,6 +83,10 @@ class TestComponent extends React.Component {
     this.onClick = this.onClick.bind(this);
   }
   onClick() {
+    store.dispatch(actions.groups.fetchBugsSingleTest(
+      this.props.test,
+      this.props.bugSuggestions
+    ));
     store.dispatch(actions.groups.toggleExpanded(
       Boolean(!this.props.expanded[this.props.name]),
       this.props.name,


### PR DESCRIPTION
Since the performance issue with GraphQL is limited to the bug suggestions, we don't need to disable the entire app.  The real fix, of course is to get all the queries to fall within our performance thresholds.

However, in the mean-time we can re-enable the main app and make the fetch of bug suggestions be on-demand.  When the user clicks a test, then it makes the call(s) for only that test.

If this approach isn't agree-able, we could entirely disable the calls to bug suggestions, but still let the users see the tests themselves.

This is the on-demand approach.