### PR TITLE
Bug 1456894 - Replace more ProvidePlugin usages with explicit imports

### DIFF
--- a/neutrino-custom/base.js
+++ b/neutrino-custom/base.js
@@ -277,7 +277,6 @@ module.exports = neutrino => {
             jQuery: require.resolve('jquery'),
             'window.$': require.resolve('jquery'),
             'window.jQuery': require.resolve('jquery'),
-            React: require.resolve('react'),
         });
 
     neutrino.config.devtool('source-map');

--- a/neutrino-custom/base.js
+++ b/neutrino-custom/base.js
@@ -278,7 +278,6 @@ module.exports = neutrino => {
             'window.$': require.resolve('jquery'),
             'window.jQuery': require.resolve('jquery'),
             React: require.resolve('react'),
-            _: require.resolve('lodash'),
         });
 
     neutrino.config.devtool('source-map');

--- a/neutrino-custom/base.js
+++ b/neutrino-custom/base.js
@@ -273,9 +273,8 @@ module.exports = neutrino => {
     neutrino.config
         .plugin('provide')
         .use(webpack.ProvidePlugin, {
-            $: require.resolve('jquery'),
+            // Required since AngularJS and jquery.flot don't import jQuery themselves.
             jQuery: require.resolve('jquery'),
-            'window.$': require.resolve('jquery'),
             'window.jQuery': require.resolve('jquery'),
         });
 

--- a/neutrino-custom/lint.js
+++ b/neutrino-custom/lint.js
@@ -62,7 +62,6 @@ module.exports = neutrino => {
                 globals: [
                     '$',
                     'jQuery',
-                    'React',
                     'SERVICE_DOMAIN',
                 ]
             }

--- a/neutrino-custom/lint.js
+++ b/neutrino-custom/lint.js
@@ -61,7 +61,6 @@ module.exports = neutrino => {
                 },
                 globals: [
                     '$',
-                    '_',
                     'jQuery',
                     'React',
                     'SERVICE_DOMAIN',

--- a/neutrino-custom/lint.js
+++ b/neutrino-custom/lint.js
@@ -60,8 +60,6 @@ module.exports = neutrino => {
                     'spaced-comment': 'off',
                 },
                 globals: [
-                    '$',
-                    'jQuery',
                     'SERVICE_DOMAIN',
                 ]
             }

--- a/tests/ui/unit/init.js
+++ b/tests/ui/unit/init.js
@@ -10,7 +10,6 @@ import Adapter from 'enzyme-adapter-react-16';
 
 // Global variables are set here instead of with webpack.ProvidePlugin
 // because neutrino removes plugin definitions for karma runs
-window.$ = jQuery;
 window.jQuery = jQuery;
 
 configure({ adapter: new Adapter() });

--- a/tests/ui/unit/init.js
+++ b/tests/ui/unit/init.js
@@ -1,7 +1,6 @@
 // Karma/webpack entry for tests
 
 import jQuery from 'jquery';
-import _ from 'lodash';
 import React from 'react';
 // Manually import angular since angular-mocks doesn't do so itself
 import 'angular';
@@ -14,7 +13,6 @@ import Adapter from 'enzyme-adapter-react-16';
 // because neutrino removes plugin definitions for karma runs
 window.$ = jQuery;
 window.jQuery = jQuery;
-window._ = _;
 window.React = React;
 
 configure({ adapter: new Adapter() });

--- a/tests/ui/unit/init.js
+++ b/tests/ui/unit/init.js
@@ -1,7 +1,6 @@
 // Karma/webpack entry for tests
 
 import jQuery from 'jquery';
-import React from 'react';
 // Manually import angular since angular-mocks doesn't do so itself
 import 'angular';
 import 'angular-mocks';
@@ -13,7 +12,6 @@ import Adapter from 'enzyme-adapter-react-16';
 // because neutrino removes plugin definitions for karma runs
 window.$ = jQuery;
 window.jQuery = jQuery;
-window.React = React;
 
 configure({ adapter: new Adapter() });
 

--- a/tests/ui/unit/react/revisions.tests.jsx
+++ b/tests/ui/unit/react/revisions.tests.jsx
@@ -1,4 +1,6 @@
+import React from 'react';
 import { mount } from 'enzyme';
+
 import { Revision, Initials } from '../../../../ui/job-view/Revision';
 import {
   RevisionList,

--- a/ui/details-panel/AnnotationsTab.jsx
+++ b/ui/details-panel/AnnotationsTab.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular/index.es2015';
 

--- a/ui/details-panel/AutoclassifyTab.jsx
+++ b/ui/details-panel/AutoclassifyTab.jsx
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { react2angular } from 'react2angular/index.es2015';

--- a/ui/details-panel/FailureSummaryTab.jsx
+++ b/ui/details-panel/FailureSummaryTab.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular/index.es2015';
 import Highlighter from 'react-highlight-words';

--- a/ui/details-panel/JobDetailsPane.jsx
+++ b/ui/details-panel/JobDetailsPane.jsx
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular/index.es2015';
 

--- a/ui/details-panel/JobDetailsPane.jsx
+++ b/ui/details-panel/JobDetailsPane.jsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular/index.es2015';
 

--- a/ui/details-panel/autoclassify/AutoclassifyToolbar.jsx
+++ b/ui/details-panel/autoclassify/AutoclassifyToolbar.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 
 export default class AutoclassifyToolbar extends React.Component {

--- a/ui/details-panel/autoclassify/ErrorLine.jsx
+++ b/ui/details-panel/autoclassify/ErrorLine.jsx
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup } from 'reactstrap';

--- a/ui/details-panel/autoclassify/ErrorLine.jsx
+++ b/ui/details-panel/autoclassify/ErrorLine.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup } from 'reactstrap';
 

--- a/ui/details-panel/autoclassify/LineOption.jsx
+++ b/ui/details-panel/autoclassify/LineOption.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup, Label, Input } from 'reactstrap';
 import Select from 'react-select';

--- a/ui/details-panel/autoclassify/StaticLineOption.jsx
+++ b/ui/details-panel/autoclassify/StaticLineOption.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import Highlighter from 'react-highlight-words';
 

--- a/ui/helpers/autoclassifyHelper.jsx
+++ b/ui/helpers/autoclassifyHelper.jsx
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 export const stringOverlap = function (str1, str2) {
   // Get a measure of the similarity of two strings by a simple process
   // of tokenizing and then computing the ratio of the tokens in common to

--- a/ui/helpers/autoclassifyHelper.jsx
+++ b/ui/helpers/autoclassifyHelper.jsx
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import React from 'react';
 
 export const stringOverlap = function (str1, str2) {
   // Get a measure of the similarity of two strings by a simple process

--- a/ui/helpers/jobHelper.js
+++ b/ui/helpers/jobHelper.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import { thPlatformMap } from '../js/constants';
 
 const btnClasses = {

--- a/ui/helpers/jobHelper.js
+++ b/ui/helpers/jobHelper.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import _ from 'lodash';
 
 import { thPlatformMap } from '../js/constants';

--- a/ui/job-view/JobGroup.jsx
+++ b/ui/job-view/JobGroup.jsx
@@ -1,5 +1,6 @@
+import _ from 'lodash';
 import PropTypes from 'prop-types';
-import * as _ from 'lodash';
+
 import JobButton from './JobButton';
 import JobCountComponent from './JobCount';
 import { getBtnClass, getStatus } from "../helpers/jobHelper";

--- a/ui/job-view/JobGroup.jsx
+++ b/ui/job-view/JobGroup.jsx
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import JobButton from './JobButton';

--- a/ui/job-view/PushJobs.jsx
+++ b/ui/job-view/PushJobs.jsx
@@ -1,6 +1,7 @@
+import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as _ from 'lodash';
+
 import { thPlatformMap, thEvents } from '../js/constants';
 import { getPushTableId, getPlatformRowId } from '../helpers/aggregateIdHelper';
 import Platform from './Platform';

--- a/ui/job-view/PushList.jsx
+++ b/ui/job-view/PushList.jsx
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { react2angular } from 'react2angular/index.es2015';

--- a/ui/job-view/PushLoadErrors.jsx
+++ b/ui/job-view/PushLoadErrors.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import { getAllUrlParams } from '../helpers/locationHelper';

--- a/ui/job-view/Revision.jsx
+++ b/ui/job-view/Revision.jsx
@@ -1,4 +1,6 @@
+import _ from 'lodash';
 import PropTypes from 'prop-types';
+
 import { parseAuthor } from '../helpers/revisionHelper';
 
 export function Initials(props) {

--- a/ui/job-view/Revision.jsx
+++ b/ui/job-view/Revision.jsx
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import { parseAuthor } from '../helpers/revisionHelper';

--- a/ui/job-view/RevisionList.jsx
+++ b/ui/job-view/RevisionList.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Revision } from './Revision';

--- a/ui/js/components/auth.js
+++ b/ui/js/components/auth.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import treeherder from '../treeherder';
 import AuthService from '../auth/AuthService';
 import { loggedOutUser } from '../auth/auth-utils';

--- a/ui/js/components/perf/compare.js
+++ b/ui/js/components/perf/compare.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import treeherder from '../../treeherder';
 import trendTableTemplate from '../../../partials/perf/trendtable.html';
 import compareTableTemplate from '../../../partials/perf/comparetable.html';

--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import treeherder from '../treeherder';
 import { getApiUrl } from "../../helpers/urlHelper";
 

--- a/ui/js/controllers/bugfiler.js
+++ b/ui/js/controllers/bugfiler.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import _ from 'lodash';
 
 import treeherder from '../treeherder';

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import logViewerApp from '../logviewer';
 import { getInspectTaskUrl, getReftestUrl } from "../../helpers/urlHelper";
 import { isReftest } from "../../helpers/jobHelper";

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import Mousetrap from 'mousetrap';
 
 import treeherderApp from '../treeherder_app';

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import _ from 'lodash';
 import Mousetrap from 'mousetrap';
 

--- a/ui/js/controllers/perf/alerts.js
+++ b/ui/js/controllers/perf/alerts.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import angular from 'angular';
 
 import perf from '../../perf';

--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import metricsgraphics from 'metrics-graphics';
 
 import perf from '../../perf';

--- a/ui/js/controllers/perf/dashboard.js
+++ b/ui/js/controllers/perf/dashboard.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import perf from '../../perf';
 import { thDefaultRepo, phBlockers, phTimeRanges } from "../../constants";
 

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -2,6 +2,7 @@
 // TODO: Vet/fix the use-before-defines to ensure switching var
 // to let/const won't break anything.
 
+import $ from 'jquery';
 import _ from 'lodash';
 import angular from 'angular';
 import Mousetrap from 'mousetrap';
@@ -615,7 +616,7 @@ perf.controller('GraphsCtrl', [
                         resultSetData: _.map(
                             seriesData[series.signature],
                             'push_id'),
-                        thSeries: jQuery.extend({}, series),
+                        thSeries: $.extend({}, series),
                         jobIdData: _.map(seriesData[series.signature], 'job_id'),
                         idData: _.map(seriesData[series.signature], 'id')
                     };

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -2,6 +2,7 @@
 // TODO: Vet/fix the use-before-defines to ensure switching var
 // to let/const won't break anything.
 
+import _ from 'lodash';
 import angular from 'angular';
 import Mousetrap from 'mousetrap';
 

--- a/ui/js/directives/treeherder/log_viewer_steps.js
+++ b/ui/js/directives/treeherder/log_viewer_steps.js
@@ -1,3 +1,5 @@
+import $ from 'jquery';
+
 import treeherder from '../../treeherder';
 import lvLogStepsTemplate from '../../../partials/logviewer/lvLogSteps.html';
 

--- a/ui/js/directives/treeherder/top_nav_bar.js
+++ b/ui/js/directives/treeherder/top_nav_bar.js
@@ -1,3 +1,5 @@
+import $ from 'jquery';
+
 import treeherder from '../../treeherder';
 import thWatchedRepoTemplate from '../../../partials/main/thWatchedRepo.html';
 import thWatchedRepoInfoDropDownTemplate from '../../../partials/main/thWatchedRepoInfoDropDown.html';

--- a/ui/js/models/bug_job_map.js
+++ b/ui/js/models/bug_job_map.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import angular from 'angular';
 
 import treeherder from '../treeherder';

--- a/ui/js/models/bug_job_map.js
+++ b/ui/js/models/bug_job_map.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import _ from 'lodash';
 import angular from 'angular';
 

--- a/ui/js/models/build_platform.js
+++ b/ui/js/models/build_platform.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import angular from 'angular';
 
 import treeherder from '../treeherder';

--- a/ui/js/models/classification.js
+++ b/ui/js/models/classification.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import angular from 'angular';
 
 import treeherder from '../treeherder';

--- a/ui/js/models/job.js
+++ b/ui/js/models/job.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import angular from 'angular';
 
 import treeherder from '../treeherder';

--- a/ui/js/models/option_collection.js
+++ b/ui/js/models/option_collection.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import treeherder from '../treeherder';
 import { getApiUrl } from '../../helpers/urlHelper';
 

--- a/ui/js/models/perf/alerts.js
+++ b/ui/js/models/perf/alerts.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import treeherder from '../../treeherder';
 import { getApiUrl } from "../../../helpers/urlHelper";
 import {

--- a/ui/js/models/perf/series.js
+++ b/ui/js/models/perf/series.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import treeherder from '../../treeherder';
 import { getProjectUrl, getApiUrl } from "../../../helpers/urlHelper";
 

--- a/ui/js/models/repository.js
+++ b/ui/js/models/repository.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import treeherder from '../treeherder';
 import { getApiUrl } from '../../helpers/urlHelper';
 import { thRepoGroupOrder } from "../constants";

--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import angular from 'angular';
 import jsyaml from 'js-yaml';
 import { Queue, slugid } from 'taskcluster-client-web';

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -2,6 +2,8 @@
 // TODO: Vet/fix the use-before-defines to ensure switching var
 // to let/const won't break anything (such as bug 1443667).
 
+import _ from 'lodash';
+
 import { thPlatformMap, thOptionOrder, thEvents } from '../constants';
 import { escapeId, getGroupMapKey } from '../../helpers/aggregateIdHelper';
 import treeherder from '../treeherder';

--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-use-before-define */
 
+import _ from 'lodash';
+
 import treeherder from '../treeherder';
 import { getStatus } from '../../helpers/jobHelper';
 import { thFailureResults, thDefaultFilterResultStates, thEvents } from "../constants";

--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import treeherder from '../treeherder';
 import tcJobActionsTemplate from '../../partials/main/tcjobactions.html';
 import { thPlatformMap } from '../constants';

--- a/ui/js/services/perf/compare.js
+++ b/ui/js/services/perf/compare.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import treeherder from '../../treeherder';
 import { getApiUrl } from "../../../helpers/urlHelper";
 import { phTimeRanges } from "../../constants";

--- a/ui/js/services/perf/math.js
+++ b/ui/js/services/perf/math.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import treeherder from '../../treeherder';
 
 treeherder.factory('math', [

--- a/ui/js/services/pinboard.js
+++ b/ui/js/services/pinboard.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import treeherder from '../treeherder';
 import { thPinboardCountError, thEvents } from "../constants";
 

--- a/ui/js/services/taskcluster.js
+++ b/ui/js/services/taskcluster.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { OIDCCredentialAgent, fromNow } from 'taskcluster-client-web';
 
 const thTaskcluster = (() => {

--- a/ui/js/services/tcactions.js
+++ b/ui/js/services/tcactions.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import jsone from 'json-e';
 import { Queue } from 'taskcluster-client-web';
 

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import _ from 'lodash';
 import jsyaml from 'js-yaml';
 import { Queue, slugid } from 'taskcluster-client-web';

--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import jsyaml from 'js-yaml';
 import { Queue, slugid } from 'taskcluster-client-web';
 

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import Mousetrap from 'mousetrap';
 
 import treeherder from '../js/treeherder';

--- a/ui/plugins/pinboard.js
+++ b/ui/plugins/pinboard.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import _ from 'lodash';
 import Mousetrap from 'mousetrap';
 

--- a/ui/plugins/similar_jobs/controller.js
+++ b/ui/plugins/similar_jobs/controller.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import angular from 'angular';
 
 import treeherder from '../../js/treeherder';

--- a/ui/plugins/similar_jobs/controller.js
+++ b/ui/plugins/similar_jobs/controller.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import _ from 'lodash';
 import angular from 'angular';
 


### PR DESCRIPTION
Since `ProvidePlugin` doesn't play nicely with our karma tests, and also performs CJS imports rather than ES6.