### PR TITLE
Remove Angular timeout and rootScope.apply in React code

### DIFF
--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -368,7 +368,6 @@ export default class DetailsPanel extends React.Component {
 
     if (!spaceRemaining) {
       this.thNotify.send(thPinboardCountError, 'danger', { sticky: true });
-      this.$rootScope.$apply();
       return;
     }
 
@@ -381,7 +380,6 @@ export default class DetailsPanel extends React.Component {
       }
       if (showError) {
         this.thNotify.send(thPinboardCountError, 'danger', { sticky: true });
-        this.$rootScope.$apply();
       }
     });
   }

--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -19,7 +19,6 @@ export default class PinBoard extends React.Component {
 
     const { $injector } = this.props;
     this.thNotify = $injector.get('thNotify');
-    this.$timeout = $injector.get('$timeout');
     this.ThResultSetStore = $injector.get('ThResultSetStore');
     this.$rootScope = $injector.get('$rootScope');
 
@@ -81,15 +80,15 @@ export default class PinBoard extends React.Component {
       // just forgot to hit enter. Returns false if invalid
       errorFree = this.saveEnteredBugNumber();
       if (!errorFree) {
-        this.$timeout(this.thNotify.send('Please enter a valid bug number', 'danger'));
+        this.thNotify.send('Please enter a valid bug number', 'danger');
       }
     }
     if (!this.canSaveClassifications() && isLoggedIn) {
-      this.$timeout(this.thNotify.send('Please classify this failure before saving', 'danger'));
+      this.thNotify.send('Please classify this failure before saving', 'danger');
       errorFree = false;
     }
     if (!isLoggedIn) {
-      this.$timeout(this.thNotify.send('Must be logged in to save job classifications', 'danger'));
+      this.thNotify.send('Must be logged in to save job classifications', 'danger');
       errorFree = false;
     }
     if (errorFree) {
@@ -193,8 +192,7 @@ export default class PinBoard extends React.Component {
           throw new Error(formatModelError(resp, `Unable to send retrigger${plurality}`));
         }
       })
-      .catch(error => this.$timeout(this.thNotify.send(error, 'danger')))
-      .finally(() => this.$rootScope.$apply());
+      .catch(error => this.thNotify.send(error, 'danger'));
   }
 
   cancelAllPinnedJobsTitle() {

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -27,7 +27,6 @@ export default class ActionBar extends React.Component {
     this.$interpolate = $injector.get('$interpolate');
     this.$uibModal = $injector.get('$uibModal');
     this.$rootScope = $injector.get('$rootScope');
-    this.$timeout = $injector.get('$timeout');
 
     this.state = {
       customJobActionsShowing: false,
@@ -49,7 +48,6 @@ export default class ActionBar extends React.Component {
         case 'parsed':
           $('.logviewer-btn')[0].click();
       }
-      this.$rootScope.$apply();
     });
 
     this.jobRetriggerUnlisten = this.$rootScope.$on(thEvents.jobRetrigger, (event, job) => {
@@ -99,14 +97,14 @@ export default class ActionBar extends React.Component {
                 });
             })
         ).then(() => {
-            this.$timeout(this.thNotify.send('Retrigger request sent', 'success'));
+            this.thNotify.send('Retrigger request sent', 'success');
         }, (e) => {
             // Generic error eg. the user doesn't have LDAP access
-            this.$timeout(this.thNotify.send(
-                formatModelError(e, 'Unable to send retrigger'), 'danger'));
+            this.thNotify.send(
+                formatModelError(e, 'Unable to send retrigger'), 'danger');
         }));
     } else {
-        this.$timeout(this.thNotify.send('Must be logged in to retrigger a job', 'danger'));
+        this.thNotify.send('Must be logged in to retrigger a job', 'danger');
     }
   }
 
@@ -118,12 +116,10 @@ export default class ActionBar extends React.Component {
     }
     if (!user.isLoggedIn) {
       this.thNotify.send('Must be logged in to backfill a job', 'danger');
-      this.$rootScope.$apply();
       return;
     }
     if (!selectedJob.id) {
       this.thNotify.send('Job not yet loaded for backfill', 'warning');
-      this.$rootScope.$apply();
       return;
     }
 
@@ -145,18 +141,16 @@ export default class ActionBar extends React.Component {
                   input: {},
                   staticActionVariables: results.staticActionVariables,
                 }).then(() => {
-                  this.$timeout(() => this.thNotify.send(
+                  this.thNotify.send(
                     `Request sent to backfill job via actions.json (${actionTaskId})`,
-                    'success'),
-                  );
+                    'success');
                 }, (e) => {
                   // The full message is too large to fit in a Treeherder
                   // notification box.
-                  this.$timeout(() => this.thNotify.send(
+                  this.thNotify.send(
                     formatTaskclusterError(e),
                     'danger',
-                    { sticky: true }),
-                  );
+                    { sticky: true });
                 });
               }
             }
@@ -185,25 +179,22 @@ export default class ActionBar extends React.Component {
 
               const task = taskcluster.refreshTimestamps(jsyaml.safeLoad(action));
               queue.createTask(actionTaskId, task).then(function () {
-                this.$timeout(() => this.thNotify.send(
+                this.thNotify.send(
                   `Request sent to backfill job via actions.yml (${actionTaskId})`,
-                  'success'),
-                );
+                  'success');
               }, (e) => {
                 // The full message is too large to fit in a Treeherder
                 // notification box.
-                this.$timeout(() => this.thNotify.send(
+                this.thNotify.send(
                   formatTaskclusterError(e),
                   'danger',
-                  { sticky: true }),
-                );
+                  { sticky: true });
               });
             });
           })
       ));
     } else {
       this.thNotify.send('Unable to backfill this job type!', 'danger', { sticky: true });
-      this.$rootScope.$apply();
     }
   }
 
@@ -258,14 +249,12 @@ export default class ActionBar extends React.Component {
         })
     )).then(() => {
       this.thNotify.send('Cancel request sent', 'success');
-      this.$rootScope.$apply();
     }).catch(function (e) {
       this.thNotify.send(
         formatModelError(e, 'Unable to cancel job'),
         'danger',
         { sticky: true },
       );
-      this.$rootScope.$apply();
     });
   }
 

--- a/ui/job-view/pushes/PushList.jsx
+++ b/ui/job-view/pushes/PushList.jsx
@@ -23,7 +23,6 @@ export default class PushList extends React.Component {
     const { $injector, repoName } = this.props;
 
     this.$rootScope = $injector.get('$rootScope');
-    this.$timeout = $injector.get('$timeout');
     this.thNotify = $injector.get('thNotify');
     this.ThResultSetStore = $injector.get('ThResultSetStore');
 
@@ -48,9 +47,7 @@ export default class PushList extends React.Component {
 
     this.pushesLoadedUnlisten = this.$rootScope.$on(thEvents.pushesLoaded, () => {
       const pushList = this.ThResultSetStore.getPushArray();
-      this.$timeout(() => {
-        this.setState({ pushList, loadingPushes: false });
-      }, 0);
+      this.setState({ pushList, loadingPushes: false });
     });
 
     this.jobsLoadedUnlisten = this.$rootScope.$on(thEvents.jobsLoaded, () => {
@@ -62,10 +59,7 @@ export default class PushList extends React.Component {
           this.setSelectedJobFromQueryString(selectedJobId);
         }
       }
-
-      this.$timeout(() => {
-        this.setState({ pushList, jobsReady: true });
-      }, 0);
+      this.setState({ pushList, jobsReady: true });
     });
 
     this.jobClickUnlisten = this.$rootScope.$on(thEvents.jobClick, (ev, job) => {
@@ -239,10 +233,8 @@ export default class PushList extends React.Component {
   }
 
   noMoreUnclassifiedFailures() {
-    this.$timeout(() => {
-      this.thNotify.send('No unclassified failures to select.');
-      this.$rootScope.$emit(thEvents.clearSelectedJob);
-    });
+    this.thNotify.send('No unclassified failures to select.');
+    this.$rootScope.$emit(thEvents.clearSelectedJob);
   }
 
   selectJob(job, jobEl) {


### PR DESCRIPTION
There were lots of places where we needed to use ``$rootScope.$apply()`` and ``$timeout`` to get AngularJS to display things.  This was primarily for ``thNotify`` which is still Angular.  But now ``thNotify`` calls ``$timeout`` itself, so we don't need these.  This just removes them.

``thNotify`` will be converted once ``ThResultSetStore`` is converted, because it's used in that store.