### PR TITLE
Bug 1469561 - Reshape Settings

### DIFF
--- a/tests/autoclassify/test_classify_failures.py
+++ b/tests/autoclassify/test_classify_failures.py
@@ -80,8 +80,7 @@ def test_no_autoclassify_job_success(text_log_errors_failure_lines,
         assert failure_line.error.classified_failures.count() == 0
 
 
-def test_autoclassify_update_job_classification(failure_lines, classified_failures,
-                                                test_job_2, mock_autoclassify_jobs_true):
+def test_autoclassify_update_job_classification(failure_lines, classified_failures, test_job_2):
     for i, item in enumerate(classified_failures):
         item.bug_number = "1234%i" % i
         item.save()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -542,11 +542,6 @@ def test_perf_signature(test_repository, test_perf_framework):
 
 
 @pytest.fixture
-def mock_autoclassify_jobs_true(monkeypatch):
-    monkeypatch.setattr(settings, 'AUTOCLASSIFY_JOBS', True)
-
-
-@pytest.fixture
 def mock_bugzilla_api_request(monkeypatch):
     """Mock fetch_json() used by Bugzilla ETL to return a local sample file."""
     import treeherder.etl.bugzilla

--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -3,10 +3,12 @@ import time
 
 import pytest
 import responses
-from django.conf import settings
 from django.core.cache import cache
 
-from treeherder.etl.buildapi import (CACHE_KEYS,
+from treeherder.etl.buildapi import (BUILDS4H_URL,
+                                     CACHE_KEYS,
+                                     PENDING_URL,
+                                     RUNNING_URL,
                                      Builds4hJobsProcess,
                                      PendingJobsProcess,
                                      RunningJobsProcess)
@@ -23,7 +25,7 @@ def mock_buildapi_pending_url(activate_responses):
     )
     with open(path) as f:
         mocked_content = f.read()
-    responses.add(responses.GET, settings.BUILDAPI_PENDING_URL,
+    responses.add(responses.GET, PENDING_URL,
                   body=mocked_content, status=200,
                   content_type='application/json')
 
@@ -38,7 +40,7 @@ def mock_buildapi_running_url(activate_responses):
     )
     with open(path) as f:
         mocked_content = f.read()
-    responses.add(responses.GET, settings.BUILDAPI_RUNNING_URL,
+    responses.add(responses.GET, RUNNING_URL,
                   body=mocked_content, status=200,
                   content_type='application/json')
 
@@ -53,7 +55,7 @@ def mock_buildapi_builds4h_url(activate_responses):
     )
     with open(path) as f:
         mocked_content = f.read()
-    responses.add(responses.GET, settings.BUILDAPI_BUILDS4H_URL,
+    responses.add(responses.GET, BUILDS4H_URL,
                   body=mocked_content, status=200,
                   content_type='application/json')
 
@@ -68,7 +70,7 @@ def mock_buildapi_builds4h_missing1_url(activate_responses):
     )
     with open(path) as f:
         mocked_content = f.read()
-    responses.add(responses.GET, settings.BUILDAPI_BUILDS4H_URL,
+    responses.add(responses.GET, BUILDS4H_URL,
                   body=mocked_content, status=200,
                   content_type='application/json')
 
@@ -83,7 +85,7 @@ def mock_buildapi_builds4h_missing_branch_url(activate_responses):
     )
     with open(path) as f:
         mocked_content = f.read()
-    responses.add(responses.GET, settings.BUILDAPI_BUILDS4H_URL,
+    responses.add(responses.GET, BUILDS4H_URL,
                   body=mocked_content, status=200,
                   content_type='application/json')
 

--- a/tests/etl/test_runnable_jobs.py
+++ b/tests/etl/test_runnable_jobs.py
@@ -1,9 +1,9 @@
 import responses
 
-from treeherder.config.settings import (TASKCLUSTER_INDEX_URL,
-                                        TASKCLUSTER_RUNNABLE_JOBS_URL)
 from treeherder.etl.buildbot import get_symbols_and_platforms
-from treeherder.etl.runnable_jobs import (RunnableJobsProcess,
+from treeherder.etl.runnable_jobs import (RUNNABLE_JOBS_URL,
+                                          TASKCLUSTER_INDEX_URL,
+                                          RunnableJobsProcess,
                                           _taskcluster_runnable_jobs)
 from treeherder.model.models import (BuildPlatform,
                                      JobType,
@@ -13,7 +13,7 @@ from treeherder.model.models import (BuildPlatform,
 
 TASK_ID = 'AFq3FRt4TyiTwIN7fUqOQg'
 CONTENT1 = {'taskId': TASK_ID}
-RUNNABLE_JOBS_URL = TASKCLUSTER_RUNNABLE_JOBS_URL.format(task_id=TASK_ID)
+RUNNABLE_JOBS_URL = RUNNABLE_JOBS_URL.format(task_id=TASK_ID)
 JOB_NAME = 'job name'
 API_RETURN = {
     'build_platform': 'plaform name',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -17,8 +17,6 @@ PULSE_EXCHANGE_NAMESPACE = 'test'
 BUGFILER_API_KEY = "12345helloworld"
 BUGFILER_API_URL = "https://thisisnotbugzilla.org"
 
-AUTOCLASSIFY_JOBS = True
-
 # some of the auth/login tests can be faster if we don't require "django_db"
 # access.  But if we use the defaults in config.settings, we also get the
 # ``ModelBackend``, which will try to access the DB.  This ensures we don't

--- a/tests/webapp/api/test_failureline.py
+++ b/tests/webapp/api/test_failureline.py
@@ -179,7 +179,6 @@ def test_update_failure_line_mark_job_with_human_note(test_job,
 
 
 def test_update_failure_line_mark_job_with_auto_note(test_job,
-                                                     mock_autoclassify_jobs_true,
                                                      test_repository,
                                                      text_log_errors_failure_lines,
                                                      classified_failures,
@@ -216,8 +215,7 @@ def test_update_failure_line_mark_job_with_auto_note(test_job,
     assert notes[1].text == "note"
 
 
-def test_update_failure_lines(mock_autoclassify_jobs_true,
-                              test_repository,
+def test_update_failure_lines(test_repository,
                               classified_failures,
                               eleven_jobs_stored,
                               client,
@@ -298,7 +296,6 @@ def test_update_failure_line_ignore(test_job,
 
 
 def test_update_failure_line_all_ignore_mark_job(test_job,
-                                                 mock_autoclassify_jobs_true,
                                                  text_log_errors_failure_lines,
                                                  classified_failures,
                                                  client,
@@ -339,7 +336,6 @@ def test_update_failure_line_all_ignore_mark_job(test_job,
 
 
 def test_update_failure_line_partial_ignore_mark_job(test_job,
-                                                     mock_autoclassify_jobs_true,
                                                      text_log_errors_failure_lines,
                                                      classified_failures,
                                                      client,

--- a/tests/webapp/api/test_text_log_error.py
+++ b/tests/webapp/api/test_text_log_error.py
@@ -175,7 +175,6 @@ def test_update_error_mark_job_with_human_note(client,
 
 def test_update_error_line_mark_job_with_auto_note(client,
                                                    test_job,
-                                                   mock_autoclassify_jobs_true,
                                                    text_log_errors_failure_lines,
                                                    classified_failures,
                                                    test_user):
@@ -211,7 +210,6 @@ def test_update_error_line_mark_job_with_auto_note(client,
 
 
 def test_update_errors(client,
-                       mock_autoclassify_jobs_true,
                        test_repository,
                        text_log_errors_failure_lines,
                        classified_failures,
@@ -288,7 +286,6 @@ def test_update_error_ignore(client, test_job, text_log_errors_failure_lines,
 
 def test_update_error_all_ignore_mark_job(client,
                                           test_job,
-                                          mock_autoclassify_jobs_true,
                                           text_log_errors_failure_lines,
                                           classified_failures,
                                           test_user):
@@ -327,7 +324,6 @@ def test_update_error_all_ignore_mark_job(client,
 
 def test_update_error_partial_ignore_mark_job(client,
                                               test_job,
-                                              mock_autoclassify_jobs_true,
                                               text_log_errors_failure_lines,
                                               classified_failures,
                                               test_user):

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -14,57 +14,55 @@ from treeherder.config.utils import (connection_should_use_tls,
 
 env = environ.Env()
 
+# Top Level configuration
 DEBUG = env.bool("TREEHERDER_DEBUG", default=False)
 ENABLE_DEBUG_TOOLBAR = env.bool("ENABLE_DEBUG_TOOLBAR", False)
 
 GRAPHQL = env.bool("GRAPHQL", default=True)
 
-# Default to retaining data for ~4 months.
-DATA_CYCLE_DAYS = env.int("DATA_CYCLE_DAYS", default=120)
-# Determines the number of jobs we try to delete per iteration when
-# cycling data
-DATA_CYCLE_CHUNK_SIZE = env.int("DATA_CYCLE_CHUNK_SIZE", default=100)
-DATA_CYCLE_SLEEP_TIME = env.int("DATA_CYCLE_SLEEP_TIME", default=0)
-
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = env("TREEHERDER_DJANGO_SECRET_KEY")
 
+# Hosts
+SITE_URL = env("SITE_URL", default="http://localhost:8000/")
+SITE_HOSTNAME = furl(SITE_URL).host
+ALLOWED_HOSTS = [SITE_HOSTNAME]
+
+# URL handling
+APPEND_SLASH = False
 ROOT_URLCONF = "treeherder.config.urls"
 WSGI_APPLICATION = 'treeherder.config.wsgi.application'
 
-TIME_ZONE = "UTC"
-USE_I18N = False
-USE_L10N = True
+# Application definition
+INSTALLED_APPS = [
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    # Disable Django's own staticfiles handling in favour of WhiteNoise, for
+    # greater consistency between gunicorn and `./manage.py runserver`.
+    'whitenoise.runserver_nostatic',
+    'django.contrib.staticfiles',
 
-# Files in this directory will be served by WhiteNoise at the site root.
-WHITENOISE_ROOT = path("..", "dist")
+    # 3rd party apps
+    'rest_framework',
+    'hawkrest',
+    'corsheaders',
+    'django_filters',
+    'graphene_django',
 
-STATIC_ROOT = path("static")
-STATIC_URL = "/static/"
-
-# Default minimum regression threshold for perfherder is 2% (otherwise
-# e.g. the build size tests will alert on every commit)
-PERFHERDER_REGRESSION_THRESHOLD = 2
-
-# Various settings for treeherder's t-test "sliding window" alert algorithm
-PERFHERDER_ALERTS_MIN_BACK_WINDOW = 12
-PERFHERDER_ALERTS_MAX_BACK_WINDOW = 24
-PERFHERDER_ALERTS_FORE_WINDOW = 12
-
-# Only generate alerts for data newer than this time in seconds in perfherder
-PERFHERDER_ALERTS_MAX_AGE = timedelta(weeks=2)
-
-# Create hashed+gzipped versions of assets during collectstatic,
-# which will then be served by WhiteNoise with a suitable max-age.
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
-
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'APP_DIRS': True,
-    },
+    # treeherder apps
+    'treeherder.model',
+    'treeherder.webapp',
+    'treeherder.log_parser',
+    'treeherder.etl',
+    'treeherder.perf',
+    'treeherder.autoclassify',
+    'treeherder.credentials',
+    'treeherder.seta',
 ]
+if DEBUG:
+    INSTALLED_APPS.append('django_extensions')
 
+# Middleware
 MIDDLEWARE = [middleware for middleware in [
     # Adds custom New Relic annotations. Must be first so all transactions are annotated.
     'treeherder.middleware.NewRelicMiddleware',
@@ -84,14 +82,70 @@ MIDDLEWARE = [middleware for middleware in [
     'treeherder.middleware.FixedHawkResponseMiddleware',
 ] if middleware]
 
-if ENABLE_DEBUG_TOOLBAR:
-    # django-debug-toolbar requires that not only DEBUG be set, but that the request IP
-    # be in Django's INTERNAL_IPS setting. When using Vagrant, requests don't come from localhost:
-    # http://blog.joshcrompton.com/2014/01/how-to-make-django-debug-toolbar-display-when-using-vagrant/
-    # If the Vagrant IPs vary by platform or if there isn't a consistent IP when we switch to Docker,
-    # we'll have to do: https://github.com/jazzband/django-debug-toolbar/pull/805#issuecomment-240976813
-    INTERNAL_IPS = ['127.0.0.1', '10.0.2.2']
+# Templating
+TEMPLATES = [{
+    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    'APP_DIRS': True,
+}]
 
+# Database
+# The database config is defined using environment variables of form:
+#
+#   'mysql://username:password@host:optional_port/database_name'
+#
+# which django-environ converts into the Django DB settings dict format.
+DATABASES = {
+    'default': env.db_url('DATABASE_URL'),
+}
+
+# We're intentionally not using django-environ's query string options feature,
+# since it hides configuration outside of the repository, plus could lead to
+# drift between environments.
+for alias in DATABASES:
+    # Persist database connections for 5 minutes, to avoid expensive reconnects.
+    DATABASES[alias]['CONN_MAX_AGE'] = 300
+    DATABASES[alias]['OPTIONS'] = {
+        # Override Django's default connection charset of 'utf8', otherwise it's
+        # still not possible to insert non-BMP unicode into utf8mb4 tables.
+        'charset': 'utf8mb4',
+    }
+    if DATABASES[alias]['HOST'] != 'localhost':
+        # Use TLS when connecting to RDS.
+        DATABASES[alias]['OPTIONS']['ssl'] = {
+            'ca': 'deployment/aws/combined-ca-bundle.pem',
+        }
+
+# Caches
+REDIS_URL = env('REDIS_URL')
+if connection_should_use_tls(REDIS_URL):
+    # Connect using TLS on Heroku.
+    REDIS_URL = get_tls_redis_url(REDIS_URL)
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': REDIS_URL,
+        'OPTIONS': {
+            # Override the default of no timeout, to avoid connection hangs.
+            'SOCKET_CONNECT_TIMEOUT': 5,
+        },
+    },
+}
+
+# Internationalization
+TIME_ZONE = "UTC"
+USE_I18N = False
+USE_L10N = True
+
+# Static files (CSS, JavaScript, Images)
+STATIC_ROOT = path("static")
+STATIC_URL = "/static/"
+
+# Create hashed+gzipped versions of assets during collectstatic,
+# which will then be served by WhiteNoise with a suitable max-age.
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+
+# Authentication
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
     'treeherder.auth.backends.AuthBackend',
@@ -109,41 +163,7 @@ LOGIN_REDIRECT_URL_FAILURE = '/'
 # Path to redirect to on logout.
 LOGOUT_REDIRECT_URL = '/'
 
-INSTALLED_APPS = [
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    # Disable Django's own staticfiles handling in favour of WhiteNoise, for
-    # greater consistency between gunicorn and `./manage.py runserver`.
-    'whitenoise.runserver_nostatic',
-    'django.contrib.staticfiles',
-    # 3rd party apps
-    'rest_framework',
-    'hawkrest',
-    'corsheaders',
-    'django_filters',
-    'graphene_django',
-    # treeherder apps
-    'treeherder.model',
-    'treeherder.webapp',
-    'treeherder.log_parser',
-    'treeherder.etl',
-    'treeherder.perf',
-    'treeherder.autoclassify',
-    'treeherder.credentials',
-    'treeherder.seta',
-]
-
-if ENABLE_DEBUG_TOOLBAR:
-    INSTALLED_APPS.append('debug_toolbar')
-
-if DEBUG:
-    INSTALLED_APPS.append('django_extensions')
-
-# A sample logging configuration. The only tangible logging
-# performed by this configuration is to send an email to
-# the site admins on every HTTP 500 error.
-# See http://docs.djangoproject.com/en/dev/topics/logging for
-# more details on how to customize your logging configuration.
+# Logging
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -196,6 +216,58 @@ LOGGING = {
     }
 }
 
+# SECURITY
+USE_X_FORWARDED_HOST = True
+USE_X_FORWARDED_PORT = True
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+if SITE_URL.startswith('https://'):
+    SECURE_SSL_REDIRECT = True
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    SECURE_HSTS_SECONDS = int(timedelta(days=365).total_seconds())
+    # Mark session and CSRF cookies as being HTTPS-only.
+    CSRF_COOKIE_SECURE = True
+    SESSION_COOKIE_SECURE = True
+
+SECURE_CONTENT_TYPE_NOSNIFF = True  # Set the `X-Content-Type-Options` header to `nosniff`.
+SECURE_BROWSER_XSS_FILTER = True  # Sets the `X-XSS-Protection` header.
+
+# System Checks
+SILENCED_SYSTEM_CHECKS = [
+    # We can't set CSRF_COOKIE_HTTPONLY to True since the requests to the API
+    # made using Angular's `httpProvider` require access to the cookie.
+    'security.W017',
+    # We can't set X_FRAME_OPTIONS to DENY since renewal of auth token requires
+    # opening an invisible iframe with the same origin.
+    'security.W019'
+]
+
+# User Agents
+# User agents which will be blocked from making requests to the site.
+DISALLOWED_USER_AGENTS = (
+    # Note: This intentionally does not match the command line curl
+    # tool's default User Agent, only the library used by eg PHP.
+    re.compile(r'^libcurl/'),
+    re.compile(r'^Python-urllib/'),
+    re.compile(r'^python-requests/'),
+    # ActiveData blocked for excessive API requests (bug 1289830)
+    re.compile(r'^ActiveData-ETL'),
+)
+
+
+# THIRD PARTY APPS
+
+# Auth0 setup
+AUTH0_DOMAIN = env('AUTH0_DOMAIN', default="auth.mozilla.auth0.com")
+AUTH0_CLIENTID = env('AUTH0_CLIENTID', default="q8fZZFfGEmSB2c5uSI8hOkKdDGXnlo5z")
+
+# Set the `X-Frame-Options` header, which forbids embedding of site pages in frames other than origin.
+# AUTH0 renewal opens the auth handler page in an invisible frame
+# hence requiring the need to support frames with same origin
+X_FRAME_OPTIONS = 'SAMEORIGIN'
+
+# Celery
 CELERY_QUEUES = [
     Queue('default', Exchange('default'), routing_key='default'),
     # queue for failed jobs/logs
@@ -236,17 +308,15 @@ if connection_should_use_tls(BROKER_URL):
 
 # Recommended by CloudAMQP:
 # https://www.cloudamqp.com/docs/celery.html
-BROKER_HEARTBEAT = None
 BROKER_CONNECTION_TIMEOUT = 30
-CELERY_RESULT_BACKEND = None
-CELERY_SEND_EVENTS = False
-CELERY_EVENT_QUEUE_EXPIRES = 60
-
-CELERY_IGNORE_RESULT = True
-
+BROKER_HEARTBEAT = None
 CELERY_ACCEPT_CONTENT = ['json']
-CELERY_TASK_SERIALIZER = 'json'
+CELERY_EVENT_QUEUE_EXPIRES = 60
+CELERY_IGNORE_RESULT = True
+CELERY_RESULT_BACKEND = None
 CELERY_RESULT_SERIALIZER = 'json'
+CELERY_SEND_EVENTS = False
+CELERY_TASK_SERIALIZER = 'json'
 
 # default value when no task routing info is specified
 CELERY_DEFAULT_QUEUE = 'default'
@@ -327,76 +397,73 @@ CELERYBEAT_SCHEDULE = {
     },
 }
 
-# rest-framework settings
+# CORS Headers
+CORS_ORIGIN_ALLOW_ALL = True  # allow requests from any host
+
+# Debug Toolbar
+if ENABLE_DEBUG_TOOLBAR:
+    # django-debug-toolbar requires that not only DEBUG be set, but that the request IP
+    # be in Django's INTERNAL_IPS setting. When using Vagrant, requests don't come from localhost:
+    # http://blog.joshcrompton.com/2014/01/how-to-make-django-debug-toolbar-display-when-using-vagrant/
+    # If the Vagrant IPs vary by platform or if there isn't a consistent IP when we switch to Docker,
+    # we'll have to do: https://github.com/jazzband/django-debug-toolbar/pull/805#issuecomment-240976813
+    INTERNAL_IPS = ['127.0.0.1', '10.0.2.2']
+
+if ENABLE_DEBUG_TOOLBAR:
+    INSTALLED_APPS.append('debug_toolbar')
+
+# Elasticsearch
+ELASTICSEARCH_URL = env.str('ELASTICSEARCH_URL', default='')
+
+# Hawkrest
+HAWK_CREDENTIALS_LOOKUP = 'treeherder.webapp.api.auth.hawk_lookup'
+
+# Rest Framework
 REST_FRAMEWORK = {
-    'DEFAULT_PARSER_CLASSES': (
-        'rest_framework.parsers.JSONParser',
-    ),
-    'DEFAULT_FILTER_BACKENDS': (
-        'rest_framework_filters.backends.DjangoFilterBackend',
-    ),
-    'DEFAULT_RENDERER_CLASSES': (
-        'rest_framework.renderers.JSONRenderer',
-        'rest_framework.renderers.BrowsableAPIRenderer',
-    ),
-    'DEFAULT_THROTTLE_CLASSES': (
-        'treeherder.webapp.api.throttling.HawkClientThrottle',
-    ),
-    'DEFAULT_THROTTLE_RATES': {
-        'jobs': '220/minute',
-        'push': '400/minute'  # temporary increase: https://bugzilla.mozilla.org/show_bug.cgi?id=1232776
-    },
-    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.AcceptHeaderVersioning',
-    'DEFAULT_VERSION': '1.0',
     'ALLOWED_VERSIONS': ('1.0',),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
         'hawkrest.HawkAuthentication',
     ),
-    'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
+    'DEFAULT_FILTER_BACKENDS': ('rest_framework_filters.backends.DjangoFilterBackend',),
+    'DEFAULT_PARSER_CLASSES': ('rest_framework.parsers.JSONParser',),
+    'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAuthenticatedOrReadOnly',),
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer',
     ),
+    'DEFAULT_THROTTLE_CLASSES': ('treeherder.webapp.api.throttling.HawkClientThrottle',),
+    'DEFAULT_THROTTLE_RATES': {
+        'jobs': '220/minute',
+        'push': '400/minute'  # temporary increase: https://bugzilla.mozilla.org/show_bug.cgi?id=1232776
+    },
+    'DEFAULT_VERSION': '1.0',
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.AcceptHeaderVersioning',
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 
-# User agents which will be blocked from making requests to the site.
-DISALLOWED_USER_AGENTS = (
-    # Note: This intentionally does not match the command line curl
-    # tool's default User Agent, only the library used by eg PHP.
-    re.compile(r'^libcurl/'),
-    re.compile(r'^Python-urllib/'),
-    re.compile(r'^python-requests/'),
-    # ActiveData blocked for excessive API requests (bug 1289830)
-    re.compile(r'^ActiveData-ETL'),
-)
+# Whitenoise
+# Files in this directory will be served by WhiteNoise at the site root.
+WHITENOISE_ROOT = path("..", "dist")
 
-SITE_URL = env("SITE_URL", default="http://localhost:8000/")
-SITE_HOSTNAME = furl(SITE_URL).host
-APPEND_SLASH = False
 
-BUILDAPI_PENDING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-pending.js"
-BUILDAPI_RUNNING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-running.js"
-BUILDAPI_BUILDS4H_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-4hr.js.gz"
-ALLTHETHINGS_URL = "https://secure.pub.build.mozilla.org/builddata/reports/allthethings.json"
-TASKCLUSTER_INDEX_URL = 'https://index.taskcluster.net/v1/task/gecko.v2.%s.latest.taskgraph.decision'
-TASKCLUSTER_RUNNABLE_JOBS_URL = 'https://public-artifacts.taskcluster.net/{task_id}/0/public/runnable-jobs.json.gz'
+# TREEHERDER
 
+# API
 # the amount of time we cache bug suggestion lookups (to speed up loading the bug
 # suggestions or autoclassify panels for recently finished jobs)
 BUG_SUGGESTION_CACHE_TIMEOUT = 86400
 
-# the max size of a posted request to treeherder client during Buildbot
-# data job ingestion.
-# If TreeherderCollections are larger, they will be chunked
-# to this size.
-BUILDAPI_PENDING_CHUNK_SIZE = 500
-BUILDAPI_RUNNING_CHUNK_SIZE = 500
-BUILDAPI_BUILDS4H_CHUNK_SIZE = 500
+REPO_GROUPS = {
+    'trunk': ['mozilla-central', 'mozilla-inbound', 'autoland'],
+    'firefox-releases': ['mozilla-beta', 'mozilla-release'],
+    'comm-releases': ['comm-beta', 'comm-release'],
+}
 
-PARSER_MAX_STEP_ERROR_LINES = 100
-PARSER_MAX_SUMMARY_LINES = 200
-FAILURE_LINES_CUTOFF = 35
+# Autoclassification
+AUTOCLASSIFY_JOBS = env.bool("AUTOCLASSIFY_JOBS", default=True)
 
+# Bugzilla
 # BZ_API_URL is used to fetch bug suggestions from bugzilla
 # BUGFILER_API_URL is used when filing bugs
 # these are no longer necessarily the same so stage treeherder can submit
@@ -405,58 +472,53 @@ BZ_API_URL = "https://bugzilla.mozilla.org"
 BUGFILER_API_URL = env("BUGZILLA_API_URL", default=BZ_API_URL)
 BUGFILER_API_KEY = env("BUGZILLA_API_KEY", default=None)
 
-# Auth0 setup
-AUTH0_DOMAIN = env('AUTH0_DOMAIN', default="auth.mozilla.auth0.com")
-AUTH0_CLIENTID = env('AUTH0_CLIENTID', default="q8fZZFfGEmSB2c5uSI8hOkKdDGXnlo5z")
+# Data Cycling
+# Default to retaining data for ~4 months.
+DATA_CYCLE_DAYS = env.int("DATA_CYCLE_DAYS", default=120)
+# Determines the number of jobs we try to delete per iteration when
+# cycling data
+DATA_CYCLE_CHUNK_SIZE = env.int("DATA_CYCLE_CHUNK_SIZE", default=100)
+DATA_CYCLE_SLEEP_TIME = env.int("DATA_CYCLE_SLEEP_TIME", default=0)
 
+# ETL
+# the max size of a posted request to treeherder client during Buildbot
+# data job ingestion.
+# If TreeherderCollections are larger, they will be chunked
+# to this size.
+BUILDAPI_PENDING_CHUNK_SIZE = 500
+BUILDAPI_RUNNING_CHUNK_SIZE = 500
+BUILDAPI_BUILDS4H_CHUNK_SIZE = 500
+
+BUILDAPI_PENDING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-pending.js"
+BUILDAPI_RUNNING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-running.js"
+BUILDAPI_BUILDS4H_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-4hr.js.gz"
+ALLTHETHINGS_URL = "https://secure.pub.build.mozilla.org/builddata/reports/allthethings.json"
+TASKCLUSTER_INDEX_URL = 'https://index.taskcluster.net/v1/task/gecko.v2.%s.latest.taskgraph.decision'
+TASKCLUSTER_RUNNABLE_JOBS_URL = 'https://public-artifacts.taskcluster.net/{task_id}/0/public/runnable-jobs.json.gz'
+
+# Log Parsing
+PARSER_MAX_STEP_ERROR_LINES = 100
+FAILURE_LINES_CUTOFF = 35
+
+# Orange Factor
 ORANGEFACTOR_SUBMISSION_URL = "https://brasstacks.mozilla.com/orangefactor/api/saveclassification"
 ORANGEFACTOR_HAWK_ID = "treeherder"
 ORANGEFACTOR_HAWK_KEY = env("ORANGEFACTOR_HAWK_KEY", default=None)
 
-# this setting allows requests from any host
-CORS_ORIGIN_ALLOW_ALL = True
+# Perfherder
+# Default minimum regression threshold for perfherder is 2% (otherwise
+# e.g. the build size tests will alert on every commit)
+PERFHERDER_REGRESSION_THRESHOLD = 2
 
-ALLOWED_HOSTS = [SITE_HOSTNAME]
+# Various settings for treeherder's t-test "sliding window" alert algorithm
+PERFHERDER_ALERTS_MIN_BACK_WINDOW = 12
+PERFHERDER_ALERTS_MAX_BACK_WINDOW = 24
+PERFHERDER_ALERTS_FORE_WINDOW = 12
 
-USE_X_FORWARDED_HOST = True
-USE_X_FORWARDED_PORT = True
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+# Only generate alerts for data newer than this time in seconds in perfherder
+PERFHERDER_ALERTS_MAX_AGE = timedelta(weeks=2)
 
-if SITE_URL.startswith('https://'):
-    SECURE_SSL_REDIRECT = True
-    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
-    SECURE_HSTS_PRELOAD = True
-    SECURE_HSTS_SECONDS = int(timedelta(days=365).total_seconds())
-    # Mark session and CSRF cookies as being HTTPS-only.
-    CSRF_COOKIE_SECURE = True
-    SESSION_COOKIE_SECURE = True
-
-# Set the `X-Content-Type-Options` header to `nosniff`.
-SECURE_CONTENT_TYPE_NOSNIFF = True
-# Set the `X-XSS-Protection` header.
-SECURE_BROWSER_XSS_FILTER = True
-# Set the `X-Frame-Options` header, which forbids embedding of site pages in frames other than origin.
-# AUTH0 renewal opens the auth handler page in an invisible frame
-# hence requiring the need to support frames with same origin
-X_FRAME_OPTIONS = 'SAMEORIGIN'
-
-SILENCED_SYSTEM_CHECKS = [
-    # We can't set CSRF_COOKIE_HTTPONLY to True since the requests to the API
-    # made using Angular's `httpProvider` require access to the cookie.
-    'security.W017',
-    # We can't set X_FRAME_OPTIONS to DENY since renewal of auth token requires
-    # opening an invisible iframe with the same origin.
-    'security.W019'
-]
-
-# Enable integration between autoclassifier and jobs
-AUTOCLASSIFY_JOBS = env.bool("AUTOCLASSIFY_JOBS", default=True)
-
-# timeout for requests to external sources
-# like ftp.mozilla.org or hg.mozilla.org
-REQUESTS_TIMEOUT = 30
-TREEHERDER_USER_AGENT = 'treeherder/{}'.format(SITE_HOSTNAME)
-
+# Pulse
 # The pulse uri that is passed to kombu
 PULSE_URI = env("PULSE_URI", default="amqps://guest:guest@pulse.mozilla.org/")
 
@@ -492,27 +554,17 @@ PULSE_DATA_INGESTION_SOURCES = env.json(
 
 PULSE_PUSH_SOURCES = env.json(
     "PULSE_PUSH_SOURCES",
-    default=[
-        {
-            "exchange": "exchange/taskcluster-github/v1/push",
-            "routing_keys": [
-                '#'
-            ],
-        },
-        {
-            "exchange": "exchange/taskcluster-github/v1/pull-request",
-            "routing_keys": [
-                '#'
-            ],
-        },
-        {
-            "exchange": "exchange/hgpushes/v1",
-            "routing_keys": [
-                "#"
-            ]
-        }
-        # ... other CI systems
-    ])
+    default=[{
+        "exchange": "exchange/taskcluster-github/v1/push",
+        "routing_keys": ['#'],
+    }, {
+        "exchange": "exchange/taskcluster-github/v1/pull-request",
+        "routing_keys": ['#'],
+    }, {
+        "exchange": "exchange/hgpushes/v1",
+        "routing_keys": ["#"]
+    }],
+)
 
 # Used for making API calls to Pulse Guardian, such as detecting bindings on
 # the current ingestion queue.
@@ -533,57 +585,12 @@ PULSE_DATA_INGESTION_QUEUES_DURABLE = True
 # For local data ingestion, you probably should set this to True
 PULSE_DATA_INGESTION_QUEUES_AUTO_DELETE = False
 
+# Push Loader
 GITHUB_CLIENT_ID = env("GITHUB_CLIENT_ID", default=None)
 GITHUB_CLIENT_SECRET = env("GITHUB_CLIENT_SECRET", default=None)
 
-# The database config is defined using environment variables of form:
-#   'mysql://username:password@host:optional_port/database_name'
-# ...which django-environ converts into the Django DB settings dict format.
-DATABASES = {
-    'default': env.db_url('DATABASE_URL'),
-}
-
-# We're intentionally not using django-environ's query string options feature,
-# since it hides configuration outside of the repository, plus could lead to
-# drift between environments.
-for alias in DATABASES:
-    # Persist database connections for 5 minutes, to avoid expensive reconnects.
-    DATABASES[alias]['CONN_MAX_AGE'] = 300
-    DATABASES[alias]['OPTIONS'] = {
-        # Override Django's default connection charset of 'utf8', otherwise it's
-        # still not possible to insert non-BMP unicode into utf8mb4 tables.
-        'charset': 'utf8mb4',
-    }
-    if DATABASES[alias]['HOST'] != 'localhost':
-        # Use TLS when connecting to RDS.
-        DATABASES[alias]['OPTIONS']['ssl'] = {
-            'ca': 'deployment/aws/combined-ca-bundle.pem',
-        }
-
-REDIS_URL = env('REDIS_URL')
-
-if connection_should_use_tls(REDIS_URL):
-    # Connect using TLS on Heroku.
-    REDIS_URL = get_tls_redis_url(REDIS_URL)
-
-CACHES = {
-    'default': {
-        'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': REDIS_URL,
-        'OPTIONS': {
-            # Override the default of no timeout, to avoid connection hangs.
-            'SOCKET_CONNECT_TIMEOUT': 5,
-        },
-    },
-}
-
-HAWK_CREDENTIALS_LOOKUP = 'treeherder.webapp.api.auth.hawk_lookup'
-
-# Configuration for elasticsearch backend
-ELASTICSEARCH_URL = env.str('ELASTICSEARCH_URL', default='')
-
-REPO_GROUPS = {
-    'trunk': ['mozilla-central', 'mozilla-inbound', 'autoland'],
-    'firefox-releases': ['mozilla-beta', 'mozilla-release'],
-    'comm-releases': ['comm-beta', 'comm-release'],
-}
+# Timeouts
+# timeout for requests to external sources
+# like ftp.mozilla.org or hg.mozilla.org
+REQUESTS_TIMEOUT = 30
+TREEHERDER_USER_AGENT = 'treeherder/{}'.format(SITE_HOSTNAME)

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -449,9 +449,6 @@ WHITENOISE_ROOT = path("..", "dist")
 
 # TREEHERDER
 
-# Autoclassification
-AUTOCLASSIFY_JOBS = env.bool("AUTOCLASSIFY_JOBS", default=True)
-
 # Bugzilla
 # BZ_API_URL is used to fetch bug suggestions from bugzilla
 # BUGFILER_API_URL is used when filing bugs

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -570,4 +570,3 @@ PULSE_DATA_INGESTION_QUEUES_AUTO_DELETE = False
 # timeout for requests to external sources
 # like ftp.mozilla.org or hg.mozilla.org
 REQUESTS_TIMEOUT = 30
-TREEHERDER_USER_AGENT = 'treeherder/{}'.format(SITE_HOSTNAME)

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -472,14 +472,6 @@ BZ_API_URL = "https://bugzilla.mozilla.org"
 BUGFILER_API_URL = env("BUGZILLA_API_URL", default=BZ_API_URL)
 BUGFILER_API_KEY = env("BUGZILLA_API_KEY", default=None)
 
-# Data Cycling
-# Default to retaining data for ~4 months.
-DATA_CYCLE_DAYS = env.int("DATA_CYCLE_DAYS", default=120)
-# Determines the number of jobs we try to delete per iteration when
-# cycling data
-DATA_CYCLE_CHUNK_SIZE = env.int("DATA_CYCLE_CHUNK_SIZE", default=100)
-DATA_CYCLE_SLEEP_TIME = env.int("DATA_CYCLE_SLEEP_TIME", default=0)
-
 # ETL
 # the max size of a posted request to treeherder client during Buildbot
 # data job ingestion.

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -237,8 +237,10 @@ SILENCED_SYSTEM_CHECKS = [
     # We can't set CSRF_COOKIE_HTTPONLY to True since the requests to the API
     # made using Angular's `httpProvider` require access to the cookie.
     'security.W017',
-    # We can't set X_FRAME_OPTIONS to DENY since renewal of auth token requires
-    # opening an invisible iframe with the same origin.
+    # We can't set X_FRAME_OPTIONS to DENY since renewal of an Auth0 token
+    # requires opening the auth handler page in an invisible iframe with the
+    # same origin.  This is the default setting ('SAMEORIGIN') for Django's
+    # X_FRAME_OPTIONS setting so it isn't set in this file.
     'security.W019'
 ]
 
@@ -260,11 +262,6 @@ DISALLOWED_USER_AGENTS = (
 # Auth0 setup
 AUTH0_DOMAIN = env('AUTH0_DOMAIN', default="auth.mozilla.auth0.com")
 AUTH0_CLIENTID = env('AUTH0_CLIENTID', default="q8fZZFfGEmSB2c5uSI8hOkKdDGXnlo5z")
-
-# Set the `X-Frame-Options` header, which forbids embedding of site pages in frames other than origin.
-# AUTH0 renewal opens the auth handler page in an invisible frame
-# hence requiring the need to support frames with same origin
-X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 # Celery
 CELERY_QUEUES = [

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -461,22 +461,6 @@ BZ_API_URL = "https://bugzilla.mozilla.org"
 BUGFILER_API_URL = env("BUGZILLA_API_URL", default=BZ_API_URL)
 BUGFILER_API_KEY = env("BUGZILLA_API_KEY", default=None)
 
-# ETL
-# the max size of a posted request to treeherder client during Buildbot
-# data job ingestion.
-# If TreeherderCollections are larger, they will be chunked
-# to this size.
-BUILDAPI_PENDING_CHUNK_SIZE = 500
-BUILDAPI_RUNNING_CHUNK_SIZE = 500
-BUILDAPI_BUILDS4H_CHUNK_SIZE = 500
-
-BUILDAPI_PENDING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-pending.js"
-BUILDAPI_RUNNING_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-running.js"
-BUILDAPI_BUILDS4H_URL = "https://secure.pub.build.mozilla.org/builddata/buildjson/builds-4hr.js.gz"
-ALLTHETHINGS_URL = "https://secure.pub.build.mozilla.org/builddata/reports/allthethings.json"
-TASKCLUSTER_INDEX_URL = 'https://index.taskcluster.net/v1/task/gecko.v2.%s.latest.taskgraph.decision'
-TASKCLUSTER_RUNNABLE_JOBS_URL = 'https://public-artifacts.taskcluster.net/{task_id}/0/public/runnable-jobs.json.gz'
-
 # Log Parsing
 PARSER_MAX_STEP_ERROR_LINES = 100
 FAILURE_LINES_CUTOFF = 35

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -565,8 +565,3 @@ PULSE_DATA_INGESTION_QUEUES_DURABLE = True
 # are closed.
 # For local data ingestion, you probably should set this to True
 PULSE_DATA_INGESTION_QUEUES_AUTO_DELETE = False
-
-# Timeouts
-# timeout for requests to external sources
-# like ftp.mozilla.org or hg.mozilla.org
-REQUESTS_TIMEOUT = 30

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -566,10 +566,6 @@ PULSE_DATA_INGESTION_QUEUES_DURABLE = True
 # For local data ingestion, you probably should set this to True
 PULSE_DATA_INGESTION_QUEUES_AUTO_DELETE = False
 
-# Push Loader
-GITHUB_CLIENT_ID = env("GITHUB_CLIENT_ID", default=None)
-GITHUB_CLIENT_SECRET = env("GITHUB_CLIENT_SECRET", default=None)
-
 # Timeouts
 # timeout for requests to external sources
 # like ftp.mozilla.org or hg.mozilla.org

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -16,7 +16,6 @@ env = environ.Env()
 
 # Top Level configuration
 DEBUG = env.bool("TREEHERDER_DEBUG", default=False)
-ENABLE_DEBUG_TOOLBAR = env.bool("ENABLE_DEBUG_TOOLBAR", False)
 
 GRAPHQL = env.bool("GRAPHQL", default=True)
 
@@ -74,7 +73,7 @@ MIDDLEWARE = [middleware for middleware in [
     # to be served by WhiteNoise, avoiding the need for Apache/nginx on Heroku.
     'treeherder.middleware.CustomWhiteNoise',
     'django.middleware.gzip.GZipMiddleware',
-    'debug_toolbar.middleware.DebugToolbarMiddleware' if ENABLE_DEBUG_TOOLBAR else False,
+    'debug_toolbar.middleware.DebugToolbarMiddleware' if DEBUG else False,
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -401,7 +400,7 @@ CELERYBEAT_SCHEDULE = {
 CORS_ORIGIN_ALLOW_ALL = True  # allow requests from any host
 
 # Debug Toolbar
-if ENABLE_DEBUG_TOOLBAR:
+if DEBUG:
     # django-debug-toolbar requires that not only DEBUG be set, but that the request IP
     # be in Django's INTERNAL_IPS setting. When using Vagrant, requests don't come from localhost:
     # http://blog.joshcrompton.com/2014/01/how-to-make-django-debug-toolbar-display-when-using-vagrant/
@@ -409,7 +408,6 @@ if ENABLE_DEBUG_TOOLBAR:
     # we'll have to do: https://github.com/jazzband/django-debug-toolbar/pull/805#issuecomment-240976813
     INTERNAL_IPS = ['127.0.0.1', '10.0.2.2']
 
-if ENABLE_DEBUG_TOOLBAR:
     INSTALLED_APPS.append('debug_toolbar')
 
 # Elasticsearch

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -449,17 +449,6 @@ WHITENOISE_ROOT = path("..", "dist")
 
 # TREEHERDER
 
-# API
-# the amount of time we cache bug suggestion lookups (to speed up loading the bug
-# suggestions or autoclassify panels for recently finished jobs)
-BUG_SUGGESTION_CACHE_TIMEOUT = 86400
-
-REPO_GROUPS = {
-    'trunk': ['mozilla-central', 'mozilla-inbound', 'autoland'],
-    'firefox-releases': ['mozilla-beta', 'mozilla-release'],
-    'comm-releases': ['comm-beta', 'comm-release'],
-}
-
 # Autoclassification
 AUTOCLASSIFY_JOBS = env.bool("AUTOCLASSIFY_JOBS", default=True)
 

--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -33,7 +33,7 @@ def make_request(url, method='GET', headers=None,
                  timeout=settings.REQUESTS_TIMEOUT, **kwargs):
     """A wrapper around requests to set defaults & call raise_for_status()."""
     headers = headers or {}
-    headers['User-Agent'] = settings.TREEHERDER_USER_AGENT
+    headers['User-Agent'] = 'treeherder/{}'.format(settings.SITE_HOSTNAME)
     # Work around bug 1305768.
     if 'queue.taskcluster.net' in url:
         headers['x-taskcluster-skip-cache'] = 'true'

--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -29,8 +29,7 @@ class CollectionNotStoredException(Exception):
         )
 
 
-def make_request(url, method='GET', headers=None,
-                 timeout=settings.REQUESTS_TIMEOUT, **kwargs):
+def make_request(url, method='GET', headers=None, timeout=30, **kwargs):
     """A wrapper around requests to set defaults & call raise_for_status()."""
     headers = headers or {}
     headers['User-Agent'] = 'treeherder/{}'.format(settings.SITE_HOSTNAME)

--- a/treeherder/etl/push_loader.py
+++ b/treeherder/etl/push_loader.py
@@ -1,7 +1,7 @@
 import logging
 
+import environ
 import newrelic.agent
-from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 
 from treeherder.etl.common import (fetch_json,
@@ -9,6 +9,7 @@ from treeherder.etl.common import (fetch_json,
 from treeherder.etl.push import store_push_data
 from treeherder.model.models import Repository
 
+env = environ.Env()
 logger = logging.getLogger(__name__)
 
 
@@ -61,8 +62,8 @@ class PushLoader(object):
 class GithubTransformer(object):
 
     CREDENTIALS = {
-        "client_id": settings.GITHUB_CLIENT_ID,
-        "client_secret": settings.GITHUB_CLIENT_SECRET
+        "client_id": env("GITHUB_CLIENT_ID", default=None),
+        "client_secret": env("GITHUB_CLIENT_SECRET", default=None),
     }
 
     def __init__(self, message_body):

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -1,7 +1,6 @@
 import logging
 
 import newrelic.agent
-from django.conf import settings
 
 from treeherder.autoclassify.tasks import autoclassify
 from treeherder.log_parser.crossreference import crossreference_job
@@ -72,7 +71,7 @@ def parse_logs(job_id, job_log_ids, priority):
 
         success = crossreference_error_lines(job)
 
-        if success and settings.AUTOCLASSIFY_JOBS:
+        if success:
             logger.debug("Scheduling autoclassify for job %i", job_id)
             autoclassify.apply_async(
                 args=[job_id],

--- a/treeherder/model/error_summary.py
+++ b/treeherder/model/error_summary.py
@@ -3,12 +3,15 @@ import re
 
 from django.core.cache import cache
 
-from treeherder.config.settings import BUG_SUGGESTION_CACHE_TIMEOUT
 from treeherder.model.models import (Bugscache,
                                      TextLogError)
 
 logger = logging.getLogger(__name__)
 
+
+# the amount of time we cache bug suggestion lookups (to speed up loading the
+# bug suggestions or autoclassify panels for recently finished jobs)
+BUG_SUGGESTION_CACHE_TIMEOUT = 86400
 
 LEAK_RE = re.compile(r'\d+ bytes leaked \((.+)\)$|leak at (.+)$')
 CRASH_RE = re.compile(r'.+ application crashed \[@ (.+)\]$')

--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -1,6 +1,5 @@
 import datetime
 
-from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from treeherder.model.models import (Job,
@@ -26,7 +25,7 @@ class Command(BaseCommand):
             '--days',
             action='store',
             dest='days',
-            default=settings.DATA_CYCLE_DAYS,
+            default=120,
             type=int,
             help='Data cycle interval expressed in days'
         )
@@ -34,7 +33,7 @@ class Command(BaseCommand):
             '--chunk-size',
             action='store',
             dest='chunk_size',
-            default=settings.DATA_CYCLE_CHUNK_SIZE,
+            default=100,
             type=int,
             help=('Define the size of the chunks '
                   'Split the job deletes into chunks of this size')
@@ -43,7 +42,7 @@ class Command(BaseCommand):
             '--sleep-time',
             action='store',
             dest='sleep_time',
-            default=settings.DATA_CYCLE_SLEEP_TIME,
+            default=0,
             type=int,
             help='How many seconds to pause between each query'
         )

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -571,9 +571,6 @@ class Job(models.Model):
         """
         Updates a job's state after being verified by a sheriff
         """
-        if not settings.AUTOCLASSIFY_JOBS:
-            return
-
         if not self.is_fully_verified():
             return
 

--- a/treeherder/webapp/api/utils.py
+++ b/treeherder/webapp/api/utils.py
@@ -3,9 +3,14 @@ from datetime import (datetime,
                       timedelta)
 
 import django_filters
-from django.conf import settings
 
 from treeherder.model.models import Repository
+
+REPO_GROUPS = {
+    'trunk': ['mozilla-central', 'mozilla-inbound', 'autoland'],
+    'firefox-releases': ['mozilla-beta', 'mozilla-release'],
+    'comm-releases': ['comm-beta', 'comm-release'],
+}
 
 
 class NumberInFilter(django_filters.filters.BaseInFilter,
@@ -50,8 +55,8 @@ def get_repository(name):
     if name == 'all':
         return queryset.filter(active_status='active')
 
-    if name in settings.REPO_GROUPS:
-        param = settings.REPO_GROUPS[name]
+    if name in REPO_GROUPS:
+        param = REPO_GROUPS[name]
     else:
         param = [name]
 

--- a/vagrant/env.sh
+++ b/vagrant/env.sh
@@ -8,7 +8,6 @@ export ELASTICSEARCH_URL='http://localhost:9200'
 export REDIS_URL='redis://localhost:6379'
 
 export TREEHERDER_DEBUG='True'
-export ENABLE_DEBUG_TOOLBAR='True'
 export TREEHERDER_DJANGO_SECRET_KEY='secret-key-of-at-least-50-characters-to-pass-check-deploy'
 export NEW_RELIC_CONFIG_FILE='newrelic.ini'
 export NEW_RELIC_DEVELOPER_MODE='True'


### PR DESCRIPTION
This organises our core settings into three groups: Django, Third Party, & Treeherder (project level).  Internally to the latter two the settings have been grouped into either App or related sections in alphabetical order (to aid scanning the file).  Any settings only used in one place have also been moved to the respective usage site.