### PR TITLE
Bug 1440774 - Convert AngularJS dependency factories to ES6 imports

### DIFF
--- a/tests/ui/unit/init.js
+++ b/tests/ui/unit/init.js
@@ -15,7 +15,6 @@ require('angular-sanitize');
 require('angular-local-storage');
 require('angular-toarrayfilter');
 require('mousetrap');
-require('js-yaml');
 require('ngreact');
 require('angular1-ui-bootstrap4');
 require('angular-marked');

--- a/ui/entry-index.js
+++ b/ui/entry-index.js
@@ -25,7 +25,6 @@ require('angular-local-storage');
 require('bootstrap/dist/js/bootstrap');
 require('angular1-ui-bootstrap4');
 require('mousetrap');
-require('js-yaml');
 require('angular-marked');
 require('ngreact');
 require('jquery.scrollto');

--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -1,3 +1,5 @@
+import metricsgraphics from 'metrics-graphics';
+
 perf.controller('CompareChooserCtrl', [
     '$state', '$stateParams', '$scope', '$q', 'ThRepositoryModel', 'ThResultSetModel',
     'phCompareDefaultNewRepo', 'phCompareDefaultOriginalRepo',
@@ -865,9 +867,9 @@ perf.controller('CompareSubtestResultsCtrl', [
     }]);
 
 perf.controller('CompareSubtestDistributionCtrl', ['$scope', '$stateParams', '$q', 'ThRepositoryModel',
-    'PhSeries', 'ThResultSetModel', 'metricsgraphics',
+    'PhSeries', 'ThResultSetModel',
     function CompareSubtestDistributionCtrl($scope, $stateParams, $q, ThRepositoryModel,
-        PhSeries, ThResultSetModel, metricsgraphics) {
+        PhSeries, ThResultSetModel) {
         $scope.originalRevision = $stateParams.originalRevision;
         $scope.newRevision = $stateParams.newRevision;
         $scope.originalSubtestSignature = $stateParams.originalSubtestSignature;

--- a/ui/js/controllers/tcjobactions.js
+++ b/ui/js/controllers/tcjobactions.js
@@ -1,13 +1,15 @@
+import Ajv from 'ajv';
+import jsonSchemaDefaults from 'json-schema-defaults';
+import jsyaml from 'js-yaml';
 import { slugid } from 'taskcluster-client-web';
 
 treeherder.controller('TCJobActionsCtrl', [
     '$scope', '$uibModalInstance', 'ThResultSetStore',
     'ThTaskclusterErrors',
     'thNotify', 'job', 'repoName', 'resultsetId', 'tcactions',
-    'jsyaml', 'Ajv', 'jsonSchemaDefaults',
     function ($scope, $uibModalInstance, ThResultSetStore,
              ThTaskclusterErrors, thNotify,
-             job, repoName, resultsetId, tcactions, jsyaml, Ajv, jsonSchemaDefaults) {
+             job, repoName, resultsetId, tcactions) {
         const ajv = new Ajv({ format: 'full', verbose: true, allErrors: true });
         let decisionTaskId;
         let originalTaskId;

--- a/ui/js/filters.js
+++ b/ui/js/filters.js
@@ -1,4 +1,4 @@
-/* Filters */
+import numeral from 'numeral';
 
 treeherder.filter('showOrHide', function () {
     // determine whether this is a label for a job group (like mochitest)
@@ -173,7 +173,7 @@ treeherder.filter('absoluteValue', function () {
     };
 });
 
-treeherder.filter('abbreviatedNumber', ['numeral', function (numeral) {
+treeherder.filter('abbreviatedNumber', function () {
     return input =>
         ((input.toString().length <= 5) ? input : numeral(input).format('0.0a'));
-}]);
+});

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -1,12 +1,13 @@
+import jsyaml from 'js-yaml';
 import { Queue, slugid } from 'taskcluster-client-web';
 import thTaskcluster from '../services/taskcluster';
 
 treeherder.factory('ThResultSetModel', ['$http', '$location',
     '$q', '$interpolate', 'thUrl', 'tcactions',
-    'thServiceDomain', 'ThJobModel', 'jsyaml',
+    'thServiceDomain', 'ThJobModel',
     function ($http, $location, $q, $interpolate, thUrl,
         tcactions, thServiceDomain,
-        ThJobModel, jsyaml) {
+        ThJobModel) {
 
         var MAX_RESULTSET_FETCH_SIZE = 100;
 

--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -185,16 +185,6 @@ treeherder.factory('thPlatformName', [
         };
     }]);
 
-treeherder.factory('jsyaml', [
-    function () {
-        return require('js-yaml');
-    }]);
-
-treeherder.factory('Ajv', [
-    function () {
-        return require('ajv');
-    }]);
-
 // The Custom Actions modal is accessible from both the PushActionMenu and the
 // job-details-actionbar.  So leave this as Angular for now, till we
 // migrate job-details-actionbar to React.
@@ -221,11 +211,6 @@ treeherder.factory('customPushActions', [
         };
     }]);
 
-treeherder.factory('jsonSchemaDefaults', [
-    function () {
-        return require('json-schema-defaults');
-    }]);
-
 treeherder.factory('thExtendProperties', [
     /* Version of _.extend that works with property descriptors */
     function () {
@@ -250,14 +235,4 @@ treeherder.factory('thExtendProperties', [
             }
             return dest;
         };
-    }]);
-
-treeherder.factory('numeral', [
-    function () {
-        return require('numeral');
-    }]);
-
-treeherder.factory('metricsgraphics', [
-    function () {
-        return require('metrics-graphics');
     }]);

--- a/ui/js/services/tcactions.js
+++ b/ui/js/services/tcactions.js
@@ -1,11 +1,10 @@
+import jsone from 'json-e';
 import { Queue } from 'taskcluster-client-web';
 import thTaskcluster from './taskcluster';
 
 treeherder.factory('tcactions', [
     '$q', '$http', 'thNotify',
     function ($q, $http, thNotify) {
-        const jsone = require('json-e');
-
         return {
             render: (template, context) => jsone(template, context),
             submit: ({ action, actionTaskId, decisionTaskId, taskId,

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -1,3 +1,4 @@
+import jsyaml from 'js-yaml';
 import { Queue, slugid } from 'taskcluster-client-web';
 import thTaskcluster from '../js/services/taskcluster';
 import { getStatus } from '../helpers/jobHelper';
@@ -10,7 +11,7 @@ treeherder.controller('PluginCtrl', [
     '$q', 'thPinboard',
     'ThJobDetailModel', 'thBuildApi', 'thNotify', 'ThJobLogUrlModel', 'ThModelErrors', 'ThTaskclusterErrors',
     'thTabs', '$timeout', 'thReftestStatus', 'ThResultSetStore',
-    'PhSeries', 'thServiceDomain', 'jsyaml', 'tcactions',
+    'PhSeries', 'thServiceDomain', 'tcactions',
     function PluginCtrl(
         $scope, $rootScope, $location, $http, $interpolate, $uibModal,
         thUrl, ThJobClassificationModel,
@@ -19,7 +20,7 @@ treeherder.controller('PluginCtrl', [
         $q, thPinboard,
         ThJobDetailModel, thBuildApi, thNotify, ThJobLogUrlModel, ThModelErrors, ThTaskclusterErrors, thTabs,
         $timeout, thReftestStatus, ThResultSetStore, PhSeries,
-        thServiceDomain, jsyaml, tcactions) {
+        thServiceDomain, tcactions) {
 
         $scope.job = {};
         $scope.revisionList = [];


### PR DESCRIPTION
Since it's the cleaner way to declare dependencies and is another small step towards migrating away from AngularJS.