### PR TITLE
Bug 1281821 - use PULSE_URI instead of PULSE_URL for publishing to Pulse

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,6 +10,7 @@ CELERY_ALWAYS_EAGER = True
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 
 # Reconfigure pulse to operate on default vhost of rabbitmq
+PULSE_URI = BROKER_URL
 PULSE_URL = BROKER_URL
 PULSE_EXCHANGE_NAMESPACE = 'test'
 

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -494,6 +494,14 @@ PERFHERDER_ALERTS_FORE_WINDOW = 12
 PERFHERDER_ALERTS_MAX_AGE = timedelta(weeks=2)
 
 # Pulse
+# Credentials URL for access to Pulse with our credentials for pushing to Pulse
+# queues for tasks like retriggering a job.  This has been kept in a separate
+# variable so we can deploy the consolidation of our Pulse credentials
+# separately from wrapping them into a service.
+# More details here: https://bugzilla.mozilla.org/show_bug.cgi?id=1281821
+# TODO: remove this in favour of settings.PULSE_URL
+PULSE_URI = env("PULSE_URI", default="amqps://guest:guest@pulse.mozilla.org/")
+
 # The pulse url that is passed to kombu
 PULSE_URL = env("PULSE_URL", default="amqps://guest:guest@pulse.mozilla.org/")
 

--- a/treeherder/model/tasks.py
+++ b/treeherder/model/tasks.py
@@ -32,7 +32,7 @@ class LazyPublisher(object):
         if not self.publisher and settings.PULSE_EXCHANGE_NAMESPACE:
             self.publisher = TreeherderPublisher(
                 namespace=settings.PULSE_EXCHANGE_NAMESPACE,
-                uri=settings.PULSE_URL,
+                uri=settings.PULSE_URI,
                 schemas=PULSE_SCHEMAS
             )
 


### PR DESCRIPTION
This partially reverts the changes in 6e7b1efac so the code which publishes to Pulse keeps using the credentials in `PULSE_URI` so we can deploy that change separately.