### PR TITLE
Document Services Directory Pattern with an ADR

### DIFF
--- a/docs/adrs.rst
+++ b/docs/adrs.rst
@@ -7,3 +7,5 @@ More context can be found in this blog post: http://thinkrelevance.com/blog/2011
 
 .. toctree::
     :maxdepth: 1
+
+    arch/adr-001.rst

--- a/docs/adrs.rst
+++ b/docs/adrs.rst
@@ -1,0 +1,9 @@
+Architecture Decision Records
+=============================
+
+An architecture decision record is a short text file describing a set of forces and the decision in response to those forces.
+
+More context can be found in this blog post: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+
+.. toctree::
+    :maxdepth: 1

--- a/docs/arch/adr-001.rst
+++ b/docs/arch/adr-001.rst
@@ -1,0 +1,24 @@
+ADR 1: Services Directory
+=========================
+
+Context
+-------
+This project uses many types of services in its general operation.
+They are configured in different places around the application, including but not limited to the global settings module, ``treeherder/config/settings.py``, and ``treeherder/model/models.py``.
+We define a service in the sense `The Twelve-Factor App does <https://12factor.net/backing-services>`_.
+
+Decision
+--------
+Configure external services in the ``treeherder/services`` directory to provide a consistent import API to other engineers.
+Each service is free to define its own module/package structure but should aim to expose a clean interface for importing.
+We will move relevant settings into their relevant services module/package since it is expected engineers will import a configured service not, for instance, a URL to said service.
+
+Status
+------
+Accepted.
+
+Consequences
+------------
+Engineers will import configured services in the form: ``from treeherder.services.elasticsearch import index``.
+
+Service authors will attempt to keep related settings out of ``settings.py`` and provide simple APIs for importing the configured service.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,3 +17,4 @@ Welcome to the Treeherder documentation!
    troubleshooting
    testcases
    admin
+   adrs


### PR DESCRIPTION
This starts off our use of ADRs (Architecture Decision Records) by documenting how the services directory (`treeherder/services`) should be used.

Since this is the first ADR it's the ideal place to discuss documentation/directory structure layout of ADRs themselves so comments/opinions on how we do ADRs are appreciated and welcomed!