### PR TITLE
Bug 1437938 - Remove unused /jobs/update_state/ API

### DIFF
--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -427,9 +427,6 @@ class Job(models.Model):
     """
     This class represents a build or test job in Treeherder
     """
-    INCOMPLETE_STATES = ["running", "pending"]
-    STATES = INCOMPLETE_STATES + ["completed"]
-
     objects = JobManager()
 
     id = models.BigAutoField(primary_key=True)

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -328,36 +328,6 @@ class JobsViewSet(viewsets.ViewSet):
 
         return Response(response_body)
 
-    @detail_route(methods=['post'])
-    def update_state(self, request, project, pk=None):
-        """
-        Change the state of a job.
-        """
-        state = request.data.get('state', None)
-
-        # check that this state is valid
-        if state not in Job.STATES:
-            return Response(
-                {"message": ("'{0}' is not a valid state.  Must be "
-                             "one of: {1}".format(
-                                 state,
-                                 ", ".join(Job.STATES)
-                             ))},
-                status=HTTP_400_BAD_REQUEST,
-            )
-
-        if not pk:  # pragma nocover
-            return Response({"message": "job id required"}, status=HTTP_400_BAD_REQUEST)
-
-        try:
-            job = Job.objects.get(repository__name=project,
-                                  id=pk)
-            job.state = state
-            job.save()
-        except ObjectDoesNotExist:
-            return Response("No job with id: {0}".format(pk), status=HTTP_404_NOT_FOUND)
-        return Response({"message": "state updated to '{0}'".format(state)})
-
     @list_route(methods=['post'], permission_classes=[IsAuthenticated])
     def cancel(self, request, project):
         try:


### PR DESCRIPTION
The remaining REST API job submitters are using `JobsViewSet.create` to transition jobs from one state to the next instead.

This makes the various `*STATES` constants unused. (I'd thought they were used for validation during ingestion, but I guess not. We at least have the jsonschema validation for pulse - i think that's enough for now?)