### PR TITLE
Bug 1450972 - Fix pin wrong job from failure summary tab

### DIFF
--- a/ui/plugins/failure_summary/main.html
+++ b/ui/plugins/failure_summary/main.html
@@ -9,6 +9,7 @@
       logs="job_log_urls"
       jobLogUrls="job_log_urls"
       logParseStatus="logParseStatus"
+      watch-depth="reference"
     />
   </div>
 </div>


### PR DESCRIPTION
This has to do with my usage of ``ng-react``.  It didn't notice the job had changed in scope in angular, so it left the failure summary tab the same, which would pin the previous job.  This watches the "reference" of the job which will re-render when the job changes in ``scope``.