### PR TITLE
Bug 1401518 - Make Add new jobs menu require a decision task

### DIFF
--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -116,12 +116,18 @@ treeherderApp.controller('ResultSetCtrl', [
         });
 
         $scope.getDecisionTaskVisibility = function () {
-            let dtId = ThResultSetStore.getGeckoDecisionTaskId($scope.repoName, $scope.resultset.id);
-            if (dtId.$$state.value === 'No decision task') {
-                $scope.isDecisionTaskVisible = false;
-            } else {
-                $scope.isDecisionTaskVisible = true;
-            }
+            let dtId = ThResultSetStore.getGeckoDecisionTaskId(
+                $scope.repoName,
+                $scope.resultset.id
+            ).then(function () {
+                if (dtId.$$state.value === 'No decision task') {
+                    $scope.isDecisionTaskVisible = false;
+                } else {
+                    $scope.isDecisionTaskVisible = true;
+                }
+            }, function (e) {
+                console.log(e);
+            });
         };
 
         $scope.addNewJobsMenuTitle = function () {

--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -109,6 +109,48 @@ treeherderApp.controller('ResultSetCtrl', [
             $rootScope.selectedJob = job;
         };
 
+        $rootScope.$on(thEvents.applyNewJobs, function (ev, resultSetId) {
+            if ($scope.resultset.id === resultSetId) {
+                $scope.getDecisionTaskVisibility();
+            }
+        });
+
+        $scope.getDecisionTaskVisibility = function () {
+            let dtId = ThResultSetStore.getGeckoDecisionTaskId($scope.repoName, $scope.resultset.id);
+            if (dtId.$$state.value === 'No decision task') {
+                $scope.isDecisionTaskVisible = false;
+            } else {
+                $scope.isDecisionTaskVisible = true;
+            }
+        };
+
+        $scope.addNewJobsMenuTitle = function () {
+            let title = "";
+
+            // Ensure resultset is available on initial page load
+            if (!$scope.resultset.id) {
+                // still loading
+                return undefined;
+            }
+
+            if (!$scope.user.loggedin) {
+                title = title.concat("must be logged in / ");
+            }
+
+            if (!$scope.isDecisionTaskVisible) {
+                title = title.concat("a decision task is required");
+            }
+
+            if (title === "") {
+                title = "Add new jobs to this push";
+            } else {
+                // Cut off trailing "/ " if one exists, capitalize first letter
+                title = title.replace(/\/ $/, "");
+                title = title.replace(/^./, l => l.toUpperCase());
+            }
+            return title;
+        };
+
         $scope.toggleRevisions = function () {
 
             ThResultSetStore.loadRevisions(

--- a/ui/partials/main/thActionButton.html
+++ b/ui/partials/main/thActionButton.html
@@ -11,18 +11,18 @@
   </button>
   <!-- Menu contents -->
   <ul class="dropdown-menu pull-right">
-    <li title="{{user.loggedin ? '' : 'Must be logged in'}}"
-        class="{{user.loggedin ? '' : 'disabled'}}">
-        <a target="_blank" data-ignore-job-clear-on-click
-           title="Add new jobs to this push"
+    <li><button target="_blank" data-ignore-job-clear-on-click
+           ng-attr-title="{{addNewJobsMenuTitle()}}"
+           ng-class="!user.loggedin || !isDecisionTaskVisible ? 'disabled' : ''"
+           ng-disabled="!user.loggedin || !isDecisionTaskVisible"
            href="" class="dropdown-item"
            ng-hide="resultset.isRunnableVisible"
-           ng-click="showRunnableJobs()">Add new jobs</a></li>
-    <li><a target="_blank" data-ignore-job-clear-on-click
-           title="Hide Runnable Jobs"
+           ng-click="showRunnableJobs()">Add new jobs</button></li>
+    <li><button target="_blank" data-ignore-job-clear-on-click
+           title="Hide new jobs from this push"
            href="" class="dropdown-item"
            ng-show="resultset.isRunnableVisible"
-           ng-click="deleteRunnableJobs()">Hide Runnable Jobs</a></li>
+           ng-click="deleteRunnableJobs()">Hide runnable jobs</button></li>
     <li><a target="_blank" data-ignore-job-clear-on-click class="dropdown-item"
            href="https://secure.pub.build.mozilla.org/buildapi/self-serve/{{::repoName}}/rev/{{::resultset.revision}}">BuildAPI</a></li>
     <li><a target="_blank" data-ignore-job-clear-on-click


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1401518](https://bugzilla.mozilla.org/show_bug.cgi?id=1435023).

This PR is similar to PR https://github.com/mozilla/treeherder/pull/3077 but with a minor change hopefully to reduce JobsViewSet.retrieve back to a sane level. As Ed mentioned this is hard to evaluate locally, or even on stage, per comments in Bug [1435023](https://bugzilla.mozilla.org/show_bug.cgi?id=1435023). It got revealed when it went live on prod.

I will outline in code comments the differences, and remaining tweaks.

Mildly tested on OSX 10.12.6:
Release **58.0.1 (64-bit)**