### PR TITLE
Bug 1463079 - Remove the preAssignBindingsEnabled workaround

### DIFF
--- a/ui/js/components/perf/compare.js
+++ b/ui/js/components/perf/compare.js
@@ -26,16 +26,18 @@ treeherder.component('phCompareTable', {
         releaseBlockerCriteria: '@'
     },
     controller: ['$attrs', function ($attrs) {
-        // TODO: Use $onInit() so the legacy preAssignBindingsEnabled pref
-        // doesn't have to be enabled in perfapp.js
         const ctrl = this;
 
-        if (!ctrl.baseTitle) {
-            ctrl.baseTitle = "Base";
-        }
-        if (!ctrl.newTitle) {
-            ctrl.newTitle = "New";
-        }
+        ctrl.$onInit = function () {
+            if (!ctrl.baseTitle) {
+                ctrl.baseTitle = "Base";
+            }
+            if (!ctrl.newTitle) {
+                ctrl.newTitle = "New";
+            }
+            ctrl.updateFilteredTestList();
+        };
+
         ctrl.getCompareClasses = function (cr, type) {
             if (cr.isEmpty) return 'subtest-empty';
             if (type === 'row' && cr.highlightedTest) return 'active subtest-highlighted';
@@ -83,8 +85,6 @@ treeherder.component('phCompareTable', {
               testName => ({ testName, results: ctrl.filteredResultList[testName] })
             );
         };
-
-        ctrl.updateFilteredTestList();
     }]
 });
 
@@ -136,21 +136,24 @@ treeherder.component('distributionGraph', {
     },
     controller: [function () {
         const ctrl = this;
-        const cvs = document.getElementById("distribution-graph-new");
-        const ctx = cvs.getContext("2d");
-        cvs.setAttribute("id", "distribution-graph-current");
-        ctrl.maxValue = Math.max.apply(null, ctrl.replicates);
-        ctrl.minValue = Math.min.apply(null, ctrl.replicates);
-        if (ctrl.maxValue - ctrl.minValue > 1) {
-            ctrl.maxValue = Math.ceil(ctrl.maxValue*1.001);
-            ctrl.minValue = Math.floor(ctrl.minValue/1.001);
-        }
-        ctx.globalAlpha = 0.3;
-        ctrl.replicates.forEach((value) => {
-            ctx.beginPath();
-            ctx.arc(180/(ctrl.maxValue - ctrl.minValue)*(value - ctrl.minValue) + 5, 18, 5, 0, 360);
-            ctx.fillStyle = 'white';
-            ctx.fill();
-        });
+
+        ctrl.$onInit = function () {
+            const cvs = document.getElementById("distribution-graph-new");
+            const ctx = cvs.getContext("2d");
+            cvs.setAttribute("id", "distribution-graph-current");
+            ctrl.maxValue = Math.max.apply(null, ctrl.replicates);
+            ctrl.minValue = Math.min.apply(null, ctrl.replicates);
+            if (ctrl.maxValue - ctrl.minValue > 1) {
+                ctrl.maxValue = Math.ceil(ctrl.maxValue*1.001);
+                ctrl.minValue = Math.floor(ctrl.minValue/1.001);
+            }
+            ctx.globalAlpha = 0.3;
+            ctrl.replicates.forEach((value) => {
+                ctx.beginPath();
+                ctx.arc(180/(ctrl.maxValue - ctrl.minValue)*(value - ctrl.minValue) + 5, 18, 5, 0, 360);
+                ctx.fillStyle = 'white';
+                ctx.fill();
+            });
+        };
     }]
 });

--- a/ui/js/perfapp.js
+++ b/ui/js/perfapp.js
@@ -19,12 +19,6 @@ perf.config(['$compileProvider', '$locationProvider', '$httpProvider', '$statePr
         $compileProvider.commentDirectivesEnabled(false);
         $compileProvider.cssClassDirectivesEnabled(false);
 
-        // Revert to the legacy Angular <=1.5 pre-assign bindings behaviour:
-        // https://docs.angularjs.org/guide/migration#commit-bcd0d4
-        // TODO: Move component/directive controller initialization logic that relies on bindings
-        // being present (eg that in phCompareTable) into the controller's $onInit() instead.
-        $compileProvider.preAssignBindingsEnabled(true);
-
         // Revert to the legacy Angular <=1.5 URL hash prefix to save breaking existing links:
         // https://docs.angularjs.org/guide/migration#commit-aa077e8
         $locationProvider.hashPrefix('');


### PR DESCRIPTION
AngularJS 1.6 changed the way controller bindings were initialised, but allowed users to revert to the previous behaviour by setting `preAssignBindingsEnabled(true)`.

As part of our upgrade from AngularJS 1.5 to 1.6, we set that pref in Perfherder, to fix the bug 1428958 regression.

However AngularJS 1.7 has now removed the pref, so we need to actually fix the root cause - by moving any controller logic that is dependant on the bindings into the `.$onInit()` method, which is only called after all of the bindings are guaranteed to exist.

See:
https://docs.angularjs.org/guide/migration#migrate1.5to1.6-ng-services-$compile

Testing this locally shows the regression in bug 1428958 no longer occurs, and as far as I can tell all other functionality in Perfherder works fine (and there are no new exceptions seen in the console).