### PR TITLE
Add the Windows MinGW Platform to the Platform Mapping

### DIFF
--- a/ui/js/constants.js
+++ b/ui/js/constants.js
@@ -70,6 +70,7 @@ export const platformMap = {
     "windows2012-64-noopt": "Windows 2012 x64 NoOpt",
     "windows2012-64-devedition": "Windows 2012 x64 DevEdition",
     "windows2012-64-dmd": "Windows 2012 x64 DMD",
+    "windows-mingw32": "Windows MinGW",
 
     "android-2-2-armv6": "Android 2.2 Armv6",
     "android-2-2": "Android 2.2",


### PR DESCRIPTION
Once https://bugzilla.mozilla.org/show_bug.cgi?id=1439365 lands it will look like this: https://treeherder.mozilla.org/#/jobs?repo=try&revision=b1e1956ee2daa787cc623f09f7675e89c86987fc

It'd be nice to have a nice platform mapping for MinGW.