### PR TITLE
Always pass taskId (possibly null) in action context

### DIFF
--- a/ui/js/services/tcactions.js
+++ b/ui/js/services/tcactions.js
@@ -25,7 +25,7 @@ treeherder.factory('tcactions', [
                            }) => {
                 const context = _.defaults({}, {
                     taskGroupId: decisionTaskId,
-                    taskId,
+                    taskId: taskId || null,
                     input,
                 }, staticActionVariables);
                 const queue = new Queue({ credentialAgent: thTaskcluster.getAgent() });


### PR DESCRIPTION
The action spec[*] requires that this property be set, but allows it to be
null.

[*] https://docs.taskcluster.net/docs/manual/using/actions/spec#json-e-context

/cc @helfi92 @imbstack 