### PR TITLE
Bug 1467545 - Display a warning when accessing Treeherder with ESR52

### DIFF
--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -9,16 +9,21 @@ treeherderApp.controller('MainCtrl', [
     '$scope', '$rootScope', '$location', '$timeout', '$q',
     'ThRepositoryModel', 'thPinboard', 'thTabs', '$document',
     'thClassificationTypes', '$interval', '$window',
-    'thJobFilters', 'ThResultSetStore',
+    'thJobFilters', 'ThResultSetStore', 'thNotify',
     '$http',
     '$httpParamSerializer',
     function MainController(
         $scope, $rootScope, $location, $timeout, $q,
         ThRepositoryModel, thPinboard, thTabs, $document,
         thClassificationTypes, $interval, $window,
-        thJobFilters, ThResultSetStore,
+        thJobFilters, ThResultSetStore, thNotify,
         $http,
         $httpParamSerializer) {
+
+        if (window.navigator.userAgent.indexOf('Firefox/52') !== -1) {
+          thNotify.send('Firefox ESR52 is not supported. Please update to ESR60 or ideally release/beta/nightly.',
+                        'danger', { sticky: true });
+        }
 
         /*
          *  revisionPollInterval: How often we check revision.txt for changes


### PR DESCRIPTION
Since ESR52 support for Treeherder is wontfix, and this way users won't waste time trying to figure out why it isn't working.

Example:

![screenshot_2018-06-07 11 mozilla-inbound](https://user-images.githubusercontent.com/501702/41119995-32c77f5a-6a8c-11e8-8822-ededf65e450e.png)

(This warning will display "Firefox ESR52 not supported" for other browsers based on ESR52 but that aren't called Firefox, but using the correct wording in those scenarios is an edge case really not worth handling.)