### PR TITLE
Bug 1489284 - Remove unused angular-resource

### DIFF
--- a/neutrino-custom/base.js
+++ b/neutrino-custom/base.js
@@ -35,7 +35,6 @@ module.exports = neutrino => {
         const jsDeps = [
             'angular',
             'angular-local-storage',
-            'angular-resource',
             'angular-route',
             'angular-sanitize',
             'angular-ui-router',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "angular": "1.7.3",
     "angular-clipboard": "1.6.2",
     "angular-local-storage": "0.7.1",
-    "angular-resource": "1.7.3",
     "angular-route": "1.7.3",
     "angular-sanitize": "1.7.3",
     "angular-ui-router": "0.4.3",

--- a/ui/js/logviewer.js
+++ b/ui/js/logviewer.js
@@ -4,8 +4,8 @@ import treeherderModule from './treeherder';
 
 const logViewerApp = angular.module('logviewer', [treeherderModule.name]);
 
-logViewerApp.config(['$compileProvider', '$locationProvider', '$resourceProvider',
-    function ($compileProvider, $locationProvider, $resourceProvider) {
+logViewerApp.config(['$compileProvider', '$locationProvider',
+    function ($compileProvider, $locationProvider) {
         // Disable debug data & legacy comment/class directive syntax, as recommended by:
         // https://docs.angularjs.org/guide/production
         $compileProvider.debugInfoEnabled(false);
@@ -15,12 +15,6 @@ logViewerApp.config(['$compileProvider', '$locationProvider', '$resourceProvider
         // Revert to the legacy Angular <=1.5 URL hash prefix to save breaking existing links:
         // https://docs.angularjs.org/guide/migration#commit-aa077e8
         $locationProvider.hashPrefix('');
-
-        // Don't strip trailing slashes from calculated URLs
-        $resourceProvider.defaults.stripTrailingSlashes = false;
-
-        // All queries should be cancellable by default (why is this configurable??)
-        $resourceProvider.defaults.cancellable = true;
     }]);
 
 export default logViewerApp;

--- a/ui/js/treeherder.js
+++ b/ui/js/treeherder.js
@@ -1,8 +1,6 @@
 import angular from 'angular';
-import ngResource from 'angular-resource';
 import ngSanitize from 'angular-sanitize';
 
 export default angular.module('treeherder', [
-  ngResource,
   ngSanitize,
 ]);

--- a/ui/js/treeherder_app.js
+++ b/ui/js/treeherder_app.js
@@ -12,9 +12,7 @@ const treeherderApp = angular.module('treeherder.app', [
 ]);
 
 treeherderApp.config(['$compileProvider', '$locationProvider', '$routeProvider', '$httpProvider',
-    '$logProvider', '$resourceProvider',
-    function ($compileProvider, $locationProvider, $routeProvider, $httpProvider, $logProvider,
-             $resourceProvider) {
+    function ($compileProvider, $locationProvider, $routeProvider, $httpProvider) {
         // Disable debug data & legacy comment/class directive syntax, as recommended by:
         // https://docs.angularjs.org/guide/production
         $compileProvider.debugInfoEnabled(false);
@@ -24,16 +22,6 @@ treeherderApp.config(['$compileProvider', '$locationProvider', '$routeProvider',
         // Revert to the legacy Angular <=1.5 URL hash prefix to save breaking existing links:
         // https://docs.angularjs.org/guide/migration#commit-aa077e8
         $locationProvider.hashPrefix('');
-
-        // Don't strip trailing slashes from calculated URLs
-        $resourceProvider.defaults.stripTrailingSlashes = false;
-
-        // All queries should be cancellable by default (why is this configurable??)
-        $resourceProvider.defaults.cancellable = true;
-
-        // enable or disable debug messages using $log.
-        // comment out the next line to enable them
-        $logProvider.debugEnabled(false);
 
         $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
         $httpProvider.defaults.xsrfCookieName = 'csrftoken';

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,10 +206,6 @@ angular-mocks@1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/angular-mocks/-/angular-mocks-1.7.3.tgz#6568d50e64e81180273f9ec6a062ea255159f6ac"
 
-angular-resource@1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/angular-resource/-/angular-resource-1.7.3.tgz#0b378d203cc15a8f2807ab1b2279a262d6bfff80"
-
 angular-route@1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/angular-route/-/angular-route-1.7.3.tgz#245c7ea7d18514c1d08201588092db7df210e7c6"


### PR DESCRIPTION
The last usage of it was removed in bug 1450039. See:
https://docs.angularjs.org/api/ngResource

Since the DI arguments were already being updated, I've also removed the configuration of `$logProvider`, since we no longer use `$log`.