### PR TITLE
Update eslint-plugin-import to v2.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "deepmerge": "1.5.2",
     "eslint": "3.19.0",
     "eslint-config-airbnb": "15.1.0",
-    "eslint-plugin-import": "2.12.0",
+    "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jsx-a11y": "5.1.1",
     "eslint-plugin-react": "7.10.0",
     "font-awesome": "4.7.0",

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,6 @@
     "deepmerge",
     "eslint",
     "eslint-config-airbnb",
-    "eslint-plugin-import",
     "eslint-plugin-jsx-a11y",
     "html-loader",
     "karma",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,9 +2978,9 @@ eslint-plugin-babel@^4.0.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.1.2.tgz#79202a0e35757dd92780919b2336f1fa2fe53c1e"
 
-eslint-plugin-import@2.12.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz#dad31781292d6664b25317fd049d2e2b2f02205d"
+eslint-plugin-import@2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz#6b17626d2e3e6ad52cfce8807a845d15e22111a8"
   dependencies:
     contains-path "^0.1.0"
     debug "^2.6.8"


### PR DESCRIPTION
And remove the Renovate exclusion, since unlike some of the other ESLint dependencies that aren't compatible with Neutrino 4/ESLint 3, this plugin is still compatible - so is fine to receive automatic updates.