### PR TITLE
Add compact itertool to replace list, loop, if pattern

### DIFF
--- a/treeherder/autoclassify/matchers.py
+++ b/treeherder/autoclassify/matchers.py
@@ -16,6 +16,7 @@ from treeherder.model.models import (MatcherManager,
                                      TextLogError,
                                      TextLogErrorMatch)
 from treeherder.services.elasticsearch import search
+from treeherder.utils.itertools import compact
 
 logger = logging.getLogger(__name__)
 
@@ -35,12 +36,7 @@ class Matcher(object):
         self.db_object = db_object
 
     def __call__(self, text_log_errors):
-        rv = []
-        for text_log_error in text_log_errors:
-            match = self.match(text_log_error)
-            if match:
-                rv.append(match)
-        return rv
+        return compact(self.match(tle) for tle in text_log_errors)
 
     def match(self, text_log_error):
         best_match = self.query_best(text_log_error)

--- a/treeherder/services/elasticsearch/helpers.py
+++ b/treeherder/services/elasticsearch/helpers.py
@@ -3,6 +3,8 @@ import logging
 from elasticsearch import TransportError
 from elasticsearch.helpers import bulk as es_bulk
 
+from treeherder.utils.itertools import compact
+
 from .connection import es_conn
 from .mapping import (DOC_TYPE,
                       INDEX_NAME,
@@ -38,13 +40,12 @@ def bulk(iterable, index=INDEX_NAME, doc_type=DOC_TYPE, action='index'):
     https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.Elasticsearch.bulk
     https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
     """
-    actions = (dict_to_op(
+    actions = compact(dict_to_op(
         to_dict(model),
         index_name=INDEX_NAME,
         doc_type=DOC_TYPE,
         op_type=action,
     ) for model in iterable)
-    actions = [x for x in actions if x]  # dict_to_op can return Nones currently
 
     # fail fast if there are no actions
     if not actions:

--- a/treeherder/utils/itertools.py
+++ b/treeherder/utils/itertools.py
@@ -1,0 +1,24 @@
+def icompact(iterable):
+    """
+    Lazily remove empty values from an iterable.
+
+        >>> list(icompact(range(3)))
+        [1, 2]
+        >>> list(icompact(['thing', 1, 0, None, 'bar', {}]))
+        ['thing', 1, 'bar']
+
+    """
+    return (x for x in iterable if x)
+
+
+def compact(iterable):
+    """
+    Returns a new list with all empty values removed from the iterable.
+
+        >>> compact(range(3))
+        [1, 2]
+        >>> compact(['thing', 1, 0, None, 'bar', {}])
+        ['thing', 1, 'bar']
+
+    """
+    return list(icompact(iterable))


### PR DESCRIPTION
This adds the `compact` and `icompact` itertools.

They allow one to turn code like:
```
a_list = []
for thing in things:
    if thing:
        a_list.append(thing)
return a_list
```

into 

```
return compact(things)
```

or

```
return compact(some_func(t) for t in things)
```