### PR TITLE
Bug 1496115 - Improve IFV bug details test suite field

### DIFF
--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -270,13 +270,19 @@ class FailuresSerializer(serializers.ModelSerializer):
 
 
 class TestSuiteField(serializers.Field):
-    """Removes all characters before /"""
-    def to_representation(self, field_value):
-        return re.sub(r'.+/', '', field_value)
+    """Removes all characters from test_suite that's also found in platform"""
+
+    def to_representation(self, value):
+        build_type = value['build_type']
+        platform = value['job__machine_platform__platform']
+        test_suite = value['job__signature__job_type_name']
+        new_string = test_suite.replace('test-{}'.format(platform), '')
+        new_test_suite = new_string.replace(build_type, '')
+        return re.sub(r'^.(/|-)|(/|-)$', '', new_test_suite)
 
 
 class FailuresByBugSerializer(serializers.ModelSerializer):
-    test_suite = TestSuiteField(source="job__signature__job_type_name")
+    test_suite = TestSuiteField(source='*')
     platform = serializers.CharField(source="job__machine_platform__platform")
     revision = serializers.CharField(source="job__push__revision")
     tree = serializers.CharField(source="job__repository__name")

--- a/ui/intermittent-failures/BugDetailsView.jsx
+++ b/ui/intermittent-failures/BugDetailsView.jsx
@@ -49,7 +49,7 @@ const BugDetailsView = (props) => {
     {
       Header: 'Test Suite',
       accessor: 'test_suite',
-      minWidth: 200,
+      minWidth: 150,
     },
     {
       Header: 'Machine Name',


### PR DESCRIPTION
I've removed build type and platform from the test suite field string and refactored the regex. I've looked at a few different bugs to ensure this looked good. @jmaher could you also take a look and confirm this still captures the required info? If you want to test it, I'll probably have to push to prototype unless you're using a mirror of the prod db (so there's enough data in the BugJobMap model).