### PR TITLE
Bug 1371843 - Expose Clear all when the pinboard is dirty

### DIFF
--- a/ui/partials/main/thPinboardPanel.html
+++ b/ui/partials/main/thPinboardPanel.html
@@ -85,8 +85,9 @@
             ng-disabled="!user.loggedin || !canSaveClassifications()">save
     </button>
     <button class="btn btn-light-bordered btn-xs dropdown-toggle save-btn-dropdown"
-            title="{{ !hasPinnedJobs() ? 'No pinned jobs' : 'Additional pinboard functions' }}"
-            ng-disabled="!hasPinnedJobs()"
+            title="{{ !hasPinnedJobs() && !pinboardIsDirty() ? 'No pinned jobs' :
+                      'Additional pinboard functions' }}"
+            ng-disabled="!hasPinnedJobs() && !pinboardIsDirty()"
             type="button"
             data-toggle="dropdown">
       <span class="caret"></span>

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -184,6 +184,13 @@ treeherder.controller('PinboardCtrl', [
                    (thisClass.failure_classification_id === 2 && thisClass.text.length > 7));
         };
 
+        // Facilitates Clear all if no jobs pinned to reset pinboard UI
+        $scope.pinboardIsDirty = function () {
+            return $scope.classification.text !== '' ||
+                   thPinboard.hasRelatedBugs() ||
+                   $scope.classification.failure_classification_id !== 4;
+        };
+
         // Dynamic btn/anchor title for classification save
         $scope.saveUITitle = function (category) {
             var title = "";


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1371843](https://bugzilla.mozilla.org/show_bug.cgi?id=1371843).

This changes the classification save drop down, such that when the user enters a bug number, or enters classification text, or modifies the classification drop down, the Save drop down is exposed, allowing the user to "Clear all" (effectively resetting the UI inputs).

Proposed:
![pinboarddirtyproposed](https://user-images.githubusercontent.com/3660661/36077506-bc8120b0-0f39-11e8-8d5b-a9598dbfc3f7.jpg)

Mildly tested on OSX 10.12.6:
Release **58.0.1 (64-bit)**