### PR TITLE
Bug 1490832 - Show trigger missing/talos jobs UI to all users

### DIFF
--- a/ui/job-view/details/tabs/autoclassify/AutoclassifyToolbar.jsx
+++ b/ui/job-view/details/tabs/autoclassify/AutoclassifyToolbar.jsx
@@ -10,7 +10,7 @@ export default class AutoclassifyToolbar extends React.Component {
       return 'Must be logged in';
     }
     if (!user.isStaff) {
-      return 'Insufficeint permissions';
+      return 'Insufficient permissions';
     }
     if (condition) {
       return activeTitle;

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -131,7 +131,7 @@ export default class Push extends React.Component {
 
   render() {
     const {
-      push, isLoggedIn, isStaff, $injector, repoName, currentRepo,
+      push, isLoggedIn, $injector, repoName, currentRepo,
       filterModel, notificationSupported,
     } = this.props;
     const { watched, runnableVisible, hasBoundaryError, boundaryError } = this.state;
@@ -157,7 +157,6 @@ export default class Push extends React.Component {
           jobCounts={job_counts}
           watchState={watched}
           isLoggedIn={isLoggedIn}
-          isStaff={isStaff}
           repoName={repoName}
           filterModel={filterModel}
           $injector={$injector}
@@ -197,6 +196,5 @@ Push.propTypes = {
   filterModel: PropTypes.object.isRequired,
   repoName: PropTypes.string.isRequired,
   isLoggedIn: PropTypes.bool.isRequired,
-  isStaff: PropTypes.bool.isRequired,
   notificationSupported: PropTypes.bool.isRequired,
 };

--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -104,7 +104,7 @@ export default class PushActionMenu extends React.PureComponent {
   }
 
   render() {
-    const { isLoggedIn, isStaff, repoName, revision, runnableVisible,
+    const { isLoggedIn, repoName, revision, runnableVisible,
             hideRunnableJobsCb, showRunnableJobsCb, pushId } = this.props;
     const { topOfRangeUrl, bottomOfRangeUrl, customJobActionsShowing } = this.state;
 
@@ -141,18 +141,18 @@ export default class PushActionMenu extends React.PureComponent {
             className="dropdown-item"
             href={`https://secure.pub.build.mozilla.org/buildapi/self-serve/${repoName}/rev/${revision}`}
           >BuildAPI</a></li>
-          {isStaff && this.triggerMissingRepos.includes(repoName) &&
+          {this.triggerMissingRepos.includes(repoName) &&
             <li
-              className="dropdown-item"
+              title={isLoggedIn ? 'Trigger all jobs that were optimized away' : 'Must be logged in'}
+              className={isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'}
               onClick={() => this.triggerMissingJobs(revision)}
             >Trigger missing jobs</li>
           }
-          {isStaff &&
-            <li
-              className="dropdown-item"
-              onClick={() => this.triggerAllTalosJobs(revision)}
-            >Trigger all Talos jobs</li>
-          }
+          <li
+            title={isLoggedIn ? 'Trigger all talos performance tests' : 'Must be logged in'}
+            className={isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'}
+            onClick={() => this.triggerAllTalosJobs(revision)}
+          >Trigger all Talos jobs</li>
           <li><a
             target="_blank"
             rel="noopener noreferrer"
@@ -189,7 +189,6 @@ export default class PushActionMenu extends React.PureComponent {
 
 PushActionMenu.propTypes = {
   runnableVisible: PropTypes.bool.isRequired,
-  isStaff: PropTypes.bool.isRequired,
   isLoggedIn: PropTypes.bool.isRequired,
   revision: PropTypes.string.isRequired,
   repoName: PropTypes.string.isRequired,

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -157,7 +157,7 @@ export default class PushHeader extends React.PureComponent {
   }
 
   render() {
-    const { repoName, isLoggedIn, pushId, isStaff, jobCounts, author,
+    const { repoName, isLoggedIn, pushId, jobCounts, author,
             revision, runnableVisible, $injector, watchState,
             showRunnableJobsCb, hideRunnableJobsCb, cycleWatchState,
             notificationSupported } = this.props;
@@ -241,7 +241,6 @@ export default class PushHeader extends React.PureComponent {
             }
             <PushActionMenu
               isLoggedIn={isLoggedIn}
-              isStaff={isStaff || false}
               runnableVisible={runnableVisible}
               revision={revision}
               repoName={repoName}
@@ -271,7 +270,6 @@ PushHeader.propTypes = {
   hideRunnableJobsCb: PropTypes.func.isRequired,
   cycleWatchState: PropTypes.func.isRequired,
   isLoggedIn: PropTypes.bool.isRequired,
-  isStaff: PropTypes.bool.isRequired,
   notificationSupported: PropTypes.bool.isRequired,
   jobCounts: PropTypes.object,
   watchState: PropTypes.string,

--- a/ui/job-view/pushes/PushList.jsx
+++ b/ui/job-view/pushes/PushList.jsx
@@ -329,7 +329,7 @@ export default class PushList extends React.Component {
   render() {
     const { $injector, user, repoName, revision, currentRepo, filterModel } = this.props;
     const { pushList, loadingPushes, jobsReady, notificationSupported } = this.state;
-    const { isLoggedIn, isStaff } = user;
+    const { isLoggedIn } = user;
 
     return (
       <div>
@@ -344,7 +344,6 @@ export default class PushList extends React.Component {
               push={push}
               isLoggedIn={isLoggedIn || false}
               currentRepo={currentRepo}
-              isStaff={isStaff}
               repoName={repoName}
               filterModel={filterModel}
               $injector={$injector}


### PR DESCRIPTION
...rather than just to users with the `is_staff` Django permission (which mostly maps to sheriffs). This prevents the confusing UX of UI elements being unknowingly hidden to users who are missing the `is_staff` permission.

The check existed since these features used to use pulse_actions via Treeherder's API (which had coarser permissions controls), whereas now they use Taskcluster's API client side - so this check is purely aesthetic, since people could just use Taskcluster's API/UIs directly.

If certain groups of users should be prevented from accidentally scheduling too many jobs, access should instead be controlled via Taskcluster scopes at the task configuration level.