### PR TITLE
Bug 1478663 - Update graphql related libraries

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -223,17 +223,17 @@ idna==2.7 \
 # required for taskcluster
 slugid==1.0.7 --hash=sha256:6dab3c7eef0bb423fb54cb7752e0f466ddd0ee495b78b763be60e8a27f69e779
 
-graphene-django==2.0.0 \
-    --hash=sha256:5cabf46b59f242a533fe1df1912c87d5ad6606246937609be2e6c9086cfdf7a4 \
-    --hash=sha256:70d9358bc48c806b6a9458e8344f0a1211cd1f1ef923a092aa55e6bcacc2c3fc
+graphene-django==2.1.0 \
+    --hash=sha256:b336eecbf03e6fa12a53288d22015c7035727ffaa8fdd89c93fd41d9b942dd91 \
+    --hash=sha256:6abc3ec4f1dcbd91faeb3ce772b428e431807b8ec474f9dae918cff74bf7f6b1
 
 # Used by graphene-django
-graphene==2.1.2 \
-    --hash=sha256:8fd8e6195c56c15b2936e7dee2e156692eba4752ee1978f65e10925eafe8d014 \
-    --hash=sha256:98e74c32d0415e5b5362738c1c1cb4b7a4e411b5d3d828abb29ccd3efb378c44
-graphql-core==2.0 \
-    --hash=sha256:539355351343dede3ecb771e0d273a1b72405cb6d64f45bb8f92ecc4d7109af0 \
-    --hash=sha256:4830699be53f9154273fa15726fc8b0c90bc22bbb8fc7c932586503b3cb9330e
+graphene==2.1.3 \
+    --hash=sha256:faa26573b598b22ffd274e2fd7a4c52efa405dcca96e01a62239482246248aa3 \
+    --hash=sha256:b8ec446d17fa68721636eaad3d6adc1a378cb6323e219814c8f98c9928fc9642
+graphql-core==2.1 \
+    --hash=sha256:9462e22e32c7f03b667373ec0a84d95fba10e8ce2ead08f29fbddc63b671b0c1 \
+    --hash=sha256:889e869be5574d02af77baf1f30b5db9ca2959f1c9f5be7b2863ead5a3ec6181
 graphql-relay==0.4.5 --hash=sha256:2716b7245d97091af21abf096fabafac576905096d21ba7118fba722596f65db
 typing==3.6.4 \
     --hash=sha256:b2c689d54e1144bbcfd191b0832980a21c2dbcf7b5ff7a66248a60c90e951eb8 \

--- a/treeherder/webapp/graphql/schema.py
+++ b/treeherder/webapp/graphql/schema.py
@@ -5,8 +5,7 @@ from graphql.utils.ast_to_dict import ast_to_dict
 
 from treeherder.model import error_summary
 from treeherder.model.models import *
-from treeherder.webapp.graphql.helpers import (OptimizedFilterConnectionField,
-                                               optimize)
+from treeherder.webapp.graphql.helpers import optimize
 from treeherder.webapp.graphql.types import ObjectScalar
 
 
@@ -122,7 +121,7 @@ class PushGraph(DjangoObjectType):
         filter_fields = ('revision', )
         interfaces = (graphene.relay.Node, )
 
-    jobs = OptimizedFilterConnectionField(JobGraph)
+    jobs = DjangoFilterConnectionField(JobGraph)
 
     def resolve_jobs(self, info, **kwargs):
         field_map = {
@@ -142,7 +141,7 @@ class PushGraph(DjangoObjectType):
 
 
 class Query(graphene.ObjectType):
-    all_jobs = OptimizedFilterConnectionField(JobGraph)
+    all_jobs = DjangoFilterConnectionField(JobGraph)
     all_job_details = DjangoFilterConnectionField(JobDetailGraph)
     all_build_platforms = graphene.List(BuildPlatformGraph)
     all_machine_platforms = graphene.List(MachinePlatformGraph)


### PR DESCRIPTION
Travis was failing on the original pyup-bot PRs, since the updates need to all be made at once.

The `DjangoFilterConnectionField` workaround has been removed, since it should no longer required, as the new release includes:
https://github.com/graphql-python/graphene-django/pull/224

Release notes:
* https://github.com/graphql-python/graphql-core/releases/tag/v2.1.0
* https://github.com/graphql-python/graphene/releases/tag/v2.1.3
* https://github.com/graphql-python/graphene-django/releases/tag/v2.1rc0
* https://github.com/graphql-python/graphene-django/releases/tag/v2.1rc1
* https://github.com/graphql-python/graphene-django/releases/tag/v2.1.0

Closes #3806.
Closes #3807.
Closes #3808.