### PR TITLE
Make Construction of the Pulse Connection Lazy

### DIFF
--- a/tests/services/pulse/test_connection.py
+++ b/tests/services/pulse/test_connection.py
@@ -1,0 +1,32 @@
+import os
+
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.functional import Promise
+from kombu import Connection
+from pytest import raises
+
+from treeherder.services.pulse.connection import (build_connection,
+                                                  pulse_conn)
+
+
+def test_build_connection():
+    os.environ["PULSE_URL"] = "amqp://guest:guest@pulse.mozilla.org/"
+    conn = build_connection()
+    del os.environ["PULSE_URL"]
+
+    assert isinstance(conn, Connection)
+
+
+def test_pulse_conn_is_lazy():
+    """
+    Confirm pulse_conn is a lazy object.
+
+    With no PULSE_URL set this should fail with a ImproperlyConfigured when the
+    wrapped build_connection is called and tries to access it in the env
+    """
+    assert isinstance(pulse_conn, Promise)
+
+    with raises(ImproperlyConfigured):
+        # Django's lazy function requires we access a wrapped object to trigger
+        # running it.  Assigning it to a variable is not enough.
+        print(pulse_conn)

--- a/treeherder/services/pulse/connection.py
+++ b/treeherder/services/pulse/connection.py
@@ -1,18 +1,19 @@
 import environ
+from django.utils.functional import lazy
 from kombu import Connection
 
 env = environ.Env()
 
-# Used to specify the PulseGuardian account that will be used to create
-# ingestion queues for the exchanges specified in ``PULSE_SOURCE_EXCHANGES``.
-# See https://pulse.mozilla.org/whats_pulse for more info.
-# Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/?ssl=1"
-config = env.url("PULSE_URL")
+
+def build_connection():
+    """Build a Kombu Broker connection to Mozilla Pulse."""
+    # Used to specify the PulseGuardian account that will be used to create
+    # ingestion queues for the exchanges specified in ``PULSE_SOURCE_EXCHANGES``.
+    # See https://pulse.mozilla.org/whats_pulse for more info.
+    # Example: "amqp://myuserid:mypassword@pulse.mozilla.org:5672/?ssl=1"
+    pulse_url = env.url("PULSE_URL")
+
+    return Connection(pulse_url.geturl())
 
 
-def build_connection(url):
-    """Build a Kombu Broker connection to Mozilla Pulse with the given url."""
-    return Connection(url)
-
-
-pulse_conn = build_connection(config.geturl())
+pulse_conn = lazy(build_connection, Connection)()


### PR DESCRIPTION
This is another (better!) version of #3921 making use of Django's `lazy` wrapper instead of `SimpleLazyObject`.  It includes some basic tests to confirm the connection object acts as expected, similar to intent (but not execution) to our `test_setup` tests.

Locally I've used this with a manually set `PULSE_URL` to pull both Job and Push messages from Pulse.