### PR TITLE
Bug 1473777 - Fix error message if job is missing

### DIFF
--- a/ui/job-view/PushList.jsx
+++ b/ui/job-view/PushList.jsx
@@ -151,11 +151,11 @@ export default class PushList extends React.Component {
             { sticky: true, linkText: 'Load push', url });
 
         });
-      }, function () {
+      }).catch((error) => {
         // the job wasn't found in the db.  Either never existed,
         // or was expired and deleted.
-        this.thNotify.send(
-          `Unable to find job with id ${selectedJobId}`,
+        this.$location.search('selectedJob', null);
+        this.thNotify.send(`Selected Job - ${error}`,
           'danger',
           { sticky: true });
       });

--- a/ui/js/controllers/logviewer.js
+++ b/ui/js/controllers/logviewer.js
@@ -199,10 +199,10 @@ logViewerApp.controller('LogviewerCtrl', [
                 JobDetailModel.getJobDetails({ job_guid: job.job_guid }).then((jobDetails) => {
                     $scope.job_details = jobDetails;
                 });
-            }, () => {
+            }).catch((error) => {
                 $scope.loading = false;
                 $scope.jobExists = false;
-                thNotify.send('The job does not exist or has expired', 'danger', { sticky: true });
+                thNotify.send(`${error}`, 'danger', { sticky: true });
             });
         };
 

--- a/ui/models/job.js
+++ b/ui/models/job.js
@@ -76,7 +76,14 @@ export default class JobModel {
   static get(repoName, pk, signal) {
     // a static method to retrieve a single instance of JobModel
     return fetch(`${uri}${pk}/`, { signal })
-      .then(response => response.json().then(data => new JobModel(data)));
+      .then(async (response) => {
+        if (response.ok) {
+          const job = await response.json();
+          return new JobModel(job);
+        }
+        const text = await response.text();
+        throw Error(`Loading job with id ${pk} : ${text}`);
+      });
   }
 
   static getSimilarJobs(repoName, pk, options, config) {


### PR DESCRIPTION
I think that this is much closer to the pattern I want to follow for error handling with ``fetch`` when we want to return model "instances" rather than raw JS objects.  There's more work to be done with these models to establish a consistent pattern.  And I will revisit this when I address [Bug 1473777](https://bugzilla.mozilla.org/show_bug.cgi?id=1473777) as a whole for all the models and ``fetch`` handling.

This, however, fixes two cases where the ``job.id`` comes from the url, and could therefore be easily invalid.