### PR TITLE
Use loaded property in pages instead of overriding wait_for_page_to_load

### DIFF
--- a/tests/selenium/pages/perfherder.py
+++ b/tests/selenium/pages/perfherder.py
@@ -9,10 +9,9 @@ class Perfherder(Base):
 
     _add_test_data_locator = (By.ID, 'add-test-data-button')
 
-    def wait_for_page_to_load(self):
-        self.wait.until(lambda _: self.is_element_displayed(
-            By.CSS_SELECTOR, '#graph canvas'))
-        return self
+    @property
+    def loaded(self):
+        return self.is_element_displayed(By.CSS_SELECTOR, '#graph canvas')
 
     def add_test_data(self):
         self.find_element(*self._add_test_data_locator).click()

--- a/tests/selenium/pages/treeherder.py
+++ b/tests/selenium/pages/treeherder.py
@@ -33,9 +33,9 @@ class Treeherder(Base):
     _unclassified_filter_locator = (By.CSS_SELECTOR, '.btn-unclassified-failures')
     _watched_repos_locator = (By.CSS_SELECTOR, '#watched-repo-navbar th-watched-repo')
 
-    def wait_for_page_to_load(self):
-        self.wait.until(lambda _: self.find_elements(*self._watched_repos_locator))
-        return self
+    @property
+    def loaded(self):
+        return self.find_elements(*self._watched_repos_locator)
 
     @property
     def active_filters(self):


### PR DESCRIPTION
This allows any PyPOM plugins that implement the `pypom_after_wait_for_page_to_load` hook. See http://pypom.readthedocs.io/en/latest/plugins.html for more details.