### PR TITLE
Bug 1495520 - Travis: Fix MySQL connection errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,18 @@ group: edge
 matrix:
   include:
 
-    # Job 1: Linters
+    - env: js-tests
+      language: node_js
+      node_js: "10"
+      cache:
+        directories:
+          - node_modules
+      install:
+        - source ./bin/travis-setup.sh js_env
+      script:
+        - yarn test
+        - yarn build
+
     - env: python2-linters
       sudo: false
       language: python
@@ -24,40 +35,7 @@ matrix:
         - git grep -El '^#!/.+\b(bash|sh)\b' | xargs shellcheck
         - make html
 
-    # Job 2: Python 3 linters
-    - env: python3-linters
-      language: python
-      python: "3.6.5"
-      cache:
-        directories:
-          - ${HOME}/venv
-      install:
-        - source ./bin/travis-setup.sh services python_env
-        # Create the test database for `manage.py check --deploy`.
-        - mysql -u root -e 'create database test_treeherder;'
-      script:
-        - pip check
-        - flake8 --show-source
-        - SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' ./manage.py check --deploy --fail-level WARNING
-        # Remove these once we get the roughly equivalent pytest sanity tests working under Python 3.
-        - ./manage.py migrate
-        - ./manage.py makemigrations --check
-
-    # Job 3: Nodejs UI tests
-    - env: js-tests
-      language: node_js
-      node_js: "10"
-      cache:
-        directories:
-          - node_modules
-      install:
-        - source ./bin/travis-setup.sh js_env
-      script:
-        - yarn test
-        - yarn build
-
-    # Job 4: Python Tests - Main
-    - env: python-tests-main
+    - env: python2-tests-main
       language: python
       python: "2.7.15"
       cache:
@@ -76,8 +54,7 @@ matrix:
         # https://docs.python.org/2/using/cmdline.html#cmdoption-3
         - python -3 -m pytest tests/ --runslow --ignore=tests/selenium/
 
-    # Job 5: Python Tests - Selenium integration
-    - env: python-tests-selenium
+    - env: python2-tests-selenium
       language: python
       python: "2.7.15"
       cache:
@@ -94,6 +71,24 @@ matrix:
         # Using Python 2's `-3` mode to surface DeprecationWarnings for Python 3 incompatibilities:
         # https://docs.python.org/2/using/cmdline.html#cmdoption-3
         - python -3 -m pytest tests/selenium/ --driver Firefox
+
+    - env: python3-smoketest
+      language: python
+      python: "3.6.5"
+      cache:
+        directories:
+          - ${HOME}/venv
+      install:
+        - source ./bin/travis-setup.sh services python_env
+        # Create the test database for `manage.py check --deploy`.
+        - mysql -u root -e 'create database test_treeherder;'
+      script:
+        - pip check
+        - flake8 --show-source
+        - SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' ./manage.py check --deploy --fail-level WARNING
+        # Remove these once we get the roughly equivalent pytest sanity tests working under Python 3.
+        - ./manage.py migrate
+        - ./manage.py makemigrations --check
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,22 +26,18 @@ matrix:
 
     # Job 2: Python 3 linters
     - env: python3-linters
-      sudo: false
       language: python
       python: "3.6.5"
       cache:
         directories:
           - ${HOME}/venv
       install:
-        - source ./bin/travis-setup.sh python_env
+        - source ./bin/travis-setup.sh services python_env
         # Create the test database for `manage.py check --deploy`.
         - mysql -u root -e 'create database test_treeherder;'
       script:
         - pip check
         - flake8 --show-source
-        # Temporarily running these in the linters job to avoid impacting job count and thus Travis end-to-end times.
-        # Prevent connections during check/migrate/makemigrations to a non-existent Elasticsearch server.
-        - unset ELASTICSEARCH_URL
         - SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' ./manage.py check --deploy --fail-level WARNING
         # Remove these once we get the roughly equivalent pytest sanity tests working under Python 3.
         - ./manage.py migrate


### PR DESCRIPTION
1. **Switch Python 3 job to GCE infrastructure**
Since we need MySQL to be running, and it's no longer started by default in the non-GCE Docker images:
travis-ci/travis-cookbooks#988 (comment)

2. **Re-order job matrix/adjust naming**
The Python 3 sub-job runs more than just linters, so the old name was not correct. The comments have been removed since they mostly duplicate the name in `env`.