### PR TITLE
Bug 1437818 - Enable ESLint rule react/no-array-index-key

### DIFF
--- a/neutrino-custom/lint.js
+++ b/neutrino-custom/lint.js
@@ -54,7 +54,6 @@ module.exports = neutrino => {
                     'quotes': 'off',
                     'radix': 'off',
                     'react/forbid-prop-types': 'off',
-                    'react/no-array-index-key': 'off',
                     'react/no-danger': 'off',
                     'react/no-multi-comp': 'off',
                     'react/prop-types': 'off',

--- a/ui/details-panel/AnnotationsTab.jsx
+++ b/ui/details-panel/AnnotationsTab.jsx
@@ -36,8 +36,8 @@ function RelatedBug(props) {
     <span>
       <p className="annotations-bug-header font-weight-bold">Bugs</p>
       <ul className="annotations-bug-list">
-        {bugs.map((bug, index) => (
-          <li key={index}>
+        {bugs.map(bug => (
+          <li key={bug.bug_id}>
             <RelatedBugSaved
               bug={bug}
               deleteBug={deleteBug}
@@ -98,9 +98,9 @@ function AnnotationsTable(props) {
         </tr>
       </thead>
       <tbody>
-        {classifications.map((classification, index) => (
+        {classifications.map(classification => (
           <TableRow
-            key={index}
+            key={classification.id}
             dateFilter={dateFilter}
             classification={classification}
             deleteClassification={deleteClassification}

--- a/ui/job-view/RevisionList.jsx
+++ b/ui/job-view/RevisionList.jsx
@@ -14,12 +14,12 @@ export class RevisionList extends React.PureComponent {
     return (
       <span className="revision-list col-5">
         <ul className="list-unstyled">
-          {push.revisions.map((revision, i) =>
+          {push.revisions.map(revision =>
             (<Revision
               linkifyBugsFilter={this.linkifyBugsFilter}
               revision={revision}
               repo={repo}
-              key={i}
+              key={revision.revision}
             />)
           )}
           {this.hasMore &&

--- a/ui/plugins/failure_summary_panel.jsx
+++ b/ui/plugins/failure_summary_panel.jsx
@@ -44,9 +44,9 @@ class SuggestionsListItem extends React.Component {
         {/* <!--Open recent bugs--> */}
         {this.props.suggestion.valid_open_recent &&
         <ul className="list-unstyled failure-summary-bugs">
-          {this.props.suggestion.bugs.open_recent.map((bug, index) =>
+          {this.props.suggestion.bugs.open_recent.map(bug =>
             (<BugListItem
-              key={index}
+              key={bug.id}
               bug={bug}
               selectedJob={this.props.selectedJob}
               pinboardService={this.props.pinboardService}
@@ -71,9 +71,9 @@ class SuggestionsListItem extends React.Component {
         {this.props.suggestion.valid_all_others && (this.state.suggestionShowMore
           || !this.props.suggestion.valid_open_recent) &&
           <ul className="list-unstyled failure-summary-bugs">
-            {this.props.suggestion.bugs.all_others.map((bug, index) =>
+            {this.props.suggestion.bugs.all_others.map(bug =>
               (<BugListItem
-                key={index}
+                key={bug.id}
                 bug={bug}
                 selectedJob={this.props.selectedJob}
                 pinboardService={this.props.pinboardService}
@@ -138,15 +138,18 @@ function BugListItem(props) {
 
 
 function ErrorsList(props) {
-  const errorListItem = props.errors.map((error, index) =>
-    (<li key={index}>{error.name} : {error.result}.
+  const errorListItem = props.errors.map((error, key) => (
+    <li
+      key={key} // eslint-disable-line react/no-array-index-key
+    >{error.name} : {error.result}.
       <a
         title="Open in Log Viewer"
         target="_blank"
         rel="noopener"
         href={error.lvURL}
       ><span className="ml-1">View log</span></a>
-    </li>));
+    </li>
+  ));
 
   return (
     <li>
@@ -167,7 +170,7 @@ function FailureSummaryPanel(props) {
     <ul className="list-unstyled failure-summary-list">
       {props.suggestions && props.suggestions.map((suggestion, index) =>
         (<SuggestionsListItem
-          key={index}
+          key={index}  // eslint-disable-line react/no-array-index-key
           index={index}
           suggestion={suggestion}
           user={props.user}
@@ -196,14 +199,14 @@ function FailureSummaryPanel(props) {
         </li>}
 
       {props.jobLogUrls && !props.tabs.failureSummary.is_loading && !props.jobLogsAllParsed &&
-       props.jobLogUrls.map((job, index) =>
-         (<li key={index}>
+       props.jobLogUrls.map(jobLog =>
+         (<li key={jobLog.id}>
            <p className="failure-summary-line-empty mb-0">Log parsing in progress.<br />
              <a
                title="Open the raw log in a new window"
                target="_blank"
                rel="noopener"
-               href={job.url}
+               href={jobLog.url}
              >The raw log</a>
              <span>is available. This panel will automatically recheck every 5 seconds.</span></p>
          </li>))}

--- a/ui/test-view/redux/modules/groups.js
+++ b/ui/test-view/redux/modules/groups.js
@@ -37,6 +37,7 @@ export const getTestDataQuery = revision => encodeURIComponent(`
                   }
                   jobLog {
                     failureLine {
+                      id
                       test
                       subtest
                       message

--- a/ui/test-view/ui/Groups.jsx
+++ b/ui/test-view/ui/Groups.jsx
@@ -87,8 +87,8 @@ class Groups extends React.Component {
               <th key="test">Test</th>
             </tr>
           </thead>
-          {this.props.fetchStatus === 'HasData' ? Object.entries(this.props.rowData).map(([name, rows], tkey) => (
-            <tbody key={tkey}>
+          {this.props.fetchStatus === 'HasData' ? Object.entries(this.props.rowData).map(([name, rows]) => (
+            <tbody key={name}>
               <tr style={{ backgroundColor: '#f9f9f9' }}>
                 <td colSpan={4} style={{ textAlign: 'center', fontSize: '1.5rem' }}>
                   <code style={{ color: '#000', backgroundColor: 'transparent' }}>
@@ -96,8 +96,8 @@ class Groups extends React.Component {
                   </code>
                 </td>
               </tr>
-              {Object.entries(rows).map(([testName, test], rkey) => (
-                <tr key={rkey}>
+              {Object.entries(rows).map(([testName, test]) => (
+                <tr key={testName}>
                   <BugCount testName={testName} test={test} jobGroup={name} />
                   <Test name={testName} test={test} jobGroup={name} />
                 </tr>

--- a/ui/test-view/ui/Test.jsx
+++ b/ui/test-view/ui/Test.jsx
@@ -104,11 +104,10 @@ class TestComponent extends React.Component {
     return (
       <div className="test-detail-list">
         <div className="bottom-separator"><strong>Test Group: {this.props.test.group}</strong></div>
-        {this.props.test.jobs.map((job, key) => (
-          <div key={key}>
+        {this.props.test.jobs.map(job => (
+          <div key={job.id}>
             <Platform
               job={job}
-              key={key}
               platform={platformMap[job.buildPlatform.platform]}
               option={this.props.options[job.optionCollectionHash]}
               repo={this.props.repo}
@@ -119,8 +118,8 @@ class TestComponent extends React.Component {
               repo={this.props.repo}
             />
             {job.tier > 1 && <span className="tier badge">Tier-{job.tier}</span>}
-            <div>{job.failureLines.map((failureLine, jlkey) => (
-              <span key={jlkey}>
+            <div>{job.failureLines.map(failureLine => (
+              <span key={failureLine.id}>
                 {failureLine && <div>
                   <span>
                     {failureLine.action === 'TEST_RESULT' && <div className="failure-line">
@@ -145,8 +144,8 @@ class TestComponent extends React.Component {
         ))}
         {this.props.test.bugs && <div>
           <div className="bottom-separator"><strong>Bugs:</strong></div>
-          {Object.values(this.props.test.bugs).map((bug, key) => (
-            <div key={key}><Link
+          {Object.values(this.props.test.bugs).map(bug => (
+            <div key={bug.id}><Link
               to={`https://bugzilla.mozilla.org/show_bug.cgi?id=${bug.id}`}
               target="_blank"
               rel="noopener"
@@ -165,10 +164,10 @@ class TestComponent extends React.Component {
           onClick={this.onClick}
         >{this.props.name}</span>
         <span className="platform-list">
-          {this.props.test.jobs.map((job, key) => (
+          {this.props.test.jobs.map(job => (
             <Platform
               job={job}
-              key={key}
+              key={job.id}
               platform={platformMap[job.buildPlatform.platform]}
               option={this.props.options[job.optionCollectionHash]}
               repo={this.props.repo}


### PR DESCRIPTION
In some of these cases there wasn't an ``id`` I could use, so I had to use a field that WILL be unique.  Sometimes that's the revision hash, or sometimes it's just the text that's displayed.