### PR TITLE
Bug 1352862 - Restore the 'i' keyboard shortcut to toggle in-progress jobs

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -443,7 +443,7 @@ treeherderApp.controller('MainCtrl', [
             }],
 
             // Shortcut: ignore selected in the autoclasify panel
-            ['i', function () {
+            ['ctrl+i', function () {
                 if (thTabs.selectedTab === "autoClassification") {
                     $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyIgnore));
                 }

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -269,51 +269,140 @@ treeherderApp.controller('MainCtrl', [
             return false;
         };
 
+        // Keep these in alphabetical order so we don't accidentally introduce
+        // conflicts.
         const keyShortcuts = [
-            // Shortcut: toggle display in-progress jobs (pending/running)
-            ['i', function () {
-                $scope.$evalAsync($scope.toggleInProgress());
-            }],
-
-            // Shortcut: select previous job
-            ['left', function () {
-                $rootScope.$emit(thEvents.changeSelection,
-                                 'previous',
-                                 thJobNavSelectors.ALL_JOBS);
-            }],
-
-            // Shortcut: select next job
-            ['right', function () {
-                $rootScope.$emit(thEvents.changeSelection,
-                                 'next',
-                                 thJobNavSelectors.ALL_JOBS);
-            }],
-
-            // Shortcut: select next unclassified failure
-            ['n', function () {
-                $rootScope.$emit(thEvents.changeSelection,
-                                 'next',
-                                 thJobNavSelectors.UNCLASSIFIED_FAILURES);
-            }],
-
-            // Shortcut: select previous unclassified failure
-            ['p', function () {
-                $rootScope.$emit(thEvents.changeSelection,
-                                 'previous',
-                                 thJobNavSelectors.UNCLASSIFIED_FAILURES);
-            }],
-
-            // Shortcut: select next job tab
-            [['t'], function () {
-                if ($scope.selectedJob) {
-                    $scope.$evalAsync(
-                        $rootScope.$emit(thEvents.selectNextTab)
-                    );
+            // Shortcut: select all remaining unverified lines on the current job
+            ['a', () => {
+                if (thTabs.selectedTab === "autoClassification") {
+                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyChangeSelection,
+                                                       'all_next',
+                                                       false));
                 }
             }],
 
+            // Shortcut: pin selected job to pinboard and add a related bug
+            ['b', (ev) => {
+                if ($scope.selectedJob) {
+                    $rootScope.$emit(thEvents.addRelatedBug,
+                                     $rootScope.selectedJob);
+
+                    // Prevent shortcut key overflow during focus
+                    ev.preventDefault();
+
+                    $timeout(
+                        () => {
+                            $("#related-bug-input").focus();
+                        }, 0);
+                }
+            }, (ev, element) => {
+                if (element.id === "pinboard-classification-select") {
+                    return false;
+                }
+                return null;
+            }],
+
+            // Shortcut: pin selected job to pinboard and enter classification
+            ['c', (ev) => {
+                if ($scope.selectedJob) {
+                    $scope.$evalAsync(
+                        $rootScope.$emit(thEvents.jobPin, $rootScope.selectedJob)
+                    );
+
+                    // Prevent shortcut key overflow during focus
+                    ev.preventDefault();
+
+                    $timeout(
+                        () => {
+                            $("#classification-comment").focus();
+                        }, 0);
+                }
+            }, (ev, element) => {
+                if (element.id === "pinboard-classification-select") {
+                    return false;
+                }
+                return null;
+            }],
+
+            // Shortcut: toggle edit mode for selected lines
+            ['e', () => {
+                if (thTabs.selectedTab === "autoClassification") {
+                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyToggleEdit));
+                }
+            }],
+
+            // Shortcut: enter a quick filter
+            ['f', (ev) => {
+                // Prevent shortcut key overflow during focus
+                ev.preventDefault();
+                $('#quick-filter').focus();
+            }],
+
+            // Shortcut: clear the quick filter field
+            ['ctrl+shift+f', (ev) => {
+                // Prevent shortcut key overflow during focus
+                ev.preventDefault();
+                $scope.$evalAsync($scope.clearFilterBox());
+            }],
+
+            // Shortcut: toggle display in-progress jobs (pending/running)
+            ['i', () => {
+                $scope.$evalAsync($scope.toggleInProgress());
+            }],
+
+            // Shortcut: ignore selected in the autoclasify panel
+            ['ctrl+i', () => {
+                if (thTabs.selectedTab === "autoClassification") {
+                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyIgnore));
+                }
+            }],
+
+            // Shortcut: select next unclassified failure
+            [['j', 'n'], () => {
+                $rootScope.$emit(thEvents.changeSelection,
+                                 'next',
+                                 thJobNavSelectors.UNCLASSIFIED_FAILURES);
+            }],
+
+            // Shortcut: select next unverified log line
+            ['ctrl+j', (ev) => {
+                if (thTabs.selectedTab === "autoClassification") {
+                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyChangeSelection,
+                                                       'next',
+                                                       !ev.shiftKey));
+                }
+            }],
+
+            // Shortcut: select previous unclassified failure
+            [['k', 'p'], () => {
+                $rootScope.$emit(thEvents.changeSelection,
+                                 'previous',
+                                 thJobNavSelectors.UNCLASSIFIED_FAILURES);
+            }],
+
+            // Shortcut: select previous unverified log line
+            ['ctrl+k', (ev) => {
+                if (thTabs.selectedTab === "autoClassification") {
+                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyChangeSelection,
+                                                       'previous',
+                                                       !ev.shiftKey));
+                }
+            }],
+
+            // Shortcut: open the logviewer for the selected job
+            ['l', () => {
+                if (thTabs.selectedTab === "autoClassification") {
+                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyOpenLogViewer));
+                } else if ($scope.selectedJob) {
+                    $scope.$evalAsync($rootScope.$emit(thEvents.openLogviewer));
+                }
+            }],
+
+            // Shortcut: Next/prev unclassified failure
+            // For 'n' and 'p', see 'j' and 'k' above
+
             // Shortcut: retrigger selected job
-            ['r', function () {
+            ['r', () => {
                 if ($scope.selectedJob) {
                     $scope.$evalAsync(
                         $rootScope.$emit(thEvents.jobRetrigger,
@@ -322,8 +411,63 @@ treeherderApp.controller('MainCtrl', [
                 }
             }],
 
+            // Shortcut: save all in the autoclasify panel
+            ['ctrl+s', () => {
+                if (thTabs.selectedTab === "autoClassification") {
+                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifySaveAll));
+                }
+            }],
+
+            // Shortcut: select next job tab
+            ['t', () => {
+                if ($scope.selectedJob) {
+                    $scope.$evalAsync(
+                        $rootScope.$emit(thEvents.selectNextTab)
+                    );
+                }
+            }],
+
+            // Shortcut: display only unclassified failures
+            ['u', () => {
+                $scope.$evalAsync($scope.toggleUnclassifiedFailures);
+            }],
+
+            // Shortcut: clear the pinboard
+            ['ctrl+shift+u', () => {
+                $scope.$evalAsync($rootScope.$emit(thEvents.clearPinboard));
+            }],
+
+            // Shortcut: toggle more/fewer options in the autoclassify panel
+            ['x', () => {
+                if (thTabs.selectedTab === "autoClassification") {
+                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyToggleExpandOptions));
+                }
+            }],
+
+            // Shortcut: ignore selected in the autoclasify panel
+            [['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'o'], (ev) => {
+                if (thTabs.selectedTab === "autoClassification") {
+                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifySelectOption,
+                                                       ev.key === "o" ? "manual" : ev.key));
+                }
+            }],
+
+            // Shortcut: select previous job
+            ['left', () => {
+                $rootScope.$emit(thEvents.changeSelection,
+                                 'previous',
+                                 thJobNavSelectors.ALL_JOBS);
+            }],
+
+            // Shortcut: select next job
+            ['right', () => {
+                $rootScope.$emit(thEvents.changeSelection,
+                                 'next',
+                                 thJobNavSelectors.ALL_JOBS);
+            }],
+
             // Shortcut: pin selected job to pinboard
-            ['space', function (ev) {
+            ['space', (ev) => {
                 // If a job is selected add it otherwise
                 // let the browser handle the spacebar
                 if ($scope.selectedJob) {
@@ -336,178 +480,29 @@ treeherderApp.controller('MainCtrl', [
                 }
             }],
 
-            // Shortcut: display only unclassified failures
-            ['u', function () {
-                $scope.$evalAsync($scope.toggleUnclassifiedFailures);
-            }],
-
-            // Shortcut: pin selected job to pinboard and add a related bug
-            ['b', function (ev) {
-                if ($scope.selectedJob) {
-                    $rootScope.$emit(thEvents.addRelatedBug,
-                                     $rootScope.selectedJob);
-
-                    // Prevent shortcut key overflow during focus
-                    ev.preventDefault();
-
-                    $timeout(
-                        function () {
-                            $("#related-bug-input").focus();
-                        }, 0);
-                }
-            }, function (ev, element) {
-                if (element.id === "pinboard-classification-select") {
-                    return false;
-                }
-                return null;
-            }],
-
-            // Shortcut: pin selected job to pinboard and enter classification
-            ['c', function (ev) {
-                if ($scope.selectedJob) {
-                    $scope.$evalAsync(
-                        $rootScope.$emit(thEvents.jobPin, $rootScope.selectedJob)
-                    );
-
-                    // Prevent shortcut key overflow during focus
-                    ev.preventDefault();
-
-                    $timeout(
-                        function () {
-                            $("#classification-comment").focus();
-                        }, 0);
-                }
-            }, function (ev, element) {
-                if (element.id === "pinboard-classification-select") {
-                    return false;
-                }
-                return null;
-            }],
-
-            // Shortcut: enter a quick filter
-            ['f', function (ev) {
-                // Prevent shortcut key overflow during focus
-                ev.preventDefault();
-
-                $('#quick-filter').focus();
-            }],
-
-            // Shortcut: clear the quick filter field
-            ['ctrl+shift+f', function (ev) {
-                // Prevent shortcut key overflow during focus
-                ev.preventDefault();
-
-                $scope.$evalAsync($scope.clearFilterBox());
-            }],
-
             // Shortcut: escape closes any open panels and clears selected job
-            ['escape', function () {
+            ['escape', () => {
                 $scope.$evalAsync($scope.closeJob());
                 $scope.$evalAsync($scope.setOnscreenShortcutsShowing(false));
             }],
 
-            // Shortcut: clear the pinboard
-            ['ctrl+shift+u', function () {
-                $scope.$evalAsync($rootScope.$emit(thEvents.clearPinboard));
-            }],
-
             // Shortcut: save pinboard classification and related bugs
-            ['ctrl+enter', function () {
+            ['ctrl+enter', () => {
                 $scope.$evalAsync($rootScope.$emit(thEvents.saveClassification));
-            }, function () {
+            }, () => (
                 // Make this work regardless of form controls etc.
-                return false;
-            }],
-
-            // Shortcut: open the logviewer for the selected job
-            ['l', function () {
-                if (thTabs.selectedTab === "autoClassification") {
-                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyOpenLogViewer));
-                } else if ($scope.selectedJob) {
-                    $scope.$evalAsync($rootScope.$emit(thEvents.openLogviewer));
-                }
-            }],
+                false
+            )],
 
             // Shortcut: delete classification and related bugs
-            ['ctrl+backspace', function () {
+            ['ctrl+backspace', () => {
                 if ($scope.selectedJob) {
                     $scope.$evalAsync($rootScope.$emit(thEvents.deleteClassification));
                 }
             }],
 
-            // Shortcut: save all in the autoclasify panel
-            ['s', function () {
-                if (thTabs.selectedTab === "autoClassification") {
-                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifySaveAll));
-                }
-            }],
-
-            // Shortcut: ignore selected in the autoclasify panel
-            ['ctrl+i', function () {
-                if (thTabs.selectedTab === "autoClassification") {
-                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyIgnore));
-                }
-            }],
-
-            // Shortcut: ignore selected in the autoclasify panel
-            [['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'o'], function (ev) {
-                if (thTabs.selectedTab === "autoClassification") {
-                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifySelectOption,
-                                                       ev.key === "o" ? "manual" : ev.key));
-                }
-            }],
-
-            // Shortcut: toggle edit mode for selected lines
-            ['e', function () {
-                if (thTabs.selectedTab === "autoClassification") {
-                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyToggleEdit));
-                }
-            }],
-
-            // Shortcut: toggle more/fewer options in the autoclassify panel
-            ['x', function () {
-                if (thTabs.selectedTab === "autoClassification") {
-                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyToggleExpandOptions));
-                }
-            }],
-
-            // Shortcut: select next unverified log line
-            [['j', 'shift+j'], function (ev) {
-                if (thTabs.selectedTab === "autoClassification") {
-                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyChangeSelection,
-                                                       'next',
-                                                       !ev.shiftKey));
-                } else {
-                    $rootScope.$emit(thEvents.changeSelection,
-                                     'next',
-                                     thJobNavSelectors.UNCLASSIFIED_FAILURES);
-                }
-            }],
-
-            // Shortcut: select previous unverified log line
-            [['k', 'shift+k'], function (ev) {
-                if (thTabs.selectedTab === "autoClassification") {
-                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyChangeSelection,
-                                                       'previous',
-                                                       !ev.shiftKey));
-                } else {
-                    $rootScope.$emit(thEvents.changeSelection,
-                                     'previous',
-                                     thJobNavSelectors.UNCLASSIFIED_FAILURES);
-                }
-            }],
-
-            // Shortcut: select all remaining unverified lines on the current job
-            [['a'], function () {
-                if (thTabs.selectedTab === "autoClassification") {
-                    $scope.$evalAsync($rootScope.$emit(thEvents.autoclassifyChangeSelection,
-                                                       'all_next',
-                                                       false));
-                }
-            }],
-
             // Shortcut: display onscreen keyboard shortcuts
-            ['?', function () {
+            ['?', () => {
                 $scope.$evalAsync($scope.setOnscreenShortcutsShowing(true));
             }]
         ];

--- a/ui/partials/main/thShortcutTable.html
+++ b/ui/partials/main/thShortcutTable.html
@@ -14,32 +14,32 @@
         <th colspan=2>Jobs View</th>
       </tr>
       <tbody>
-        <tr><td><kbd>esc</kbd></td>
-          <td>Close all open panels</td></tr>
         <tr><td><kbd>f</kbd></td>
           <td>Enter a quick filter</td></tr>
         <tr>
           <td><kbd>ctrl</kbd><kbd>shift</kbd><kbd>f</kbd></td>
           <td>Clear the quick filter</td>
         </tr>
-        <tr><td><kbd>&larr;</kbd></td>
-          <td>Select previous job</td></tr>
-        <tr><td><kbd>&rarr;</kbd></td>
-          <td>Select next job</td></tr>
-        <tr><td><kbd>k</kbd> or <kbd>p</kbd></td>
-          <td>Select previous unclassified failure</td></tr>
+        <tr><td><kbd>i</kbd></td>
+          <td>Toggle pending and running jobs</td></tr>
         <tr><td><kbd>j</kbd> or <kbd>n</kbd></td>
           <td>Select next unclassified failure</td></tr>
-        <tr><td><kbd>t</kbd></td>
-          <td>Select next info tab</td></tr>
+        <tr><td><kbd>k</kbd> or <kbd>p</kbd></td>
+          <td>Select previous unclassified failure</td></tr>
         <tr><td><kbd>l</kbd></td>
           <td>Open the logviewer for the selected job</td></tr>
         <tr><td><kbd>r</kbd></td>
           <td>Retrigger selected job</td></tr>
-        <tr><td><kbd>u</td>
+        <tr><td><kbd>t</kbd></td>
+          <td>Select next info tab</td></tr>
+        <tr><td><kbd>u</kbd></td>
           <td>Toggle showing only unclassified jobs</td></tr>
-        <tr><td><kbd>i</td>
-          <td>Toggle pending and running jobs</td></tr>
+        <tr><td><kbd>&rarr;</kbd></td>
+          <td>Select next job</td></tr>
+        <tr><td><kbd>&larr;</kbd></td>
+          <td>Select previous job</td></tr>
+        <tr><td><kbd>esc</kbd></td>
+          <td>Close all open panels</td></tr>
         <tr><td><kbd>ctrl</kbd> or <kbd>cmd</kbd></td>
           <td>Toggle pinning a job during click selection</td></tr>
       </tbody>
@@ -47,41 +47,39 @@
         <th colspan=2>Pinboard</th>
       </tr>
       <tbody>
-        <tr><td><kbd>spacebar</kbd></td>
-          <td>Add a selected job to the pinboard</td></tr>
         <tr><td><kbd>b</kbd></td>
           <td>Add a selected job to the pinboard + enter related bug</td></tr>
         <tr><td><kbd>c</kbd></td>
           <td>Add a selected job to the pinboard + enter classification</td></tr>
-        <tr><td><kbd>ctrl</kbd><kbd>enter</kbd></td>
-          <td>Save pinboard classification and related bugs</td></tr>
         <tr>
           <td><kbd>ctrl</kbd><kbd>shift</kbd><kbd>u</kbd></td>
           <td>Clear the pinboard</td>
         </tr>
+        <tr><td><kbd>spacebar</kbd></td>
+          <td>Add a selected job to the pinboard</td></tr>
+        <tr><td><kbd>ctrl</kbd><kbd>enter</kbd></td>
+          <td>Save pinboard classification and related bugs</td></tr>
         <tr><td><kbd>ctrl</kbd><kbd>backspace</kbd></td>
           <td>Delete job classification and related bugs</td></tr>
         <tr>
           <th colspan=2>Autoclassify Panel</th>
         </tr>
-        <tr><td><kbd>j</kbd></td>
-          <td>Select next failure</td></tr>
-        <tr><td><kbd>k</kbd></td>
-          <td>Select previous failure</td></tr>
         <tr><td><kbd>a</kbd></td>
           <td>Add all subsequent lines to the selection</td></tr>
-        <tr><td><kbd>0</kbd>-<kbd>9</kbd></td>
-          <td>Select the Nth classification option</td></tr>
-        <tr><td><kbd>ctrl</kbd><kbd>i</kbd></td>
-          <td>Ignore the failure</td></tr>
-        <tr><td><kbd>m</kbd></td>
-          <td>Select the manual classification option</td></tr>
-        <tr><td><kbd>s</kbd></td>
-          <td>Save all classifications</td></tr>
         <tr><td><kbd>e</kbd></td>
           <td>Toggle editing selected lines</td></tr>
+        <tr><td><kbd>ctrl</kbd><kbd>i</kbd></td>
+          <td>Ignore the failure</td></tr>
+        <tr><td><kbd>ctrl</kbd><kbd>j</kbd></td>
+          <td>Select next failure</td></tr>
+        <tr><td><kbd>ctrl</kbd><kbd>k</kbd></td>
+          <td>Select previous failure</td></tr>
         <tr><td><kbd>x</kbd></td>
           <td>Toggle showing additional classification suggestions</td></tr>
+        <tr><td><kbd>ctrl</kbd><kbd>s</kbd></td>
+          <td>Save all classifications</td></tr>
+        <tr><td><kbd>0</kbd>-<kbd>9</kbd></td>
+          <td>Select the Nth classification option</td></tr>
       </tbody>
       <tr>
         <th colspan=2>Help</th>

--- a/ui/partials/main/thShortcutTable.html
+++ b/ui/partials/main/thShortcutTable.html
@@ -72,7 +72,7 @@
           <td>Add all subsequent lines to the selection</td></tr>
         <tr><td><kbd>0</kbd>-<kbd>9</kbd></td>
           <td>Select the Nth classification option</td></tr>
-        <tr><td><kbd>i</kbd></td>
+        <tr><td><kbd>ctrl</kbd><kbd>i</kbd></td>
           <td>Ignore the failure</td></tr>
         <tr><td><kbd>m</kbd></td>
           <td>Select the manual classification option</td></tr>

--- a/ui/plugins/auto_classification/controller.js
+++ b/ui/plugins/auto_classification/controller.js
@@ -748,7 +748,8 @@ treeherder.controller('ThAutoclassifyErrorsController', ['$scope', '$element',
                 }
                 elem = elem.parent();
             }
-            ctrl.onToggleSelect({ lineIds: [id], clear: !event.ctrlKey });
+            // ctrl+click on mac is same as right-click, so use meta key instead
+            ctrl.onToggleSelect({ lineIds: [id], clear: !(event.ctrlKey || event.metaKey) });
         };
     }
 ]);


### PR DESCRIPTION
This wasn't super urgent, but it was also scratching my own itch, so I went ahead and did it.  :)

The ``i`` shortcut was getting overridden by the same key for the autoclassify panel because it was listed twice.  This makes the autoclassify one need a ``ctrl``.

This also tries to clean up the keyboard shortcuts and alphabetize them so we don't introduce conflicts.  

An additional small thing to allow multi-select on mac in the autoclassify panel (already worked on windows) is so I can do A/B testing easier against the ReactJS version.