### PR TITLE
Bug 1498139 - Fix when selected job is out of push range

### DIFF
--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -122,12 +122,17 @@ export const scrollToElement = function scrollToElement(el, duration) {
   }
 };
 
-export const findGroupInstance = function findGroupInstance(job) {
+export const findGroupElement = function findGroupElement(job) {
   const { push_id, job_group_symbol, tier, platform, platform_option } = job;
   const groupMapKey = getGroupMapKey(push_id, job_group_symbol, tier, platform, platform_option);
   const viewContent = $('.th-view-content');
-  const groupEl = viewContent.find(
+
+  return viewContent.find(
     `span[data-group-key='${groupMapKey}']`).first();
+};
+
+export const findGroupInstance = function findGroupInstance(job) {
+  const groupEl = findGroupElement(job);
 
   if (groupEl.length) {
     return findInstance(groupEl[0]);

--- a/ui/job-view/context/Pushes.jsx
+++ b/ui/job-view/context/Pushes.jsx
@@ -351,8 +351,6 @@ export class Pushes extends React.Component {
     const { jobMap, pushList } = this.state;
 
     if (jobList.length) {
-      const push = pushList.find(push => push.id === jobList[0].push_id);
-      push.jobsLoaded = true;
       // lodash ``keyBy`` is significantly faster than doing a ``reduce``
       this.setValue({
         jobMap: { ...jobMap, ...keyBy(jobList, 'id') },

--- a/ui/job-view/context/SelectedJob.jsx
+++ b/ui/job-view/context/SelectedJob.jsx
@@ -4,9 +4,11 @@ import $ from 'jquery';
 
 import { thJobNavSelectors } from '../../helpers/constants';
 import {
+  findGroupElement,
   findGroupInstance,
   findJobInstance,
   findSelectedInstance,
+  scrollToElement,
 } from '../../helpers/job';
 import { getUrlParam, setUrlParam } from '../../helpers/location';
 import { getJobsUrl } from '../../helpers/url';
@@ -130,6 +132,13 @@ class SelectedJobClass extends React.Component {
     const newSelectedElement = findJobInstance(job.id, true);
     if (newSelectedElement) {
       newSelectedElement.setSelected(true);
+    } else {
+      // If the job is in a group count, then the job element won't exist, but
+      // its group will.  We can try scrolling to that.
+      const groupEl = findGroupElement(job);
+      if (groupEl) {
+        scrollToElement(groupEl);
+      }
     }
 
     // If a timeout is passed in, this will cause a pause before

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -73,11 +73,11 @@ class Push extends React.Component {
   getJobGroupInfo(job) {
     const {
       job_group_name: name, job_group_symbol,
-      platform, platform_option, tier,
+      platform, platform_option, tier, push_id,
     } = job;
     const symbol = job_group_symbol === '?' ? '' : job_group_symbol;
     const mapKey = getGroupMapKey(
-      symbol, tier, platform, platform_option);
+      push_id, symbol, tier, platform, platform_option);
 
     return { name, tier, symbol, mapKey };
   }
@@ -128,8 +128,12 @@ class Push extends React.Component {
   }
 
   mapPushJobs(jobs, skipJobMap) {
+    const { updateJobMap, recalculateUnclassifiedCounts, push } = this.props;
+
+    // whether or not we got any jobs for this push, the operation to fetch
+    // them has completed.
+    push.jobsLoaded = true;
     if (jobs.length > 0) {
-      const { updateJobMap, recalculateUnclassifiedCounts, push } = this.props;
       const { jobList } = this.state;
       const newIds = jobs.map(job => job.id);
       // remove old versions of jobs we just fetched.


### PR DESCRIPTION
This also has a related fix when a job that's selected is within a job group count.  We won't be able to find the job element to scroll it into view.  So we look for the group instead.