### PR TITLE
Bug 1497306 - fix intermittents commenter

### DIFF
--- a/treeherder/intermittents_commenter/commenter.py
+++ b/treeherder/intermittents_commenter/commenter.py
@@ -227,6 +227,9 @@ class Commenter(object):
             logger.warning('error fetching bugzilla metadata for bugs due to {}'.format(e))
             return None
 
+        if response.headers['Content-Type'] == 'text/html; charset=UTF-8':
+            return None
+
         data = response.json()
         if 'bugs' not in data:
             return None

--- a/treeherder/intermittents_commenter/commenter.py
+++ b/treeherder/intermittents_commenter/commenter.py
@@ -314,7 +314,7 @@ class Commenter(object):
         """batch requests for bugzilla data in groups of 1200 (which is the safe
            limit for not hitting the max url length)"""
         min = 0
-        max = 1200
+        max = 600
         bugs_list = []
         bug_ids_length = len(bug_ids)
 
@@ -323,6 +323,6 @@ class Commenter(object):
             if data:
                 bugs_list += data
             min = max
-            max = max + 1200
+            max = max + 600
 
         return {bug['id']: bug for bug in bugs_list} if len(bugs_list) else None


### PR DESCRIPTION
Update max number of bugs that can be retrieved at a time via bugzilla (in fetch_all_bug_details). This seems to have changed from last Monday where we were able to fetch 1200 bugs at a time (and there were 1200+ comments). I'll be investigating further.