### PR TITLE
Bug 1437968 - Remove unused refdata APIs

### DIFF
--- a/treeherder/webapp/api/refdata.py
+++ b/treeherder/webapp/api/refdata.py
@@ -10,27 +10,6 @@ from treeherder.webapp.api import serializers as th_serializers
 #####################
 
 
-class ProductViewSet(viewsets.ReadOnlyModelViewSet):
-
-    """ViewSet for the refdata Product model"""
-    queryset = models.Product.objects.all()
-    serializer_class = th_serializers.ProductSerializer
-
-
-class BuildPlatformViewSet(viewsets.ReadOnlyModelViewSet):
-
-    """ViewSet for the refdata BuildPlatform model"""
-    queryset = models.BuildPlatform.objects.all()
-    serializer_class = th_serializers.BuildPlatformSerializer
-
-
-class JobGroupViewSet(viewsets.ReadOnlyModelViewSet):
-
-    """ViewSet for the refdata JobGroup model"""
-    queryset = models.JobGroup.objects.all()
-    serializer_class = th_serializers.JobGroupSerializer
-
-
 class RepositoryViewSet(viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata Repository model"""
@@ -38,20 +17,6 @@ class RepositoryViewSet(viewsets.ReadOnlyModelViewSet):
         active_status='active').select_related(
             'repository_group')
     serializer_class = th_serializers.RepositorySerializer
-
-
-class MachinePlatformViewSet(viewsets.ReadOnlyModelViewSet):
-
-    """ViewSet for the refdata MachinePlatform model"""
-    queryset = models.MachinePlatform.objects.all()
-    serializer_class = th_serializers.MachinePlatformSerializer
-
-
-class MachineViewSet(viewsets.ReadOnlyModelViewSet):
-
-    """ViewSet for the refdata Machine model"""
-    queryset = models.Machine.objects.all()
-    serializer_class = th_serializers.MachineSerializer
 
 
 class OptionCollectionHashViewSet(viewsets.ViewSet):
@@ -67,13 +32,6 @@ class OptionCollectionHashViewSet(viewsets.ViewSet):
                         'options': [{'name': name} for
                                     name in option_names]})
         return Response(ret)
-
-
-class JobTypeViewSet(viewsets.ReadOnlyModelViewSet):
-
-    """ViewSet for the refdata JobType model"""
-    queryset = models.JobType.objects.all()
-    serializer_class = th_serializers.JobTypeSerializer
 
 
 class FailureClassificationViewSet(viewsets.ReadOnlyModelViewSet):

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -42,27 +42,6 @@ class RepositorySerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class ProductSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = models.Product
-        fields = '__all__'
-
-
-class BuildPlatformSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = models.BuildPlatform
-        fields = '__all__'
-
-
-class MachinePlatformSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = models.MachinePlatform
-        fields = '__all__'
-
-
 class JobSerializer(serializers.ModelSerializer):
 
     def to_representation(self, job):
@@ -105,27 +84,6 @@ class JobSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Job
-        fields = '__all__'
-
-
-class JobGroupSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = models.JobGroup
-        fields = '__all__'
-
-
-class JobTypeSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = models.JobType
-        fields = '__all__'
-
-
-class MachineSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = models.Machine
         fields = '__all__'
 
 

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -101,12 +101,6 @@ class ExtendedRouter(routers.DefaultRouter):
 
 # refdata endpoints:
 default_router = ExtendedRouter()
-default_router.register(r'product', refdata.ProductViewSet)
-default_router.register(r'machine', refdata.MachineViewSet)
-default_router.register(r'machineplatform', refdata.MachinePlatformViewSet)
-default_router.register(r'buildplatform', refdata.BuildPlatformViewSet)
-default_router.register(r'jobgroup', refdata.JobGroupViewSet)
-default_router.register(r'jobtype', refdata.JobTypeViewSet)
 default_router.register(r'repository', refdata.RepositoryViewSet)
 default_router.register(r'optioncollectionhash', refdata.OptionCollectionHashViewSet,
                         base_name='optioncollectionhash')


### PR DESCRIPTION
New Relic says zero requests to these in the last 7 days:
* BuildPlatformViewSet
* MachineViewSet
* ProductViewSet

...and these have only been accessed <= 2 times:
* JobGroupViewSet
* JobTypeViewSet
* MachinePlatformViewSet