### PR TITLE
Bug 1450022 - Remove unused focusMe directive

### DIFF
--- a/ui/js/directives/treeherder/main.js
+++ b/ui/js/directives/treeherder/main.js
@@ -15,28 +15,6 @@ treeherder.directive('blurThis', ['$timeout', function ($timeout) {
     };
 }]);
 
-// Directive focusMe which sets a global focus state for elements
-// which listen to it via ''focus-me="focusInput'' in angular markup
-treeherder.directive('focusMe', [
-    '$timeout',
-    function ($timeout) {
-        return {
-            link: function (scope, element, attrs) {
-                scope.$watch(attrs.focusMe, function (value) {
-                    if (value) {
-                        $timeout(function () {
-                            element[0].focus();
-                        }, 0);
-                    } else {
-                        $timeout(function () {
-                            element[0].blur();
-                        }, 0);
-                    }
-                });
-            },
-        };
-    }]);
-
 // Allow copy to system clipboard during hover
 treeherder.directive('copyValue', [
     function () {


### PR DESCRIPTION
Its last usage was in `ui/partials/main/thPinboardPanel.html`.

(I ran the script from bug 1441164 for the first time since then - this was the only unused thing found)