### PR TITLE
Bug 1434307 - Docs: Update read-only replica GRANTs

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -32,6 +32,8 @@ as of November 2016 (obviously you should replace `myuser` and
     GRANT SELECT ON treeherder.failure_classification to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.failure_line to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.failure_match to 'myuser' REQUIRE SSL;
+    GRANT SELECT ON treeherder.group to 'myuser' REQUIRE SSL;
+    GRANT SELECT ON treeherder.group_failure_lines to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.job to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.job_detail to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.job_group to 'myuser' REQUIRE SSL;
@@ -61,8 +63,6 @@ as of November 2016 (obviously you should replace `myuser` and
     GRANT SELECT ON treeherder.text_log_error_match to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.text_log_error_metadata to 'myuser' REQUIRE SSL;
     GRANT SELECT ON treeherder.text_log_step to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.text_log_summary to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.text_log_summary_line to 'myuser' REQUIRE SSL;
 
 If new tables are added, you can generate a new set of grant
 statements using the following SQL:

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -12,64 +12,63 @@ who can access publically available information in a read-only
 manner (omitting sensitive data like session tokens).
 
 The following SQL should be sufficient to generate such a user
-as of November 2016 (obviously you should replace `myuser` and
-`mysecurepassword`):
+(obviously you should replace `myuser` and `mysecurepassword`):
 
 .. code-block:: sql
 
-    CREATE USER 'myuser' IDENTIFIED BY 'mysecurepassword';
+    CREATE USER 'myuser' IDENTIFIED BY 'mysecurepassword' REQUIRE SSL;
 
     -- Tables where we want to allow only partial access.
     -- Whilst `password` is not used (and randomly generated), it's still safer to exclude it.
-    GRANT SELECT (id, username, email) ON treeherder.auth_user to 'myuser' REQUIRE SSL;
+    GRANT SELECT (id, username, email) ON treeherder.auth_user to 'myuser';
 
     -- Tables containing no sensitive data.
-    GRANT SELECT ON treeherder.bug_job_map to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.bugscache to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.build_platform to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.classified_failure to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.commit to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.failure_classification to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.failure_line to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.failure_match to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.group to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.group_failure_lines to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.job to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.job_detail to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.job_group to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.job_log to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.job_note to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.job_type to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.machine to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.machine_platform to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.matcher to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.option to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.option_collection to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.performance_alert to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.performance_alert_summary to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.performance_bug_template to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.performance_datum to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.performance_framework to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.performance_signature to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.product to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.push to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.reference_data_signatures to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.repository to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.repository_group to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.runnable_job to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.seta_jobpriority to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.taskcluster_metadata to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.text_log_error to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.text_log_error_match to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.text_log_error_metadata to 'myuser' REQUIRE SSL;
-    GRANT SELECT ON treeherder.text_log_step to 'myuser' REQUIRE SSL;
+    GRANT SELECT ON treeherder.bug_job_map to 'myuser';
+    GRANT SELECT ON treeherder.bugscache to 'myuser';
+    GRANT SELECT ON treeherder.build_platform to 'myuser';
+    GRANT SELECT ON treeherder.classified_failure to 'myuser';
+    GRANT SELECT ON treeherder.commit to 'myuser';
+    GRANT SELECT ON treeherder.failure_classification to 'myuser';
+    GRANT SELECT ON treeherder.failure_line to 'myuser';
+    GRANT SELECT ON treeherder.failure_match to 'myuser';
+    GRANT SELECT ON treeherder.group to 'myuser';
+    GRANT SELECT ON treeherder.group_failure_lines to 'myuser';
+    GRANT SELECT ON treeherder.job to 'myuser';
+    GRANT SELECT ON treeherder.job_detail to 'myuser';
+    GRANT SELECT ON treeherder.job_group to 'myuser';
+    GRANT SELECT ON treeherder.job_log to 'myuser';
+    GRANT SELECT ON treeherder.job_note to 'myuser';
+    GRANT SELECT ON treeherder.job_type to 'myuser';
+    GRANT SELECT ON treeherder.machine to 'myuser';
+    GRANT SELECT ON treeherder.machine_platform to 'myuser';
+    GRANT SELECT ON treeherder.matcher to 'myuser';
+    GRANT SELECT ON treeherder.option to 'myuser';
+    GRANT SELECT ON treeherder.option_collection to 'myuser';
+    GRANT SELECT ON treeherder.performance_alert to 'myuser';
+    GRANT SELECT ON treeherder.performance_alert_summary to 'myuser';
+    GRANT SELECT ON treeherder.performance_bug_template to 'myuser';
+    GRANT SELECT ON treeherder.performance_datum to 'myuser';
+    GRANT SELECT ON treeherder.performance_framework to 'myuser';
+    GRANT SELECT ON treeherder.performance_signature to 'myuser';
+    GRANT SELECT ON treeherder.product to 'myuser';
+    GRANT SELECT ON treeherder.push to 'myuser';
+    GRANT SELECT ON treeherder.reference_data_signatures to 'myuser';
+    GRANT SELECT ON treeherder.repository to 'myuser';
+    GRANT SELECT ON treeherder.repository_group to 'myuser';
+    GRANT SELECT ON treeherder.runnable_job to 'myuser';
+    GRANT SELECT ON treeherder.seta_jobpriority to 'myuser';
+    GRANT SELECT ON treeherder.taskcluster_metadata to 'myuser';
+    GRANT SELECT ON treeherder.text_log_error to 'myuser';
+    GRANT SELECT ON treeherder.text_log_error_match to 'myuser';
+    GRANT SELECT ON treeherder.text_log_error_metadata to 'myuser';
+    GRANT SELECT ON treeherder.text_log_step to 'myuser';
 
 If new tables are added, you can generate a new set of grant
 statements using the following SQL:
 
 .. code-block:: sql
 
-    SELECT CONCAT('GRANT SELECT ON ', table_schema, '.', table_name, ' to ''myuser'' REQUIRE SSL;') AS grant_stmt
+    SELECT CONCAT('GRANT SELECT ON ', table_schema, '.', table_name, ' to ''myuser'';') AS grant_stmt
     FROM information_schema.TABLES
     WHERE table_schema = 'treeherder'
     AND table_name NOT REGEXP 'django_|auth_|credentials';


### PR DESCRIPTION
### 1) Sync the table lists
Generated using the approach documented at the end of the page:
https://treeherder.readthedocs.io/admin.html#direct-database-access

The changes are required since bug 1373008 added the `group` and `group_failure_lines` tables and #2532 removed `text_log_summary` and `text_log_summary_line`.

### 2) Fix REQUIRE SSL SQL deprecation warnings
Now that we're using MySQL 5.7, we can specify `REQUIRE SSL` on the `CREATE USER` statement, rather than having to do so on the individual GRANTs. Compare:
https://dev.mysql.com/doc/refman/5.6/en/create-user.html
https://dev.mysql.com/doc/refman/5.7/en/create-user.html

Prevents:
```
1 warning(s): 1287 Using GRANT statement to modify existing user's
properties other than privileges is deprecated and will be removed
in future release. Use ALTER USER statement for this operation.
```