### PR TITLE
Bug 1464273 - Fix classified/unclassified in Filters menu

### DIFF
--- a/ui/js/controllers/filters.js
+++ b/ui/js/controllers/filters.js
@@ -78,11 +78,12 @@ treeherderApp.controller('JobFilterCtrl', [
          * neither or both.
          */
         $scope.toggleClassifiedFilter = function () {
-            const func = $scope.classifiedFilter? thJobFilters.addFilter: thJobFilters.removeFilter;
+            const func = $scope.classifiedFilter ? thJobFilters.removeFilter : thJobFilters.addFilter;
             func(thJobFilters.classifiedState, 'classified');
         };
+
         $scope.toggleUnClassifiedFilter = function () {
-            const func = $scope.unClassifiedFilter? thJobFilters.addFilter: thJobFilters.removeFilter;
+            const func = $scope.unClassifiedFilter ? thJobFilters.removeFilter : thJobFilters.addFilter;
             func(thJobFilters.classifiedState, 'unclassified');
         };
 


### PR DESCRIPTION
Somehow the add/remove filter got reversed, so this fixes that part.

There is one edge-case where if you uncheck both classified and unclassified, it defaults back to BOTH being shown.  This was intentional as it's useless to hide both unclassified and classified.  Then no jobs whatsoever will show.

However, when you uncheck both, then it SHOULD pop back to checking both.  But due to a quirk in angular with the click event, it will set the filters to show both, but the last checkbox will show unclicked.  I could work-around this with some conditional usage of ``preventDefault``, but I don't think it's worth it.  When this converts to React, that problem will be moot, since it's use of ``state`` will manage that better.