### PR TITLE
Bug 1466084 - Docs: Install recommonmark as an editable dependency

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -9,4 +9,7 @@ sphinx-rtd-theme==0.4.1
 # https://github.com/rtfd/recommonmark/issues/92
 # ...and we need the fix for:
 # https://github.com/rtfd/recommonmark/issues/51
-https://github.com/rtfd/recommonmark/archive/master.zip
+# Editable mode is required to force the latest version to be
+# installed, since Read The Docs doesn't use --upgrade and has an
+# older incompatible version of recommonmark pre-installed.
+-e git+git://github.com/rtfd/recommonmark.git#egg=recommonmark

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,9 @@ multi_line_output = 1
 force_grid_wrap = true
 line_length = 140
 known_first_party = tests
+# Required since we install recommonmark as an editable install from GitHub:
+# https://github.com/timothycrosley/isort/issues/386
+known_third_party = recommonmark
 
 [tool:pytest]
 testpaths = tests


### PR DESCRIPTION
Since Read The Docs has a pre-installed older version installed, and doesn't use `--upgrade` with pip, so we have to force the latest version to be installed by using "editable" (`-e`) mode:
https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support

This fixes the exception that occurred on Read the Docs (but wasn't seen on Travis, since it doesn't have the pre-installed older version):
https://readthedocs.org/projects/treeherder/builds/7564451/