### PR TITLE
Bug 1457917 - Fix the display of logs in the log viewer

### DIFF
--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -164,7 +164,7 @@ logViewerApp.controller('LogviewerCtrl', [
                 $scope.logViewerTitle = job.get_title();
 
                 if (job.logs && job.logs.length) {
-                    $scope.reftestUrl = `${getReftestUrl(job.logs[0].url)}&only_show_unexpected=1`;
+                    $scope.rawLogURL = job.logs[0].url;
                 }
 
                 // set the result value and shading color class
@@ -186,11 +186,9 @@ logViewerApp.controller('LogviewerCtrl', [
                 }
 
                 // Test to expose the reftest button in the logviewer actionbar
-                $scope.isReftest = () => {
-                    if (job.job_group_name) {
-                        return isReftest(job);
-                    }
-                };
+                if ($scope.rawLogURL && job.job_group_name && isReftest(job)) {
+                    $scope.reftestUrl = `${getReftestUrl($scope.rawLogURL)}&only_show_unexpected=1`;
+                }
 
                 // get the revision and linkify it
                 ThResultSetModel.getResultSet($scope.repoName, job.result_set_id).then((data) => {

--- a/ui/logviewer.html
+++ b/ui/logviewer.html
@@ -57,7 +57,7 @@
           </li>
 
           <!-- Ref test button -->
-          <li ng-if="isReftest()" ng-cloak>
+          <li ng-if="reftestUrl" ng-cloak>
             <a title="Open the Reftest Analyser in a new window"
                target="_blank" rel="noopener"
                href="{{reftestUrl}}">


### PR DESCRIPTION
Reverts the accidental change to the raw log URL from here:
https://github.com/mozilla/treeherder/commit/5d237353598a531337fc91c6e09a32a03d9b457a#diff-4f14c25b423d5c12f4983b7229fedeb1L165

And updates the reftest URL handling to take into account:
https://github.com/mozilla/treeherder/commit/5d237353598a531337fc91c6e09a32a03d9b457a#diff-189002a90173e09fe81da88161e6e80dL63
