### PR TITLE
Bump pytest to latest, 3.4.2

### DIFF
--- a/tests/jenkins/requirements.txt
+++ b/tests/jenkins/requirements.txt
@@ -1,7 +1,7 @@
 # pyup: ignore file
 mozlog==3.7
 PyPOM==1.3.0
-pytest==3.4.1
+pytest==3.4.2
 pytest-metadata==1.6.0
 pytest-selenium==1.11.4
 pytest-xdist==1.22.2


### PR DESCRIPTION
Full ad-hoc log here (with 5 failures, while the next ad-hoc from master, had 6, so this should be fine): https://gist.github.com/stephendonner/d9adb8a0c9fd8c4b8466f482bc330fc9

@edmorley r?