### PR TITLE
Change pageSize query param back to page_size

### DIFF
--- a/ui/intermittent-failures/View.jsx
+++ b/ui/intermittent-failures/View.jsx
@@ -109,7 +109,7 @@ const withView = defaultState => WrappedComponent =>
   updateState(updatedObj, updateTable = false) {
     this.setState(updatedObj, () => {
       const { startday, endday, tree, page, pageSize, bug } = this.state;
-      const params = { startday, endday, tree, page, pageSize };
+      const params = { startday, endday, tree, page, page_size: pageSize };
 
       if (bug) {
         params.bug = bug;


### PR DESCRIPTION
I accidentally left out the proper querystring param `page_size` during the redux removal. Tested it locally.