### PR TITLE
Bug 1468650 - Use caching with ESLint & lint more files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const Neutrino = require('neutrino');
+
 const api = new Neutrino([path.resolve('./neutrino-custom/development.js')]);
 
 module.exports = api.custom.eslintrc();

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ npm-error.log
 # vi
 *.swp
 
+# Caches
 .pytest_cache/
+.eslintcache
 
 # PyCharm
 .idea/

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "scripts": {
     "build": "node ./node_modules/neutrino/bin/neutrino build --presets ./neutrino-custom/production.js",
-    "lint": "node ./node_modules/eslint/bin/eslint.js --ext .js,.jsx ui/",
+    "lint": "node ./node_modules/eslint/bin/eslint.js --cache --ext js,jsx \".*.js\" \"*.js\" ui/",
     "start": "node ./node_modules/neutrino/bin/neutrino start --presets ./neutrino-custom/development.js",
     "start:local": "BACKEND_DOMAIN=http://localhost:8000 node ./node_modules/neutrino/bin/neutrino start --presets ./neutrino-custom/development.js",
     "start:stage": "BACKEND_DOMAIN=https://treeherder.allizom.org node ./node_modules/neutrino/bin/neutrino start --presets ./neutrino-custom/development.js",


### PR DESCRIPTION
Enabling the ESLint caching reduces `yarn lint` time by 60%. 

See:
https://eslint.org/docs/user-guide/command-line-interface#caching

This also adds JS files in the repo root to the list of files that are linted, and fixes a subsequent lint error in `.eslintrc.js`.