### PR TITLE
Bug 1116372 - exclude "intermittent needs filing" FailureClassifcations

### DIFF
--- a/treeherder/webapp/api/refdata.py
+++ b/treeherder/webapp/api/refdata.py
@@ -38,7 +38,7 @@ class OptionCollectionHashViewSet(viewsets.ViewSet):
 class FailureClassificationViewSet(viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata FailureClassification model"""
-    queryset = models.FailureClassification.objects.all()
+    queryset = models.FailureClassification.objects.exclude(name="intermittent needs filing")
     serializer_class = th_serializers.FailureClassificationSerializer
 
 #############################


### PR DESCRIPTION
Remove this type of FailureClassifcation from the API so they no longer
appear in the UI.