### PR TITLE
Bug 1437974 - Remove unused SETA APIs

### DIFF
--- a/treeherder/webapp/api/seta.py
+++ b/treeherder/webapp/api/seta.py
@@ -2,8 +2,6 @@ from rest_framework import (status,
                             viewsets)
 from rest_framework.response import Response
 
-from treeherder.etl.seta import Treecodes
-from treeherder.seta.analyze_failures import get_failures_fixed_by_commit
 from treeherder.seta.job_priorities import (SetaError,
                                             seta_job_scheduling)
 
@@ -27,26 +25,3 @@ class SetaJobPriorityViewSet(viewsets.ViewSet):
             return Response(seta_job_scheduling(project, build_system_type, priority))
         except SetaError as e:
             return Response(str(e), status=status.HTTP_400_BAD_REQUEST)
-
-
-class SetaFailuresFixedByCommit(viewsets.ViewSet):
-    def list(self, request):
-        ''' Routing to /api/seta/failures-fixed-by-commit/
-
-        Returns jobs annotated with fixed by commit (no empty string) grouped by
-        annotation text (generally a revision that fixes the issue).
-
-        NOTE: This API is not necessary for SETA's normal functioning. It is for feature parity and inspection.
-        '''
-        return Response({'failures': get_failures_fixed_by_commit()})
-
-
-class SetaJobTypes(viewsets.ViewSet):
-    def list(self, request, project):
-        ''' Routing to /api/project/{project}/seta/job-types/
-
-        Returns all distinct jobtypes for a project.
-
-        NOTE: This API is not necessary for SETA's normal functioning. It is for feature parity and inspection.
-        '''
-        return Response({'jobtypes': Treecodes(project).query_jobtypes()})

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -42,12 +42,6 @@ project_bound_router.register(
 )
 
 project_bound_router.register(
-    r'seta/job-types',
-    seta.SetaJobTypes,
-    base_name='seta-job-types'
-)
-
-project_bound_router.register(
     r'resultset',
     push.PushViewSet,
     base_name='resultset',
@@ -139,9 +133,6 @@ default_router.register(r'jobdetail', jobs.JobDetailViewSet,
                         base_name='jobdetail')
 default_router.register(r'auth', auth.AuthViewSet,
                         base_name='auth')
-default_router.register(r'seta/failures-fixed-by-commit',
-                        seta.SetaFailuresFixedByCommit,
-                        base_name='seta_failures_fixed_by_commit')
 
 urlpatterns = [
     url(r'^project/(?P<project>[\w-]{0,50})/',


### PR DESCRIPTION
These endpoints have not been accessed in the last 7 days, and in the case of `SetaFailuresFixedByCommit` only ever timed out anyway.

They were only ever used for debugging, for which we now have redash.