### PR TITLE
[RFC] Bug 1455448: Update treeherder to use new index for decision tasks.

### DIFF
--- a/tests/seta/conftest.py
+++ b/tests/seta/conftest.py
@@ -59,7 +59,7 @@ def runnable_jobs_data():
 @pytest.fixture
 def tc_latest_gecko_decision_index(test_repository):
     return {
-        "namespace": "gecko.v2.{}.latest.firefox.decision".format(test_repository),
+        "namespace": "gecko.v2.{}.latest.taskgraph.decision".format(test_repository),
         "taskId": "XVDNiP07RNaaEghhvkZJWg",
         "rank": 0,
         "data": {},

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -378,7 +378,7 @@ BUILDAPI_PENDING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson
 BUILDAPI_RUNNING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-running.js"
 BUILDAPI_BUILDS4H_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-4hr.js.gz"
 ALLTHETHINGS_URL = "https://secure.pub.build.mozilla.org/builddata/reports/allthethings.json"
-TASKCLUSTER_INDEX_URL = 'https://index.taskcluster.net/v1/task/gecko.v2.%s.latest.firefox.decision'
+TASKCLUSTER_INDEX_URL = 'https://index.taskcluster.net/v1/task/gecko.v2.%s.latest.taskgraph.decision'
 TASKCLUSTER_RUNNABLE_JOBS_URL = 'https://public-artifacts.taskcluster.net/{task_id}/0/public/runnable-jobs.json.gz'
 
 # the amount of time we cache bug suggestion lookups (to speed up loading the bug

--- a/treeherder/seta/update_job_priority.py
+++ b/treeherder/seta/update_job_priority.py
@@ -107,10 +107,10 @@ def query_sanitized_data(repo_name='mozilla-inbound'):
 
      It stores the minimal sanitized data from runnable apis under ~/.mozilla/seta/<task_id>.json
 
-     [1] https://index.taskcluster.net/v1/task/gecko.v2.%s.latest.firefox.decision/
+     [1] https://index.taskcluster.net/v1/task/gecko.v2.%s.latest.taskgraph.decision/
      [2] Index's data structure:
       {
-        "namespace": "gecko.v2.mozilla-inbound.latest.firefox.decision",
+        "namespace": "gecko.v2.mozilla-inbound.latest.taskgraph.decision",
         "taskId": "Dh9ZvFk5QCSprJ877cgUmw",
         "rank": 0,
         "data": {},


### PR DESCRIPTION
I don't quite understand where this is used, so I'm not sure when this should land.

The old indexes still work, and will stick around for some time for backwards compatibility. The corresponding m-c changes have landed on all trunk and release branches, but haven't actively merged them to any project branches.