### PR TITLE
IFV - remove bug lookup in serializer

### DIFF
--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -320,14 +320,6 @@ class FailuresQueryParamsSerializer(serializers.Serializer):
         if bug is None and self.context == 'requireBug':
             raise serializers.ValidationError('This field is required.')
 
-        elif bug:
-            try:
-                models.Bugscache.objects.get(id=bug)
-
-            except ObjectDoesNotExist:
-                raise serializers.ValidationError(
-                      '{} does not exist or is not an intermittent failure.'.format(bug))
-
         return bug
 
     def validate_tree(self, tree):


### PR DESCRIPTION
The bug id lookup in validate_bug is querying bugscache rather than bugjobmap to check for a valid bug id. This would be an easy fix but I'm thinking it should be removed instead since it's kind of an 'extra' feature and to change it I'd have to do:
`bugs = BugJobMap.objects.filter(bug_id=id)` which isn't as quick as a 'get' lookup (and a bit redundant since it'll be doing that in the View with additional filters).