### PR TITLE
Bug 1444644 - Update Bootstrap from v4.0.0-beta.2 to v4.0.0

### DIFF
--- a/neutrino-custom/base.js
+++ b/neutrino-custom/base.js
@@ -41,7 +41,7 @@ module.exports = neutrino => {
             'angular-ui-router',
             'angular1-ui-bootstrap4',
             'auth0-js',
-            'bootstrap/dist/js/bootstrap',
+            'bootstrap',
             'hawk',
             'jquery',
             'jquery.scrollto',
@@ -247,8 +247,6 @@ module.exports = neutrino => {
             jQuery: require.resolve('jquery'),
             'window.$': require.resolve('jquery'),
             'window.jQuery': require.resolve('jquery'),
-            // Required by Bootstrap 4: https://getbootstrap.com/docs/4.0/getting-started/webpack/
-            Popper: ['popper.js', 'default'],
             React: require.resolve('react'),
             _: require.resolve('lodash'),
         });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "angular-ui-router": "0.4.3",
     "angular1-ui-bootstrap4": "2.4.22",
     "auth0-js": "9.3.3",
-    "bootstrap": "4.0.0-beta.2",
+    "bootstrap": "4.0.0",
     "deepmerge": "1.5.2",
     "eslint-config-airbnb": "15.1.0",
     "eslint-plugin-jsx-a11y": "5.1.1",

--- a/ui/entry-index.js
+++ b/ui/entry-index.js
@@ -1,11 +1,11 @@
 // Webpack entry point for index.html
 
 // Vendor Styles
-import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
 import 'font-awesome/css/font-awesome.css';
 
 // Vendor JS
-import 'bootstrap/dist/js/bootstrap';
+import 'bootstrap';
 import 'jquery.scrollto';
 
 // Treeherder Styles

--- a/ui/entry-logviewer.js
+++ b/ui/entry-logviewer.js
@@ -1,11 +1,11 @@
 // Webpack entry point for logviewer.html
 
 // Vendor Styles
-import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
 import 'font-awesome/css/font-awesome.css';
 
 // Vendor JS
-import 'bootstrap/dist/js/bootstrap';
+import 'bootstrap';
 
 // Logviewer Styles
 import './css/treeherder-global.css';

--- a/ui/entry-perf.js
+++ b/ui/entry-perf.js
@@ -1,12 +1,12 @@
 // Webpack entry point for perf.html
 
 // Vendor Styles
-import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
 import 'font-awesome/css/font-awesome.css';
 import 'metrics-graphics/dist/metricsgraphics.css';
 
 // Vendor JS
-import 'bootstrap/dist/js/bootstrap';
+import 'bootstrap';
 // The official 'flot' NPM package is out of date, so we're using 'jquery.flot'
 // instead, which is identical to https://github.com/flot/flot
 import 'jquery.flot';

--- a/ui/entry-userguide.js
+++ b/ui/entry-userguide.js
@@ -1,7 +1,7 @@
 // Webpack entry point for userguide.html
 
 // Vendor Styles
-import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
 import 'font-awesome/css/font-awesome.css';
 
 // Userguide Styles

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,9 +1243,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bootstrap@4.0.0-beta.2:
-  version "4.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-beta.2.tgz#4d67d2aa2219f062cd90bc1247e6747b9e8fd051"
+bootstrap@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0.tgz#ceb03842c145fcc1b9b4e15da2a05656ba68469a"
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
Notably:
* the `popper.js` `DefinePlugin` entry is no longer required
* the JS/CSS imports have been adjusted to match the install docs:
  https://getbootstrap.com/docs/4.0/getting-started/webpack/
  ...which shaves 23KB off the bundle size of most pages (due to the use of the minified CSS).

Release announcements:
https://blog.getbootstrap.com/2017/12/28/bootstrap-4-beta-3/
https://blog.getbootstrap.com/2018/01/18/bootstrap-4/

Release notes:
https://github.com/twbs/bootstrap/releases/tag/v4.0.0-beta.3
https://github.com/twbs/bootstrap/releases/tag/v4.0.0

Changelog:
https://github.com/twbs/bootstrap/compare/v4.0.0-beta.3...v4.0.0

Closes #3079.