### PR TITLE
Bug 1412797 - Switch to the Django 1.10+ new style middleware API

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -84,7 +84,7 @@ MIDDLEWARE_CLASSES = [middleware for middleware in [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'hawkrest.middleware.HawkResponseMiddleware',
+    'treeherder.middleware.FixedHawkResponseMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ] if middleware]
 

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -69,23 +69,23 @@ TEMPLATES = [
     },
 ]
 
-MIDDLEWARE_CLASSES = [middleware for middleware in [
+MIDDLEWARE = [middleware for middleware in [
     # Adds custom New Relic annotations. Must be first so all transactions are annotated.
     'treeherder.middleware.NewRelicMiddleware',
     # Redirect to HTTPS/set HSTS and other security headers.
     'django.middleware.security.SecurityMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     # Allows both Django static files and those specified via `WHITENOISE_ROOT`
     # to be served by WhiteNoise, avoiding the need for Apache/nginx on Heroku.
     'treeherder.middleware.CustomWhiteNoise',
     'django.middleware.gzip.GZipMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware' if ENABLE_DEBUG_TOOLBAR else False,
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'treeherder.middleware.FixedHawkResponseMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ] if middleware]
 
 if ENABLE_DEBUG_TOOLBAR:

--- a/treeherder/middleware.py
+++ b/treeherder/middleware.py
@@ -2,6 +2,7 @@ import re
 
 import newrelic.agent
 from django.utils.deprecation import MiddlewareMixin
+from hawkrest.middleware import HawkResponseMiddleware
 from whitenoise.middleware import WhiteNoiseMiddleware
 
 
@@ -60,3 +61,13 @@ class NewRelicMiddleware(MiddlewareMixin):
         # slow transactions), so for use in Insights we have to add it as a customer parameter.
         if 'HTTP_USER_AGENT' in request.META:
             newrelic.agent.add_custom_parameter('user_agent', request.META['HTTP_USER_AGENT'])
+
+
+class FixedHawkResponseMiddleware(MiddlewareMixin, HawkResponseMiddleware):
+    """
+    Makes HawkResponseMiddleware compatible with Django's new middleware API.
+
+    Remove when `MiddlewareMixin` has been added upstream:
+    https://github.com/kumar303/hawkrest/issues/38
+    """
+    pass

--- a/treeherder/middleware.py
+++ b/treeherder/middleware.py
@@ -1,6 +1,7 @@
 import re
 
 import newrelic.agent
+from django.utils.deprecation import MiddlewareMixin
 from whitenoise.middleware import WhiteNoiseMiddleware
 
 
@@ -51,7 +52,7 @@ class CustomWhiteNoise(WhiteNoiseMiddleware):
         return super(CustomWhiteNoise, self).is_immutable_file(path, url)
 
 
-class NewRelicMiddleware(object):
+class NewRelicMiddleware(MiddlewareMixin):
     """Adds custom annotations to New Relic web transactions."""
 
     def process_request(self, request):


### PR DESCRIPTION
The old API (`MIDDLEWARE_CLASSES`) has been deprecated in favour of the `MIDDLEWARE` pref. The new API is faster (since it short-circuits) and has more sensible error handling characteristics:
https://github.com/django/deps/blob/master/final/0005-improved-middleware.rst
https://docs.djangoproject.com/en/1.11/topics/http/middleware/#upgrading-middleware

To make the switch a couple of other changes are required:
* adapting any middleware not already compatible with the new API
* adjusting the order of middleware, to take into account that short-circuiting (returning early) now works properly

See individual commits for more details.