### PR TITLE
Convert onlocationchangesuccess

### DIFF
--- a/ui/helpers/filter.js
+++ b/ui/helpers/filter.js
@@ -37,6 +37,19 @@ export const thDefaultFilterResultStatuses = [
   'runnable',
 ];
 
+// changes to the url for any of these fields should reload the page
+// because it changes the query to the db
+export const reloadOnChangeParameters = [
+  'repo',
+  'revision',
+  'author',
+  'fromchange',
+  'tochange',
+  'startdate',
+  'enddate',
+  'nojobs',
+];
+
 // default filter values, when a filter is not specified in the query string
 export const thFilterDefaults = {
   resultStatus: thDefaultFilterResultStatuses,

--- a/ui/js/controllers/main.js
+++ b/ui/js/controllers/main.js
@@ -6,8 +6,7 @@ import treeherderApp from '../treeherder_app';
 import {
   thTitleSuffixLimit, thDefaultRepo, thJobNavSelectors, thEvents,
 } from '../constants';
-import { getQueryString, getUrlParam } from '../../helpers/location';
-import { parseQueryParams } from '../../helpers/url';
+import { getUrlParam } from '../../helpers/location';
 
 treeherderApp.controller('MainCtrl', [
     '$scope', '$rootScope', '$timeout',
@@ -352,40 +351,6 @@ treeherderApp.controller('MainCtrl', [
                     stopOverrides.set(key, data[2]);
                 });
             }
-        });
-
-        const getNewReloadTriggerParams = function () {
-            const locationSearch = parseQueryParams(getQueryString());
-            return ThResultSetStore.reloadOnChangeParameters.reduce(
-                (acc, prop) => (locationSearch[prop] ? { ...acc, [prop]: locationSearch[prop] } : acc), {});
-        };
-
-        $scope.cachedReloadTriggerParams = getNewReloadTriggerParams();
-
-        // reload the page if certain params were changed in the URL.  For
-        // others, such as filtering, just re-filter without reload.
-
-        // the param ``skipNextPageReload`` will cause a single run through
-        // this code to skip the page reloading even on a param that would
-        // otherwise trigger a page reload.  This is useful for a param that
-        // is being changed by code in a specific situation as opposed to when
-        // the user manually edits the URL location bar.
-        $rootScope.$on('$locationChangeSuccess', function () {
-            const newReloadTriggerParams = getNewReloadTriggerParams();
-            // if we are just setting the repo to the default because none was
-            // set initially, then don't reload the page.
-            const defaulting = newReloadTriggerParams.repo === thDefaultRepo &&
-                             !$scope.cachedReloadTriggerParams.repo;
-
-            if (!defaulting && $scope.cachedReloadTriggerParams &&
-                !_.isEqual(newReloadTriggerParams, $scope.cachedReloadTriggerParams) &&
-                !$rootScope.skipNextPageReload) {
-                $window.location.reload();
-            } else {
-                $scope.cachedReloadTriggerParams = newReloadTriggerParams;
-            }
-            $rootScope.skipNextPageReload = false;
-
         });
 
         $scope.onscreenOverlayShowing = false;

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -55,19 +55,6 @@ treeherder.factory('ThResultSetStore', [
         var rsPollingKeys = ['tochange', 'enddate', 'revision', 'author'];
         const rsFetchKeys = [...rsPollingKeys, 'fromchange', 'startdate'];
 
-        // changes to the url for any of these fields should reload the page
-        // because it changes the query to the db
-        var reloadOnChangeParameters = [
-            'repo',
-            'revision',
-            'author',
-            'fromchange',
-            'tochange',
-            'startdate',
-            'enddate',
-            'nojobs',
-        ];
-
         var registerPushPollers = function () {
 
             // these params will be passed in each time we poll to remain
@@ -1005,7 +992,6 @@ treeherder.factory('ThResultSetStore', [
             setSelectedJob: setSelectedJob,
             updateUnclassifiedFailureMap: updateUnclassifiedFailureMap,
             defaultPushCount: defaultPushCount,
-            reloadOnChangeParameters: reloadOnChangeParameters,
             recalculateUnclassifiedCounts: recalculateUnclassifiedCounts,
 
         };


### PR DESCRIPTION
Moves handling of reloading the page when certain url params change from Angular to React.

This is rebased off my other PR bug fix, so only the second commit needs reviewing here.  But there were some conflicting changes (and code in ``helpers/location`` that I needed for both PRs).