### PR TITLE
Bug 1450022 - Fix backfilling unavailable

### DIFF
--- a/ui/job-view/JobView.jsx
+++ b/ui/job-view/JobView.jsx
@@ -48,7 +48,7 @@ JobView.propTypes = {
 JobView.defaultProps = {
   revision: null,
   selectedJob: null,
-  currentRepo: { is_try_repo: true },
+  currentRepo: {},
 };
 
 treeherder.component('jobView', react2angular(

--- a/ui/job-view/JobView.jsx
+++ b/ui/job-view/JobView.jsx
@@ -47,8 +47,8 @@ JobView.propTypes = {
 // need some defaults for them.
 JobView.defaultProps = {
   revision: null,
-  selectedJob: null,
   currentRepo: {},
+  selectedJob: null,
 };
 
 treeherder.component('jobView', react2angular(

--- a/ui/job-view/JobView.jsx
+++ b/ui/job-view/JobView.jsx
@@ -24,6 +24,7 @@ const JobView = (props) => {
       </div>
       <DetailsPanel
         className={selectedJob ? '' : 'hidden'}
+        currentRepo={currentRepo}
         repoName={repoName}
         selectedJob={selectedJob}
         user={user}
@@ -42,10 +43,12 @@ JobView.propTypes = {
   selectedJob: PropTypes.object,
 };
 
+// Sometime of these props are not ready by the time this renders, so
+// need some defaults for them.
 JobView.defaultProps = {
   revision: null,
-  currentRepo: {},
   selectedJob: null,
+  currentRepo: { is_try_repo: true },
 };
 
 treeherder.component('jobView', react2angular(

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -461,7 +461,7 @@ export default class DetailsPanel extends React.Component {
             logParseStatus={logParseStatus}
             jobDetailLoading={jobDetailLoading}
             latestClassification={classifications.length ? classifications[0] : null}
-            isTryRepo={currentRepo.isTryRepo}
+            isTryRepo={currentRepo.is_try_repo}
             logViewerUrl={logViewerUrl}
             logViewerFullUrl={logViewerFullUrl}
             pinJob={this.pinJob}
@@ -504,13 +504,11 @@ export default class DetailsPanel extends React.Component {
 DetailsPanel.propTypes = {
   $injector: PropTypes.object.isRequired,
   repoName: PropTypes.string.isRequired,
+  currentRepo: PropTypes.object.isRequired,
+  user: PropTypes.object.isRequired,
   selectedJob: PropTypes.object,
-  user: PropTypes.object,
-  currentRepo: PropTypes.object,
 };
 
 DetailsPanel.defaultProps = {
   selectedJob: null,
-  user: { isLoggedIn: false, isStaff: false, email: null },
-  currentRepo: { isTryRepo: true },
 };


### PR DESCRIPTION
This was due to ``currentRepo`` not getting passed to the DetailsPanel, and it fell back
to the default value every time.  Also cleaned up a few props to make them required
without defaults.