### PR TITLE
Bug 1281821 - Consolidate PULSE_* Settings

### DIFF
--- a/docs/pulseload.md
+++ b/docs/pulseload.md
@@ -14,7 +14,7 @@ The Simple Case
 If you just want to get the same data that Treeherder gets, then you have 3 steps:
 
   1. Create a user on [Pulse Guardian] if you don't already have one
-  2. Create your ``PULSE_URI`` string
+  2. Create your ``PULSE_URL`` string
   3. Open a Vagrant terminal to read Pushes
   4. Open a Vagrant terminal to read Jobs
   5. Open a Vagrant terminal to run **Celery**
@@ -34,7 +34,7 @@ If your **Pulse User** was username: ``foo`` and password: ``bar``, your config
 string would be:
 
 ```bash
-PULSE_URI="amqp://foo:bar@pulse.mozilla.org:5671/?ssl=1"
+PULSE_URL="amqp://foo:bar@pulse.mozilla.org:5671/?ssl=1"
 ```
 
 
@@ -47,7 +47,7 @@ PULSE_URI="amqp://foo:bar@pulse.mozilla.org:5671/?ssl=1"
 ``ssh`` into Vagrant, then set your config environment variable:
 
 ```bash
-export PULSE_URI="amqp://foo:bar@pulse.mozilla.org:5671/?ssl=1"
+export PULSE_URL="amqp://foo:bar@pulse.mozilla.org:5671/?ssl=1"
 ```
 
 Next, run the Treeherder management command to read Pushes from the default **Pulse**
@@ -65,7 +65,7 @@ ingested in step 5.
 
 ### 4. Read Jobs
 
-As in step 3, open a Vagrant terminal and export your ``PULSE_URI``
+As in step 3, open a Vagrant terminal and export your ``PULSE_URL``
 variable.  Then run the following management command:
 
 ```bash

--- a/docs/pulseload.md
+++ b/docs/pulseload.md
@@ -14,7 +14,7 @@ The Simple Case
 If you just want to get the same data that Treeherder gets, then you have 3 steps:
 
   1. Create a user on [Pulse Guardian] if you don't already have one
-  2. Create your ``PULSE_DATA_INGESTION_CONFIG`` string
+  2. Create your ``PULSE_URI`` string
   3. Open a Vagrant terminal to read Pushes
   4. Open a Vagrant terminal to read Jobs
   5. Open a Vagrant terminal to run **Celery**
@@ -34,7 +34,7 @@ If your **Pulse User** was username: ``foo`` and password: ``bar``, your config
 string would be:
 
 ```bash
-PULSE_DATA_INGESTION_CONFIG="amqp://foo:bar@pulse.mozilla.org:5671/?ssl=1"
+PULSE_URI="amqp://foo:bar@pulse.mozilla.org:5671/?ssl=1"
 ```
 
 
@@ -47,7 +47,7 @@ PULSE_DATA_INGESTION_CONFIG="amqp://foo:bar@pulse.mozilla.org:5671/?ssl=1"
 ``ssh`` into Vagrant, then set your config environment variable:
 
 ```bash
-export PULSE_DATA_INGESTION_CONFIG="amqp://foo:bar@pulse.mozilla.org:5671/?ssl=1"
+export PULSE_URI="amqp://foo:bar@pulse.mozilla.org:5671/?ssl=1"
 ```
 
 Next, run the Treeherder management command to read Pushes from the default **Pulse**
@@ -65,7 +65,7 @@ ingested in step 5.
 
 ### 4. Read Jobs
 
-As in step 3, open a Vagrant terminal and export your ``PULSE_DATA_INGESTION_CONFIG``
+As in step 3, open a Vagrant terminal and export your ``PULSE_URI``
 variable.  Then run the following management command:
 
 ```bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -346,7 +346,7 @@ def pulse_consumer(exchange, request):
         exchange
     )
 
-    connection = kombu.Connection(settings.PULSE_URI)
+    connection = kombu.Connection(settings.PULSE_URL)
 
     exchange = kombu.Exchange(
         name=exchange_name,

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,7 +10,7 @@ CELERY_ALWAYS_EAGER = True
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 
 # Reconfigure pulse to operate on default vhost of rabbitmq
-PULSE_URI = BROKER_URL
+PULSE_URL = BROKER_URL
 PULSE_EXCHANGE_NAMESPACE = 'test'
 
 # Set a fake api key for testing bug filing

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -494,8 +494,8 @@ PERFHERDER_ALERTS_FORE_WINDOW = 12
 PERFHERDER_ALERTS_MAX_AGE = timedelta(weeks=2)
 
 # Pulse
-# The pulse uri that is passed to kombu
-PULSE_URI = env("PULSE_URI", default="amqps://guest:guest@pulse.mozilla.org/")
+# The pulse url that is passed to kombu
+PULSE_URL = env("PULSE_URL", default="amqps://guest:guest@pulse.mozilla.org/")
 
 # Note we will never publish any pulse messages unless the exchange namespace is
 # set this normally is your pulse username.

--- a/treeherder/model/tasks.py
+++ b/treeherder/model/tasks.py
@@ -32,7 +32,7 @@ class LazyPublisher(object):
         if not self.publisher and settings.PULSE_EXCHANGE_NAMESPACE:
             self.publisher = TreeherderPublisher(
                 namespace=settings.PULSE_EXCHANGE_NAMESPACE,
-                uri=settings.PULSE_URI,
+                uri=settings.PULSE_URL,
                 schemas=PULSE_SCHEMAS
             )
 

--- a/treeherder/services/pulse/connection.py
+++ b/treeherder/services/pulse/connection.py
@@ -7,7 +7,7 @@ env = environ.Env()
 # ingestion queues for the exchanges specified in ``PULSE_DATA_INGESTION_SOURCES``.
 # See https://pulse.mozilla.org/whats_pulse for more info.
 # Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/?ssl=1"
-config = env.url("PULSE_DATA_INGESTION_CONFIG")
+config = env.url("PULSE_URI")
 
 
 def build_connection(url):

--- a/treeherder/services/pulse/connection.py
+++ b/treeherder/services/pulse/connection.py
@@ -4,16 +4,14 @@ from kombu import Connection
 env = environ.Env()
 
 # Used to specify the PulseGuardian account that will be used to create
-# ingestion queues for the exchanges specified in ``PULSE_DATA_INGESTION_SOURCES``.
+# ingestion queues for the exchanges specified in ``PULSE_SOURCE_EXCHANGES``.
 # See https://pulse.mozilla.org/whats_pulse for more info.
 # Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/?ssl=1"
 config = env.url("PULSE_URL")
 
 
 def build_connection(url):
-    """
-    Build a Kombu Broker connection with the given url
-    """
+    """Build a Kombu Broker connection to Mozilla Pulse with the given url."""
     return Connection(url)
 
 

--- a/treeherder/services/pulse/connection.py
+++ b/treeherder/services/pulse/connection.py
@@ -7,7 +7,7 @@ env = environ.Env()
 # ingestion queues for the exchanges specified in ``PULSE_DATA_INGESTION_SOURCES``.
 # See https://pulse.mozilla.org/whats_pulse for more info.
 # Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/?ssl=1"
-config = env.url("PULSE_URI")
+config = env.url("PULSE_URL")
 
 
 def build_connection(url):

--- a/treeherder/services/pulse/sources.py
+++ b/treeherder/services/pulse/sources.py
@@ -3,6 +3,25 @@ import environ
 env = environ.Env()
 
 
+exchanges = env.list("PULSE_JOB_EXCHANGES", default=[
+    "exchange/taskcluster-treeherder/v1/jobs",
+    # "exchange/fxtesteng/jobs",
+    # ... other CI systems
+])
+projects = env.list("PULSE_JOB_PROJECTS", default=[
+    "#",
+    # some specific repos TC can ingest from
+    # "mozilla-central.#",
+    # "mozilla-inbound.#",
+])
+destinations = env.list("PULSE_JOB_DESTINATIONS", default=[
+    "#",
+    # "production",
+    # "staging",
+    # "tc-treeherder",
+])
+
+
 def get_job_sources():
     """
     Get Job ingestion source locations.
@@ -14,28 +33,12 @@ def get_job_sources():
     <destination>.<project> Wildcards such as ``#`` and ``*`` are supported for
     either field.
     """
-    sources = env.json(
-        "PULSE_DATA_INGESTION_SOURCES",
-        default=[
-            {
-                "exchange": "exchange/taskcluster-treeherder/v1/jobs",
-                "projects": [
-                    '#'
-                    # some specific repos TC can ingest from
-                    # 'mozilla-central.#',
-                    # 'mozilla-inbound.#'
-                ],
-                "destinations": [
-                    '#'
-                    # 'production',
-                    # 'staging'
-                ],
-            },
-            # ... other CI systems
-        ],
-    )
-
-    return sources
+    for exchange in exchanges:
+        yield {
+            "exchange": exchange,
+            "projects": projects,
+            "destinations": destinations,
+        }
 
 
 def get_push_sources():
@@ -62,5 +65,5 @@ def get_push_sources():
     return sources
 
 
-job_sources = get_job_sources()
+job_sources = list(get_job_sources())
 push_sources = get_push_sources()


### PR DESCRIPTION
This removes the ingestion specific Pulse URL (`PULSE_DATA_INGESTION_CONFIG`) in favour of `PULSE_URL`, removes the unused `PULSE_PUSH_SOURCES` setting, and splits the ingestion sources setting `PULSE_DATA_INGESTION_SOURCES` into three distinct ones.