### PR TITLE
Bug 1384518 - Switch from Memcached to Redis

### DIFF
--- a/bin/travis-setup.sh
+++ b/bin/travis-setup.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 export BROKER_URL='amqp://guest:guest@localhost:5672//'
 export DATABASE_URL='mysql://root@localhost/test_treeherder'
 export ELASTICSEARCH_URL='http://127.0.0.1:9200'
+export REDIS_URL='redis://localhost:6379'
 export TREEHERDER_DJANGO_SECRET_KEY='secretkey-of-at-50-characters-to-pass-check-deploy'
 
 setup_services() {

--- a/bin/travis-setup.sh
+++ b/bin/travis-setup.sh
@@ -34,6 +34,9 @@ setup_services() {
     sudo -E apt-get -yqq update
     sudo -E apt-get -yqq install --no-install-recommends --allow-unauthenticated mysql-server libmysqlclient-dev
 
+    echo '-----> Starting redis-server'
+    sudo service redis-server start
+
     echo '-----> Starting rabbitmq-server'
     sudo service rabbitmq-server start
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -193,10 +193,10 @@ djangorestframework-filters==0.10.2 \
     --hash=sha256:6d72c304d543b0e5597defe89ba581517455e86ac84efd17526eda27118236e8 \
     --hash=sha256:1f51945b46f476b8184518e2881febcf3772b606b73ce022a4b7e7ff3763895d
 
-pylibmc==1.5.2 \
-    --hash=sha256:fc54e28a9f1b5b2ec0c030da29c7ad8a15c2755bd98aaa4142eaf419d5fabb33
+django-redis==4.8.0 --hash=sha256:9660332cf9de5689a7ebbe0c623c4a0de79e0916a6ae867b5d0b94759bba46c9
 
-django-pylibmc==0.6.1 --hash=sha256:9cffdee703aaf9ebc029d9dbdee8abdd0723564b95e4b2ac59e4a668b8e58f93
+# Required by django-redis
+redis==2.10.6 --hash=sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb
 
 elasticsearch==5.5.2 \
     --hash=sha256:2e6dcdf9cb62377e0d6b82d2931ebc67b5a549081bbb531aa3be60ece33257b2 \

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -4,6 +4,7 @@ from celery import current_app
 from django.core.cache import cache
 from django.core.management import call_command
 
+from treeherder.config.utils import get_tls_redis_url
 from treeherder.etl.common import fetch_text
 
 
@@ -31,6 +32,16 @@ def test_django_cache():
     k, v = 'my_key', 'my_value'
     cache.set(k, v, 10)
     assert cache.get(k) == v
+
+
+def test_get_tls_redis_url():
+    """
+    Test conversion from REDIS_URL to the stunnel TLS URL described here:
+    https://devcenter.heroku.com/articles/securing-heroku-redis#connecting-directly-to-stunnel
+    """
+    REDIS_URL = 'redis://h:abc8069@ec2-12-34-56-78.compute-1.amazonaws.com:8069'
+    TLS_REDIS_URL = 'rediss://h:abc8069@ec2-12-34-56-78.compute-1.amazonaws.com:8070'
+    assert get_tls_redis_url(REDIS_URL) == TLS_REDIS_URL
 
 
 @current_app.task

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -12,7 +12,6 @@ from treeherder.config.utils import (connection_should_use_tls,
 env = environ.Env()
 
 TREEHERDER_MEMCACHED = env("TREEHERDER_MEMCACHED", default="127.0.0.1:11211")
-TREEHERDER_MEMCACHED_KEY_PREFIX = env("TREEHERDER_MEMCACHED_KEY_PREFIX", default="treeherder")
 
 DEBUG = env.bool("TREEHERDER_DEBUG", default=False)
 ENABLE_DEBUG_TOOLBAR = env.bool("ENABLE_DEBUG_TOOLBAR", False)
@@ -604,8 +603,6 @@ CACHES = {
         "LOCATION": MEMCACHED_LOCATION,
     },
 }
-
-KEY_PREFIX = TREEHERDER_MEMCACHED_KEY_PREFIX
 
 # This code handles the memcachier service on heroku.
 # TODO: Stop special-casing Heroku and use newer best practices from:

--- a/treeherder/config/utils.py
+++ b/treeherder/config/utils.py
@@ -10,3 +10,31 @@ def connection_should_use_tls(url):
     # certificates set up. We could try using TLS locally using self-signed certs,
     # but until Travis has support it's not overly useful.
     return hostname(url) != 'localhost'
+
+
+def get_tls_redis_url(redis_url):
+    """
+    Returns the TLS version of a Heroku REDIS_URL string.
+
+    Whilst Redis server (like memcached) doesn't natively support TLS, Heroku runs an stunnel
+    daemon on their Redis instances, which can be connected to directly by Redis clients that
+    support TLS (avoiding the need for stunnel on the client). The stunnel port is one higher
+    than the Redis server port, and the informal `rediss://` scheme used to instruct clients
+    to wrap the connection with TLS.
+
+    Will convert 'redis://h:PASSWORD@INSTANCE.compute-1.amazonaws.com:8409'
+          ...to: 'rediss://h:PASSWORD@INSTANCE.compute-1.amazonaws.com:8410'
+
+    See:
+    https://devcenter.heroku.com/articles/securing-heroku-redis#connecting-directly-to-stunnel
+    """
+    parsed_url = urlparse(redis_url)
+    # The parsed URL's `port` property is read-only, so the entire `netloc` has to be updated.
+    # The `rsplit()` approach is used instead of `replace()` in case the port happens to match
+    # against part of the username/password/domain. See:
+    # https://stackoverflow.com/a/21629125
+    # https://stackoverflow.com/a/30846649
+    netloc_minus_port = parsed_url.netloc.rsplit(':', 1)[0]
+    stunnel_port = parsed_url.port + 1
+    new_netloc = '{}:{}'.format(netloc_minus_port, stunnel_port)
+    return parsed_url._replace(scheme='rediss', netloc=new_netloc).geturl()

--- a/treeherder/config/wsgi.py
+++ b/treeherder/config/wsgi.py
@@ -8,7 +8,6 @@ this application via the ``WSGI_APPLICATION`` setting.
 """
 import os
 
-from django.core.cache.backends.memcached import BaseMemcachedCache
 from django.core.wsgi import get_wsgi_application
 
 # We defer to a DJANGO_SETTINGS_MODULE already in the environment. This breaks
@@ -18,8 +17,3 @@ from django.core.wsgi import get_wsgi_application
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "treeherder.config.settings")
 
 application = get_wsgi_application()
-
-# Fix django closing connection to MemCachier after every request:
-# https://code.djangoproject.com/ticket/11331
-# Remove when https://github.com/django/django/pull/4866 fixed.
-BaseMemcachedCache.close = lambda self, **kwargs: None

--- a/vagrant/env.sh
+++ b/vagrant/env.sh
@@ -5,6 +5,7 @@ export PATH="${HOME}/firefox:${HOME}/python/bin:${PATH}"
 export BROKER_URL='amqp://guest:guest@localhost//'
 export DATABASE_URL='mysql://root@localhost/treeherder'
 export ELASTICSEARCH_URL='http://localhost:9200'
+export REDIS_URL='redis://localhost:6379'
 
 export TREEHERDER_DEBUG='True'
 export ENABLE_DEBUG_TOOLBAR='True'

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -30,6 +30,8 @@ export PIP_DISABLE_PIP_VERSION_CHECK='True'
 echo '-----> Performing cleanup'
 # Remove the old MySQL 5.6 PPA repository, if this is an existing Vagrant instance.
 sudo rm -f /etc/apt/sources.list.d/ondrej-ubuntu-mysql-5_6-xenial.list
+# Remove memcached remnants in case this instance existed prior to the Redis switch.
+sudo -E apt-get -yqq purge --auto-remove memcached libmemcached-dev
 # Stale pyc files can cause pytest ImportMismatchError exceptions.
 find . -type f -name '*.pyc' -delete
 # Celery sometimes gets stuck and requires that celerybeat-schedule be deleted.
@@ -55,22 +57,18 @@ fi
 echo '-----> Installing/updating APT packages'
 sudo -E apt-get -yqq update
 # libgtk-3.0 and libxt-dev are required by Firefox
-# libmemcached-dev and zlib1g-dev are required by pylibmc
 # libmysqlclient-dev is required by mysqlclient
 # openjdk-8-jre-headless is required by Elasticsearch
 sudo -E apt-get -yqq install --no-install-recommends \
     libgtk-3.0 \
-    libmemcached-dev \
     libmysqlclient-dev \
     libxt-dev \
-    memcached \
     mysql-server-5.7 \
     nodejs \
     openjdk-8-jre-headless \
     rabbitmq-server \
     redis-server \
-    yarn \
-    zlib1g-dev
+    yarn
 
 if [[ "$(dpkg-query --show --showformat='${Version}' elasticsearch 2>&1)" != "$ELASTICSEARCH_VERSION" ]]; then
     echo '-----> Installing Elasticsearch'

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -68,6 +68,7 @@ sudo -E apt-get -yqq install --no-install-recommends \
     nodejs \
     openjdk-8-jre-headless \
     rabbitmq-server \
+    redis-server \
     yarn \
     zlib1g-dev
 


### PR DESCRIPTION
Since:
* Redis has additional features we need (eg for [bug 1409679](https://bugzilla.mozilla.org/show_bug.cgi?id=1409679))
* the Redis server, python client and Django backend are more actively maintained (so have persistent connections/pooling that actually works, which gives a big perf win)
* we can use Heroku's own Redis addon rather than relying on a third-party's (to hopefully prevent a repeat of the certificate expiration downtime)

Initial testing shows a 4x performance win (mostly from persistent connections now working):

![screenshot-2018-1-12 database activity - treeherder-prototype - new relic](https://user-images.githubusercontent.com/501702/35060329-13b1f8ba-fbb6-11e7-8d1d-1a46ed773883.png)

Before this is merged, Heroku Redis instances will need to be created for stage/production (already done for prototype) - likely on plan `premium-3`:
https://elements.heroku.com/addons/heroku-redis

We'll also need to pick an eviction policy:
https://devcenter.heroku.com/articles/heroku-redis#maxmemory-policy

Once deployed, the `memcachier-tls-buildpack` buildpack will no longer be required and can be removed from prototype/stage/prod, along with the `TREEHERDER_MEMCACHED` environment variable and Memcachier addon.

See the individual commit messages for details on the code changes themselves.