### PR TITLE
Bug 1465041 - Restore default webpack module resolution config

### DIFF
--- a/neutrino-custom/base.js
+++ b/neutrino-custom/base.js
@@ -271,6 +271,16 @@ module.exports = neutrino => {
             return options;
         });
 
+    // Remove additional node_modules directories added by Neutrino that cause
+    // incorrect module resolution, and restore the webpack defaults:
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1465041
+    // https://github.com/mozilla-neutrino/neutrino-dev/issues/822
+    // https://webpack.js.org/configuration/resolve/#resolve-modules
+    neutrino.config.resolve.modules.clear();
+    neutrino.config.resolve.modules.add('node_modules');
+    neutrino.config.resolveLoader.modules.clear();
+    neutrino.config.resolveLoader.modules.add('node_modules');
+
     neutrino.config
         .plugin('provide')
         .use(webpack.ProvidePlugin, {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "eslint-plugin-jsx-a11y": "5.1.1",
     "eslint-plugin-react": "7.5.1",
     "font-awesome": "4.7.0",
-    "hawk": "6.0.2",
     "history": "4.7.2",
     "html-loader": "0.5.5",
     "jquery": "3.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3582,7 +3582,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
 
-hawk@6.0.2, hawk@^6.0.2:
+hawk@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
   dependencies:


### PR DESCRIPTION
Neutrino 4 removes the webpack default module resolution of looking in a relative `node_modules` directory (and then the parent of that directory, and so on), in favour of hardcoding the repo root's `node_modules` and those of the Neutrino preset directories.

This is both unnecessary and causes incorrect module resolution, which has bitten us multiple times.

In addition to fixing the failures being seen during Heroku builds, this change means we can also remove the not-directly-used dependency on `hawk`, which we'd had to leave in to work around:
https://github.com/mozilla/treeherder/pull/3144#discussion_r164726521