### PR TITLE
Remove as_dict Helper Function

### DIFF
--- a/treeherder/webapp/api/text_log_error.py
+++ b/treeherder/webapp/api/text_log_error.py
@@ -12,7 +12,6 @@ from treeherder.model.models import (ClassifiedFailure,
                                      TextLogError)
 from treeherder.webapp.api import (pagination,
                                    serializers)
-from treeherder.webapp.api.utils import as_dict
 
 logger = logging.getLogger(__name__)
 
@@ -58,19 +57,15 @@ class TextLogErrorViewSet(viewsets.ModelViewSet):
 
             ids.append((line_id, classification_id, bug_number))
 
-        error_lines = as_dict(
-            TextLogError.objects
-            .prefetch_related('classified_failures')
-            .filter(id__in=error_line_ids), "id")
-
+        error_lines = TextLogError.objects.prefetch_related('classified_failures').filter(id__in=error_line_ids)
+        error_lines = {tle.id: tle for tle in error_lines}
         if len(error_lines) != len(error_line_ids):
             missing = error_line_ids - set(error_lines.keys())
             return ("No text log error with id: {0}".format(", ".join(missing)),
                     HTTP_404_NOT_FOUND)
 
-        classifications = as_dict(
-            ClassifiedFailure.objects.filter(id__in=classification_ids), "id")
-
+        classifications = ClassifiedFailure.objects.filter(id__in=classification_ids)
+        classifications = {c.id: c for c in classifications}
         if len(classifications) != len(classification_ids):
             missing = classification_ids - set(classifications.keys())
             return ("No classification with id: {0}".format(", ".join(missing)),

--- a/treeherder/webapp/api/utils.py
+++ b/treeherder/webapp/api/utils.py
@@ -37,10 +37,6 @@ def to_timestamp(datetime_obj):
     return None
 
 
-def as_dict(queryset, key):
-    return {getattr(item, key): item for item in queryset}
-
-
 def get_end_of_day(date):
     """Turn a date string into a datetime in order to
        add a 23:59:59.999 timestamp (default is 00:00:00)"""


### PR DESCRIPTION
With the removal of the ClassifiedFailure and FailureLine APIs in #3767 the only user of `as_dict` was the TextLogError API.  Since the function provides a lookup table of instance ID -> instance we can easily replace the uses of it with dict comprehensions.