### PR TITLE
Bug 1489507 - Fix not loading older pushes more than once

### DIFF
--- a/ui/helpers/location.js
+++ b/ui/helpers/location.js
@@ -1,4 +1,5 @@
 import { thDefaultRepo } from '../js/constants';
+import { createQueryParams } from './url';
 
 export const getQueryString = function getQueryString() {
   return location.hash.split('?')[1];
@@ -16,13 +17,17 @@ export const getRepo = function getRepo() {
   return getUrlParam('repo') || thDefaultRepo;
 };
 
+export const setLocation = function setLocation(params, hashPrefix = '/jobs') {
+  location.hash = `#${hashPrefix}${createQueryParams(params)}`;
+};
+
 export const setUrlParam = function setUrlParam(field, value, hashPrefix = '/jobs') {
   const params = getAllUrlParams();
+
   if (value) {
     params.set(field, value);
   } else {
     params.delete(field);
   }
-
-  location.hash = `#${hashPrefix}?${params.toString()}`;
+  setLocation(params, hashPrefix);
 };


### PR DESCRIPTION
This actually fixes a couple bugs I found along the way:

* The "get next N" bug was caused by passing an existing ``fromchange`` param to the ``/resultset/`` which prevented it from getting anything older than that change.  So, it would have been the same bug if you loaded the page with the ``fromchange`` already set.
* If you had an old ``fromchange`` param from prior to 10 pushes ago, it would only get the latest 10 pushes, because the count was set to 10, regardless, on first page load.
* If you had a single ``revision`` showing with the ``revision`` param in the URL, and you clicked "get next N", then it would reload the page before loading them.  It shouldn't reload.