### PR TITLE
Flatten Pulse source definitions to inline constants

### DIFF
--- a/treeherder/services/pulse/sources.py
+++ b/treeherder/services/pulse/sources.py
@@ -22,48 +22,33 @@ destinations = env.list("PULSE_JOB_DESTINATIONS", default=[
 ])
 
 
-def get_job_sources():
-    """
-    Get Job ingestion source locations.
+# Get Job ingestion source locations.
 
-    Specifies the Pulse exchanges Treeherder will ingest data from for Job
-    data.  This list will be updated as new applications come online that
-    Treeherder supports. Treeherder will subscribe with routing keys that are
-    all combinations of ``project`` and ``destination`` in the form of:
-    <destination>.<project> Wildcards such as ``#`` and ``*`` are supported for
-    either field.
-    """
-    for exchange in exchanges:
-        yield {
-            "exchange": exchange,
-            "projects": projects,
-            "destinations": destinations,
-        }
+# Specifies the Pulse exchanges Treeherder will ingest data from for Job data.
+# This list will be updated as new applications come online that Treeherder
+# supports. Treeherder will subscribe with routing keys that are all
+# combinations of ``project`` and ``destination`` in the form of:
+# <destination>.<project> Wildcards such as ``#`` and ``*`` are supported for
+# either field.
+job_sources = [{
+    "exchange": exchange,
+    "projects": projects,
+    "destinations": destinations,
+} for exchange in exchanges]
 
 
-def get_push_sources():
-    """
-    Get Push ingestion source locations.
-
-    Specifies the Pulse exchanges Treeherder will ingest data from for Push
-    data.
-    """
-    sources = env.json(
-        "PULSE_PUSH_SOURCES",
-        default=[{
-            "exchange": "exchange/taskcluster-github/v1/push",
-            "routing_keys": ['#'],
-        }, {
-            "exchange": "exchange/taskcluster-github/v1/pull-request",
-            "routing_keys": ['#'],
-        }, {
-            "exchange": "exchange/hgpushes/v1",
-            "routing_keys": ["#"]
-        }],
-    )
-
-    return sources
-
-
-job_sources = list(get_job_sources())
-push_sources = get_push_sources()
+# Get Push ingestion source locations.
+# Specifies the Pulse exchanges Treeherder will ingest data from for Push data.
+push_sources = env.json(
+    "PULSE_PUSH_SOURCES",
+    default=[{
+        "exchange": "exchange/taskcluster-github/v1/push",
+        "routing_keys": ['#'],
+    }, {
+        "exchange": "exchange/taskcluster-github/v1/pull-request",
+        "routing_keys": ['#'],
+    }, {
+        "exchange": "exchange/hgpushes/v1",
+        "routing_keys": ["#"]
+    }],
+)


### PR DESCRIPTION
This removes the `get_*` functions from the Pulse sources module in favour of inline definitions, as per the comment [here](https://github.com/mozilla/treeherder/pull/3863/files/8bd1d6afdf76d205f1a9d85c0a9b56992b541edc#r209455041).

Wrapping these values in functions provided no benefit so lets save the indentation.