### PR TITLE
Bug 1443023 - Pass missing $timeout prop to BugListItem

### DIFF
--- a/ui/plugins/failure_summary_panel.jsx
+++ b/ui/plugins/failure_summary_panel.jsx
@@ -80,6 +80,7 @@ class SuggestionsListItem extends React.Component {
                 escapeHTMLFilter={this.props.escapeHTMLFilter}
                 suggestion={this.props.suggestion}
                 highlightCommonTermsFilter={this.props.highlightCommonTermsFilter}
+                $timeout={this.props.$timeout}
                 bugClassName={bug.resolution !== "" ? "deleted" : ""}
                 title={bug.resolution !== "" ? bug.resolution : ""}
               />))}


### PR DESCRIPTION
The failure classification pin button was broken for bug suggestions that fell under the "all others" category, since the `BugListItem` for them weren't passed the `$timeout` prop, unlike for the "open recent" `BugListItem` instance.