### PR TITLE
Bug 1491133 - Optimize intermittents commenter

### DIFF
--- a/treeherder/intermittents_commenter/constants.py
+++ b/treeherder/intermittents_commenter/constants.py
@@ -1,7 +1,5 @@
 WHITEBOARD_NEEDSWORK_OWNER = '[stockwell needswork:owner]'
 
-TRIAGE_PARAMS = {'include_fields': 'product, component, priority, whiteboard'}
-
 COMPONENTS = [
     ['Core', 'Canvas: 2D'],
     ['Core', 'Canvas: WebGL'],

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -720,6 +720,9 @@ class FailuresQuerySet(models.QuerySet):
     def by_bug(self, bug_id):
         return self.filter(bug_id=int(bug_id))
 
+    def by_date(self, startday, endday):
+        return self.select_related('push', 'job').filter(job__push__time__range=(startday, endday))
+
 
 class BugJobMap(models.Model):
     '''


### PR DESCRIPTION
## Notes on changes:
* batch bugzilla queries for GET requests: 1250 is a "safe limit" (I added a bit of leeway in case more `include_fields` or other params are later added). The actual limit for url string is 16k (on Bugzilla's end) but I don't know exactly how many bug_ids that would translate to. I erred on the safe side with this and decided to limit it to 1200 per request.
Also, for the week that I was testing this I discovered that 1208 out of 1250 bugs needed access to bugs_info, so I opted to keep it simple and fetch data for all bugs.

* refactor and optimized queries: removing the filter repo by 'all' has reduced the query time by several seconds and still returns the same amount of results as with the filter on (more importantly, line 308 uses the same query as the Failures endpoint for IFV, and this small changed reduced the query time from 76 seconds to less than 1!)

* redesign get_bug_stats and create a new method for get_alt_bug_stats: currently alt_bug_stats is using the same method as bug_stats and resulted in irrelevant information being retrieved and stored.

I tested the daily and weekly commenter locally. Weekly runs really fast now.