### PR TITLE
Bug 1476243 - Convert lodash .mapValues() to native ES6 JS

### DIFF
--- a/ui/js/models/resultset.js
+++ b/ui/js/models/resultset.js
@@ -267,7 +267,12 @@ treeherder.factory('ThResultSetModel', ['$http', '$location',
                     const graph = resp.data;
 
                     // Build a mapping of buildbot buildername to taskcluster tasklabel for bbb tasks
-                    const builderToTask = _.omit(_.invert(_.mapValues(graph, 'task.payload.buildername')), [undefined]);
+                    const builderToTask = _.omit(_.invert(Object.entries(graph)
+                    .reduce((a, [key, { task.payload.buildername }]) => {
+                      a[key] = task.payload.buildername;
+                      return a;
+                    }, {}
+                  )), [undefined]);
                     const allLabels = Object.keys(graph);
 
                     const tclabels = [];


### PR DESCRIPTION
Lodash .mapValues() has been converted to es6 using Object.entries and reduce.