### PR TITLE
Fix benign JS exception when filtering

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -594,9 +594,10 @@ treeherderApp.controller('MainCtrl', [
         // we have to set the field match type here so that the UI can either
         // show a text field for entering a value, or switch to a drop-down select.
         $scope.setFieldMatchType = function () {
-            $scope.newFieldFilter.matchType=$scope.fieldChoices[$scope.newFieldFilter.field].matchType;
-            $scope.newFieldFilter.choices=$scope.fieldChoices[$scope.newFieldFilter.field].choices;
-
+            if ($scope.newFieldFilter.field) {
+              $scope.newFieldFilter.matchType = $scope.fieldChoices[$scope.newFieldFilter.field].matchType;
+              $scope.newFieldFilter.choices = $scope.fieldChoices[$scope.newFieldFilter.field].choices;
+            }
         };
 
         // for most match types we want to show just the raw value.  But for


### PR DESCRIPTION
This is a trivial little check to avoid throwing an exception when you click the "filter" button on the toolbar.  It has no effect, but should be quieted.  Didn't seem worth a bug.  :)