### PR TITLE
Fix text color on closed repos

### DIFF
--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -145,6 +145,11 @@ secondary-nav-bar {
     padding-right: 5px;
 }
 
+.watched-repo-main-btn:visited,
+.watched-repo-main-btn:link {
+    color: lightgrey;
+}
+
 .watched-repo-info-btn {
     padding-left: 6px;
     padding-right: 9px;


### PR DESCRIPTION
The visited color was too close to the red background color for closed repos.  So needed to specifically set it to lightgrey.  This item was formerly a ``<span>`` in button format, but it changed to an ``<a>`` when converted to ReactJS.  So we needed this extra formatting.