### PR TITLE
Bug 1472204 - Fix generation of job machine URL

### DIFF
--- a/ui/job-view/details/summary/SummaryPanel.jsx
+++ b/ui/job-view/details/summary/SummaryPanel.jsx
@@ -18,18 +18,19 @@ export default class SummaryPanel extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!nextProps.selectedJob || !Object.keys(nextProps.selectedJob).length) {
+    const { selectedJob } = nextProps;
+    if (!selectedJob || !Object.keys(selectedJob).length) {
       return;
     }
 
-    this.setJobMachineUrl(nextProps);
+    this.setJobMachineUrl(selectedJob);
   }
 
-  async setJobMachineUrl(props) {
+  async setJobMachineUrl(job) {
     let machineUrl = null;
 
     try {
-      machineUrl = await getJobMachineUrl(props);
+      machineUrl = await getJobMachineUrl(job);
     } catch (err) {
       machineUrl = '';
     }


### PR DESCRIPTION
Previously the URL was being set to the empty string, rather than:
`https://tools.taskcluster.net/provisioners/...`