### PR TITLE
Test Pulse Scripts

### DIFF
--- a/docs/pulseload.md
+++ b/docs/pulseload.md
@@ -112,34 +112,24 @@ push_sources = [
 #### Jobs
 Job Exchanges and Projects can be configured in the environment like so:
 
-``PULSE_JOB_EXCHANGES`` defines a list of exchanges to listen to.
+``PULSE_JOB_SOURCES`` defines a list of exchanges with projects.
 ```bash
-export PULSE_JOB_EXCHANGES="exchange/taskcluster-treeherder/v1/jobs,exchange/fxtesteng/jobs"
+export PULSE_JOB_SOURCES="exchange/taskcluster-treeherder/v1/jobs.mozilla-central:mozilla-inbound,exchange/fxtesteng/jobs.#",
 ```
 
-``PULSE_JOB_PROJECTS`` defines a list of projects to listen to.
-```bash
-export PULSE_JOB_PROJECTS="try,mozilla-central"
-```
+In this example we've defined two exchanges:
 
-The source settings are combined such that all `projects` are applied to **each** `exchange`.
-The example settings above would produce the following settings:
+* ``exchange/taskcluster-treeherder/v1/jobs``
+* ``exchange/fxtesteng/jobs``
 
-```python
-[{
-    "exchange": "exchange/taskcluster-treeherder/v1/jobs",
-    "projects": [
-        "try",
-        "mozilla-central",
-    ],
-}, {
-    "exchange": "exchange/fxtesteng/jobs",
-    "projects": [
-        "try",
-        "mozilla-central",
-    ],
-}]
-```
+The taskcluster-treeherder exchange defines two projects:
+
+* ``mozilla-central``
+* ``mozilla-inbound``
+
+The ``fxtesteng`` exchange defines a wildcard (``#``) for its project.
+
+When Jobs are read from Pulse and added to Treeherder's celery queue we generate a routing key by prepending ``#.`` to each project key.
 
 
 ### Advanced Celery options

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -340,10 +340,19 @@ def activate_responses(request):
     request.addfinalizer(fin)
 
 
-def pulse_consumer(exchange, request):
-    exchange_name = 'exchange/treeherder/v1/{}'.format(exchange)
+@pytest.fixture
+def pulse_connection():
+    """
+    Build a Pulse connection with the Kombu library
 
-    connection = kombu.Connection(settings.PULSE_URL)
+    This is a non-lazy mirror of our Pulse service's build_connection as
+    explained in: https://bugzilla.mozilla.org/show_bug.cgi?id=1484196
+    """
+    return kombu.Connection(settings.BROKER_URL)
+
+
+def pulse_consumer(connection, exchange, request):
+    exchange_name = 'exchange/treeherder/v1/{}'.format(exchange)
 
     exchange = kombu.Exchange(
         name=exchange_name,
@@ -370,8 +379,8 @@ def pulse_consumer(exchange, request):
 
 
 @pytest.fixture
-def pulse_action_consumer(request):
-    return pulse_consumer('job-actions', request)
+def pulse_action_consumer(pulse_connection, request):
+    return pulse_consumer(pulse_connection, 'job-actions', request)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from treeherder.model.models import (Commit,
                                      JobNote,
                                      Push,
                                      TextLogErrorMetadata)
+from treeherder.services.pulse.exchange import get_exchange
 
 
 def pytest_addoption(parser):
@@ -381,6 +382,13 @@ def pulse_consumer(connection, exchange, request):
 @pytest.fixture
 def pulse_action_consumer(pulse_connection, request):
     return pulse_consumer(pulse_connection, 'job-actions', request)
+
+
+@pytest.fixture
+def pulse_exchange(pulse_connection, request):
+    def build_exchange(name, create_exchange):
+        return get_exchange(pulse_connection, name, create=create_exchange)
+    return build_exchange
 
 
 @pytest.fixture

--- a/tests/services/pulse/test_consumers.py
+++ b/tests/services/pulse/test_consumers.py
@@ -1,0 +1,61 @@
+from treeherder.services.pulse import (JobConsumer,
+                                       PushConsumer,
+                                       prepare_consumer)
+from treeherder.services.pulse.consumers import bind_to
+
+from .utils import create_and_destroy_exchange
+
+
+def test_bind_to(pulse_connection, pulse_exchange):
+    job_consumer = JobConsumer(pulse_connection)
+    exchange = pulse_exchange("exchange/taskcluster-treeherder/v1/jobs", create_exchange=True)
+    routing_key = "test_routing_key"
+
+    binding = bind_to(job_consumer, exchange, routing_key)
+
+    # Our Consumer should only have one consumer
+    assert len(job_consumer.consumers) == 1
+
+    queue = job_consumer.consumers[0]["queues"]
+
+    # check construction of kombu.Queue from Consumer.bind_to
+    assert queue.exchange == exchange
+    assert queue.routing_key == routing_key
+
+    # test Consumer.get_binding_str constructed a correct binding string
+    assert binding == "{} {}".format(exchange.name, routing_key)
+
+
+def test_prepare_consumer(pulse_connection, pulse_exchange):
+    # create the exchange in the local RabbitMQ instance
+    job_exchange = "exchange/taskcluster-treeherder/v1/jobs"
+    with create_and_destroy_exchange(pulse_connection, job_exchange):
+        job_consumer = prepare_consumer(
+            pulse_connection,
+            JobConsumer,
+            ["{}.test_project".format(job_exchange)],
+            lambda key: "foo.{}".format(key),
+        )
+
+    assert isinstance(job_consumer, JobConsumer)
+    assert len(job_consumer.consumers) == 1
+
+    queue = job_consumer.consumers[0]["queues"]
+    assert queue.routing_key == "foo.test_project"
+    assert queue.exchange.name == "exchange/taskcluster-treeherder/v1/jobs"
+
+    push_exchange = "exchange/taskcluster-github/v1/push"
+    with create_and_destroy_exchange(pulse_connection, push_exchange):
+        push_consumer = prepare_consumer(
+            pulse_connection,
+            PushConsumer,
+            ["{}.test_key".format(push_exchange)],
+        )
+
+    assert isinstance(push_consumer, PushConsumer)
+    assert len(push_consumer.consumers) == 1
+
+    # check the bound queues were configured based on sources correctly
+    queue = push_consumer.consumers[0]["queues"]
+    assert queue.routing_key == "test_key"
+    assert queue.exchange.name == "exchange/taskcluster-github/v1/push"

--- a/tests/services/pulse/test_exchange.py
+++ b/tests/services/pulse/test_exchange.py
@@ -1,0 +1,19 @@
+from kombu import Exchange
+
+from treeherder.services.pulse.exchange import get_exchange
+
+from .utils import create_and_destroy_exchange
+
+
+def test_get_existing_exchange(pulse_connection):
+    with create_and_destroy_exchange(pulse_connection, "foobar"):
+        # shouldn't throw an error about a non-existant connection
+        get_exchange(pulse_connection, "foobar")
+
+
+def test_get_new_exchange(pulse_connection):
+    """Test we can create a new exchange on the given connection."""
+    exchange = get_exchange(pulse_connection, "new_exchange", create=True)
+
+    assert isinstance(exchange, Exchange)
+    assert exchange.name == "new_exchange"

--- a/tests/services/pulse/utils.py
+++ b/tests/services/pulse/utils.py
@@ -1,0 +1,21 @@
+import contextlib
+
+from treeherder.services.pulse.exchange import get_exchange
+
+
+@contextlib.contextmanager
+def create_and_destroy_exchange(connection, name):
+    """
+    Simple context manager to create and delete an Exchange
+
+    Primarily used with testing this is allows a user to create an Exchange
+    with the given name using the given connection and know it will be
+    destroyed when the context manager exits.
+
+    This has been implemented as a context manager as creating both a yielding
+    fixture and a fixture which takes an argument appears to not be possible
+    with pytest.
+    """
+    exchange = get_exchange(connection, name, create=True)
+    yield exchange
+    exchange.delete()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -11,7 +11,6 @@ CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 
 # Reconfigure pulse to operate on default vhost of rabbitmq
 PULSE_URI = BROKER_URL
-PULSE_URL = BROKER_URL
 
 # Set a fake api key for testing bug filing
 BUGFILER_API_KEY = "12345helloworld"

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -506,6 +506,3 @@ PERFHERDER_ALERTS_MAX_AGE = timedelta(weeks=2)
 # More details here: https://bugzilla.mozilla.org/show_bug.cgi?id=1281821
 # TODO: remove this in favour of settings.PULSE_URL
 PULSE_URI = env("PULSE_URI", default="amqps://guest:guest@pulse.mozilla.org/")
-
-# The pulse url that is passed to kombu
-PULSE_URL = env("PULSE_URL", default="amqps://guest:guest@pulse.mozilla.org/")

--- a/treeherder/etl/management/commands/read_pulse_jobs.py
+++ b/treeherder/etl/management/commands/read_pulse_jobs.py
@@ -1,8 +1,8 @@
 from django.core.management.base import BaseCommand
 
 from treeherder.services.pulse import (JobConsumer,
-                                       get_exchange,
                                        job_sources,
+                                       prepare_consumer,
                                        pulse_conn)
 
 
@@ -16,27 +16,13 @@ class Command(BaseCommand):
     help = "Read jobs from a set of pulse exchanges and queue for ingestion"
 
     def handle(self, *args, **options):
-        new_bindings = []
-
         with pulse_conn as connection:
-            consumer = JobConsumer(connection, "jobs")
-
-            for source in job_sources:
-                exchange = get_exchange(connection, source["exchange"])
-
-                for project in source["projects"]:
-                    routing_key = "#.{}".format(project)
-                    consumer.bind_to(exchange=exchange, routing_key=routing_key)
-                    new_binding_str = consumer.get_binding_str(exchange.name, routing_key)
-                    new_bindings.append(new_binding_str)
-
-                    self.stdout.write(
-                        "Pulse queue {} bound to: {}".format(
-                            consumer.queue_name,
-                            new_binding_str
-                        ))
-
-            consumer.prune_bindings(new_bindings)
+            consumer = prepare_consumer(
+                connection,
+                JobConsumer,
+                job_sources,
+                lambda key: "#.{}".format(key),
+            )
 
             try:
                 consumer.run()

--- a/treeherder/etl/management/commands/read_pulse_pushes.py
+++ b/treeherder/etl/management/commands/read_pulse_pushes.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 
 from treeherder.services.pulse import (PushConsumer,
-                                       get_exchange,
+                                       prepare_consumer,
                                        pulse_conn,
                                        push_sources)
 
@@ -16,29 +16,12 @@ class Command(BaseCommand):
     help = "Read pushes from a set of pulse exchanges and queue for ingestion"
 
     def handle(self, *args, **options):
-        new_bindings = []
-
         with pulse_conn as connection:
-            consumer = PushConsumer(connection, "resultsets")
-
-            for source in push_sources:
-                exchange, _, routing_keys = source.partition('.')
-                exchange = get_exchange(connection, exchange)
-
-                for routing_key in routing_keys.split(','):
-                    consumer.bind_to(exchange, routing_key)
-                    new_binding_str = consumer.get_binding_str(
-                        exchange.name,
-                        routing_key)
-                    new_bindings.append(new_binding_str)
-
-                    self.stdout.write(
-                        "Pulse queue {} bound to: {}".format(
-                            consumer.queue_name,
-                            new_binding_str
-                        ))
-
-            consumer.prune_bindings(new_bindings)
+            consumer = prepare_consumer(
+                connection,
+                PushConsumer,
+                push_sources,
+            )
 
             try:
                 consumer.run()

--- a/treeherder/services/pulse/__init__.py
+++ b/treeherder/services/pulse/__init__.py
@@ -1,7 +1,7 @@
 from .connection import pulse_conn
 from .consumers import (JobConsumer,
-                        PushConsumer)
-from .exchange import get_exchange
+                        PushConsumer,
+                        prepare_consumer)
 from .publisher import publish_job_action
 from .sources import (job_sources,
                       push_sources)
@@ -9,8 +9,8 @@ from .sources import (job_sources,
 __all__ = [
     "JobConsumer",
     "PushConsumer",
-    "get_exchange",
     "job_sources",
+    "prepare_consumer",
     "publish_job_action",
     "pulse_conn",
     "push_sources",

--- a/treeherder/services/pulse/consumers.py
+++ b/treeherder/services/pulse/consumers.py
@@ -20,11 +20,12 @@ class PulseConsumer(ConsumerMixin):
     """
     Consume jobs from Pulse exchanges
     """
-    def __init__(self, connection, queue_suffix):
+
+    def __init__(self, connection):
         self.connection = connection
         self.consumers = []
         self.queue = None
-        self.queue_name = "queue/{}/{}".format(connection.userid, queue_suffix)
+        self.queue_name = "queue/{}/{}".format(connection.userid, self.queue_suffix)
 
     def get_consumers(self, Consumer, channel):
         return [
@@ -87,6 +88,7 @@ class PulseConsumer(ConsumerMixin):
 
 
 class JobConsumer(PulseConsumer):
+    queue_suffix = "jobs"
 
     def on_message(self, body, message):
         exchange = message.delivery_info['exchange']
@@ -100,6 +102,7 @@ class JobConsumer(PulseConsumer):
 
 
 class PushConsumer(PulseConsumer):
+    queue_suffix = "resultsets"
 
     def on_message(self, body, message):
         exchange = message.delivery_info['exchange']

--- a/treeherder/services/pulse/exchange.py
+++ b/treeherder/services/pulse/exchange.py
@@ -1,14 +1,20 @@
 from kombu import Exchange
 
 
-def get_exchange(connection, name):
-    """Get a Kombu Exchange object using the passed in name."""
-    # When creating this exchange object, it is important that it be set to
-    # ``passive=True``.  This will prevent any attempt by Kombu to actually
-    # create the exchange.
-    exchange = Exchange(name, type="topic", passive=True)
+def get_exchange(connection, name, create=False):
+    """
+    Get a Kombu Exchange object using the passed in name.
 
-    # ensure the exchange exists.  Throw an error if it doesn't
-    exchange(connection).declare()
+    Can create an Exchange but this is typically not wanted in production-like
+    environments and only useful for testing.
+    """
+    exchange = Exchange(name, type="topic", passive=not create)
 
-    return exchange
+    # bind the exchange to our connection so operations can be performed on it
+    bound_exchange = exchange(connection)
+
+    # ensure the exchange exists.  Throw an error if it was created with
+    # passive=True and it doesn't exist.
+    bound_exchange.declare()
+
+    return bound_exchange

--- a/treeherder/services/pulse/sources.py
+++ b/treeherder/services/pulse/sources.py
@@ -1,34 +1,31 @@
+"""
+Job and Push sources
+
+Both source types define an exchange path followed by one or more routing key
+parts. Routing keys are specified after a period (".") separated by colons
+(":"). Routing keys use a colon separator to avoid problems with defining
+multiple push sources in an environment variable which are comma separated.
+"""
 import environ
 
 env = environ.Env()
 
 
-exchanges = env.list("PULSE_JOB_EXCHANGES", default=[
-    "exchange/taskcluster-treeherder/v1/jobs",
-    # "exchange/fxtesteng/jobs",
-    # ... other CI systems
-])
-projects = env.list("PULSE_JOB_PROJECTS", default=[
-    "#",
-    # some specific repos TC can ingest from
-    # "mozilla-central.#",
-    # "mozilla-inbound.#",
-])
-
-
-# Specifies the Pulse exchanges Treeherder will ingest data from for Jobs. This
-# list will be updated as new applications come online that Treeherder
-# supports.  Treeherder will subscribe with routing keys that are the project
-# names.  Wildcards such as ``#`` and ``*`` are supported for the project
-# field.
-job_sources = [{
-    "exchange": exchange,
-    "projects": projects,
-} for exchange in exchanges]
+# Specifies the Pulse exchanges Treeherder will ingest data from for Jobs.
+# Projects specified after the period (".") delimiter and will be combined with
+# the wildcard ("#") when used in prepare_consumer function when called by
+# read_pulse_jobs.
+job_sources = env.list(
+    "PULSE_JOB_SOURCES",
+    default=[
+        "exchange/taskcluster-treeherder/v1/jobs.#",
+        "exchange/fxtesteng/jobs.#",
+        # ... other CI systems
+    ],
+)
 
 
 # Specifies the Pulse exchanges Treeherder will ingest data from for Push data.
-# Routing keys are specified after a period ("."), separated by commas (",").
 push_sources = [
     "exchange/taskcluster-github/v1/push.#",
     "exchange/taskcluster-github/v1/pull-request.#",


### PR DESCRIPTION
This refactors the two Pulse scripts, `read_pulse_jobs` and `read_pulse_pushes` to use a common function for their consumer construction and source parsing.  In doing so we can now test this part of both scripts.

Note: this changes the Job sources configuration to a list of strings and how the Push source's routing keys are delimited so they are both the same.

Note2: this makes our `get_exchange` function slightly more useful by allowing us to configure it to create exchanges upon declaration of a bound `Exchange` instance.  It also returns the bound instance so we can perform actions on it elsewhere.