### PR TITLE
Fix job updating

### DIFF
--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -148,7 +148,6 @@ treeherder.factory('ThResultSetStore', [
             lastPolltime = Date.now();
             jobUpdatesPromise
                 .then(function (jobList) {
-                    jobList = jobList.reduce((a, b) => [...a, ...b], []);
                     if (jobList.length > 0) {
                         lastJobUpdate = getLastModifiedJobTime(jobList);
                         // group joblist by 'result_set_id'


### PR DESCRIPTION
Unfortunately I didn't notice that commit e40793192110f53bb5ecb94cb81c81c0a0a986b2 broke updating.

This was due to there being an unnecessary _.flatten which got converted to a reduce.  Just removing the line fixes updating.