### PR TITLE
Bug 1465838 - add ci-admin and ci-configuration repos

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1246,5 +1246,31 @@
         "repository_group": 8,
         "description": ""
     }
+},
+{
+    "pk": 97,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "hg",
+        "name": "ci-admin",
+        "url": "https://hg.mozilla.org/build/ci-admin",
+        "active_status": "active",
+        "codebase": "ci-admin",
+        "repository_group": 9,
+        "description": "Administrative scripts for Firefox CI"
+    }
+},
+{
+    "pk": 98,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "hg",
+        "name": "ci-configuration",
+        "url": "https://hg.mozilla.org/build/ci-configuration",
+        "active_status": "active",
+        "codebase": "ci-admin",
+        "repository_group": 9,
+        "description": "Administrative configuration for Firefox CI"
+    }
 }
 ]

--- a/treeherder/model/fixtures/repository_group.json
+++ b/treeherder/model/fixtures/repository_group.json
@@ -62,5 +62,13 @@
         "name": "comm-repositories",
         "description": "Repositories for Seamonkey/Thunderbird development"
     }
+},
+{
+    "pk": 9,
+    "model": "model.repositorygroup",
+    "fields": {
+        "name": "ci-admin",
+        "description": "Administration of Firefox CI"
+    }
 }
 ]


### PR DESCRIPTION
These are in a new dedicated repository_group.

I don't really know what the 'codebase' parameter does -- is that a foreign key that I'll need to update somewhere?