### PR TITLE
Bug 1438555 - Fix Classifying a failure in the middle of the page breaks n/p navigation

### DIFF
--- a/ui/job-view/JobButton.jsx
+++ b/ui/job-view/JobButton.jsx
@@ -10,6 +10,7 @@ export default class JobButtonComponent extends React.Component {
 
     this.$rootScope = $injector.get('$rootScope');
     this.thEvents = $injector.get('thEvents');
+    this.thJobFilters = $injector.get('thJobFilters');
     this.ThResultSetStore = $injector.get('ThResultSetStore');
 
     this.state = {
@@ -61,7 +62,19 @@ export default class JobButtonComponent extends React.Component {
   }
 
   setSelected(isSelected) {
+    const { job, platform, filterPlatformCb } = this.props;
+    // if a job was just classified, and we are in unclassified only mode,
+    // then the job no longer meets the filter criteria.  However, if it
+    // is still selected, then it should stay visible so that next/previous
+    // navigation still works.  Then, as soon as the selection changes, it
+    // it will disappear.  So visible must be contingent on the filters AND
+    // whether it is still selected.
+    job.visible = this.thJobFilters.showJob(job);
     this.setState({ isSelected });
+    // filterPlatformCb will keep a job and platform visible if it contains
+    // the selected job, so we must pass in if this job is selected or not.
+    const selectedJobId = isSelected ? job.id : null;
+    filterPlatformCb(platform, selectedJobId);
   }
 
   toggleRunnableSelected() {

--- a/ui/job-view/JobGroup.jsx
+++ b/ui/job-view/JobGroup.jsx
@@ -96,7 +96,7 @@ export default class JobGroup extends React.Component {
   }
 
   render() {
-    const { group, $injector, repoName } = this.props;
+    const { group, $injector, repoName, filterPlatformCb, platform } = this.props;
     this.items = this.groupButtonsAndCounts(group.jobs);
 
     return (
@@ -124,6 +124,8 @@ export default class JobGroup extends React.Component {
                   status={getStatus(job)}
                   failureClassificationId={job.failure_classification_id}
                   repoName={repoName}
+                  filterPlatformCb={filterPlatformCb}
+                  platform={platform}
                   hasGroup
                   key={job.id}
                   ref={i}

--- a/ui/job-view/JobsAndGroups.jsx
+++ b/ui/job-view/JobsAndGroups.jsx
@@ -6,7 +6,7 @@ import { getStatus } from "../helpers/jobHelper";
 
 export default class JobsAndGroups extends React.Component {
   render() {
-    const { $injector, groups, repoName } = this.props;
+    const { $injector, groups, repoName, platform, filterPlatformCb } = this.props;
 
     return (
       <td className="job-row">
@@ -17,6 +17,8 @@ export default class JobsAndGroups extends React.Component {
                 group={group}
                 repoName={repoName}
                 $injector={$injector}
+                filterPlatformCb={filterPlatformCb}
+                platform={platform}
                 refOrder={i}
                 key={group.mapKey}
                 ref={i}
@@ -32,6 +34,8 @@ export default class JobsAndGroups extends React.Component {
                 visible={job.visible}
                 status={getStatus(job)}
                 failureClassificationId={job.failure_classification_id}
+                filterPlatformCb={filterPlatformCb}
+                platform={platform}
                 hasGroup={false}
                 key={job.id}
                 ref={i}

--- a/ui/job-view/Platform.jsx
+++ b/ui/job-view/Platform.jsx
@@ -13,7 +13,7 @@ const PlatformName = (props) => {
 
 export default class Platform extends React.Component {
   render() {
-    const { platform, $injector, repoName } = this.props;
+    const { platform, $injector, repoName, filterPlatformCb } = this.props;
 
     return (
       <tr id={platform.id} key={platform.id}>
@@ -22,6 +22,8 @@ export default class Platform extends React.Component {
           groups={platform.groups}
           repoName={repoName}
           $injector={$injector}
+          filterPlatformCb={filterPlatformCb}
+          platform={platform}
         />
       </tr>
     );

--- a/ui/job-view/PushList.jsx
+++ b/ui/job-view/PushList.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import Push from './Push';
-import { findInstance, findSelectedInstance, scrollToElement } from '../helpers/jobHelper';
+import {
+  findInstance,
+  findSelectedInstance,
+  findJobInstance,
+  scrollToElement
+} from '../helpers/jobHelper';
 import PushLoadErrors from './PushLoadErrors';
 
 export default class PushList extends React.Component {
@@ -82,6 +87,15 @@ export default class PushList extends React.Component {
         }
       }
     );
+
+    this.jobsClassifiedUnlisten = this.$rootScope.$on(
+      this.thEvents.jobsClassified, (ev, { jobs }) => {
+        Object.values(jobs).forEach((job) => {
+          findJobInstance(job.id).props.job.failure_classification_id = job.failure_classification_id;
+        });
+        this.$rootScope.$emit(this.thEvents.globalFilterChanged);
+      }
+    );
   }
 
   componentWillUnmount() {
@@ -91,6 +105,7 @@ export default class PushList extends React.Component {
     this.clearSelectedJobUnlisten();
     this.changeSelectionUnlisten();
     this.jobsLoadedUnlisten();
+    this.jobsClassifiedUnlisten();
   }
 
   getNextPushes(count, keepFilters) {


### PR DESCRIPTION
The problem here was that when a job was classified in "unclassified only" mode, then it disappeared.  When we had ``clonejobs.js`` it still existed, but was hidden.  In React, it's actually gone.  So we had no idea how to find the right NEXT job, and it just started at the beginning.  This change will keep a job visible in unclassified only mode as long as its selected.  As soon as you nav off the job, it disappears.

This had to pass a reference of each job's ``Platform`` as well as a callback function for filtering platforms so that when a job is set to no longer selected, we can check if it then disappears and the group or entire platform should be "disappeared."  Since this partially hinges off of whether the job is or WAS selected, we have to pass the ``selectedJobId`` around a bit more.

This also fixes [Bug 1438315](https://bugzilla.mozilla.org/show_bug.cgi?id=1438315) - Pinned jobs take a long time to show the annotation.  These two bugs were related so it made sense to fix them at the same time.