### PR TITLE
Fix dates on NotificationsMenu

### DIFF
--- a/ui/job-view/headerbars/NotificationsMenu.jsx
+++ b/ui/job-view/headerbars/NotificationsMenu.jsx
@@ -81,7 +81,7 @@ export default class NotificationsMenu extends React.Component {
               >
                 <span title={`${notification.message} ${notification.linkText}`}>
                   <span className={this.getSeverityClass(notification.severity)} />&nbsp;
-                  <small className="text-muted">{toShortDateStr(notification.created)}</small>
+                  <small className="text-muted">{toShortDateStr(notification.created / 1000)}</small>
                   &nbsp;{notification.message}&nbsp;
                   <a
                     target="_blank"


### PR DESCRIPTION
The dates were all off because the ``toShortDateStr`` function
expects timestamps in seconds, but we were passing
milliseconds.  Just need to divide by 1000.