### PR TITLE
Use TextLogErrorMatch Instances

### DIFF
--- a/treeherder/autoclassify/autoclassify.py
+++ b/treeherder/autoclassify/autoclassify.py
@@ -31,10 +31,11 @@ def match_errors(job, matchers=None):
     if job.result not in ["testfailed", "busted", "exception"]:
         return
 
-    unmatched_errors = set(TextLogError.objects.filter(step__job=job, classified_failures=None)
-                                               .prefetch_related('step', '_metadata', '_metadata__failure_line'))
+    all_errors = set(TextLogError.objects.filter(step__job=job, classified_failures=None)
+                                         .prefetch_related('step', '_metadata', '_metadata__failure_line'))
+    errors = [t for t in all_errors if t.metadata and t.metadata.failure_line]
 
-    if not unmatched_errors:
+    if not errors:
         logger.info("Skipping autoclassify of job %i because it has no unmatched errors", job.id)
         return
 

--- a/treeherder/autoclassify/autoclassify.py
+++ b/treeherder/autoclassify/autoclassify.py
@@ -51,6 +51,10 @@ def match_errors(job, matchers=None):
 
         update_db(matches)
 
+        # did we find matches for every error?
+        matches_over_threshold = {m.text_log_error_id for m in matches if m.score >= AUTOCLASSIFY_GOOD_ENOUGH_RATIO}
+        all_matched = {tle.id for tle in all_errors} <= matches_over_threshold
+
         create_note(job, all_matched)
     except Exception:
         logger.error("Autoclassification of job %s failed", job.id)

--- a/treeherder/autoclassify/matchers.py
+++ b/treeherder/autoclassify/matchers.py
@@ -120,13 +120,6 @@ class PreciseTestMatcher(Matcher):
 
 class ElasticSearchTestMatcher(Matcher):
     """Looks for existing failures using Elasticsearch."""
-    def __call__(self, text_log_errors):
-        """Check Elasticsearch has been configured."""
-        if not settings.ELASTICSEARCH_URL:
-            return []
-
-        return super(ElasticSearchTestMatcher, self).__call__(text_log_errors)
-
     @newrelic.agent.function_trace()
     def query_best(self, text_log_error):
         """
@@ -135,6 +128,9 @@ class ElasticSearchTestMatcher(Matcher):
         Uses a filtered search checking test, status, expected, and the message
         as a phrase query with non-alphabet tokens removed.
         """
+        if not settings.ELASTICSEARCH_URL:
+            return []
+
         failure_line = text_log_error.metadata.failure_line
 
         if failure_line.action != "test_result" or not failure_line.message:


### PR DESCRIPTION
⚠️ ~**Blocked by #3592**~  ⚠️ 

This replaces our use of the `Match` named tuple and other tuples for passing data around when matching with unsaved `TextLogErrorMatch` instances.  It allows us to avoid tracking unmatched errors until the end of matching where we can do a set operation on the in-memory objects.

Unfortunately the changes [listed below] are all intertwined since I couldn't come up with a nice way to split the commits up.

A general overview of considered-nice changes:
* No more mutating the `unmatched_errors` list inside child functions
* All functionality removed from the Matcher parent class
* Pass one TextLogError to a matcher at a time instead of looping the matchers once and passing all errors to each one

This set of changes paves the way for pulling the scoring of matches out of the matching code, something I'm hoping will aid tweaking the matchers/scoring once I've implemented metrics on them.