### PR TITLE
Bug 1452213 - Correctly set RunnableJobs group

### DIFF
--- a/treeherder/etl/runnable_jobs.py
+++ b/treeherder/etl/runnable_jobs.py
@@ -104,6 +104,7 @@ class RunnableJobsProcess(RunnableJobsTransformerMixin):
                     defaults={'build_platform': build_platform,
                               'machine_platform': machine_platform,
                               'job_type': job_type,
+                              'job_group': job_group,
                               'option_collection_hash': option_collection_hash,
                               'repository': repo})
 


### PR DESCRIPTION
Previously all created/updated `RunnableJobs` entries were using the `job_group` default of `2`, rather than the actual job group ID.

Not bothering to add a test since `RunnableJobs` will be going away once buildbot supported is removed.