### PR TITLE
Remove unused autoclassify events

### DIFF
--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -249,7 +249,6 @@ export const thEvents = {
   deleteClassification: 'delete-classification-EVT',
   openLogviewer: 'open-logviewer-EVT',
   autoclassifyIgnore: 'ac-ignore-EVT',
-  autoclassifyToggleEdit: 'ac-toggle-edit-EVT',
   toggleFieldFilterVisible: 'toggle-field-filter-visible-EVT',
 };
 

--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -248,7 +248,6 @@ export const thEvents = {
   saveClassification: 'save-classification-EVT',
   deleteClassification: 'delete-classification-EVT',
   openLogviewer: 'open-logviewer-EVT',
-  autoclassifyVerified: 'ac-verified-EVT',
   autoclassifySaveAll: 'ac-save-all-EVT',
   autoclassifySave: 'ac-save-EVT',
   autoclassifyIgnore: 'ac-ignore-EVT',

--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -248,7 +248,6 @@ export const thEvents = {
   saveClassification: 'save-classification-EVT',
   deleteClassification: 'delete-classification-EVT',
   openLogviewer: 'open-logviewer-EVT',
-  autoclassifySaveAll: 'ac-save-all-EVT',
   autoclassifySave: 'ac-save-EVT',
   autoclassifyIgnore: 'ac-ignore-EVT',
   autoclassifySelectOption: 'ac-select-EVT',

--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -249,7 +249,6 @@ export const thEvents = {
   deleteClassification: 'delete-classification-EVT',
   openLogviewer: 'open-logviewer-EVT',
   autoclassifyIgnore: 'ac-ignore-EVT',
-  autoclassifySelectOption: 'ac-select-EVT',
   autoclassifyChangeSelection: 'ac-change-selection-EVT',
   autoclassifyToggleExpandOptions: 'ac-toggle-expand-options-EVT',
   autoclassifyToggleEdit: 'ac-toggle-edit-EVT',

--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -248,7 +248,6 @@ export const thEvents = {
   saveClassification: 'save-classification-EVT',
   deleteClassification: 'delete-classification-EVT',
   openLogviewer: 'open-logviewer-EVT',
-  autoclassifySave: 'ac-save-EVT',
   autoclassifyIgnore: 'ac-ignore-EVT',
   autoclassifySelectOption: 'ac-select-EVT',
   autoclassifyChangeSelection: 'ac-change-selection-EVT',

--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -249,7 +249,6 @@ export const thEvents = {
   deleteClassification: 'delete-classification-EVT',
   openLogviewer: 'open-logviewer-EVT',
   autoclassifyIgnore: 'ac-ignore-EVT',
-  autoclassifyToggleExpandOptions: 'ac-toggle-expand-options-EVT',
   autoclassifyToggleEdit: 'ac-toggle-edit-EVT',
   toggleFieldFilterVisible: 'toggle-field-filter-visible-EVT',
 };

--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -249,7 +249,6 @@ export const thEvents = {
   deleteClassification: 'delete-classification-EVT',
   openLogviewer: 'open-logviewer-EVT',
   autoclassifyIgnore: 'ac-ignore-EVT',
-  autoclassifyChangeSelection: 'ac-change-selection-EVT',
   autoclassifyToggleExpandOptions: 'ac-toggle-expand-options-EVT',
   autoclassifyToggleEdit: 'ac-toggle-edit-EVT',
   autoclassifyOpenLogViewer: 'ac-open-log-viewer-EVT',

--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -251,7 +251,6 @@ export const thEvents = {
   autoclassifyIgnore: 'ac-ignore-EVT',
   autoclassifyToggleExpandOptions: 'ac-toggle-expand-options-EVT',
   autoclassifyToggleEdit: 'ac-toggle-edit-EVT',
-  autoclassifyOpenLogViewer: 'ac-open-log-viewer-EVT',
   toggleFieldFilterVisible: 'toggle-field-filter-visible-EVT',
 };
 

--- a/ui/job-view/details/tabs/autoclassify/AutoclassifyTab.jsx
+++ b/ui/job-view/details/tabs/autoclassify/AutoclassifyTab.jsx
@@ -44,17 +44,6 @@ class AutoclassifyTab extends React.Component {
     this.autoclassifyChangeSelectionUnlisten = this.$rootScope.$on(thEvents.autoclassifyChangeSelection,
       (ev, direction, clear) => this.onChangeSelection(direction, clear));
 
-    this.autoclassifySaveAllUnlisten = this.$rootScope.$on(thEvents.autoclassifySaveAll,
-      () => {
-        const pendingLines = Array.from(this.state.inputByLine.values());
-        if (pendingLines.every(line => this.canSave(line.id))) {
-          this.onSaveAll(pendingLines);
-        } else {
-          const msg = (this.state.canClassify ? 'lines not classified' : 'Not logged in');
-          this.thNotify.send(`Can't save: ${msg}`, 'danger');
-        }
-      });
-
     this.autoclassifySaveUnlisten = this.$rootScope.$on(thEvents.autoclassifySave,
       () => {
         const { selectedLineIds, canClassify } = this.state;
@@ -104,7 +93,6 @@ class AutoclassifyTab extends React.Component {
 
   componentWillUnmount() {
     this.autoclassifyChangeSelectionUnlisten();
-    this.autoclassifySaveAllUnlisten();
     this.autoclassifySaveUnlisten();
     this.autoclassifyToggleEditUnlisten();
     this.autoclassifyOpenLogViewerUnlisten();

--- a/ui/job-view/details/tabs/autoclassify/AutoclassifyTab.jsx
+++ b/ui/job-view/details/tabs/autoclassify/AutoclassifyTab.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { thEvents } from '../../../../helpers/constants';
-import { getLogViewerUrl, getProjectJobUrl } from '../../../../helpers/url';
+import { getProjectJobUrl } from '../../../../helpers/url';
 import TextLogErrorsModel from '../../../../models/textLogErrors';
 
 import AutoclassifyToolbar from './AutoclassifyToolbar';
@@ -44,9 +44,6 @@ class AutoclassifyTab extends React.Component {
     this.autoclassifyToggleEditUnlisten = this.$rootScope.$on(thEvents.autoclassifyToggleEdit,
       () => this.onToggleEditable());
 
-    this.autoclassifyOpenLogViewerUnlisten = this.$rootScope.$on(thEvents.autoclassifyOpenLogViewer,
-      () => this.onOpenLogViewer());
-
     // TODO: Once we're not using ng-react any longer and
     // are hosted completely in React, then try moving this
     // .bind code to the constructor.
@@ -54,7 +51,6 @@ class AutoclassifyTab extends React.Component {
     this.setErrorLineInput = this.setErrorLineInput.bind(this);
     this.jobChanged = this.jobChanged.bind(this);
     this.onToggleEditable = this.onToggleEditable.bind(this);
-    this.onOpenLogViewer = this.onOpenLogViewer.bind(this);
     this.onIgnore = this.onIgnore.bind(this);
     this.onSave = this.onSave.bind(this);
     this.onSaveAll = this.onSaveAll.bind(this);
@@ -76,7 +72,6 @@ class AutoclassifyTab extends React.Component {
 
   componentWillUnmount() {
     this.autoclassifyToggleEditUnlisten();
-    this.autoclassifyOpenLogViewerUnlisten();
   }
 
   /**
@@ -118,17 +113,6 @@ class AutoclassifyTab extends React.Component {
     const editable = selectedIds.some(id => !editableLineIds.has(id));
 
     this.setEditable(selectedIds, editable);
-  }
-
-  onOpenLogViewer() {
-    const { selectedJob } = this.props;
-    const { selectedLineIds, errorLines } = this.state;
-    let lineNumber = null;
-
-    if (selectedLineIds.size) {
-      lineNumber = errorLines.find(line => selectedLineIds.has(line.id)).data.line_number + 1;
-    }
-    window.open(getLogViewerUrl(selectedJob.id, this.$rootScope.repoName, lineNumber));
   }
 
   getPendingLines() {

--- a/ui/job-view/details/tabs/autoclassify/AutoclassifyTab.jsx
+++ b/ui/job-view/details/tabs/autoclassify/AutoclassifyTab.jsx
@@ -117,7 +117,6 @@ class AutoclassifyTab extends React.Component {
     const pending = pendingLines || Array.from(this.state.inputByLine.values());
     this.save(pending)
       .then(() => {
-        this.signalFullyClassified();
         this.setState({ selectedLineIds: new Set() });
       });
   }
@@ -126,12 +125,7 @@ class AutoclassifyTab extends React.Component {
    * Save all selected lines
    */
   onSave() {
-    this.save(this.getSelectedLines())
-      .then(() => {
-        if (this.getPendingLines().length === 0) {
-          this.signalFullyClassified();
-        }
-      });
+    this.save(this.getSelectedLines());
   }
 
   /**
@@ -263,16 +257,6 @@ class AutoclassifyTab extends React.Component {
 
     inputByLine.set(id, input);
     this.setState({ inputByLine });
-  }
-
-  /**
-   * Emit an event indicating that the job has been fully classified
-   */
-  signalFullyClassified() {
-    const { selectedJob } = this.props;
-
-    // Emit this event to get the main UI to update
-    this.$rootScope.$emit(thEvents.autoclassifyVerified, { jobs: { [selectedJob.id]: selectedJob } });
   }
 
   /**

--- a/ui/job-view/details/tabs/autoclassify/AutoclassifyTab.jsx
+++ b/ui/job-view/details/tabs/autoclassify/AutoclassifyTab.jsx
@@ -41,9 +41,6 @@ class AutoclassifyTab extends React.Component {
   }
 
   async componentDidMount() {
-    this.autoclassifyToggleEditUnlisten = this.$rootScope.$on(thEvents.autoclassifyToggleEdit,
-      () => this.onToggleEditable());
-
     // TODO: Once we're not using ng-react any longer and
     // are hosted completely in React, then try moving this
     // .bind code to the constructor.
@@ -68,10 +65,6 @@ class AutoclassifyTab extends React.Component {
     if (this.props.selectedJob.id !== prevProps.selectedJob.id) {
       this.fetchErrorData();
     }
-  }
-
-  componentWillUnmount() {
-    this.autoclassifyToggleEditUnlisten();
   }
 
   /**

--- a/ui/job-view/details/tabs/autoclassify/AutoclassifyTab.jsx
+++ b/ui/job-view/details/tabs/autoclassify/AutoclassifyTab.jsx
@@ -44,19 +44,6 @@ class AutoclassifyTab extends React.Component {
     this.autoclassifyChangeSelectionUnlisten = this.$rootScope.$on(thEvents.autoclassifyChangeSelection,
       (ev, direction, clear) => this.onChangeSelection(direction, clear));
 
-    this.autoclassifySaveUnlisten = this.$rootScope.$on(thEvents.autoclassifySave,
-      () => {
-        const { selectedLineIds, canClassify } = this.state;
-
-        if (Array.from(selectedLineIds).every(id => this.canSave(id))) {
-          this.onSave();
-        } else {
-          const msg = (canClassify ? 'selected lines not classified' : 'Not logged in');
-          this.thNotify.send(`Can't save: ${msg}`, 'danger');
-        }
-      },
-    );
-
     this.autoclassifyToggleEditUnlisten = this.$rootScope.$on(thEvents.autoclassifyToggleEdit,
       () => this.onToggleEditable());
 
@@ -93,7 +80,6 @@ class AutoclassifyTab extends React.Component {
 
   componentWillUnmount() {
     this.autoclassifyChangeSelectionUnlisten();
-    this.autoclassifySaveUnlisten();
     this.autoclassifyToggleEditUnlisten();
     this.autoclassifyOpenLogViewerUnlisten();
   }

--- a/ui/job-view/details/tabs/autoclassify/ErrorLine.jsx
+++ b/ui/job-view/details/tabs/autoclassify/ErrorLine.jsx
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup } from 'reactstrap';
@@ -54,9 +53,6 @@ class ErrorLine extends React.Component {
   }
 
   componentDidMount() {
-    this.autoclassifySelectOptionUnlisten = this.$rootScope.$on(thEvents.autoclassifySelectOption,
-      (ev, key) => this.onEventSelectOption(key));
-
     this.autoclassifyIgnoreUnlisten = this.$rootScope.$on(thEvents.autoclassifyIgnore,
                    () => this.onEventIgnore());
 
@@ -68,7 +64,6 @@ class ErrorLine extends React.Component {
   }
 
   componentWillUnmount() {
-    this.autoclassifySelectOptionUnlisten();
     this.autoclassifyIgnoreUnlisten();
     this.autoclassifyToggleExpandOptionsUnlisten();
   }
@@ -91,41 +86,6 @@ class ErrorLine extends React.Component {
     } else {
       selectedOption.ignoreAlways = !selectedOption.ignoreAlways;
       this.onOptionChange(selectedOption);
-    }
-  }
-
-  /**
-   * Select a specified options
-   * @param {string} option - numeric id of the option to select or '=' to select the
-   manual option
-   */
-  onEventSelectOption(option) {
-    const { isSelected, errorLine } = this.props;
-    const { isEditable, options } = this.state;
-    let id;
-
-    if (!isSelected || !isEditable) {
-      return;
-    }
-    if (option === 'manual') {
-      id = `${errorLine.id}-manual`;
-    } else {
-      const idx = parseInt(option);
-      const selectableOptions = options.filter(option => option.selectable);
-      if (selectableOptions[idx]) {
-        id = selectableOptions[idx].id;
-      }
-    }
-    if (!this.optionsById.has(id)) {
-      return;
-    }
-    if (id !== this.state.selectedOption.id) {
-      this.state.selectedOption.id = id;
-
-      this.optionChanged();
-    }
-    if (option === '=') {
-      $(`#${this.props.errorLine.id}-manual-bug`).focus();
     }
   }
 

--- a/ui/job-view/details/tabs/autoclassify/ErrorLine.jsx
+++ b/ui/job-view/details/tabs/autoclassify/ErrorLine.jsx
@@ -56,16 +56,12 @@ class ErrorLine extends React.Component {
     this.autoclassifyIgnoreUnlisten = this.$rootScope.$on(thEvents.autoclassifyIgnore,
                    () => this.onEventIgnore());
 
-    this.autoclassifyToggleExpandOptionsUnlisten = this.$rootScope.$on(thEvents.autoclassifyToggleExpandOptions,
-                   () => this.onEventToggleExpandOptions());
-
     this.onOptionChange = this.onOptionChange.bind(this);
     this.onManualBugNumberChange = this.onManualBugNumberChange.bind(this);
   }
 
   componentWillUnmount() {
     this.autoclassifyIgnoreUnlisten();
-    this.autoclassifyToggleExpandOptionsUnlisten();
   }
 
   /**
@@ -87,16 +83,6 @@ class ErrorLine extends React.Component {
       selectedOption.ignoreAlways = !selectedOption.ignoreAlways;
       this.onOptionChange(selectedOption);
     }
-  }
-
-  /**
-   * Expand or collapse hidden options
-   */
-  onEventToggleExpandOptions() {
-    if (!this.props.isSelected || !this.state.isEditable) {
-      return;
-    }
-    this.setState({ showHidden: !this.state.showHidden });
   }
 
   /**


### PR DESCRIPTION
These are several autoclassify events that were used only from keyboard shortcuts.  This removes the events and the handlers for them.  Either only ``$emit``ed, or only consumed.  So they're no no-ops.

There is one event left: ``autoclassifyIgnore`` which is both ``$emit``ed and consumed, so I'll address that in a separate PR.