### PR TITLE
Bug 1482833 - fix commenter celery task

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -395,17 +395,17 @@ CELERYBEAT_SCHEDULE = {
         }
     },
     'daily-intermittents-commenter': {
-        # Executes every morning at 7 a.m. UTC except sunday
+        # Executes every morning at 7 a.m. UTC except monday
         'task': 'intermittents-commenter',
-        'schedule': crontab(minute=0, hour=7, day_of_week='monday-saturday'),
+        'schedule': crontab(minute=0, hour=7, day_of_week='tuesday-sunday'),
         'options': {
             'queue': 'intermittents_commenter'
         },
     },
     'weekly-intermittents-commenter': {
-        # Executes every sunday morning at 7 a.m. UTC
+        # Executes every monday morning at 7 a.m. UTC
         'task': 'intermittents-commenter',
-        'schedule': crontab(minute=0, hour=7, day_of_week='sunday'),
+        'schedule': crontab(minute=0, hour=7, day_of_week='monday'),
         'kwargs': {'weekly_mode': True},
         'options': {
             'queue': 'intermittents_commenter'

--- a/treeherder/intermittents_commenter/commenter.py
+++ b/treeherder/intermittents_commenter/commenter.py
@@ -176,7 +176,7 @@ class Commenter(object):
             else:
                 self.submit_bug_changes(bug['changes'], bug['bug_id'])
                 # sleep between comment submissions to avoid overwhelming servers
-                time.sleep(1)
+                time.sleep(0.5)
 
         logger.warning('There were {} comments for this {} task.'.format(
                        len(all_bug_changes), 'weekly' if self.weekly_mode else 'daily'))

--- a/treeherder/intermittents_commenter/tasks.py
+++ b/treeherder/intermittents_commenter/tasks.py
@@ -3,7 +3,7 @@ from celery import task
 from treeherder.intermittents_commenter.commenter import Commenter
 
 
-@task(name='intermittents-commenter', soft_time_limit=30 * 60, time_limit=31 * 60)
+@task(name='intermittents-commenter', soft_time_limit=75 * 60, time_limit=76 * 60)
 def run_commenter(weekly_mode=False):
     """Run the intermittents commenter in either daily or weekly mode."""
     process = Commenter(weekly_mode=weekly_mode)

--- a/treeherder/intermittents_commenter/tasks.py
+++ b/treeherder/intermittents_commenter/tasks.py
@@ -3,7 +3,7 @@ from celery import task
 from treeherder.intermittents_commenter.commenter import Commenter
 
 
-@task(name='intermittents-commenter', soft_time_limit=75 * 60, time_limit=76 * 60)
+@task(name='intermittents-commenter', soft_time_limit=120 * 60, time_limit=121 * 60)
 def run_commenter(weekly_mode=False):
     """Run the intermittents commenter in either daily or weekly mode."""
     process = Commenter(weekly_mode=weekly_mode)


### PR DESCRIPTION
Change intermittents-commenter task soft and hard time limits (Sunday's commenter only posted 482 comments out of 1,251 bugs) and time.sleep in print_or_submit_changes (per Dylan's comment about rate limit for post requests: " For authenticated requests, no limit currently. In general get-bug clients should not do more than two requests per second ... " [here](https://github.com/mozilla/treeherder/pull/3571), this wasn't actually updated).