### PR TITLE
Bug 1483231 - Remove Pulse Namespace Configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -341,10 +341,7 @@ def activate_responses(request):
 
 
 def pulse_consumer(exchange, request):
-    exchange_name = 'exchange/{}/v1/{}'.format(
-        settings.PULSE_EXCHANGE_NAMESPACE,
-        exchange
-    )
+    exchange_name = 'exchange/treeherder/v1/{}'.format(exchange)
 
     connection = kombu.Connection(settings.PULSE_URL)
 

--- a/tests/services/pulse/test_publisher.py
+++ b/tests/services/pulse/test_publisher.py
@@ -1,11 +1,8 @@
-from django.conf import settings
-
 from treeherder.services.pulse import publish_job_action
 
 
 def test_publish_job_action(pulse_action_consumer):
     publish_job_action(
-        settings.PULSE_EXCHANGE_NAMESPACE,
         version=1,
         build_system_type="test build system",
         project="a project",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -12,7 +12,6 @@ CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 # Reconfigure pulse to operate on default vhost of rabbitmq
 PULSE_URI = BROKER_URL
 PULSE_URL = BROKER_URL
-PULSE_EXCHANGE_NAMESPACE = 'test'
 
 # Set a fake api key for testing bug filing
 BUGFILER_API_KEY = "12345helloworld"

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -509,7 +509,3 @@ PULSE_URI = env("PULSE_URI", default="amqps://guest:guest@pulse.mozilla.org/")
 
 # The pulse url that is passed to kombu
 PULSE_URL = env("PULSE_URL", default="amqps://guest:guest@pulse.mozilla.org/")
-
-# Note we will never publish any pulse messages unless the exchange namespace is
-# set this normally is your pulse username.
-PULSE_EXCHANGE_NAMESPACE = env("PULSE_EXCHANGE_NAMESPACE", default=None)

--- a/treeherder/model/tasks.py
+++ b/treeherder/model/tasks.py
@@ -1,6 +1,5 @@
 import newrelic.agent
 from celery import task
-from django.conf import settings
 from django.core.management import call_command
 
 from treeherder.model.models import Job
@@ -32,12 +31,8 @@ def publish_job_action(project, action, job_id, requester):
     newrelic.agent.add_custom_parameter("job_id", str(job_id))
     newrelic.agent.add_custom_parameter("requester", requester)
 
-    if not settings.PULSE_EXCHANGE_NAMESPACE:
-        return
-
     job = Job.objects.get(id=job_id)
     pulse_publish_job_action(
-        settings.PULSE_EXCHANGE_NAMESPACE,
         version=1,
         build_system_type=job.signature.build_system_type,
         project=project,

--- a/treeherder/services/pulse/publisher.py
+++ b/treeherder/services/pulse/publisher.py
@@ -32,7 +32,7 @@ def load_schemas():
     return schemas
 
 
-def publish_job_action(namespace, **message_kwargs):
+def publish_job_action(**message_kwargs):
     # create a connection to Pulse
     # TODO: use pulse_conn once we've combined PULSE_URI and PULSE_URL
     connection = Connection(settings.PULSE_URI)
@@ -42,7 +42,7 @@ def publish_job_action(namespace, **message_kwargs):
     producer = Producer(
         channel=connection,
         exchange=Exchange(
-            name="exchange/{}/v1/job-actions".format(namespace),
+            name="exchange/treeherder/v1/job-actions",
             type='topic',
             durable=True,
             delivery_mode='persistent'


### PR DESCRIPTION
This removes the `PULSE_EXCHANGE_NAMESPACE` configuration option opting to force all exchanges to use either `treeherder` or `test`.