### PR TITLE
Remove Configurability of Pulse Destinations (2)

### DIFF
--- a/docs/pulseload.md
+++ b/docs/pulseload.md
@@ -121,12 +121,7 @@ you would set:
 export PULSE_JOB_PROJECTS="try,mozilla-central"
 ```
 
-``PULSE_JOB_DESTINATIONS`` defines a list of destinations to push to.
-```bash
-export PULSE_JOB_DESTINATIONS="#"
-```
-
-The source settings are combined such that all `projects` and `destinations` are applied to **each** `exchange`.
+The source settings are combined such that all `projects` are applied to **each** `exchange`.
 The example settings above would produce the following settings:
 
 ```python
@@ -136,17 +131,11 @@ The example settings above would produce the following settings:
         "try",
         "mozilla-central",
     ],
-    "destinations": [
-        "#",
-    ],
 }, {
     "exchange": "exchange/fxtesteng/jobs",
     "projects": [
         "try",
         "mozilla-central",
-    ],
-    "destinations": [
-        "#",
     ],
 }]
 ```

--- a/docs/submitting_data.md
+++ b/docs/submitting_data.md
@@ -79,27 +79,20 @@ Submit a [Treeherder bug] with the following information:
 ```python
 {
     "exchange": "exchange/my-pulse-user/v1/jobs",
-    "destinations": [
-        'treeherder'
-    ],
     "projects": [
         'mozilla-inbound._'
     ],
 },
 ```
 
-Treeherder will bind to the exchange looking for all combinations of routing
-keys from ``destinations`` and ``projects`` listed above.  For example with
-the above config, we will only load jobs with routing keys of
-``treeherder.mozilla-inbound._``
+Treeherder will bind to the exchange looking for all combinations of it and the
+``projects``.  For example with the above config, we will only load jobs from
+the ``mozilla-inbound._`` project.
 
-If you want all jobs from your exchange to be loaded, you could simplify the
-config by having values:
+If you want all jobs from your exchange to be loaded, you can use the ``#``
+wildcard like so:
 
 ```python
-"destinations": [
-    '#'
-],
 "projects": [
     '#'
 ],
@@ -107,7 +100,7 @@ config by having values:
 
 If you want one config to go to Treeherder Staging and a different one to go
 to Production, please specify that in the bug.  You could use the same exchange
-with different routing key settings, or two separate exchanges.  The choice is
+with different project settings, or two separate exchanges.  The choice is
 yours.
 
 

--- a/treeherder/etl/management/commands/read_pulse_jobs.py
+++ b/treeherder/etl/management/commands/read_pulse_jobs.py
@@ -25,19 +25,16 @@ class Command(BaseCommand):
                 exchange = get_exchange(connection, source["exchange"])
 
                 for project in source["projects"]:
-                    for destination in source['destinations']:
-                        routing_key = "{}.{}".format(destination, project)
-                        consumer.bind_to(exchange, routing_key)
-                        new_binding_str = consumer.get_binding_str(
-                            exchange.name,
-                            routing_key)
-                        new_bindings.append(new_binding_str)
+                    routing_key = "#.{}".format(project)
+                    consumer.bind_to(exchange=exchange, routing_key=routing_key)
+                    new_binding_str = consumer.get_binding_str(exchange.name, routing_key)
+                    new_bindings.append(new_binding_str)
 
-                        self.stdout.write(
-                            "Pulse queue {} bound to: {}".format(
-                                consumer.queue_name,
-                                new_binding_str
-                            ))
+                    self.stdout.write(
+                        "Pulse queue {} bound to: {}".format(
+                            consumer.queue_name,
+                            new_binding_str
+                        ))
 
             consumer.prune_bindings(new_bindings)
 

--- a/treeherder/services/pulse/sources.py
+++ b/treeherder/services/pulse/sources.py
@@ -14,26 +14,16 @@ projects = env.list("PULSE_JOB_PROJECTS", default=[
     # "mozilla-central.#",
     # "mozilla-inbound.#",
 ])
-destinations = env.list("PULSE_JOB_DESTINATIONS", default=[
-    "#",
-    # "production",
-    # "staging",
-    # "tc-treeherder",
-])
 
 
-# Get Job ingestion source locations.
-
-# Specifies the Pulse exchanges Treeherder will ingest data from for Job data.
-# This list will be updated as new applications come online that Treeherder
-# supports. Treeherder will subscribe with routing keys that are all
-# combinations of ``project`` and ``destination`` in the form of:
-# <destination>.<project> Wildcards such as ``#`` and ``*`` are supported for
-# either field.
+# Specifies the Pulse exchanges Treeherder will ingest data from for Jobs. This
+# list will be updated as new applications come online that Treeherder
+# supports.  Treeherder will subscribe with routing keys that are the project
+# names.  Wildcards such as ``#`` and ``*`` are supported for the project
+# field.
 job_sources = [{
     "exchange": exchange,
     "projects": projects,
-    "destinations": destinations,
 } for exchange in exchanges]
 
 


### PR DESCRIPTION
This is the second attempt at the changes from #3884 

This PR contains a fix for the routing key in the `read_pulse_jobs` command as per #3927 