### PR TITLE
Remove unnecessary param from FiltersMenu

### DIFF
--- a/ui/job-view/headerbars/FiltersMenu.jsx
+++ b/ui/job-view/headerbars/FiltersMenu.jsx
@@ -12,7 +12,7 @@ function FiltersMenu(props) {
   const { urlParams: { resultStatus, classifiedState } } = filterModel;
 
   const pinAllShownJobs = () => {
-    const shownJobs = resultSetStore.getAllShownJobs(this.props.pushId);
+    const shownJobs = resultSetStore.getAllShownJobs();
 
     pinJobs(shownJobs);
     if (!selectedJob) {


### PR DESCRIPTION
This isn't needed/used in this context.  We want all showing jobs spanning all pushes.  Copy paste error.