### PR TITLE
Use the logged in user, for who to notify of interactive tasks, rather than the push user.

### DIFF
--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -182,7 +182,7 @@ class ActionBar extends React.Component {
         decisionTaskId,
         taskId: results.originalTaskId,
         input: {
-          notify: job.who,
+          notify: user.email,
         },
         staticActionVariables: results.staticActionVariables,
       });


### PR DESCRIPTION
I haven't tested this.