### PR TITLE
Bug 1438060 - Remove unused /push/revisions/ API

### DIFF
--- a/tests/ui/mock/resultset_list.json
+++ b/tests/ui/mock/resultset_list.json
@@ -13,7 +13,6 @@
       "revision_count": 1,
       "author": "john@doe.com",
       "comments": "Back out bug 1071880 for causing bug 1083952.",
-      "revisions_uri": "/api/project/mozilla-inbound/resultset/1/revisions/",
       "push_timestamp": 1424272815,
       "revisions": [
         {
@@ -31,7 +30,6 @@
       "revision_count": 1,
       "author": "john@doe.com",
       "comments": "Bug 1133254 - Dehandlify shape-updating object methods, allow setting multiple flags on an object at once, r=terrence.",
-      "revisions_uri": "/api/project/mozilla-inbound/resultset/2/revisions/",
       "push_timestamp": 1424272126,
       "revisions": [
         {

--- a/tests/ui/unit/react/revisions.tests.jsx
+++ b/tests/ui/unit/react/revisions.tests.jsx
@@ -31,7 +31,6 @@ describe('Revision list component', () => {
         const push = {
             "id": 151371,
             "revision": "5a110ad242ead60e71d2186bae78b1fb766ad5ff",
-            "revisions_uri": "/api/project/mozilla-inbound/resultset/151371/revisions/",
             "revision_count": 3,
             "author": "ryanvm@gmail.com",
             "push_timestamp": 1481326280,

--- a/tests/webapp/api/test_push_api.py
+++ b/tests/webapp/api/test_push_api.py
@@ -35,7 +35,6 @@ def test_push_list_basic(webapp, eleven_jobs_stored, test_repository):
         u'revision',
         u'revisions',
         u'revision_count',
-        u'revisions_uri',
         u'push_timestamp',
     ])
     for rs in results:

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -7,10 +7,8 @@ from rest_framework.response import Response
 from rest_framework.status import (HTTP_400_BAD_REQUEST,
                                    HTTP_404_NOT_FOUND)
 
-from serializers import (CommitSerializer,
-                         PushSerializer)
-from treeherder.model.models import (Commit,
-                                     Job,
+from serializers import PushSerializer
+from treeherder.model.models import (Job,
                                      Push,
                                      Repository)
 from treeherder.model.tasks import publish_job_action
@@ -170,19 +168,6 @@ class PushViewSet(viewsets.ViewSet):
             serializer = PushSerializer(push)
             return Response(serializer.data)
         except Push.DoesNotExist:
-            return Response("No push with id: {0}".format(pk),
-                            status=HTTP_404_NOT_FOUND)
-
-    @detail_route()
-    def revisions(self, request, project, pk=None):
-        """
-        GET method for revisions of a push
-        """
-        try:
-            serializer = CommitSerializer(Commit.objects.filter(push_id=pk),
-                                          many=True)
-            return Response(serializer.data)
-        except Commit.DoesNotExist:
             return Response("No push with id: {0}".format(pk),
                             status=HTTP_404_NOT_FOUND)
 

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.models import User
 from rest_framework import serializers
-from rest_framework.reverse import reverse
 
 from treeherder.model import models
 from treeherder.webapp.api.utils import to_timestamp
@@ -222,11 +221,6 @@ class CommitSerializer(serializers.ModelSerializer):
 
 class PushSerializer(serializers.ModelSerializer):
 
-    def get_revisions_uri(self, obj):
-        return reverse("push-revisions",
-                       kwargs={"project": obj.repository.name,
-                               "pk": obj.id})
-
     def get_revisions(self, push):
         serializer = CommitSerializer(
             instance=push.commits.all().order_by('-id')[:20],
@@ -239,7 +233,6 @@ class PushSerializer(serializers.ModelSerializer):
     def get_push_timestamp(self, push):
         return to_timestamp(push.time)
 
-    revisions_uri = serializers.SerializerMethodField()
     revisions = serializers.SerializerMethodField()
     revision_count = serializers.SerializerMethodField()
     push_timestamp = serializers.SerializerMethodField()
@@ -248,6 +241,6 @@ class PushSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Push
-        fields = ['id', 'revision', 'author', 'revisions_uri',
+        fields = ['id', 'revision', 'author',
                   'revisions', 'revision_count', 'push_timestamp',
                   'repository_id']


### PR DESCRIPTION
Since revision details are included in the response from the `/push/` API, so there's never any need to fetch them separately.

(And if anyone wants more than the first 20 commits, they should be using hg.mozilla.org's API instead.)