### PR TITLE
Change message in FailuresQueryParamsSerializer

### DIFF
--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -325,7 +325,8 @@ class FailuresQueryParamsSerializer(serializers.Serializer):
                 models.Bugscache.objects.get(id=bug)
 
             except ObjectDoesNotExist:
-                raise serializers.ValidationError('{} does not exist.'.format(bug))
+                raise serializers.ValidationError(
+                      '{} does not exist or is not an intermittent failure.'.format(bug))
 
         return bug
 


### PR DESCRIPTION
clarify error message in validate_bug since a bug can exist in bugzilla
but not exist in our bugscache if its not an intermittent failure

This pertains to the changes made in the two error handling bugs [1460999](https://bugzilla.mozilla.org/show_bug.cgi?id=1460999) and [1486660](https://bugzilla.mozilla.org/show_bug.cgi?id=1486660).