### PR TITLE
Revert "Update pyyaml from 3.12 to 4.1 (#3719)"

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -147,8 +147,7 @@ sqlparse==0.2.4 \
     --hash=sha256:ce028444cfab83be538752a2ffdb56bc417b7784ff35bb9a3062413717807dec
 
 # Used directly and also by Django's YAML serializer.
-PyYAML==4.1 \
-    --hash=sha256:a9b322285f419429402d5ce15e8f6d5c7a64f659eb87251af8b35c106f00a8e3
+PyYAML==3.12 --hash=sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab
 
 django-environ==0.4.5 \
     --hash=sha256:c57b3c11ec1f319d9474e3e5a79134f40174b17c7cc024bbb2fad84646b120c4 \


### PR DESCRIPTION
This reverts commit 3ca4df665737e121214c5d57e7ace5bd383fd847 since the new version of pyyaml has been unpublished, causing:
https://travis-ci.org/mozilla/treeherder/jobs/398044815#L583