### PR TITLE
Improve the stability of the test_select_unclassified_job tests

### DIFF
--- a/tests/selenium/test_select_unclassified_job.py
+++ b/tests/selenium/test_select_unclassified_job.py
@@ -16,6 +16,7 @@ def test_jobs(eleven_job_blobs, failure_classifications, test_repository):
 
 def test_select_next_unclassified_job(base_url, selenium, test_jobs):
     page = Treeherder(selenium, base_url).open()
+    page.wait.until(lambda _: len(page.all_jobs) == len(test_jobs))
     for i in range(len(test_jobs)):
         page.select_next_unclassified_job()
         assert page.all_jobs[i].selected
@@ -23,6 +24,7 @@ def test_select_next_unclassified_job(base_url, selenium, test_jobs):
 
 def test_select_previous_unclassified_job(base_url, selenium, test_jobs):
     page = Treeherder(selenium, base_url).open()
+    page.wait.until(lambda _: len(page.all_jobs) == len(test_jobs))
     for i in reversed(range(len(test_jobs))):
         page.select_previous_unclassified_job()
         assert page.all_jobs[i].selected


### PR DESCRIPTION
I was able to reproduce intermittent failures in these tests. This additional wait appear to make them solid. /cc @rbillings 