### PR TITLE
Bug 1450038 - Replace usages of dangerouslySetInnerHTML with Markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-fontawesome": "1.6.1",
     "react-highlight-words": "0.11.0",
     "react-hot-loader": "3.1.3",
+    "react-markdown": "3.3.4",
     "react-redux": "5.0.7",
     "react-router-dom": "4.3.1",
     "react-select": "1.2.1",

--- a/tests/ui/unit/react/revisions.tests.jsx
+++ b/tests/ui/unit/react/revisions.tests.jsx
@@ -4,74 +4,73 @@ import { mount } from 'enzyme';
 import { Revision, Initials } from '../../../../ui/job-view/Revision';
 import {
   RevisionList,
-  MoreRevisionsLink
+  MoreRevisionsLink,
 } from '../../../../ui/job-view/RevisionList';
 
 describe('Revision list component', () => {
-  let $injector, mockData;
-  beforeEach(angular.mock.module('treeherder'));
-  beforeEach(inject((_$injector_) => {
-    $injector = _$injector_;
+  let mockData;
+
+  beforeEach(() => {
 
     const repo = {
       id: 2,
       repository_group: {
-        name: "development",
-        description: ""
+        name: 'development',
+        description: '',
       },
-      name: "mozilla-inbound",
-      dvcs_type: "hg",
-      url: "https://hg.mozilla.org/integration/mozilla-inbound",
+      name: 'mozilla-inbound',
+      dvcs_type: 'hg',
+      url: 'https://hg.mozilla.org/integration/mozilla-inbound',
       branch: null,
-      codebase: "gecko",
-      description: "",
-      active_status: "active",
+      codebase: 'gecko',
+      description: '',
+      active_status: 'active',
       performance_alerts_enabled: true,
-      pushlogURL: "https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml"
+      pushlogURL: 'https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml',
     };
     // Mock these simple functions so we don't have to call ThRepositoryModel.load() first to use them
-    repo.getRevisionHref = () => `${repo.url}/rev/${push.revision}`;
     repo.getPushLogHref = revision => `${repo.pushlogURL}?changeset=${revision}`;
 
         const push = {
             id: 151371,
-            revision: "5a110ad242ead60e71d2186bae78b1fb766ad5ff",
+            revision: '5a110ad242ead60e71d2186bae78b1fb766ad5ff',
             revision_count: 3,
-            author: "ryanvm@gmail.com",
+            author: 'ryanvm@gmail.com',
             push_timestamp: 1481326280,
             repository_id: 2,
             revisions: [{
                 result_set_id: 151371,
                 repository_id: 2,
-                revision: "5a110ad242ead60e71d2186bae78b1fb766ad5ff",
-                author: "André Bargull <andre.bargull@gmail.com>",
-                comments: "Bug 1319926 - Part 2: Collect telemetry about deprecated String generics methods. r=jandem"
+                revision: '5a110ad242ead60e71d2186bae78b1fb766ad5ff',
+                author: 'André Bargull <andre.bargull@gmail.com>',
+                comments: 'Bug 1319926 - Part 2: Collect telemetry about deprecated String generics methods. r=jandem',
             }, {
                 result_set_id: 151371,
                 repository_id: 2,
-                revision: "07d6bf74b7a2552da91b5e2fce0fa0bc3b457394",
-                author: "André Bargull <andre.bargull@gmail.com>",
-                comments: "Bug 1319926 - Part 1: Warn when deprecated String generics methods are used. r=jandem"
+                revision: '07d6bf74b7a2552da91b5e2fce0fa0bc3b457394',
+                author: 'André Bargull <andre.bargull@gmail.com>',
+                comments: 'Bug 1319926 - Part 1: Warn when deprecated String generics methods are used. r=jandem',
             }, {
                 result_set_id: 151371,
                 repository_id: 2,
-                revision: "e83eaf2380c65400dc03c6f3615d4b2cef669af3",
-                author: "Frédéric Wang <fred.wang@free.fr>",
-                comments: "Bug 1322743 - Add STIX Two Math to the list of math fonts. r=karlt"
-            }]
+                revision: 'e83eaf2380c65400dc03c6f3615d4b2cef669af3',
+                author: 'Frédéric Wang <fred.wang@free.fr>',
+                comments: 'Bug 1322743 - Add STIX Two Math to the list of math fonts. r=karlt',
+            }],
         };
         mockData = {
             push,
-            repo
+            repo,
         };
-    }));
+    repo.getRevisionHref = () => `${repo.url}/rev/${push.revision}`;
+  });
 
   it('renders the correct number of revisions in a list', () => {
     const wrapper = mount(
       <RevisionList
-        repo={mockData.repo} push={mockData.push}
-        $injector={$injector}
-      />
+        repo={mockData.repo}
+        push={mockData.push}
+      />,
     );
     expect(wrapper.find(Revision).length).toEqual(mockData.push.revision_count);
   });
@@ -81,9 +80,9 @@ describe('Revision list component', () => {
 
     const wrapper = mount(
       <RevisionList
-        repo={mockData.repo} push={mockData.push}
-        $injector={$injector}
-      />
+        repo={mockData.repo}
+        push={mockData.push}
+      />,
     );
     expect(wrapper.find(MoreRevisionsLink).length).toEqual(1);
   });
@@ -91,33 +90,31 @@ describe('Revision list component', () => {
 });
 
 describe('Revision item component', () => {
-  let linkifyBugsFilter, mockData;
-  beforeEach(angular.mock.module('treeherder'));
-  beforeEach(inject((_$injector_, $filter) => {
-    linkifyBugsFilter = $filter('linkifyBugs');
+  let mockData;
 
+  beforeEach(() => {
     const repo = {
       id: 2,
       repository_group: {
-        name: "development",
-        description: ""
+        name: 'development',
+        description: '',
       },
-      name: "mozilla-inbound",
-      dvcs_type: "hg",
-      url: "https://hg.mozilla.org/integration/mozilla-inbound",
+      name: 'mozilla-inbound',
+      dvcs_type: 'hg',
+      url: 'https://hg.mozilla.org/integration/mozilla-inbound',
       branch: null,
-      codebase: "gecko",
-      description: "",
-      active_status: "active",
+      codebase: 'gecko',
+      description: '',
+      active_status: 'active',
       performance_alerts_enabled: true,
-      pushlogURL: "https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml"
+      pushlogURL: 'https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml',
     };
     const revision = {
       result_set_id: 151371,
       repository_id: 2,
-      revision: "5a110ad242ead60e71d2186bae78b1fb766ad5ff",
-      author: "André Bargull <andre.bargull@gmail.com>",
-      comments: "Bug 1319926 - Part 2: Collect telemetry about deprecated String generics methods. r=jandem"
+      revision: '5a110ad242ead60e71d2186bae78b1fb766ad5ff',
+      author: 'André Bargull <andre.bargull@gmail.com>',
+      comments: 'Bug 1319926 - Part 2: Collect telemetry about deprecated String generics methods. r=jandem',
     };
     // Mock these simple functions so we don't have to call ThRepositoryModel.load() first to use them
     repo.getRevisionHref = () => `${repo.url}/rev/${revision.revision}`;
@@ -125,29 +122,27 @@ describe('Revision item component', () => {
 
     mockData = {
       revision,
-      repo
+      repo,
     };
-  }));
+  });
 
   it('renders a linked revision', () => {
     const wrapper = mount(
       <Revision
         repo={mockData.repo}
         revision={mockData.revision}
-        linkifyBugsFilter={linkifyBugsFilter}
       />);
-    const link = wrapper.find('a');
+    const link = wrapper.find('a').first();
     expect(link.length).toEqual(1);
     expect(link.props().href).toEqual(mockData.repo.getRevisionHref());
     expect(link.props().title).toEqual(`Open revision ${mockData.revision.revision} on ${mockData.repo.url}`);
   });
 
-  it(`renders the contributors' initials`, () => {
+  it('renders the contributors\' initials', () => {
     const wrapper = mount(
       <Revision
         repo={mockData.repo}
         revision={mockData.revision}
-        linkifyBugsFilter={linkifyBugsFilter}
       />);
     const initials = wrapper.find('.user-push-initials');
     expect(initials.length).toEqual(1);
@@ -159,28 +154,26 @@ describe('Revision item component', () => {
       <Revision
         repo={mockData.repo}
         revision={mockData.revision}
-        linkifyBugsFilter={linkifyBugsFilter}
       />);
 
     const comment = wrapper.find('.revision-comment em');
-    expect(comment.html()).toEqual('<em data-job-clear-on-click="true">Bug <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1319926" data-bugid="1319926" title="bugzilla.mozilla.org">1319926</a> - Part 2: Collect telemetry about deprecated String generics methods. r=jandem</em>');
+    expect(comment.html()).toEqual('<em data-job-clear-on-click="true"><div><p>Bug <a title="bugzilla.mozilla.org" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1319926">1319926</a> - Part 2: Collect telemetry about deprecated String generics methods. r=jandem</p></div></em>');
   });
 
   it('marks the revision as backed out if the words "Back/Backed out" appear in the comments', () => {
-    mockData.revision.comments = "Backed out changeset a6e2d96c1274 (bug 1322565) for eslint failure";
+    mockData.revision.comments = 'Backed out changeset a6e2d96c1274 (bug 1322565) for eslint failure';
     let wrapper = mount(
       <Revision
         repo={mockData.repo}
         revision={mockData.revision}
-        linkifyBugsFilter={linkifyBugsFilter}
       />);
     expect(wrapper.find({ 'data-tags': 'backout' }).length).toEqual(1);
 
-    mockData.revision.comments = "Back out changeset a6e2d96c1274 (bug 1322565) for eslint failure";
+    mockData.revision.comments = 'Back out changeset a6e2d96c1274 (bug 1322565) for eslint failure';
     wrapper = mount(
       <Revision
-        repo={mockData.repo} revision={mockData.revision}
-        linkifyBugsFilter={linkifyBugsFilter}
+        repo={mockData.repo}
+        revision={mockData.revision}
       />);
     expect(wrapper.find({ 'data-tags': 'backout' }).length).toEqual(1);
   });
@@ -201,29 +194,35 @@ describe('More revisions link component', () => {
 });
 
 describe('initials filter', function () {
-  const email = "foo@bar.baz";
+  const email = 'foo@bar.baz';
   it('initializes a one-word name', function () {
     const name = 'Starscream';
-    const initials = mount(<Initials title={`${name}: ${email}`}
-                                     author={name}
-    />);
+    const initials = mount(
+      <Initials
+        title={`${name}: ${email}`}
+        author={name}
+      />);
     expect(initials.html()).toEqual('<span title="Starscream: foo@bar.baz"><span class="user-push-icon"><i class="fa fa-user-o" aria-hidden="true" data-job-clear-on-click="true"></i></span><div class="icon-superscript user-push-initials" data-job-clear-on-click="true">S</div></span>');
   });
 
   it('initializes a two-word name', function () {
     const name = 'Optimus Prime';
-    const initials = mount(<Initials title={`${name}: ${email}`}
-                                     author={name}
-    />);
+    const initials = mount(
+      <Initials
+        title={`${name}: ${email}`}
+        author={name}
+      />);
     const userPushInitials = initials.find('.user-push-initials');
     expect(userPushInitials.html()).toEqual('<div class="icon-superscript user-push-initials" data-job-clear-on-click="true">OP</div>');
   });
 
   it('initializes a three-word name', function () {
     const name = 'Some Other Transformer';
-    const initials = mount(<Initials title={`${name}: ${email}`}
-                                     author={name}
-    />);
+    const initials = mount(
+      <Initials
+        title={`${name}: ${email}`}
+        author={name}
+      />);
     const userPushInitials = initials.find('.user-push-initials');
     expect(userPushInitials.html()).toEqual('<div class="icon-superscript user-push-initials" data-job-clear-on-click="true">ST</div>');
   });

--- a/tests/ui/unit/urlHelper.tests.js
+++ b/tests/ui/unit/urlHelper.tests.js
@@ -1,10 +1,10 @@
-import { linkifyURLs, linkifyRevisions } from "../../../ui/helpers/url";
+import { linkifyURLs, linkifyRevisions } from '../../../ui/helpers/url';
 
 describe('linkifyURLs helper', () => {
 
   it('linkifies a URL', () => {
     expect(linkifyURLs('https://www.mozilla.org'))
-      .toEqual('<a href="https://www.mozilla.org" target="_blank" rel="noopener">https://www.mozilla.org</a>');
+      .toEqual('[https://www.mozilla.org](https://www.mozilla.org)');
   });
 
   it('does not linkify a non-URL', () => {
@@ -13,19 +13,19 @@ describe('linkifyURLs helper', () => {
 
   it('linkifies a mix of URL and non-URL', () => {
     expect(linkifyURLs('This is a test: https://www.mozilla.org Did I pass?'))
-      .toEqual('This is a test: <a href="https://www.mozilla.org" target="_blank" rel="noopener">https://www.mozilla.org</a> Did I pass?');
+      .toEqual('This is a test: [https://www.mozilla.org](https://www.mozilla.org) Did I pass?');
   });
 });
 
 describe('linkifyRevisions helper', () => {
   let repo;
-  beforeEach(angular.mock.module('treeherder'));
+
   beforeEach((() => {
     repo = {
       id: 1,
       repository_group: {
         description: '',
-        name: 'development'
+        name: 'development',
       },
       name: 'mozilla-central',
       dvcs_type: 'hg',
@@ -35,12 +35,12 @@ describe('linkifyRevisions helper', () => {
 
   it('linkifies a 20 char revision', () => {
     expect(linkifyRevisions('1234567890ab', repo))
-      .toEqual("<a href='https://hg.mozilla.org/mozilla/central/rev/1234567890ab'>1234567890ab</a>");
+      .toEqual('[1234567890ab](https://hg.mozilla.org/mozilla/central/rev/1234567890ab)');
   });
 
   it('linkifies a 40 char revision', () => {
     expect(linkifyRevisions('dec7c40f3be3fc3e2b0a7c7f968757a9541b5efb', repo))
-      .toEqual("<a href='https://hg.mozilla.org/mozilla/central/rev/dec7c40f3be3fc3e2b0a7c7f968757a9541b5efb'>dec7c40f3be3fc3e2b0a7c7f968757a9541b5efb</a>");
+      .toEqual('[dec7c40f3be3fc3e2b0a7c7f968757a9541b5efb](https://hg.mozilla.org/mozilla/central/rev/dec7c40f3be3fc3e2b0a7c7f968757a9541b5efb)');
   });
 
   it('does not linkify a non revision', () => {

--- a/ui/css/treeherder-details-panel.css
+++ b/ui/css/treeherder-details-panel.css
@@ -483,6 +483,11 @@ annotations-tab {
   background: #fff;
 }
 
+.classification-revisions div,
+.classification-revisions div > p {
+  display: inline;
+}
+
 .annotations-bug-list {
   list-style: none inside none;
   padding-left: 0;

--- a/ui/css/treeherder-resultsets.css
+++ b/ui/css/treeherder-resultsets.css
@@ -179,6 +179,14 @@ th-action-button .btn-push {
   color: #777;
 }
 
+.revision-comment div {
+  display: inline-block;
+}
+
+.revision-comment div > p {
+  display: inline;
+}
+
 /*
  * Job table
  */

--- a/ui/job-view/Push.jsx
+++ b/ui/job-view/Push.jsx
@@ -147,7 +147,6 @@ export default class Push extends React.Component {
           {currentRepo &&
             <RevisionList
               push={push}
-              $injector={$injector}
               repo={currentRepo}
             />
           }

--- a/ui/job-view/Revision.jsx
+++ b/ui/job-view/Revision.jsx
@@ -1,8 +1,9 @@
-import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+import ReactMarkdown from 'react-markdown';
 
 import { parseAuthor } from '../helpers/revision';
+import { linkifyBugs } from '../helpers/url';
 
 export function Initials(props) {
   const str = props.author || '';
@@ -36,10 +37,9 @@ Initials.propTypes = {
 export class Revision extends React.PureComponent {
   constructor(props) {
     super(props);
-    const { revision, linkifyBugsFilter } = this.props;
+    const { revision } = this.props;
 
     this.comment = revision.comments.split('\n')[0];
-    this.escapedCommentHTML = { __html: linkifyBugsFilter(_.escape(this.comment)) };
     this.tags = this.comment.search('Backed out') >= 0 || this.comment.search('Back out') >= 0 ?
         'backout' : '';
   }
@@ -64,7 +64,7 @@ export class Revision extends React.PureComponent {
         />
         <span title={this.comment}>
           <span className="revision-comment">
-            <em dangerouslySetInnerHTML={this.escapedCommentHTML} data-job-clear-on-click />
+            <em data-job-clear-on-click><ReactMarkdown source={linkifyBugs(this.comment)} /></em>
           </span>
         </span>
       </span>
@@ -73,7 +73,6 @@ export class Revision extends React.PureComponent {
 }
 
 Revision.propTypes = {
-  linkifyBugsFilter: PropTypes.func.isRequired,
   revision: PropTypes.object.isRequired,
   repo: PropTypes.object.isRequired,
 };

--- a/ui/job-view/RevisionList.jsx
+++ b/ui/job-view/RevisionList.jsx
@@ -6,7 +6,6 @@ import { Revision } from './Revision';
 export class RevisionList extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.linkifyBugsFilter = this.props.$injector.get('linkifyBugsFilter');
     this.hasMore = props.push.revision_count > props.push.revisions.length;
   }
 
@@ -18,7 +17,6 @@ export class RevisionList extends React.PureComponent {
         <ul className="list-unstyled">
           {push.revisions.map(revision =>
             (<Revision
-              linkifyBugsFilter={this.linkifyBugsFilter}
               revision={revision}
               repo={repo}
               key={revision.revision}
@@ -38,7 +36,6 @@ export class RevisionList extends React.PureComponent {
 
 RevisionList.propTypes = {
   push: PropTypes.object.isRequired,
-  $injector: PropTypes.object.isRequired,
   repo: PropTypes.object.isRequired,
 };
 

--- a/ui/job-view/details/summary/ClassificationsPanel.jsx
+++ b/ui/job-view/details/summary/ClassificationsPanel.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ReactMarkdown from 'react-markdown';
 
 import { linkifyRevisions, getBugUrl } from '../../../helpers/url';
 
@@ -13,7 +14,6 @@ export default function ClassificationsPanel(props) {
   const classificationTypes = $injector.get('thClassificationTypes');
 
   const repo = ThRepositoryModel.getRepo(repoName);
-  const repoURLHTML = { __html: linkifyRevisions(classification.text, repo) };
   const failureId = classification.failure_classification_id;
   const iconClass = `${(failureId === 7 ? 'fa-star-o' : 'fa fa-star')} star-${job.result}`;
   const classificationName = classificationTypes.classifications[failureId];
@@ -34,7 +34,9 @@ export default function ClassificationsPanel(props) {
           ><em> {bugs[0].bug_id}</em></a>}
       </li>
       {classification.text.length > 0 &&
-        <li><em dangerouslySetInnerHTML={repoURLHTML} /></li>
+      <li className="classification-revisions"><em>
+        <ReactMarkdown source={linkifyRevisions(classification.text, repo)} />
+      </em></li>
       }
       <li className="revision-comment">
         {dateFilter(classification.created, 'EEE MMM d, H:mm:ss')}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1134,6 +1134,10 @@ backo2@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
 
+bail@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.3.tgz#63cfb9ddbac829b02a3128cd53224be78e6c21a3"
+
 balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
@@ -1503,6 +1507,18 @@ chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+character-entities-legacy@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz#7c6defb81648498222c9855309953d05f4d63a9c"
+
+character-entities@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.2.tgz#58c8f371c0774ef0ba9b2aca5f00d8f100e6e363"
+
+character-reference-invalid@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz#21e421ad3d84055952dab4a43a04e73cd425d3ed"
+
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
@@ -1647,6 +1663,10 @@ coa@~1.0.1:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+collapse-white-space@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.4.tgz#ce05cf49e54c3277ae573036a26851ba430a0091"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -3975,6 +3995,17 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.2.tgz#1fa6e49213cb7885b75d15862fb3f3d96c884f41"
+
+is-alphanumerical@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz#1138e9ae5040158dc6ff76b820acd6b7a181fd40"
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -3989,7 +4020,7 @@ is-boolean-object@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -4018,6 +4049,10 @@ is-data-descriptor@^1.0.0:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-decimal@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.2.tgz#894662d6a8709d307f3a276ca4339c8fa5dff0ff"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -4097,6 +4132,10 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-hexadecimal@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz#b6e710d7d07bb66b98cb8cece5c9b4921deeb835"
+
 is-my-ip-valid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
@@ -4151,7 +4190,7 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-obj@^1.0.0:
+is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
@@ -4209,9 +4248,17 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-whitespace-character@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz#ede53b4c6f6fb3874533751ec9280d01928d03ed"
+
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
+is-word-character@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.2.tgz#46a5dac3f2a1840898b91e576cd40d493f3ae553"
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -4766,6 +4813,10 @@ map-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
+
+markdown-escapes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.2.tgz#e639cbde7b99c841c0bacc8a07982873b46d2122"
 
 marked@^0.3.3:
   version "0.3.19"
@@ -5527,6 +5578,17 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
 
+parse-entities@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.2.tgz#9eaf719b29dc3bd62246b4332009072e01527777"
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
@@ -6206,6 +6268,16 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
+react-markdown@3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-3.3.4.tgz#4002599ad133c649923a49aedc06b2f3af2016b6"
+  dependencies:
+    prop-types "^15.6.1"
+    remark-parse "^5.0.0"
+    unified "^6.1.5"
+    unist-util-visit "^1.3.0"
+    xtend "^4.0.1"
+
 react-popper@^0.10.4:
   version "0.10.4"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.10.4.tgz#af2a415ea22291edd504678d7afda8a6ee3295aa"
@@ -6541,6 +6613,26 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -6563,7 +6655,7 @@ repeat-string@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-0.2.2.tgz#c7a8d3236068362059a7e4651fc6884e8b1fb4ae"
 
-repeat-string@^1.5.2, repeat-string@^1.6.1:
+repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -6572,6 +6664,10 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
+
+replace-ext@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -7050,6 +7146,10 @@ stackframe@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
 
+state-toggle@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.1.tgz#c3cb0974f40a6a0f8e905b96789eb41afa1cde3a"
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -7324,6 +7424,18 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+trim-trailing-lines@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz#e0ec0810fd3c3f1730516b45f49083caaf2774d9"
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+
+trough@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.2.tgz#7f1663ec55c480139e2de5e486c6aef6cc24a535"
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -7377,6 +7489,24 @@ underscore@~1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
 
+unherit@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.1.tgz#132748da3e88eab767e08fabfbb89c5e9d28628c"
+  dependencies:
+    inherits "^2.0.1"
+    xtend "^4.0.1"
+
+unified@^6.1.5:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
+
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -7393,6 +7523,26 @@ uniq@^1.0.1:
 uniqs@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/uniqs/-/uniqs-2.0.0.tgz#ffede4b36b25290696e6e165d4a59edb998e6b02"
+
+unist-util-is@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz#86b5dad104d0bbfbeb1db5f5c92f3570575c12cb"
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+
+unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.3.1.tgz#c019ac9337a62486be58531bc27e7499ae7d55c7"
+  dependencies:
+    unist-util-is "^2.1.1"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -7517,6 +7667,25 @@ vary@~1.1.2:
 vendors@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.2.tgz#7fcb5eef9f5623b156bcea89ec37d63676f21801"
+
+vfile-location@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.3.tgz#083ba80e50968e8d420be49dd1ea9a992131df77"
+
+vfile-message@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.1.tgz#51a2ccd8a6b97a7980bb34efb9ebde9632e93677"
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 vm-browserify@0.0.4:
   version "0.0.4"
@@ -7732,6 +7901,10 @@ wtf-8@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
 
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+
 xmlhttprequest-ssl@1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz#185a888c04eca46c3e4070d99f7b49de3528992d"
@@ -7740,7 +7913,7 @@ xmlhttprequest@1:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 
-xtend@^4.0.0:
+xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
This converts them to Markdown.  The generated Markdown has a few extra elements in it which caused some formatting issues.  So I had to add CSS overrides for them.

The Angular ``linkifyBugs`` filter is still used on the secondary nav bar, which I'll convert in an upcoming PR.

Apologies for the noise in the tests.  I went ahead and fixed a bunch of the stuff that fails our lint rules.  Also ends up those tests don't need angular at all anymore.  Feel free to skip reviewing them, if you like.  I didn't change what they test.  I just changed the expected result to be markdown instead of HTML.