### PR TITLE
Bug 1428045 - Fix flake8 errors on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
         - source ./bin/travis-setup.sh python_env
       script:
         - pip check
+        - flake8 --show-source
 
     # Job 3: Nodejs UI tests
     - env: ui-tests

--- a/lints/queuelint.py
+++ b/lints/queuelint.py
@@ -24,7 +24,7 @@ for item in code.body:
         queues_list = item.value
 
 if queues_list is None:
-    print "Failed to find list of queues in settings file"
+    print("Failed to find list of queues in settings file")
     sys.exit(1)
 
 for call in queues_list.elts:
@@ -33,11 +33,11 @@ for call in queues_list.elts:
 procfile_queues = set(procfile_queues)
 
 if settings_queues != procfile_queues:
-    print "ERROR - mismatches found"
+    print("ERROR - mismatches found")
     missing_procfile = procfile_queues - settings_queues
     if missing_procfile:
-        print "The following queues were in the Procfile, but not in the settings file:\n%s\n" % "\n".join(missing_procfile)
+        print("The following queues were in the Procfile, but not in the settings file:\n%s\n" % "\n".join(missing_procfile))
     missing_settings = settings_queues - procfile_queues
     if missing_settings:
-        print "The following queues were in the settings, but not in the Procfile:\n%s\n" % "\n".join(missing_settings)
+        print("The following queues were in the settings, but not in the Procfile:\n%s\n" % "\n".join(missing_settings))
     sys.exit(1)

--- a/lints/queuelint.py
+++ b/lints/queuelint.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import ast
 import re
 import sys

--- a/tests/etl/test_perf_schema.py
+++ b/tests/etl/test_perf_schema.py
@@ -23,7 +23,7 @@ def test_perf_schema(suite_value, test_value, expected_fail):
     }
     datum['suites'][0].update(suite_value)
     datum['suites'][0]['subtests'][0].update(test_value)
-    print datum
+    print(datum)
     if expected_fail:
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(datum, perf_schema)

--- a/tests/etl/test_perf_schema.py
+++ b/tests/etl/test_perf_schema.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import json
 
 import jsonschema

--- a/tests/etl/test_text.py
+++ b/tests/etl/test_text.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from treeherder.etl.text import (astral_filter,
+                                 filter_re)
+
+
+def test_filter_re_matching():
+    points = [
+        u"\U00010045",
+        u"\U00010053",
+        u"\U00010054",
+    ]
+    for point in points:
+        assert bool(filter_re.match(point)) is True
+
+
+def test_filter_not_matching():
+    points = [
+        u"\U00000045",
+        u"\U00000053",
+        u"\U00000054",
+    ]
+    for point in points:
+        assert bool(filter_re.match(point)) is False
+
+
+def test_astra_filter_emoji():
+    output = astral_filter(u'🍆')
+    expected = '<U+01F346>'
+    assert output == expected
+
+
+def test_astra_filter_hex_value():
+    """check the expected outcome is also not changed"""
+    hex_values = '\U00000048\U00000049'
+    assert hex_values == astral_filter(hex_values)

--- a/tests/log_parser/test_tasks.py
+++ b/tests/log_parser/test_tasks.py
@@ -42,7 +42,7 @@ def test_parse_log(test_repository, failure_classifications, jobs_with_local_log
     store_job_data(test_repository, jobs)
 
     # this log generates 4 job detail objects at present
-    print JobDetail.objects.count() == 4
+    print(JobDetail.objects.count() == 4)
 
 
 def test_create_error_summary(failure_classifications,

--- a/tests/log_parser/test_tasks.py
+++ b/tests/log_parser/test_tasks.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import pytest
 
 from tests.test_utils import add_log_response

--- a/tests/model/test_bugscache.py
+++ b/tests/model/test_bugscache.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import json
 import os
 from datetime import (datetime,

--- a/tests/model/test_bugscache.py
+++ b/tests/model/test_bugscache.py
@@ -120,7 +120,7 @@ def test_get_recent_resolved_bugs(transactional_db, sample_bugs):
     _update_bugscache(bug_list)
 
     suggestions = Bugscache.search(search_term)
-    print suggestions
+    print(suggestions)
     assert len(suggestions['open_recent']) == 0
     all_others_bugs = [b['id'] for b in suggestions['all_others']]
     assert all_others_bugs == exp_bugs

--- a/tests/model/test_error_summary.py
+++ b/tests/model/test_error_summary.py
@@ -30,9 +30,9 @@ PIPE_DELIMITED_LINE_TEST_CASES = (
     ),
     (
         (
-            "TEST-UNEXPECTED-FAIL "
-            "| mainthreadio "
-            "| File 'c:\users\cltbld~1.t-w' was accessed and we were not expecting it: {'Count': 6, 'Duration': 0.112512, 'RunCount': 6}"
+            r"TEST-UNEXPECTED-FAIL "
+            r"| mainthreadio "
+            r"| File 'c:\users\cltbld~1.t-w' was accessed and we were not expecting it: {'Count': 6, 'Duration': 0.112512, 'RunCount': 6}"
         ),
         'mainthreadio'
     ),

--- a/tests/webapp/api/test_bugzilla.py
+++ b/tests/webapp/api/test_bugzilla.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from __future__ import print_function
+
 import json
 
 import responses

--- a/tests/webapp/api/test_bugzilla.py
+++ b/tests/webapp/api/test_bugzilla.py
@@ -16,8 +16,8 @@ def test_create_bug(webapp, eleven_jobs_stored, activate_responses, test_user):
         headers = {}
         requestdata = json.loads(request.body)
         requestheaders = request.headers
-        print requestdata
-        print requestheaders
+        print(requestdata)
+        print(requestheaders)
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
         assert requestdata['product'] == "Bugzilla"
         assert requestdata['description'] == u"Filed by: {}\n\nIntermittent Description".format(test_user.email.replace('@', " [at] "))
@@ -65,8 +65,8 @@ def test_create_bug_with_unicode(webapp, eleven_jobs_stored, activate_responses,
         headers = {}
         requestdata = json.loads(request.body)
         requestheaders = request.headers
-        print requestdata
-        print requestheaders
+        print(requestdata)
+        print(requestheaders)
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
         assert requestdata['product'] == "Bugzilla"
         assert requestdata['description'] == u"Filed by: {}\n\nIntermittent “description” string".format(test_user.email.replace('@', " [at] "))
@@ -155,7 +155,7 @@ def test_create_crash_bug(webapp, eleven_jobs_stored, activate_responses, test_u
 
     content = json.loads(resp.content)
 
-    print content
+    print(content)
     assert content['success'] == 323
 
 
@@ -168,8 +168,8 @@ def test_create_unauthenticated_bug(webapp, eleven_jobs_stored, activate_respons
         headers = {}
         requestdata = json.loads(request.body)
         requestheaders = request.headers
-        print requestdata
-        print requestheaders
+        print(requestdata)
+        print(requestheaders)
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
         assert requestdata['product'] == "Bugzilla"
         assert requestdata['description'] == u"Filed by: MyName\n\nIntermittent Description"
@@ -210,7 +210,7 @@ def test_create_unauthenticated_bug(webapp, eleven_jobs_stored, activate_respons
 
     content = json.loads(resp.content)
 
-    print content
+    print(content)
     assert content['detail'] == "Authentication credentials were not provided."
 
 
@@ -223,8 +223,8 @@ def test_create_bug_with_long_crash_signature(webapp, eleven_jobs_stored, activa
         headers = {}
         requestdata = json.loads(request.body)
         requestheaders = request.headers
-        print requestdata
-        print requestheaders
+        print(requestdata)
+        print(requestheaders)
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
         assert requestdata['product'] == "Bugzilla"
         assert requestdata['description'] == u"Filed by: MyName\n\nIntermittent Description"
@@ -269,5 +269,5 @@ def test_create_bug_with_long_crash_signature(webapp, eleven_jobs_stored, activa
 
     content = json.loads(resp.content)
 
-    print content
+    print(content)
     assert content['failure'] == "Crash signature can't be more than 2048 characters."

--- a/tests/webapp/api/test_job_details_api.py
+++ b/tests/webapp/api/test_job_details_api.py
@@ -44,13 +44,13 @@ def test_job_details(test_repository, failure_classifications,
             repository = test_repository2
             push_id = 2
             i = 1
-        print (i, repository)
+        print(i, repository)
         job = create_generic_job(job_guid, repository, push_id,
                                  generic_reference_data)
         JobDetail.objects.create(
             job=job, **params)
         i += 1
-    print JobDetail.objects.filter(job__guid='abcd')
+    print(JobDetail.objects.filter(job__guid='abcd'))
 
     # trying to get them all should return an error
     resp = webapp.get(reverse('jobdetail-list'), expect_errors=True)

--- a/tests/webapp/api/test_job_details_api.py
+++ b/tests/webapp/api/test_job_details_api.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from django.core.urlresolvers import reverse
 
 from tests.test_utils import create_generic_job

--- a/treeherder/etl/artifact.py
+++ b/treeherder/etl/artifact.py
@@ -2,6 +2,7 @@ import logging
 
 import dateutil.parser
 import simplejson as json
+import six
 from django.db import transaction
 from django.db.utils import IntegrityError
 
@@ -161,7 +162,7 @@ def serialize_artifact_json_blobs(artifacts):
         blob = artifact['blob']
         if (artifact['type'].lower() == 'json' and
                 not isinstance(blob, str) and
-                not isinstance(blob, unicode)):
+                not isinstance(blob, six.text_type)):
             artifact['blob'] = json.dumps(blob)
 
     return artifacts

--- a/treeherder/etl/artifact.py
+++ b/treeherder/etl/artifact.py
@@ -161,8 +161,7 @@ def serialize_artifact_json_blobs(artifacts):
     for artifact in artifacts:
         blob = artifact['blob']
         if (artifact['type'].lower() == 'json' and
-                not isinstance(blob, str) and
-                not isinstance(blob, six.text_type)):
+                not isinstance(blob, six.string_types)):
             artifact['blob'] = json.dumps(blob)
 
     return artifacts

--- a/treeherder/etl/jobs.py
+++ b/treeherder/etl/jobs.py
@@ -7,6 +7,7 @@ import newrelic.agent
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.utils import IntegrityError
+from past.builtins import long
 
 from treeherder.etl.artifact import (serialize_artifact_json_blobs,
                                      store_job_artifacts)

--- a/treeherder/etl/perf.py
+++ b/treeherder/etl/perf.py
@@ -4,6 +4,7 @@ import os
 from hashlib import sha1
 
 import simplejson as json
+import six
 from jsonschema import validate
 
 from treeherder.model.models import OptionCollection
@@ -23,7 +24,7 @@ def _get_signature_hash(signature_properties):
     signature_prop_values = signature_properties.keys()
     str_values = []
     for value in signature_properties.values():
-        if not isinstance(value, basestring):
+        if not isinstance(value, six.string_types):
             str_values.append(json.dumps(value, sort_keys=True))
         else:
             str_values.append(value)

--- a/treeherder/etl/text.py
+++ b/treeherder/etl/text.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import re
 
 if len(u"\U0010FFFF") != 1:
@@ -7,7 +8,25 @@ if len(u"\U0010FFFF") != 1:
 filter_re = re.compile(ur"([\U00010000-\U0010FFFF])", re.U)
 
 
+def convert_unicode_character_to_ascii_repr(match_obj):
+    """
+    Converts a matched pattern from a unicode character to an ASCII representation
+
+    For example the emoji 🍆 would get converted to the literal <U+01F346>
+    """
+    match = match_obj.group(0)
+    code_point = ord(match)
+
+    hex_repr = hex(code_point)
+    hex_code_point = hex_repr[2:]
+
+    hex_value = hex_code_point.zfill(6).upper()
+
+    return '<U+{}>'.format(hex_value)
+
+
 def astral_filter(text):
     if text is None:
         return text
-    return filter_re.sub(lambda x: "<U+%s>" % hex(ord(x.group(0)))[2:].zfill(6).upper(), text)
+
+    return filter_re.sub(convert_unicode_character_to_ascii_repr, text)

--- a/treeherder/etl/text.py
+++ b/treeherder/etl/text.py
@@ -10,7 +10,7 @@ if len(u"\U0010FFFF") != 1:
 if six.PY3:
     filter_re = re.compile(r"([\U00010000-\U0010FFFF])")
 else:
-    filter_re = re.compile(ur"([\U00010000-\U0010FFFF])", re.U)
+    filter_re = re.compile(ur"([\U00010000-\U0010FFFF])", re.U)  # noqa: E999
 
 
 def convert_unicode_character_to_ascii_repr(match_obj):

--- a/treeherder/etl/text.py
+++ b/treeherder/etl/text.py
@@ -1,11 +1,16 @@
 # -*- coding: utf-8 -*-
 import re
 
+import six
+
 if len(u"\U0010FFFF") != 1:
     raise Exception('Python has been compiled in UCS-2 mode which is not supported.')
 
 # Regexp that matches all non-BMP unicode characters.
-filter_re = re.compile(ur"([\U00010000-\U0010FFFF])", re.U)
+if six.PY3:
+    filter_re = re.compile(r"([\U00010000-\U0010FFFF])")
+else:
+    filter_re = re.compile(ur"([\U00010000-\U0010FFFF])", re.U)
 
 
 def convert_unicode_character_to_ascii_repr(match_obj):

--- a/treeherder/perf/management/commands/test_analyze_perf.py
+++ b/treeherder/perf/management/commands/test_analyze_perf.py
@@ -60,9 +60,9 @@ class Command(BaseCommand):
         option_collection_hash = pc.get_option_collection_hash()
 
         # print csv header
-        print ','.join(["project", "platform", "signature", "series",
+        print(','.join(["project", "platform", "signature", "series",
                         "testrun_id", "push_timestamp", "change",
-                        "percent change", "t-value", "revision"])
+                        "percent change", "t-value", "revision"]))
 
         for project in options['project']:
             if options['signature']:
@@ -112,11 +112,11 @@ class Command(BaseCommand):
                         else:
                             pct_change = 0.0
                         delta = (new_value - initial_value)
-                        print ','.join(map(
+                        print(','.join(map(
                             lambda v: str(v),
                             [project, series_properties['machine_platform'],
                              signature, self._get_series_description(
                                  option_collection_hash,
                                  series_properties),
                              r.testrun_id, r.push_timestamp, delta,
-                             pct_change, r.t, revision[0:12]]))
+                             pct_change, r.t, revision[0:12]])))

--- a/treeherder/perf/management/commands/test_analyze_perf.py
+++ b/treeherder/perf/management/commands/test_analyze_perf.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from django.conf import settings
 from django.core.management.base import (BaseCommand,
                                          CommandError)

--- a/treeherder/perfalert/perfalert/__init__.py
+++ b/treeherder/perfalert/perfalert/__init__.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 
 
 def analyze(revision_data, weight_fn=None):
@@ -72,6 +73,7 @@ def calc_t(w1, w2, weight_fn=None):
     return delta_s / (((s1['variance'] / s1['n']) + (s2['variance'] / s2['n'])) ** 0.5)
 
 
+@functools.total_ordering
 class RevisionDatum(object):
     '''
     This class represents a specific revision and the set of values for it
@@ -94,8 +96,11 @@ class RevisionDatum(object):
         # Whether a perf regression or improvement was found
         self.change_detected = False
 
-    def __cmp__(self, o):
-        return cmp(self.push_timestamp, o.push_timestamp)
+    def __eq__(self, o):
+        return self.push_timestamp == o.push_timestamp
+
+    def __lt__(self, o):
+        return self.push_timestamp < o.push_timestamp
 
     def __repr__(self):
         values_str = '[ %s ]' % ', '.join(['%.3f' % value for value in


### PR DESCRIPTION
Fixes all flake8 errors when running under Python 3[.6.4].

I added tests and pulled apart the lambda in `astra_filter` so I could ensure any changes I made to the regex wouldn't break things.