### PR TITLE
Reraise SystemExit and don't manually notify NewRelic

### DIFF
--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -58,6 +58,12 @@ def parse_logs(job_id, job_log_ids, priority):
                 # Papertrail will still show output
                 raise
 
+            if isinstance(e, SystemExit):
+                # stop parsing further logs because the process was told to
+                # exit, this is commonly because the Heroku Dynos were
+                # restarted.
+                raise
+
             if first_exception is None:
                 first_exception = e
 


### PR DESCRIPTION
from @edmorley in IRC:

> On stage I'm seeing SystemExit exceptions for the log parser. My guess is that they are from when Heroku restarts the dynos for deploys, and we're explicitly reporting them to new relic here: https://github.com/mozilla/treeherder/pull/3978/files#diff-5546087e69bcb9c951baba3b64b1ffb9R66

This checks for `SystemExit` and reraises it.  We want to stop parsing logs as soon as we get this exception and not manually notify NewRelic.