### PR TITLE
Bug 1479973 - Fix issues with login and using custom actions

### DIFF
--- a/ui/job-view/JobView.jsx
+++ b/ui/job-view/JobView.jsx
@@ -58,7 +58,6 @@ class JobView extends React.Component {
   componentDidMount() {
     this.toggleFieldFilterVisible = this.toggleFieldFilterVisible.bind(this);
     this.updateDimensions = this.updateDimensions.bind(this);
-    this.setUser = this.setUser.bind(this);
     this.pinJobs = this.pinJobs.bind(this);
 
     window.addEventListener('resize', this.updateDimensions);
@@ -165,6 +164,12 @@ class JobView extends React.Component {
       user, isFieldFilterVisible, filterBarFilters, serverChangedDelayed,
       defaultPushListPct, defaultDetailsHeight, latestSplitPct, serverChanged,
     } = this.state;
+    // TODO: Move this to the constructor.  We are hitting some issues where
+    // this function is not yet bound, so we are not getting logged in, even
+    // when the user IS logged in.  Placing this here ensures the we can't
+    // render when this function is not bound.
+    // See Bug 1480166
+    this.setUser = this.setUser.bind(this);
     // SplitPane will adjust the CSS height of the top component, but not the
     // bottom component.  So the scrollbars won't work in the DetailsPanel when
     // we resize.  Therefore, we must calculate the new

--- a/ui/job-view/PushActionMenu.jsx
+++ b/ui/job-view/PushActionMenu.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { getUrlParam } from '../helpers/location';
 import { formatModelError, formatTaskclusterError } from '../helpers/errorMessage';
 import { thEvents } from '../js/constants';
+import tcJobActionsTemplate from '../partials/main/tcjobactions.html';
 
 export default class PushActionMenu extends React.PureComponent {
 
@@ -14,15 +15,7 @@ export default class PushActionMenu extends React.PureComponent {
     this.thNotify = $injector.get('thNotify');
     this.ThResultSetStore = $injector.get('ThResultSetStore');
     this.ThResultSetModel = $injector.get('ThResultSetModel');
-
-    // customPushActions uses $uibModal which doesn't work well in the
-    // unit tests.  So if we fail to inject here, that's OK.
-    // Bug 1437736
-    try {
-      this.customPushActions = $injector.get('customPushActions');
-    } catch (ex) {
-      this.customPushActions = {};
-    }
+    this.$uibModal = $injector.get('$uibModal');
 
     this.revision = this.props.revision;
     this.pushId = this.props.pushId;
@@ -106,8 +99,24 @@ export default class PushActionMenu extends React.PureComponent {
       });
   }
 
+  customJobAction() {
+    const { repoName, pushId, isLoggedIn } = this.props;
+
+    this.$uibModal.open({
+      template: tcJobActionsTemplate,
+      controller: 'TCJobActionsCtrl',
+      size: 'lg',
+      resolve: {
+        job: () => null,
+        repoName: () => repoName,
+        resultsetId: () => pushId,
+        isLoggedIn: () => isLoggedIn,
+      },
+    });
+  }
+
   render() {
-    const { isLoggedIn, isStaff, repoName, revision, pushId, runnableVisible,
+    const { isLoggedIn, isStaff, repoName, revision, runnableVisible,
             hideRunnableJobsCb, showRunnableJobsCb } = this.props;
     const { topOfRangeUrl, bottomOfRangeUrl } = this.state;
 
@@ -165,7 +174,7 @@ export default class PushActionMenu extends React.PureComponent {
           >Mark with Bugherder</a></li>
           <li
             className="dropdown-item"
-            onClick={() => this.customPushActions.open(repoName, pushId)}
+            onClick={() => this.customJobAction()}
             title="View/Edit/Submit Action tasks for this push"
           >Custom Push Action...</li>
           <li><a

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -271,7 +271,7 @@ export default class ActionBar extends React.Component {
   }
 
   customJobAction() {
-    const { repoName, selectedJob } = this.props;
+    const { repoName, selectedJob, user } = this.props;
 
     this.$uibModal.open({
       template: tcJobActionsTemplate,
@@ -281,6 +281,7 @@ export default class ActionBar extends React.Component {
         job: () => selectedJob,
         repoName: () => repoName,
         resultsetId: () => selectedJob.result_set_id,
+        isLoggedIn: () => user.isLoggedIn,
       },
     });
   }

--- a/ui/js/controllers/tcjobactions.js
+++ b/ui/js/controllers/tcjobactions.js
@@ -7,9 +7,9 @@ import treeherder from '../treeherder';
 import { formatTaskclusterError } from '../../helpers/errorMessage';
 
 treeherder.controller('TCJobActionsCtrl', [
-    '$scope', '$uibModalInstance', 'ThResultSetStore',
+    '$scope', '$uibModalInstance', 'ThResultSetStore', 'isLoggedIn',
     'thNotify', 'job', 'repoName', 'resultsetId', 'tcactions',
-    function ($scope, $uibModalInstance, ThResultSetStore,
+    function ($scope, $uibModalInstance, ThResultSetStore, isLoggedIn,
              thNotify,
              job, repoName, resultsetId, tcactions) {
         const ajv = new Ajv({ format: 'full', verbose: true, allErrors: true });
@@ -18,6 +18,7 @@ treeherder.controller('TCJobActionsCtrl', [
         let originalTask;
         let validate;
         $scope.input = {};
+        $scope.isLoggedIn = isLoggedIn;
 
         $scope.cancel = function () {
             $uibModalInstance.dismiss('cancel');

--- a/ui/js/services/main.js
+++ b/ui/js/services/main.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 
 import treeherder from '../treeherder';
-import tcJobActionsTemplate from '../../partials/main/tcjobactions.html';
 import { thPlatformMap } from '../constants';
 
 
@@ -104,29 +103,3 @@ treeherder.factory('thPlatformName', () => (name) => {
     }
     return platformName;
 });
-
-// The Custom Actions modal is accessible from both the PushActionMenu and the
-// job-details-actionbar.  So leave this as Angular for now, till we
-// migrate job-details-actionbar to React.
-treeherder.factory('customPushActions', [
-    '$uibModal',
-    function ($uibModal) {
-        return {
-          open(repoName, pushId) {
-            $uibModal.open({
-              template: tcJobActionsTemplate,
-              controller: 'TCJobActionsCtrl',
-              size: 'lg',
-              resolve: {
-                job: () => null,
-                repoName: function () {
-                  return repoName;
-                },
-                resultsetId: function () {
-                  return pushId;
-                },
-              },
-            });
-          },
-        };
-    }]);

--- a/ui/partials/main/tcjobactions.html
+++ b/ui/partials/main/tcjobactions.html
@@ -27,10 +27,10 @@
   </div>
 </div>
 <div class="modal-footer">
-  <button ng-if="user.isLoggedIn" class="btn btn-primary-soft" ng-click="triggerAction()" ng-attr-title="{{user.isLoggedIn ? 'Trigger this action' : 'Not logged in'}}" ng-disabled="triggering">
+  <button ng-if="isLoggedIn" class="btn btn-primary-soft" ng-click="triggerAction()" ng-attr-title="{{isLoggedIn ? 'Trigger this action' : 'Not logged in'}}" ng-disabled="triggering">
     <span class="fa fa-check-square-o" aria-hidden="true"></span>
     <span ng-if="triggering">Triggering</span>
     <span ng-if="!triggering">Trigger</span>
   </button>
-  <p ng-if="!user.isLoggedIn" class="help-block">Custom actions require login</p>
+  <p ng-if="!isLoggedIn" class="help-block">Custom actions require login</p>
 </div>


### PR DESCRIPTION
The ``PushActionBar`` was mistakenly still using the AngularJS service for Custom Actions.  But the bigger problem was that the Custom Actions dialog was still relying on ``$rootScope`` to get the logged in ``user``.  When I converted the ``PrimaryNavBar`` to React, along with the login, I moved the storage of ``user`` into the ``state`` of ``JobView`` and removed it from ``$rootScope``.  So I had should have then been passing ``isLoggedIn`` into the Custom Actions dialog, but I didn't.  This corrects it.

Not using that Angular service for Custom Actions will now also fix [Bug 1437736](https://bugzilla.mozilla.org/show_bug.cgi?id=1437736).

I also moved the ``bind`` of ``user`` into the ``render`` function of ``JobView``.  To be honest, I'm not clear why this would be necessary, but it seems to have cleared up the login problem.  I opened  [Bug 1480166](https://bugzilla.mozilla.org/show_bug.cgi?id=1480166) to move the ``bind`` calls to the constructors when we're pure ReactJS.  This feels a bit hacky, but it seems to be working better and is trivial to fix later.  I hope that's ok.  :)

Testing
------
I asked apavel|sheriffduty for his help testing this on prototype.  He said it worked well for him.