### PR TITLE
Bug 1483301 - Raise the New Relic Python agent's shutdown_timeout

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -7,15 +7,24 @@
 # unless NEW_RELIC_DEVELOPER_MODE is set.
 
 [newrelic]
+
 log_file = stdout
+
 # Turn on the capturing of request parameters.
 attributes.include = request.parameters.*
+
 # Disable client-side monitoring JS injection, due to there being no way for
 # users to opt-out. See:
 # https://groups.google.com/forum/#!topic/mozilla.dev.webdev/ragGTzhyY2w
 browser_monitoring.enabled = false
 
+# Raise the maximum time allowed for the agent's final upload upon exit (default 2.5s),
+# to make it less likely that New Relic submissions can get lost. The duration must be
+# less than gunicorn's `graceful_timeout` (30 seconds).
+shutdown_timeout = 15
+
 [import-hook:django]
+
 # The agent doesn't annotate Django management commands by default:
 # https://docs.newrelic.com/docs/agents/python-agent/supported-features/python-background-tasks#django
 # List finite-duration commands here to enable their annotation by the agent.


### PR DESCRIPTION
So that the agent has longer to upload the final submission when Heroku restarts gunicorn (eg daily restarts or deploys).

See:
https://docs.newrelic.com/docs/agents/python-agent/configuration/python-agent-configuration#shutdown-timeout