### PR TITLE
Bug 1483267 - Respect Celery Soft Time Limit in Log Parsing

### DIFF
--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -54,13 +54,15 @@ def parse_logs(job_id, job_log_ids, priority):
     exceptions = []
     for job_log in job_logs:
         parser = parser_tasks.get(job_log.name)
-        if parser:
-            try:
-                parser(job_log)
-            except Exception as e:
-                exceptions.append(e)
-            else:
-                completed_names.add(job_log.name)
+        if not parser:
+            continue
+
+        try:
+            parser(job_log)
+        except Exception as e:
+            exceptions.append(e)
+        else:
+            completed_names.add(job_log.name)
 
     if exceptions:
         raise exceptions[0]


### PR DESCRIPTION
This re-raises Celery's `SoftTimeLimitExceeded` so it can be handled elsewhere and logs all non-timeout exceptions to NewRelic.  It tracks non-timeout exceptions using a boolean flag since we don't care about what they were, just that they happened so we don't do further processing.