### PR TITLE
Bug 1427598 - Upgrade Elasticsearch to 6.2.4

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,8 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"
   # for DB access from host
   config.vm.network "forwarded_port", guest: 3306, host: 3308, host_ip: "127.0.0.1"
+  # for Elasticsearch access from host
+  config.vm.network "forwarded_port", guest: 9200, host: 9201, host_ip: "127.0.0.1"
 
   if !Vagrant::Util::Platform.windows?
     # On platforms where NFS is used (ie all but Windows), we still have to use

--- a/bin/travis-setup.sh
+++ b/bin/travis-setup.sh
@@ -12,11 +12,11 @@ export TREEHERDER_DJANGO_SECRET_KEY='secretkey-of-at-50-characters-to-pass-check
 export PYTHONWARNINGS='ignore:Overriding __eq__ blocks inheritance of __hash__ in 3.x:DeprecationWarning'
 
 setup_services() {
-    ELASTICSEARCH_VERSION="5.5.0"
+    ELASTICSEARCH_VERSION="6.2.4"
     if [[ "$(dpkg-query --show --showformat='${Version}' elasticsearch 2>&1)" != "$ELASTICSEARCH_VERSION" ]]; then
         echo '-----> Installing Elasticsearch'
         curl -sSfo /tmp/elasticsearch.deb "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.deb"
-        sudo dpkg -i --force-confold /tmp/elasticsearch.deb
+        sudo dpkg -i --force-confnew /tmp/elasticsearch.deb
         sudo service elasticsearch restart
     else
         sudo service elasticsearch start

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -188,9 +188,9 @@ django-redis==4.9.0 \
 # Required by django-redis
 redis==2.10.6 --hash=sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb
 
-elasticsearch==5.5.2 \
-    --hash=sha256:2e6dcdf9cb62377e0d6b82d2931ebc67b5a549081bbb531aa3be60ece33257b2 \
-    --hash=sha256:8539e30c33fa0ad09617893a458056a35a654c92226390c30a07a3776bb8a94f  # pyup: <6 # Bug 1427598
+elasticsearch==6.2.0 \
+    --hash=sha256:503c498234dd572896e563386181d7cb966ab3db68b0b132a26c5dabfd5dde24 \
+    --hash=sha256:b106fa3e01750376a42f8a9882bd84d630fda58c7aba38b4fec797d11c0bd0a2
 
 # required by requests and elasticsearch
 urllib3==1.22 \

--- a/treeherder/autoclassify/matchers.py
+++ b/treeherder/autoclassify/matchers.py
@@ -201,11 +201,8 @@ class ElasticSearchTestMatcher(Matcher):
                 'bool': {
                     'filter': filters,
                     'must': [{
-                        'match': {
-                            'message': {
-                                'query': failure_line.message[:1024],
-                                'type': 'phrase'
-                            },
+                        'match_phrase': {
+                            'message': failure_line.message[:1024],
                         },
                     }],
                 },

--- a/treeherder/services/elasticsearch/mapping.py
+++ b/treeherder/services/elasticsearch/mapping.py
@@ -1,6 +1,6 @@
-boolean_notanalyzed = {'type': 'boolean', 'index': 'not_analyzed'}
-integer_notanalyzed = {'type': 'integer', 'index': 'not_analyzed'}
-keyword_notanalyzed = {'type': 'keyword', 'index': 'not_analyzed'}
+boolean = {'type': 'boolean'}
+integer = {'type': 'integer'}
+keyword = {'type': 'keyword'}
 
 DOC_TYPE = 'failure-line'
 INDEX_NAME = 'failure-lines'
@@ -10,13 +10,13 @@ INDEX_SETTINGS = {
         'mappings': {
             'failure-line': {
                 'properties': {
-                    'job_guid': keyword_notanalyzed,
-                    'test': keyword_notanalyzed,
-                    'subtest': keyword_notanalyzed,
-                    'status': keyword_notanalyzed,
-                    'expected': keyword_notanalyzed,
-                    'best_classification': integer_notanalyzed,
-                    'best_is_verified': boolean_notanalyzed,
+                    'job_guid': keyword,
+                    'test': keyword,
+                    'subtest': keyword,
+                    'status': keyword,
+                    'expected': keyword,
+                    'best_classification': integer,
+                    'best_is_verified': boolean,
                     'message': {
                         'type': 'text',
                         'analyzer': 'message_analyzer',

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -15,7 +15,7 @@ PYTHON_DIR="$HOME/python"
 
 cd "$SRC_DIR"
 
-ELASTICSEARCH_VERSION="5.5.0"
+ELASTICSEARCH_VERSION="6.2.4"
 GECKODRIVER_VERSION="0.20.0"
 PYTHON_VERSION="$(sed 's/python-//' runtime.txt)"
 PIP_VERSION="9.0.1"
@@ -74,7 +74,7 @@ sudo -E apt-get -yqq install --no-install-recommends \
 if [[ "$(dpkg-query --show --showformat='${Version}' elasticsearch 2>&1)" != "$ELASTICSEARCH_VERSION" ]]; then
     echo '-----> Installing Elasticsearch'
     curl -sSfo /tmp/elasticsearch.deb "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION.deb"
-    sudo dpkg -i /tmp/elasticsearch.deb
+    sudo dpkg -i --confnew /tmp/elasticsearch.deb
     # Override the new ES 5.x default minimum heap size of 2GB.
     sudo sed -i 's/.*ES_JAVA_OPTS=.*/ES_JAVA_OPTS="-Xms256m -Xmx1g"/' /etc/default/elasticsearch
     sudo systemctl enable elasticsearch.service 2>&1


### PR DESCRIPTION
This upgrades Elasticsearch to 6.2.4, fixing the index mapping and search query to work with the later version.