### PR TITLE
Bug 1443331 - Add a checkbox to hide results that don't have data for both the old and new revisions

### DIFF
--- a/ui/js/components/perf/compare.js
+++ b/ui/js/components/perf/compare.js
@@ -49,6 +49,7 @@ treeherder.component('phCompareTable', {
         }
         function shouldBeShown(result) {
             return (!ctrl.filterOptions.showOnlyImportant || result.isMeaningful) &&
+                (!ctrl.filterOptions.showOnlyComparable || 'newIsBetter' in result) &&
                 (!ctrl.filterOptions.showOnlyConfident || result.isConfident) &&
                 (!ctrl.filterOptions.showOnlyBlockers || result.isBlocker) &&
                 (!ctrl.filterOptions.showOnlyNoise || result.isNoiseMetric);

--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -381,6 +381,7 @@ perf.controller('CompareResultsCtrl', [
                 framework: $scope.filterOptions.framework.id,
                 filter: $scope.filterOptions.filter,
                 showOnlyImportant: $scope.filterOptions.showOnlyImportant ? 1 : undefined,
+                showOnlyComparable: $scope.filterOptions.showOnlyComparable ? 1 : undefined,
                 showOnlyConfident: $scope.filterOptions.showOnlyConfident ? 1 : undefined,
                 showOnlyNoise: $scope.filterOptions.showOnlyNoise ? 1 : undefined,
             };
@@ -434,6 +435,8 @@ perf.controller('CompareResultsCtrl', [
                 filter: $stateParams.filter || "",
                 showOnlyImportant: Boolean($stateParams.showOnlyImportant !== undefined &&
                                            parseInt($stateParams.showOnlyImportant)),
+                showOnlyComparable: Boolean($stateParams.showOnlyComparable !== undefined &&
+                                           parseInt($stateParams.showOnlyComparable)),
                 showOnlyConfident: Boolean($stateParams.showOnlyConfident !== undefined &&
                                            parseInt($stateParams.showOnlyConfident)),
                 showOnlyNoise: Boolean($stateParams.showOnlyNoise !== undefined &&
@@ -464,6 +467,7 @@ perf.controller('CompareResultsCtrl', [
                 }
                 $scope.$watchGroup(['filterOptions.filter',
                     'filterOptions.showOnlyImportant',
+                    'filterOptions.showOnlyComparable',
                     'filterOptions.showOnlyConfident',
                     'filterOptions.showOnlyNoise'],
                     updateURL);
@@ -679,6 +683,8 @@ perf.controller('CompareSubtestResultsCtrl', [
                     filter: $stateParams.filter || "",
                     showOnlyImportant: Boolean($stateParams.showOnlyImportant !== undefined &&
                                                parseInt($stateParams.showOnlyImportant)),
+                    showOnlyComparable: Boolean($stateParams.showOnlyComparable !== undefined &&
+                                               parseInt($stateParams.showOnlyComparable)),
                     showOnlyConfident: Boolean($stateParams.showOnlyConfident !== undefined &&
                                                parseInt($stateParams.showOnlyConfident)),
                     showOnlyNoise: Boolean($stateParams.showOnlyNoise !== undefined &&
@@ -688,12 +694,14 @@ perf.controller('CompareSubtestResultsCtrl', [
                 $scope.$watchGroup([
                     'filterOptions.filter',
                     'filterOptions.showOnlyImportant',
+                    'filterOptions.showOnlyComparable',
                     'filterOptions.showOnlyConfident',
                     'filterOptions.showOnlyNoise'
                 ], function () {
                     $state.transitionTo('comparesubtest', {
                         filter: $scope.filterOptions.filter,
                         showOnlyImportant: $scope.filterOptions.showOnlyImportant ? 1 : undefined,
+                        showOnlyComparable: $scope.filterOptions.showOnlyComparable ? 1 : undefined,
                         showOnlyConfident: $scope.filterOptions.showOnlyConfident ? 1 : undefined,
                         showOnlyNoise: $scope.filterOptions.showOnlyNoise ? 1 : undefined
                     }, {
@@ -713,6 +721,7 @@ perf.controller('CompareSubtestResultsCtrl', [
                     $state.go('comparesubtest', {
                         filter: $scope.filterOptions.filter,
                         showOnlyImportant: $scope.filterOptions.showOnlyImportant ? 1 : undefined,
+                        showOnlyComparable: $scope.filterOptions.showOnlyComparable ? 1 : undefined,
                         showOnlyConfident: $scope.filterOptions.showOnlyConfident ? 1 : undefined,
                         selectedTimeRange: $scope.selectedTimeRange.value
                     });

--- a/ui/js/controllers/perf/dashboard.js
+++ b/ui/js/controllers/perf/dashboard.js
@@ -158,6 +158,8 @@ perf.controller('dashCtrl', [
             filter: $stateParams.filter || "",
             showOnlyImportant: Boolean($stateParams.showOnlyImportant !== undefined &&
                                        parseInt($stateParams.showOnlyImportant)),
+            showOnlyComparable: Boolean($stateParams.showOnlyComparable !== undefined &&
+                                       parseInt($stateParams.showOnlyComparable)),
             showOnlyConfident: Boolean($stateParams.showOnlyConfident !== undefined &&
                                        parseInt($stateParams.showOnlyConfident)),
             showOnlyBlockers: Boolean($stateParams.showOnlyBlockers !== undefined &&
@@ -169,6 +171,7 @@ perf.controller('dashCtrl', [
                 topic: $scope.topic,
                 filter: $scope.filterOptions.filter,
                 showOnlyImportant: $scope.filterOptions.showOnlyImportant ? 1 : undefined,
+                showOnlyComparable: $scope.filterOptions.showOnlyComparable ? 1 : undefined,
                 showOnlyConfident: $scope.filterOptions.showOnlyConfident ? 1 : undefined,
                 showOnlyBlockers: $scope.filterOptions.showOnlyBlockers ? 1 : undefined,
                 repo: $scope.selectedRepo.name === thDefaultRepo ? undefined : $scope.selectedRepo.name,
@@ -190,6 +193,7 @@ perf.controller('dashCtrl', [
             $scope.$watchGroup([
                 'filterOptions.filter',
                 'filterOptions.showOnlyImportant',
+                'filterOptions.showOnlyComparable',
                 'filterOptions.showOnlyConfident',
                 'filterOptions.showOnlyBlockers'
             ], updateURL);
@@ -338,6 +342,8 @@ perf.controller('dashSubtestCtrl', [
             filter: $stateParams.filter || "",
             showOnlyImportant: Boolean($stateParams.showOnlyImportant !== undefined &&
                                        parseInt($stateParams.showOnlyImportant)),
+            showOnlyComparable: Boolean($stateParams.showOnlyComparable !== undefined &&
+                                       parseInt($stateParams.showOnlyComparable)),
             showOnlyConfident: Boolean($stateParams.showOnlyConfident !== undefined &&
                                        parseInt($stateParams.showOnlyConfident)),
             showOnlyBlockers: Boolean($stateParams.showOnlyBlockers !== undefined &&
@@ -348,6 +354,7 @@ perf.controller('dashSubtestCtrl', [
                 topic: $scope.topic,
                 filter: $scope.filterOptions.filter,
                 showOnlyImportant: $scope.filterOptions.showOnlyImportant ? 1 : undefined,
+                showOnlyComparable: $scope.filterOptions.showOnlyComparable ? 1 : undefined,
                 showOnlyConfident: $scope.filterOptions.showOnlyConfident ? 1 : undefined,
                 repo: $scope.selectedRepo.name === thDefaultRepo ? undefined : $scope.selectedRepo.name,
                 timerange: ($scope.selectedTimeRange.value !== defaultTimeRange) ? $scope.selectedTimeRange.value : undefined
@@ -368,6 +375,7 @@ perf.controller('dashSubtestCtrl', [
             $scope.$watchGroup([
                 'filterOptions.filter',
                 'filterOptions.showOnlyImportant',
+                'filterOptions.showOnlyComparable',
                 'filterOptions.showOnlyConfident'
             ], updateURL);
 

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -46,13 +46,13 @@ perf.config(['$compileProvider', '$locationProvider', '$httpProvider', '$statePr
             .state('compare', {
                 title: 'Compare',
                 template: compareCtrlTemplate,
-                url: '/compare?originalProject&originalRevision?&newProject&newRevision&hideMinorChanges&framework&filter&showOnlyImportant&showOnlyConfident&selectedTimeRange&showOnlyNoise?',
+                url: '/compare?originalProject&originalRevision?&newProject&newRevision&hideMinorChanges&framework&filter&showOnlyComparable&showOnlyImportant&showOnlyConfident&selectedTimeRange&showOnlyNoise?',
                 controller: 'CompareResultsCtrl'
             })
             .state('comparesubtest', {
                 title: 'Compare - Subtests',
                 template: compareSubtestCtrlTemplate,
-                url: '/comparesubtest?originalProject&originalRevision?&newProject&newRevision&originalSignature&newSignature&filter&showOnlyImportant&showOnlyConfident&framework&selectedTimeRange&showOnlyNoise?',
+                url: '/comparesubtest?originalProject&originalRevision?&newProject&newRevision&originalSignature&newSignature&filter&showOnlyComparable&showOnlyImportant&showOnlyConfident&framework&selectedTimeRange&showOnlyNoise?',
                 controller: 'CompareSubtestResultsCtrl'
             })
             .state('comparechooser', {
@@ -64,13 +64,13 @@ perf.config(['$compileProvider', '$locationProvider', '$httpProvider', '$statePr
             .state('dashboard', {
                 title: 'Perfherder Dashboard',
                 template: dashboardTemplate,
-                url: '/dashboard?topic&filter&showOnlyImportant&showOnlyConfident&showOnlyBlockers&repo&timerange&revision',
+                url: '/dashboard?topic&filter&showOnlyComparable&showOnlyImportant&showOnlyConfident&showOnlyBlockers&repo&timerange&revision',
                 controller: 'dashCtrl'
             })
             .state('dashboardsubtest', {
                 title: 'Perfherder Dashboard - Subtests',
                 template: dashboardSubtestTemplate,
-                url: '/dashboardsubtest?topic&filter&showOnlyImportant&showOnlyConfident&baseSignature&variantSignature&repo&timerange&revision',
+                url: '/dashboardsubtest?topic&filter&showOnlyComparable&showOnlyImportant&showOnlyConfident&baseSignature&variantSignature&repo&timerange&revision',
                 controller: 'dashSubtestCtrl'
             })
             .state('comparesubtestdistribution', {

--- a/ui/partials/perf/comparetable.html
+++ b/ui/partials/perf/comparetable.html
@@ -12,6 +12,14 @@
            ng-change="$ctrl.updateFilteredTestList()"
            ng-model-options="{debounce: 250}"/>
   </div>
+  <div class="checkbox" uib-tooltip="At least 1 result for old and new revision">
+    <label>
+      <input type="checkbox"
+             ng-model="$ctrl.filterOptions.showOnlyComparable"
+             ng-change="$ctrl.updateFilteredTestList()"/>
+      Hide un-comparable results
+    </label>
+  </div>
   <div class="checkbox" uib-tooltip="Non-trivial changes (2%+)">
     <label>
       <input type="checkbox"


### PR DESCRIPTION
Basically I searched for 'showOnlyConfident' and cargo-culted that code everywhere.  I ran it with `yarn start` and it seems to work fine for me.