### PR TITLE
Remove id_window Decorator

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -286,3 +286,6 @@ furl==1.0.1 \
     --hash=sha256:6bb7d9ed238a0104db3a638307be7abc35ec989d883f5882e01cb000b9bdbc32
 orderedmultidict==0.7.11 \
     --hash=sha256:dc2320ca694d90dca4ecc8b9c5fdf71ca61d6c079d6feb085ef8d41585419a36
+first==2.0.1 \
+    --hash=sha256:3bb3de3582cb27071cfb514f00ed784dc444b7f96dc21e140de65fe00585c95e \
+    --hash=sha256:41d5b64e70507d0c3ca742d68010a76060eea8a3d863e9b5130ab11a4a91aa0e

--- a/tests/autoclassify/test_matchers.py
+++ b/tests/autoclassify/test_matchers.py
@@ -1,0 +1,27 @@
+import time
+
+from treeherder.autoclassify.matchers import time_boxed
+
+
+def test_time_boxed_enough_budget():
+    an_iterable = range(3)
+
+    def quick_sleep(x):
+        time.sleep(.1)
+        return x
+
+    items = list(time_boxed(quick_sleep, an_iterable, time_budget=5000))
+
+    assert len(items) == 3
+
+
+def test_time_boxed_cutoff():
+    an_iterable = range(3)
+
+    def quick_sleep(x):
+        time.sleep(1)
+        return x
+
+    items = list(time_boxed(quick_sleep, an_iterable, time_budget=2000))
+
+    assert len(items) < 3

--- a/tests/autoclassify/test_matchers.py
+++ b/tests/autoclassify/test_matchers.py
@@ -1,8 +1,28 @@
 import time
 
-from treeherder.autoclassify.matchers import (score_matches,
+from treeherder.autoclassify.matchers import (score_by_classified_fail_id,
+                                              score_matches,
                                               time_boxed)
-from treeherder.model.models import FailureLine, TextLogErrorMatch
+from treeherder.model.models import (FailureLine,
+                                     TextLogErrorMatch)
+
+
+def test_score_by_classified_fail_id(classified_failures):
+    matches = [(m, m.score) for m in TextLogErrorMatch.objects.all()]
+
+    first_match = TextLogErrorMatch.objects.first()
+
+    classified_failure_id, scored_match = score_by_classified_fail_id(matches)
+    match, score = scored_match
+
+    assert match == first_match
+    assert score == first_match.score
+    assert classified_failure_id == first_match.classified_failure_id
+
+
+def test_score_by_classified_fail_id_empty_input():
+    output = score_by_classified_fail_id(None)
+    assert output is None
 
 
 def test_score_matches_empty_return():

--- a/tests/autoclassify/test_matchers.py
+++ b/tests/autoclassify/test_matchers.py
@@ -1,6 +1,37 @@
 import time
 
-from treeherder.autoclassify.matchers import time_boxed
+from treeherder.autoclassify.matchers import (score_matches,
+                                              time_boxed)
+from treeherder.model.models import FailureLine, TextLogErrorMatch
+
+
+def test_score_matches_empty_return():
+    output = list(score_matches(matches=None))
+    assert output == []
+
+    output = list(score_matches(matches=FailureLine.objects.none()))
+    assert output == []
+
+
+def test_score_matches(classified_failures):
+    matches = TextLogErrorMatch.objects.all()
+    output = list(score_matches(matches))
+    assert len(output) == 1  # both matches have score of 1.0
+
+    TextLogErrorMatch.objects.update(score=0.8)
+
+    matches = TextLogErrorMatch.objects.all()
+    output = list(score_matches(matches))
+    assert len(output) == 1  # neither match above threshold, but first returned
+
+
+def test_score_matches_with_manipulated_score(classified_failures):
+    matches = TextLogErrorMatch.objects.all()
+
+    output = list(score_matches(matches, score_multiplier=(8, 10)))
+    assert len(output) == 1
+    score = float(output[0][1])
+    assert score == 0.8
 
 
 def test_time_boxed_enough_budget():

--- a/tests/utils/test_queryset.py
+++ b/tests/utils/test_queryset.py
@@ -1,0 +1,70 @@
+from tests.autoclassify.utils import (create_failure_lines,
+                                      test_line)
+from treeherder.model.models import FailureLine
+from treeherder.utils.queryset import (chunked_qs,
+                                       chunked_qs_reverse)
+
+
+def test_chunked_qs(test_job):
+    # create 25 failure lines
+    create_failure_lines(test_job, [(test_line, {}) for i in range(25)])
+
+    qs = FailureLine.objects.all()
+    chunks = list(chunked_qs(qs, chunk_size=5))
+
+    one = chunks[0]
+    two = chunks[1]
+    five = chunks[4]
+
+    assert len(one) == 5
+    assert one[0].id == 1
+    assert one[4].id == 5
+
+    assert len(two) == 5
+    assert two[0].id == 6
+    assert two[4].id == 10
+
+    assert len(five) == 5
+    assert five[0].id == 21
+    assert five[4].id == 25
+
+
+def test_chunked_qs_with_empty_qs():
+    chunks = list(chunked_qs(FailureLine.objects.none()))
+
+    assert len(chunks) == 0
+
+
+def test_chunked_qs_reverse(test_job):
+    """
+    Test `chunked_qs_reverse` function
+
+    Specifically checks the length of chunks and their items don't overlap.
+    """
+    # create 25 failure lines
+    create_failure_lines(test_job, [(test_line, {}) for i in range(25)])
+
+    qs = FailureLine.objects.all()
+    chunks = list(chunked_qs_reverse(qs, chunk_size=5))
+
+    one = chunks[0]
+    two = chunks[1]
+    five = chunks[4]
+
+    assert len(one) == 5
+    assert one[0].id == 25
+    assert one[4].id == 21
+
+    assert len(two) == 5
+    assert two[0].id == 20
+    assert two[4].id == 16
+
+    assert len(five) == 5
+    assert five[0].id == 5
+    assert five[4].id == 1
+
+
+def test_chunked_qs_reverse_with_empty_qs():
+    chunks = list(chunked_qs_reverse(FailureLine.objects.none()))
+
+    assert len(chunks) == 0

--- a/treeherder/autoclassify/matchers.py
+++ b/treeherder/autoclassify/matchers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import division
 
 import logging
@@ -53,6 +54,34 @@ class Matcher(object):
     @abstractmethod
     def query_best(self, text_log_error):
         pass
+
+
+def score_matches(matches, score_multiplier=(1, 1)):
+    """
+    Get scores for the given matches
+
+    Given a QuerySet of TextLogErrorMatchs produce a score for each one until
+    Good Enough™.  An optional score multiplier can be passed in.
+    """
+    # TODO: this should probably loop the input returning all scores unless one
+    # is bigger than the Good Enough ratio.  Otherwise we only take the first
+    # score from each _chunk_ of the queryset which is meaningless to the
+    # score.
+    if matches is None:
+        return
+
+    match = matches.first()
+    if match is None:
+        return
+
+    # generate a new score from the current match
+    dividend, divisor = score_multiplier
+    score = match.score * dividend / divisor
+
+    yield (match, score)
+
+    if score >= AUTOCLASSIFY_GOOD_ENOUGH_RATIO:
+        return
 
 
 def time_boxed(func, iterable, time_budget, *args):

--- a/treeherder/autoclassify/matchers.py
+++ b/treeherder/autoclassify/matchers.py
@@ -55,6 +55,24 @@ class Matcher(object):
         pass
 
 
+def time_boxed(func, iterable, time_budget, *args):
+    """
+    Apply a function to the items of an iterable within a given time budget
+
+    Loop the given iterable, calling the given function on each item. The expended
+    time is compared to the given time budget after each iteration.
+    """
+    time_budget = time_budget / 1000  # budget in milliseconds
+    start = time.time()
+
+    for thing in iterable:
+        yield func(thing, *args)
+
+        end = time.time() - start
+        if end > time_budget:
+            # Putting the condition at the end of the loop ensures that we
+            # always run it once, which is useful for testing
+            return
 
 
 class id_window(object):

--- a/treeherder/autoclassify/matchers.py
+++ b/treeherder/autoclassify/matchers.py
@@ -11,6 +11,7 @@ from difflib import SequenceMatcher
 import newrelic.agent
 from django.conf import settings
 from django.db.models import Q
+from first import first
 from six import add_metaclass
 
 from treeherder.autoclassify.autoclassify import AUTOCLASSIFY_GOOD_ENOUGH_RATIO
@@ -54,6 +55,23 @@ class Matcher(object):
     @abstractmethod
     def query_best(self, text_log_error):
         pass
+
+
+def score_by_classified_fail_id(matches):
+    """
+    Get a tuple of the best (match, score) and its ClassifiedFailure ID
+    """
+    if not matches:
+        return
+
+    # list of (match, score) pairs
+    # get the best score
+    match_and_score = first(matches, key=lambda m: (-m[1], -m[0].classified_failure_id))
+    if not match_and_score:
+        return
+
+    match, score = match_and_score
+    return match.classified_failure_id, score
 
 
 def score_matches(matches, score_multiplier=(1, 1)):


### PR DESCRIPTION
This replaces the `id_window` decorator with some composable functions and aims to extract the core functionality from id_window making them reusable.

Along the way I also documented everything in `matchers.py`, using the `pep257` tool to see what it was like (pretty good!) and added another QuerySet chunking function that works in the opposite direction.