### PR TITLE
Bug 1443667 - Fix 'tier' not yet assigned when getJobGroupInfo() creates map

### DIFF
--- a/tests/ui/mock/mappedGroup.json
+++ b/tests/ui/mock/mappedGroup.json
@@ -1,6 +1,7 @@
 {
   "name": "Web platform tests with e10s",
   "symbol": "W-e10s",
+  "tier": 1,
   "jobs": [
     {
       "build_architecture": "-",
@@ -120,6 +121,6 @@
       "selected": false
     }
   ],
-  "mapKey": "313281W-e10sundefinedlinux64debug",
+  "mapKey": "313281W-e10s1linux64debug",
   "visible": true
 }

--- a/tests/ui/mock/mappedGroupDups.json
+++ b/tests/ui/mock/mappedGroupDups.json
@@ -1,6 +1,7 @@
 {
   "name": "Spidermonkey builds",
   "symbol": "SM",
+  "tier": 1,
   "jobs": [
     {
       "build_architecture": "-",
@@ -276,6 +277,6 @@
       "selected": false
     }
   ],
-  "mapKey": "313293SMundefinedlinux64opt",
+  "mapKey": "313293SM1linux64opt",
   "visible": true
 }

--- a/ui/job-view/JobGroup.jsx
+++ b/ui/job-view/JobGroup.jsx
@@ -9,13 +9,14 @@ import { failedResults } from "../js/constants";
 class GroupSymbol extends React.PureComponent {
   render() {
     const { symbol, tier, toggleExpanded } = this.props;
+    const groupSymbol = symbol === '?' ? '' : symbol;
 
     return (
       <button
         className="btn group-symbol"
         data-ignore-job-clear-on-click
         onClick={toggleExpanded}
-      >{symbol}{tier && <span className="small text-muted">[tier {tier}]</span>}
+      >{groupSymbol}{tier !== 1 && <span className="small text-muted">[tier {tier}]</span>}
       </button>
     );
   }

--- a/ui/job-view/JobsAndGroups.jsx
+++ b/ui/job-view/JobsAndGroups.jsx
@@ -11,7 +11,7 @@ export default class JobsAndGroups extends React.Component {
     return (
       <td className="job-row">
         {groups.map((group) => {
-          if (group.symbol !== '?') {
+          if (group.tier !== 1 || group.symbol !== '?') {
             return (
               group.visible && <JobGroup
                 group={group}

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -910,20 +910,18 @@ treeherder.factory('ThResultSetStore', [
           )
         );
 
-        var getJobGroupInfo = function (job) {
+        const getJobGroupInfo = function (job) {
+          const {
+            job_group_name: name, job_group_symbol,
+            platform, platform_option, result_set_id, tier
+          } = job;
+          // this has to do with group sorting so that the tier-1 ungrouped
+          // jobs show first, and the tier>1 ungrouped jobs show last.
+          const symbol = tier > 1 ? '' : job_group_symbol;
+          const mapKey = thAggregateIds.getGroupMapKey(
+            result_set_id, symbol, tier, platform, platform_option);
 
-            var name = job.job_group_name;
-            var symbol = job.job_group_symbol;
-            var mapKey = thAggregateIds.getGroupMapKey(job.result_set_id, symbol, tier, job.platform, job.platform_option);
-            var tier;
-
-            if (job.tier && job.tier !== 1) {
-                if (symbol === "?") {
-                    symbol = "";
-                }
-                tier = job.tier;
-            }
-            return { name: name, tier: tier, symbol: symbol, mapKey: mapKey };
+          return { name, tier, symbol, mapKey };
         };
 
         /*

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -249,7 +249,6 @@ treeherder.factory('ThResultSetStore', [
                     // maps to help finding objects to update/add
                     rsMap: {},
                     jobMap: {},
-                    grpMap: {},
                     unclassifiedFailureMap: {},
                     // count of unclassified for the currently enabled tiers
                     unclassifiedFailureCountForTiers: 0,
@@ -392,17 +391,6 @@ treeherder.factory('ThResultSetStore', [
                         jobs: {}
                     };
                     plMapElement.groups[gr_obj.symbol] = grMapElement;
-
-                    // check if we need to copy groupState from an existing group
-                    // object.  This would be set if a user explicitly clicked
-                    // a group to toggle it expanded/collapsed.
-                    // This value will have been overwritten by the _.extend
-                    // in mapPushJobs.
-                    var oldGroup = repoData.grpMap[gr_obj.mapKey];
-                    if (oldGroup) {
-                        gr_obj.groupState = oldGroup.grp_obj.groupState;
-                    }
-                    repoData.grpMap[gr_obj.mapKey] = grMapElement;
 
                     // jobs
                     for (var j_i = 0; j_i < gr_obj.jobs.length; j_i++) {


### PR DESCRIPTION
I went ahead and optimized the deconstruction, too.  Since this function is called a lot, every bit helps for speed.  :)