### PR TITLE
Bug 1443815 - Add graphene debug middleware support

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -105,6 +105,12 @@ MIDDLEWARE_CLASSES = [middleware for middleware in [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ] if middleware]
 
+GRAPHENE = {
+    'MIDDLEWARE': [
+        'graphene_django.debug.DjangoDebugMiddleware',
+    ]
+}
+
 if ENABLE_DEBUG_TOOLBAR:
     # django-debug-toolbar requires that not only DEBUG be set, but that the request IP
     # be in Django's INTERNAL_IPS setting. When using Vagrant, requests don't come from localhost:

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -105,11 +105,12 @@ MIDDLEWARE_CLASSES = [middleware for middleware in [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ] if middleware]
 
-GRAPHENE = {
-    'MIDDLEWARE': [
-        'graphene_django.debug.DjangoDebugMiddleware',
-    ]
-}
+GRAPHENE = env.json('GRAPHENE', default={"MIDDLEWARE": []})
+# This could be set to the following to enable debugging of GraphQL queries:
+# GRAPHENE = {"MIDDLEWARE": ["graphene_django.debug.DjangoDebugMiddleware", ]}
+# For more info, see:
+# http://docs.graphene-python.org/projects/django/en/latest/debug/
+
 
 if ENABLE_DEBUG_TOOLBAR:
     # django-debug-toolbar requires that not only DEBUG be set, but that the request IP

--- a/treeherder/webapp/graphql/schema.py
+++ b/treeherder/webapp/graphql/schema.py
@@ -1,4 +1,5 @@
 import graphene
+from graphene_django.debug import DjangoDebug
 from graphene_django.filter import DjangoFilterConnectionField
 from graphene_django.types import DjangoObjectType
 from graphql.utils.ast_to_dict import ast_to_dict
@@ -152,6 +153,8 @@ class Query(graphene.ObjectType):
     all_failure_classifications = graphene.List(FailureClassificationGraph)
     all_pushes = DjangoFilterConnectionField(PushGraph)
     all_text_log_steps = graphene.List(TextLogStepGraph)
+
+    debug = graphene.Field(DjangoDebug, name='__debug')
 
     def resolve_all_jobs(self, info, **kwargs):
         return Job.objects.filter(**kwargs)


### PR DESCRIPTION
With this, if you add the following to your GraphQL query, you'll see the exact SQL that was executed:

    __debug {
      sql {
        rawSql
      }
    }

This sits on top of the ``graphene-django`` PR, so only the second commit is relevant here.