### PR TITLE
Use $id instead of id

### DIFF
--- a/schemas/pulse-job.yml
+++ b/schemas/pulse-job.yml
@@ -263,7 +263,6 @@ properties:
       Definition of the Job Info for a job.  These are extra data
       fields that go along with a job that will be displayed in
       the details panel within Treeherder.
-    id: "jobInfo"
     type: object
     properties:
       summary:


### PR DESCRIPTION
This schema is a version-6 schema, which uses $id instead of id.

I'm not sure why this is here at all -- perhaps it could just be omitted?  A search for `jobInfo` over the entire repo doesn't find anything that seems to be referring to this subschema.