### PR TITLE
Bug 1434456 - Remove scrollbar from shortcut table in userguide

### DIFF
--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -410,7 +410,7 @@ h4 {
     width:100%;
 }
 
-#shortcut-table-card {
+#onscreen-shortcuts div div.card {
     max-height: 90vh;
     overflow: auto;
 }

--- a/ui/partials/main/thShortcutTable.html
+++ b/ui/partials/main/thShortcutTable.html
@@ -1,4 +1,4 @@
-<div class="card" id="shortcut-table-card">
+<div class="card">
   <div class="card-header">
     <h3>Keyboard shortcuts
       <a ng-show="onscreenShortcutsShowing"


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1434456](https://bugzilla.mozilla.org/show_bug.cgi?id=1434456).

This removes the unwanted scrollbar in the User Guide introduced by PR https://github.com/mozilla/treeherder/pull/3129 in bug [1430171](https://bugzilla.mozilla.org/show_bug.cgi?id=1430171).

User Guide before and after:
![beforeafter](https://user-images.githubusercontent.com/3660661/36041964-47187a1e-0d98-11e8-99e1-d68e8216bcdc.jpg)

In this change we only target the parent `onscreen-shortcuts` id and traverse across the ng-include into the shortcut partial, targeting the same div element the prior change did. But this way, the User Guide, or any other use of the of the shortcut component will always be clean. Only the onscreen instance of it will have a scroll bar.

Tested on OSX 10.12.6:
Release **58.0.1 (64-bit)**