### PR TITLE
Bug 1463079 - Fix hiding series in perfherder graphs view

### DIFF
--- a/ui/partials/perf/graphsctrl.html
+++ b/ui/partials/perf/graphsctrl.html
@@ -17,7 +17,7 @@
                 <a href="" ng-click="addTestData('addRelatedPlatform', series.signature)" title="Add related platforms">{{series.platform}}</a><br/>
                 <div class="signature"><small>{{series.signature}}</small></div>
               </div>
-              <input title="Show/Hide series" type="checkbox" ng-model="series.visible" class="show-hide-check" ng-click="showHideSeries(series.signature)">
+              <input title="Show/Hide series" type="checkbox" ng-model="series.visible" class="show-hide-check" ng-change="showHideSeries(series.signature)">
           </td>
         </tr>
       </table>


### PR DESCRIPTION
Apparently angular wasn't so happy about the event being bound to
"ng-click", but "ng-change" (which is what's recommended by the
angular documentation) works fine.