### PR TITLE
Bug 1486660 - IFV UI error-handling additions

### DIFF
--- a/ui/css/intermittent-failures.css
+++ b/ui/css/intermittent-failures.css
@@ -100,3 +100,28 @@ ul {
   list-style-type: none;
   text-align: left;
 }
+
+.loading {
+  position: fixed;
+  z-index: 999;
+  height: 2em;
+  width: 2em;
+  overflow: show;
+  margin: auto;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+
+/* overlay */
+.loading:before {
+  content: '';
+  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(20, 19, 19, 0.3);
+}

--- a/ui/intermittent-failures/BugDetailsView.jsx
+++ b/ui/intermittent-failures/BugDetailsView.jsx
@@ -101,7 +101,7 @@ class BugDetailsView extends React.Component {
 
     if (bug !== bugId) {
       updateBugDetails(bug, summary, stateName.detailsView);
-      fetchData(bugzillaBugsApi('rest/bug', { include_fields: 'summary,id', id: bug }), 'BUGZILLA_BUG_DETAILS');
+      fetchData(bugzillaBugsApi('bug', { include_fields: 'summary,id', id: bug }), 'BUGZILLA_BUG_DETAILS');
     }
     // the table library fetches data directly when its component mounts and in response
     // to a user selecting pagesize or page; this condition will prevent duplicate requests
@@ -194,7 +194,7 @@ class BugDetailsView extends React.Component {
             back</Link></span>
           </Col>
         </Row>
-        {errorMessages.length === 0 && bugDetails.results &&
+        {errorMessages.length === 0 &&
         <React.Fragment>
           <Row>
             <Col xs="12" className="mx-auto"><h1>Details for Bug {!bugId ? '' : bugId}</h1></Col>
@@ -203,15 +203,15 @@ class BugDetailsView extends React.Component {
             <Col xs="12" className="mx-auto"><p className="subheader">{`${prettyDate(from)} to ${prettyDate(to)} UTC`}</p>
             </Col>
           </Row>
+          {summary &&
+          <Row>
+            <Col xs="4" className="mx-auto"><p className="text-secondary text-center">{summary}</p></Col>
+          </Row>}
+          {bugDetails && bugDetails.count &&
+          <Row>
+            <Col xs="12" className="mx-auto"><p className="text-secondary">{bugDetails.count} total failures</p></Col>
+          </Row>}
         </React.Fragment>}
-        {summary && bugDetails.results &&
-        <Row>
-          <Col xs="4" className="mx-auto"><p className="text-secondary text-center">{summary}</p></Col>
-        </Row>}
-        {bugDetails && bugDetails.count &&
-        <Row>
-          <Col xs="12" className="mx-auto"><p className="text-secondary">{bugDetails.count} total failures</p></Col>
-        </Row>}
 
         <ErrorBoundary
           stateName={stateName.detailsViewGraphs}

--- a/ui/intermittent-failures/ErrorBoundary.jsx
+++ b/ui/intermittent-failures/ErrorBoundary.jsx
@@ -34,11 +34,10 @@ ErrorBoundary.propTypes = {
     PropTypes.shape({}),
     PropTypes.bool,
   ]),
-  errorFound: PropTypes.func,
+  errorFound: PropTypes.func.isRequired,
 };
 
 ErrorBoundary.defaultProps = {
-  errorFound: null,
   children: null,
 };
 

--- a/ui/intermittent-failures/ErrorBoundary.jsx
+++ b/ui/intermittent-failures/ErrorBoundary.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { hasError } from './redux/actions';
+import { prettyErrorMessages } from './constants';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  componentDidCatch() {
+    const { errorFound, stateName } = this.props;
+
+    // display fallback UI and reset isFetching to turn off the loading spinner
+    this.setState({ hasError: true }, () => errorFound(stateName));
+
+    // TODO: set up a logger to record error and { componentStack }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <p className="text-danger py-2">{prettyErrorMessages.default}</p>;
+    }
+    return this.props.children;
+  }
+}
+
+ErrorBoundary.propTypes = {
+  stateName: PropTypes.string.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.shape({}),
+    PropTypes.bool,
+  ]),
+  errorFound: PropTypes.func,
+};
+
+ErrorBoundary.defaultProps = {
+  errorFound: null,
+  children: null,
+};
+
+const mapDispatchToProps = dispatch => ({
+  errorFound: name => dispatch(hasError(name)),
+});
+
+export default connect(null, mapDispatchToProps)(ErrorBoundary);

--- a/ui/intermittent-failures/ErrorMessages.jsx
+++ b/ui/intermittent-failures/ErrorMessages.jsx
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import { Alert } from 'reactstrap';
 import { processErrorMessage } from './helpers';
 
-const ErrorMessages = (props) => {
-  const messages = processErrorMessage(props.failureMessage, props.failureStatus);
+const ErrorMessages = ({ failureMessage, failureStatus, errorMessages }) => {
+  const messages = errorMessages.length > 0 ? errorMessages : processErrorMessage(failureMessage, failureStatus);
+
   return (
     <div>
       {messages.map(message =>
@@ -17,11 +18,15 @@ const ErrorMessages = (props) => {
 ErrorMessages.propTypes = {
   failureMessage: PropTypes.object,
   failureStatus: PropTypes.number,
+  errorMessages: PropTypes.array,
 };
 
 ErrorMessages.defaultProps = {
   failureMessage: null,
   failureStatus: null,
+  errorMessages: PropTypes.arrayOf(
+    PropTypes.string,
+  ),
 };
 
 export default ErrorMessages;

--- a/ui/intermittent-failures/constants.js
+++ b/ui/intermittent-failures/constants.js
@@ -44,12 +44,15 @@ export const treeOptions = [
   'comm-releases',
 ];
 
+// we only want bug_ui and tree_ui to be used for UI validation, because
+// if there is a valid type used but its a non-existent repo or bug_id
+// we want to see that message from the api response
 export const prettyErrorMessages = {
   startday: 'startday is required and must be in YYYY-MM-DD format.',
   endday: 'endday is required and must be in YYYY-MM-DD format.',
-  // bug: 'bug is required and must be a valid integer.',
-  // tree: 'tree is required and must be a valid repository.',
-  default: 'Something went wrong. Please try again later.',
+  bug_ui: 'bug is required and must be a valid integer.',
+  tree_ui: 'tree is required and must be a valid repository or repository group.',
+  default: 'Something went wrong.',
   status503: 'There was a problem retrieving the data. Please try again in a minute.',
 };
 

--- a/ui/intermittent-failures/helpers.js
+++ b/ui/intermittent-failures/helpers.js
@@ -65,11 +65,9 @@ export const calculateMetrics = function calculateMetricsForGraphs(data) {
 };
 
 export const updateQueryParams = function updateHistoryWithQueryParams(view, queryParams, history, location) {
-  if (queryParams !== history.location.search) {
     history.replace({ pathname: view, search: queryParams });
     // we do this so the api's won't be called twice (location/history updates will trigger a lifecycle hook)
     location.search = queryParams;
-  }
 };
 
 export const sortData = function sortData(data, sortBy, desc) {
@@ -86,18 +84,6 @@ export const sortData = function sortData(data, sortBy, desc) {
     return 0;
   });
   return data;
-};
-
-export const checkQueryParams = function checkQueryParams(obj) {
-  if (!obj.tree) {
-    obj.tree = 'trunk';
-  }
-  if (!obj.startday || !obj.endday) {
-    const { from, to } = setDateRange(moment().utc(), 7);
-    obj.startday = from;
-    obj.endday = to;
-  }
-  return obj;
 };
 
 export const processErrorMessage = function processErrorMessage(errorMessage, status) {
@@ -117,4 +103,23 @@ export const processErrorMessage = function processErrorMessage(errorMessage, st
     }
   }
   return messages || [prettyErrorMessages.default];
+};
+
+export const validateQueryParams = function validateQueryParams(params, bugRequired = false) {
+  const messages = [];
+  const dateFormat = /\d{4}[-]\d{2}[-]\d{2}/;
+
+  if (!params.tree) {
+    messages.push(prettyErrorMessages.tree_ui);
+  }
+  if (!params.startday || params.startday.search(dateFormat) === -1) {
+    messages.push(prettyErrorMessages.startday);
+  }
+  if (!params.endday || params.endday.search(dateFormat) === -1) {
+    messages.push(prettyErrorMessages.endday);
+  }
+  if (bugRequired && (!params.bug || isNaN(params.bug))) {
+    messages.push(prettyErrorMessages.bug_ui);
+  }
+  return messages;
 };

--- a/ui/intermittent-failures/redux/actions.js
+++ b/ui/intermittent-failures/redux/actions.js
@@ -48,7 +48,7 @@ export const fetchBugsThenBugzilla = (url, name) => (dispatch, getState) => (
     if (!getState().bugsData.failureStatus) {
       const { results } = getState().bugsData.data;
       const bugs_list = formatBugs(results);
-      return dispatch(fetchBugData(bugzillaBugsApi('rest/bug', {
+      return dispatch(fetchBugData(bugzillaBugsApi('bug', {
         include_fields: 'id,status,summary,whiteboard',
         id: bugs_list,
       }), `BUGZILLA_${name}`));

--- a/ui/intermittent-failures/redux/reducers.js
+++ b/ui/intermittent-failures/redux/reducers.js
@@ -2,18 +2,30 @@ import moment from 'moment';
 
 import { setDateRange } from '../helpers';
 
-export const fetchData = (name = '') => (state = { data: {}, message: {}, failureStatus: null }, action) => {
+export const fetchData = (name = '') => (state = { data: {}, message: {}, failureStatus: null, isFetching: true }, action) => {
   switch (action.type) {
+    case `REQUESTING_${name}_DATA`:
+      return {
+        ...state,
+        isFetching: true,
+      };
     case `FETCH_${name}_SUCCESS`:
       return {
         ...state,
         data: action.data,
+        isFetching: false,
       };
     case `FETCH_${name}_FAILURE`:
       return {
         ...state,
         message: action.message,
         failureStatus: action.failureStatus,
+        isFetching: false,
+      };
+    case `${name}_ERROR`:
+      return {
+        ...state,
+        isFetching: false,
       };
     default:
       return state;


### PR DESCRIPTION
Add spinner to ease transitions, add error boundaries,
add query param validation prior to api requests.

## Notes
This is part 2 (part 1 was [bug 1460999](https://bugzilla.mozilla.org/show_bug.cgi?id=1460999))

I ended up having to refactor some of the changes I had made in part 1 in part because it either added unnecessary complexity or because of a bug I found while working on the spinner (multiple requests being made when the parent component mounts and the table library mounts - that also created a dilemma where we don't want to hide this table library for an error alert or it'll remount when the error is fixed, causing said problem).

I tested the validateQueryParams functionality locally. 
