### PR TITLE
Bug 1469777 - Sanitise and Catch Bugs Cache FTS Errors

### DIFF
--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -239,8 +239,10 @@ class Bugscache(models.Model):
             [search_term_fulltext, search_term_like, time_limit, max_size],
         )
 
-        return {"open_recent": [model_to_dict(item, exclude=["modified"]) for item in recent],
-                "all_others": [model_to_dict(item, exclude=["modified"]) for item in all_others]}
+        open_recent = [model_to_dict(item, exclude=["modified"]) for item in recent_qs]
+        all_others = [model_to_dict(item, exclude=["modified"]) for item in all_others_qs]
+
+        return {"open_recent": open_recent, "all_others": all_others}
 
 
 class Machine(NamedModel):

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -205,7 +205,7 @@ class Bugscache(models.Model):
         time_limit = datetime.datetime.now() - datetime.timedelta(days=90)
 
         # Wrap search term so it is used as a phrase in the full-text search.
-        search_term_fulltext = '"%s"' % search_term.replace("\"", "")
+        search_term_fulltext = '"%s"' % search_term.replace("\"", "").replace("-", " ")
 
         # Substitute escape and wildcard characters, so the search term is used
         # literally in the LIKE statement.


### PR DESCRIPTION
This covers two separate but related changes:
* Fix the specific error case for the Job linked [in bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1469777#c2)
* Catch the general error cases where the DB returns an error due to FTS syntax errors.

Note: I caught the error cases with `Exception` as using `ProgrammingError` and parsing out specific DB error codes felt too brittle given the log output is the useful part.