### PR TITLE
Bug 1489407 - Docs: Pin to older version of CommonMark to fix build

### DIFF
--- a/bin/travis-setup.sh
+++ b/bin/travis-setup.sh
@@ -55,7 +55,7 @@ setup_python_env() {
 }
 
 setup_docs() {
-    pip install -r requirements/docs.txt
+    pip install -U -r requirements/docs.txt
 }
 
 setup_geckodriver() {

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -13,3 +13,4 @@ sphinx-rtd-theme==0.4.1
 # installed, since Read The Docs doesn't use --upgrade and has an
 # older incompatible version of recommonmark pre-installed.
 -e git+git://github.com/rtfd/recommonmark.git#egg=recommonmark
+commonmark==0.7.5


### PR DESCRIPTION
CommonMark has made a breaking package change in a minor version release (0.8.0), so we need to pin to the last working release. See:
https://github.com/rtfd/CommonMark-py/issues/134

Fixes:

```
  ...
  File ".../recommonmark/recommonmark/parser.py", line 9, in <module>
    from CommonMark import Parser
ImportError: No module named CommonMark
```

The Travis docs setup step has also been modified to always upgrade dependencies, which will mean we will catch cases like this on Travis next time.

I've not added a comment to `requirements/docs.txt`, since pyup will open a PR to update the dependency (which will fail for now, but pass once they fix upstream) - and it will be a pain to have to manually edit that pyup PR to remove the comment (we probably want to keep the commonmark explicit version entry long term, not just until they resolve the issue).