### PR TITLE
Consolidate *Match Models

### DIFF
--- a/tests/autoclassify/test_classify_failures.py
+++ b/tests/autoclassify/test_classify_failures.py
@@ -137,12 +137,16 @@ def test_autoclassified_after_manual_classification(test_user,
         error_line.metadata.refresh_from_db()
         failure_line.refresh_from_db()
 
-    assert test_error_lines[0].matches.count() == 1
-    assert test_failure_lines[0].error.matches.count() == 1
-    assert test_error_lines[0].metadata.best_classification == test_error_lines[0].classified_failures.all()[0]
-    assert test_failure_lines[0].best_classification == test_failure_lines[0].classified_failures.all()[0]
-    assert test_error_lines[0].metadata.best_is_verified
-    assert test_failure_lines[0].best_is_verified
+    tle1 = test_error_lines[0]
+    fl1 = test_failure_lines[0]
+
+    assert tle1.matches.count() == 1
+    assert tle1.metadata.best_classification == tle1.classified_failures.first()
+    assert tle1.metadata.best_is_verified
+
+    assert fl1.error.matches.count() == 1
+    assert fl1.error.metadata.best_classification == fl1.error.classified_failures.first()
+    assert fl1.best_is_verified
 
 
 def test_autoclassified_no_update_after_manual_classification_1(test_job_2,

--- a/tests/autoclassify/test_classify_failures.py
+++ b/tests/autoclassify/test_classify_failures.py
@@ -137,8 +137,8 @@ def test_autoclassified_after_manual_classification(test_user,
         error_line.metadata.refresh_from_db()
         failure_line.refresh_from_db()
 
-    assert len(test_error_lines[0].matches.all()) == 1
-    assert len(test_failure_lines[0].matches.all()) == 1
+    assert test_error_lines[0].matches.count() == 1
+    assert test_failure_lines[0].error.matches.count() == 1
     assert test_error_lines[0].metadata.best_classification == test_error_lines[0].classified_failures.all()[0]
     assert test_failure_lines[0].best_classification == test_failure_lines[0].classified_failures.all()[0]
     assert test_error_lines[0].metadata.best_is_verified

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -437,9 +437,13 @@ def classified_failures(test_job, text_log_errors_failure_lines, test_matcher,
         if failure_line.job_guid == test_job.guid:
             classified_failure = ClassifiedFailure()
             classified_failure.save()
-            failure_line.set_classification(test_matcher,
-                                            classified_failure,
-                                            mark_best=True)
+
+            failure_line.error.set_classification(
+                test_matcher,
+                classified_failure,
+                mark_best=True,
+            )
+
             classified_failures.append(classified_failure)
 
     if settings.ELASTICSEARCH_URL:

--- a/tests/model/test_classified_failure.py
+++ b/tests/model/test_classified_failure.py
@@ -31,7 +31,7 @@ def test_set_bug_duplicate(failure_lines, classified_failures, test_matcher):
         score=0.8,
     )
 
-    assert len(failure_lines[0].matches.all()) == 2
+    assert failure_lines[0].matches.count() == 2
     rv = classified_failures[1].set_bug(1234)
     assert rv == classified_failures[0]
     assert rv.bug_number == 1234

--- a/tests/webapp/api/test_failureline.py
+++ b/tests/webapp/api/test_failureline.py
@@ -106,7 +106,7 @@ def test_update_failure_line_replace(test_repository,
 
     assert failure_line.best_classification == classified_failures[1]
     assert failure_line.best_is_verified
-    assert len(failure_line.classified_failures.all()) == 2
+    assert failure_line.classified_failures.count() == 2
     assert error_line.metadata.failure_line == failure_line
     assert error_line.metadata.best_classification == classified_failures[1]
     assert error_line.metadata.best_is_verified

--- a/tests/webapp/api/test_failureline.py
+++ b/tests/webapp/api/test_failureline.py
@@ -107,7 +107,7 @@ def test_update_failure_line_replace(test_repository,
 
     assert failure_line.best_classification == classified_failure
     assert failure_line.best_is_verified
-    assert failure_line.classified_failures.count() == 2
+    assert failure_line.error.classified_failures.count() == 2
     assert error_line.metadata.failure_line == failure_line
     assert error_line.metadata.best_classification == classified_failure
     assert error_line.metadata.best_is_verified

--- a/tests/webapp/api/test_failureline.py
+++ b/tests/webapp/api/test_failureline.py
@@ -103,17 +103,18 @@ def test_update_failure_line_replace(test_repository,
     failure_line.refresh_from_db()
     error_line.metadata.refresh_from_db()
     error_line.refresh_from_db()
+    classified_failure = classified_failures[1]
 
-    assert failure_line.best_classification == classified_failures[1]
+    assert failure_line.best_classification == classified_failure
     assert failure_line.best_is_verified
     assert failure_line.classified_failures.count() == 2
     assert error_line.metadata.failure_line == failure_line
-    assert error_line.metadata.best_classification == classified_failures[1]
+    assert error_line.metadata.best_classification == classified_failure
     assert error_line.metadata.best_is_verified
 
     expected_matcher = "ManualDetector"
-    assert failure_line.matches.get(classified_failure_id=classified_failures[1].id).matcher_name == expected_matcher
-    assert error_line.matches.get(classified_failure_id=classified_failures[1].id).matcher_name == expected_matcher
+    assert failure_line.error.matches.get(classified_failure=classified_failure).matcher_name == expected_matcher
+    assert error_line.matches.get(classified_failure=classified_failure).matcher_name == expected_matcher
 
 
 def test_update_failure_line_mark_job(test_repository, test_job,

--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -305,22 +305,24 @@ def test_job_error_lines(client, eleven_jobs_stored, failure_lines, classified_f
     failures = resp.json()
     assert isinstance(failures, list)
 
+    failure = failures[0]
+
     exp_failure_keys = ["id", "job_guid", "repository", "job_log", "action", "line",
                         "test", "subtest", "status", "expected", "message",
                         "signature", "level", "created", "modified", "matches",
                         "best_classification", "best_is_verified", "classified_failures",
                         "unstructured_bugs"]
 
-    assert set(failures[0].keys()) == set(exp_failure_keys)
+    assert set(failure.keys()) == set(exp_failure_keys)
 
-    matches = failures[0]["matches"]
+    matches = failure["matches"]
     assert isinstance(matches, list)
 
     exp_matches_keys = ["id", "matcher_name", "score", "classified_failure"]
 
     assert set(matches[0].keys()) == set(exp_matches_keys)
 
-    classified = failures[0]["classified_failures"][0]
+    classified = failure["classified_failures"][0]
     assert isinstance(classified, dict)
 
     exp_classified_keys = ["id", "bug_number", "bug"]

--- a/tests/webapp/api/test_text_log_error.py
+++ b/tests/webapp/api/test_text_log_error.py
@@ -107,13 +107,13 @@ def test_update_error_replace(client,
 
     assert failure_line.best_classification == classified_failure
     assert failure_line.best_is_verified
-    assert failure_line.classified_failures.count() == 2
+    assert failure_line.error.classified_failures.count() == 2
     assert error_line.metadata.failure_line == failure_line
     assert error_line.metadata.best_classification == classified_failure
     assert error_line.metadata.best_is_verified
 
     expected_matcher = "ManualDetector"
-    assert failure_line.matches.get(classified_failure=classified_failure).matcher_name == expected_matcher
+    assert failure_line.error.matches.get(classified_failure=classified_failure).matcher_name == expected_matcher
     assert error_line.matches.get(classified_failure=classified_failure).matcher_name == expected_matcher
 
 
@@ -538,8 +538,7 @@ def test_update_error_change_bug(client,
     assert error_line.metadata.best_is_verified is False
 
     assert 78910 not in [item.bug_number for item in classified_failures]
-    body = {"best_classification": classified_failures[0].id,
-            "bug_number": 78910}
+    body = {"best_classification": classified_failure.id, "bug_number": 78910}
 
     resp = client.put(
         reverse("text-log-error-detail", kwargs={"pk": error_line.id}),

--- a/tests/webapp/api/test_text_log_error.py
+++ b/tests/webapp/api/test_text_log_error.py
@@ -103,16 +103,18 @@ def test_update_error_replace(client,
     failure_line.refresh_from_db()
     error_line.metadata.refresh_from_db()
 
-    assert failure_line.best_classification == classified_failures[1]
+    classified_failure = classified_failures[1]
+
+    assert failure_line.best_classification == classified_failure
     assert failure_line.best_is_verified
     assert failure_line.classified_failures.count() == 2
     assert error_line.metadata.failure_line == failure_line
-    assert error_line.metadata.best_classification == classified_failures[1]
+    assert error_line.metadata.best_classification == classified_failure
     assert error_line.metadata.best_is_verified
 
     expected_matcher = "ManualDetector"
-    assert failure_line.matches.get(classified_failure_id=classified_failures[1].id).matcher_name == expected_matcher
-    assert error_line.matches.get(classified_failure_id=classified_failures[1].id).matcher_name == expected_matcher
+    assert failure_line.matches.get(classified_failure=classified_failure).matcher_name == expected_matcher
+    assert error_line.matches.get(classified_failure=classified_failure).matcher_name == expected_matcher
 
 
 def test_update_error_mark_job(client,
@@ -525,12 +527,14 @@ def test_update_error_change_bug(client,
     text_log_errors, failure_lines = text_log_errors_failure_lines
     client.force_authenticate(user=test_user)
 
+    classified_failure = classified_failures[0]
     failure_line = failure_lines[0]
     error_line = text_log_errors[0]
-    assert failure_line.best_classification == classified_failures[0]
+
+    assert failure_line.best_classification == classified_failure
     assert failure_line.best_is_verified is False
     assert error_line.metadata.failure_line == failure_line
-    assert error_line.metadata.best_classification == classified_failures[0]
+    assert error_line.metadata.best_classification == classified_failure
     assert error_line.metadata.best_is_verified is False
 
     assert 78910 not in [item.bug_number for item in classified_failures]

--- a/tests/webapp/api/test_text_log_error.py
+++ b/tests/webapp/api/test_text_log_error.py
@@ -547,14 +547,15 @@ def test_update_error_change_bug(client,
 
     assert resp.status_code == 200
 
-    classified_failures[0].refresh_from_db()
-    failure_line.refresh_from_db()
-    error_line.metadata.refresh_from_db()
+    classified_failure = ClassifiedFailure.objects.get(id=classified_failure.id)
+    failure_line = FailureLine.objects.get(id=failure_line.id)
+    error_line = TextLogError.objects.get(id=error_line.id)
 
-    assert failure_line.best_classification == classified_failures[0]
+    assert failure_line.best_classification == classified_failure
     assert failure_line.best_classification.bug_number == 78910
     assert failure_line.best_is_verified
-    assert error_line.metadata.best_classification == classified_failures[0]
+
+    assert error_line.metadata.best_classification == classified_failure
     assert error_line.metadata.best_is_verified
     assert error_line.metadata.best_classification.bug_number == 78910
 

--- a/tests/webapp/api/test_text_log_error.py
+++ b/tests/webapp/api/test_text_log_error.py
@@ -105,7 +105,7 @@ def test_update_error_replace(client,
 
     assert failure_line.best_classification == classified_failures[1]
     assert failure_line.best_is_verified
-    assert len(failure_line.classified_failures.all()) == 2
+    assert failure_line.classified_failures.count() == 2
     assert error_line.metadata.failure_line == failure_line
     assert error_line.metadata.best_classification == classified_failures[1]
     assert error_line.metadata.best_is_verified

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -941,45 +941,11 @@ class FailureLine(models.Model):
                             .select_related('classified_failure')
                             .first())
 
-    def set_classification(self, matcher_name, classification=None, bug_number=None,
-                           mark_best=False):
-        with transaction.atomic():
-            if classification is None:
-                if bug_number:
-                    classification, _ = ClassifiedFailure.objects.get_or_create(
-                        bug_number=bug_number)
-                else:
-                    classification = ClassifiedFailure.objects.create()
-
-            new_link = FailureMatch(
-                failure_line=self,
-                classified_failure=classification,
-                matcher_name=matcher_name,
-                score=1)
-            new_link.save()
-
-            if mark_best:
-                self.best_classification = classification
-                self.save(update_fields=['best_classification'])
-
-            if self.error:
-                TextLogErrorMatch.objects.create(
-                    text_log_error=self.error,
-                    classified_failure=classification,
-                    matcher_name=matcher_name,
-                    score=1)
-                if mark_best:
-                    self.error.metadata.best_classification = classification
-                    self.error.metadata.save(update_fields=['best_classification'])
-
-            self.elastic_search_insert()
-        return classification, new_link
-
     def mark_best_classification_verified(self, classification):
         if (classification and
             classification.id not in self.classified_failures.values_list('id', flat=True)):
             logger.debug("Adding new classification to TextLogError")
-            self.set_classification("ManualDetector", classification=classification)
+            self.error.set_classification("ManualDetector", classification=classification)
 
         self.best_classification = classification
         self.best_is_verified = True
@@ -1376,7 +1342,7 @@ class TextLogError(models.Model):
                 new_link_failure.save()
 
             if mark_best:
-                self.mark_best_classification(classification)
+                self.mark_best_classification(classification.id)
 
         return classification, new_link
 

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -1369,13 +1369,13 @@ class TextLogError(models.Model):
         else:
             self.metadata.best_classification = classification
             self.metadata.best_is_verified = True
-            self.metadata.save()
+            self.metadata.save(update_fields=['best_classification', 'best_is_verified'])
 
         failure_line = self.get_failure_line()
         if failure_line:
             failure_line.best_classification = classification
             failure_line.best_is_verified = True
-            failure_line.save()
+            failure_line.save(update_fields=['best_classification', 'best_is_verified'])
             failure_line.elastic_search_insert()
 
     def get_failure_line(self):

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -941,21 +941,6 @@ class FailureLine(models.Model):
                             .select_related('classified_failure')
                             .first())
 
-    def mark_best_classification_verified(self, classification):
-        if (classification and
-            classification.id not in self.classified_failures.values_list('id', flat=True)):
-            logger.debug("Adding new classification to TextLogError")
-            self.error.set_classification("ManualDetector", classification=classification)
-
-        self.best_classification = classification
-        self.best_is_verified = True
-        self.save()
-        if self.error:
-            self.error.metadata.best_classification = classification
-            self.error.metadata.best_is_verified = True
-            self.error.metadata.save(update_fields=["best_classification", "best_is_verified"])
-        self.elastic_search_insert()
-
     def _serialized_components(self):
         if self.action == "test_result":
             return ["TEST-UNEXPECTED-%s" % self.status.upper(),

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -1020,15 +1020,6 @@ class FailureLine(models.Model):
 
         return rv
 
-    def update_autoclassification(self):
-        """
-        If a job is manually classified and has a single line in the logs matching a single
-        FailureLine, but the FailureLine has not matched any ClassifiedFailure, add a
-        new match due to the manual classification.
-        """
-        classification, _ = self.set_classification("ManualDetector")
-        self.mark_best_classification_verified(classification)
-
     def elastic_search_insert(self):
         if not settings.ELASTICSEARCH_URL:
             return
@@ -1433,15 +1424,6 @@ class TextLogError(models.Model):
             self.metadata.failure_line.best_is_verified = True
             self.metadata.failure_line.save()
             self.metadata.failure_line.elastic_search_insert()
-
-    def update_autoclassification(self):
-        """
-        If a job is manually classified and has a single line in the logs matching a single
-        TextLogError, but the TextLogError has not matched any ClassifiedFailure, add a
-        new match due to the manual classification.
-        """
-        classification, _ = self.set_classification("ManualDetector")
-        self.mark_best_classification_verified(classification)
 
     def get_failure_line(self):
         """Get a related FailureLine instance if one exists."""

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -1370,11 +1370,13 @@ class TextLogError(models.Model):
             self.metadata.best_classification = classification
             self.metadata.best_is_verified = True
             self.metadata.save()
-        if self.metadata.failure_line:
-            self.metadata.failure_line.best_classification = classification
-            self.metadata.failure_line.best_is_verified = True
-            self.metadata.failure_line.save()
-            self.metadata.failure_line.elastic_search_insert()
+
+        failure_line = self.get_failure_line()
+        if failure_line:
+            failure_line.best_classification = classification
+            failure_line.best_is_verified = True
+            failure_line.save()
+            failure_line.elastic_search_insert()
 
     def get_failure_line(self):
         """Get a related FailureLine instance if one exists."""

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -1310,26 +1310,17 @@ class TextLogError(models.Model):
             else:
                 classification = ClassifiedFailure.objects.create()
 
-        new_link = TextLogErrorMatch(
+        match = TextLogErrorMatch.objects.create(
             text_log_error=self,
             classified_failure=classification,
             matcher_name=matcher_name,
-            score=1)
-        new_link.save()
-
-        if self.metadata and self.metadata.failure_line:
-            new_link_failure = FailureMatch(
-                failure_line=self.metadata.failure_line,
-                classified_failure=classification,
-                matcher_name=matcher_name,
-                score=1)
-
-            new_link_failure.save()
+            score=1,
+        )
 
         if mark_best:
             self.mark_best_classification(classification.id)
 
-        return classification, new_link
+        return classification, match
 
     def mark_best_classification(self, classification_id):
         """

--- a/treeherder/webapp/api/failureline.py
+++ b/treeherder/webapp/api/failureline.py
@@ -71,7 +71,8 @@ class FailureLineViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
 
             by_project[failure_line.repository.name].append(failure_line.job_guid)
 
-            failure_line.mark_best_classification_verified(classification)
+            if failure_line.error:
+                failure_line.error.mark_best_classification_verified(classification)
 
         for project, job_guids in iteritems(by_project):
             for job in Job.objects.filter(guid__in=job_guids):

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -383,8 +383,7 @@ class JobsViewSet(viewsets.ViewSet):
         Get a list of test failure lines for the job
         """
         try:
-            job = Job.objects.get(repository__name=project,
-                                  id=pk)
+            job = Job.objects.get(repository__name=project, id=pk)
             queryset = (FailureLine.objects.filter(job_guid=job.guid)
                                            .prefetch_related("matches"))
             failure_lines = [serializers.FailureLineNoStackSerializer(obj).data

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -117,15 +117,15 @@ class ClassifiedFailureSerializer(serializers.ModelSerializer):
         exclude = ['failure_lines', 'created', 'modified', 'text_log_errors']
 
 
-class FailureMatchSerializer(serializers.ModelSerializer):
+class TextLogErrorMatchSerializer(serializers.ModelSerializer):
 
     class Meta:
-        model = models.FailureMatch
-        exclude = ['failure_line']
+        model = models.TextLogErrorMatch
+        exclude = ['text_log_error']
 
 
 class FailureLineNoStackSerializer(serializers.ModelSerializer):
-    matches = FailureMatchSerializer(many=True)
+    matches = TextLogErrorMatchSerializer(many=True)
     classified_failures = ClassifiedFailureSerializer(many=True)
     unstructured_bugs = NoOpSerializer(read_only=True)
 
@@ -145,7 +145,7 @@ class TextLogErrorMetadataSerializer(serializers.ModelSerializer):
 
 
 class TextLogErrorSerializer(serializers.ModelSerializer):
-    matches = FailureMatchSerializer(many=True)
+    matches = TextLogErrorMatchSerializer(many=True)
     classified_failures = ClassifiedFailureSerializer(many=True)
     bug_suggestions = NoOpSerializer(read_only=True)
     metadata = TextLogErrorMetadataSerializer(read_only=True)

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -125,7 +125,6 @@ class TextLogErrorMatchSerializer(serializers.ModelSerializer):
 
 
 class FailureLineNoStackSerializer(serializers.ModelSerializer):
-    classified_failures = ClassifiedFailureSerializer(many=True)
     unstructured_bugs = NoOpSerializer(read_only=True)
 
     class Meta:
@@ -145,11 +144,14 @@ class FailureLineNoStackSerializer(serializers.ModelSerializer):
             matches = failure_line.error.matches.all()
         except AttributeError:  # failure_line.error can return None
             matches = []
-
         tle_serializer = TextLogErrorMatchSerializer(matches, many=True)
+
+        classified_failures = models.ClassifiedFailure.objects.filter(error_matches__in=matches)
+        cf_serializer = ClassifiedFailureSerializer(classified_failures, many=True)
 
         response = super(FailureLineNoStackSerializer, self).to_representation(failure_line)
         response['matches'] = tle_serializer.data
+        response['classified_failures'] = cf_serializer.data
         return response
 
 


### PR DESCRIPTION
This consolidates the `FailureMatch` and `TextLogErrorMatch` models, giving us one source of truth for matches.  It also simplifies the creation of matches and setting classifications, removing a nice chunk of essentially duplicate code!