### PR TITLE
Bug 1405666 - Enable mousetrap shortcuts inside checkboxes

### DIFF
--- a/ui/partials/main/thGlobalTopNavPanel.html
+++ b/ui/partials/main/thGlobalTopNavPanel.html
@@ -98,6 +98,7 @@
                      class="dropdown-item">
                 <input id="tier-checkbox"
                        type="checkbox"
+                       class="mousetrap"
                        ng-model="tiers[tier]"
                        ng-disabled="isSingleTierSelected() && tiers[tier] == true"
                        ng-change="tierToggled(tier)">tier {{::tier}}
@@ -125,6 +126,7 @@
               <span ng-repeat="filterName in group.resultStatuses" >
                 <label class="{{::checkClass}} dropdown-item">
                   <input type="checkbox"
+                         class="mousetrap"
                          id="{{::filterName}}"
                          ng-model="resultStatusFilters[filterName]"
                          ng-change="toggleResultStatusFilter(filterName)"> {{::filterName}}

--- a/ui/partials/main/thRepoMenuItem.html
+++ b/ui/partials/main/thRepoMenuItem.html
@@ -1,6 +1,6 @@
 <li>
   <input type="checkbox"
-         class="dropdown-checkbox"
+         class="dropdown-checkbox mousetrap"
          ng-checked="repoModel.watchedRepos.includes(repo.name)"
          ng-click="repoModel.toggleWatched(repo.name)"
          title="toggle watching this repo">


### PR DESCRIPTION
This may fix Bugzilla bug [1405666](https://bugzilla.mozilla.org/show_bug.cgi?id=1405666).

A bit of a speculative PR based on the description and workflow in the bug, but this enables the ability to issue mousetrap shortcuts when any main navbar checkbox input has focus.

Proposed (checkbox focus, navigated via `>` key to "next job"):

![checkfocuskeyshortcutproposed](https://user-images.githubusercontent.com/3660661/38772002-1c14b04a-3ffb-11e8-9ccd-ee60aab802fd.jpg)

It seems to work as expected on Nightly and Chrome.

Tested on OSX 10.12.6:
Nightly **61.0a1 (2018-04-13) (64-bit)**
Chrome Release **65.0.3325.181 (64-bit)**