### PR TITLE
Revert BugJobMap foreign key part of 4db1aa4 (bug 1367362)

### DIFF
--- a/tests/autoclassify/test_classify_failures.py
+++ b/tests/autoclassify/test_classify_failures.py
@@ -130,7 +130,7 @@ def test_autoclassified_after_manual_classification(test_user,
     bug = bugs.first()
 
     BugJobMap.objects.create(job=test_job_2,
-                             bug=bug,
+                             bug_id=bug.id,
                              user=test_user)
     JobNote.objects.create(job=test_job_2,
                            failure_classification_id=4,

--- a/tests/webapp/api/test_bug_job_map_api.py
+++ b/tests/webapp/api/test_bug_job_map_api.py
@@ -60,7 +60,7 @@ def test_bug_job_map_list(webapp, test_repository, eleven_jobs_stored, test_user
     expected = list()
 
     for (i, job) in enumerate(jobs):
-        bjm = BugJobMap.objects.create(job=job, bug=bugs[i],
+        bjm = BugJobMap.objects.create(job=job, bug_id=bugs[i].id,
                                        user=test_user)
         expected.append({
             "job_id": job.id,
@@ -90,7 +90,7 @@ def test_bug_job_map_detail(webapp, eleven_jobs_stored, test_repository,
     expected = list()
 
     bjm = BugJobMap.objects.create(job=job,
-                                   bug=bug,
+                                   bug_id=bug.id,
                                    user=test_user)
 
     pk = "{0}-{1}".format(job.id, bug.id)
@@ -122,7 +122,7 @@ def test_bug_job_map_delete(webapp, eleven_jobs_stored, test_repository,
     bug = bugs[0]
 
     BugJobMap.objects.create(job=job,
-                             bug=bug,
+                             bug_id=bug.id,
                              user=test_user)
 
     client = APIClient()

--- a/treeherder/model/migrations/0022_modify_bugscache_and_bugjobmap.py
+++ b/treeherder/model/migrations/0022_modify_bugscache_and_bugjobmap.py
@@ -18,25 +18,6 @@ class Migration(migrations.Migration):
             field=models.CharField(blank=True, default='', max_length=100),
         ),
         migrations.AlterField(
-            model_name='bugjobmap',
-            name='bug_id',
-            field=models.PositiveIntegerField(db_index=True, db_column='bug_id'),
-        ),
-        migrations.RenameField(
-            model_name='bugjobmap',
-            old_name='bug_id',
-            new_name='bug',
-        ),
-        migrations.AlterUniqueTogether(
-            name='bugjobmap',
-            unique_together=set([('job', 'bug')]),
-        ),
-        migrations.AlterField(
-            model_name='bugjobmap',
-            name='bug',
-            field=models.ForeignKey(on_delete=models.CASCADE, to='model.Bugscache', related_name='bugmap'),
-        ),
-        migrations.AlterField(
             model_name='push',
             name='time',
             field=models.DateTimeField(db_index=True),

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -689,13 +689,13 @@ class BugJobMap(models.Model):
     id = models.BigAutoField(primary_key=True)
 
     job = models.ForeignKey(Job, on_delete=models.CASCADE)
-    bug = models.ForeignKey(Bugscache, on_delete=models.CASCADE, related_name='bugmap')
+    bug_id = models.PositiveIntegerField(db_index=True)
     created = models.DateTimeField(default=timezone.now)
     user = models.ForeignKey(User, on_delete=models.CASCADE, null=True)  # null if autoclassified
 
     class Meta:
         db_table = "bug_job_map"
-        unique_together = ('job', 'bug')
+        unique_together = ('job', 'bug_id')
 
     @property
     def who(self):

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -180,7 +180,6 @@ class JobDetailSerializer(serializers.ModelSerializer):
 
 
 class BugJobMapSerializer(serializers.ModelSerializer):
-    bug_id = serializers.PrimaryKeyRelatedField(source="bug", read_only=True)
     job_id = serializers.PrimaryKeyRelatedField(
         source="job", read_only=True)
 


### PR DESCRIPTION
Since unfortunately the migration failed on stage due to:
```
IntegrityError: (1452, 'Cannot add or update a child row: a foreign
key constraint fails (`treeherder`.`#sql-1c26_1936a5`, CONSTRAINT
`bug_job_map_bug_id_013db14b_fk_bugscache_id` FOREIGN KEY (`bug_id`)
REFERENCES `bugscache` (`id`))')
```

I believe this is due to the fact that bug numbers are sometimes manually entered when classifying failures (eg for infra failures), meaning that not every bug ID in `BugJobMap` is for an intermittent bug, and so doesn't exist in `Bugscache` (which is currently only populated with bugs that have the keyword `intermittent-failure`).

This wasn't caught on prototype, since whilst that has some failure classifications saved, none of them where hand-entered and so all existed in `Bugscache`, satisfying the new constraint.

I've edited the existing migrations file since in most environments it won't have already run (I'll fix up prototype/stage by hand). The non-FK changes have been left as-is, since they are working fine.