### PR TITLE
Bug 1428919 - Vagrant: Update to latest Bento image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,13 +26,14 @@ Vagrant.configure("2") do |config|
     # The Bento boxes (https://github.com/chef/bento) are recommended over the
     # Canonical ones, since they more closely follow Vagrant best practices.
     override.vm.box = "bento/ubuntu-16.04"
-    override.vm.box_version = ">= 2.3.5"
+    override.vm.box_version = ">= 201802.02.0"
     vb.name = "treeherder"
     vb.memory = "3072"
   end
 
   config.vm.provider "hyperv" do |hv, override|
-    override.vm.box = "ericmann/trusty64"
+    override.vm.box = "bento/ubuntu-16.04"
+    override.vm.box_version = ">= 201801.02.0"
     hv.vmname = "treeherder"
     hv.memory = "3072"
   end

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -56,6 +56,7 @@ fi
 
 echo '-----> Installing/updating APT packages'
 sudo -E apt-get -yqq update
+sudo -E apt-get -yqq dist-upgrade
 # libgtk-3.0 and libxt-dev are required by Firefox
 # libmysqlclient-dev is required by mysqlclient
 # openjdk-8-jre-headless is required by Elasticsearch


### PR DESCRIPTION
To pick up the newer kernel/security updates. Only takes effect when people destroy/recreate their VM, so also adds a `dist-upgrade` to upgrade existing boxes. (The older Bento box had a broken kernel config so `dist-upgrade` can't upgrade the kernel, but it's better than nothing.)

Also switches the Hyper-V provider to the Bento images for parity, since Bento now create Hyper-V variants too.

For available box versions, see:
https://app.vagrantup.com/bento/boxes/ubuntu-16.04

The `box` name cannot be factored out of the provider blocks due to:
https://github.com/hashicorp/vagrant/issues/9452