### PR TITLE
Bug 1461649 - Enable dev-server's polling watch mode in Vagrant

### DIFF
--- a/neutrino-custom/development.js
+++ b/neutrino-custom/development.js
@@ -35,4 +35,14 @@ module.exports = neutrino => {
                 }
             }
         });
+
+    if (process.env.USE_WATCH_POLLING) {
+      // Inside Vagrant filesystem watching has to be performed using polling mode,
+      // since inotify doesn't work with Virtualbox shared folders.
+      neutrino.config.devServer.set('watchOptions', {
+        // Poll only once a second and ignore the node_modules folder to keep CPU usage down.
+        poll: 1000,
+        ignored: /node_modules/,
+      });
+    }
 };

--- a/vagrant/env.sh
+++ b/vagrant/env.sh
@@ -15,3 +15,7 @@ export NEW_RELIC_DEVELOPER_MODE='True'
 
 # Enable Firefox headless mode, avoiding the need for xvfb.
 export MOZ_HEADLESS=1
+
+# Allow dev-servers to know they should enable polling mode for filesystem watching,
+# since inotify is not supported by Virtualbox shared folders.
+export USE_WATCH_POLLING=1


### PR DESCRIPTION
This allows the webpack-dev-server filesystem watching to work even inside Vagrant (such as when using `yarn start:local`), where the Virtualbox shared folders mean that standard inotify watching does not work:
https://webpack.js.org/configuration/dev-server/#devserver-watchoptions-