### PR TITLE
Remove fixed deprecation warning from filterwarnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,8 +47,6 @@ filterwarnings =
     ignore:sys.exc_clear\(\) not supported in 3.x; use except clauses:DeprecationWarning
     ignore:classic int division:DeprecationWarning:django.db.backends.base.schema
     ignore:In 3.x, reload\(\) is renamed to imp.reload\(\):DeprecationWarning:django.db.migrations.loader
-    # https://github.com/pytest-dev/pytest-django/issues/596
-    ignore:MarkInfo objects are deprecated:DeprecationWarning:pytest_django.plugin
 markers =
     slow: mark a test as slow.
 xfail_strict = true


### PR DESCRIPTION
Since the pytest-django update in #3672 included the fix for:
https://github.com/pytest-dev/pytest-django/issues/596