### PR TITLE
Replace BugJobMap.objects.create() with BugJobMap.create()

### DIFF
--- a/tests/autoclassify/test_classify_failures.py
+++ b/tests/autoclassify/test_classify_failures.py
@@ -119,9 +119,11 @@ def test_autoclassified_after_manual_classification(test_user,
     test_error_lines, test_failure_lines = create_lines(test_job_2, lines)
     bug = bugs.first()
 
-    BugJobMap.objects.create(job=test_job_2,
-                             bug_id=bug.id,
-                             user=test_user)
+    BugJobMap.create(
+        job_id=test_job_2.id,
+        bug_id=bug.id,
+        user=test_user
+    )
     JobNote.objects.create(job=test_job_2,
                            failure_classification_id=4,
                            user=test_user,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -683,7 +683,8 @@ def bug_data(eleven_jobs_stored, test_repository, test_push, bugs):
                                          Option)
     jobs = Job.objects.all()
     bug_id = bugs[0].id
-    BugJobMap.objects.create(job=jobs[0], bug_id=bug_id)
+    job_id = jobs[0].id
+    BugJobMap.create(job_id=job_id, bug_id=bug_id)
     query_string = '?startday=2012-05-09&endday=2018-05-10&tree={}'.format(
         test_repository.name)
 

--- a/tests/model/test_classified_failure.py
+++ b/tests/model/test_classified_failure.py
@@ -1,9 +1,12 @@
 from decimal import Decimal
 
+from django.contrib.auth.models import User
+
 from tests.autoclassify.utils import (create_lines,
                                       test_line)
 from treeherder.autoclassify.autoclassify import mark_best_classification
-from treeherder.model.models import (ClassifiedFailure,
+from treeherder.model.models import (BugJobMap,
+                                     ClassifiedFailure,
                                      FailureLine,
                                      TextLogErrorMatch,
                                      TextLogErrorMetadata)
@@ -62,20 +65,31 @@ def test_set_bug_duplicate(text_log_errors_failure_lines, classified_failures, t
 
 def test_update_autoclassification_bug(test_job, test_job_2, classified_failures):
     classified_failure = classified_failures[0]
+    user = User.objects.create()
+
+    # create some TextLogErrors attached to test_job_2
+    text_log_errors, _ = create_lines(test_job_2, [(test_line, {})])
 
     # Job 1 has two failure lines so nothing should be updated
-    assert test_job.update_autoclassification_bug(1234) is None
+    assert classified_failure.bug_number is None
 
-    lines = [(test_line, {})]
-    error_lines, _ = create_lines(test_job_2, lines)
-
-    mark_best_classification(error_lines[0], classified_failures[0])
+    # Create a BugJobMap
+    BugJobMap.create(
+        job_id=test_job.id,
+        bug_id=1234,
+        user=user,
+    )
+    mark_best_classification(text_log_errors[0], classified_failure)
     assert classified_failure.bug_number is None
 
     metadata = TextLogErrorMetadata.objects.get(text_log_error__step__job=test_job_2)
     metadata.failure_line = FailureLine.objects.get(pk=3)
     metadata.save()
 
-    assert test_job_2.update_autoclassification_bug(1234) == classified_failures[0]
-    classified_failures[0].refresh_from_db()
-    assert classified_failures[0].bug_number == 1234
+    BugJobMap.create(
+        job_id=test_job_2.id,
+        bug_id=1234,
+        user=user,
+    )
+    classified_failure.refresh_from_db()
+    assert classified_failure.bug_number == 1234

--- a/tests/webapp/api/test_bug_job_map_api.py
+++ b/tests/webapp/api/test_bug_job_map_api.py
@@ -59,8 +59,12 @@ def test_bug_job_map_list(client, test_repository, eleven_jobs_stored, test_user
     expected = list()
 
     for (i, job) in enumerate(jobs):
-        bjm = BugJobMap.objects.create(job=job, bug_id=bugs[i].id,
-                                       user=test_user)
+        bjm = BugJobMap.create(
+            job_id=job.id,
+            bug_id=bugs[i].id,
+            user=test_user,
+        )
+
         expected.append({
             "job_id": job.id,
             "bug_id": bugs[i].id,
@@ -87,9 +91,11 @@ def test_bug_job_map_detail(client, eleven_jobs_stored, test_repository,
     bug = bugs[0]
     expected = list()
 
-    bjm = BugJobMap.objects.create(job=job,
-                                   bug_id=bug.id,
-                                   user=test_user)
+    bjm = BugJobMap.create(
+        job_id=job.id,
+        bug_id=bug.id,
+        user=test_user,
+    )
 
     pk = "{0}-{1}".format(job.id, bug.id)
 
@@ -119,9 +125,11 @@ def test_bug_job_map_delete(client, eleven_jobs_stored, test_repository,
     job = Job.objects.all()[0]
     bug = bugs[0]
 
-    BugJobMap.objects.create(job=job,
-                             bug_id=bug.id,
-                             user=test_user)
+    BugJobMap.create(
+        job_id=job.id,
+        bug_id=bug.id,
+        user=test_user,
+    )
 
     if not test_no_auth:
         client.force_authenticate(user=test_user)

--- a/treeherder/webapp/api/bug.py
+++ b/treeherder/webapp/api/bug.py
@@ -1,3 +1,4 @@
+from django.db import IntegrityError
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.status import HTTP_404_NOT_FOUND
@@ -15,17 +16,17 @@ class BugJobMapViewSet(viewsets.ViewSet):
         job_id = int(request.data['job_id'])
         bug_id = int(request.data['bug_id'])
 
-        bug_map = BugJobMap.objects.filter(job_id=job_id, bug_id=bug_id).first()
-        if bug_map:
-            return Response({"message": "Bug job map skipped: mapping already exists"}, 200)
+        try:
+            BugJobMap.create(
+                job_id=job_id,
+                bug_id=bug_id,
+                user=request.user,
+            )
+            message = "Bug job map saved"
+        except IntegrityError:
+            message = "Bug job map skipped: mapping already exists"
 
-        BugJobMap.create(
-            job_id=job_id,
-            bug_id=bug_id,
-            user=request.user,
-        )
-
-        return Response({"message": "Bug job map saved"})
+        return Response({"message": message})
 
     def destroy(self, request, project, pk=None):
         """

--- a/treeherder/webapp/api/bug.py
+++ b/treeherder/webapp/api/bug.py
@@ -11,20 +11,19 @@ from .serializers import BugJobMapSerializer
 class BugJobMapViewSet(viewsets.ViewSet):
 
     def create(self, request, project):
-        """
-        Add a new relation between a job and a bug
-        """
-        job_id, bug_id = map(int, (request.data['job_id'],
-                                   request.data['bug_id']))
+        """Add a new relation between a job and a bug."""
+        job_id = int(request.data['job_id'])
+        bug_id = int(request.data['bug_id'])
 
-        _, created = BugJobMap.objects.get_or_create(
-            job_id=job_id, bug_id=bug_id, defaults={
-                'user': request.user
-            })
-        if created:
-            return Response({
-                "message": "Bug job map skipped: mapping already exists"
-            }, 200)
+        bug_map = BugJobMap.objects.filter(job_id=job_id, bug_id=bug_id).first()
+        if bug_map:
+            return Response({"message": "Bug job map skipped: mapping already exists"}, 200)
+
+        BugJobMap.create(
+            job_id=job_id,
+            bug_id=bug_id,
+            user=request.user,
+        )
 
         return Response({"message": "Bug job map saved"})
 


### PR DESCRIPTION
This replaces uses of BugJobMap's default manager methods `.create()` and `.get_or_create()` with the classmethod `create()`.  The use of `.save()` is a Django-ism that, while great if you know Django and think to check for it, is an implicit code path hidden behind standard ORM calls.

Previously the `update_autoclassification_bug` method updated the BugJobMap's Job's TextLogMetadata.best_classification's bug number to that of the one used to create the BugJobMap.  This is now done as part of the `.create()` classmethod so it's explicit and clear it's being done (and hopefully better documented!)