### PR TITLE
Bug 1468573 - Fix missing peer dependency warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "yarn": "1.7.0"
   },
   "dependencies": {
+    "@types/angular": "1.6.46",
+    "@types/prop-types": "15.5.3",
+    "@types/react": "16.3.17",
+    "@types/react-dom": "16.0.6",
     "ajv": "6.5.1",
     "angular": "1.7.2",
     "angular-clipboard": "1.6.2",
@@ -25,7 +29,9 @@
     "bootstrap": "4.1.1",
     "d3": "4.13.0",
     "deepmerge": "1.5.2",
+    "eslint": "3.19.0",
     "eslint-config-airbnb": "15.1.0",
+    "eslint-plugin-import": "2.12.0",
     "eslint-plugin-jsx-a11y": "5.1.1",
     "eslint-plugin-react": "7.5.1",
     "font-awesome": "4.7.0",
@@ -74,6 +80,7 @@
     "fetch-mock": "6.4.4",
     "jasmine-core": "3.1.0",
     "jasmine-jquery": "2.1.1",
+    "karma": "1.7.1",
     "karma-firefox-launcher": "1.1.0",
     "karma-jasmine": "1.1.2",
     "neutrino-preset-karma": "4.2.1"

--- a/renovate.json
+++ b/renovate.json
@@ -7,14 +7,18 @@
   ],
   "ignoreDeps": [
     "deepmerge",
+    "eslint",
     "eslint-config-airbnb",
+    "eslint-plugin-import",
     "eslint-plugin-jsx-a11y",
     "eslint-plugin-react",
+    "html-loader",
+    "karma",
     "neutrino",
     "neutrino-lint-base",
     "neutrino-preset-karma",
     "neutrino-preset-react",
-    "raw-loader"
+    "react-hot-loader"
   ],
   "reviewers": [
     "@mozilla/treeherder-admins"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/angular@1.6.46":
+  version "1.6.46"
+  resolved "https://registry.yarnpkg.com/@types/angular/-/angular-1.6.46.tgz#bebd357e91021636ad2a8aea85a3592db505656e"
+
 "@types/angular@^1.6.39":
   version "1.6.47"
   resolved "https://registry.yarnpkg.com/@types/angular/-/angular-1.6.47.tgz#f7a31279a02c0892ed9aa76aae2da1b17791bacd"
@@ -19,6 +23,23 @@
 "@types/node@*":
   version "10.3.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.3.tgz#8798d9e39af2fa604f715ee6a6b19796528e46c3"
+
+"@types/prop-types@15.5.3":
+  version "15.5.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.3.tgz#bef071852dca2a2dbb65fecdb7bfb30cedae2de2"
+
+"@types/react-dom@16.0.6":
+  version "16.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.6.tgz#f1a65a4e7be8ed5d123f8b3b9eacc913e35a1a3c"
+  dependencies:
+    "@types/node" "*"
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@16.3.17":
+  version "16.3.17"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.17.tgz#d59d1a632570b0713946ed9c2949d994773633c5"
+  dependencies:
+    csstype "^2.2.0"
 
 abbrev@1:
   version "1.1.1"
@@ -1982,6 +2003,10 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
+csstype@^2.2.0:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.3.tgz#2504152e6e1cc59b32098b7f5d6a63f16294c1f7"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -2808,7 +2833,7 @@ eslint-plugin-babel@^4.0.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.1.2.tgz#79202a0e35757dd92780919b2336f1fa2fe53c1e"
 
-eslint-plugin-import@^2.2.0:
+eslint-plugin-import@2.12.0, eslint-plugin-import@^2.2.0:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz#dad31781292d6664b25317fd049d2e2b2f02205d"
   dependencies:
@@ -2858,7 +2883,7 @@ eslint-restricted-globals@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
 
-eslint@^3.16.1:
+eslint@3.19.0, eslint@^3.16.1:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
   dependencies:
@@ -4388,7 +4413,7 @@ karma-webpack@^2.0.2:
     source-map "^0.5.6"
     webpack-dev-middleware "^1.12.0"
 
-karma@^1.5.0:
+karma@1.7.1, karma@^1.5.0:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/karma/-/karma-1.7.1.tgz#85cc08e9e0a22d7ce9cca37c4a1be824f6a2b1ae"
   dependencies:


### PR DESCRIPTION
These were previously being pulled in implicitly via sub-dependencies.

They are also added to the Renovate ignore list, since the old version of Neutrino we're using is designed to work with specific versions, and so we can't update to the newer versions until we're on latest Neutrino.