### PR TITLE
Bug 1458633 - Fix bug wrongly added to list of bugs for classification

### DIFF
--- a/ui/details-panel/autoclassify/StaticLineOption.jsx
+++ b/ui/details-panel/autoclassify/StaticLineOption.jsx
@@ -36,7 +36,7 @@ export default function StaticLineOption(props) {
         {!canClassify || pinBoard.isPinned(job) &&
           <button
             className="btn btn-xs btn-light-bordered"
-            onClick={pinBoard.addBug({ id: option.bugNumber }, job)}
+            onClick={() => pinBoard.addBug({ id: option.bugNumber }, job)}
             title="add to list of bugs to associate with all pinned jobs"
           ><i className="fa fa-thumb-tack" /></button>}
         {!!option.bugResolution &&

--- a/ui/plugins/auto_classification/main.html
+++ b/ui/plugins/auto_classification/main.html
@@ -1,4 +1,5 @@
 <autoclassify-tab
+  ng-if="tabService.tabs.autoClassification.enabled"
   job="job"
   logs-parsed="jobLogsAllParsed"
   has-logs="job_log_urls.length > 0"

--- a/ui/plugins/perf_details/main.html
+++ b/ui/plugins/perf_details/main.html
@@ -1,6 +1,7 @@
 <div>
   <div>
     <performance-tab
+      ng-if="tabService.tabs.perfDetails.enabled"
       perf-job-detail="perfJobDetail"
       repo-name="repoName"
       revision="jobRevision"


### PR DESCRIPTION
The ``onClick`` function was getting executed because it was a command rather than  a function which would initiate the command.

I also added more complete disabling for this and the perf tab in the case that it's not being used.  This prevents their code getting executed in the background when they are irrelevant.