### PR TITLE
Bug 1498275 - Fix expanding runnable job counts

### DIFF
--- a/ui/job-view/pushes/JobGroup.jsx
+++ b/ui/job-view/pushes/JobGroup.jsx
@@ -53,10 +53,6 @@ export class JobGroupComponent extends React.Component {
     return { expanded: state.expanded || nextProps.pushGroupState === 'expanded' };
   }
 
-  componentDidMount() {
-    this.toggleExpanded = this.toggleExpanded.bind(this);
-  }
-
   setExpanded(isExpanded) {
     this.setState({ expanded: isExpanded });
   }
@@ -121,6 +117,8 @@ export class JobGroupComponent extends React.Component {
     } = this.props;
     const { expanded } = this.state;
     const { buttons, counts } = this.groupButtonsAndCounts(groupJobs, expanded);
+
+    this.toggleExpanded = this.toggleExpanded.bind(this);
 
     return (
       <span


### PR DESCRIPTION
This is another case where it we're not getting bound to ``this`` properly.  I've been blaming these on possible oddness with ``react2angular``.  I'm still of the opinion that that's the case.  When we move to a pure React app, then we can move these to the ``constructor``.  That's https://bugzilla.mozilla.org/show_bug.cgi?id=1480166.