### PR TITLE
Bug 1400258: Add chain-of-trust log type.

### DIFF
--- a/treeherder/etl/jobs.py
+++ b/treeherder/etl/jobs.py
@@ -346,7 +346,8 @@ def _schedule_log_parsing(job, job_logs, result):
     task_types = {
         "errorsummary_json",
         "buildbot_text",
-        "builds-4h"
+        "builds-4h",
+        "chain-of-trust",
     }
 
     job_log_ids = []

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -48,7 +48,8 @@ def parse_logs(job_id, job_log_ids, priority):
     parser_tasks = {
         "errorsummary_json": store_failure_lines,
         "buildbot_text": parse_unstructured_log,
-        "builds-4h": parse_unstructured_log
+        "builds-4h": parse_unstructured_log,
+        "chain-of-trust": parse_unstructured_log,
     }
 
     completed_names = set()


### PR DESCRIPTION
Treeherder doesn't yet support multiple unstructured logs, so I'm just posting this for posterity.