### PR TITLE
Simplify Cross-referencing Machinery

### DIFF
--- a/treeherder/log_parser/crossreference.py
+++ b/treeherder/log_parser/crossreference.py
@@ -108,22 +108,6 @@ class ErrorSummaryMatchConvertor(object):
         except AttributeError:
             return None, None
 
-        msg = f(as_dict(failure_line)).split("\n", 1)[0]
+        msg = f(failure_line.to_mozlog_format()).split("\n", 1)[0]
 
         return msg, lambda x: x.endswith(msg.strip())
-
-
-def as_dict(failure_line):
-    """Convert a FailureLine into a dict in the format expected as input to
-    mozlog formatters.
-
-    :param failure_line: The FailureLine to convert."""
-    rv = {"action": failure_line.action,
-          "line_number": failure_line.line}
-    for key in ["test", "subtest", "status", "expected", "message", "signature", "level",
-                "stack", "stackwalk_stdout", "stackwalk_stderr"]:
-        value = getattr(failure_line, key)
-        if value is not None:
-            rv[key] = value
-
-    return rv

--- a/treeherder/log_parser/crossreference.py
+++ b/treeherder/log_parser/crossreference.py
@@ -20,6 +20,7 @@ def crossreference_job(job):
 
     :job: - Job for which to perform the crossreferencing
     """
+    logger.debug("Crossreference %s: started", job.id)
 
     if job.autoclassify_status >= Job.CROSSREFERENCED:
         logger.info("Job %i already crossreferenced", job.id)

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -69,7 +69,7 @@ def parse_logs(job_id, job_log_ids, priority):
         ("buildbot_text" in completed_names or
          "builds-4h" in completed_names)):
 
-        success = crossreference_error_lines(job)
+        success = crossreference_job(job)
 
         if success:
             logger.debug("Scheduling autoclassify for job %i", job_id)
@@ -98,11 +98,3 @@ def store_failure_lines(job_log):
     errorsummary file."""
     logger.debug('Running store_failure_lines for job %s', job_log.job.id)
     failureline.store_failure_lines(job_log)
-
-
-def crossreference_error_lines(job):
-    """Match structured (FailureLine) and unstructured (TextLogError) lines
-    for a job."""
-    logger.debug("Crossreference %s: started", job.id)
-    success = crossreference_job(job)
-    return success

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -20,6 +20,7 @@ from django.db.utils import ProgrammingError
 from django.forms import model_to_dict
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
+from six import iteritems
 
 from ..services.elasticsearch import (bulk,
                                       index)
@@ -1032,6 +1033,28 @@ class FailureLine(models.Model):
             'created': self.created,
             'modified': self.modified,
         }
+
+    def to_mozlog_format(self):
+        """Convert a FailureLine into a mozlog formatted dictionary."""
+        data = {
+            "action": self.action,
+            "line_number": self.line,
+            "test": self.test,
+            "subtest": self.subtest,
+            "status": self.status,
+            "expected": self.expected,
+            "message": self.message,
+            "signature": self.signature,
+            "level": self.level,
+            "stack": self.stack,
+            "stackwalk_stdout": self.stackwalk_stdout,
+            "stackwalk_stderr": self.stackwalk_stderr,
+        }
+
+        # Remove empty values
+        data = {k: v for k, v in iteritems(data) if v}
+
+        return data
 
 
 class Group(models.Model):


### PR DESCRIPTION
Two changes that don't really fit anywhere else:

The `crossreference_error_lines` function was a defunct wrapper fo `crossreference_job`.

`as_dict` was a misnamed function to convert a `FailureLine` instance into a mozlog compatible dictionary.