### PR TITLE
Convert Redis URL to stunnel variant with furl

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -282,3 +282,7 @@ ecdsa==0.13 \
     --hash=sha256:40d002cf360d0e035cf2cb985e1308d41aaa087cbfc135b2dc2d844296ea546c
 future==0.16.0 \
     --hash=sha256:e39ced1ab767b5936646cedba8bcce582398233d6a627067d4c6a454c90cfedb
+furl==1.0.1 \
+    --hash=sha256:6bb7d9ed238a0104db3a638307be7abc35ec989d883f5882e01cb000b9bdbc32
+orderedmultidict==0.7.11 \
+    --hash=sha256:dc2320ca694d90dca4ecc8b9c5fdf71ca61d6c079d6feb085ef8d41585419a36

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -4,13 +4,13 @@ import re
 from datetime import timedelta
 
 import environ
+from furl import furl
 from kombu import (Exchange,
                    Queue)
 
 from treeherder import path
 from treeherder.config.utils import (connection_should_use_tls,
-                                     get_tls_redis_url,
-                                     hostname)
+                                     get_tls_redis_url)
 
 env = environ.Env()
 
@@ -371,7 +371,7 @@ DISALLOWED_USER_AGENTS = (
 )
 
 SITE_URL = env("SITE_URL", default="http://localhost:8000/")
-SITE_HOSTNAME = hostname(SITE_URL)
+SITE_HOSTNAME = furl(SITE_URL).host
 APPEND_SLASH = False
 
 BUILDAPI_PENDING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-pending.js"


### PR DESCRIPTION
[Furl](https://github.com/gruns/furl) is a great little library for handling URL manipulation.  I find it greatly simplifies urlparse code into a much more pythonic structure.

This PR is a precursor to some Elasticsearch work that I'd like to use furl for too.