### PR TITLE
Fix iSort Tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ skip = .git,__pycache__,.vagrant,node_modules,migrations
 multi_line_output = 1
 force_grid_wrap = true
 line_length = 140
+known_first_party = tests
 
 [tool:pytest]
 testpaths = tests


### PR DESCRIPTION
This explicitly sets our `tests` directory as a first party in `isort`.

We started seeing errors from isort here: https://travis-ci.org/mozilla/treeherder/jobs/403057132

The [related PR](https://github.com/mozilla/treeherder/pull/3781) has no changes related to those errors, we hadn't updated our isort version or config in the last few months.