### PR TITLE
Bug 1443832 - Disable compilation of class and comment directives

### DIFF
--- a/ui/js/logviewer.js
+++ b/ui/js/logviewer.js
@@ -6,8 +6,11 @@ const logViewerApp = angular.module('logviewer', [treeherderModule.name]);
 
 logViewerApp.config(['$compileProvider', '$locationProvider', '$resourceProvider',
     function ($compileProvider, $locationProvider, $resourceProvider) {
-        // Disable debug data, as recommended by https://docs.angularjs.org/guide/production
+        // Disable debug data & legacy comment/class directive syntax, as recommended by:
+        // https://docs.angularjs.org/guide/production
         $compileProvider.debugInfoEnabled(false);
+        $compileProvider.commentDirectivesEnabled(false);
+        $compileProvider.cssClassDirectivesEnabled(false);
 
         // Revert to the legacy Angular <=1.5 URL hash prefix to save breaking existing links:
         // https://docs.angularjs.org/guide/migration#commit-aa077e8

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -13,8 +13,11 @@ import tooltipGraphsTemplate from '../partials/perf/tooltipgraphs.html';
 // configure the router here, after we have defined all the controllers etc
 perf.config(['$compileProvider', '$locationProvider', '$httpProvider', '$stateProvider', '$urlRouterProvider',
     function ($compileProvider, $locationProvider, $httpProvider, $stateProvider, $urlRouterProvider) {
-        // Disable debug data, as recommended by https://docs.angularjs.org/guide/production
+        // Disable debug data & legacy comment/class directive syntax, as recommended by:
+        // https://docs.angularjs.org/guide/production
         $compileProvider.debugInfoEnabled(false);
+        $compileProvider.commentDirectivesEnabled(false);
+        $compileProvider.cssClassDirectivesEnabled(false);
 
         // Revert to the legacy Angular <=1.5 pre-assign bindings behaviour:
         // https://docs.angularjs.org/guide/migration#commit-bcd0d4

--- a/ui/js/treeherder_app.js
+++ b/ui/js/treeherder_app.js
@@ -41,8 +41,11 @@ treeherderApp.config(['$compileProvider', '$locationProvider', '$routeProvider',
     '$logProvider', '$resourceProvider', 'localStorageServiceProvider',
     function ($compileProvider, $locationProvider, $routeProvider, $httpProvider, $logProvider,
              $resourceProvider, localStorageServiceProvider) {
-        // Disable debug data, as recommended by https://docs.angularjs.org/guide/production
+        // Disable debug data & legacy comment/class directive syntax, as recommended by:
+        // https://docs.angularjs.org/guide/production
         $compileProvider.debugInfoEnabled(false);
+        $compileProvider.commentDirectivesEnabled(false);
+        $compileProvider.cssClassDirectivesEnabled(false);
 
         // Revert to the legacy Angular <=1.5 URL hash prefix to save breaking existing links:
         // https://docs.angularjs.org/guide/migration#commit-aa077e8

--- a/ui/js/userguide.js
+++ b/ui/js/userguide.js
@@ -5,8 +5,11 @@ import thShortcutTableTemplate from '../partials/main/thShortcutTable.html';
 const userguideApp = angular.module('userguide', []);
 
 userguideApp.config(['$compileProvider', function ($compileProvider) {
-    // Disable debug data, as recommended by https://docs.angularjs.org/guide/production
+    // Disable debug data & legacy comment/class directive syntax, as recommended by:
+    // https://docs.angularjs.org/guide/production
     $compileProvider.debugInfoEnabled(false);
+    $compileProvider.commentDirectivesEnabled(false);
+    $compileProvider.cssClassDirectivesEnabled(false);
 }]).run(['$templateCache', ($templateCache) => {
     // Templates used by ng-include have to be manually put in the template cache.
     // Those used by directives should instead be imported at point of use.


### PR DESCRIPTION
Since we don't use them, and disabling improves compile performance:
https://docs.angularjs.org/guide/production#disable-comment-and-css-class-directives