### PR TITLE
Bug 1470506 - Fix ctrl+click to toggle pin job

### DIFF
--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -325,8 +325,8 @@ export default class DetailsPanel extends React.Component {
   toggleJobPin(job) {
     const { pinnedJobs } = this.state;
 
-    if (pinnedJobs.includes(job)) {
-      this.unPinJob(job);
+    if (pinnedJobs[job.id]) {
+      this.unPinJob(job.id);
     } else {
       this.pinJob(job);
     }


### PR DESCRIPTION
I was treating ``pinnnedJobs`` as an array, but it's an object, so it doesn't have the ``includes`` function.  I was also passing the whole ``job`` to the ``unPinJob`` function when that function only takes the ``id``.  I considered making that function take the whole ``job`` to be consistent with ``pinJob``.  But then I felt that it's best to keep it as-is and pass as little information into the function as it needs to do its operation.

Tests:
* cmd+click on a job to pin and un-pin it.
* click ``x`` on pinned job to un-pin
* space-bar to pin
* filtering jobs to a small sub-set, clicking "pin all shown jobs" and then cmd+clicking to unpin some of them
* several combinations of these actions