### PR TITLE
Replace uses of some_queryset.all()[0] with some_queryset.first()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -689,7 +689,7 @@ def bug_data(eleven_jobs_stored, test_repository, test_push, bugs):
 
     return {
         'tree': test_repository.name,
-        'option': Option.objects.all()[0],
+        'option': Option.objects.first(),
         'bug_id': bug_id,
         'job': jobs[0],
         'jobs': jobs,

--- a/tests/e2e/test_client_job_ingestion.py
+++ b/tests/e2e/test_client_job_ingestion.py
@@ -465,7 +465,7 @@ def test_post_job_with_buildapi_artifact(test_repository, failure_classification
     assert Job.objects.count() == 1
     assert JobDetail.objects.count() == 1
 
-    buildbot_request_id_detail = JobDetail.objects.all()[0]
+    buildbot_request_id_detail = JobDetail.objects.first()
     assert buildbot_request_id_detail.title == 'buildbot_request_id'
     assert buildbot_request_id_detail.value == str(1234)
     assert buildbot_request_id_detail.url is None

--- a/tests/etl/test_buildapi.py
+++ b/tests/etl/test_buildapi.py
@@ -185,7 +185,7 @@ def test_ingest_running_job_fields(push_stored,
     etl_process.run()
 
     assert Job.objects.count() == 1
-    assert time.mktime(Job.objects.all()[0].start_time.timetuple()) > 0
+    assert time.mktime(Job.objects.first().start_time.timetuple()) > 0
 
 
 def test_ingest_builds4h_jobs_1_missing_push(push_stored,

--- a/tests/etl/test_load_artifacts.py
+++ b/tests/etl/test_load_artifacts.py
@@ -36,7 +36,7 @@ def test_load_long_job_details(test_job):
 
     assert JobDetail.objects.count() == 1
 
-    jd = JobDetail.objects.all()[0]
+    jd = JobDetail.objects.first()
     assert jd.title == long_title[:max_length("title")]
     assert jd.value == long_value[:max_length("value")]
     assert jd.url == long_url[:max_length("url")]

--- a/tests/etl/test_perf_data_adapters.py
+++ b/tests/etl/test_perf_data_adapters.py
@@ -204,7 +204,7 @@ def test_load_generic_data(test_repository,
     store_performance_artifact(perf_job, submit_datum)
     assert 8 == PerformanceSignature.objects.all().count()
     assert 1 == PerformanceFramework.objects.all().count()
-    framework = PerformanceFramework.objects.all()[0]
+    framework = PerformanceFramework.objects.first()
     assert framework_name == framework.name
 
     perf_datum = datum['blob']
@@ -481,5 +481,5 @@ def test_last_updated(test_repository, test_issue_tracker,
                               generic_reference_data,
                               reverse_push_range=True)
     assert PerformanceSignature.objects.count() == 1
-    signature = PerformanceSignature.objects.all()[0]
+    signature = PerformanceSignature.objects.first()
     assert signature.last_updated == max(Push.objects.values_list('time', flat=True))

--- a/tests/webapp/api/test_bug_job_map_api.py
+++ b/tests/webapp/api/test_bug_job_map_api.py
@@ -43,7 +43,7 @@ def test_create_bug_job_map(client, test_job, mock_message_broker,
         assert BugJobMap.objects.count() == 0
     else:
         assert BugJobMap.objects.count() == 1
-        bug_job_map = BugJobMap.objects.all()[0]
+        bug_job_map = BugJobMap.objects.first()
 
         assert bug_job_map.job_id == submit_obj['job_id']
         assert bug_job_map.bug_id == submit_obj['bug_id']
@@ -83,7 +83,7 @@ def test_bug_job_map_detail(client, eleven_jobs_stored, test_repository,
     """
     test retrieving a list of bug_job_map
     """
-    job = Job.objects.all()[0]
+    job = Job.objects.first()
     bug = bugs[0]
     expected = list()
 
@@ -116,7 +116,7 @@ def test_bug_job_map_delete(client, eleven_jobs_stored, test_repository,
     """
     test deleting a bug_job_map object
     """
-    job = Job.objects.all()[0]
+    job = Job.objects.first()
     bug = bugs[0]
 
     BugJobMap.objects.create(job=job,

--- a/tests/webapp/api/test_performance_alerts_api.py
+++ b/tests/webapp/api/test_performance_alerts_api.py
@@ -202,7 +202,7 @@ def test_alerts_post(client, test_repository, test_perf_signature,
     assert resp.status_code == 200
     assert PerformanceAlert.objects.count() == 1
 
-    alert = PerformanceAlert.objects.all()[0]
+    alert = PerformanceAlert.objects.first()
     assert alert.status == PerformanceAlert.UNTRIAGED
     assert alert.manually_created
     assert alert.amount_pct == 100

--- a/tests/webapp/api/test_performance_alertsummary_api.py
+++ b/tests/webapp/api/test_performance_alertsummary_api.py
@@ -201,7 +201,7 @@ def test_alert_summary_post(client, test_repository, test_issue_tracker,
     assert resp.status_code == 200
 
     assert PerformanceAlertSummary.objects.count() == 1
-    alert_summary = PerformanceAlertSummary.objects.all()[0]
+    alert_summary = PerformanceAlertSummary.objects.first()
     assert alert_summary.repository == test_repository
     assert alert_summary.framework == test_perf_signature.framework
     assert alert_summary.prev_push_id == post_blob['prev_push_id']


### PR DESCRIPTION
This makes use of Django's [`.first()` method](https://docs.djangoproject.com/en/2.1/ref/models/querysets/#django.db.models.query.QuerySet.first) instead of indexing the QuerySets.  It's a little nicer to use in practice.