### PR TITLE
Bug 1483419 - remove componentWillReceiveProps in IFV

### DIFF
--- a/ui/intermittent-failures/DropdownMenuItems.jsx
+++ b/ui/intermittent-failures/DropdownMenuItems.jsx
@@ -3,56 +3,30 @@ import Icon from 'react-fontawesome';
 import PropTypes from 'prop-types';
 import { DropdownMenu, DropdownItem } from 'reactstrap';
 
-export default class DropdownMenuItems extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedItem: this.props.default,
-    };
-    this.changeSelection = this.changeSelection.bind(this);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.default) {
-      this.setState({ selectedItem: nextProps.default });
-    }
-  }
-
-  changeSelection(event) {
-    const { selectedItem } = this.state;
-    const selectedText = event.target.innerText;
-
-    if (selectedText !== selectedItem) {
-      this.setState({ selectedItem: selectedText }, () => this.props.updateData(selectedText));
-    }
-  }
-
-  render() {
-    const { selectedItem } = this.state;
-    const { options } = this.props;
-
-    return (
-      <DropdownMenu>
-        {options.map(item =>
-          (<DropdownItem key={item} onClick={this.changeSelection}>
-            <Icon
-              name="check"
-              className={`pr-1 ${selectedItem === item ? '' : 'hide'}`}
-            />
-            {item}
-          </DropdownItem>))}
-      </DropdownMenu>
-    );
-  }
-}
+const DropdownMenuItems = ({ selectedItem, updateData, options }) =>
+(
+  <DropdownMenu>
+    {options.map(item =>
+      (<DropdownItem key={item} onClick={event => updateData(event.target.innerText)}>
+        <Icon
+          name="check"
+          className={`pr-1 ${selectedItem === item ? '' : 'hide'}`}
+        />
+        {item}
+      </DropdownItem>))}
+  </DropdownMenu>
+);
 
 DropdownMenuItems.propTypes = {
   updateData: PropTypes.func,
-  default: PropTypes.string,
+  selectedItem: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 DropdownMenuItems.defaultProps = {
   updateData: null,
-  default: null,
+  selectedItem: null,
 };
+
+export default DropdownMenuItems;
+

--- a/ui/intermittent-failures/DropdownMenuItems.jsx
+++ b/ui/intermittent-failures/DropdownMenuItems.jsx
@@ -29,4 +29,3 @@ DropdownMenuItems.defaultProps = {
 };
 
 export default DropdownMenuItems;
-

--- a/ui/intermittent-failures/Graph.jsx
+++ b/ui/intermittent-failures/Graph.jsx
@@ -18,11 +18,11 @@ import PropTypes from 'prop-types';
 
 export default class Graph extends React.Component {
 
-  componentWillReceiveProps(nextProps) {
-    const { specs } = this.props;
-    if (specs.data !== nextProps.data) {
-      specs.data = nextProps.data;
-      MG.data_graphic(this.props.specs);
+  componentDidUpdate() {
+    const { specs, data } = this.props;
+    if (specs.data !== data) {
+      specs.data = data;
+      MG.data_graphic(specs);
     }
   }
 
@@ -32,7 +32,7 @@ export default class Graph extends React.Component {
 
       specs.target = element;
       specs.data = data;
-      MG.data_graphic(this.props.specs);
+      MG.data_graphic(specs);
     }
   }
 

--- a/ui/intermittent-failures/Navigation.jsx
+++ b/ui/intermittent-failures/Navigation.jsx
@@ -18,6 +18,7 @@ export default class Navigation extends React.Component {
   }
 
   render() {
+    const { updateState, tree } = this.props;
     return (
       <Navbar expand fixed="top" className="top-navbar">
         <span className="lightorange">Intermittent Failures View </span>
@@ -29,8 +30,8 @@ export default class Navigation extends React.Component {
             </DropdownToggle>
             <DropdownMenuItems
               options={treeOptions}
-              updateData={tree => this.props.updateState({ tree })}
-              default={this.props.tree}
+              updateData={tree => updateState({ tree })}
+              selectedItem={tree}
             />
           </UncontrolledDropdown>
         </Collapse>

--- a/ui/intermittent-failures/View.jsx
+++ b/ui/intermittent-failures/View.jsx
@@ -43,10 +43,10 @@ const withView = defaultState => WrappedComponent =>
     this.setQueryParams();
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { location } = nextProps;
+  componentDidUpdate(prevProps) {
+    const { location } = this.props;
     // update all data if the user edits dates, tree or bug via the query params
-    if (location.search !== this.props.location.search) {
+    if (prevProps.location.search !== location.search) {
       this.checkQueryValidation(parseQueryParams(location.search), this.state.initialParamsSet);
     }
   }
@@ -86,7 +86,7 @@ const withView = defaultState => WrappedComponent =>
     this.setState({ tableFailureStatus: null, isFetchingTable: true });
     const { data, failureStatus } = await getData(url);
 
-    if (defaultState.route === '/main' && !failureStatus) {
+    if (defaultState.route === '/main' && !failureStatus && data.results.length) {
       const bugs_list = formatBugs(data.results);
       const bugzillaUrl = bugzillaBugsApi('bug', {
         include_fields: 'id,status,summary,whiteboard',


### PR DESCRIPTION
I didn't see a compelling use case for getDerivedStateFromProps. It didn't seem to improve performance in `View` compared to componentDidUpdate and added unnecessary complexity, so I didn't use it.