### PR TITLE
Bug 1462625 - Fix TypeError when selecting buildbot jobs

### DIFF
--- a/ui/plugins/controller.js
+++ b/ui/plugins/controller.js
@@ -232,7 +232,7 @@ treeherder.controller('PluginCtrl', [
                             title: "Buildername",
                             value: $scope.job.ref_data_name
                         });
-                        $scope.buildernameIndex = $scope.job_details.findIndex({ title: "Buildername" });
+                        $scope.buildernameIndex = $scope.job_details.findIndex(({ title }) => title === 'Buildername');
                     }
 
                     // the third result comes from the jobLogUrl promise


### PR DESCRIPTION
This was changed from `_.findIndex()` to `Array.prototype.findIndex()` in #3537, however was using the former's `_.matches()` shorthand style, which isn't supported by the ES6 equivalent.

https://lodash.com/docs#findIndex
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex