### PR TITLE
Remove filters from ES query

### DIFF
--- a/tests/autoclassify/test_classify_failures.py
+++ b/tests/autoclassify/test_classify_failures.py
@@ -233,14 +233,9 @@ def test_classify_es(test_job_2, failure_lines, classified_failures):
 
     do_autoclassify(test_job_2, test_failure_lines, [ElasticSearchTestMatcher])
 
-    expected_classified = test_failure_lines[:4]
-    expected_unclassified = test_failure_lines[4:]
-
-    for actual in expected_classified:
-        assert [item.id for item in actual.classified_failures.all()] == [classified_failures[0].id]
-
-    for item in expected_unclassified:
-        assert item.classified_failures.count() == 0
+    for failure_line in test_failure_lines:
+        classified_fail_ids = [item.id for item in failure_line.classified_failures.all()]
+        assert classified_fail_ids == [classified_failures[0].id]
 
 
 def test_classify_multiple(test_job_2, failure_lines, classified_failures):

--- a/treeherder/autoclassify/matchers.py
+++ b/treeherder/autoclassify/matchers.py
@@ -195,19 +195,12 @@ class ElasticSearchTestMatcher(Matcher):
             logger.debug("Skipped elasticsearch matching")
             return
 
-        filters = [
-            {'term': {'test': failure_line.test}},
-            {'term': {'status': failure_line.status}},
-            {'term': {'expected': failure_line.expected}},
-            {'exists': {'field': 'best_classification'}}
-        ]
-        if failure_line.subtest:
-            query = filters.append({'term': {'subtest': failure_line.subtest}})
-
         query = {
             'query': {
                 'bool': {
-                    'filter': filters,
+                    'filter': [{
+                        'exists': {'field': 'best_classification'},
+                    }],
                     'must': [{
                         'match_phrase': {
                             'message': failure_line.message[:1024],


### PR DESCRIPTION
This removes all filters from the auto-classification Elasticsearch query so we can measure how many results it produces over the next few days.  Once we have some data on that we can tune further.