### PR TITLE
Split Documentation Source and Build Files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - flake8 --show-source
         - isort --check-only --diff --quiet
         - git grep -El '^#!/.+\b(bash|sh)\b' | xargs shellcheck
-        - make -C docs html
+        - make html
 
     # Job 2: Python 3 linters
     - env: python3-linters

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 # Makefile for Sphinx documentation
 
-SPHINXOPTS    = -n -W .
+SPHINXOPTS    = -n -W
 SPHINXBUILD   = sphinx-build
 BUILDDIR      = _build
+SOURCEDIR     = docs
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -20,9 +21,9 @@ clean:
 	rm -rf $(BUILDDIR)/*
 
 html:
-	$(SPHINXBUILD) -b html $(SPHINXOPTS) $(BUILDDIR)
+	$(SPHINXBUILD) -b html $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)"
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)."
 
 livehtml:
-	sphinx-autobuild -b html --poll $(SPHINXOPTS) $(BUILDDIR)
+	sphinx-autobuild -b html --poll $(SPHINXOPTS) $(SOURCEDIR) $(BUILDDIR) -B -p 8001

--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -100,7 +100,7 @@ Building the docs locally
   .. code-block:: bash
 
      > pip install -r requirements/docs.txt
-     > make -C docs livehtml
+     > make livehtml
 
 * Visit http://127.0.0.1:8000 to view the docs.
 * Source changes will result in automatic rebuilds and browser page reload.


### PR DESCRIPTION
This pushes the source RST files down into a separate directory so they don't live at the save level as the output folder.  This is both in-keeping with how new Sphinx projects are laid out and aids separation of the two types of files.  It has the bonus effect of making fuzzy searching better by not polluting results with built files.