### PR TITLE
Only Send Events When ES Returns 1+ Results

### DIFF
--- a/treeherder/autoclassify/management/commands/es_benchmark.py
+++ b/treeherder/autoclassify/management/commands/es_benchmark.py
@@ -89,7 +89,6 @@ class Command(BaseCommand):
 
         duration = 1000 * (time.time() - t0)
         self.stderr.write("Total lines %d" % total_lines)
-        self.stderr.write("Total lines in matcher %d" % matcher.lines)
         self.stderr.write("Called ElasticSearch %i times" % matcher.calls)
         self.stderr.write("Took %dms" % duration)
 

--- a/treeherder/autoclassify/matchers.py
+++ b/treeherder/autoclassify/matchers.py
@@ -167,7 +167,6 @@ class ElasticSearchTestMatcher(Matcher):
 
     def __init__(self, *args, **kwargs):
         Matcher.__init__(self, *args, **kwargs)
-        self.lines = 0
         self.calls = 0
 
     @with_failure_lines

--- a/treeherder/autoclassify/matchers.py
+++ b/treeherder/autoclassify/matchers.py
@@ -214,17 +214,18 @@ class ElasticSearchTestMatcher(Matcher):
                          failure_line.expected, failure_line.message)
             raise
 
-        args = (
-            text_log_error.id,
-            failure_line.id,
-            len(results),
-        )
-        logger.info('text_log_error=%i failure_line=%i Elasticsearch produced %i results' % args)
-        newrelic.agent.record_custom_event('es_matches', {
-            'num_results': len(results),
-            'text_log_error_id': text_log_error.id,
-            'failure_line_id': failure_line.id,
-        })
+        if len(results) > 1:
+            args = (
+                text_log_error.id,
+                failure_line.id,
+                len(results),
+            )
+            logger.info('text_log_error=%i failure_line=%i Elasticsearch produced %i results' % args)
+            newrelic.agent.record_custom_event('es_matches', {
+                'num_results': len(results),
+                'text_log_error_id': text_log_error.id,
+                'failure_line_id': failure_line.id,
+            })
 
         scorer = MatchScorer(failure_line.message)
         matches = [(item, item['message']) for item in results]


### PR DESCRIPTION
Currently we do that after every search and after looking at the data in NR it seems we _rarely_ get a single result back, so the graph produced is actually tracking "the search did not error" giving us this graph:

![](https://cl.ly/2i1T452Z0t2q/Image%202018-04-30%20at%203.32.26%20pm.png)

([Live view](https://insights.newrelic.com/accounts/677903/explorer/events?eventType=es_matches&duration=1800000))

Instead we should start with tracking searches that return at least one result so we can effectively see changes when changing the search params.

This sets events to only be sent (to logs and NR) when we get results from Elasticsearch.  