### PR TITLE
Bug 1453760 - fix commenter update_whiteboard

### DIFF
--- a/treeherder/intermittents_commenter/commenter.py
+++ b/treeherder/intermittents_commenter/commenter.py
@@ -223,7 +223,8 @@ class Commenter(object):
         return False
 
     def update_whiteboard(self, existing, new):
-        return re.sub('\[stockwell.*?\]', new, existing)
+        whiteboard = re.sub('\[stockwell.*?\]', '', existing)
+        return whiteboard + new
 
     def new_request(self):
         session = requests.Session()


### PR DESCRIPTION
handle the case where no existing stockwell text was found or whiteboard is an empty string