### PR TITLE
Bug 1453760 - Intermittent commenter daily celery task fix

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -397,17 +397,17 @@ CELERYBEAT_SCHEDULE = {
         }
     },
     'daily-intermittents-commenter': {
-        # Executes every morning at 7 a.m. UTC
+        # Executes every morning at 7 a.m. UTC except sunday
         'task': 'intermittents-commenter',
-        'schedule': crontab(minute=0, hour=7),
+        'schedule': crontab(minute=0, hour=7, day_of_week='monday-saturday'),
         'options': {
             'queue': 'intermittents_commenter'
         },
     },
     'weekly-intermittents-commenter': {
-        # Executes every sunday morning at 8 a.m. UTC
+        # Executes every sunday morning at 7 a.m. UTC
         'task': 'intermittents-commenter',
-        'schedule': crontab(minute=0, hour=8, day_of_week='sunday'),
+        'schedule': crontab(minute=0, hour=7, day_of_week='sunday'),
         'kwargs': {'weekly_mode': True},
         'options': {
             'queue': 'intermittents_commenter'


### PR DESCRIPTION
Adjust the daily celery task to reflect what's in the OrangeFactor crontab:
daily runs every day except the day the weekly task runs. (previous research
showed me otherwise, but we should probably go with what the crontab has).