### PR TITLE
Bug 1310241 - Switch to the cache-based Django session engine

### DIFF
--- a/tests/auth/test_backends.py
+++ b/tests/auth/test_backends.py
@@ -1,12 +1,15 @@
 import time
+from importlib import import_module
 
 import pytest
+from django.conf import settings
 from django.contrib.auth.models import User
-from django.contrib.sessions.models import Session
 from django.core.urlresolvers import reverse
 
 from treeherder.auth.backends import (AuthBackend,
                                       AuthenticationFailed)
+
+SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
 
 @pytest.mark.parametrize(
@@ -63,8 +66,7 @@ def test_existing_email_create_user(test_user, webapp, monkeypatch, exp_username
     webapp.get(reverse("auth-login"), headers={"Authorization": "Bearer meh", "idToken": "meh", "expiresAt": str(expires_at)})
 
     session_key = webapp.cookies["sessionid"]
-    session = Session.objects.get(session_key=session_key)
-    session_data = session.get_decoded()
+    session_data = SessionStore(session_key=session_key)
 
     new_user = User.objects.get(id=session_data.get('_auth_user_id'))
 

--- a/tests/webapp/api/test_auth.py
+++ b/tests/webapp/api/test_auth.py
@@ -1,7 +1,8 @@
 import time
+from importlib import import_module
 
 import pytest
-from django.contrib.sessions.models import Session
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from mohawk import Sender
 from rest_framework import status
@@ -12,6 +13,8 @@ from rest_framework.test import APIRequestFactory
 from treeherder.auth.backends import AuthBackend
 from treeherder.model.models import User
 from treeherder.webapp.api import permissions
+
+SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
 
 class AuthenticatedView(APIView):
@@ -125,8 +128,7 @@ def test_auth_login_and_logout(test_ldap_user, webapp, monkeypatch):
                status=200)
 
     session_key = webapp.cookies["sessionid"]
-    session = Session.objects.get(session_key=session_key)
-    session_data = session.get_decoded()
+    session_data = SessionStore(session_key=session_key)
     user = User.objects.get(id=session_data.get('_auth_user_id'))
 
     assert user.id == test_ldap_user.id

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -95,6 +95,9 @@ AUTHENTICATION_BACKENDS = [
     'treeherder.auth.backends.AuthBackend',
 ]
 
+# Use the cache-based backend rather than the default of database.
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
+
 # Path to redirect to on successful login.
 LOGIN_REDIRECT_URL = '/'
 
@@ -107,7 +110,6 @@ LOGOUT_REDIRECT_URL = '/'
 INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
-    'django.contrib.sessions',
     # Disable Django's own staticfiles handling in favour of WhiteNoise, for
     # greater consistency between gunicorn and `./manage.py runserver`.
     'whitenoise.runserver_nostatic',


### PR DESCRIPTION
The cache-based engine stores session data in our Redis cache rather
than in the `django_sessions` table in the MySQL database.

This has several advantages:
* faster access (session lookups occur for virtually all API requests)
* expired sessions are automatically cleaned up (the database engine
  requires that the `clearsessions` command be run periodically)
* fewer secrets being stored in the database and its backups

See:
https://docs.djangoproject.com/en/1.11/topics/http/sessions/#configuring-sessions
https://docs.djangoproject.com/en/1.11/ref/settings/#session-engine

We're not concerned about very occasional session loss, so don't need
the persistence guarantees of the related `cached_db` engine.

The `INSTALLED_APPS` entry is being removed since it's only purpose
is to load the session database model.