### PR TITLE
Bug 1454075 - Clean up login button and remove dead class

### DIFF
--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -122,6 +122,12 @@ label.dropdown-item {
     padding-right: 14px;
 }
 
+.nav-login-btn-unavail {
+    font-size: 12px;
+    color: grey;
+    cursor: not-allowed;
+}
+
 .th-context-navbar {
     background-color: #354048;
     overflow: visible;

--- a/ui/js/components/auth.js
+++ b/ui/js/components/auth.js
@@ -18,7 +18,7 @@ treeherder.component("login", {
               ng-if="$ctrl.user.loggedin">
           <button id="logoutLabel" title="Logged in as: {{$ctrl.user.email}}" role="button"
                   data-toggle="dropdown"
-                  class="btn btn-view-nav btn-right-navbar">
+                  class="btn btn-view-nav">
             <div class="dropdown-toggle">
                 <div class="nav-user-icon">
                   <span class="fa fa-user pull-left"></span>
@@ -33,11 +33,11 @@ treeherder.component("login", {
           </ul>
         </span>
 
-        <span class="btn btn-right-navbar nav-login-btn"
+        <span class="btn nav-login-btn"
            ng-if="!$ctrl.user.loggedin && $ctrl.userCanLogin"
            ng-click="$ctrl.login()">Login/Register</span>
         <span ng-if="!$ctrl.userCanLogin"
-              class="midgray"
+              class="nav-login-btn nav-login-btn-unavail"
               title="SERVICE_DOMAIN does not match host domain">Login not available</span>
     `,
     bindings: {

--- a/ui/partials/main/thGlobalTopNavPanel.html
+++ b/ui/partials/main/thGlobalTopNavPanel.html
@@ -19,7 +19,7 @@
       <span class="dropdown" ng-controller="NotificationCtrl">
         <button id="notificationLabel" title="Recent notifications" role="button"
                 data-toggle="dropdown"
-                class="btn btn-view-nav btn-right-navbar nav-menu-btn">
+                class="btn btn-view-nav nav-menu-btn">
           <span class="fa fa-bell-o lightgray"></span>
         </button>
         <ul id="notification-dropdown" class="dropdown-menu nav-dropdown-menu-right" role="menu" aria-labelledby="notificationLabel">
@@ -52,7 +52,7 @@
       <span class="dropdown">
         <button id="infraLabel" title="Infrastructure status" role="button"
                 data-toggle="dropdown"
-                class="btn btn-view-nav btn-right-navbar nav-menu-btn dropdown-toggle">Infra
+                class="btn btn-view-nav nav-menu-btn dropdown-toggle">Infra
         </button>
         <ul id="infra-dropdown" class="dropdown-menu nav-dropdown-menu-right container" role="menu" aria-labelledby="infraLabel"
             ng-include="'partials/main/thInfraMenu.html'">
@@ -64,7 +64,7 @@
         <span th-checkbox-dropdown-container class="dropdown">
           <button id="repoLabel" title="Watch a repo" role="button"
                   data-toggle="dropdown"
-                  class="btn btn-view-nav btn-right-navbar nav-menu-btn dropdown-toggle">Repos
+                  class="btn btn-view-nav nav-menu-btn dropdown-toggle">Repos
           </button>
           <span id="repo-dropdown" class="dropdown-menu nav-dropdown-menu-right container">
             <ul class="checkbox-dropdown-menu row"
@@ -112,7 +112,7 @@
         <span th-checkbox-dropdown-container class="dropdown">
           <button id="filterLabel" title="Set filters" role="button"
                   data-toggle="dropdown"
-                  class="btn btn-view-nav btn-right-navbar nav-menu-btn dropdown-toggle">Filters
+                  class="btn btn-view-nav nav-menu-btn dropdown-toggle">Filters
           </button>
           <ul id="filter-dropdown"
               class="dropdown-menu nav-dropdown-menu-right checkbox-dropdown-menu"
@@ -166,7 +166,7 @@
       <span id="help-menu" class="dropdown">
         <button id="helpLabel" title="Treeherder help" role="button"
                 data-toggle="dropdown"
-                class="btn btn-view-nav btn-right-navbar nav-help-btn dropdown-toggle">
+                class="btn btn-view-nav nav-help-btn dropdown-toggle">
           <span class="fa fa-question-circle lightgray nav-help-icon"></span>
         </button>
         <ul class="dropdown-menu nav-dropdown-menu-right icon-menu" role="menu" aria-labelledby="helpLabel"

--- a/ui/perf.html
+++ b/ui/perf.html
@@ -43,7 +43,7 @@
         <span class="dropdown">
           <button id="helpLabel" title="Perfherder help" role="button"
                   data-toggle="dropdown"
-                  class="btn btn-view-nav btn-right-navbar nav-help-btn dropdown-toggle">
+                  class="btn btn-view-nav nav-help-btn dropdown-toggle">
             <span class="fa fa-question-circle lightgray nav-help-icon"></span>
           </button>
           <ul class="dropdown-menu nav-dropdown-menu-right icon-menu" role="menu" aria-labelledby="helpLabel"


### PR DESCRIPTION
This hopefully fixes Bugzilla bug [1454075](https://bugzilla.mozilla.org/show_bug.cgi?id=1454075).

A tiny nit that nobody really sees except developers. This improves the Login button a little when the user is running the standalone yarn server and not vagrant. The old login text was oversized and the button had no padding. I stared at it for months and eventually did something about it.

Current:
![current](https://user-images.githubusercontent.com/3660661/38757984-fbcf18de-3f3c-11e8-92fe-88cc7ad8b6cb.jpg)

Proposed:
![proposed](https://user-images.githubusercontent.com/3660661/38757990-ffe74c34-3f3c-11e8-9c95-1c6d96f5bda4.jpg)

At the same time, there's a `btn-right-navbar` class that was apparently made redundant during the React work. So let's remove that at the same time.

Tested on OSX 10.12.6:
Nightly **61.0a1 (2018-04-12) (64-bit)**

