### PR TITLE
Bug 1450971 - Fix package hash errors after PyPI API change

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -119,6 +119,7 @@ futures==3.2.0; python_version < '3' \
 
 # Required by jsonschema
 functools32==3.2.3-2; python_version < '3' \
+    --hash=sha256:f6253dfbe0538ad2e387bd8fdfd9293c925d63553f5813c4e587745416501e6d \
     --hash=sha256:89d824aa6c358c421a234d7f9ee0bd75933a67c29588ce50aaa3acdf4d403fa0
 
 # Required by djangorestframework's API documentation
@@ -136,7 +137,9 @@ MarkupSafe==1.0 \
 
 # Required by coreapi
 itypes==1.1.0 --hash=sha256:c6e77bb9fd68a4bfeb9d958fea421802282451a25bac4913ec94db82a899c073
-uritemplate==3.0.0 --hash=sha256:1b9c467a940ce9fb9f50df819e8ddd14696f89b9a8cc87ac77952ba416e0a8fd
+uritemplate==3.0.0 \
+    --hash=sha256:1b9c467a940ce9fb9f50df819e8ddd14696f89b9a8cc87ac77952ba416e0a8fd \
+    --hash=sha256:01c69f4fe8ed503b2951bef85d996a9d22434d2431584b5b107b2981ff416fbd
 
 requests==2.18.4 \
     --hash=sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b \


### PR DESCRIPTION
The PyPI API now returns package download URLs in a different order than before, causing errors in cases where not all hashes were listed and there were multiple matching candidates (such as both `.zip` and `.tar.gz` versions of the sdist archives).

See:
https://github.com/pypa/pypi-legacy/issues/790

This adds the hashes for the alternate package variants to fix the errors when pip installing from a clean environment.