### PR TITLE
Make Pulse Connection Lazy

### DIFF
--- a/treeherder/services/pulse/connection.py
+++ b/treeherder/services/pulse/connection.py
@@ -7,7 +7,7 @@ env = environ.Env()
 # ingestion queues for the exchanges specified in ``PULSE_SOURCE_EXCHANGES``.
 # See https://pulse.mozilla.org/whats_pulse for more info.
 # Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/?ssl=1"
-config = env.url("PULSE_URL")
+config = env.url("PULSE_URL", default="amqp://guest:guest@localhost//")
 
 
 def build_connection(url):

--- a/treeherder/services/pulse/connection.py
+++ b/treeherder/services/pulse/connection.py
@@ -1,18 +1,19 @@
 import environ
+from django.utils.functional import SimpleLazyObject
 from kombu import Connection
 
 env = environ.Env()
 
-# Used to specify the PulseGuardian account that will be used to create
-# ingestion queues for the exchanges specified in ``PULSE_SOURCE_EXCHANGES``.
-# See https://pulse.mozilla.org/whats_pulse for more info.
-# Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/?ssl=1"
-config = env.url("PULSE_URL", default="amqp://guest:guest@localhost//")
+
+def build_connection():
+    """Build a Kombu Broker connection to Mozilla Pulse."""
+    # Used to specify the PulseGuardian account that will be used to create
+    # ingestion queues for the exchanges specified in ``PULSE_SOURCE_EXCHANGES``.
+    # See https://pulse.mozilla.org/whats_pulse for more info.
+    # Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/?ssl=1"
+    pulse_url = env.url("PULSE_URL")
+
+    return Connection(pulse_url.get_url())
 
 
-def build_connection(url):
-    """Build a Kombu Broker connection to Mozilla Pulse with the given url."""
-    return Connection(url)
-
-
-pulse_conn = build_connection(config.geturl())
+pulse_conn = SimpleLazyObject(build_connection)


### PR DESCRIPTION
~This sets the default for our Pulse connection to a local guest account.~

This wraps the Pulse connection so the package's import doesn't attempt to construct the connection.

This came up during Travis testing #3919.  The linter checks run the Django's checks framework which triggers an import of the Pulse service.  The connection is built on import but the linter job has a minimal environment set up.