### PR TITLE
Add Classification Efficacy Metrics

### DIFF
--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -8,6 +8,7 @@ from collections import (OrderedDict,
                          defaultdict)
 from hashlib import sha1
 
+import newrelic.agent
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.validators import MinLengthValidator
@@ -548,13 +549,26 @@ class Job(models.Model):
         if not self.is_fully_verified():
             return
 
+        classification = 'autoclassified intermittent'
+
         already_classified = (JobNote.objects.filter(job=self)
-                                             .exclude(failure_classification__name='autoclassified intermittent')
+                                             .exclude(failure_classification__name=classification)
                                              .exists())
         if already_classified:
             # Don't add an autoclassification note if a Human already
             # classified this job.
             return
+
+        already_autoclassified = JobNote.objects.filter(failure_classification__name=classification, job=self).exists()
+        if already_autoclassified and user:
+            # Send event to NewRelic when a User verifies an autoclassified failure.
+            matches = (TextLogErrorMatch.objects.filter(text_log_error__step__job=self)
+                                                .select_related('matcher'))
+            for match in matches:
+                newrelic.agent.record_custom_event('user_verified_classification', {
+                    'matcher': match.matcher.name,
+                    'job_id': self.id,
+                })
 
         JobNote.create_autoclassify_job_note(job=self, user=user)
 


### PR DESCRIPTION
This adds a custom NewRelic event to track when a user classified a failure that we had already picked up via auto-classification.

I added the change to `create_autoclassify_job_note` as I thought it would need to be further changed for this to pass in a matcher name/instance.  It turned out to not be necessary but the change is a nice simplification either way.