### PR TITLE
Bug 1453760 - skip bug when bug metadata is not retrievable

### DIFF
--- a/tests/intermittents_commenter/test_commenter.py
+++ b/tests/intermittents_commenter/test_commenter.py
@@ -12,7 +12,6 @@ def test_intermittents_commenter(bug_data):
     alt_endday = endday
 
     process = Commenter(weekly_mode=True, dry_run=True)
-    comment_params = process.generate_bug_changes(startday, endday, alt_startday, alt_endday)
     url = process.create_url(bug_data['bug_id']) + '?include_fields={}'.format(TRIAGE_PARAMS['include_fields'])
 
     content = {
@@ -33,6 +32,11 @@ def test_intermittents_commenter(bug_data):
                     json=content,
                     match_querystring=True,
                     status=200))
+
+    resp = process.fetch_bug_details(TRIAGE_PARAMS, bug_data['bug_id'])
+    assert resp == content['bugs'][0]
+
+    comment_params = process.generate_bug_changes(startday, endday, alt_startday, alt_endday)
 
     with open('tests/intermittents_commenter/expected_comment.text', 'r') as comment:
         expected_comment = comment.read()

--- a/treeherder/intermittents_commenter/commenter.py
+++ b/treeherder/intermittents_commenter/commenter.py
@@ -70,6 +70,8 @@ class Commenter(object):
             # recommend disabling when more than 150 failures tracked over 21 days
             if alt_bug_stats[bug_id]['total'] >= 150:
                 bug_info, whiteboard = self.check_bug_info(bug_info, bug_id)
+                if bug_info is None:
+                    continue
 
                 if not self.check_whiteboard_status(whiteboard):
                     priority = 3
@@ -79,17 +81,26 @@ class Commenter(object):
                 priority = self.assign_priority(priority, counts)
                 if priority == 2:
                     bug_info, whiteboard = self.check_bug_info(bug_info, bug_id)
+                    if bug_info is None:
+                        continue
+
                     change_priority, whiteboard = self.check_needswork_owner(change_priority, bug_info, whiteboard)
 
                 # change [stockwell needswork] to [stockwell unknown] when failures drop below 20 failures/week
                 if (counts['total'] < 20):
                     bug_info, whiteboard = self.check_bug_info(bug_info, bug_id)
+                    if bug_info is None:
+                        continue
+
                     whiteboard = self.check_needswork(whiteboard)
 
                 if bug_id in top_bugs:
                     rank = top_bugs.index(bug_id)+1
             else:
                 bug_info, whiteboard = self.check_bug_info(bug_info, bug_id)
+                if bug_info is None:
+                    continue
+
                 change_priority, whiteboard = self.check_needswork_owner(change_priority, bug_info, whiteboard)
 
             comment = template.render(bug_id=bug_id,
@@ -109,7 +120,7 @@ class Commenter(object):
                               'comment': {'body': comment}
                             }
                            }
-            if whiteboard:
+            if whiteboard != bug_info['whiteboard']:
                 bug_changes['changes']['whiteboard'] = whiteboard
             if change_priority:
                 bug_changes['changes']['priority'] = change_priority

--- a/treeherder/intermittents_commenter/commenter.py
+++ b/treeherder/intermittents_commenter/commenter.py
@@ -70,6 +70,7 @@ class Commenter(object):
             # recommend disabling when more than 150 failures tracked over 21 days
             if alt_bug_stats[bug_id]['total'] >= 150:
                 bug_info, whiteboard = self.check_bug_info(bug_info, bug_id)
+                # if fetch_bug_details fails (called in check_bug_info), None is returned
                 if bug_info is None:
                     continue
 
@@ -81,6 +82,7 @@ class Commenter(object):
                 priority = self.assign_priority(priority, counts)
                 if priority == 2:
                     bug_info, whiteboard = self.check_bug_info(bug_info, bug_id)
+                    # if fetch_bug_details fails (called in check_bug_info), None is returned
                     if bug_info is None:
                         continue
 
@@ -89,6 +91,7 @@ class Commenter(object):
                 # change [stockwell needswork] to [stockwell unknown] when failures drop below 20 failures/week
                 if (counts['total'] < 20):
                     bug_info, whiteboard = self.check_bug_info(bug_info, bug_id)
+                    # if fetch_bug_details fails (called in check_bug_info), None is returned
                     if bug_info is None:
                         continue
 
@@ -98,6 +101,7 @@ class Commenter(object):
                     rank = top_bugs.index(bug_id)+1
             else:
                 bug_info, whiteboard = self.check_bug_info(bug_info, bug_id)
+                # if fetch_bug_details fails (called in check_bug_info), None is returned
                 if bug_info is None:
                     continue
 


### PR DESCRIPTION
without an env API key, certain bug metadata is not retrievable (401);
skip those bugs since too much logic is dependent on that data;
update bug_changes whiteboard only if the whiteboard has changed"