### PR TITLE
Bug 1460218 - Update to Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
     # Job 3: Nodejs UI tests
     - env: js-tests
       language: node_js
-      node_js: "8"
+      node_js: "10"
       cache:
         directories:
           - node_modules
@@ -89,7 +89,7 @@ matrix:
           - ${HOME}/venv
           - node_modules
       install:
-        - nvm install 8
+        - nvm install 10
         - source ./bin/travis-setup.sh services python_env geckodriver js_env
       before_script:
         # Run in `before_script` to prevent the selenium tests from still being run if the UI build fails.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "MPL-2.0",
   "engines": {
-    "node": "8.x",
+    "node": "10.x",
     "yarn": "1.x"
   },
   "dependencies": {

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -42,10 +42,10 @@ ln -sf "$SRC_DIR/vagrant/.profile" "$HOME/.profile"
 sudo ln -sf "$SRC_DIR/vagrant/env.sh" /etc/profile.d/treeherder.sh
 . vagrant/env.sh
 
-if ! grep -qs 'node_8.x' /etc/apt/sources.list.d/nodesource.list; then
+if ! grep -qs 'node_10.x' /etc/apt/sources.list.d/nodesource.list; then
     echo '-----> Adding APT repository for Node.js'
     curl -sSf https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
-    echo 'deb https://deb.nodesource.com/node_8.x xenial main' | sudo tee /etc/apt/sources.list.d/nodesource.list > /dev/null
+    echo 'deb https://deb.nodesource.com/node_10.x xenial main' | sudo tee /etc/apt/sources.list.d/nodesource.list > /dev/null
 fi
 
 if [[ ! -f /etc/apt/sources.list.d/yarn.list ]]; then


### PR DESCRIPTION
Node.js 10 is the new LTS:
https://github.com/nodejs/Release#release-schedule
https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.1.0

This updates Vagrant, Travis and Heroku (the latter uses the version from `package.json`) from Node 8.

`yarn build` times on Travis are now 15% faster (189s -> 161s, using best of 3 runs of each).