### PR TITLE
Simplify Auto-Classification Saving

### DIFF
--- a/tests/model/test_classified_failure.py
+++ b/tests/model/test_classified_failure.py
@@ -55,7 +55,7 @@ def test_update_autoclassification_bug(test_job, test_job_2,
     create_failure_lines(test_job_2, lines)
     error_lines = create_text_log_errors(test_job_2, lines)
 
-    error_lines[0].mark_best_classification(classified_failures[0])
+    error_lines[0].mark_best_classification(classified_failures[0].id)
     assert classified_failures[0].bug_number is None
 
     assert test_job_2.update_autoclassification_bug(1234) == classified_failures[0]

--- a/treeherder/autoclassify/autoclassify.py
+++ b/treeherder/autoclassify/autoclassify.py
@@ -61,6 +61,7 @@ def find_matches(unmatched_errors):
 
     for matcher in Matcher.objects.registered_matchers():
         matches = matcher(unmatched_errors)
+        # matches: generator of Match tuples: (TextLogError, ClassifiedFailure.id, score)
         for match in matches:
             logger.info("Matched error %i with intermittent %i",
                         match.text_log_error.id, match.classified_failure_id)
@@ -80,11 +81,19 @@ def update_db(job, matches, all_matched):
                            ClassifiedFailure.objects.filter(
                                id__in=[match.classified_failure_id for _, match in matches])}
     for matcher, match in matches:
+        # matcher: Matcher Model instance
+        # match: tuple of (TextLogError, ClassifiedFailure.id, score)
         classified_failure = classified_failures[match.classified_failure_id]
         matches_by_error[match.text_log_error].add((matcher, match, classified_failure))
 
     for text_log_error, matches in iteritems(matches_by_error):
+        # text_log_error: TextLogError instance
+        # matches: (Matcher instance, (TextLogError, ClassifiedFailure.id, score)
         for (matcher, match, classified_failure) in matches:
+            # matcher: Matcher model instance
+            # match: Match tuple (TextLogError, ClassifiedFailure.id, score)
+            # classified_failure: ClassifiedFailure model instance
+
             try:
                 TextLogErrorMatch.objects.create(
                     score=match.score,

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -1409,7 +1409,7 @@ class TextLogError(models.Model):
 
         return classification, new_link
 
-    def mark_best_classification(self, classification):
+    def mark_best_classification(self, classification_id):
         """
         Set the given FailureClassification as the best one
 
@@ -1418,6 +1418,8 @@ class TextLogError(models.Model):
 
         If no TextLogErrorMetadata instance exists one will be created.
         """
+        classification = ClassifiedFailure.objects.get(id=classification_id)
+
         if self.metadata is None:
             TextLogErrorMetadata.objects.create(
                 text_log_error=self,


### PR DESCRIPTION
This simplifies how we save matched failures to the DB.  It specifically tries to improve the readability of `update_db` which was doing a few things before.

I took a stab at this once I realised I was really struggling to pick apart what the variables held at various places.