### PR TITLE
Bug 1492273 - Convert selectedJob to a React context

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -17,10 +17,7 @@
                  </div>
                </div>
             </div>
-            <job-view
-              revision="revision"
-              selected-job="selectedJob"
-            />
+            <job-view />
         </div>
 
         <th-notification-box></th-notification-box>

--- a/ui/job-view/KeyboardShortcuts.jsx
+++ b/ui/job-view/KeyboardShortcuts.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { HotKeys } from 'react-hotkeys';
 
-import { thEvents, thJobNavSelectors } from '../js/constants';
+import { thEvents } from '../js/constants';
 import { withPinnedJobs } from './context/PinnedJobs';
+import { withSelectedJob } from './context/SelectedJob';
 
 const keyMap = {
   addRelatedBug: 'b',
@@ -41,14 +42,10 @@ class KeyboardShortcuts extends React.Component {
     this.pinEditComment = this.pinEditComment.bind(this);
     this.quickFilter = this.quickFilter.bind(this);
     this.clearFilter = this.clearFilter.bind(this);
-    this.nextUnclassified = this.nextUnclassified.bind(this);
-    this.previousUnclassified = this.previousUnclassified.bind(this);
     this.openLogviewer = this.openLogviewer.bind(this);
     this.jobRetrigger = this.jobRetrigger.bind(this);
     this.selectNextTab = this.selectNextTab.bind(this);
     this.clearPinboard = this.clearPinboard.bind(this);
-    this.previousJob = this.previousJob.bind(this);
-    this.nextJob = this.nextJob.bind(this);
     this.pinJob = this.pinJob.bind(this);
     this.clearSelectedJob = this.clearSelectedJob.bind(this);
     this.saveClassification = this.saveClassification.bind(this);
@@ -64,41 +61,9 @@ class KeyboardShortcuts extends React.Component {
    * Job Navigation Shortcuts
    */
 
-  // select next unclassified failure
-  nextUnclassified() {
-    this.$rootScope.$emit(
-      thEvents.changeSelection,
-      'next',
-      thJobNavSelectors.UNCLASSIFIED_FAILURES);
-  }
-
-  // select previous unclassified failure
-  previousUnclassified() {
-    this.$rootScope.$emit(
-      thEvents.changeSelection,
-      'previous',
-      thJobNavSelectors.UNCLASSIFIED_FAILURES);
-  }
-
-  // select previous job
-  previousJob() {
-    this.$rootScope.$emit(
-      thEvents.changeSelection,
-      'previous',
-      thJobNavSelectors.ALL_JOBS);
-  }
-
-  // select next job
-  nextJob() {
-    this.$rootScope.$emit(
-      thEvents.changeSelection,
-      'next',
-      thJobNavSelectors.ALL_JOBS);
-  }
-
   // close any open panels and clears selected job
   clearSelectedJob() {
-    this.$rootScope.$emit(thEvents.clearSelectedJob);
+    this.props.clearSelectedJob();
     this.$rootScope.setOnscreenShortcutsShowing(false);
     this.$rootScope.$apply();
   }
@@ -221,22 +186,22 @@ class KeyboardShortcuts extends React.Component {
   }
 
   render() {
-    const { filterModel } = this.props;
+    const { filterModel, changeSelectedJob } = this.props;
     const handlers = {
       addRelatedBug: ev => this.doKey(ev, this.addRelatedBug),
       pinEditComment: ev => this.doKey(ev, this.pinEditComment),
       quickFilter: ev => this.doKey(ev, this.quickFilter),
       clearFilter: ev => this.doKey(ev, this.clearFilter),
       toggleInProgress: ev => this.doKey(ev, filterModel.toggleInProgress),
-      nextUnclassified: ev => this.doKey(ev, this.nextUnclassified),
-      previousUnclassified: ev => this.doKey(ev, this.previousUnclassified),
+      nextUnclassified: ev => this.doKey(ev, () => changeSelectedJob('next', true)),
+      previousUnclassified: ev => this.doKey(ev, () => changeSelectedJob('previous', true)),
       openLogviewer: ev => this.doKey(ev, this.openLogviewer),
       jobRetrigger: ev => this.doKey(ev, this.jobRetrigger),
       selectNextTab: ev => this.doKey(ev, this.selectNextTab),
       toggleUnclassifiedFailures: ev => this.doKey(ev, filterModel.toggleUnclassifiedFailures),
       clearPinboard: ev => this.doKey(ev, this.clearPinboard),
-      previousJob: ev => this.doKey(ev, this.previousJob),
-      nextJob: ev => this.doKey(ev, this.nextJob),
+      previousJob: ev => this.doKey(ev, () => changeSelectedJob('previous')),
+      nextJob: ev => this.doKey(ev, () => changeSelectedJob('next')),
       pinJob: ev => this.doKey(ev, this.pinJob),
       toggleOnScreenShortcuts: ev => this.doKey(ev, this.toggleOnScreenShortcuts),
       /* these should happen regardless of being in an input field */
@@ -266,6 +231,8 @@ KeyboardShortcuts.propTypes = {
   pinJob: PropTypes.func.isRequired,
   unPinAll: PropTypes.func.isRequired,
   children: PropTypes.array.isRequired,
+  clearSelectedJob: PropTypes.func.isRequired,
+  changeSelectedJob: PropTypes.func.isRequired,
   selectedJob: PropTypes.object,
 };
 
@@ -273,4 +240,4 @@ KeyboardShortcuts.defaultProps = {
   selectedJob: null,
 };
 
-export default withPinnedJobs(KeyboardShortcuts);
+export default withPinnedJobs(withSelectedJob(KeyboardShortcuts));

--- a/ui/job-view/context/PinnedJobs.jsx
+++ b/ui/job-view/context/PinnedJobs.jsx
@@ -86,7 +86,7 @@ export class PinnedJobs extends React.Component {
 
   pinJobs(jobsToPin) {
     const { pinnedJobs } = this.state;
-    const { notify, selectFirstJob } = this.props;
+    const { notify } = this.props;
     const spaceRemaining = MAX_SIZE - Object.keys(pinnedJobs).length;
     const showError = jobsToPin.length > spaceRemaining;
     const newPinnedJobs = jobsToPin.slice(0, spaceRemaining).reduce((acc, job) => ({ ...acc, [job.id]: job }), {});
@@ -100,7 +100,6 @@ export class PinnedJobs extends React.Component {
       pinnedJobs: { ...pinnedJobs, ...newPinnedJobs },
       isPinBoardVisible: true,
     }, () => {
-      selectFirstJob(Object.values(newPinnedJobs));
       if (showError) {
         notify.send(COUNT_ERROR, 'danger', { sticky: true });
       }
@@ -188,6 +187,5 @@ export function withPinnedJobs(Component) {
 
 PinnedJobs.propTypes = {
   notify: PropTypes.object.isRequired,
-  selectFirstJob: PropTypes.func.isRequired,
   children: PropTypes.object.isRequired,
 };

--- a/ui/job-view/context/SelectedJob.jsx
+++ b/ui/job-view/context/SelectedJob.jsx
@@ -1,0 +1,272 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import $ from 'jquery';
+
+import {
+  findJobInstance,
+  findSelectedInstance, scrollToElement,
+} from '../../helpers/job';
+import { getUrlParam, setUrlParam } from '../../helpers/location';
+import { getJobsUrl } from '../../helpers/url';
+import JobModel from '../../models/job';
+import PushModel from '../../models/push';
+import { withPinnedJobs } from './PinnedJobs';
+import { thJobNavSelectors } from '../../js/constants';
+
+const SelectedJobContext = React.createContext({});
+
+class SelectedJobClass extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const { $injector } = this.props;
+    this.ThResultSetStore = $injector.get('ThResultSetStore');
+
+    this.state = {
+      selectedJob: null,
+    };
+    this.value = {
+      ...this.state,
+      setSelectedJob: this.setSelectedJob,
+      clearSelectedJob: this.clearSelectedJob,
+      changeSelectedJob: this.changeSelectedJob,
+    };
+  }
+
+  componentDidMount() {
+    this.setSelectedJob = this.setSelectedJob.bind(this);
+    this.clearSelectedJob = this.clearSelectedJob.bind(this);
+    this.changeSelectedJob = this.changeSelectedJob.bind(this);
+    this.noMoreUnclassifiedFailures = this.noMoreUnclassifiedFailures.bind(this);
+
+    // TODO: this.value needs to now get the bound versions of the functions.
+    // But when we move the function binding to the constructors, we won't
+    // have to re-do this in componentDidMount.
+    this.value = {
+      ...this.state,
+      setSelectedJob: this.setSelectedJob,
+      clearSelectedJob: this.clearSelectedJob,
+      changeSelectedJob: this.changeSelectedJob,
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    const { jobsLoaded } = this.props;
+
+    if (jobsLoaded !== prevProps.jobsLoaded) {
+      this.setSelectedJobFromQueryString();
+    }
+  }
+
+  setValue(newState, callback) {
+    this.value = { ...this.value, ...newState };
+    this.setState(newState, callback);
+  }
+
+  /**
+   * If the URL has a query string param of ``selectedJob`` then select
+   * that job on load.
+   *
+   * If that job isn't in any of the loaded pushes, then throw
+   * an error and provide a link to load it with the right push.
+   */
+  setSelectedJobFromQueryString() {
+    const { notify } = this.props;
+    const { repoName, selectedJob } = this.state;
+    const selectedJobIdStr = getUrlParam('selectedJob');
+    const selectedJobId = parseInt(selectedJobIdStr);
+
+    if (selectedJobIdStr && (!selectedJob || selectedJob.id !== selectedJobId)) {
+      const jobMap = this.ThResultSetStore.getJobMap();
+      const selectedJobEl = jobMap[selectedJobIdStr];
+
+      // select the job in question
+      if (selectedJobEl) {
+        this.setSelectedJob(selectedJobEl.job_obj);
+      } else {
+        // If the ``selectedJob`` was not mapped, then we need to notify
+        // the user it's not in the range of the current result set list.
+        JobModel.get(repoName, selectedJobId).then((job) => {
+          PushModel.get(job.result_set_id).then(async (resp) => {
+            if (resp.ok) {
+              const push = await resp.json();
+              const newPushUrl = getJobsUrl({ repo: repoName, revision: push.data.revision, selectedJob: selectedJobId });
+
+              this.clearSelectedJob();
+
+              // the job exists, but isn't in any loaded push.
+              // provide a message and link to load the right push
+              notify.send(
+                `Selected job id: ${selectedJobId} not within current push range.`,
+                'danger',
+                { sticky: true, linkText: 'Load push', newPushUrl });
+            } else {
+              throw Error(`Unable to find push with id ${job.result_set_id} for selected job`);
+            }
+          });
+        }).catch((error) => {
+          // the job wasn't found in the db.  Either never existed,
+          // or was expired and deleted.
+          this.clearSelectedJob();
+          notify.send(`Selected Job - ${error}`,
+            'danger',
+            { sticky: true });
+        });
+      }
+    } else if (!selectedJobIdStr && selectedJob) {
+      this.setValue({ selectedJob: null });
+    }
+  }
+
+  setSelectedJob(job, timeout = 0) {
+    const { selectedJob } = this.state;
+
+    if (selectedJob) {
+      const selected = findSelectedInstance();
+      if (selected) selected.setSelected(false);
+    }
+    const newSelectedElement = findJobInstance(job.id, true);
+    newSelectedElement.setSelected(true);
+
+    // If a timeout is passed in, this will cause a pause before
+    // the selection takes place.  This allows for quick-switching
+    // with hotkeys.
+    if (this.jobChangedTimeout) {
+      window.clearTimeout(this.jobChangedTimeout);
+    }
+    this.jobChangedTimeout = window.setTimeout(() => {
+      this.setValue({ selectedJob: job }, () => {
+        setUrlParam('selectedJob', job.id);
+        this.jobChangedTimeout = null;
+      });
+    }, timeout);
+  }
+
+  clearSelectedJob() {
+    const { pinnedJobs } = this.props;
+
+    if (!Object.keys(pinnedJobs).length) {
+      this.setValue({ selectedJob: null });
+      setUrlParam('selectedJob', null);
+      const selected = findSelectedInstance();
+      if (selected) selected.setSelected(false);
+    }
+  }
+
+  noMoreUnclassifiedFailures() {
+    const { pinnedJobs, notify } = this.props;
+
+    notify.send('No unclassified failures to select.');
+    this.clearSelectedJob(Object.keys(pinnedJobs).length);
+  }
+
+  changeSelectedJob(direction, unclassifiedOnly) {
+    const { pinnedJobs } = this.props;
+    const jobNavSelector = unclassifiedOnly ?
+      thJobNavSelectors.UNCLASSIFIED_FAILURES : thJobNavSelectors.ALL_JOBS;
+    const jobMap = this.ThResultSetStore.getJobMap();
+    // Get the appropriate next index based on the direction and current job
+    // selection (if any).  Must wrap end to end.
+    const getIndex = direction === 'next' ?
+      (idx, jobs) => (idx + 1 > jobs.length - 1 ? 0 : idx + 1) :
+      (idx, jobs) => (idx - 1 < 0 ? jobs.length - 1 : idx - 1);
+
+    // TODO: (bug 1434679) Move from using jquery here to find the next/prev
+    // component.  This could perhaps be done either with:
+    // * Document functions like ``querySelectorAll``, etc.
+    // * ReactJS with ReactDOM and props.children
+
+    // Filter the list of possible jobs down to ONLY ones in the .th-view-content
+    // div (excluding pinBoard) and then to the specific selector passed
+    // in.  And then to only VISIBLE (not filtered away) jobs.  The exception
+    // is for the .selected-job.  Even if the ``visible`` field is set to false,
+    // this includes it because it is the anchor from which we find
+    // the next/previous job.
+    //
+    // The .selected-job can be ``visible: false``, but still showing to the
+    // user.  This can happen when filtered to unclassified failures only,
+    // and you then classify the selected job.  It's ``visible`` field is set
+    // to false, but it is still showing to the user because it is still
+    // selected.  This is very important to the sheriff workflow.  As soon as
+    // selection changes away from it, the job will no longer be visible.
+    const jobs = $('.th-view-content')
+      .find(jobNavSelector.selector)
+      .filter(':visible, .selected-job');
+
+    if (jobs.length) {
+      const selectedEl = jobs.filter('.selected-job').first();
+      const selIdx = jobs.index(selectedEl);
+      const idx = getIndex(selIdx, jobs);
+      const jobEl = $(jobs[idx]);
+
+      if (selIdx !== idx) {
+        const jobId = jobEl.attr('data-job-id');
+
+        if (jobMap && jobMap[jobId]) {
+          scrollToElement(jobEl);
+          // Delay loading details for the new job right away,
+          // in case the user is switching rapidly between jobs
+          this.setSelectedJob(jobMap[jobId].job_obj, 200);
+          return;
+        }
+      } else {
+        this.noMoreUnclassifiedFailures();
+      }
+    } else {
+      this.noMoreUnclassifiedFailures();
+    }
+    // if there was no new job selected, then ensure that we clear any job that
+    // was previously selected.
+    if ($('.selected-job').css('display') === 'none') {
+      this.clearSelectedJob(Object.keys(pinnedJobs).length);
+    }
+  }
+
+  clearIfEligibleTarget(target) {
+    if (target.hasAttribute('data-job-clear-on-click')) {
+      this.clearSelectedJob();
+    }
+  }
+
+  render() {
+    return (
+      <SelectedJobContext.Provider value={this.value}>
+        <div
+          className="d-flex flex-column h-100"
+          onClick={evt => this.clearIfEligibleTarget(evt.target)}
+        >
+          {this.props.children}
+        </div>
+      </SelectedJobContext.Provider>
+    );
+  }
+
+}
+
+SelectedJobClass.propTypes = {
+  jobsLoaded: PropTypes.bool.isRequired,
+  notify: PropTypes.object.isRequired,
+  pinnedJobs: PropTypes.object.isRequired,
+  children: PropTypes.object.isRequired,
+  $injector: PropTypes.object.isRequired,
+};
+
+export const SelectedJob = withPinnedJobs(SelectedJobClass);
+
+export function withSelectedJob(Component) {
+  return function SelectedJobComponent(props) {
+    return (
+      <SelectedJobContext.Consumer>
+        {context => (
+          <Component
+            {...props}
+            selectedJob={context.selectedJob}
+            setSelectedJob={context.setSelectedJob}
+            clearSelectedJob={context.clearSelectedJob}
+            changeSelectedJob={context.changeSelectedJob}
+          />
+        )}
+      </SelectedJobContext.Consumer>
+    );
+  };
+}

--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -11,6 +11,7 @@ import BugJobMapModel from '../../models/bugJobMap';
 import JobClassificationModel from '../../models/classification';
 import JobModel from '../../models/job';
 import { withPinnedJobs } from '../context/PinnedJobs';
+import { withSelectedJob } from '../context/SelectedJob';
 
 class PinBoard extends React.Component {
   constructor(props) {
@@ -326,11 +327,6 @@ class PinBoard extends React.Component {
     }
   }
 
-  viewJob(job) {
-    this.$rootScope.selectedJob = job;
-    this.$rootScope.$emit(thEvents.jobClick, job);
-  }
-
   retriggerAllPinnedJobs() {
     JobModel.retrigger(
       Object.keys(this.props.pinnedJobs),
@@ -343,7 +339,7 @@ class PinBoard extends React.Component {
   render() {
     const {
       selectedJob, revisionList, isLoggedIn, isPinBoardVisible, classificationTypes,
-      pinnedJobs, pinnedJobBugs, removeBug, unPinJob,
+      pinnedJobs, pinnedJobBugs, removeBug, unPinJob, setSelectedJob,
     } = this.props;
     const {
       failureClassificationId, failureClassificationComment,
@@ -367,7 +363,7 @@ class PinBoard extends React.Component {
                   <span
                     className={`btn pinned-job ${getJobBtnClass(job)} ${selectedJobId === job.id ? 'btn-lg selected-job' : 'btn-xs'}`}
                     title={getHoverText(job)}
-                    onClick={() => this.viewJob(job)}
+                    onClick={() => setSelectedJob(job)}
                     data-job-id={job.job_id}
                   >{job.job_type_symbol}</span>
                   <span
@@ -544,6 +540,7 @@ PinBoard.propTypes = {
   removeBug: PropTypes.func.isRequired,
   unPinJob: PropTypes.func.isRequired,
   unPinAll: PropTypes.func.isRequired,
+  setSelectedJob: PropTypes.func.isRequired,
   selectedJob: PropTypes.object,
   email: PropTypes.string,
   revisionList: PropTypes.array,
@@ -555,4 +552,4 @@ PinBoard.defaultProps = {
   revisionList: [],
 };
 
-export default withPinnedJobs(PinBoard);
+export default withSelectedJob(withPinnedJobs(PinBoard));

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -10,6 +10,7 @@ import JobModel from '../../../models/job';
 import TaskclusterModel from '../../../models/taskcluster';
 import CustomJobActions from '../../CustomJobActions';
 import LogUrls from './LogUrls';
+import { withSelectedJob } from '../../context/SelectedJob';
 import { withPinnedJobs } from '../../context/PinnedJobs';
 
 class ActionBar extends React.Component {
@@ -21,7 +22,6 @@ class ActionBar extends React.Component {
     this.thNotify = $injector.get('thNotify');
     this.ThResultSetStore = $injector.get('ThResultSetStore');
     this.$interpolate = $injector.get('$interpolate');
-    this.$uibModal = $injector.get('$uibModal');
     this.$rootScope = $injector.get('$rootScope');
 
     this.state = {
@@ -347,4 +347,4 @@ ActionBar.defaultProps = {
   jobLogUrls: [],
 };
 
-export default withPinnedJobs(ActionBar);
+export default withSelectedJob(withPinnedJobs(ActionBar));

--- a/ui/job-view/details/summary/StatusPanel.jsx
+++ b/ui/job-view/details/summary/StatusPanel.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { getStatus } from '../../../helpers/job';
+import { withSelectedJob } from '../../context/SelectedJob';
 
-export default function StatusPanel(props) {
+function StatusPanel(props) {
   const { selectedJob } = props;
   const shadingClass = `result-status-shading-${getStatus(selectedJob)}`;
 
@@ -28,3 +29,4 @@ StatusPanel.propTypes = {
   selectedJob: PropTypes.object.isRequired,
 };
 
+export default withSelectedJob(StatusPanel);

--- a/ui/job-view/details/summary/SummaryPanel.jsx
+++ b/ui/job-view/details/summary/SummaryPanel.jsx
@@ -4,11 +4,12 @@ import PropTypes from 'prop-types';
 import { getSearchStr, getTimeFields, getJobMachineUrl } from '../../../helpers/job';
 import { getInspectTaskUrl, getJobSearchStrHref } from '../../../helpers/url';
 
+import { withSelectedJob } from '../../context/SelectedJob';
 import ActionBar from './ActionBar';
 import ClassificationsPanel from './ClassificationsPanel';
 import StatusPanel from './StatusPanel';
 
-export default class SummaryPanel extends React.Component {
+class SummaryPanel extends React.Component {
   constructor(props) {
     super(props);
 
@@ -36,14 +37,16 @@ export default class SummaryPanel extends React.Component {
     let machineUrl = null;
     let machineUrlStatus = '';
 
-    try {
-      machineUrl = await getJobMachineUrl(selectedJob);
-    } catch (err) {
-      machineUrlStatus = '(Load error)';
-      console.error(`Error fetching machine URL: ${err}`); // eslint-disable-line no-console
-    }
-    if (machineUrl !== prevMachineUrl) {
-      this.setState({ machineUrl, machineUrlStatus });
+    if ('taskcluster_metadata' in selectedJob) {
+      try {
+        machineUrl = await getJobMachineUrl(selectedJob);
+      } catch (err) {
+        machineUrlStatus = '(Load error)';
+        console.error(`Error fetching machine URL: ${err}`); // eslint-disable-line no-console
+      }
+      if (machineUrl !== prevMachineUrl) {
+        this.setState({ machineUrl, machineUrlStatus });
+      }
     }
   }
 
@@ -71,7 +74,6 @@ export default class SummaryPanel extends React.Component {
       <div id="summary-panel">
         <ActionBar
           repoName={repoName}
-          selectedJob={selectedJob}
           logParseStatus={logParseStatus}
           isTryRepo={currentRepo.is_try_repo}
           logViewerUrl={logViewerUrl}
@@ -100,7 +102,7 @@ export default class SummaryPanel extends React.Component {
                   currentRepo={currentRepo}
                   $injector={$injector}
                 />}
-              <StatusPanel selectedJob={selectedJob} />
+              <StatusPanel />
               <div>
                 <li className="small">
                   <label title="">Job</label>
@@ -213,3 +215,5 @@ SummaryPanel.defaultProps = {
   logViewerUrl: null,
   logViewerFullUrl: null,
 };
+
+export default withSelectedJob(SummaryPanel);

--- a/ui/job-view/details/tabs/AnnotationsTab.jsx
+++ b/ui/job-view/details/tabs/AnnotationsTab.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { thEvents } from '../../../js/constants';
 import { getBugUrl } from '../../../helpers/url';
+import { withSelectedJob } from '../../context/SelectedJob';
 
 function RelatedBugSaved(props) {
   const { deleteBug, bug } = props;
@@ -137,7 +138,7 @@ AnnotationsTable.propTypes = {
   dateFilter: PropTypes.func.isRequired,
 };
 
-export default class AnnotationsTab extends React.Component {
+class AnnotationsTab extends React.Component {
   constructor(props) {
     super(props);
 
@@ -253,3 +254,5 @@ AnnotationsTab.propTypes = {
 AnnotationsTab.defaultProps = {
   selectedJob: null,
 };
+
+export default withSelectedJob(AnnotationsTab);

--- a/ui/job-view/details/tabs/SimilarJobsTab.jsx
+++ b/ui/job-view/details/tabs/SimilarJobsTab.jsx
@@ -8,13 +8,13 @@ import { getSlaveHealthUrl, getJobsUrl } from '../../../helpers/url';
 import JobModel from '../../../models/job';
 import PushModel from '../../../models/push';
 import TextLogStepModel from '../../../models/textLogStep';
+import { withSelectedJob } from '../../context/SelectedJob';
 
-export default class SimilarJobsTab extends React.Component {
+class SimilarJobsTab extends React.Component {
   constructor(props) {
     super(props);
 
     const { $injector } = this.props;
-    this.$rootScope = $injector.get('$rootScope');
     this.thNotify = $injector.get('thNotify');
 
     this.pageSize = 20;
@@ -287,4 +287,11 @@ SimilarJobsTab.propTypes = {
   $injector: PropTypes.object.isRequired,
   repoName: PropTypes.string.isRequired,
   classificationMap: PropTypes.object.isRequired,
+  selectedJob: PropTypes.object,
 };
+
+SimilarJobsTab.defaultProps = {
+  selectedJob: null,
+};
+
+export default withSelectedJob(SimilarJobsTab);

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -13,6 +13,7 @@ import AutoclassifyTab from './autoclassify/AutoclassifyTab';
 import AnnotationsTab from './AnnotationsTab';
 import SimilarJobsTab from './SimilarJobsTab';
 import { withPinnedJobs } from '../../context/PinnedJobs';
+import { withSelectedJob } from '../../context/SelectedJob';
 
 class TabsPanel extends React.Component {
   constructor(props) {
@@ -94,9 +95,9 @@ class TabsPanel extends React.Component {
   render() {
     const {
       jobDetails, jobLogUrls, logParseStatus, suggestions, errors, user, bugs,
-      bugSuggestionsLoading, selectedJob, perfJobDetail, repoName, jobRevision,
+      bugSuggestionsLoading, perfJobDetail, repoName, jobRevision,
       classifications, togglePinBoardVisibility, isPinBoardVisible, pinnedJobs,
-      classificationMap, logViewerFullUrl, reftestUrl, $injector,
+      classificationMap, logViewerFullUrl, reftestUrl, $injector, clearSelectedJob,
     } = this.props;
     const { showAutoclassifyTab, tabIndex } = this.state;
     const countPinnedJobs = Object.keys(pinnedJobs).length;
@@ -138,7 +139,7 @@ class TabsPanel extends React.Component {
                 />
               </span>
               <span
-                onClick={() => this.$rootScope.$emit(thEvents.clearSelectedJob)}
+                onClick={() => clearSelectedJob(countPinnedJobs)}
                 className="btn details-panel-close-btn"
               ><span className="fa fa-times" /></span>
             </span>
@@ -149,7 +150,6 @@ class TabsPanel extends React.Component {
           <TabPanel>
             <FailureSummaryTab
               suggestions={suggestions}
-              selectedJob={selectedJob}
               errors={errors}
               bugSuggestionsLoading={bugSuggestionsLoading}
               jobLogUrls={jobLogUrls}
@@ -161,7 +161,6 @@ class TabsPanel extends React.Component {
           </TabPanel>
           {showAutoclassifyTab && <TabPanel>
             <AutoclassifyTab
-              job={selectedJob}
               hasLogs={!!jobLogUrls.length}
               logsParsed={logParseStatus !== 'pending'}
               logParseStatus={logParseStatus}
@@ -173,14 +172,12 @@ class TabsPanel extends React.Component {
             <AnnotationsTab
               classificationMap={classificationMap}
               classifications={classifications}
-              selectedJob={selectedJob}
               bugs={bugs}
               $injector={$injector}
             />
           </TabPanel>
           <TabPanel>
             <SimilarJobsTab
-              selectedJob={selectedJob}
               repoName={repoName}
               classificationMap={classificationMap}
               $injector={$injector}
@@ -210,9 +207,9 @@ TabsPanel.propTypes = {
   pinnedJobs: PropTypes.object.isRequired,
   bugs: PropTypes.array.isRequired,
   user: PropTypes.object.isRequired,
+  clearSelectedJob: PropTypes.func.isRequired,
   perfJobDetail: PropTypes.array,
   suggestions: PropTypes.array,
-  selectedJob: PropTypes.object,
   jobRevision: PropTypes.string,
   errors: PropTypes.array,
   bugSuggestionsLoading: PropTypes.bool,
@@ -235,4 +232,4 @@ TabsPanel.defaultProps = {
   reftestUrl: null,
 };
 
-export default withPinnedJobs(TabsPanel);
+export default withSelectedJob(withPinnedJobs(TabsPanel));

--- a/ui/job-view/details/tabs/autoclassify/ErrorLine.jsx
+++ b/ui/job-view/details/tabs/autoclassify/ErrorLine.jsx
@@ -10,11 +10,12 @@ import { getBugUrl, getLogViewerUrl } from '../../../../helpers/url';
 import LineOption from './LineOption';
 import LineOptionModel from './LineOptionModel';
 import StaticLineOption from './StaticLineOption';
+import { withSelectedJob } from '../../../context/SelectedJob';
 
 const GOOD_MATCH_SCORE = 0.75;
 const BAD_MATCH_SCORE = 0.25;
 
-export default class ErrorLine extends React.Component {
+class ErrorLine extends React.Component {
   constructor(props) {
     super(props);
 
@@ -488,7 +489,7 @@ export default class ErrorLine extends React.Component {
 
   render() {
     const {
-      errorLine, job, canClassify, isSelected, isEditable, setEditable,
+      errorLine, selectedJob, canClassify, isSelected, isEditable, setEditable,
       $injector, toggleSelect,
     } = this.props;
     const {
@@ -497,7 +498,7 @@ export default class ErrorLine extends React.Component {
 
     const failureLine = errorLine.data.metadata.failure_line;
     const searchLine = errorLine.data.bug_suggestions.search;
-    const logUrl = getLogViewerUrl(job.id, this.$rootScope.repoName, errorLine.data.line_number + 1);
+    const logUrl = getLogViewerUrl(selectedJob.id, this.$rootScope.repoName, errorLine.data.line_number + 1);
     const status = this.getStatus();
 
     return (
@@ -585,7 +586,6 @@ export default class ErrorLine extends React.Component {
                 {options.map(option => (
                   (showHidden || !option.hidden) && <li key={option.id}>
                     <LineOption
-                      job={job}
                       errorLine={errorLine}
                       optionModel={option}
                       selectedOption={selectedOption}
@@ -607,7 +607,6 @@ export default class ErrorLine extends React.Component {
                 {extraOptions.map(option => (
                   <li key={option.id}>
                     <LineOption
-                      job={job}
                       errorLine={errorLine}
                       optionModel={option}
                       selectedOption={selectedOption}
@@ -626,7 +625,6 @@ export default class ErrorLine extends React.Component {
 
           {!errorLine.verified && !isEditable && canClassify && <div>
             <StaticLineOption
-              job={job}
               errorLine={errorLine}
               option={selectedOption}
               numOptions={options.length}
@@ -643,7 +641,7 @@ export default class ErrorLine extends React.Component {
 }
 
 ErrorLine.propTypes = {
-  job: PropTypes.object.isRequired,
+  selectedJob: PropTypes.object.isRequired,
   errorLine: PropTypes.object.isRequired,
   isSelected: PropTypes.bool.isRequired,
   isEditable: PropTypes.bool.isRequired,
@@ -660,3 +658,5 @@ ErrorLine.defaultProps = {
   errorMatchers: null,
   prevErrorLine: null,
 };
+
+export default withSelectedJob(ErrorLine);

--- a/ui/job-view/details/tabs/autoclassify/LineOption.jsx
+++ b/ui/job-view/details/tabs/autoclassify/LineOption.jsx
@@ -10,6 +10,7 @@ import { getBugUrl, getLogViewerUrl, getReftestUrl } from '../../../../helpers/u
 import BugFiler from '../../BugFiler';
 import { thEvents } from '../../../../js/constants';
 import { getAllUrlParams } from '../../../../helpers/location';
+import { withSelectedJob } from '../../../context/SelectedJob';
 import { withPinnedJobs } from '../../../context/PinnedJobs';
 
 /**
@@ -59,7 +60,7 @@ class LineOption extends React.Component {
 
   render() {
     const {
-      job,
+      selectedJob,
       errorLine,
       optionModel,
       selectedOption,
@@ -74,8 +75,8 @@ class LineOption extends React.Component {
     } = this.props;
     const { isBugFilerOpen, repoName } = this.state;
     const option = optionModel;
-    let logUrl = job.logs.filter(x => x.name.endsWith('_json'));
-    logUrl = logUrl[0] ? logUrl[0].url : job.logs[0].url;
+    let logUrl = selectedJob.logs.filter(x => x.name.endsWith('_json'));
+    logUrl = logUrl[0] ? logUrl[0].url : selectedJob.logs[0].url;
 
     return (
       <div className="classification-option">
@@ -97,10 +98,10 @@ class LineOption extends React.Component {
               className={canClassify ? '' : 'hidden'}
             />}
             {!!option.bugNumber && <span className="line-option-text">
-              {(!canClassify || job.id in pinnedJobs) &&
+              {(!canClassify || selectedJob.id in pinnedJobs) &&
                 <button
                   className="btn btn-xs btn-light-bordered"
-                  onClick={() => addBug({ id: option.bugNumber }, job)}
+                  onClick={() => addBug({ id: option.bugNumber }, selectedJob)}
                   title="add to list of bugs to associate with all pinned jobs"
                 ><i className="fa fa-thumb-tack" /></button>}
               {!!option.bugResolution &&
@@ -180,10 +181,10 @@ class LineOption extends React.Component {
           suggestion={errorLine.data.bug_suggestions}
           suggestions={[errorLine.data.bug_suggestions]}
           fullLog={logUrl}
-          parsedLog={`${location.origin}/${getLogViewerUrl(job.id, repoName)}`}
-          reftestUrl={isReftest(job) ? getReftestUrl(logUrl) : ''}
+          parsedLog={`${location.origin}/${getLogViewerUrl(selectedJob.id, repoName)}`}
+          reftestUrl={isReftest(selectedJob) ? getReftestUrl(logUrl) : ''}
           successCallback={this.bugFilerCallback}
-          jobGroupName={job.job_group_name}
+          jobGroupName={selectedJob.job_group_name}
           notify={this.thNotify}
         />}
       </div>
@@ -194,7 +195,7 @@ class LineOption extends React.Component {
 
 LineOption.propTypes = {
   $injector: PropTypes.object.isRequired,
-  job: PropTypes.object.isRequired,
+  selectedJob: PropTypes.object.isRequired,
   errorLine: PropTypes.object.isRequired,
   optionModel: PropTypes.object.isRequired,
   canClassify: PropTypes.bool.isRequired,
@@ -214,4 +215,4 @@ LineOption.defaultProps = {
   manualBugNumber: undefined,
 };
 
-export default withPinnedJobs(LineOption);
+export default withSelectedJob(withPinnedJobs(LineOption));

--- a/ui/job-view/details/tabs/autoclassify/StaticLineOption.jsx
+++ b/ui/job-view/details/tabs/autoclassify/StaticLineOption.jsx
@@ -4,6 +4,7 @@ import Highlighter from 'react-highlight-words';
 
 import { getSearchWords } from '../../../../helpers/display';
 import { getBugUrl } from '../../../../helpers/url';
+import { withSelectedJob } from '../../../context/SelectedJob';
 import { withPinnedJobs } from '../../../context/PinnedJobs';
 
 /**
@@ -11,7 +12,7 @@ import { withPinnedJobs } from '../../../context/PinnedJobs';
  */
 function StaticLineOption(props) {
   const {
-    job, canClassify, errorLine, option, numOptions, setEditable, ignoreAlways,
+    selectedJob, canClassify, errorLine, option, numOptions, setEditable, ignoreAlways,
     manualBugNumber, pinnedJobs, addBug,
   } = props;
 
@@ -27,10 +28,10 @@ function StaticLineOption(props) {
       </div>
 
       {!!option.bugNumber && <span className="line-option-text">
-        {(!canClassify || job.id in pinnedJobs) &&
+        {(!canClassify || selectedJob.id in pinnedJobs) &&
           <button
             className="btn btn-xs btn-light-bordered"
-            onClick={() => addBug({ id: option.bugNumber }, job)}
+            onClick={() => addBug({ id: option.bugNumber }, selectedJob)}
             title="add to list of bugs to associate with all pinned jobs"
           ><i className="fa fa-thumb-tack" /></button>}
         {!!option.bugResolution &&
@@ -77,7 +78,7 @@ function StaticLineOption(props) {
 }
 
 StaticLineOption.propTypes = {
-  job: PropTypes.object.isRequired,
+  selectedJob: PropTypes.object.isRequired,
   errorLine: PropTypes.object.isRequired,
   option: PropTypes.object.isRequired,
   numOptions: PropTypes.number.isRequired,
@@ -93,4 +94,4 @@ StaticLineOption.defaultProps = {
   manualBugNumber: undefined,
 };
 
-export default withPinnedJobs(StaticLineOption);
+export default withSelectedJob(withPinnedJobs(StaticLineOption));

--- a/ui/job-view/details/tabs/failureSummary/BugListItem.jsx
+++ b/ui/job-view/details/tabs/failureSummary/BugListItem.jsx
@@ -4,6 +4,7 @@ import Highlighter from 'react-highlight-words';
 
 import { getSearchWords } from '../../../../helpers/display';
 import { getBugUrl } from '../../../../helpers/url';
+import { withSelectedJob } from '../../../context/SelectedJob';
 import { withPinnedJobs } from '../../../context/PinnedJobs';
 
 
@@ -55,4 +56,4 @@ BugListItem.defaultProps = {
   title: null,
 };
 
-export default withPinnedJobs(BugListItem);
+export default withSelectedJob(withPinnedJobs(BugListItem));

--- a/ui/job-view/details/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/job-view/details/tabs/failureSummary/FailureSummaryTab.jsx
@@ -9,6 +9,7 @@ import ErrorsList from './ErrorsList';
 import ListItem from './ListItem';
 import SuggestionsListItem from './SuggestionsListItem';
 import BugFiler from '../../BugFiler';
+import { withSelectedJob } from '../../../context/SelectedJob';
 import { withPinnedJobs } from '../../../context/PinnedJobs';
 
 class FailureSummaryTab extends React.Component {
@@ -70,7 +71,6 @@ class FailureSummaryTab extends React.Component {
               index={index}
               suggestion={suggestion}
               toggleBugFiler={() => this.fileBug(suggestion)}
-              selectedJob={selectedJob}
             />))}
 
           {!!errors.length &&
@@ -154,4 +154,4 @@ FailureSummaryTab.defaultProps = {
   logViewerFullUrl: null,
 };
 
-export default withPinnedJobs(FailureSummaryTab);
+export default withSelectedJob(withPinnedJobs(FailureSummaryTab));

--- a/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
@@ -20,7 +20,7 @@ export default class SuggestionsListItem extends React.Component {
 
   render() {
     const {
-      suggestion, selectedJob, toggleBugFiler,
+      suggestion, toggleBugFiler,
     } = this.props;
     const { suggestionShowMore } = this.state;
 
@@ -44,7 +44,6 @@ export default class SuggestionsListItem extends React.Component {
             (<BugListItem
               key={bug.id}
               bug={bug}
-              selectedJob={selectedJob}
               suggestion={suggestion}
             />))}
 
@@ -65,7 +64,6 @@ export default class SuggestionsListItem extends React.Component {
               (<BugListItem
                 key={bug.id}
                 bug={bug}
-                selectedJob={selectedJob}
                 suggestion={suggestion}
                 bugClassName={bug.resolution !== '' ? 'deleted' : ''}
                 title={bug.resolution !== '' ? bug.resolution : ''}
@@ -82,6 +80,5 @@ export default class SuggestionsListItem extends React.Component {
 
 SuggestionsListItem.propTypes = {
   suggestion: PropTypes.object.isRequired,
-  selectedJob: PropTypes.object.isRequired,
   toggleBugFiler: PropTypes.func.isRequired,
 };

--- a/ui/job-view/headerbars/FiltersMenu.jsx
+++ b/ui/job-view/headerbars/FiltersMenu.jsx
@@ -3,12 +3,22 @@ import PropTypes from 'prop-types';
 
 import { thAllResultStatuses } from '../../js/constants';
 import { withPinnedJobs } from '../context/PinnedJobs';
+import { withSelectedJob } from '../context/SelectedJob';
 
 const resultStatusMenuItems = thAllResultStatuses.filter(rs => rs !== 'runnable');
 
 function FiltersMenu(props) {
-  const { filterModel, pinJobs, resultSetStore } = props;
+  const { filterModel, pinJobs, resultSetStore, selectedJob, setSelectedJob } = props;
   const { urlParams: { resultStatus, classifiedState } } = filterModel;
+
+  const pinAllShownJobs = () => {
+    const shownJobs = resultSetStore.getAllShownJobs(this.props.pushId);
+
+    pinJobs(shownJobs);
+    if (!selectedJob) {
+      setSelectedJob(shownJobs[0]);
+    }
+  };
 
   return (
     <span>
@@ -63,7 +73,7 @@ function FiltersMenu(props) {
           <li
             title="Pin all jobs that pass the global filters"
             className="dropdown-item"
-            onClick={() => pinJobs(resultSetStore.getAllShownJobs())}
+            onClick={pinAllShownJobs}
           >Pin all showing</li>
           <li
             title="Show only superseded jobs"
@@ -84,7 +94,13 @@ function FiltersMenu(props) {
 FiltersMenu.propTypes = {
   filterModel: PropTypes.object.isRequired,
   pinJobs: PropTypes.func.isRequired,
+  setSelectedJob: PropTypes.func.isRequired,
   resultSetStore: PropTypes.object.isRequired,
+  selectedJob: PropTypes.object,
 };
 
-export default withPinnedJobs(FiltersMenu);
+FiltersMenu.defaultProps = {
+  selectedJob: null,
+};
+
+export default withSelectedJob(withPinnedJobs(FiltersMenu));

--- a/ui/job-view/pushes/JobButton.jsx
+++ b/ui/job-view/pushes/JobButton.jsx
@@ -67,8 +67,7 @@ export default class JobButtonComponent extends React.Component {
     this.setState({ isSelected });
     // filterPlatformCb will keep a job and platform visible if it contains
     // the selected job, so we must pass in if this job is selected or not.
-    const selectedJobId = isSelected ? job.id : null;
-    filterPlatformCb(platform, selectedJobId);
+    filterPlatformCb(platform, isSelected ? job.id : null);
   }
 
   toggleRunnableSelected() {

--- a/ui/job-view/pushes/JobGroup.jsx
+++ b/ui/job-view/pushes/JobGroup.jsx
@@ -37,19 +37,25 @@ GroupSymbol.defaultProps = {
 export default class JobGroup extends React.Component {
   constructor(props) {
     super(props);
-    const { $injector } = this.props;
+    const { $injector, pushGroupState } = this.props;
     this.$rootScope = $injector.get('$rootScope');
 
     // The group should be expanded initially if the global group state is expanded
     const groupState = getUrlParam('group_state');
     const duplicateJobs = getUrlParam('duplicate_jobs');
     this.state = {
-      expanded: groupState === 'expanded',
+      expanded: groupState === 'expanded' || pushGroupState === 'expanded',
       showDuplicateJobs: duplicateJobs === 'visible',
     };
   }
 
-  componentWillMount() {
+  static getDerivedStateFromProps(nextProps, state) {
+    // We should expand this group if it's own state is set to be expanded,
+    // or if the push was set to have all groups expanded.
+    return { expanded: state.expanded || nextProps.pushGroupState === 'expanded' };
+  }
+
+  componentDidMount() {
     // TODO: Move this state up to PushList and pass groupState and duplicates
     // as props.  In PushList, it will listen for history changes to set
     // the values.
@@ -190,5 +196,6 @@ JobGroup.propTypes = {
   filterModel: PropTypes.object.isRequired,
   filterPlatformCb: PropTypes.func.isRequired,
   platform: PropTypes.object.isRequired,
+  pushGroupState: PropTypes.string.isRequired,
   $injector: PropTypes.object.isRequired,
 };

--- a/ui/job-view/pushes/JobsAndGroups.jsx
+++ b/ui/job-view/pushes/JobsAndGroups.jsx
@@ -6,7 +6,10 @@ import { getStatus } from '../../helpers/job';
 
 export default class JobsAndGroups extends React.Component {
   render() {
-    const { $injector, groups, repoName, platform, filterPlatformCb, filterModel } = this.props;
+    const {
+      $injector, groups, repoName, platform, filterPlatformCb, filterModel,
+      pushGroupState,
+    } = this.props;
 
     return (
       <td className="job-row" data-job-clear-on-click>
@@ -21,6 +24,7 @@ export default class JobsAndGroups extends React.Component {
                 filterPlatformCb={filterPlatformCb}
                 platform={platform}
                 key={group.mapKey}
+                pushGroupState={pushGroupState}
               />
             );
           }
@@ -53,4 +57,5 @@ JobsAndGroups.propTypes = {
   filterModel: PropTypes.object.isRequired,
   filterPlatformCb: PropTypes.func.isRequired,
   platform: PropTypes.object.isRequired,
+  pushGroupState: PropTypes.string.isRequired,
 };

--- a/ui/job-view/pushes/Platform.jsx
+++ b/ui/job-view/pushes/Platform.jsx
@@ -16,7 +16,9 @@ PlatformName.propTypes = {
 };
 
 export default function Platform(props) {
-  const { platform, $injector, repoName, filterPlatformCb, filterModel } = props;
+  const {
+    platform, $injector, repoName, filterPlatformCb, filterModel, pushGroupState,
+  } = props;
   const { title, groups, id } = platform;
 
   return (
@@ -29,6 +31,7 @@ export default function Platform(props) {
         filterPlatformCb={filterPlatformCb}
         platform={platform}
         filterModel={filterModel}
+        pushGroupState={pushGroupState}
       />
     </tr>
   );
@@ -40,4 +43,5 @@ Platform.propTypes = {
   $injector: PropTypes.object.isRequired,
   filterModel: PropTypes.object.isRequired,
   filterPlatformCb: PropTypes.func.isRequired,
+  pushGroupState: PropTypes.string.isRequired,
 };

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -30,11 +30,13 @@ export default class Push extends React.Component {
       last_job_counts: job_counts ? { ...job_counts } : null,
       hasBoundaryError: false,
       boundaryError: '',
+      pushGroupState: 'collapsed',
     };
   }
   componentDidMount() {
     this.showRunnableJobs = this.showRunnableJobs.bind(this);
     this.hideRunnableJobs = this.hideRunnableJobs.bind(this);
+    this.expandAllPushGroups = this.expandAllPushGroups.bind(this);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -45,6 +47,16 @@ export default class Push extends React.Component {
     this.setState({
       hasBoundaryError: true,
       boundaryError: error,
+    });
+  }
+
+  expandAllPushGroups(callback) {
+    // This sets the group state once, then unsets it in the callback.  This
+    // has the result of triggering an expand on all the groups, but then
+    // gives control back to each group to decide to expand or not.
+    this.setState({ pushGroupState: 'expanded' }, () => {
+      this.setState({ pushGroupState: 'collapsed' });
+      callback();
     });
   }
 
@@ -134,7 +146,9 @@ export default class Push extends React.Component {
       push, isLoggedIn, $injector, repoName, currentRepo,
       filterModel, notificationSupported,
     } = this.props;
-    const { watched, runnableVisible, hasBoundaryError, boundaryError } = this.state;
+    const {
+      watched, runnableVisible, hasBoundaryError, boundaryError, pushGroupState,
+    } = this.state;
     const { id, push_timestamp, revision, job_counts, author } = push;
 
     if (hasBoundaryError) {
@@ -164,6 +178,7 @@ export default class Push extends React.Component {
           showRunnableJobsCb={this.showRunnableJobs}
           hideRunnableJobsCb={this.hideRunnableJobs}
           cycleWatchState={() => this.cycleWatchState()}
+          expandAllPushGroups={this.expandAllPushGroups}
           notificationSupported={notificationSupported}
         />
         <div className="push-body-divider" />
@@ -180,6 +195,7 @@ export default class Push extends React.Component {
               push={push}
               repoName={repoName}
               filterModel={filterModel}
+              pushGroupState={pushGroupState}
               $injector={$injector}
             />
           </span>

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -8,6 +8,7 @@ import { getJobsUrl } from '../../helpers/url';
 import PushModel from '../../models/push';
 import JobModel from '../../models/job';
 import { withPinnedJobs } from '../context/PinnedJobs';
+import { withSelectedJob } from '../context/SelectedJob';
 
 // url params we don't want added from the current querystring to the revision
 // and author links.
@@ -151,10 +152,15 @@ class PushHeader extends React.PureComponent {
   }
 
   pinAllShownJobs() {
-    const { pinJobs } = this.props;
+    const { selectedJob, setSelectedJob, pinJobs, expandAllPushGroups } = this.props;
     const shownJobs = this.ThResultSetStore.getAllShownJobs(this.props.pushId);
 
-    pinJobs(shownJobs);
+    expandAllPushGroups(() => {
+      pinJobs(shownJobs);
+      if (!selectedJob) {
+        setSelectedJob(shownJobs[0]);
+      }
+    });
   }
 
   render() {
@@ -271,15 +277,19 @@ PushHeader.propTypes = {
   hideRunnableJobsCb: PropTypes.func.isRequired,
   cycleWatchState: PropTypes.func.isRequired,
   isLoggedIn: PropTypes.bool.isRequired,
+  setSelectedJob: PropTypes.func.isRequired,
   pinJobs: PropTypes.func.isRequired,
+  expandAllPushGroups: PropTypes.func.isRequired,
   notificationSupported: PropTypes.bool.isRequired,
   jobCounts: PropTypes.object,
   watchState: PropTypes.string,
+  selectedJob: PropTypes.object,
 };
 
 PushHeader.defaultProps = {
+  selectedJob: null,
   jobCounts: null,
   watchState: 'none',
 };
 
-export default withPinnedJobs(PushHeader);
+export default withSelectedJob(withPinnedJobs(PushHeader));

--- a/ui/js/constants.js
+++ b/ui/js/constants.js
@@ -246,8 +246,6 @@ export const thPerformanceBranches = ['autoland', 'mozilla-inbound'];
  * The set of custom Treeherder events.
  */
 export const thEvents = {
-  // fired (surprisingly) when a job is clicked
-  jobClick: 'job-click-EVT',
   // fired with a selected job on 't'
   selectNextTab: 'select-next-tab-EVT',
   // fired with a selected job on 'r'
@@ -258,18 +256,14 @@ export const thEvents = {
   jobsLoaded: 'jobs-loaded-EVT',
   // when new pushes are prepended, or appended
   pushesLoaded: 'pushes-loaded-EVT',
-  // after deselecting a job via click outside/esc
-  clearSelectedJob: 'clear-selected-job-EVT',
   // fired when a global filter has changed
   globalFilterChanged: 'status-filter-changed-EVT',
   groupStateChanged: 'group-state-changed-EVT',
   duplicateJobsVisibilityChanged: 'duplicate-jobs-visibility-changed-EVT',
   showRunnableJobs: 'show-runnable-jobs-EVT',
   deleteRunnableJobs: 'delete-runnable-jobs-EVT',
-  changeSelection: 'next-previous-job-EVT',
   saveClassification: 'save-classification-EVT',
   deleteClassification: 'delete-classification-EVT',
-  selectJob: 'select-job-EVT',
   applyNewJobs: 'apply-new-jobs-EVT',
   openLogviewer: 'open-logviewer-EVT',
   autoclassifyVerified: 'ac-verified-EVT',

--- a/ui/js/models/resultsets_store.js
+++ b/ui/js/models/resultsets_store.js
@@ -218,16 +218,6 @@ treeherder.factory('ThResultSetStore', [
             if (_.isEmpty(repoData)) {
                 repoData = {
                     name: repoName,
-
-                    // This keeps track of the selected job.  The selected job,
-                    // when rendered, will be given a class of ``selected-job``,
-                    // but the directive may lose track of that class when we are
-                    // updating with new jobs.  In the event the row with the
-                    // selected job is being re-rendered, knowing which one is
-                    // selected here in the model will allow us to apply the
-                    // correct styling to it.
-                    lastJobObjSelected: {},
-
                     // maps to help finding objects to update/add
                     rsMap: {},
                     jobMap: {},
@@ -257,17 +247,6 @@ treeherder.factory('ThResultSetStore', [
             return shownJobs.filter(job => job.result_set_id === pushId && job.visible);
           }
           return shownJobs.filter(job => job.visible);
-        };
-
-        var getSelectedJob = function () {
-            return {
-                job: repoData.lastJobObjSelected,
-            };
-        };
-
-        var setSelectedJob = function (lastJobObjSelected) {
-            repoData.lastJobObjSelected = lastJobObjSelected;
-            $timeout(() => { $rootScope.selectedJob = lastJobObjSelected; });
         };
 
         var getPlatformKey = function (name, option) {
@@ -988,10 +967,8 @@ treeherder.factory('ThResultSetStore', [
             toggleSelectedRunnableJob: toggleSelectedRunnableJob,
             getPush: getPush,
             getPushArray: getPushArray,
-            getSelectedJob: getSelectedJob,
             getFilteredUnclassifiedFailureCount: getFilteredUnclassifiedFailureCount,
             getAllUnclassifiedFailureCount: getAllUnclassifiedFailureCount,
-            setSelectedJob: setSelectedJob,
             updateUnclassifiedFailureMap: updateUnclassifiedFailureMap,
             defaultPushCount: defaultPushCount,
             recalculateUnclassifiedCounts: recalculateUnclassifiedCounts,


### PR DESCRIPTION
I feel like I start all my PRs with an apology for how large they are, so here goes: Sorry for how large this one is...

I did my best to break this up into some logical chunks.  The commits don't sit on their own, but are only used to group similar functionality changes (and code cleanup that I noticed on the way) together.  If this makes it harder to review, I could squash a couple together.  Especially these two:

* Bug 1492273 - Move job selection functions to a Context
* Bug 1492273 - Put new SelectedJob Context into use 
