### PR TITLE
Bug 1462267 - Remove unnecessary react-test-renderer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,7 @@
     "jasmine-jquery": "2.1.1",
     "karma-firefox-launcher": "1.1.0",
     "karma-jasmine": "1.1.2",
-    "neutrino-preset-karma": "4.2.1",
-    "react-test-renderer": "16.3.2"
+    "neutrino-preset-karma": "4.2.1"
   },
   "scripts": {
     "build": "node ./node_modules/neutrino/bin/neutrino build --presets ./neutrino-custom/production.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6194,7 +6194,7 @@ react-table@6.8.2:
   dependencies:
     classnames "^2.2.5"
 
-react-test-renderer@16.3.2, react-test-renderer@^16.0.0-0:
+react-test-renderer@^16.0.0-0:
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
   dependencies:


### PR DESCRIPTION
Since `enzyme-adapter-react-16` now has it as a dependency rather than a peer dependency:
http://airbnb.io/enzyme/docs/installation/#working-with-react-16