### PR TITLE
Use the Elasticsearch env var Heroku gives us

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
         - flake8 --show-source
         # Temporarily running these in the linters job to avoid impacting job count and thus Travis end-to-end times.
         # Prevent connections during check/migrate/makemigrations to a non-existent Elasticsearch server.
-        - unset ELASTICSEARCH_URL
+        - unset FOUNDELASTICSEARCH_URL
         - SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' ./manage.py check --deploy --fail-level WARNING
         # Remove these once we get the roughly equivalent pytest sanity tests working under Python 3.
         - ./manage.py migrate

--- a/bin/travis-setup.sh
+++ b/bin/travis-setup.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # This script must be sourced, so that the environment variables are set in the calling shell.
 export BROKER_URL='amqp://guest:guest@localhost:5672//'
 export DATABASE_URL='mysql://root@localhost/test_treeherder'
-export ELASTICSEARCH_URL='http://127.0.0.1:9200'
+export FOUNDELASTICSEARCH_URL='http://127.0.0.1:9200'
 export REDIS_URL='redis://localhost:6379'
 export TREEHERDER_DJANGO_SECRET_KEY='secretkey-of-at-50-characters-to-pass-check-deploy'
 # Suppress warnings shown during pytest startup when using `python2 -3` mode.
@@ -44,7 +44,7 @@ setup_services() {
     sudo service rabbitmq-server start
 
     echo '-----> Waiting for Elasticsearch to be ready'
-    while ! curl "${ELASTICSEARCH_URL}" &> /dev/null; do sleep 1; done
+    while ! curl "${FOUNDELASTICSEARCH_URL}" &> /dev/null; do sleep 1; done
 }
 
 setup_python_env() {

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -583,6 +583,6 @@ CACHES = {
 HAWK_CREDENTIALS_LOOKUP = 'treeherder.webapp.api.auth.hawk_lookup'
 
 # Configuration for elasticsearch backend
-ELASTICSEARCH_URL = env.str('ELASTICSEARCH_URL', default='')
+ELASTICSEARCH_URL = env.str('FOUNDELASTICSEARCH_URL', default='')
 
 TRUNK_REPO_NAMES = ['mozilla-central', 'mozilla-inbound', 'autoland', 'fx-team']

--- a/vagrant/env.sh
+++ b/vagrant/env.sh
@@ -4,7 +4,7 @@ export PATH="${HOME}/firefox:${HOME}/python/bin:${PATH}"
 
 export BROKER_URL='amqp://guest:guest@localhost//'
 export DATABASE_URL='mysql://root@localhost/treeherder'
-export ELASTICSEARCH_URL='http://localhost:9200'
+export FOUNDELASTICSEARCH_URL='http://localhost:9200'
 export REDIS_URL='redis://localhost:6379'
 
 export TREEHERDER_DEBUG='True'


### PR DESCRIPTION
This is not an ideal change but I don't see a nicer way to handle it.  Even if we shadowed the provisioned variable with our own Heroku or Elastic could potentially update the URL and we'd be out of sync.