### PR TITLE
Bug 1353753 - Update legacy Treestatus URLs

### DIFF
--- a/ui/js/models/repository.js
+++ b/ui/js/models/repository.js
@@ -47,8 +47,7 @@ treeherder.factory('ThRepositoryModel', [
         const getUnsupportedTreeStatus = function (repoName) {
             return {
                 status: "unsupported",
-                message_of_the_day: repoName +
-                    ' is not supported in <a href="https://api.pub.build.mozilla.org/treestatus">api.pub.build.mozilla.org/treestatus</a>',
+                message_of_the_day: `${repoName} is not listed on <a href="https://mozilla-releng.net/treestatus">TreeStatus</a>`,
                 reason: "",
                 tree: repoName
             };
@@ -61,8 +60,8 @@ treeherder.factory('ThRepositoryModel', [
         const getErrorTreeStatus = function (repoName) {
             return {
                 status: "error",
-                message_of_the_day: 'Error reaching <a href="https://api.pub.build.mozilla.org/treestatus">api.pub.build.mozilla.org/treestatus</a>',
-                reason: 'Error reaching <a href="https://api.pub.build.mozilla.org/treestatus">api.pub.build.mozilla.org/treestatus</a>',
+                message_of_the_day: 'Unable to connect to the <a href="https://mozilla-releng.net/treestatus">TreeStatus</a> API',
+                reason: '',
                 tree: repoName
             };
         };

--- a/ui/js/services/treestatus.js
+++ b/ui/js/services/treestatus.js
@@ -6,7 +6,7 @@ treeherder.factory('treeStatus', [
         const urlBase = "https://treestatus.mozilla-releng.net/trees/";
 
         const getTreeStatusName = function (name) {
-            // the thunderbird names in api.pub.build.mozilla.org/treestatus don't match what
+            // The thunderbird names in TreeStatus don't match what
             // we use, so translate them.  pretty hacky, yes...
             // TODO: Move these to the repository fixture in the service.
             if (name.indexOf("comm-") >= 0 && name !== "try-comm-central") {


### PR DESCRIPTION
TreeStatus has long since moved to:
https://mozilla-releng.net/treestatus