### PR TITLE
Bug 1291954 - Highlight tsan errors

### DIFF
--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -351,6 +351,7 @@ class ErrorParser(ParserBase):
         "E/GeckoLinker",
         "SUMMARY: AddressSanitizer",
         "SUMMARY: LeakSanitizer",
+        "SUMMARY: ThreadSanitizer",
         "Automation Error:",
         "command timed out:",
         "wget: unable ",


### PR DESCRIPTION
I'd like to make tsan tier1, but the current Failure Summary for them is kind of bad. One thing that would help is recognizing the SUMMARY: line as with {Address,Leak}Sanitizer.