### PR TITLE
Add generic ErrorBoundary

### DIFF
--- a/ui/job-view/PushList.jsx
+++ b/ui/job-view/PushList.jsx
@@ -13,6 +13,7 @@ import PushLoadErrors from './PushLoadErrors';
 import { thEvents } from '../js/constants';
 import JobModel from '../models/job';
 import PushModel from '../models/push';
+import ErrorBoundary from '../shared/ErrorBoundary';
 
 export default class PushList extends React.Component {
 
@@ -277,16 +278,21 @@ export default class PushList extends React.Component {
       <div>
         {jobsReady && <span className="hidden ready" />}
         {repoName && pushList.map(push => (
-          <Push
-            push={push}
-            isLoggedIn={isLoggedIn || false}
-            currentRepo={currentRepo}
-            isStaff={isStaff}
-            repoName={repoName}
-            $injector={$injector}
+          <ErrorBoundary
+            errorClasses="pl-2 border-top border-bottom border-dark d-block"
+            message={`Error on push with revision ${push.revision}: `}
             key={push.id}
-            notificationSupported={notificationSupported}
-          />
+          >
+            <Push
+              push={push}
+              isLoggedIn={isLoggedIn || false}
+              currentRepo={currentRepo}
+              isStaff={isStaff}
+              repoName={repoName}
+              $injector={$injector}
+              notificationSupported={notificationSupported}
+            />
+          </ErrorBoundary>
         ))}
         {loadingPushes &&
           <div

--- a/ui/job-view/headerbars/SecondaryNavBar.jsx
+++ b/ui/job-view/headerbars/SecondaryNavBar.jsx
@@ -6,6 +6,7 @@ import { getBtnClass } from '../../helpers/job';
 import { getRepo, getUrlParam } from '../../helpers/location';
 import WatchedRepo from './WatchedRepo';
 import RepositoryModel from '../../models/repository';
+import ErrorBoundary from '../../shared/ErrorBoundary';
 
 const MAX_WATCHED_REPOS = 3;
 const WATCHED_REPOS_STORAGE_KEY = 'thWatchedRepos';
@@ -220,14 +221,19 @@ export default class SecondaryNavBar extends React.Component {
         <span className="justify-content-between w-100 d-flex flex-wrap">
           <span className="d-flex push-left watched-repos">
             {watchedRepos.map(watchedRepo => (
-              <WatchedRepo
+              <ErrorBoundary
+                errorClasses="pl-1 pr-1 btn-view-nav border-right"
+                message={`Error watching ${watchedRepo.name}: `}
                 key={watchedRepo.name}
-                repo={watchedRepo}
-                repoName={repoName}
-                $injector={$injector}
-                unwatchRepo={this.unwatchRepo}
-                setCurrentRepoTreeStatus={setCurrentRepoTreeStatus}
-              />
+              >
+                <WatchedRepo
+                  repo={watchedRepo}
+                  repoName={repoName}
+                  $injector={$injector}
+                  unwatchRepo={this.unwatchRepo}
+                  setCurrentRepoTreeStatus={setCurrentRepoTreeStatus}
+                />
+              </ErrorBoundary>
             ))}
           </span>
           <form role="search" className="form-inline flex-row">

--- a/ui/shared/ErrorBoundary.jsx
+++ b/ui/shared/ErrorBoundary.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+    };
+  }
+
+  componentDidCatch(error) {
+    this.setState({
+      hasError: true,
+      error,
+    });
+  }
+
+  render() {
+    const { children, errorClasses, message } = this.props;
+    const { hasError, error } = this.state;
+
+    if (hasError) {
+      return <span className={errorClasses}>{message} {error.toString()}</span>;
+    }
+    return children;
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.object.isRequired,
+  errorClasses: PropTypes.string,
+  message: PropTypes.string,
+};
+
+ErrorBoundary.defaultProps = {
+  errorClasses: '',
+  message: '',
+};


### PR DESCRIPTION
This is a proposal for a generic ``ErrorBoundary`` that allows a little customization.  I wanted something that would fit into different shaped areas.  So we can pass classes that will color and shape it, based on the context.

Here's an error with a ``WatchedRepo``:

![screenshot 2018-08-28 15 40 09](https://user-images.githubusercontent.com/419924/44754874-abfde080-aad8-11e8-8642-dba8952c4a14.png)

Here's an error with a ``Push``:

![screenshot 2018-08-28 15 46 35](https://user-images.githubusercontent.com/419924/44755129-a48b0700-aad9-11e8-9a25-a41905d548e0.png)


The advantage of this over having a ``componentDidCatch`` in a particular component is that, as the docs say they do NOT catch "Errors thrown in the error boundary itself (rather than its children)".  

I am **certain** there is room for improvement here, but it's a starting point.  Maybe it should support more than one line, not really sure.  Opinions?  :)