### PR TITLE
Document JobNotes

### DIFF
--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -812,8 +812,7 @@ class JobNote(models.Model):
         if note:
             self.job.failure_classification_id = note.failure_classification.id
         else:
-            self.job.failure_classification_id = FailureClassification.objects.values_list(
-                'id', flat=True).get(name='not classified')
+            self.job.failure_classification_id = FailureClassification.objects.get(name='not classified').id
         self.job.save()
 
     def _ensure_classification(self):

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -876,7 +876,14 @@ class JobNote(models.Model):
 
     @classmethod
     def create_autoclassify_job_note(self, job, user=None):
+        """
+        Create a JobNote, possibly via auto-classification.
 
+        Create mappings from the given Job to Bugs via verified Classifications
+        of this Job.
+
+        Also creates a JobNote.
+        """
         # Only insert bugs for verified failures since these are automatically
         # mirrored to ES and the mirroring can't be undone
         bug_numbers = set(ClassifiedFailure.objects


### PR DESCRIPTION
This is a collection of documentation and tweaks to the JobNote model that didn't seem worth splitting up.  Hopefully the commits are succinct enough to make review easy though.

#### Documentation
Added docstrings and comments erring on the side of excessiveness since this model is heavily used in classification via the Failure Summary tab.  It's also used from auto-classification and I needed to work out why.

#### Tweaks
A couple of little bits that probably don't optimise anything but helped me get my head around what was happening.