### PR TITLE
Bug 1436943 - Login fails with "Unrecognized identity" when using Google authentication

### DIFF
--- a/tests/auth/test_backends.py
+++ b/tests/auth/test_backends.py
@@ -12,7 +12,9 @@ from treeherder.auth.backends import (AuthBackend,
 @pytest.mark.parametrize(
     ('user_info', 'exp_username', 'exp_exception'),
     [({'sub': 'email', 'email': 'biped@mozilla.com'}, 'email/biped@mozilla.com', False),  # email clientId
-     ({'sub': 'Mozilla-LDAP', 'email': 'biped@mozilla.com'}, 'mozilla-ldap/biped@mozilla.com', False),  # ldap clientId
+     ({'sub': 'ad|Mozilla-LDAP|biped', 'email': 'biped@mozilla.com'}, 'mozilla-ldap/biped@mozilla.com', False),  # ldap clientId
+     ({'sub': 'github|0000', 'email': 'biped@gmail.com'}, 'github/biped@gmail.com', False),  # github clientId
+     ({'sub': 'google-oauth2|0000', 'email': 'biped@mozilla.com'}, 'google/biped@mozilla.com', False),  # google clientId
      ({'sub': 'meh', 'email': 'biped@mozilla.com'}, 'None', True),  # invalid clientId, exception
      ])
 def test_get_username_from_userinfo(user_info, exp_username, exp_exception):

--- a/treeherder/auth/backends.py
+++ b/treeherder/auth/backends.py
@@ -73,6 +73,8 @@ class AuthBackend(object):
             return "email/" + email
         elif "github" in subject:
             return "github/" + email
+        elif "google" in subject:
+            return "google/" + email
         else:
             raise AuthenticationFailed("Unrecognized identity")
 


### PR DESCRIPTION
Presently, when you login with google you are prompted with a screen
that tells you to login using a different provider. However, if you try to
login with google using a "@mozilla.com", then there is a
blank page saying Unrecognized identity.

This commit will allow a user to login with Google when he tries to login with a `mozilla.com` email.