### PR TITLE
Pull Apart Classification Methods

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from requests import Request
 from requests_hawk import HawkAuth
 from rest_framework.test import APIClient
 
+from treeherder.autoclassify.autoclassify import mark_best_classification
 from treeherder.client.thclient import TreeherderClient
 from treeherder.etl.jobs import store_job_data
 from treeherder.etl.push import store_push_data
@@ -427,11 +428,10 @@ def classified_failures(test_job, text_log_errors_failure_lines, test_matcher,
 
     for failure_line in failure_lines:
         if failure_line.job_guid == test_job.guid:
-            classified_failure = ClassifiedFailure()
-            classified_failure.save()
+            classified_failure = ClassifiedFailure.objects.create()
 
             failure_line.error.set_classification(test_matcher, classified_failure)
-            failure_line.error.mark_best_classification(classified_failure)
+            mark_best_classification(failure_line.error, classified_failure)
 
             classified_failures.append(classified_failure)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -430,7 +430,7 @@ def classified_failures(test_job, text_log_errors_failure_lines, test_matcher,
         if failure_line.job_guid == test_job.guid:
             classified_failure = ClassifiedFailure.objects.create()
 
-            failure_line.error.set_classification(test_matcher, classified_failure)
+            failure_line.error.create_match(test_matcher, classified_failure)
             mark_best_classification(failure_line.error, classified_failure)
 
             classified_failures.append(classified_failure)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -431,7 +431,7 @@ def classified_failures(test_job, text_log_errors_failure_lines, test_matcher,
             classified_failure.save()
 
             failure_line.error.set_classification(test_matcher, classified_failure)
-            failure_line.error.mark_best_classification(classified_failure.id)
+            failure_line.error.mark_best_classification(classified_failure)
 
             classified_failures.append(classified_failure)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -430,11 +430,8 @@ def classified_failures(test_job, text_log_errors_failure_lines, test_matcher,
             classified_failure = ClassifiedFailure()
             classified_failure.save()
 
-            failure_line.error.set_classification(
-                test_matcher,
-                classified_failure,
-                mark_best=True,
-            )
+            failure_line.error.set_classification(test_matcher, classified_failure)
+            failure_line.error.mark_best_classification(classified_failure.id)
 
             classified_failures.append(classified_failure)
 

--- a/tests/model/test_classified_failure.py
+++ b/tests/model/test_classified_failure.py
@@ -1,8 +1,8 @@
 from decimal import Decimal
 
-from tests.autoclassify.utils import (create_failure_lines,
-                                      create_text_log_errors,
+from tests.autoclassify.utils import (create_lines,
                                       test_line)
+from treeherder.autoclassify.autoclassify import mark_best_classification
 from treeherder.model.models import (ClassifiedFailure,
                                      FailureLine,
                                      TextLogErrorMatch,
@@ -61,10 +61,9 @@ def test_update_autoclassification_bug(test_job, test_job_2, classified_failures
     assert test_job.update_autoclassification_bug(1234) is None
 
     lines = [(test_line, {})]
-    create_failure_lines(test_job_2, lines)
-    error_lines = create_text_log_errors(test_job_2, lines)
+    error_lines, _ = create_lines(test_job_2, lines)
 
-    error_lines[0].mark_best_classification(classified_failures[0].id)
+    mark_best_classification(error_lines[0], classified_failures[0])
     assert classified_failure.bug_number is None
 
     metadata = TextLogErrorMetadata.objects.get(text_log_error__step__job=test_job_2)

--- a/treeherder/autoclassify/autoclassify.py
+++ b/treeherder/autoclassify/autoclassify.py
@@ -151,7 +151,7 @@ def update_db(matches):
         # TODO: document what this does
         best_match = match.text_log_error.best_automatic_match(AUTOCLASSIFY_CUTOFF_RATIO)
         if best_match:
-            match.text_log_error.mark_best_classification(match.classified_failure_id)
+            match.text_log_error.mark_best_classification(match.classified_failure)
 
 
 def create_note(job, all_matched):

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -1193,7 +1193,6 @@ class TextLogError(models.Model):
                 .select_related('classified_failure')
                 .first())
 
-    @transaction.atomic
     def set_classification(self, matcher_name, classification):
         TextLogErrorMatch.objects.create(
             text_log_error=self,

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -819,7 +819,7 @@ class JobNote(models.Model):
             text_log_error.set_classification("ManualDetector", classification)
 
         if len(add_bugs) == 1 and not existing_bugs:
-            text_log_error.mark_best_classification_verified(classification)
+            text_log_error.verify_classification(classification)
 
     def save(self, *args, **kwargs):
         super(JobNote, self).save(*args, **kwargs)
@@ -1185,9 +1185,15 @@ class TextLogError(models.Model):
             score=1,
         )
 
-    def mark_best_classification_verified(self, classification):
+    def verify_classification(self, classification):
+        """
+        Mark the given ClassifiedFailure as verified by a human.
+
+        Handles no related FailureLine and duplicating the data onto
+        FailureLine.
+        """
         if classification not in self.classified_failures.all():
-            self.set_classification("ManualDetector", classification=classification)
+            self.set_classification("ManualDetector", classification)
 
         if self.metadata is None:
             TextLogErrorMetadata.objects.create(text_log_error=self,

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -934,13 +934,6 @@ class FailureLine(models.Model):
         except TextLogErrorMetadata.DoesNotExist:
             return None
 
-    def best_automatic_match(self, min_score=0):
-        """Find the best related match above a given minimum score."""
-        return (self.matches.filter(score__gt=min_score)
-                            .order_by("-score", "-classified_failure__id")
-                            .select_related('classified_failure')
-                            .first())
-
     def _serialized_components(self):
         if self.action == "test_result":
             return ["TEST-UNEXPECTED-%s" % self.status.upper(),
@@ -1184,15 +1177,6 @@ class TextLogError(models.Model):
         from treeherder.model import error_summary
         return error_summary.bug_suggestions_line(self)
 
-    def best_automatic_match(self, min_score=0):
-        return (TextLogErrorMatch.objects
-                .filter(text_log_error__id=self.id,
-                        score__gt=min_score)
-                .order_by("-score",
-                          "-classified_failure_id")
-                .select_related('classified_failure')
-                .first())
-
     def set_classification(self, matcher_name, classification):
         TextLogErrorMatch.objects.create(
             text_log_error=self,
@@ -1200,31 +1184,6 @@ class TextLogError(models.Model):
             matcher_name=matcher_name,
             score=1,
         )
-
-    def mark_best_classification(self, classification):
-        """
-        Set the given FailureClassification as the best one
-
-        Given an instance of FailureClassification links this TextLogError and
-        a possible FailureLine to it, denoting it's the best possible match.
-
-        If no TextLogErrorMetadata instance exists one will be created.
-        """
-        if self.metadata is None:
-            TextLogErrorMetadata.objects.create(
-                text_log_error=self,
-                best_classification=classification
-            )
-            return
-
-        self.metadata.best_classification = classification
-        self.metadata.save(update_fields=['best_classification'])
-
-        if self.metadata.failure_line:
-            self.metadata.failure_line.best_classification = classification
-            self.metadata.failure_line.save(update_fields=['best_classification'])
-
-            self.metadata.failure_line.elastic_search_insert()
 
     def mark_best_classification_verified(self, classification):
         if classification not in self.classified_failures.all():

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -816,7 +816,7 @@ class JobNote(models.Model):
 
         for bug_number in add_bugs:
             classification, _ = ClassifiedFailure.objects.get_or_create(bug_number=bug_number)
-            classification, _ = text_log_error.set_classification("ManualDetector", classification)
+            text_log_error.set_classification("ManualDetector", classification)
 
         if len(add_bugs) == 1 and not existing_bugs:
             text_log_error.mark_best_classification_verified(classification)
@@ -1195,14 +1195,12 @@ class TextLogError(models.Model):
 
     @transaction.atomic
     def set_classification(self, matcher_name, classification):
-        match = TextLogErrorMatch.objects.create(
+        TextLogErrorMatch.objects.create(
             text_log_error=self,
             classified_failure=classification,
             matcher_name=matcher_name,
             score=1,
         )
-
-        return classification, match
 
     def mark_best_classification(self, classification):
         """

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -816,7 +816,7 @@ class JobNote(models.Model):
 
         for bug_number in add_bugs:
             classification, _ = ClassifiedFailure.objects.get_or_create(bug_number=bug_number)
-            text_log_error.set_classification("ManualDetector", classification)
+            text_log_error.create_match("ManualDetector", classification)
 
         if len(add_bugs) == 1 and not existing_bugs:
             text_log_error.verify_classification(classification)
@@ -1177,7 +1177,12 @@ class TextLogError(models.Model):
         from treeherder.model import error_summary
         return error_summary.bug_suggestions_line(self)
 
-    def set_classification(self, matcher_name, classification):
+    def create_match(self, matcher_name, classification):
+        """
+        Create a TextLogErrorMatch instance
+
+        Typically used for manual "matches" or tests.
+        """
         TextLogErrorMatch.objects.create(
             text_log_error=self,
             classified_failure=classification,
@@ -1193,7 +1198,7 @@ class TextLogError(models.Model):
         FailureLine.
         """
         if classification not in self.classified_failures.all():
-            self.set_classification("ManualDetector", classification)
+            self.create_match("ManualDetector", classification)
 
         if self.metadata is None:
             TextLogErrorMetadata.objects.create(text_log_error=self,

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -815,8 +815,9 @@ class JobNote(models.Model):
             return
 
         for bug_number in add_bugs:
-            classification, _ = text_log_error.set_classification("ManualDetector",
-                                                                  bug_number=bug_number)
+            classification, _ = ClassifiedFailure.objects.get_or_create(bug_number=bug_number)
+            classification, _ = text_log_error.set_classification("ManualDetector", classification)
+
         if len(add_bugs) == 1 and not existing_bugs:
             text_log_error.mark_best_classification_verified(classification)
 
@@ -1193,14 +1194,7 @@ class TextLogError(models.Model):
                 .first())
 
     @transaction.atomic
-    def set_classification(self, matcher_name, classification=None, bug_number=None):
-        if classification is None:
-            if bug_number:
-                classification, _ = ClassifiedFailure.objects.get_or_create(
-                    bug_number=bug_number)
-            else:
-                classification = ClassifiedFailure.objects.create()
-
+    def set_classification(self, matcher_name, classification):
         match = TextLogErrorMatch.objects.create(
             text_log_error=self,
             classified_failure=classification,

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -1210,7 +1210,7 @@ class TextLogError(models.Model):
 
         return classification, match
 
-    def mark_best_classification(self, classification_id):
+    def mark_best_classification(self, classification):
         """
         Set the given FailureClassification as the best one
 
@@ -1219,8 +1219,6 @@ class TextLogError(models.Model):
 
         If no TextLogErrorMetadata instance exists one will be created.
         """
-        classification = ClassifiedFailure.objects.get(id=classification_id)
-
         if self.metadata is None:
             TextLogErrorMetadata.objects.create(
                 text_log_error=self,

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -1193,7 +1193,7 @@ class TextLogError(models.Model):
                 .first())
 
     @transaction.atomic
-    def set_classification(self, matcher_name, classification=None, bug_number=None, mark_best=False):
+    def set_classification(self, matcher_name, classification=None, bug_number=None):
         if classification is None:
             if bug_number:
                 classification, _ = ClassifiedFailure.objects.get_or_create(
@@ -1207,9 +1207,6 @@ class TextLogError(models.Model):
             matcher_name=matcher_name,
             score=1,
         )
-
-        if mark_best:
-            self.mark_best_classification(classification.id)
 
         return classification, match
 

--- a/treeherder/webapp/api/failureline.py
+++ b/treeherder/webapp/api/failureline.py
@@ -72,7 +72,7 @@ class FailureLineViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
             by_project[failure_line.repository.name].append(failure_line.job_guid)
 
             if failure_line.error and classification is not None:
-                failure_line.error.mark_best_classification_verified(classification)
+                failure_line.error.verify_classification(classification)
 
         for project, job_guids in iteritems(by_project):
             for job in Job.objects.filter(guid__in=job_guids):

--- a/treeherder/webapp/api/failureline.py
+++ b/treeherder/webapp/api/failureline.py
@@ -71,7 +71,7 @@ class FailureLineViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
 
             by_project[failure_line.repository.name].append(failure_line.job_guid)
 
-            if failure_line.error:
+            if failure_line.error and classification is not None:
                 failure_line.error.mark_best_classification_verified(classification)
 
         for project, job_guids in iteritems(by_project):

--- a/treeherder/webapp/api/text_log_error.py
+++ b/treeherder/webapp/api/text_log_error.py
@@ -95,7 +95,7 @@ class TextLogErrorViewSet(viewsets.ModelViewSet):
                 classification = None
 
             jobs.add(error_line.step.job)
-            error_line.mark_best_classification_verified(classification)
+            error_line.verify_classification(classification)
 
         for job in jobs:
             job.update_after_verification(user)


### PR DESCRIPTION
This pulls apart the methods `set_classification`, `mark_best_classification`, and `mark_best_classification_verified` refactoring them in various ways.  It's a bit of a grab-bag of changes but the commits should aid review.  On a high level this was my working out what these methods did and were trying to do (while trying to add more metrics collection) and realising that after verious changes/consolidations they would be more helpful in their refactored form.

There's one slight functionality change hidden away in here: we don't create an empty `ClassifiedFailure` when doing updates via the API.