### PR TITLE
Bug 1481137 - fix commenter weekly task

### DIFF
--- a/treeherder/intermittents_commenter/commenter.py
+++ b/treeherder/intermittents_commenter/commenter.py
@@ -71,10 +71,8 @@ class Commenter(object):
             if alt_bug_stats[bug_id]['total'] >= 150:
                 bug_info, whiteboard = self.check_bug_info(bug_info, bug_id)
                 # if fetch_bug_details fails (called in check_bug_info), None is returned
-                if bug_info is None:
-                    continue
 
-                if not self.check_whiteboard_status(whiteboard):
+                if whiteboard is not None and not self.check_whiteboard_status(whiteboard):
                     priority = 3
                     whiteboard = self.update_whiteboard(whiteboard, '[stockwell disable-recommended]')
 
@@ -83,29 +81,23 @@ class Commenter(object):
                 if priority == 2:
                     bug_info, whiteboard = self.check_bug_info(bug_info, bug_id)
                     # if fetch_bug_details fails (called in check_bug_info), None is returned
-                    if bug_info is None:
-                        continue
-
-                    change_priority, whiteboard = self.check_needswork_owner(change_priority, bug_info, whiteboard)
+                    if bug_info is not None:
+                        change_priority, whiteboard = self.check_needswork_owner(change_priority, bug_info, whiteboard)
 
                 # change [stockwell needswork] to [stockwell unknown] when failures drop below 20 failures/week
                 if (counts['total'] < 20):
                     bug_info, whiteboard = self.check_bug_info(bug_info, bug_id)
                     # if fetch_bug_details fails (called in check_bug_info), None is returned
-                    if bug_info is None:
-                        continue
-
-                    whiteboard = self.check_needswork(whiteboard)
+                    if whiteboard is not None:
+                        whiteboard = self.check_needswork(whiteboard)
 
                 if bug_id in top_bugs:
                     rank = top_bugs.index(bug_id)+1
             else:
                 bug_info, whiteboard = self.check_bug_info(bug_info, bug_id)
                 # if fetch_bug_details fails (called in check_bug_info), None is returned
-                if bug_info is None:
-                    continue
-
-                change_priority, whiteboard = self.check_needswork_owner(change_priority, bug_info, whiteboard)
+                if bug_info is not None:
+                    change_priority, whiteboard = self.check_needswork_owner(change_priority, bug_info, whiteboard)
 
             comment = template.render(bug_id=bug_id,
                                       total=counts['total'],
@@ -124,7 +116,8 @@ class Commenter(object):
                               'comment': {'body': comment}
                             }
                            }
-            if whiteboard != bug_info['whiteboard']:
+
+            if bug_info is not None and whiteboard != bug_info['whiteboard']:
                 bug_changes['changes']['whiteboard'] = whiteboard
             if change_priority:
                 bug_changes['changes']['priority'] = change_priority


### PR DESCRIPTION
Fix key error with whiteboard and change condition involving bug_info (bug meta)
since it isn't needed to generate comments, only to potentially change
whiteboard status and priority (so we shouldn't actually pass).

Locally tested the daily comments like so: `./manage.py run_intermittents_commenter --dry-run`
and with the `-w` flag for weekly.