### PR TITLE
Bug 1441215 - Fix unwanted reload of detail panel

### DIFF
--- a/ui/job-view/PushList.jsx
+++ b/ui/job-view/PushList.jsx
@@ -54,10 +54,14 @@ export default class PushList extends React.Component {
 
     this.jobsLoadedUnlisten = this.$rootScope.$on(this.thEvents.jobsLoaded, () => {
       const pushList = [...this.ThResultSetStore.getPushArray()];
-      const selectedJobId = parseInt(this.$location.search().selectedJob);
-      if (selectedJobId) {
-        this.setSelectedJobFromQueryString(selectedJobId);
+
+      if (!this.state.jobsReady) {
+        const selectedJobId = parseInt(this.$location.search().selectedJob);
+        if (selectedJobId) {
+          this.setSelectedJobFromQueryString(selectedJobId);
+        }
       }
+
       this.$timeout(() => {
         this.setState({ pushList, jobsReady: true });
       }, 0);


### PR DESCRIPTION
We should only try to set selected job from url (and thereby loading the details panel) on a page first load.  Otherwise, it reloads every time we fetch new jobs.