### PR TITLE
Bug 1470509 - Fix action bar links to reftest analyser

### DIFF
--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -320,7 +320,7 @@ export default class ActionBar extends React.Component {
                 title="Launch the Reftest Analyser in a new window"
                 target="_blank"
                 rel="noopener"
-                href={getReftestUrl(jobLogUrl)}
+                href={getReftestUrl(jobLogUrl.url)}
               ><span className="fa fa-bar-chart-o" /></a>
             </li>))}
             {this.canCancel() && <li>


### PR DESCRIPTION
Previously the log URL object was being passed instead of the URL, causing the generated URL to contain `logurl=[object Object]`.