### PR TITLE
Bug 1441851 - Fix thNotify calls using old-style sticky argument

### DIFF
--- a/ui/job-view/PushActionMenu.jsx
+++ b/ui/job-view/PushActionMenu.jsx
@@ -54,7 +54,8 @@ export default class PushActionMenu extends React.PureComponent {
           }, (e) => {
             this.thNotify.send(
               this.ThModelErrors.format(e, "The action 'trigger missing jobs' failed"),
-              'danger', true
+              'danger',
+              { sticky: true }
             );
           });
       });

--- a/ui/job-view/PushHeader.jsx
+++ b/ui/job-view/PushHeader.jsx
@@ -137,7 +137,8 @@ export default class PushHeader extends React.PureComponent {
     )).catch((e) => {
         this.thNotify.send(
           this.ThModelErrors.format(e, "Failed to cancel all jobs"),
-          'danger', true
+          'danger',
+          { sticky: true }
         );
     });
   }

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -491,7 +491,8 @@ treeherder.controller('PluginCtrl', [
             }).catch(function (e) {
                 thNotify.send(
                     ThModelErrors.format(e, "Unable to cancel job"),
-                    "danger", true
+                    "danger",
+                    { sticky: true }
                 );
             });
         };


### PR DESCRIPTION
The third argument was changed from a bool to an options object in bug 1402062 - so these instances would fail with:
`Error: Must pass an object as last argument to thNotify.send!`