### PR TITLE
Bug 1438469 - Improve InfoPanel.is_open to include check for job result

### DIFF
--- a/tests/selenium/pages/treeherder.py
+++ b/tests/selenium/pages/treeherder.py
@@ -213,7 +213,8 @@ class Treeherder(Base):
         @property
         def is_open(self):
             return self.root.is_displayed() and \
-                not self.find_elements(*self._loading_locator)
+                not self.find_elements(*self._loading_locator) and \
+                self.job_details.result
 
         @property
         def job_details(self):


### PR DESCRIPTION
There appears to be a moment between clicking the job and the result/details being populated. This fix means we don't return from the wait for the info panel to be displayed until the job result is populated.

I ran the tests/selenium/test_filter_jobs_by_failure_result.py::test_filter_jobs_by_failure_result[testfailed] 100 times without failure with this patch applied.