### PR TITLE
Bug 1442556 - Improve rendering speed in treeherder by removing refs

### DIFF
--- a/ui/job-view/JobButton.jsx
+++ b/ui/job-view/JobButton.jsx
@@ -136,5 +136,4 @@ JobButtonComponent.propTypes = {
   visible: PropTypes.bool.isRequired,
   status: PropTypes.string.isRequired,
   failureClassificationId: PropTypes.number,  // runnable jobs won't have this
-  hasGroup: PropTypes.bool.isRequired,
 };

--- a/ui/job-view/JobGroup.jsx
+++ b/ui/job-view/JobGroup.jsx
@@ -4,6 +4,7 @@ import JobButton from './JobButton';
 import JobCountComponent from './JobCount';
 import { getBtnClass, getStatus } from "../helpers/jobHelper";
 import { getUrlParam } from "../helpers/locationHelper";
+import { failedResults } from "../js/constants";
 
 export default class JobGroup extends React.Component {
   constructor(props) {
@@ -36,6 +37,14 @@ export default class JobGroup extends React.Component {
       }
     );
     this.toggleExpanded = this.toggleExpanded.bind(this);
+
+    const { group } = this.props;
+    this.items = this.groupButtonsAndCounts(group.jobs);
+  }
+
+  componentWillReceiveProps(newProps) {
+    const { group } = newProps;
+    this.items = this.groupButtonsAndCounts(group.jobs);
   }
 
   componentWillUnmount() {
@@ -63,7 +72,7 @@ export default class JobGroup extends React.Component {
           btnClass: getBtnClass(status, job.failure_classification_id),
           countText: status
         };
-        if (['testfailed', 'busted', 'exception'].includes(status) ||
+        if (failedResults.includes(status) ||
           (typeSymbolCounts[job.job_type_symbol] > 1 && this.state.showDuplicateJobs)) {
           // render the job itself, not a count
           buttons.push(job);
@@ -97,7 +106,6 @@ export default class JobGroup extends React.Component {
 
   render() {
     const { group, $injector, repoName, filterPlatformCb, platform } = this.props;
-    this.items = this.groupButtonsAndCounts(group.jobs);
 
     return (
       <span className="platform-group">
@@ -116,7 +124,7 @@ export default class JobGroup extends React.Component {
 
           <span className="group-content">
             <span className="group-job-list">
-              {this.items.buttons.map((job, i) => (
+              {this.items.buttons.map(job => (
                 <JobButton
                   job={job}
                   $injector={$injector}
@@ -126,10 +134,7 @@ export default class JobGroup extends React.Component {
                   repoName={repoName}
                   filterPlatformCb={filterPlatformCb}
                   platform={platform}
-                  hasGroup
                   key={job.id}
-                  ref={i}
-                  refOrder={i}
                 />
               ))}
             </span>

--- a/ui/job-view/JobsAndGroups.jsx
+++ b/ui/job-view/JobsAndGroups.jsx
@@ -10,7 +10,7 @@ export default class JobsAndGroups extends React.Component {
 
     return (
       <td className="job-row">
-        {groups.map((group, i) => {
+        {groups.map((group) => {
           if (group.symbol !== '?') {
             return (
               group.visible && <JobGroup
@@ -19,9 +19,7 @@ export default class JobsAndGroups extends React.Component {
                 $injector={$injector}
                 filterPlatformCb={filterPlatformCb}
                 platform={platform}
-                refOrder={i}
                 key={group.mapKey}
-                ref={i}
               />
             );
           }
@@ -36,10 +34,7 @@ export default class JobsAndGroups extends React.Component {
                 failureClassificationId={job.failure_classification_id}
                 filterPlatformCb={filterPlatformCb}
                 platform={platform}
-                hasGroup={false}
                 key={job.id}
-                ref={i}
-                refOrder={i}
               />
             ))
           );

--- a/ui/job-view/Platform.jsx
+++ b/ui/job-view/Platform.jsx
@@ -11,28 +11,21 @@ function PlatformName(props) {
   );
 }
 
-// Contrary to what this rule says, we must use a class since PushJobs sets
-// a `ref` on `Platform`, and refs can't be used with stateless functions:
-// https://reactjs.org/docs/refs-and-the-dom.html#refs-and-functional-components
-// https://github.com/yannickcr/eslint-plugin-react/issues/1004
-// eslint-disable-next-line react/prefer-stateless-function
-export default class Platform extends React.Component {
-  render() {
-    const { platform, $injector, repoName, filterPlatformCb } = this.props;
+export default function Platform(props) {
+  const { platform, $injector, repoName, filterPlatformCb } = props;
 
-    return (
-      <tr id={platform.id} key={platform.id}>
-        <PlatformName platform={platform} />
-        <JobsAndGroups
-          groups={platform.groups}
-          repoName={repoName}
-          $injector={$injector}
-          filterPlatformCb={filterPlatformCb}
-          platform={platform}
-        />
-      </tr>
-    );
-  }
+  return (
+    <tr id={platform.id} key={platform.id}>
+      <PlatformName platform={platform} />
+      <JobsAndGroups
+        groups={platform.groups}
+        repoName={repoName}
+        $injector={$injector}
+        filterPlatformCb={filterPlatformCb}
+        platform={platform}
+      />
+    </tr>
+  );
 }
 
 Platform.propTypes = {

--- a/ui/job-view/PushJobs.jsx
+++ b/ui/job-view/PushJobs.jsx
@@ -222,15 +222,13 @@ export default class PushJobs extends React.Component {
     return (
       <table id={this.aggregateId} className="table-hover">
         <tbody onMouseDown={this.onMouseDown}>
-          {platforms ? Object.keys(platforms).map((id, i) => (
+          {platforms ? Object.keys(platforms).map(id => (
           platforms[id].visible &&
           <Platform
             platform={platforms[id]}
             repoName={repoName}
             $injector={$injector}
             key={id}
-            ref={id}
-            refOrder={i}
             filterPlatformCb={this.filterPlatform}
           />
         )) : <tr>

--- a/ui/js/constants.js
+++ b/ui/js/constants.js
@@ -1,5 +1,3 @@
-// Remove disabling when there is more than one export in the file.
-// eslint-disable-next-line import/prefer-default-export
 export const platformMap = {
     linux32: "Linux",
     "linux32-devedition": "Linux DevEdition",
@@ -143,3 +141,5 @@ export const platformMap = {
     "release-mozilla-release-": "Balrog Publishing",
     other: "Other"
 };
+
+export const failedResults = ['testfailed', 'busted', 'exception'];


### PR DESCRIPTION
These refs were not actually used, so can be removed.  It does appear to
improve rendering speed, especially when changin filtering.  I had noticed
that the JobGroup was re-rendering more times than it should, and this
change stops that.  I believe more work is to be done here, but this is one
step.

This also includes a couple other small tweaks that may help speed.