### PR TITLE
Bug 1480009 - Fix add new jobs not showing

### DIFF
--- a/ui/js/services/jobfilters.js
+++ b/ui/js/services/jobfilters.js
@@ -234,11 +234,13 @@ treeherder.factory('thJobFilters', [
 
         function _checkFieldFilters(job) {
           return Object.entries(cachedFieldFilters).every(([field, values]) => {
-            const jobFieldValue = String(_getJobFieldValue(job, field)).toLowerCase();
+            let jobFieldValue = _getJobFieldValue(job, field);
 
+            // If ``job`` does not have this field, then don't filter.
+            // Consider it a pass.  i.e.: runnable jobs have no ``tier`` field.
             if (jobFieldValue) {
-              // if a filter is added somehow, but the job object doesn't
-              // have that field, then don't filter.  Consider it a pass.
+              // All filter values are stored as lower case strings
+              jobFieldValue = String(jobFieldValue).toLowerCase();
 
               switch (FIELD_CHOICES[field].matchType) {
 


### PR DESCRIPTION
"Add new jobs" adds a set of "runnable" jobs to the push.  These job objects have no field ``tier``.  If we are filtering by a field (``tier`` is a special field filter that we always filter against) that is not in the ``job`` object, we should consider it a pass and show the job.

When I cast ``jobFieldValue`` to a String and did ``toLowerCase``, it would take a result of ``undefined`` and make it into a ``String`` "undefined".  When I then checked ``if(jobFieldValue)`` then it came back true, because the string was valid.  Then when we compared the showing ``tier``s of ``[1, 2]`` to "undefined", it didn't find it and was told not to show the job.  Oops.

So this defers the ``toLowerCase`` till after I've checked if it's ``undefined``.  
