### PR TITLE
Bug 1473505 - Fix ctrl + click job should select it

### DIFF
--- a/ui/job-view/PushJobs.jsx
+++ b/ui/job-view/PushJobs.jsx
@@ -99,6 +99,10 @@ export default class PushJobs extends React.Component {
       if (ev.button === 1) { // Middle click
         this.handleLogViewerClick(jobId);
       } else if (ev.metaKey || ev.ctrlKey) { // Pin job
+        if (!this.$rootScope.selectedJob) {
+          this.ThResultSetStore.setSelectedJob(job);
+          this.selectJob(job, ev.target);
+        }
         this.$rootScope.$emit(thEvents.toggleJobPin, job);
       } else if (job.state === 'runnable') { // Toggle runnable
         this.handleRunnableClick(job);

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -332,9 +332,6 @@ export default class DetailsPanel extends React.Component {
     } else {
       this.pinJob(job);
     }
-    if (!this.selectedJob) {
-      this.selectJob(job);
-    }
   }
 
   pulsePinCount() {


### PR DESCRIPTION
Whether a job is selected should come from outside the ``DetailsPanel`` in this case.  And it needs to be set on ``$rootScope`` still.

Also, where I was checking it in the ``DetailsPanel`` doesn't exist.  ``this.selectedJob`` should have been ``this.props.selectedJob`` anyway.