### PR TITLE
Renovate: Ignore @types/* packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "yarn": "1.9.4"
   },
   "dependencies": {
-    "@types/angular": "1.6.49",
-    "@types/prop-types": "15.5.5",
-    "@types/react": "16.4.9",
-    "@types/react-dom": "16.0.7",
+    "@types/angular": "*",
+    "@types/prop-types": "*",
+    "@types/react": "*",
+    "@types/react-dom": "*",
     "ajv": "6.5.2",
     "angular": "1.7.2",
     "angular-clipboard": "1.6.2",

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,10 @@
     ":unpublishSafe"
   ],
   "ignoreDeps": [
+    "@types/angular",
+    "@types/prop-types",
+    "@types/react",
+    "@types/react-dom",
     "deepmerge",
     "eslint",
     "eslint-config-airbnb",

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,7 +57,11 @@
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.1.tgz#f3a81587ad8d0ef33cdad6f3b4310774fcc1053e"
 
-"@types/angular@1.6.49", "@types/angular@^1.6.39":
+"@types/angular@*":
+  version "1.6.50"
+  resolved "https://registry.yarnpkg.com/@types/angular/-/angular-1.6.50.tgz#8b6599088d80f68ef0cad7d3a2062248ebe72b3d"
+
+"@types/angular@^1.6.39":
   version "1.6.49"
   resolved "https://registry.yarnpkg.com/@types/angular/-/angular-1.6.49.tgz#8a5dd666100155d27cda9801f961360eb24b8d96"
 
@@ -75,20 +79,20 @@
   version "10.5.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.8.tgz#6f14ccecad1d19332f063a6a764f8907801fece0"
 
-"@types/prop-types@*", "@types/prop-types@15.5.5":
+"@types/prop-types@*":
   version "15.5.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.5.tgz#17038dd322c2325f5da650a94d5f9974943625e3"
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@16.0.7":
+"@types/react-dom@*":
   version "16.0.7"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.7.tgz#54d0f867a76b90597e8432030d297982f25c20ba"
   dependencies:
     "@types/node" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.4.9":
+"@types/react@*":
   version "16.4.9"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.9.tgz#98b4dba5a0419dbd594f5dbbb2479e1e153431bb"
   dependencies:


### PR DESCRIPTION
To reduce the Renovate PR noise from them, since they only contain TypeScript definitions, which we don't use.

(We only list them in our dependencies to prevent the missing `peerDependencies` warnings due to `react2angular` listing them in its `package.json`. Once we no longer use `react2angular` we can remove them entirely.)