### PR TITLE
Bug 1485089 - Change commenter daily task

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -345,9 +345,9 @@ CELERYBEAT_SCHEDULE = {
         }
     },
     'daily-intermittents-commenter': {
-        # Executes every morning at 7 a.m. UTC except monday
+        # Executes every morning at 6 a.m. UTC except monday
         'task': 'intermittents-commenter',
-        'schedule': crontab(minute=0, hour=7, day_of_week='tuesday-sunday'),
+        'schedule': crontab(minute=0, hour=6, day_of_week='tuesday-sunday'),
         'options': {
             'queue': 'intermittents_commenter'
         },


### PR DESCRIPTION
Change daily task time to run one hour earlier since it appears that
the tuesday daily task is running at the same time the RDS snapshot occurs
and might be contributing to the celery task timeout exception (more info is
outlined as a comment on the bugzilla bug).