### PR TITLE
Bug 1435998 - Fix/enable eslint 'strict'

### DIFF
--- a/docs/ui/plugin.rst
+++ b/docs/ui/plugin.rst
@@ -29,8 +29,6 @@ Create a controller
 
 The most basic of controllers would look like this::
 
-    "use strict";
-
     treeherder.controller('JobFooPluginCtrl',
         function JobFooPluginCtrl($scope) {
 

--- a/neutrino-custom/lint.js
+++ b/neutrino-custom/lint.js
@@ -77,7 +77,6 @@ module.exports = neutrino => {
                     'react/require-default-props': 'off',
                     'space-infix-ops': 'off',
                     'spaced-comment': 'off',
-                    'strict': 'off',
                     'vars-on-top': 'off',
                 },
                 globals: [

--- a/tests/ui/unit/controllers/bugfiler.tests.js
+++ b/tests/ui/unit/controllers/bugfiler.tests.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* jasmine specs for controllers go here */
 
 describe('BugFilerCtrl', function() {

--- a/tests/ui/unit/controllers/jobs.tests.js
+++ b/tests/ui/unit/controllers/jobs.tests.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* jasmine specs for controllers go here */
 
 describe('JobsCtrl', function(){

--- a/tests/ui/unit/controllers/pinboard.tests.js
+++ b/tests/ui/unit/controllers/pinboard.tests.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* jasmine specs for controllers go here */
 
 describe('PinboardCtrl', function(){

--- a/tests/ui/unit/filters.tests.js
+++ b/tests/ui/unit/filters.tests.js
@@ -1,5 +1,3 @@
-'use strict';
-
 describe('linkifyURLs filter', function() {
     var $filter;
     beforeEach(angular.mock.module('treeherder'));

--- a/tests/ui/unit/init.js
+++ b/tests/ui/unit/init.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Karma/webpack entry for tests
 
 // Global variables are set here instead of with webpack.ProvidePlugin

--- a/tests/ui/unit/models/jobs.tests.js
+++ b/tests/ui/unit/models/jobs.tests.js
@@ -1,5 +1,3 @@
-'use strict';
-
 require('../../../../ui/js/models/job.js');
 describe('ThJobModel', function(){
 

--- a/tests/ui/unit/models/resultsets.tests.js
+++ b/tests/ui/unit/models/resultsets.tests.js
@@ -1,5 +1,3 @@
-'use strict';
-
 describe('ThResultSetStore', function(){
 
     var $httpBackend,

--- a/tests/ui/unit/react/revisions.tests.jsx
+++ b/tests/ui/unit/react/revisions.tests.jsx
@@ -1,4 +1,3 @@
-'use strict';
 const mount = require('enzyme').mount;
 const revisions = require('../../../../ui/js/reactrevisions.jsx');
 const RevisionList = revisions.RevisionList;

--- a/ui/entry-failureviewer.js
+++ b/ui/entry-failureviewer.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Webpack entry point for failurereviewer.html
 // Scripts and styles included here are automatically included on the page at build time
 

--- a/ui/entry-index.js
+++ b/ui/entry-index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Webpack entry point for index.html
 // Scripts and styles included here are automatically included on the page at build time
 require('./js/config');

--- a/ui/entry-logviewer.js
+++ b/ui/entry-logviewer.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Webpack entry point for logviewer.html
 // Scripts and styles included here are automatically included on the page at build time
 require('./js/config');

--- a/ui/entry-perf.js
+++ b/ui/entry-perf.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Webpack entry point for perf.html
 // Scripts and styles included here are automatically included on the page at build time
 

--- a/ui/entry-userguide.js
+++ b/ui/entry-userguide.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Webpack entry point for userguide.html
 // Scripts and styles included here are automatically included on the page at build time
 

--- a/ui/js/cache-templates.js
+++ b/ui/js/cache-templates.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // This is a run block which, when used on an angular module, loads all
 // of the partials in /ui/partials and /ui/plugins into the Angular
 // template cache. This means that ng-includes and templateUrls will not

--- a/ui/js/components/logviewer/logviewer.js
+++ b/ui/js/components/logviewer/logviewer.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.component('thLogViewer', {
     templateUrl: 'partials/logviewer/logviewer.html',
     controller: ['$sce', '$location', '$element', '$scope', '$rootScope',

--- a/ui/js/components/perf/compare.js
+++ b/ui/js/components/perf/compare.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.component('phCompareTable', {
     templateUrl: ['$attrs', function ($attrs) {
         if ($attrs.type === 'trend') {

--- a/ui/js/config/index.js
+++ b/ui/js/config/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Check for a config file and use it if available
 try {
     // (Requiring via context allows us to avoid ugly warnings when no file is present)

--- a/ui/js/config/sample.local.conf.js
+++ b/ui/js/config/sample.local.conf.js
@@ -1,5 +1,3 @@
-'use strict';
-
 //treeherder.config(['$logProvider', 'ThLogConfigProvider',
 //    function($logProvider, ThLogConfigProvider) {
 //

--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherder.controller('BugFilerCtrl', [
     '$scope', '$uibModalInstance', '$http', 'summary',
     'search_terms', 'fullLog', 'parsedLog', 'reftest', 'selectedJob',

--- a/ui/js/controllers/failureviewer.js
+++ b/ui/js/controllers/failureviewer.js
@@ -1,5 +1,3 @@
-'use strict';
-
 failureViewerApp.controller('FailureViewerCtrl', [
     '$q', '$location', '$rootScope', '$scope', '$window',
     'thUrl', 'thNotify', 'ThClassifiedFailuresModel',

--- a/ui/js/controllers/filters.js
+++ b/ui/js/controllers/filters.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherderApp.controller('JobFilterCtrl', [
     '$scope', '$rootScope',
     'thResultStatusList', 'thEvents', 'thJobFilters',

--- a/ui/js/controllers/jobs.js
+++ b/ui/js/controllers/jobs.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherderApp.controller('JobsCtrl', [
     '$scope', '$rootScope', '$routeParams',
     'thDefaultRepo',

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -1,5 +1,3 @@
-'use strict';
-
 logViewerApp.controller('LogviewerCtrl', [
     '$location', '$window', '$document', '$rootScope', '$scope',
     '$timeout', 'ThTextLogStepModel', 'ThJobDetailModel',

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherderApp.controller('MainCtrl', [
     '$scope', '$rootScope', '$location', '$timeout', '$q',
     'ThLog', 'ThRepositoryModel', 'thPinboard', 'thTabs', '$document',

--- a/ui/js/controllers/notification.js
+++ b/ui/js/controllers/notification.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherderApp.controller('NotificationCtrl', [
     '$scope', 'thNotify',
     function NotificationCtrl($scope, thNotify) {

--- a/ui/js/controllers/perf/alerts.js
+++ b/ui/js/controllers/perf/alerts.js
@@ -1,5 +1,3 @@
-"use strict";
-
 perf.factory('PhBugs', [
     '$http', '$httpParamSerializer', '$interpolate', '$rootScope', 'dateFilter', 'thServiceDomain',
     function ($http, $httpParamSerializer, $interpolate, $rootScope, dateFilter, thServiceDomain) {

--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -1,5 +1,3 @@
-"use strict";
-
 perf.controller('CompareChooserCtrl', [
     '$state', '$stateParams', '$scope', '$q', 'ThRepositoryModel', 'ThResultSetModel',
     'phCompareDefaultNewRepo', 'phCompareDefaultOriginalRepo',

--- a/ui/js/controllers/perf/dashboard.js
+++ b/ui/js/controllers/perf/dashboard.js
@@ -1,5 +1,3 @@
-"use strict";
-
 perf.value('defaultTimeRange', 86400 * 2);
 
 perf.controller('dashCtrl', [

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -1,5 +1,3 @@
-"use strict";
-
 perf.controller('GraphsCtrl', [
     '$state', '$stateParams', '$scope', '$rootScope', '$uibModal',
     '$window', 'thServiceDomain', '$q', '$timeout', 'PhSeries', 'PhAlerts',

--- a/ui/js/controllers/repository.js
+++ b/ui/js/controllers/repository.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherderApp.controller('RepositoryMenuCtrl', [
     '$scope', 'ThRepositoryModel',
     function RepositoryMenuCtrl(

--- a/ui/js/controllers/settings.js
+++ b/ui/js/controllers/settings.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherderApp.controller('SettingsCtrl',
     function SheriffController() {
     }

--- a/ui/js/controllers/tcjobactions.js
+++ b/ui/js/controllers/tcjobactions.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { slugid } from 'taskcluster-client-web';
 
 treeherder.controller('TCJobActionsCtrl', [

--- a/ui/js/controllers/userguide.js
+++ b/ui/js/controllers/userguide.js
@@ -1,5 +1,3 @@
-"use strict";
-
 userguideApp.controller('UserguideCtrl', ['$scope',
     function UserguideCtrl($scope) {
 

--- a/ui/js/directives/treeherder/bottom_nav_panel.js
+++ b/ui/js/directives/treeherder/bottom_nav_panel.js
@@ -1,6 +1,3 @@
-'use strict';
-
-
 treeherder.directive('thPinnedJob', [
     'thResultStatusInfo', 'thResultStatus',
     function (thResultStatusInfo, thResultStatus) {

--- a/ui/js/directives/treeherder/clonejobs.js
+++ b/ui/js/directives/treeherder/clonejobs.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* Directives */
 treeherder.directive('thCloneJobs', [
     '$rootScope', 'ThLog', 'thUrl', 'thCloneHtml',

--- a/ui/js/directives/treeherder/log_viewer_steps.js
+++ b/ui/js/directives/treeherder/log_viewer_steps.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.directive('lvLogSteps', ['$timeout', ($timeout) => {
     function getOffsetOfStep(order) {
         const el = $('.lv-step[order="' + order + '"]');

--- a/ui/js/directives/treeherder/main.js
+++ b/ui/js/directives/treeherder/main.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.directive('ngRightClick', [
     '$parse',
     function ($parse) {

--- a/ui/js/directives/treeherder/resultsets.js
+++ b/ui/js/directives/treeherder/resultsets.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.directive('thActionButton', function () {
     return {
         restrict: "E",

--- a/ui/js/directives/treeherder/top_nav_bar.js
+++ b/ui/js/directives/treeherder/top_nav_bar.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.directive('thWatchedRepo', [
     'ThLog', 'ThRepositoryModel',
     function (ThLog, ThRepositoryModel) {

--- a/ui/js/failureviewer.js
+++ b/ui/js/failureviewer.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var failureViewerApp = angular.module('failureviewer', ['treeherder']);
 
 failureViewerApp.config(['$compileProvider', '$locationProvider',

--- a/ui/js/filters.js
+++ b/ui/js/filters.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* Filters */
 
 treeherder.filter('showOrHide', function () {

--- a/ui/js/logviewer.js
+++ b/ui/js/logviewer.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var logViewerApp = angular.module('logviewer', ['treeherder']);
 
 logViewerApp.config(['$compileProvider', '$locationProvider', '$resourceProvider',

--- a/ui/js/models/bug_job_map.js
+++ b/ui/js/models/bug_job_map.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThBugJobMapModel', [
     '$http', 'thUrl',
     function ($http, thUrl) {

--- a/ui/js/models/bug_suggestions.js
+++ b/ui/js/models/bug_suggestions.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherder.factory('ThBugSuggestionsModel', [
     '$resource', 'thUrl', function ($resource, thUrl) {
         return $resource(thUrl.getRootUrl('/project/:project/jobs/:jobId/bug_suggestions/'));

--- a/ui/js/models/build_platform.js
+++ b/ui/js/models/build_platform.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThBuildPlatformModel', [
     '$http', 'thUrl',
     function ($http, thUrl) {

--- a/ui/js/models/classification.js
+++ b/ui/js/models/classification.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThJobClassificationModel', [
     '$http', 'thUrl',
     function ($http, thUrl) {

--- a/ui/js/models/classified_failure.js
+++ b/ui/js/models/classified_failure.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThClassifiedFailuresModel', [
     '$http', '$q', 'thUrl',
     function ($http, $q, thUrl) {

--- a/ui/js/models/failure_lines.js
+++ b/ui/js/models/failure_lines.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThFailureLinesModel', [
     '$http', '$q', 'thUrl',
     function ($http, $q, thUrl) {

--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThJobModel', [
     '$http', 'thUrl', 'thPlatformName', '$q',
     function ($http, thUrl, thPlatformName, $q) {

--- a/ui/js/models/job_detail.js
+++ b/ui/js/models/job_detail.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThJobDetailModel', [
     '$http', 'thUrl', function ($http, thUrl) {
         return {

--- a/ui/js/models/job_group.js
+++ b/ui/js/models/job_group.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThJobGroupModel', [
     '$http', 'thUrl',
     function ($http, thUrl) {

--- a/ui/js/models/job_log_url.js
+++ b/ui/js/models/job_log_url.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThJobLogUrlModel', [
     '$http', 'thUrl',
     function ($http, thUrl) {

--- a/ui/js/models/job_type.js
+++ b/ui/js/models/job_type.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThJobTypeModel', [
     '$http', 'thUrl',
     function ($http, thUrl) {

--- a/ui/js/models/matcher.js
+++ b/ui/js/models/matcher.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThMatcherModel', [
     '$http', 'thUrl',
     function ($http, thUrl) {

--- a/ui/js/models/option_collection.js
+++ b/ui/js/models/option_collection.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThOptionCollectionModel', [
     '$http', 'thUrl',
     function ($http, thUrl) {

--- a/ui/js/models/perf/alerts.js
+++ b/ui/js/models/perf/alerts.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherder.factory('PhAlerts', [
     '$http', '$httpParamSerializer', '$q', 'thServiceDomain', 'ThOptionCollectionModel', 'PhSeries',
     'phAlertSummaryStatusMap', 'phAlertStatusMap', 'thPerformanceBranches', 'displayNumberFilter',

--- a/ui/js/models/perf/performance_framework.js
+++ b/ui/js/models/perf/performance_framework.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherder.factory(
     'PhFramework', [
         '$http', 'thServiceDomain',

--- a/ui/js/models/perf/series.js
+++ b/ui/js/models/perf/series.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherder.factory('PhSeries', ['$http', 'thServiceDomain', 'ThOptionCollectionModel', '$q', function ($http, thServiceDomain, ThOptionCollectionModel, $q) {
 
     var _getTestName = function (signatureProps) {

--- a/ui/js/models/repository.js
+++ b/ui/js/models/repository.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThRepositoryModel', [
     '$http', 'thUrl', '$rootScope', 'ThLog', '$interval',
     '$q', 'treeStatus', 'thRepoGroupOrder',

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { Queue, slugid } from 'taskcluster-client-web';
 import thTaskcluster from '../services/taskcluster';
 

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThResultSetStore', [
     '$rootScope', '$q', '$location', '$interval', 'thPlatformMap',
     'ThResultSetModel', 'ThJobModel', 'thEvents',

--- a/ui/js/models/runnable_job.js
+++ b/ui/js/models/runnable_job.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThRunnableJobModel', [
     'thUrl', 'ThJobModel',
     function (thUrl, ThJobModel) {

--- a/ui/js/models/text_log_errors.js
+++ b/ui/js/models/text_log_errors.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThTextLogErrorsModel', [
     '$http', '$q', 'thUrl',
     function ($http, $q, thUrl) {

--- a/ui/js/models/text_log_step.js
+++ b/ui/js/models/text_log_step.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThTextLogStepModel', [
     '$resource', 'thUrl', function ($resource, thUrl) {
         return $resource(thUrl.getRootUrl('/project/:project/jobs/:jobId/text_log_steps/'));

--- a/ui/js/models/user.js
+++ b/ui/js/models/user.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThUserModel', [
     '$http', 'thUrl', 'thNotify', '$q',
     function ($http, thUrl, thNotify, $q) {

--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -1,3 +1,1 @@
-"use strict";
-
 module.exports = angular.module("perf", ['ui.router', 'ui.bootstrap', 'treeherder', 'angular-clipboard']);

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -1,5 +1,3 @@
-"use strict";
-
 // configure the router here, after we have defined all the controllers etc
 perf.config(['$compileProvider', '$locationProvider', '$httpProvider', '$stateProvider', '$urlRouterProvider',
     function ($compileProvider, $locationProvider, $httpProvider, $stateProvider, $urlRouterProvider) {

--- a/ui/js/providers.js
+++ b/ui/js/providers.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherder.provider('thServiceDomain', function () {
     this.$get = function () {
         // The SERVICE_DOMAIN global is set by webpack's DefinePlugin.

--- a/ui/js/reactrevisions.jsx
+++ b/ui/js/reactrevisions.jsx
@@ -1,5 +1,3 @@
-'use strict';
-
 const PropTypes = require('prop-types');
 
 const MoreRevisionsLink = props => (

--- a/ui/js/services/buildapi.js
+++ b/ui/js/services/buildapi.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('thBuildApi', [
     '$http', 'thNotify',
     function ($http, thNotify) {

--- a/ui/js/services/classifications.js
+++ b/ui/js/services/classifications.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('thClassificationTypes', [
     '$http', 'thUrl',
     function ($http, thUrl) {

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
    This service handles whether or not a job, job group or platform row should
    be displayed based on the filter settings.

--- a/ui/js/services/jsonpushes.js
+++ b/ui/js/services/jsonpushes.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.service('JsonPushes', ['$http', '$q', function ($http, $q) {
     // error handler helper
     var prevRevsErrHandler = function (response) {

--- a/ui/js/services/log.js
+++ b/ui/js/services/log.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('ThLog', [
     '$log', 'ThLogConfig',
     function ($log, ThLogConfig) {

--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { Queue } from 'taskcluster-client-web';
 import thTaskcluster from './taskcluster';
 

--- a/ui/js/services/perf/compare.js
+++ b/ui/js/services/perf/compare.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherder.factory('PhCompare', [
     '$q', '$http', '$httpParamSerializer', 'thServiceDomain', 'PhSeries', 'math', 'phTimeRanges',
     function ($q, $http, $httpParamSerializer, thServiceDomain, PhSeries, math, phTimeRanges) {

--- a/ui/js/services/perf/math.js
+++ b/ui/js/services/perf/math.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherder.factory('math', [
     function () {
         function percentOf(a, b) {

--- a/ui/js/services/pinboard.js
+++ b/ui/js/services/pinboard.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('thPinboard', [
     'ThJobClassificationModel', '$rootScope', 'thEvents',
     'ThBugJobMapModel', 'thNotify', 'ThModelErrors', 'ThLog', 'ThResultSetStore', 'thPinboardCountError',

--- a/ui/js/services/treestatus.js
+++ b/ui/js/services/treestatus.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('treeStatus', [
     '$http',
     function ($http) {

--- a/ui/js/treeherder.js
+++ b/ui/js/treeherder.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*exported treeherder*/
 module.exports = angular.module('treeherder',
     ['ngResource', 'ngSanitize', 'LocalStorageModule']);

--- a/ui/js/treeherder_app.js
+++ b/ui/js/treeherder_app.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var treeherderApp = angular.module('treeherder.app',
     ['treeherder', 'ui.bootstrap', 'ngRoute',
         'mc.resizer', 'angular-toArrayFilter', 'react',

--- a/ui/js/userguide.js
+++ b/ui/js/userguide.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var userguideApp = angular.module('userguide', []);
 
 userguideApp.config(['$compileProvider', function ($compileProvider) {

--- a/ui/js/values.js
+++ b/ui/js/values.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import treeFavicon from '../img/tree_open.png';
 import closedTreeFavicon from '../img/tree_closed.png';
 import { platformMap } from './constants';

--- a/ui/plugins/annotations/controller.js
+++ b/ui/plugins/annotations/controller.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherder.controller('AnnotationsPluginCtrl', [
     '$scope', '$rootScope', 'ThLog', 'thNotify',
     'thEvents', 'ThResultSetStore', 'thTabs',

--- a/ui/plugins/annotations_panel.jsx
+++ b/ui/plugins/annotations_panel.jsx
@@ -1,4 +1,3 @@
-'use strict';
 import PropTypes from 'prop-types';
 
 const RelatedBugSaved = (props) => {

--- a/ui/plugins/auto_classification/controller.js
+++ b/ui/plugins/auto_classification/controller.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherder.factory('thStringOverlap', function () {
     return function (str1, str2) {
         // Get a measure of the similarity of two strings by a simple process

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { Queue, slugid } from 'taskcluster-client-web';
 import thTaskcluster from '../js/services/taskcluster';
 

--- a/ui/plugins/failure_summary/controller.js
+++ b/ui/plugins/failure_summary/controller.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherder.controller('BugsPluginCtrl', [
     '$scope', '$rootScope', 'ThLog', 'ThTextLogStepModel',
     'ThBugSuggestionsModel', 'thPinboard', 'thEvents',

--- a/ui/plugins/failure_summary_panel.jsx
+++ b/ui/plugins/failure_summary_panel.jsx
@@ -1,4 +1,3 @@
-'use strict';
 const PropTypes = require('prop-types');
 
 class SuggestionsListItem extends React.Component {

--- a/ui/plugins/job_details_pane.jsx
+++ b/ui/plugins/job_details_pane.jsx
@@ -1,4 +1,3 @@
-'use strict';
 const PropTypes = require('prop-types');
 
 // using ES6 arrow function syntax throws an error for this particular component

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherder.controller('PinboardCtrl', [
     '$scope', '$rootScope', '$document', '$timeout', 'thEvents', 'thPinboard', 'thNotify', 'ThLog',
     function PinboardCtrl(

--- a/ui/plugins/similar_jobs/controller.js
+++ b/ui/plugins/similar_jobs/controller.js
@@ -1,5 +1,3 @@
-"use strict";
-
 treeherder.controller('SimilarJobsPluginCtrl', [
     '$scope', 'ThLog', 'ThJobModel', 'ThTextLogStepModel', 'thResultStatusInfo',
     'numberFilter', 'dateFilter', 'thClassificationTypes',

--- a/ui/plugins/tabs.js
+++ b/ui/plugins/tabs.js
@@ -1,5 +1,3 @@
-'use strict';
-
 treeherder.factory('thTabs', [
     function () {
         var thTabs = {


### PR DESCRIPTION
With ES6, the `'use strict'` directives are unnecessary:
https://eslint.org/docs/rules/strict

The directives have been left in the Neutrino configs, since they are used by node directly, which doesn't yet support ES6 modules.