### PR TITLE
Bug 1281821 - Convert Pulse push configuration into a list

### DIFF
--- a/docs/pulseload.md
+++ b/docs/pulseload.md
@@ -98,23 +98,24 @@ Advanced Configuration
 ### Changing which Data to Ingest
 
 ``treeherder.services.pulse.sources`` provides default sources for both Jobs and Pushes.
-However you can override these defaults using the standard env methods show below.
 
 #### Pushes
-``PULSE_PUSH_SOURCES`` defines a list of dictionaries with exchange and routing key strings.
-```bash
-export PULSE_PUSH_SOURCES='[{"exchange": "exchange/taskcluster-github/v1/push","routing_keys": ["bugzilla#"]}]'
+``push_sources`` defines a list of exchanges with routing keys.
+It's rare you'll need to change this so it's not configurable via the environment.
+However if you wanted to, say, only get pushes to GitHub you would edit the list to look like this:
+```python
+push_sources = [
+    "exchange/taskcluster-github/v1/push.#",
+]
 ```
 
 #### Jobs
+Job Exchanges and Projects can be configured in the environment like so:
+
 ``PULSE_JOB_EXCHANGES`` defines a list of exchanges to listen to.
 ```bash
 export PULSE_JOB_EXCHANGES="exchange/taskcluster-treeherder/v1/jobs,exchange/fxtesteng/jobs"
 ```
-
-To change which exchanges you listen to for pushes, you would modify
-``PULSE_PUSH_SOURCES``.  For instance, to get only Gitbub pushes for Bugzilla,
-you would set:
 
 ``PULSE_JOB_PROJECTS`` defines a list of projects to listen to.
 ```bash
@@ -153,7 +154,7 @@ celery -A treeherder worker -B -Q pushlog,store_pulse_jobs,store_pulse_resultset
 
 * The ``pushlog`` queue loads up to the last 10 Mercurial pushes that exist.
 * The ``store_pulse_resultsets`` queue will ingest all the pushes from the exchanges
-  specified in ``PULSE_PUSH_SOURCES``.  This can be Mercurial and Github
+  specified in ``push_sources``.  This can be Mercurial and Github
 * The ``store_pulse_jobs`` queue will ingest all the jobs from the exchanges
   specified in ``PULSE_JOB_EXCHANGES``.
 

--- a/treeherder/etl/management/commands/read_pulse_pushes.py
+++ b/treeherder/etl/management/commands/read_pulse_pushes.py
@@ -22,9 +22,10 @@ class Command(BaseCommand):
             consumer = PushConsumer(connection, "resultsets")
 
             for source in push_sources:
-                exchange = get_exchange(connection, source["exchange"])
+                exchange, _, routing_keys = source.partition('.')
+                exchange = get_exchange(connection, exchange)
 
-                for routing_key in source["routing_keys"]:
+                for routing_key in routing_keys.split(','):
                     consumer.bind_to(exchange, routing_key)
                     new_binding_str = consumer.get_binding_str(
                         exchange.name,

--- a/treeherder/services/pulse/sources.py
+++ b/treeherder/services/pulse/sources.py
@@ -27,18 +27,10 @@ job_sources = [{
 } for exchange in exchanges]
 
 
-# Get Push ingestion source locations.
 # Specifies the Pulse exchanges Treeherder will ingest data from for Push data.
-push_sources = env.json(
-    "PULSE_PUSH_SOURCES",
-    default=[{
-        "exchange": "exchange/taskcluster-github/v1/push",
-        "routing_keys": ['#'],
-    }, {
-        "exchange": "exchange/taskcluster-github/v1/pull-request",
-        "routing_keys": ['#'],
-    }, {
-        "exchange": "exchange/hgpushes/v1",
-        "routing_keys": ["#"]
-    }],
-)
+# Routing keys are specified after a period ("."), separated by commas (",").
+push_sources = [
+    "exchange/taskcluster-github/v1/push.#",
+    "exchange/taskcluster-github/v1/pull-request.#",
+    "exchange/hgpushes/v1.#",
+]


### PR DESCRIPTION
This removes the `PULSE_PUSH_SOURCES` setting, converting it to a hardcoded list of strings.

In [the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1281821#c17) we discussed removing the configurability of this entirely.  I tried out converting the settings to a list of strings (with delimiters) and leaving the configurability but @edmorley [rightly pointed](https://github.com/mozilla/treeherder/pull/3926#discussion_r212340818) out it's unlikely one needs to configure them.

The strings in `push_sources` contain both exchange and routing keys in this format:

```
<exchange>.<routing key>[,<another routing key>,<yet another routing key>]
```

Once this is deployed to a Heroku env we can remove the `PULSE_PUSH_SOURCES` value from its config.