### PR TITLE
Bug 1429922 - Return tooltip to backfill menu

### DIFF
--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -113,10 +113,13 @@
               <span class="fa fa-ellipsis-h" aria-hidden="true"></span>
             </span>
             <ul class="dropdown-menu actionbar-menu" role="menu">
-              <li class="{{ canBackfill() ? '' : 'disabled' }}">
-                <a ng-attr-title="{{ backfillButtonTitle() }}"
+              <li>
+                <button id="backfill-btn" href=""
                    class="dropdown-item"
-                   ng-click="!canBackfill() || backfillJob()">Backfill</a>
+                   ng-class="!user.loggedin || !canBackfill() ? 'disabled' : ''"
+                   ng-attr-title="{{ backfillButtonTitle() }}"
+                   ng-disabled="!canBackfill()"
+                   ng-click="!canBackfill() || backfillJob()">Backfill</button>
               </li>
               <li ng-if-start="job.taskcluster_metadata">
                 <a target="_blank" class="dropdown-item" href="{{ getInspectTaskUrl(job.taskcluster_metadata.task_id) }}">Inspect Task</a>


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1429922](https://bugzilla.mozilla.org/show_bug.cgi?id=1429922).

This returns the missing backfill menu tooltip to the dropdown menu entry. I think I have the presentation logic correct, based on past functionality.

Proposed (logged out):
![loggedout](https://user-images.githubusercontent.com/3660661/34903191-5a052cca-f7fa-11e7-9ff9-2590a09076dc.jpg)

Proposed (logged in):
![loggedin](https://user-images.githubusercontent.com/3660661/34903193-627002ae-f7fa-11e7-917a-a9c58b74731f.jpg)

I intentionally left the cursor as arrow rather than disabled, since that style blocks the view of the menu. I did the same in an unrelated PR https://github.com/mozilla/treeherder/pull/3077.

Tested on OSX 10.12.6:
Release **57.0.4 (64-bit)**