### PR TITLE
Bug 1498835 - Fix toggling tier-3

### DIFF
--- a/ui/models/filter.js
+++ b/ui/models/filter.js
@@ -1,3 +1,5 @@
+import cloneDeep from 'lodash/cloneDeep';
+
 import {
   thDefaultRepo,
   thFailureResults,
@@ -39,7 +41,7 @@ export default class FilterModel {
         { ...acc, [field]: value };
     }, {});
 
-    return { ...thFilterDefaults, ...groupedValues };
+    return { ...cloneDeep(thFilterDefaults), ...groupedValues };
   }
 
   // If a param matches the defaults, then don't include it.


### PR DESCRIPTION
I need to ``cloneDeep`` the defaults object, or we end up modifying it while making changes (like checking tier-3).  That results in setting the ``defaults`` to tier 1,2,3 and comparing our current state of tier=1,2,3 means, "oh, we should just remove that param, because we match defaults."  I could have made ``addFilter`` and ``removeFilter`` ensure they don't modify the current value, instead creating a new value.  But this seems like it removes the possibility of a foot-gun.  

Happy to go that route, if preferred.  But some of these ``lodash`` functions ARE pretty nice, imo.  :)