### PR TITLE
Wrap Pulse Config and Setup in a Service

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -548,9 +548,6 @@ PULSE_PUSH_SOURCES = env.json(
     }],
 )
 
-# Used for making API calls to Pulse Guardian, such as detecting bindings on
-# the current ingestion queue.
-PULSE_GUARDIAN_URL = "https://pulseguardian.mozilla.org/"
 
 # Used to specify the PulseGuardian account that will be used to create
 # ingestion queues for the exchanges specified in ``PULSE_DATA_INGESTION_SOURCES``.

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -507,17 +507,3 @@ PULSE_URI = env("PULSE_URI", default="amqps://guest:guest@pulse.mozilla.org/")
 # Note we will never publish any pulse messages unless the exchange namespace is
 # set this normally is your pulse username.
 PULSE_EXCHANGE_NAMESPACE = env("PULSE_EXCHANGE_NAMESPACE", default=None)
-
-PULSE_PUSH_SOURCES = env.json(
-    "PULSE_PUSH_SOURCES",
-    default=[{
-        "exchange": "exchange/taskcluster-github/v1/push",
-        "routing_keys": ['#'],
-    }, {
-        "exchange": "exchange/taskcluster-github/v1/pull-request",
-        "routing_keys": ['#'],
-    }, {
-        "exchange": "exchange/hgpushes/v1",
-        "routing_keys": ["#"]
-    }],
-)

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -547,10 +547,3 @@ PULSE_PUSH_SOURCES = env.json(
         "routing_keys": ["#"]
     }],
 )
-
-
-# Used to specify the PulseGuardian account that will be used to create
-# ingestion queues for the exchanges specified in ``PULSE_DATA_INGESTION_SOURCES``.
-# See https://pulse.mozilla.org/whats_pulse for more info.
-# Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/?ssl=1"
-PULSE_DATA_INGESTION_CONFIG = env.url("PULSE_DATA_INGESTION_CONFIG", default="")

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -557,12 +557,3 @@ PULSE_GUARDIAN_URL = "https://pulseguardian.mozilla.org/"
 # See https://pulse.mozilla.org/whats_pulse for more info.
 # Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/?ssl=1"
 PULSE_DATA_INGESTION_CONFIG = env.url("PULSE_DATA_INGESTION_CONFIG", default="")
-
-# Whether the Queues created for pulse ingestion are durable or not.
-# For local data ingestion, you probably should set this to False
-PULSE_DATA_INGESTION_QUEUES_DURABLE = True
-
-# Whether the Queues created for pulse ingestion auto-delete after connections
-# are closed.
-# For local data ingestion, you probably should set this to True
-PULSE_DATA_INGESTION_QUEUES_AUTO_DELETE = False

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -508,32 +508,6 @@ PULSE_URI = env("PULSE_URI", default="amqps://guest:guest@pulse.mozilla.org/")
 # set this normally is your pulse username.
 PULSE_EXCHANGE_NAMESPACE = env("PULSE_EXCHANGE_NAMESPACE", default=None)
 
-# Specifies the Pulse exchanges Treeherder will ingest data from.  This list
-# will be updated as new applications come online that Treeherder supports.
-# Treeherder will subscribe with routing keys that are all combinations of
-# ``project`` and ``destination`` in the form of:
-#     <destination>.<project>
-# Wildcards such as ``#`` and ``*`` are supported for either field.
-PULSE_DATA_INGESTION_SOURCES = env.json(
-    "PULSE_DATA_INGESTION_SOURCES",
-    default=[
-        {
-            "exchange": "exchange/taskcluster-treeherder/v1/jobs",
-            "projects": [
-                '#'
-                # some specific repos TC can ingest from
-                # 'mozilla-central.#',
-                # 'mozilla-inbound.#'
-            ],
-            "destinations": [
-                '#'
-                # 'production',
-                # 'staging'
-            ]
-        }
-        # ... other CI systems
-    ])
-
 PULSE_PUSH_SOURCES = env.json(
     "PULSE_PUSH_SOURCES",
     default=[{

--- a/treeherder/etl/management/commands/read_pulse_jobs.py
+++ b/treeherder/etl/management/commands/read_pulse_jobs.py
@@ -1,9 +1,9 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand
-from kombu import Exchange
 
 from treeherder.services.pulse import (JobConsumer,
+                                       get_exchange,
                                        pulse_conn)
 
 
@@ -27,13 +27,7 @@ class Command(BaseCommand):
             consumer = JobConsumer(connection, "jobs")
 
             for source in sources:
-                # When creating this exchange object, it is important that it
-                # be set to ``passive=True``.  This will prevent any attempt by
-                # Kombu to actually create the exchange.
-                exchange = Exchange(source["exchange"], type="topic",
-                                    passive=True)
-                # ensure the exchange exists.  Throw an error if it doesn't
-                exchange(connection).declare()
+                exchange = get_exchange(connection, source["exchange"])
 
                 for project in source["projects"]:
                     for destination in source['destinations']:

--- a/treeherder/etl/management/commands/read_pulse_jobs.py
+++ b/treeherder/etl/management/commands/read_pulse_jobs.py
@@ -3,8 +3,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand
 from kombu import Exchange
 
-from treeherder.etl.pulse_consumer import JobConsumer
-from treeherder.services.pulse import pulse_conn
+from treeherder.services.pulse import (JobConsumer,
+                                       pulse_conn)
 
 
 class Command(BaseCommand):

--- a/treeherder/etl/management/commands/read_pulse_jobs.py
+++ b/treeherder/etl/management/commands/read_pulse_jobs.py
@@ -1,9 +1,8 @@
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand
 
 from treeherder.services.pulse import (JobConsumer,
                                        get_exchange,
+                                       job_sources,
                                        pulse_conn)
 
 
@@ -17,16 +16,12 @@ class Command(BaseCommand):
     help = "Read jobs from a set of pulse exchanges and queue for ingestion"
 
     def handle(self, *args, **options):
-        sources = settings.PULSE_DATA_INGESTION_SOURCES
-        if not sources:
-            raise ImproperlyConfigured("PULSE_DATA_INGESTION_SOURCES must be set")
-
         new_bindings = []
 
         with pulse_conn as connection:
             consumer = JobConsumer(connection, "jobs")
 
-            for source in sources:
+            for source in job_sources:
                 exchange = get_exchange(connection, source["exchange"])
 
                 for project in source["projects"]:

--- a/treeherder/etl/management/commands/read_pulse_pushes.py
+++ b/treeherder/etl/management/commands/read_pulse_pushes.py
@@ -1,10 +1,9 @@
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand
 
 from treeherder.services.pulse import (PushConsumer,
                                        get_exchange,
-                                       pulse_conn)
+                                       pulse_conn,
+                                       push_sources)
 
 
 class Command(BaseCommand):
@@ -17,16 +16,12 @@ class Command(BaseCommand):
     help = "Read pushes from a set of pulse exchanges and queue for ingestion"
 
     def handle(self, *args, **options):
-        sources = settings.PULSE_PUSH_SOURCES
-        if not sources:
-            raise ImproperlyConfigured("PULSE_DATA_INGESTION_SOURCES must be set")
-
         new_bindings = []
 
         with pulse_conn as connection:
             consumer = PushConsumer(connection, "resultsets")
 
-            for source in sources:
+            for source in push_sources:
                 exchange = get_exchange(connection, source["exchange"])
 
                 for routing_key in source["routing_keys"]:

--- a/treeherder/etl/management/commands/read_pulse_pushes.py
+++ b/treeherder/etl/management/commands/read_pulse_pushes.py
@@ -1,9 +1,9 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand
-from kombu import Exchange
 
 from treeherder.services.pulse import (PushConsumer,
+                                       get_exchange,
                                        pulse_conn)
 
 
@@ -27,13 +27,7 @@ class Command(BaseCommand):
             consumer = PushConsumer(connection, "resultsets")
 
             for source in sources:
-                # When creating this exchange object, it is important that it
-                # be set to ``passive=True``.  This will prevent any attempt by
-                # Kombu to actually create the exchange.
-                exchange = Exchange(source["exchange"], type="topic",
-                                    passive=True)
-                # ensure the exchange exists.  Throw an error if it doesn't
-                exchange(connection).declare()
+                exchange = get_exchange(connection, source["exchange"])
 
                 for routing_key in source["routing_keys"]:
                     consumer.bind_to(exchange, routing_key)

--- a/treeherder/etl/management/commands/read_pulse_pushes.py
+++ b/treeherder/etl/management/commands/read_pulse_pushes.py
@@ -3,8 +3,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand
 from kombu import Exchange
 
-from treeherder.etl.pulse_consumer import PushConsumer
-from treeherder.services.pulse import pulse_conn
+from treeherder.services.pulse import (PushConsumer,
+                                       pulse_conn)
 
 
 class Command(BaseCommand):

--- a/treeherder/etl/pulse_consumer.py
+++ b/treeherder/etl/pulse_consumer.py
@@ -38,8 +38,8 @@ class PulseConsumer(ConsumerMixin):
                 channel=self.connection.channel(),
                 exchange=exchange,
                 routing_key=routing_key,
-                durable=settings.PULSE_DATA_INGESTION_QUEUES_DURABLE,
-                auto_delete=settings.PULSE_DATA_INGESTION_QUEUES_AUTO_DELETE
+                durable=True,
+                auto_delete=False,
             )
             self.consumers.append(dict(queues=self.queue,
                                        callbacks=[self.on_message]))

--- a/treeherder/etl/pulse_consumer.py
+++ b/treeherder/etl/pulse_consumer.py
@@ -12,6 +12,11 @@ from treeherder.etl.tasks.pulse_tasks import (store_pulse_jobs,
 logger = logging.getLogger(__name__)
 
 
+# Used for making API calls to Pulse Guardian, such as detecting bindings on
+# the current ingestion queue.
+PULSE_GUARDIAN_URL = "https://pulseguardian.mozilla.org/"
+
+
 class PulseConsumer(ConsumerMixin):
     """
     Consume jobs from Pulse exchanges
@@ -83,8 +88,7 @@ class PulseConsumer(ConsumerMixin):
 
     def get_bindings(self, queue_name):
         """Get list of bindings from the pulse API"""
-        return fetch_json("{}queue/{}/bindings".format(
-            settings.PULSE_GUARDIAN_URL, queue_name))
+        return fetch_json("{}queue/{}/bindings".format(PULSE_GUARDIAN_URL, queue_name))
 
 
 class JobConsumer(PulseConsumer):

--- a/treeherder/services/pulse/__init__.py
+++ b/treeherder/services/pulse/__init__.py
@@ -1,5 +1,9 @@
 from .connection import pulse_conn
+from .consumers import (JobConsumer,
+                        PushConsumer)
 
 __all__ = [
+    "JobConsumer",
+    "PushConsumer",
     "pulse_conn",
 ]

--- a/treeherder/services/pulse/__init__.py
+++ b/treeherder/services/pulse/__init__.py
@@ -1,0 +1,5 @@
+from .connection import pulse_conn
+
+__all__ = [
+    "pulse_conn",
+]

--- a/treeherder/services/pulse/__init__.py
+++ b/treeherder/services/pulse/__init__.py
@@ -2,7 +2,8 @@ from .connection import pulse_conn
 from .consumers import (JobConsumer,
                         PushConsumer)
 from .exchange import get_exchange
-from .sources import job_sources
+from .sources import (job_sources,
+                      push_sources)
 
 __all__ = [
     "JobConsumer",
@@ -10,4 +11,5 @@ __all__ = [
     "get_exchange",
     "job_sources",
     "pulse_conn",
+    "push_sources",
 ]

--- a/treeherder/services/pulse/__init__.py
+++ b/treeherder/services/pulse/__init__.py
@@ -1,9 +1,11 @@
 from .connection import pulse_conn
 from .consumers import (JobConsumer,
                         PushConsumer)
+from .exchange import get_exchange
 
 __all__ = [
     "JobConsumer",
     "PushConsumer",
+    "get_exchange",
     "pulse_conn",
 ]

--- a/treeherder/services/pulse/__init__.py
+++ b/treeherder/services/pulse/__init__.py
@@ -2,10 +2,12 @@ from .connection import pulse_conn
 from .consumers import (JobConsumer,
                         PushConsumer)
 from .exchange import get_exchange
+from .sources import job_sources
 
 __all__ = [
     "JobConsumer",
     "PushConsumer",
     "get_exchange",
+    "job_sources",
     "pulse_conn",
 ]

--- a/treeherder/services/pulse/connection.py
+++ b/treeherder/services/pulse/connection.py
@@ -1,8 +1,14 @@
-from django.conf import settings
+import environ
 from django.core.exceptions import ImproperlyConfigured
 from kombu import Connection
 
-config = settings.PULSE_DATA_INGESTION_CONFIG
+env = environ.Env()
+
+# Used to specify the PulseGuardian account that will be used to create
+# ingestion queues for the exchanges specified in ``PULSE_DATA_INGESTION_SOURCES``.
+# See https://pulse.mozilla.org/whats_pulse for more info.
+# Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/?ssl=1"
+config = env.url("PULSE_DATA_INGESTION_CONFIG", default="")
 if not config:
     raise ImproperlyConfigured("PULSE_DATA_INGESTION_CONFIG must be set")
 

--- a/treeherder/services/pulse/connection.py
+++ b/treeherder/services/pulse/connection.py
@@ -1,5 +1,4 @@
 import environ
-from django.core.exceptions import ImproperlyConfigured
 from kombu import Connection
 
 env = environ.Env()
@@ -8,9 +7,7 @@ env = environ.Env()
 # ingestion queues for the exchanges specified in ``PULSE_DATA_INGESTION_SOURCES``.
 # See https://pulse.mozilla.org/whats_pulse for more info.
 # Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/?ssl=1"
-config = env.url("PULSE_DATA_INGESTION_CONFIG", default="")
-if not config:
-    raise ImproperlyConfigured("PULSE_DATA_INGESTION_CONFIG must be set")
+config = env.url("PULSE_DATA_INGESTION_CONFIG")
 
 
 def build_connection(url):

--- a/treeherder/services/pulse/connection.py
+++ b/treeherder/services/pulse/connection.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from kombu import Connection
+
+config = settings.PULSE_DATA_INGESTION_CONFIG
+if not config:
+    raise ImproperlyConfigured("PULSE_DATA_INGESTION_CONFIG must be set")
+
+
+def build_connection(url):
+    """
+    Build a Kombu Broker connection with the given url
+    """
+    return Connection(url)
+
+
+pulse_conn = build_connection(config.geturl())

--- a/treeherder/services/pulse/consumers.py
+++ b/treeherder/services/pulse/consumers.py
@@ -25,6 +25,7 @@ class PulseConsumer(ConsumerMixin):
         self.connection = connection
         self.consumers = []
         self.queue = None
+        # TODO: use connection.userid here?
         config = settings.PULSE_DATA_INGESTION_CONFIG
         if not config:
             raise ValueError("PULSE_DATA_INGESTION_CONFIG is required for the "

--- a/treeherder/services/pulse/consumers.py
+++ b/treeherder/services/pulse/consumers.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.conf import settings
 from kombu import (Exchange,
                    Queue)
 from kombu.mixins import ConsumerMixin
@@ -25,12 +24,7 @@ class PulseConsumer(ConsumerMixin):
         self.connection = connection
         self.consumers = []
         self.queue = None
-        # TODO: use connection.userid here?
-        config = settings.PULSE_DATA_INGESTION_CONFIG
-        if not config:
-            raise ValueError("PULSE_DATA_INGESTION_CONFIG is required for the "
-                             "JobConsumer class.")
-        self.queue_name = "queue/{}/{}".format(config.username, queue_suffix)
+        self.queue_name = "queue/{}/{}".format(connection.userid, queue_suffix)
 
     def get_consumers(self, Consumer, channel):
         return [

--- a/treeherder/services/pulse/exchange.py
+++ b/treeherder/services/pulse/exchange.py
@@ -1,0 +1,14 @@
+from kombu import Exchange
+
+
+def get_exchange(connection, name):
+    """Get a Kombu Exchange object using the passed in name."""
+    # When creating this exchange object, it is important that it be set to
+    # ``passive=True``.  This will prevent any attempt by Kombu to actually
+    # create the exchange.
+    exchange = Exchange(name, type="topic", passive=True)
+
+    # ensure the exchange exists.  Throw an error if it doesn't
+    exchange(connection).declare()
+
+    return exchange

--- a/treeherder/services/pulse/sources.py
+++ b/treeherder/services/pulse/sources.py
@@ -1,0 +1,41 @@
+import environ
+
+env = environ.Env()
+
+
+def get_job_sources():
+    """
+    Get Job ingestion source locations.
+
+    Specifies the Pulse exchanges Treeherder will ingest data from for Job
+    data.  This list will be updated as new applications come online that
+    Treeherder supports. Treeherder will subscribe with routing keys that are
+    all combinations of ``project`` and ``destination`` in the form of:
+    <destination>.<project> Wildcards such as ``#`` and ``*`` are supported for
+    either field.
+    """
+    sources = env.json(
+        "PULSE_DATA_INGESTION_SOURCES",
+        default=[
+            {
+                "exchange": "exchange/taskcluster-treeherder/v1/jobs",
+                "projects": [
+                    '#'
+                    # some specific repos TC can ingest from
+                    # 'mozilla-central.#',
+                    # 'mozilla-inbound.#'
+                ],
+                "destinations": [
+                    '#'
+                    # 'production',
+                    # 'staging'
+                ],
+            },
+            # ... other CI systems
+        ],
+    )
+
+    return sources
+
+
+job_sources = get_job_sources()

--- a/treeherder/services/pulse/sources.py
+++ b/treeherder/services/pulse/sources.py
@@ -38,4 +38,29 @@ def get_job_sources():
     return sources
 
 
+def get_push_sources():
+    """
+    Get Push ingestion source locations.
+
+    Specifies the Pulse exchanges Treeherder will ingest data from for Push
+    data.
+    """
+    sources = env.json(
+        "PULSE_PUSH_SOURCES",
+        default=[{
+            "exchange": "exchange/taskcluster-github/v1/push",
+            "routing_keys": ['#'],
+        }, {
+            "exchange": "exchange/taskcluster-github/v1/pull-request",
+            "routing_keys": ['#'],
+        }, {
+            "exchange": "exchange/hgpushes/v1",
+            "routing_keys": ["#"]
+        }],
+    )
+
+    return sources
+
+
 job_sources = get_job_sources()
+push_sources = get_push_sources()


### PR DESCRIPTION
This moves all Pulse configuration into a "service".  Like Elasticsearch this is a way to abstract and hide the lower level parts of configuring a Pulse connection and one/many consumers of it behind a [hopefully!] intuitive API.  It pulls all the settings for reading Pulse queues out of the global settings but leaves the write settings as I'm under the impression that these are going away soon[ish].

I considered further refactoring the two scripts (`read_pulse_pushes` and `read_pulse_jobs`) since they're so similar but I think that would require changing how the `PulseConsumer` class works and I didn't want to go for an even deeper dive!