### PR TITLE
Update similar inline functions to bug 1401518 to es6

### DIFF
--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -463,9 +463,8 @@ treeherder.controller('PluginCtrl', [
             } else {
                 // Cut off trailing "/ " if one exists, capitalize first letter
                 title = title.replace(/\/ $/, "");
-                title = title.replace(/^./, function (l) { return l.toUpperCase(); });
+                title = title.replace(/^./, l => l.toUpperCase());
             }
-
             return title;
         };
 

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -211,9 +211,8 @@ treeherder.controller('PinboardCtrl', [
             } else {
                 // Cut off trailing "/ " if one exists, capitalize first letter
                 title = title.replace(/\/ $/, "");
-                title = title.replace(/^./, function (l) { return l.toUpperCase(); });
+                title = title.replace(/^./, l => l.toUpperCase());
             }
-
             return title;
         };
 


### PR DESCRIPTION
Similar to the work in PR https://github.com/mozilla/treeherder/pull/3077, I knew there were some similar inline functions lying around, so let's ES6 them while we're at it.

Everything seems fine in the Pinboard and Backfill UI in local testing after the change.

Tested on OSX 10.12.6:
Nightly **60.0a1 (2018-01-24) (64-bit)**