### PR TITLE
Bug 1464840 - Add 'raptor' and 'js-bench' to perfherder_frameworks.json

### DIFF
--- a/treeherder/perf/fixtures/performance_framework.json
+++ b/treeherder/perf/fixtures/performance_framework.json
@@ -70,5 +70,21 @@
             "name": "hasal",
             "enabled": true
         }
+    },
+    {
+        "pk": 10,
+        "model": "perf.PerformanceFramework",
+        "fields": {
+            "name": "raptor",
+            "enabled": true
+        }
+    },
+    {
+        "pk": 11,
+        "model": "perf.PerformanceFramework",
+        "fields": {
+            "name": "js-bench",
+            "enabled": true
+        }
     }
 ]


### PR DESCRIPTION
These are two new performance frameworks currently under development.
For now these tasks will be unsheriffed until they are more stable,
though we still want to get a feel for the data they produce.