### PR TITLE
Bug 1420941 - Docs: Encourage users to run Vagrant provision

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,16 +23,16 @@ Setting up Vagrant
 
   .. code-block:: bash
 
-     > vagrant up
+     > vagrant up --provision
 
-  It will typically take 5 to 30 minutes for the vagrant up to
+  It will typically take 5 to 30 minutes for the vagrant provision to
   complete, depending on your network performance. If you experience
   any errors, see the :ref:`troubleshooting page
   <troubleshooting-vagrant>`. It is *very important* that the
   provisioning process complete successfully before trying to interact
   with your test instance of treeherder: some things might
   superficially seem to work a partially configured machine, but
-  it is almost guranteed that some things *will break* in
+  it is almost guaranteed that some things *will break* in
   hard-to-diagnose ways if vagrant provision is not run to completion.
 
 * Once the virtual machine is set up, connect to it using:

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -6,13 +6,13 @@ Troubleshooting
 Errors during Vagrant setup
 ---------------------------
 
-* The Vagrant provisioning process during ``vagrant up`` assumes the presence of a stable internet connection. In the event of a connection interruption during provision, you may see errors similar to *"Temporary failure resolving.."* or *"E: Unable to fetch some archives.."* after the process has completed. In that situation, you can attempt to re-provision using the command:
+* The Vagrant provisioning process during ``vagrant up --provision`` assumes the presence of a stable internet connection. In the event of a connection interruption during provision, you may see errors similar to *"Temporary failure resolving.."* or *"E: Unable to fetch some archives.."* after the process has completed. In that situation, you can attempt to re-provision using the command:
 
   .. code-block:: bash
 
      >vagrant provision
 
-  If that is still unsuccessful, you should attempt a ``vagrant destroy`` followed by another ``vagrant up``.
+  If that is still unsuccessful, you should attempt a ``vagrant destroy`` followed by another ``vagrant up --provision``.
 
 * If you encounter an error saying *"mount.nfs: requested NFS version or transport protocol is not supported"*, you should restart the kernel server service using this sequence of commands:
 
@@ -23,6 +23,6 @@ Errors during Vagrant setup
     systemctl enable nfs-kernel-server.service
     systemctl start nfs-kernel-server.service
 
-* If you encounter an error saying *"The guest machine entered an invalid state while waiting for it to boot. Valid states are 'starting, running'. The machine is in the 'poweroff' state. Please verify everything is configured properly and try again."* you should should check your host machine's virtualization technology (vt-x) is enabled in the BIOS (see this guide_), then continue with ``vagrant up``.
+* If you encounter an error saying *"The guest machine entered an invalid state while waiting for it to boot. Valid states are 'starting, running'. The machine is in the 'poweroff' state. Please verify everything is configured properly and try again."* you should should check your host machine's virtualization technology (vt-x) is enabled in the BIOS (see this guide_), then continue with ``vagrant up --provision``.
 
   .. _guide: http://www.sysprobs.com/disable-enable-virtualization-technology-bios

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 if [[ "$(lsb_release -r -s)" != "16.04" ]]; then
     echo "This machine needs to be switched to the new Ubuntu 16.04 image."
-    echo "Please run 'vagrant destroy -f && vagrant up' from the host."
+    echo "Please run 'vagrant destroy -f && vagrant up --provision' from the host."
     exit 1
 fi
 


### PR DESCRIPTION
The `--provision` flag is unnecessary for new instances, since Vagrant runs `provision` as part of the initial `up` regardless. However by including `--provision` in the suggested command, it will mean returning contributors will re-run provision when they re-use the same steps.

An alternative approach would be to mark the provision block in `Vagrantfile` as `run: "always"`, however that would slow down the `vagrant up` of core developers too (by 40s), with no way to opt-out.