### PR TITLE
Bug 1450028 - Convert Keyboard Navigation to ReactJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-fontawesome": "1.6.1",
     "react-highlight-words": "0.14.0",
     "react-hot-loader": "3.1.3",
+    "react-hotkeys": "1.1.4",
     "react-linkify": "0.2.2",
     "react-redux": "5.0.7",
     "react-router-dom": "4.3.1",

--- a/ui/job-view/JobView.jsx
+++ b/ui/job-view/JobView.jsx
@@ -16,6 +16,7 @@ import PrimaryNavBar from './headerbars/PrimaryNavBar';
 import ActiveFilters from './headerbars/ActiveFilters';
 import UpdateAvailable from './headerbars/UpdateAvailable';
 import PushList from './pushes/PushList';
+import KeyboardShortcuts from './KeyboardShortcuts';
 
 const DEFAULT_DETAILS_PCT = 40;
 const REVISION_POLL_INTERVAL = 1000 * 60 * 5;
@@ -229,7 +230,11 @@ class JobView extends React.Component {
     ), []);
 
     return (
-      <div className="d-flex flex-column h-100">
+      <KeyboardShortcuts
+        filterModel={filterModel}
+        selectedJob={selectedJob}
+        $injector={$injector}
+      >
         <PrimaryNavBar
           repos={repos}
           updateButtonClick={this.updateButtonClick}
@@ -282,7 +287,7 @@ class JobView extends React.Component {
             $injector={$injector}
           />
         </SplitPane>
-      </div>
+      </KeyboardShortcuts>
     );
   }
 }

--- a/ui/job-view/KeyboardShortcuts.jsx
+++ b/ui/job-view/KeyboardShortcuts.jsx
@@ -1,0 +1,270 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { HotKeys } from 'react-hotkeys';
+
+import { thEvents, thJobNavSelectors } from '../js/constants';
+
+const keyMap = {
+  addRelatedBug: 'b',
+  pinEditComment: 'c',
+  quickFilter: 'f',
+  clearFilter: 'ctrl+shift+f',
+  toggleInProgress: 'i',
+  nextUnclassified: ['j', 'n'],
+  previousUnclassified: ['k', 'p'],
+  openLogviewer: 'l',
+  jobRetrigger: 'r',
+  selectNextTab: 't',
+  toggleUnclassifiedFailures: 'u',
+  clearPinboard: 'ctrl+shift+u',
+  previousJob: 'left',
+  nextJob: 'right',
+  pinJob: 'space',
+  toggleOnScreenShortcuts: '?',
+  /* these should happen regardless of being in an input field */
+  clearSelectedJob: 'escape',
+  saveClassification: 'ctrl+enter',
+  deleteClassification: 'ctrl+backspace',
+};
+
+export default class KeyboardShortcuts extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const { $injector } = this.props;
+    this.$rootScope = $injector.get('$rootScope');
+  }
+
+  componentDidMount() {
+    this.addRelatedBug = this.addRelatedBug.bind(this);
+    this.pinEditComment = this.pinEditComment.bind(this);
+    this.quickFilter = this.quickFilter.bind(this);
+    this.clearFilter = this.clearFilter.bind(this);
+    this.nextUnclassified = this.nextUnclassified.bind(this);
+    this.previousUnclassified = this.previousUnclassified.bind(this);
+    this.openLogviewer = this.openLogviewer.bind(this);
+    this.jobRetrigger = this.jobRetrigger.bind(this);
+    this.selectNextTab = this.selectNextTab.bind(this);
+    this.clearPinboard = this.clearPinboard.bind(this);
+    this.previousJob = this.previousJob.bind(this);
+    this.nextJob = this.nextJob.bind(this);
+    this.pinJob = this.pinJob.bind(this);
+    this.clearSelectedJob = this.clearSelectedJob.bind(this);
+    this.saveClassification = this.saveClassification.bind(this);
+    this.deleteClassification = this.deleteClassification.bind(this);
+    this.toggleOnScreenShortcuts = this.toggleOnScreenShortcuts.bind(this);
+
+    // HotKeys requires focus be a component inside itself to work
+    // TODO: We may not need this if we wrap <body> with HotKeys.
+    document.getElementById('keyboard-shortcuts').focus();
+  }
+
+  /**
+   * Job Navigation Shortcuts
+   */
+
+  // select next unclassified failure
+  nextUnclassified() {
+    this.$rootScope.$emit(
+      thEvents.changeSelection,
+      'next',
+      thJobNavSelectors.UNCLASSIFIED_FAILURES);
+  }
+
+  // select previous unclassified failure
+  previousUnclassified() {
+    this.$rootScope.$emit(
+      thEvents.changeSelection,
+      'previous',
+      thJobNavSelectors.UNCLASSIFIED_FAILURES);
+  }
+
+  // select previous job
+  previousJob() {
+    this.$rootScope.$emit(
+      thEvents.changeSelection,
+      'previous',
+      thJobNavSelectors.ALL_JOBS);
+  }
+
+  // select next job
+  nextJob() {
+    this.$rootScope.$emit(
+      thEvents.changeSelection,
+      'next',
+      thJobNavSelectors.ALL_JOBS);
+  }
+
+  // close any open panels and clears selected job
+  clearSelectedJob() {
+    this.$rootScope.$emit(thEvents.clearSelectedJob);
+    this.$rootScope.setOnscreenShortcutsShowing(false);
+    this.$rootScope.$apply();
+  }
+
+  /**
+   * Details Panel Shortcuts
+   */
+
+  // pin selected job to pinboard
+  pinJob() {
+    const { selectedJob } = this.props;
+
+    if (selectedJob) {
+      this.$rootScope.$emit(thEvents.jobPin, selectedJob);
+    }
+  }
+
+  // pin selected job to pinboard and add a related bug
+  addRelatedBug() {
+    const { selectedJob } = this.$rootScope;
+
+    if (selectedJob) {
+      this.$rootScope.$emit(thEvents.addRelatedBug, selectedJob);
+      document.getElementById('related-bug-input').focus();
+    }
+  }
+
+  // pin selected job to pinboard and enter classification
+  pinEditComment() {
+    const { selectedJob } = this.$rootScope;
+
+    if (selectedJob) {
+      this.$rootScope.$emit(thEvents.jobPin, selectedJob);
+      document.getElementById('classification-comment').focus();
+    }
+  }
+
+  // clear the PinBoard
+  clearPinboard() {
+    this.$rootScope.$emit(thEvents.clearPinboard);
+  }
+
+  saveClassification() {
+    this.$rootScope.$emit(thEvents.saveClassification);
+  }
+
+  // delete classification and related bugs
+  deleteClassification() {
+    const { selectedJob } = this.props;
+
+    if (selectedJob) {
+      this.$rootScope.$emit(thEvents.deleteClassification);
+    }
+  }
+
+  // open the logviewer for the selected job
+  openLogviewer() {
+    this.$rootScope.$emit(thEvents.openLogviewer);
+  }
+
+  // retrigger selected job
+  jobRetrigger() {
+    const { selectedJob } = this.props;
+
+    if (selectedJob) {
+      this.$rootScope.$emit(thEvents.jobRetrigger, selectedJob);
+    }
+  }
+
+  // select next job tab
+  selectNextTab() {
+    const { selectedJob } = this.props;
+
+    if (selectedJob) {
+      this.$rootScope.$emit(thEvents.selectNextTab);
+    }
+  }
+
+  /**
+   * Filter and Help Shortcuts
+   */
+
+  // enter a quick filter
+  quickFilter() {
+    document.getElementById('quick-filter').focus();
+  }
+
+  // clear the quick filter field
+  clearFilter() {
+    const { filterModel } = this.props;
+
+    filterModel.removeFilter('searchStr');
+  }
+
+  toggleOnScreenShortcuts() {
+    this.$rootScope.setOnscreenShortcutsShowing(!this.$rootScope.onscreenShortcutsShowing);
+    this.$rootScope.$apply();
+  }
+
+  doKey(ev, callback) {
+    const element = ev.target;
+
+    // If the bug filer is opened, don't let these shortcuts work
+    if (document.body.classList.contains('filer-open')) {
+      return;
+    }
+
+    if ((element.tagName === 'INPUT' &&
+      element.type !== 'radio' && element.type !== 'checkbox') ||
+      element.tagName === 'SELECT' ||
+      element.tagName === 'TEXTAREA' ||
+      element.isContentEditable || ev.key === 'shift') {
+      return;
+    }
+
+    // If we get here, then execute the HotKey.
+    ev.preventDefault();
+    callback(ev);
+  }
+
+  render() {
+    const { filterModel } = this.props;
+    const handlers = {
+      addRelatedBug: ev => this.doKey(ev, this.addRelatedBug),
+      pinEditComment: ev => this.doKey(ev, this.pinEditComment),
+      quickFilter: ev => this.doKey(ev, this.quickFilter),
+      clearFilter: ev => this.doKey(ev, this.clearFilter),
+      toggleInProgress: ev => this.doKey(ev, filterModel.toggleInProgress),
+      nextUnclassified: ev => this.doKey(ev, this.nextUnclassified),
+      previousUnclassified: ev => this.doKey(ev, this.previousUnclassified),
+      openLogviewer: ev => this.doKey(ev, this.openLogviewer),
+      jobRetrigger: ev => this.doKey(ev, this.jobRetrigger),
+      selectNextTab: ev => this.doKey(ev, this.selectNextTab),
+      toggleUnclassifiedFailures: ev => this.doKey(ev, filterModel.toggleUnclassifiedFailures),
+      clearPinboard: ev => this.doKey(ev, this.clearPinboard),
+      previousJob: ev => this.doKey(ev, this.previousJob),
+      nextJob: ev => this.doKey(ev, this.nextJob),
+      pinJob: ev => this.doKey(ev, this.pinJob),
+      toggleOnScreenShortcuts: ev => this.doKey(ev, this.toggleOnScreenShortcuts),
+      /* these should happen regardless of being in an input field */
+      clearSelectedJob: this.clearSelectedJob,
+      saveClassification: this.saveClassification,
+      deleteClassification: this.deleteClassification,
+    };
+
+    return (
+      <HotKeys
+        id="keyboard-shortcuts"
+        className="d-flex flex-column h-100"
+        handlers={handlers}
+        keyMap={keyMap}
+        focused
+        tabIndex={-1}
+      >
+        {this.props.children}
+      </HotKeys>
+    );
+  }
+}
+
+KeyboardShortcuts.propTypes = {
+  filterModel: PropTypes.object.isRequired,
+  $injector: PropTypes.object.isRequired,
+  children: PropTypes.array.isRequired,
+  selectedJob: PropTypes.object,
+};
+
+KeyboardShortcuts.defaultProps = {
+  selectedJob: null,
+};

--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -98,7 +98,6 @@ export default class PinBoard extends React.Component {
       Promise.all([...classifyPromises, ...bugPromises]).then(() => {
         this.$rootScope.$emit(thEvents.jobsClassified, { jobs: [...jobs] });
         this.unPinAll();
-        this.completeClassification();
         this.setState({
           failureClassificationId: 4,
           failureClassificationComment: '',
@@ -111,7 +110,7 @@ export default class PinBoard extends React.Component {
       // want to accept keyboard input after this change for some
       // reason which I don't understand. Chrome (any platform)
       // or Firefox on Mac works fine though.
-      document.activeElement.blur();
+      document.getElementById('keyboard-shortcuts').focus();
     }
   }
 
@@ -283,7 +282,7 @@ export default class PinBoard extends React.Component {
     this.setState({
       enteringBugNumber: tf,
     }, () => {
-      $('#related-bug-input').focus();
+      document.getElementById('related-bug-input').focus();
     });
 
     // document.off('click', this.handleRelatedBugDocumentClick);
@@ -303,10 +302,6 @@ export default class PinBoard extends React.Component {
         $(document).on('click', this.handleRelatedBugDocumentClick);
       }, 0);
     }
-  }
-
-  completeClassification() {
-    this.$rootScope.$broadcast('blur-this', 'classification-comment');
   }
 
   isNumber(text) {

--- a/ui/job-view/headerbars/SecondaryNavBar.jsx
+++ b/ui/job-view/headerbars/SecondaryNavBar.jsx
@@ -91,7 +91,7 @@ export default class SecondaryNavBar extends React.Component {
       } else {
         filterModel.removeFilter('searchStr');
       }
-      ev.target.blur();
+      ev.target.parentElement.focus();
     }
   }
 
@@ -206,6 +206,7 @@ export default class SecondaryNavBar extends React.Component {
       <div
         id="watched-repo-navbar"
         className="th-context-navbar navbar-dark watched-repo-navbar"
+        tabIndex={-1}
       >
         <span className="justify-content-between w-100 d-flex flex-wrap">
           <span className="d-flex push-left watched-repos">
@@ -307,6 +308,7 @@ export default class SecondaryNavBar extends React.Component {
             <span
               id="quick-filter-parent"
               className="form-group form-inline"
+              tabIndex={-1}
             >
               <input
                 id="quick-filter"

--- a/ui/js/constants.js
+++ b/ui/js/constants.js
@@ -276,7 +276,6 @@ export const thEvents = {
   duplicateJobsVisibilityChanged: 'duplicate-jobs-visibility-changed-EVT',
   showRunnableJobs: 'show-runnable-jobs-EVT',
   deleteRunnableJobs: 'delete-runnable-jobs-EVT',
-  toggleUnclassifiedFailures: 'toggle-unclassified-failures-EVT',
   changeSelection: 'next-previous-job-EVT',
   addRelatedBug: 'add-related-bug-EVT',
   saveClassification: 'save-classification-EVT',

--- a/ui/js/directives/treeherder/main.js
+++ b/ui/js/directives/treeherder/main.js
@@ -1,19 +1,6 @@
 import treeherder from '../../treeherder';
 import thNotificationsBoxTemplate from '../../../partials/main/thNotificationsBox.html';
 
-// Directive blurThis which removes focus from a specific element
-treeherder.directive('blurThis', ['$timeout', function ($timeout) {
-    return function (scope, elem, attr) {
-        scope.$on('blur-this', function (event, id) {
-            if (attr.id === id) {
-                $timeout(function () {
-                    elem[0].blur();
-                }, 0);
-            }
-        });
-    };
-}]);
-
 // Allow copy to system clipboard during hover
 treeherder.directive('copyValue', [
     function () {

--- a/ui/js/directives/treeherder/main.js
+++ b/ui/js/directives/treeherder/main.js
@@ -1,49 +1,6 @@
 import treeherder from '../../treeherder';
 import thNotificationsBoxTemplate from '../../../partials/main/thNotificationsBox.html';
 
-// Allow copy to system clipboard during hover
-treeherder.directive('copyValue', [
-    function () {
-        return {
-            restrict: 'A',
-            link: function (scope, element, attrs) {
-                const cont = document.getElementById('clipboard-container');
-                const clip = document.getElementById('clipboard');
-                element.on('mouseenter', function () {
-                    cont.style.display = 'block';
-                    clip.value = attrs.copyValue;
-                    clip.focus();
-                    clip.select();
-                });
-                element.on('mouseleave', function () {
-                    cont.style.display = 'none';
-                    clip.value = '';
-                });
-            },
-        };
-    },
-]);
-
-// Prevent default behavior on left mouse click. Useful
-// for html anchor's that need to do in application actions
-// on left click but default href type functionality on
-// middle or right mouse click.
-treeherder.directive('preventDefaultOnLeftClick', [
-    function () {
-        return {
-            restrict: 'A',
-            link: function (scope, element) {
-                element.on('click', function (event) {
-                    if (event.which === 1) {
-                        event.preventDefault();
-                    }
-                    element.blur();
-                });
-            },
-        };
-    },
-]);
-
 treeherder.directive('stopPropagationOnLeftClick', [
     function () {
         return {
@@ -71,20 +28,3 @@ treeherder.directive('thNotificationBox', [
             },
         };
     }]);
-
-treeherder.directive('bugInput', function () {
-    return {
-        restrict: 'A',
-        link: function (scope, elem) {
-            elem.on('invalid', function (event) {
-                event.target.setCustomValidity('Please enter a bug number');
-            });
-            elem.on('input', function (event) {
-                event.target.setCustomValidity('');
-                event.target.value = event.target.value.trim();
-            });
-            elem.attr('type', 'text');
-            elem.attr('pattern', '\\s*\\d+\\s*');
-        },
-    };
-});

--- a/ui/models/filter.js
+++ b/ui/models/filter.js
@@ -22,6 +22,7 @@ export default class FilterModel {
     this.setOnlySuperseded = this.setOnlySuperseded.bind(this);
     this.clearNonStatusFilters = this.clearNonStatusFilters.bind(this);
     this.toggleUnclassifiedFailures = this.toggleUnclassifiedFailures.bind(this);
+    this.toggleInProgress = this.toggleInProgress.bind(this);
   }
 
   static getUrlParamsWithDefaults() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4746,6 +4746,10 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -5091,7 +5095,7 @@ moo@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
 
-mousetrap@1.6.2:
+mousetrap@1.6.2, mousetrap@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.2.tgz#caadd9cf886db0986fb2fee59a82f6bd37527587"
 
@@ -6301,6 +6305,16 @@ react-hot-loader@3.1.3, react-hot-loader@^3.0.0-beta.6:
     react-proxy "^3.0.0-alpha.0"
     redbox-react "^1.3.6"
     source-map "^0.6.1"
+
+react-hotkeys@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/react-hotkeys/-/react-hotkeys-1.1.4.tgz#a0712aa2e0c03a759fd7885808598497a4dace72"
+  dependencies:
+    lodash.isboolean "^3.0.3"
+    lodash.isequal "^4.5.0"
+    lodash.isobject "^3.0.2"
+    mousetrap "^1.5.2"
+    prop-types "^15.6.0"
 
 react-input-autosize@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
This replaces our angular keyboard shortcuts with React ones.  This package seemed pretty good.  It got the highest rating of maintenance, quality and popularity on  ``npm`` for the "shortcuts" packages that I could find.  

There is one quirk with this package: It required focus on an element that is either itself, or a child for the keys to work.  So I Wrapped everything in ``JobView`` by it.  This is fine, but since we are hosted in ``AngularJS``, there are some cases where focus can go outside of ``JobView``.  Like if you call ``element.blur()``.  So I set a ``tabIndex`` on the ``HotKeys`` element and just call focus on that, rather than doing ``.blur()`` anywhere.

``HotKeys`` requires using a ``keyMap`` and ``handlers``.  It's possible to use JUST a ``handlers`` where the object ``key`` matches the keyboard ``key``.  But that doesn't support multiple keys for the same action (I tried ``{ 'j,n': () => this.doNext() }``, but that didn't work.  So it was either use a separate ``keyMap`` or have separate entries in the ``handlers`` object for each key, pointing to the same event.  If one of you have a preference, I'm happy to change it.  :)  But the ``keyMap`` at the top of the file is a good overview of what each key does.

**Question**: What do you think about removing the ``autoclassify`` shortcuts?  Some of them are broken anyway (this fires the event, but the panel doesn't do what it says).  Some DO still work.  I didn't want to fix them in this PR.