### PR TITLE
Bug 1428958 - Enable pre-assigning bindings mode for Perfherder

### DIFF
--- a/ui/js/components/perf/compare.js
+++ b/ui/js/components/perf/compare.js
@@ -19,6 +19,8 @@ treeherder.component('phCompareTable', {
         releaseBlockerCriteria: '@'
     },
     controller: ['$attrs', function ($attrs) {
+        // TODO: Use $onInit() so the legacy preAssignBindingsEnabled pref
+        // doesn't have to be enabled in perfapp.js
         var ctrl = this;
 
         if (!ctrl.baseTitle) {

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -6,6 +6,12 @@ perf.config(['$compileProvider', '$locationProvider', '$httpProvider', '$statePr
         // Disable debug data, as recommended by https://docs.angularjs.org/guide/production
         $compileProvider.debugInfoEnabled(false);
 
+        // Revert to the legacy Angular <=1.5 pre-assign bindings behaviour:
+        // https://docs.angularjs.org/guide/migration#commit-bcd0d4
+        // TODO: Move component/directive controller initialization logic that relies on bindings
+        // being present (eg that in phCompareTable) into the controller's $onInit() instead.
+        $compileProvider.preAssignBindingsEnabled(true);
+
         // Revert to the legacy Angular <=1.5 URL hash prefix to save breaking existing links:
         // https://docs.angularjs.org/guide/migration#commit-aa077e8
         $locationProvider.hashPrefix('');


### PR DESCRIPTION
AngularJS 1.6 made bindings no longer be pre-assigned by default, which breaks Perfherder's compare view, since the controller relies on the bindings being present at initialisation. Until it is adjusted to use the new `$onInit()` method, the legacy mode has been re-enabled:
https://docs.angularjs.org/guide/migration#commit-bcd0d4