### PR TITLE
Bug 1437824 - Stop logging out users if renewal fails

### DIFF
--- a/ui/js/auth/AuthService.js
+++ b/ui/js/auth/AuthService.js
@@ -53,7 +53,6 @@ export default class AuthService {
         return this.resetRenewalTimer();
       }
     } catch (err) {
-      this.logout();
       /* eslint-disable no-console */
       console.error('Could not renew login:', err);
     }


### PR DESCRIPTION
I suspect multiple tabs are trying to renew at the same time, where one tab will throw an error hence logging users out.