### PR TITLE
Bug 1476702 - Fix login broken after update to Auth0-js 9.7.2

### DIFF
--- a/ui/js/auth/LoginCallback.jsx
+++ b/ui/js/auth/LoginCallback.jsx
@@ -31,7 +31,7 @@ export default class LoginCallback extends React.PureComponent {
     }
 
     try {
-      authResult = await parseHash(window.location.hash);
+      authResult = await parseHash({ hash: window.location.hash });
 
       if (authResult.accessToken) {
         await this.authService.saveCredentialsFromAuthResult(authResult);

--- a/ui/js/auth/auth-utils.js
+++ b/ui/js/auth/auth-utils.js
@@ -41,9 +41,9 @@ export const renew = () => (
 );
 
 // Wrapper around webAuth's parseHash
-export const parseHash = qs => (
+export const parseHash = options => (
   new Promise((resolve, reject) => {
-    webAuth.parseHash(qs, (error, authResult) => {
+    webAuth.parseHash(options, (error, authResult) => {
       if (error) {
         return reject(error);
       }


### PR DESCRIPTION
The parameter to ``parseHash`` changed in the new version.  Since we have a wrapper to that function, we need to pass the new format.

https://auth0.github.io/auth0.js/global.html#parseHash