### PR TITLE
Revert "Bug 1494665 - Open interactive tasks in a new tab after triggering (#4077)"

### DIFF
--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -42,10 +42,6 @@ export const getInspectTaskUrl = function getInspectTaskUrl(taskId) {
   return `https://tools.taskcluster.net/tasks/${taskId}`;
 };
 
-export const getInteractiveTaskUrl = function (taskId) {
-  return `https://tools.taskcluster.net/tasks/${taskId}/connect`;
-};
-
 export const getReftestUrl = function getReftestUrl(logUrl) {
   return `https://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl=${logUrl}&only_show_unexpected=1`;
 };

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -5,7 +5,7 @@ import $ from 'jquery';
 import { thEvents } from '../../../helpers/constants';
 import { formatTaskclusterError } from '../../../helpers/errorMessage';
 import { isReftest } from '../../../helpers/job';
-import { getInteractiveTaskUrl, getInspectTaskUrl, getReftestUrl } from '../../../helpers/url';
+import { getInspectTaskUrl, getReftestUrl } from '../../../helpers/url';
 import JobModel from '../../../models/job';
 import TaskclusterModel from '../../../models/taskcluster';
 import CustomJobActions from '../../CustomJobActions';
@@ -177,7 +177,7 @@ class ActionBar extends React.Component {
     const interactiveTask = results.actions.find(result => result.name === 'create-interactive');
 
     try {
-      const taskId = await TaskclusterModel.submit({
+      await TaskclusterModel.submit({
         action: interactiveTask,
         decisionTaskId,
         taskId: results.originalTaskId,
@@ -187,13 +187,10 @@ class ActionBar extends React.Component {
         staticActionVariables: results.staticActionVariables,
       });
 
-      this.thNotify.send('Request sent to create an interactive job via actions.json.', 'success');
-
-      Object.assign(window.open(), {
-        opener: null,
-        location: getInteractiveTaskUrl(taskId),
-        target: '_blank',
-      });
+      this.thNotify.send(
+        `Request sent to create an interactive job via actions.json.
+          You will soon receive an email containing a link to interact with the task.`,
+        'success');
     } catch (e) {
       // The full message is too large to fit in a Treeherder
       // notification box.


### PR DESCRIPTION
This reverts commit f96bcb910ebb83b03c43cad7d1f92eabe05fca13, per:
https://github.com/mozilla/treeherder/pull/4077#issuecomment-425909898