### PR TITLE
Bug 1453850 - Enable Python 2's `-3` mode on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,9 @@ matrix:
         # 'https://' being in the site URL. In addition, we override the test environment's debug
         # value so the tests pass. The real environment variable will be checked during deployment.
         - SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' ./manage.py check --deploy --fail-level WARNING
-        - pytest tests/ --runslow --ignore=tests/selenium/ --ignore=tests/jenkins/
+        # Using Python 2's `-3` mode to surface DeprecationWarnings for Python 3 incompatibilities:
+        # https://docs.python.org/2/using/cmdline.html#cmdoption-3
+        - python -3 -m pytest tests/ --runslow --ignore=tests/selenium/ --ignore=tests/jenkins/
 
     # Job 5: Python Tests - Selenium integration
     - env: python-tests-selenium
@@ -93,7 +95,9 @@ matrix:
         # Run in `before_script` to prevent the selenium tests from still being run if the UI build fails.
         - yarn build
       script:
-        - pytest tests/selenium/ --driver Firefox
+        # Using Python 2's `-3` mode to surface DeprecationWarnings for Python 3 incompatibilities:
+        # https://docs.python.org/2/using/cmdline.html#cmdoption-3
+        - python -3 -m pytest tests/selenium/ --driver Firefox
 
 notifications:
   email:

--- a/bin/travis-setup.sh
+++ b/bin/travis-setup.sh
@@ -8,6 +8,8 @@ export DATABASE_URL='mysql://root@localhost/test_treeherder'
 export ELASTICSEARCH_URL='http://127.0.0.1:9200'
 export REDIS_URL='redis://localhost:6379'
 export TREEHERDER_DJANGO_SECRET_KEY='secretkey-of-at-50-characters-to-pass-check-deploy'
+# Suppress warnings shown during pytest startup when using `python2 -3` mode.
+export PYTHONWARNINGS='ignore:Overriding __eq__ blocks inheritance of __hash__ in 3.x:DeprecationWarning'
 
 setup_services() {
     ELASTICSEARCH_VERSION="5.5.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,13 @@ filterwarnings =
     error
     ignore::ImportWarning
     ignore::PendingDeprecationWarning
+    # `python2 -3` mode warning that's a real bug. Remove once bug 1453837 is fixed.
+    ignore:comparing unequal types not supported in 3.x:DeprecationWarning:treeherder.auth.backends
+    # Hide `python2 -3` mode warnings that are false positives
+    ignore:Overriding __eq__ blocks inheritance of __hash__ in 3.x:DeprecationWarning
+    ignore:sys.exc_clear\(\) not supported in 3.x; use except clauses:DeprecationWarning
+    ignore:classic int division:DeprecationWarning:django.db.backends.base.schema
+    ignore:In 3.x, reload\(\) is renamed to imp.reload\(\):DeprecationWarning:django.db.migrations.loader
 markers =
     slow: mark a test as slow.
 xfail_strict = true

--- a/tests/webapp/api/test_bug_job_map_api.py
+++ b/tests/webapp/api/test_bug_job_map_api.py
@@ -75,9 +75,7 @@ def test_bug_job_map_list(client, test_repository, eleven_jobs_stored, test_user
             data={'job_id': [job.id for job in
                              jobs[job_range[0]:job_range[1]]]})
         assert resp.status_code == 200
-
-        # The order of the bug-job-map list is not guaranteed.
-        assert sorted(resp.json()) == sorted(expected[job_range[0]:job_range[1]])
+        assert resp.json() == expected[job_range[0]:job_range[1]]
 
 
 def test_bug_job_map_detail(client, eleven_jobs_stored, test_repository,


### PR DESCRIPTION
This enables `DeprecationWarnings` for things that Python 2 knows are not compatible with Python 3. The `error` entry in the pytest `filterwarnings` setting ensures these will be surfaced as exceptions and so result in test failures.

See:
https://docs.python.org/2/using/cmdline.html#cmdoption-3

The removal of `sorted()` from `test_bug_job_map_api.py` is to fix:
`DeprecationWarning: dict inequality comparisons not supported in 3.x`