### PR TITLE
Bug 1428032 - Grant visibility for new issue_tracker table

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -33,6 +33,7 @@ The following SQL should be sufficient to generate such a user
     GRANT SELECT ON treeherder.failure_match to 'myuser';
     GRANT SELECT ON treeherder.group to 'myuser';
     GRANT SELECT ON treeherder.group_failure_lines to 'myuser';
+    GRANT SELECT ON treeherder.issue_tracker to 'myuser';
     GRANT SELECT ON treeherder.job to 'myuser';
     GRANT SELECT ON treeherder.job_detail to 'myuser';
     GRANT SELECT ON treeherder.job_group to 'myuser';


### PR DESCRIPTION
Bug 1428032 introduced the `issue_tracker` table, but production database users cannot view it. I updated the docs with the SQL config script used for granting the rights.