### PR TITLE
Bug 1441493 - Use rel="noopener" for all target != null links

### DIFF
--- a/docs/submitting_data.rst
+++ b/docs/submitting_data.rst
@@ -403,7 +403,7 @@ will be rendered. Here are the possible values:
 
     .. code-block:: html
 
-      {{title}}: <a title="{{value}}" href="{{url}}" target="_blank">{{value}}</a>
+      {{title}}: <a title="{{value}}" href="{{url}}" target="_blank" rel="noopener">{{value}}</a>
 
 * **Raw Html** - The last resource for when you need to show some formatted
   content.

--- a/tests/ui/unit/filters.tests.js
+++ b/tests/ui/unit/filters.tests.js
@@ -8,7 +8,7 @@ describe('linkifyURLs filter', function() {
     it('linkifies a URL', function() {
         var linkifyURLs = $filter('linkifyURLs');
         expect(linkifyURLs('https://www.mozilla.org'))
-          .toEqual('<a href="https://www.mozilla.org" target="_blank">https://www.mozilla.org</a>');
+          .toEqual('<a href="https://www.mozilla.org" target="_blank" rel="noopener">https://www.mozilla.org</a>');
     });
 
     it('does not linkify a non-URL', function() {
@@ -19,7 +19,7 @@ describe('linkifyURLs filter', function() {
     it('linkifies a mix of URL and non-URL', function() {
         var linkifyURLs = $filter('linkifyURLs');
         expect(linkifyURLs('This is a test: https://www.mozilla.org Did I pass?'))
-          .toEqual('This is a test: <a href="https://www.mozilla.org" target="_blank">https://www.mozilla.org</a> Did I pass?');
+          .toEqual('This is a test: <a href="https://www.mozilla.org" target="_blank" rel="noopener">https://www.mozilla.org</a> Did I pass?');
     });
 });
 

--- a/ui/job-view/PushActionMenu.jsx
+++ b/ui/job-view/PushActionMenu.jsx
@@ -117,6 +117,7 @@ export default class PushActionMenu extends React.PureComponent {
           }
           <li><a
             target="_blank"
+            rel="noopener"
             className="dropdown-item"
             href={`https://secure.pub.build.mozilla.org/buildapi/self-serve/${repoName}/rev/${revision}`}
           >BuildAPI</a></li>
@@ -134,7 +135,7 @@ export default class PushActionMenu extends React.PureComponent {
           }
           <li><a
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             className="dropdown-item"
             href={`https://bugherder.mozilla.org/?cset=${revision}&tree=${repoName}`}
             title="Use Bugherder to mark the bugs in this push"

--- a/ui/job-view/PushHeader.jsx
+++ b/ui/job-view/PushHeader.jsx
@@ -194,6 +194,7 @@ export default class PushHeader extends React.PureComponent {
               className="btn btn-sm btn-push test-view-btn"
               href={`/testview.html?repo=${repoName}&revision=${revision}`}
               target="_blank"
+              rel="noopener"
               title="View details on failed test results for this push"
             >View Tests</a>
             {canCancelJobs &&

--- a/ui/job-view/PushLoadErrors.jsx
+++ b/ui/job-view/PushLoadErrors.jsx
@@ -20,6 +20,7 @@ const PushLoadErrors = (props) => {
                   <a
                     href={currentRepo.getPushLogHref(revision)}
                     target="_blank"
+                    rel="noopener"
                     title={`open revision ${revision} on ${currentRepo.url}`}
                   >(view pushlog)</a>
                 <span className="fa fa-spinner fa-pulse th-spinner" />

--- a/ui/job-view/RevisionList.jsx
+++ b/ui/job-view/RevisionList.jsx
@@ -45,6 +45,7 @@ export const MoreRevisionsLink = props => (
       <a href={props.href}
          data-ignore-job-clear-on-click
          target="_blank"
+         rel="noopener"
       >{`\u2026and more`}<i className="fa fa-external-link-square" /></a>
     </li>
 );

--- a/ui/js/components/auth.js
+++ b/ui/js/components/auth.js
@@ -102,6 +102,7 @@ treeherder.component("login", {
              * if it's successful.
              */
             ctrl.login = function () {
+                // Intentionally not using `noopener` since `window.opener` used in LoginCallback.
                 $window.open('/login.html', '_blank');
             };
 

--- a/ui/js/filters.js
+++ b/ui/js/filters.js
@@ -11,7 +11,7 @@ treeherder.filter('linkifyURLs', function () {
     return function (input) {
         var str = input || '';
         var urlpattern = /(\b(https?):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gim;
-        str = str.replace(urlpattern, '<a href="$1" target="_blank">$1</a>');
+        str = str.replace(urlpattern, '<a href="$1" target="_blank" rel="noopener">$1</a>');
         return str;
     };
 });

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -48,7 +48,7 @@
           <li ng-if="jobExists">
             <a title="{{logError ? 'Raw log link no longer exists or has expired (click for path)' :
                       'Open the raw log in a new window'}}"
-               target="_blank"
+               target="_blank" rel="noopener"
                href="{{rawLogURL}}">
               <span ng-class="logError ? 'fa-warning actionbtn-warning' : 'fa-file-text-o actionbtn-icon'"
                     class="fa"></span>
@@ -59,7 +59,7 @@
           <!-- Ref test button -->
           <li ng-if="isReftest()" ng-cloak>
             <a title="Open the Reftest Analyser in a new window"
-               target="_blank"
+               target="_blank" rel="noopener"
                href="https://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl={{rawLogURL}}&only_show_unexpected=1">
               <span class="fa fa-bar-chart-o actionbtn-icon"></span>
               <span>open analyser</span>
@@ -116,7 +116,7 @@
                 </th>
                 <td ng-cloak>
                   <a ng-if="line.url" title="{{line.value}}"
-                     href="{{line.url}}" target="_blank">{{line.value}}</a>
+                     href="{{line.url}}" target="_blank" rel="noopener">{{line.value}}</a>
                   <span ng-if="!line.url" ng-bind-html="line.value"></span>
                 </td>
               </tr>

--- a/ui/partials/main/intermittent.html
+++ b/ui/partials/main/intermittent.html
@@ -55,19 +55,19 @@
         <input id="modalParsedLog" type="checkbox"
                ng-model="checkedLogLinks.parsedLog"
                ng-true-value="'{{parsedLog}}'"/>
-        <a target="_blank" href="{{ parsedLog }}">Include Parsed Log Link</a>
+        <a target="_blank" rel="noopener" href="{{ parsedLog }}">Include Parsed Log Link</a>
       </label><br/>
       <label>
         <input id="modalFullLog" type="checkbox"
                ng-model="checkedLogLinks.fullLog"
                ng-true-value="'{{fullLog}}'"/>
-        <a target="_blank"  href="{{ fullLog }}">Include Full Log Link</a>
+        <a target="_blank" rel="noopener"  href="{{ fullLog }}">Include Full Log Link</a>
       </label><br/>
       <label id="modalReftestLogLabel" ng-if="isReftest()">
         <input id="modalReftestLog" type="checkbox"
                ng-model="checkedLogLinks.reftest"
                ng-true-value="'{{reftest}}'"/>
-        <a target="_blank" href="{{ reftest }}">Include Reftest Viewer Link</a>
+        <a target="_blank" rel="noopener" href="{{ reftest }}">Include Reftest Viewer Link</a>
       </label>
     </div>
 

--- a/ui/partials/main/thGlobalTopNavPanel.html
+++ b/ui/partials/main/thGlobalTopNavPanel.html
@@ -40,7 +40,7 @@
               <span ng-switch-default></span>
               <small class="text-muted">{{::notification.created | date:'short'}}</small>
               {{::notification.message}}
-              <a ng-if="true" target="_blank"
+              <a ng-if="true" target="_blank" rel="noopener"
                  ng-href="{{notification.url}}">{{::notification.linkText}}</a>
             </span>
           </li>

--- a/ui/partials/main/thHelpMenu.html
+++ b/ui/partials/main/thHelpMenu.html
@@ -1,47 +1,47 @@
 <li>
-  <a href="userguide.html" target="_blank"
+  <a href="userguide.html" target="_blank" rel="noopener"
      class="dropdown-item">
     <span class="fa fa-question-circle midgray"></span>
     User Guide</a>
 </li>
 <li>
-  <a href="https://treeherder.readthedocs.io/" target="_blank"
+  <a href="https://treeherder.readthedocs.io/" target="_blank" rel="noopener"
      class="dropdown-item">
     <span class="fa fa-file-code-o midgray"></span>
     Development Documentation</a>
 </li>
 <li>
-  <a href="/docs/" target="_blank"
+  <a href="/docs/" target="_blank" rel="noopener"
      class="dropdown-item">
     <span class="fa fa-code midgray"></span>
     API Reference</a>
 </li>
 <li>
-  <a href="https://wiki.mozilla.org/EngineeringProductivity/Projects/Treeherder" target="_blank"
+  <a href="https://wiki.mozilla.org/EngineeringProductivity/Projects/Treeherder" target="_blank" rel="noopener"
      class="dropdown-item">
     <span class="fa fa-file-word-o midgray"></span>
     Project Wiki</a>
 </li>
 <li>
-  <a href="https://groups.google.com/forum/#!forum/mozilla.tools.treeherder" target="_blank"
+  <a href="https://groups.google.com/forum/#!forum/mozilla.tools.treeherder" target="_blank" rel="noopener"
      class="dropdown-item">
     <span class="fa fa-envelope-o midgray"></span>
     Mailing List</a>
 </li>
 <li>
-  <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&component=Treeherder" target="_blank"
+  <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&component=Treeherder" target="_blank" rel="noopener"
      class="dropdown-item">
     <span class="fa fa-bug midgray"></span>
     Report a Bug</a>
 </li>
 <li>
-  <a href="https://github.com/mozilla/treeherder" target="_blank"
+  <a href="https://github.com/mozilla/treeherder" target="_blank" rel="noopener"
      class="dropdown-item">
     <span class="fa fa-github midgray"></span>
     Source</a>
 </li>
 <li>
-  <a href="https://whatsdeployed.io/?owner=mozilla&amp;repo=treeherder&amp;name[]=Stage&amp;url[]=https://treeherder.allizom.org/revision.txt&amp;name[]=Prod&amp;url[]=https://treeherder.mozilla.org/revision.txt" target="_blank"
+  <a href="https://whatsdeployed.io/?owner=mozilla&amp;repo=treeherder&amp;name[]=Stage&amp;url[]=https://treeherder.allizom.org/revision.txt&amp;name[]=Prod&amp;url[]=https://treeherder.mozilla.org/revision.txt" target="_blank" rel="noopener"
      class="dropdown-item">
     <span class="fa fa-question midgray"></span>
     What's Deployed?</a>

--- a/ui/partials/main/thInfraMenu.html
+++ b/ui/partials/main/thInfraMenu.html
@@ -1,31 +1,31 @@
 <li role="presentation" class="dropdown-header">Buildbot</li>
 <li>
   <a class="dropdown-item" href="https://secure.pub.build.mozilla.org/buildapi/pending"
-     target="_blank">BuildAPI: Pending</a>
+     target="_blank" rel="noopener">BuildAPI: Pending</a>
 </li>
 <li>
   <a class="dropdown-item" href="https://secure.pub.build.mozilla.org/buildapi/running"
-     target="_blank">BuildAPI: Running</a>
+     target="_blank" rel="noopener">BuildAPI: Running</a>
 </li>
 <li>
   <a class="dropdown-item" href="https://www.hostedgraphite.com/da5c920d/86a8384e-d9cf-4208-989b-9538a1a53e4b/grafana2/#/dashboard/db/ec2-dashboard"
-     target="_blank">EC2 Dashboard</a>
+     target="_blank" rel="noopener">EC2 Dashboard</a>
 </li>
 <li>
   <a class="dropdown-item" href="https://secure.pub.build.mozilla.org/builddata/reports/slave_health/"
-     target="_blank">Slave Health</a>
+     target="_blank" rel="noopener">Slave Health</a>
 </li>
 <li>
   <a class="dropdown-item" href="https://api.pub.build.mozilla.org/clobberer/"
-     target="_blank">Clobberer</a>
+     target="_blank" rel="noopener">Clobberer</a>
 </li>
 <li role="presentation" class="dropdown-divider"></li>
 <li role="presentation" class="dropdown-header">Other</li>
 <li>
   <a class="dropdown-item" href="https://mozilla-releng.net/treestatus"
-     target="_blank">TreeStatus</a>
+     target="_blank" rel="noopener">TreeStatus</a>
 </li>
 <li>
   <a class="dropdown-item" href="https://tools.taskcluster.net/diagnostics"
-     target="_blank">TaskCluster</a>
+     target="_blank" rel="noopener">TaskCluster</a>
 </li>

--- a/ui/partials/main/thRelatedBugQueued.html
+++ b/ui/partials/main/thRelatedBugQueued.html
@@ -2,7 +2,7 @@
   <a class="btn btn-xs related-bugs-link"
      title="{{::bug.summary}}"
      href="{{:: getBugUrl(bug.id) }}"
-     target="_blank"><em>{{::bug.id}}</em></a>
+     target="_blank" rel="noopener"><em>{{::bug.id}}</em></a>
   <span class="btn btn-ltgray btn-xs pinned-job-close-btn"
         ng-click="removeBug(bug.id)"
         title="remove this bug"><i class="fa fa-times"></i></span>

--- a/ui/partials/main/thWatchedRepoInfoDropDown.html
+++ b/ui/partials/main/thWatchedRepoInfoDropDown.html
@@ -10,14 +10,14 @@
   <li class="watched-repo-dropdown-item">
     <a href="https://mozilla-releng.net/treestatus/show/{{::treeStatus}}"
        class="dropdown-item"
-       target="_blank">Tree Status</a>
+       target="_blank" rel="noopener">Tree Status</a>
   </li>
   <li class="watched-repo-dropdown-item">
-    <a href="{{::pushlog}}" class="dropdown-item" target="_blank">Pushlog</a>
+    <a href="{{::pushlog}}" class="dropdown-item" target="_blank" rel="noopener">Pushlog</a>
   </li>
   <li class="watched-repo-dropdown-item">
     <a href="https://api.pub.build.mozilla.org/clobberer/?branch={{::name}}"
        class="dropdown-item"
-       target="_blank">Clobberer</a>
+       target="_blank" rel="noopener">Clobberer</a>
   </li>
 </ul>

--- a/ui/partials/perf/alertsctrl.html
+++ b/ui/partials/perf/alertsctrl.html
@@ -54,12 +54,12 @@
             {{alertSummary.resultSetMetadata.revision | limitTo: 12}}
           </button>
           <ul class="uib-dropdown-menu" uib-dropdown-menu aria-labelledby="push-dropdown">
-            <li role="menuitem"><a href="{{alertSummary.jobsURL}}" target="_blank" class="dropdown-item">Jobs</a></li>
-            <li role="menuitem"><a href="{{alertSummary.pushlogURL}}" target="_blank" class="dropdown-item">Pushlog</a></li>
+            <li role="menuitem"><a href="{{alertSummary.jobsURL}}" target="_blank" rel="noopener" class="dropdown-item">Jobs</a></li>
+            <li role="menuitem"><a href="{{alertSummary.pushlogURL}}" target="_blank" rel="noopener" class="dropdown-item">Pushlog</a></li>
           </ul>
         </span>
         <span ng-show="alertSummary.bug_number"> ·
-          <a href="{{alertSummary.getIssueTrackerUrl()}}" target="_blank">
+          <a href="{{alertSummary.getIssueTrackerUrl()}}" target="_blank" rel="noopener">
             Bug {{alertSummary.bug_number}}
           </a>
         </span>
@@ -121,17 +121,17 @@
           &nbsp;(<span ng-class="{'alert-invalid': alert.isInvalid(), 'alert-untriaged': alert.isUntriaged()}">{{alert.getStatusText()}}</span><span ng-show="alert.related_summary_id">
             <!-- Reassigned or downstream *to* another alert -->
             <span ng-if="alert.related_summary_id !== alertSummary.id">
-              to <a href="#/alerts?id={{alert.related_summary_id}}" target="_blank">alert #{{alert.related_summary_id}}</a>
+              to <a href="#/alerts?id={{alert.related_summary_id}}" target="_blank" rel="noopener">alert #{{alert.related_summary_id}}</a>
             </span>
             <!-- Reassigned or downstream *from* the another alert -->
             <span ng-if="alert.related_summary_id === alertSummary.id">
-              from <a href="#/alerts?id={{alert.summary_id}}" target="_blank" >alert #{{alert.summary_id}}</a>
+              from <a href="#/alerts?id={{alert.summary_id}}" target="_blank" rel="noopener" >alert #{{alert.summary_id}}</a>
             </span>
           </span>)&nbsp;&nbsp;
           <span class="result-links">
-            <a href="{{alert.getGraphsURL(alertSummary.resultSetMetadata.timeRange, alertSummary.repository, alertSummary.framework)}}" target="_blank">graph</a>
+            <a href="{{alert.getGraphsURL(alertSummary.resultSetMetadata.timeRange, alertSummary.repository, alertSummary.framework)}}" target="_blank" rel="noopener">graph</a>
             <span ng-if="alert.series_signature.has_subtests"> · </span>
-            <a ng-if="alert.series_signature.has_subtests" href="{{alert.getSubtestsURL(alertSummary)}}" target="_blank">subtests</a>
+            <a ng-if="alert.series_signature.has_subtests" href="{{alert.getSubtestsURL(alertSummary)}}" target="_blank" rel="noopener">subtests</a>
           </span>
         </td>
         <td class="alert-value">{{alert.prev_value|number}}</td>

--- a/ui/partials/perf/graphsctrl.html
+++ b/ui/partials/perf/graphsctrl.html
@@ -70,11 +70,11 @@
       </div>
       <div>
         <p ng-show="tooltipContent.revision">
-          <a id="tt-cset" ng-href="{{tooltipContent.pushlogURL}}" target="_blank">
+          <a id="tt-cset" ng-href="{{tooltipContent.pushlogURL}}" target="_blank" rel="noopener">
             {{tooltipContent.revision| limitTo: 12}}
           </a>
           <span ng-show="tooltipContent.prevRevision && tooltipContent.revision">
-            (<span ng-if="tooltipContent.jobId"><a id="tt-cset" ng-href="{{tooltipContent.revision | getRevisionUrl:tooltipContent.project.name}}&selectedJob={{tooltipContent.jobId}}&group_state=expanded" target="_blank">job</a>, </span><a ng-href="#/comparesubtest?originalProject={{tooltipContent.project.name}}&newProject={{tooltipContent.project.name}}&originalRevision={{tooltipContent.prevRevision}}&newRevision={{tooltipContent.revision}}&originalSignature={{selectedDataPoint.signature}}&newSignature={{selectedDataPoint.signature}}&framework={{selectedDataPoint.frameworkId}}" target="_blank">compare</a>)
+            (<span ng-if="tooltipContent.jobId"><a id="tt-cset" ng-href="{{tooltipContent.revision | getRevisionUrl:tooltipContent.project.name}}&selectedJob={{tooltipContent.jobId}}&group_state=expanded" target="_blank" rel="noopener">job</a>, </span><a ng-href="#/comparesubtest?originalProject={{tooltipContent.project.name}}&newProject={{tooltipContent.project.name}}&originalRevision={{tooltipContent.prevRevision}}&newRevision={{tooltipContent.revision}}&originalSignature={{selectedDataPoint.signature}}&newSignature={{selectedDataPoint.signature}}&framework={{selectedDataPoint.frameworkId}}" target="_blank" rel="noopener">compare</a>)
           </span>
         </p>
         <p ng-if="tooltipContent.alertSummary">
@@ -84,10 +84,10 @@
         <span class="text-muted">- {{tooltipContent.alert.isAcknowledged() ? tooltipContent.alertSummary.getStatusText() : tooltipContent.alert.getStatusText()}}
             <span ng-show="tooltipContent.alert.related_summary_id">
               <span ng-if="tooltipContent.alert.related_summary_id !== tooltipContent.alertSummary.id">
-              to <a href="#/alerts?id={{tooltipContent.alert.related_summary_id}}" target="_blank">alert #{{tooltipContent.alert.related_summary_id}}</a>
+              to <a href="#/alerts?id={{tooltipContent.alert.related_summary_id}}" target="_blank" rel="noopener">alert #{{tooltipContent.alert.related_summary_id}}</a>
             </span>
             <span ng-if="tooltipContent.alert.related_summary_id === tooltipContent.alertSummary.id">
-              from <a href="#/alerts?id={{tooltipContent.alert.related_summary_id}}" target="_blank">alert #{{tooltipContent.alert.related_summary_id}}</a>
+              from <a href="#/alerts?id={{tooltipContent.alert.related_summary_id}}" target="_blank" rel="noopener">alert #{{tooltipContent.alert.related_summary_id}}</a>
             </span>
             </span>
           </span>

--- a/ui/partials/perf/helpMenu.html
+++ b/ui/partials/perf/helpMenu.html
@@ -1,25 +1,25 @@
 <li>
-  <a class="dropdown-item" href="https://treeherder.readthedocs.io/" target="_blank">
+  <a class="dropdown-item" href="https://treeherder.readthedocs.io/" target="_blank" rel="noopener">
     <span class="fa fa-file-code-o midgray"></span>
     Development Documentation</a>
 </li>
 <li>
-  <a class="dropdown-item" href="/docs/" target="_blank">
+  <a class="dropdown-item" href="/docs/" target="_blank" rel="noopener">
     <span class="fa fa-code midgray"></span>
     API Reference</a>
 </li>
 <li>
-  <a class="dropdown-item" href="https://wiki.mozilla.org/EngineeringProductivity/Projects/Perfherder" target="_blank">
+  <a class="dropdown-item" href="https://wiki.mozilla.org/EngineeringProductivity/Projects/Perfherder" target="_blank" rel="noopener">
     <span class="fa fa-file-word-o midgray"></span>
     Project Wiki</a>
 </li>
 <li>
-  <a class="dropdown-item" href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree%20Management&component=Perfherder" target="_blank">
+  <a class="dropdown-item" href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree%20Management&component=Perfherder" target="_blank" rel="noopener">
     <span class="fa fa-bug midgray"></span>
     Report a Bug</a>
 </li>
 <li>
-  <a class="dropdown-item" href="https://github.com/mozilla/treeherder" target="_blank">
+  <a class="dropdown-item" href="https://github.com/mozilla/treeherder" target="_blank" rel="noopener">
     <span class="fa fa-github midgray"></span>
     Source</a>
 </li>

--- a/ui/plugins/annotations_panel.jsx
+++ b/ui/plugins/annotations_panel.jsx
@@ -11,6 +11,7 @@ const RelatedBugSaved = (props) => {
             <a className="btn btn-xs annotations-bug related-bugs-link"
                href={props.getBugUrl(props.bug.bug_id)}
                target="_blank"
+               rel="noopener"
                title={`View bug ${props.bug.bug_id}`}
             >
             <em>{props.bug.bug_id}</em>

--- a/ui/plugins/auto_classification/errorLine.html
+++ b/ui/plugins/auto_classification/errorLine.html
@@ -44,14 +44,14 @@
       application crashed [{{ ::failureLine.signature }}]
     </span>
     <span>[<a title="Open the log viewer in a new window"
-       target="_blank"
+       target="_blank" rel="noopener"
        href="{{ logUrl }}"
        class="">log…</a>]</span>
   </div>
   <div ng-if="!failureLine">
     <span ng-bind-html="::searchLine | escapeHTML | highlightLogLine"></span>
     <span>[<a title="Open the log viewer in a new window"
-       target="_blank"
+       target="_blank" rel="noopener"
        href="{{ logUrl }}"
        class="">log…</a>]</span>
   </div>
@@ -60,7 +60,7 @@
     <span class="fa fa-star best-classification-star"></span>
     <span class="line-option-text" ng-if="line.bugNumber">
       <a href="{{ ::getBugUrl(line.bugNumber) }}"
-         target="_blank">Bug {{ ::line.bugNumber }} -
+         target="_blank" rel="noopener">Bug {{ ::line.bugNumber }} -
         <span ng-if="line.bugSummary"
               ng-bind-html="line.bugSummary | escapeHTML"></span>
       </a>

--- a/ui/plugins/auto_classification/option.html
+++ b/ui/plugins/auto_classification/option.html
@@ -24,7 +24,7 @@
     </button>
     <span ng-if="option.bugResolution" class="classification-bug-resolution">[{{ option.bugResolution }}]</span>
     <a href="{{ ::getBugUrl(option.bugNumber) }}"
-       target="_blank">{{::option.bugNumber}} -
+       target="_blank" rel="noopener">{{::option.bugNumber}} -
       <span ng-bind-html="option.bugSummary | escapeHTML | highlightCommonTerms:line.data.bug_suggestions.search"></span>
     </a>
     <span>[ {{ option.score | number: 2 }} ]</span>
@@ -53,7 +53,7 @@
 
     <a ng-if="$ctrl.selectedOption.id == 'manual' && $ctrl.selectedOption.manualBugNumber"
        href="{{ ::getBugUrl(selectedOption.manualBugNumber) }}"
-       target="_blank">
+       target="_blank" rel="noopener">
       [view]</a>
   </span>
 

--- a/ui/plugins/auto_classification/staticOption.html
+++ b/ui/plugins/auto_classification/staticOption.html
@@ -15,7 +15,7 @@
   </button>
   <span ng-if="option.bugResolution" class="classification-bug-resolution">[{{ option.bugResolution }}]</span>
   <a href="{{ ::getBugUrl(option.bugNumber) }}"
-     target="_blank">{{::option.bugNumber}} -
+     target="_blank" rel="noopener">{{::option.bugNumber}} -
     <span ng-bind-html="option.bugSummary | escapeHTML | highlightCommonTerms:line.data.bug_suggestions.search"></span>
   </a>
   <span>[ {{ option.score | number: 2 }} ]</span>
@@ -30,7 +30,7 @@
   Bug
   <a ng-if="$ctrl.selectedOption.manualBugNumber"
      href="{{ ::getBugUrl($ctrl.selectedOption.manualBugNumber) }}"
-     target="_blank">
+     target="_blank" rel="noopener">
     {{ $ctrl.selectedOption.manualBugNumber }}</a>
   <span ng-if="!$ctrl.selectedOption.manualBugNumber">
     No bug number specified</span>

--- a/ui/plugins/failure_summary_panel.jsx
+++ b/ui/plugins/failure_summary_panel.jsx
@@ -54,6 +54,7 @@ class SuggestionsListItem extends React.Component {
                 {/* <!--All other bugs--> */}
                 {this.props.suggestion.valid_all_others && this.props.suggestion.valid_open_recent &&
                 <a target="_blank"
+                   rel="noopener"
                    href=""
                    onClick={this.clickShowMore}
                    className="show-hide-more"
@@ -110,6 +111,7 @@ const BugListItem = (props) => {
             <a className={`${props.bugClassName} ml-1`}
                href={getBugUrl}
                target="_blank"
+               rel="noopener"
                title={props.title}
             >{props.bug.id}
                 <span className={`${props.bugClassName} ml-1`} dangerouslySetInnerHTML={bugSummaryHTML} />
@@ -124,6 +126,7 @@ const ErrorsList = (props) => {
         (<li key={index}>{error.name} : {error.result}.
             <a title="Open in Log Viewer"
                target="_blank"
+               rel="noopener"
                href={error.lvURL}
             ><span className="ml-1">View log</span></a>
         </li>));
@@ -177,6 +180,7 @@ class FailureSummaryPanel extends React.Component {
                         <p className="failure-summary-line-empty mb-0">Log parsing in progress.<br />
                         <a title="Open the raw log in a new window"
                            target="_blank"
+                           rel="noopener"
                            href={job.url}
                         >The raw log</a>
                         <span>is available. This panel will automatically recheck every 5 seconds.</span></p>

--- a/ui/plugins/job_details/main.html
+++ b/ui/plugins/job_details/main.html
@@ -3,7 +3,7 @@
     <li ng-repeat="line in job_details | orderBy:'title'" class="small">
       <label>{{line.title ? line.title : 'Untitled data'}}:</label>
       <!-- URL provided -->
-      <a ng-if="line.url" title="{{line.title ? line.title : line.value}}" href="{{line.url}}" target="_blank">{{line.value}}</a>
+      <a ng-if="line.url" title="{{line.title ? line.title : line.value}}" href="{{line.url}}" target="_blank" rel="noopener">{{line.value}}</a>
       <span ng-if="line.url && line.value.endsWith('raw.log')">
         - <a title="{{line.value}}" href="https://mozilla.github.io/wptview/#/?urls={{line.url | encodeURIComponent}},{{job_details[buildernameIndex].value | encodeURIComponent}}">open in test results viewer</a>
       </span>

--- a/ui/plugins/job_details_pane.jsx
+++ b/ui/plugins/job_details_pane.jsx
@@ -22,7 +22,7 @@ function ClassificationsPane(props) {
                 <span title={classificationName.name}><i className={`fa ${iconClass}`} />
                 <span className="ml-1">{classificationName.name}</span></span>
                 {props.bugs.length > 0 &&
-                <a target="_blank" href={props.getBugUrl(props.bugs[0].bug_id)}
+                <a target="_blank" rel="noopener" href={props.getBugUrl(props.bugs[0].bug_id)}
                 title={`View bug ${props.bugs[0].bug_id}`}
                 ><em> {props.bugs[0].bug_id}</em></a>}
             </li>
@@ -62,6 +62,7 @@ const JobDetailsListItem = props => (
            href={props.labelHref}
            onClick={props.labelOnclick}
            target={props.labelTarget}
+           rel="noopener"
         >
            {props.labelText} <span className="fa fa-pencil-square-o icon-superscript" />: </a>}
         {!props.href ? <span className="ml-1">{props.text}</span> :
@@ -70,6 +71,7 @@ const JobDetailsListItem = props => (
            href={props.href}
            onClick={props.onclick}
            target={props.target}
+           rel="noopener"
         >
            {props.text}</a>}
            {props.iconClass && <span className={`ml-1${props.iconClass}`} />}

--- a/ui/plugins/perf_details/main.html
+++ b/ui/plugins/perf_details/main.html
@@ -10,7 +10,7 @@
   <ul>
     <li>
       <a href="perf.html#/comparechooser?newProject={{repoName}}&newRevision={{jobRevision}}"
-         target="_blank">Compare result against another revision</a>
+         target="_blank" rel="noopener">Compare result against another revision</a>
     </li>
   </ul>
 

--- a/ui/plugins/pluginpanel.html
+++ b/ui/plugins/pluginpanel.html
@@ -18,7 +18,7 @@
             <a ng-if="job_log_url.parse_status == 'parsed'"
                id="logviewer-btn"
                title="Open the log viewer in a new window"
-               target="_blank"
+               target="_blank" rel="noopener"
                href="{{::lvUrl}}"
                copy-value="{{::lvFullUrl}}"
                class="">
@@ -54,7 +54,7 @@
             <a id="raw-log-btn"
                class="raw-log-icon"
                title="Open the raw log in a new window"
-               target="_blank"
+               target="_blank" rel="noopener"
                href="{{::job_log_url.url}}"
                copy-value="{{::job_log_url.url}}">
               <span class="fa fa-file-text-o"></span>
@@ -87,7 +87,7 @@
           </li>
           <li ng-if="isReftest()" ng-repeat="job_log_url in job_log_urls">
             <a title="Launch the Reftest Analyser in a new window"
-               target="_blank"
+               target="_blank" rel="noopener"
                href="{{::reftestUrl}}">
               <span class="fa fa-bar-chart-o"></span>
             </a>
@@ -122,12 +122,12 @@
                    ng-click="!canBackfill() || backfillJob()">Backfill</button>
               </li>
               <li ng-if-start="job.taskcluster_metadata">
-                <a target="_blank" class="dropdown-item" href="{{ getInspectTaskUrl(job.taskcluster_metadata.task_id) }}">Inspect Task</a>
+                <a target="_blank" rel="noopener" class="dropdown-item" href="{{ getInspectTaskUrl(job.taskcluster_metadata.task_id) }}">Inspect Task</a>
               </li>
-              <li><a target="_blank" class="dropdown-item" href="{{ getInspectTaskUrl(job.taskcluster_metadata.task_id) }}/create">Edit and Retrigger</a>
+              <li><a target="_blank" rel="noopener" class="dropdown-item" href="{{ getInspectTaskUrl(job.taskcluster_metadata.task_id) }}/create">Edit and Retrigger</a>
               </li>
               <li>
-                <a target="_blank" class="dropdown-item" href="https://tools.taskcluster.net/one-click-loaner/#{{job.taskcluster_metadata.task_id}}">One Click Loaner</a>
+                <a target="_blank" rel="noopener" class="dropdown-item" href="https://tools.taskcluster.net/one-click-loaner/#{{job.taskcluster_metadata.task_id}}">One Click Loaner</a>
               </li>
               <li ng-if-end>
                 <a ng-click="customJobAction()" class="dropdown-item">Custom Action...</a>

--- a/ui/plugins/similar_jobs/main.html
+++ b/ui/plugins/similar_jobs/main.html
@@ -64,7 +64,7 @@
                         <tr>
                             <th>Machine name</th>
                             <td>
-                                <a target="_blank" href="{{ getSlaveHealthUrl(similar_job_selected.machine_name) }}">
+                                <a target="_blank" rel="noopener" href="{{ getSlaveHealthUrl(similar_job_selected.machine_name) }}">
                                     {{ similar_job_selected.machine_name }}
                                 </a>
                             </td>

--- a/ui/test-view/ui/LogViewer.jsx
+++ b/ui/test-view/ui/LogViewer.jsx
@@ -8,6 +8,7 @@ export default class LogViewer extends React.Component {
       <span className="logviewer badge">
         <Link to={`/logviewer.html#/?repo=${this.props.repo}&job_id=${this.props.job.jobId}`}
               target="_blank"
+              rel="noopener"
               title="Open the log viewer in a new window"
         >
           <img src={logUrl} className="logviewer-icon" alt="" />

--- a/ui/test-view/ui/Test.jsx
+++ b/ui/test-view/ui/Test.jsx
@@ -71,6 +71,7 @@ class Platform extends React.Component {
         <Link
           to={`/#/jobs?repo=${this.props.repo}&revision=${this.props.revision}&selectedJob=${this.props.job.jobId}`}
           target="_blank"
+          rel="noopener"
         >
           {this.getIcon(this.props.job.failureClassification.name)}
           {this.props.platform} {this.props.option}
@@ -143,6 +144,7 @@ class TestComponent extends React.Component {
           {Object.values(this.props.test.bugs).map((bug, key) => (
             <div key={key}><Link to={`https://bugzilla.mozilla.org/show_bug.cgi?id=${bug.id}`}
                                  target="_blank"
+                                 rel="noopener"
             >{bug.id} - {bug.summary}</Link></div>
           ))}
         </div>}


### PR DESCRIPTION
This helps prevent:
https://www.owasp.org/index.php/Reverse_Tabnabbing

We're not also using `noreferrer`, since most browsers now support `noopener` (https://caniuse.com/#search=noopener) and the link targets are all Mozilla properties where the referrer may be useful.

The auth.js `window.open()` has not been changed, since the login callback makes use of `window.opener`.