### PR TITLE
Bug 1458922 - Fix tier 2 tasks not displaying group symbols

### DIFF
--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -909,7 +909,7 @@ treeherder.factory('ThResultSetStore', [
           } = job;
           // this has to do with group sorting so that the tier-1 ungrouped
           // jobs show first, and the tier>1 ungrouped jobs show last.
-          const symbol = tier > 1 ? '' : job_group_symbol;
+          const symbol = tier > 1 && job_group_symbol === '?' ? '' : job_group_symbol;
           const mapKey = getGroupMapKey(
             result_set_id, symbol, tier, platform, platform_option);
 


### PR DESCRIPTION
This should ONLY have applied to tier-2 groups that didn't have a group symbol.  So just had to add the other check.