### PR TITLE
Bug 1476469 - Stop AMQP Filling Up

### DIFF
--- a/treeherder/model/error_summary.py
+++ b/treeherder/model/error_summary.py
@@ -39,7 +39,9 @@ def get_error_summary(job):
     if not errors:
         return []
 
+    # cache terms generated from error line to save excessive querying
     term_cache = {}
+
     error_summary = [bug_suggestions_line(err, term_cache) for err in errors]
     cache.set(cache_key, error_summary, BUG_SUGGESTION_CACHE_TIMEOUT)
 
@@ -57,6 +59,7 @@ def bug_suggestions_line(err, term_cache=None):
     """
     if term_cache is None:
         term_cache = {}
+
     # remove the mozharness prefix
     clean_line = get_mozharness_substring(err.line)
 

--- a/treeherder/model/error_summary.py
+++ b/treeherder/model/error_summary.py
@@ -39,7 +39,8 @@ def get_error_summary(job):
     if not errors:
         return []
 
-    error_summary = [bug_suggestions_line(err) for err in errors]
+    term_cache = {}
+    error_summary = [bug_suggestions_line(err, term_cache) for err in errors]
     cache.set(cache_key, error_summary, BUG_SUGGESTION_CACHE_TIMEOUT)
 
     return error_summary
@@ -54,8 +55,8 @@ def bug_suggestions_line(err, term_cache=None):
     for bugs.  Returns a dictionary with the cleaned line, the generated search
     term, and any bugs found with said search term.
     """
-    term_cache = {}
-
+    if term_cache is None:
+        term_cache = {}
     # remove the mozharness prefix
     clean_line = get_mozharness_substring(err.line)
 


### PR DESCRIPTION
This reinstates the removal of caching search terms when looping over TextLogErrors and adds a comment to explain why we're doing that.