### PR TITLE
Bug 1492462 - Remove actions.yaml fallback for trigger new jobs

### DIFF
--- a/ui/helpers/taskcluster.js
+++ b/ui/helpers/taskcluster.js
@@ -1,4 +1,4 @@
-import { OIDCCredentialAgent, fromNow, Queue } from 'taskcluster-client-web';
+import { OIDCCredentialAgent, Queue } from 'taskcluster-client-web';
 import { tcRootUrl, getUserSessionUrl } from './url';
 
 const taskcluster = (() => {
@@ -42,25 +42,6 @@ const taskcluster = (() => {
       } else {
         credentialAgent = null;
       }
-    },
-    refreshTimestamps: (task) => {
-      // Take a taskcluster task and make all of the timestamps
-      // new again. This is pretty much lifted verbatim from
-      // mozilla_ci_tools which was used by pulse_actions.
-      // We need to do this because action tasks are created with
-      // timestamps for expires/created/deadline that are based
-      // on the time of the original decision task creation. We must
-      // update to the current time, or Taskcluster will reject the
-      // task upon creation.
-      task.expires = fromNow('366 days');
-      task.created = fromNow(0);
-      task.deadline = fromNow('1 day');
-
-      task.payload.artifacts.forEach((artifact) => {
-        artifact.expires = fromNow('365 days');
-      });
-
-      return task;
     },
   };
 })();

--- a/ui/models/job.js
+++ b/ui/models/job.js
@@ -112,7 +112,7 @@ export default class JobModel {
         const job = await JobModel.get(repoName, id);
         const decisionTaskId = await ThResultSetStore.getGeckoDecisionTaskId(job.result_set_id);
         const results = await TaskclusterModel.load(decisionTaskId, job);
-        const retriggerTask = results && results.actions.find(result => result.name === 'retrigger');
+        const retriggerTask = results.actions.find(result => result.name === 'retrigger');
 
         try {
           await TaskclusterModel.submit({
@@ -154,7 +154,7 @@ export default class JobModel {
         const job = await JobModel.get(repoName, id);
         const decisionTaskId = await ThResultSetStore.getGeckoDecisionTaskId(job.result_set_id);
         const results = await TaskclusterModel.load(decisionTaskId, job);
-        const cancelTask = results && results.actions.find(result => result.name === 'cancel');
+        const cancelTask = results.actions.find(result => result.name === 'cancel');
 
         try {
           await TaskclusterModel.submit({


### PR DESCRIPTION
Some more cleanup that's possible now ESR52 is EOL.

As a result `TaskclusterModel.load()` can no longer return `null` (it will throw instead), so the null-checks have been removed.