### PR TITLE
Redirect user to origin if user navigates to the login route directly

### DIFF
--- a/ui/js/auth/LoginCallback.jsx
+++ b/ui/js/auth/LoginCallback.jsx
@@ -39,6 +39,7 @@ export default class LoginCallback extends React.PureComponent {
         if (window.opener) {
           window.close();
         } else {
+          // handle case where the user navigates directly to the login route
           window.location.href = window.origin;
         }
       }

--- a/ui/js/auth/LoginCallback.jsx
+++ b/ui/js/auth/LoginCallback.jsx
@@ -38,6 +38,8 @@ export default class LoginCallback extends React.PureComponent {
 
         if (window.opener) {
           window.close();
+        } else {
+          window.location.href = window.origin;
         }
       }
     } catch (err) {


### PR DESCRIPTION
STR:

1. Navigate to `localhost:8000/login.html`
2. Login

Expected: User is redirected to `localhost:8000`
Actual: The spinner is shown

Reason: The user did not click the login button in the main page of treeherder. They navigated to the login route directly.