### PR TITLE
Bug 1429988 - Minor updates for local pulse ingestion

### DIFF
--- a/docs/pulseload.rst
+++ b/docs/pulseload.rst
@@ -10,19 +10,9 @@ posting your own data.
 Configuration
 -------------
 
-Specify the exchanges to read from using environment variables. For example::
+If you don't want all the sources provided by default in ``settings.py``, you can specify the exchange, the projects, or destinations to read from using an environment variable in your vagrant shell. A working example::
 
-    PULSE_DATA_INGESTION_SOURCES = [
-        {
-            "exchange": "exchange/taskcluster-treeherder/v1/jobs",
-            "destinations": [
-                'tc-treeherder'
-            ],
-            "projects": [
-                'mozilla-inbound.#'
-            ]
-        }
-    ]
+    export PULSE_DATA_INGESTION_SOURCES='[{"exchange": "exchange/taskcluster-treeherder/v1/jobs", "destinations": ["#"], "projects": ["#"]}]'
 
 To be able to ingest from exchanges, you need to create a Pulse user with
 `Pulse Guardian`_, so

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -488,53 +488,44 @@ PULSE_EXCHANGE_NAMESPACE = env("PULSE_EXCHANGE_NAMESPACE", default=None)
 PULSE_DATA_INGESTION_SOURCES = env.json(
     "PULSE_DATA_INGESTION_SOURCES",
     default=[
-        # {
-        #     "name": "exchange/taskcluster-treeherder/v1/jobs",
-        #     "projects": [
-        #         'mozilla-central',
-        #         'mozilla-inbound'
-        #         # other repos TC can submit to
-        #     ],
-        #     "destinations": [
-        #         'production'
-        #         'staging'
-        #     ]
-        # },
-        # {
-        #     "name": "exchange/treeherder-test/jobs",
-        #     "projects": [
-        #         'mozilla-inbound'
-        #     ],
-        #     "destinations": [
-        #         'production'
-        #         'staging'
-        #     ]
-        #
-        # }
+        {
+            "exchange": "exchange/taskcluster-treeherder/v1/jobs",
+            "projects": [
+                '#'
+                # some specific repos TC can ingest from
+                # 'mozilla-central.#',
+                # 'mozilla-inbound.#'
+            ],
+            "destinations": [
+                '#'
+                # 'production',
+                # 'staging'
+            ]
+        }
         # ... other CI systems
     ])
 
 PULSE_PUSH_SOURCES = env.json(
     "PULSE_PUSH_SOURCES",
     default=[
-        # {
-        #     "exchange": "exchange/taskcluster-github/v1/push",
-        #     "routing_keys": [
-        #         '#'
-        #     ],
-        # },
-        # {
-        #     "exchange": "exchange/taskcluster-github/v1/pull-request",
-        #     "routing_keys": [
-        #         '#'
-        #     ],
-        # },
-        # {
-        #     "exchange": "exchange/hgpushes/v1",
-        #     "routing_keys": [
-        #         "#"
-        #     ]
-        # },
+        {
+            "exchange": "exchange/taskcluster-github/v1/push",
+            "routing_keys": [
+                '#'
+            ],
+        },
+        {
+            "exchange": "exchange/taskcluster-github/v1/pull-request",
+            "routing_keys": [
+                '#'
+            ],
+        },
+        {
+            "exchange": "exchange/hgpushes/v1",
+            "routing_keys": [
+                "#"
+            ]
+        }
         # ... other CI systems
     ])
 


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1429988](https://bugzilla.mozilla.org/show_bug.cgi?id=1429988).

This makes some minor updates, such that local pulse ingestion works out of the box, and the instructions and examples are a bit more clear.

I've tested the actual config changes this evening in the process of working on bug [1401518](https://bugzilla.mozilla.org/show_bug.cgi?id=1401518) and in collaboration with @camd on IRC.

Tested on OSX 10.12.6:
Release **57.0.4 (64-bit)**