### PR TITLE
Bug 1470554 - Revert ES6 arrow changes from bug 1468107

### DIFF
--- a/ui/js/models/perf/alerts.js
+++ b/ui/js/models/perf/alerts.js
@@ -65,9 +65,9 @@ treeherder.factory('PhAlerts', [
                              modification);
         };
         Object.values(phAlertStatusMap).forEach((status) => {
-            Alert.prototype['is' + capitalize(status.text)] = () => (
-                this.status === status.id
-            );
+            Alert.prototype['is' + capitalize(status.text)] = function () {
+                return this.status === status.id;
+            };
         });
         Alert.prototype.toggleStar = function () {
             const alert = this;
@@ -90,10 +90,10 @@ treeherder.factory('PhAlerts', [
                              modification);
         };
         Object.values(phAlertSummaryStatusMap).forEach((status) => {
-            AlertSummary.prototype['is' + capitalize(status.text)] = () => (
-                this.status === status.id
-            );
-            AlertSummary.prototype['mark' + capitalize(status.text)] = () => {
+            AlertSummary.prototype['is' + capitalize(status.text)] = function () {
+                return this.status === status.id;
+            };
+            AlertSummary.prototype['mark' + capitalize(status.text)] = function () {
                 this.updateStatus(status);
             };
         });


### PR DESCRIPTION
Since the functions reference `this`, and switching to the ES6 arrow function form changes the way `this` is bound, which caused the perf alert buttons to no longer appear.

Partially reverts dcc0c4a529e6216c4a7631b9c1c332c57c62cb7e (#3646).