### PR TITLE
Bug 1429230 - Add ability to terminate instances from treeherder

### DIFF
--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -2,8 +2,8 @@
 
 /* Services */
 treeherder.factory('thUrl', [
-    '$rootScope', 'thServiceDomain',
-    function ($rootScope, thServiceDomain) {
+    '$rootScope', 'thServiceDomain', 'thTaskcluster',
+    function ($rootScope, thServiceDomain, thTaskcluster) {
 
         var thUrl = {
             getRootUrl: function (uri) {
@@ -42,6 +42,15 @@ treeherder.factory('thUrl', [
             },
             getInspectTaskUrl: function (taskId) {
                 return `https://tools.taskcluster.net/task-inspector/#${taskId}`;
+            },
+            getWorkerExplorerUrl: async function (taskId) {
+                const tc = thTaskcluster.client();
+                const queue = new tc.Queue();
+                const { status } = await queue.status(taskId);
+                const { provisionerId, workerType } = status;
+                const { workerGroup, workerId } = status.runs[status.runs.length - 1];
+
+                return `https://tools.taskcluster.net/provisioners/${provisionerId}/worker-types/${workerType}/workers/${workerGroup}/${workerId}`;
             }
         };
         return thUrl;

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -640,6 +640,7 @@ treeherder.controller('PluginCtrl', [
         //fetch URLs
         $scope.getBugUrl = thUrl.getBugUrl;
         $scope.getSlaveHealthUrl = thUrl.getSlaveHealthUrl;
+        $scope.getWorkerExplorerUrl = thUrl.getWorkerExplorerUrl;
         $scope.getInspectTaskUrl = thUrl.getInspectTaskUrl;
     }
 ]);

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -144,7 +144,7 @@
                         jobLogUrls="job_log_urls"
                         getInspectTaskUrl="getInspectTaskUrl" visibleFields="visibleFields"
                         classificationTypes="classificationTypes" jobDetailLoading="job_detail_loading"
-                        repoName="repoName"></job-details-pane>
+                        getWorkerExplorerUrl="getWorkerExplorerUrl" repoName="repoName"></job-details-pane>
     </div>
   </div>
   <div id="job-tabs-panel">


### PR DESCRIPTION
Presently, when the build system type of a job is buildbot, there is a hyperlink 
on the machine name that takes a user to the slave health
dashboard. When a job runs outside of buildbot, there is a worker
explorer. A worker explorer shows information like most recent task IDs
claimed. Also, a user can perform actions on the machine if they own the
required scopes (e.g., quarantine & terminate instance).

This pull-request provides a shortcut to the worker explorer when the build system
type is not buildbot.
  