### PR TITLE
Bug 1452220 - Fix import_perf_data exception string formatting

### DIFF
--- a/treeherder/perf/management/commands/import_perf_data.py
+++ b/treeherder/perf/management/commands/import_perf_data.py
@@ -36,7 +36,7 @@ def _add_series(pc, project_name, signature_hash, signature_props, verbosity,
     platform = MachinePlatform.objects.filter(
         platform=signature_props['machine_platform']).first()
     if not platform:
-        raise Exception("Platform for %s (%s) does not exist".format(
+        raise Exception("Platform for {} ({}) does not exist".format(
             signature_hash, signature_props))
 
     framework = PerformanceFramework.objects.get(name='talos')


### PR DESCRIPTION
Since `.format()` doesn't support `%s`. 

Found by the eslint `too-many-format-args` rule.