### PR TITLE
Bug 1499141 - Convert repoName to react

### DIFF
--- a/ui/job-view/JobView.jsx
+++ b/ui/job-view/JobView.jsx
@@ -47,7 +47,6 @@ class JobView extends React.Component {
     this.$rootScope = $injector.get('$rootScope');
 
     const filterModel = new FilterModel();
-    this.$rootScope.filterModel = filterModel;
     // Set the URL to updated parameter styles, if needed.  Otherwise it's a no-op.
     filterModel.push();
     const urlParams = getAllUrlParams();
@@ -177,7 +176,6 @@ class JobView extends React.Component {
     const filterModel = new FilterModel();
     const urlParams = getAllUrlParams();
 
-    this.$rootScope.filterModel = filterModel;
     this.setState({
       filterModel,
       serverChanged: false,

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -259,6 +259,8 @@ class DetailsPanel extends React.Component {
         className={selectedJob ? 'details-panel-slide' : 'hidden'}
       >
         <PinBoard
+          repoName={repoName}
+          currentRepo={currentRepo}
           isLoggedIn={user.isLoggedIn || false}
           classificationTypes={classificationTypes}
           $injector={$injector}

--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -191,31 +191,25 @@ class PinBoard extends React.Component {
   }
 
   cancelAllPinnedJobs() {
-    const { getGeckoDecisionTaskId, notify } = this.props;
+    const { getGeckoDecisionTaskId, notify, repoName } = this.props;
 
     if (window.confirm('This will cancel all the selected jobs. Are you sure?')) {
       const jobIds = Object.keys(this.props.pinnedJobs);
 
-      JobModel.cancel(
-        jobIds,
-        this.$rootScope.repoName,
-        getGeckoDecisionTaskId,
-        notify,
-      );
-
+      JobModel.cancel(jobIds, repoName, getGeckoDecisionTaskId, notify);
       this.unPinAll();
     }
   }
 
   canSaveClassifications() {
-    const { pinnedJobBugs, isLoggedIn } = this.props;
+    const { pinnedJobBugs, isLoggedIn, currentRepo } = this.props;
     const { failureClassificationId, failureClassificationComment } = this.state;
 
     return this.hasPinnedJobs() && isLoggedIn &&
       (!!Object.keys(pinnedJobBugs).length ||
         (failureClassificationId !== 4 && failureClassificationId !== 2) ||
-        this.$rootScope.currentRepo.is_try_repo ||
-        this.$rootScope.currentRepo.repository_group.name === 'project repositories' ||
+        currentRepo.is_try_repo ||
+        currentRepo.repository_group.name === 'project repositories' ||
         (failureClassificationId === 4 && failureClassificationComment.length > 0) ||
         (failureClassificationId === 2 && failureClassificationComment.length > 7));
   }
@@ -332,10 +326,11 @@ class PinBoard extends React.Component {
   }
 
   retriggerAllPinnedJobs() {
-    const { getGeckoDecisionTaskId, notify } = this.props;
+    const { getGeckoDecisionTaskId, notify, repoName } = this.props;
+
     JobModel.retrigger(
       Object.keys(this.props.pinnedJobs),
-      this.$rootScope.repoName,
+      repoName,
       getGeckoDecisionTaskId,
       notify,
     );
@@ -549,6 +544,8 @@ PinBoard.propTypes = {
   getGeckoDecisionTaskId: PropTypes.func.isRequired,
   setSelectedJob: PropTypes.func.isRequired,
   notify: PropTypes.func.isRequired,
+  repoName: PropTypes.string.isRequired,
+  currentRepo: PropTypes.object.isRequired,
   selectedJob: PropTypes.object,
   email: PropTypes.string,
   revisionTips: PropTypes.array,

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -165,6 +165,7 @@ class TabsPanel extends React.Component {
               logsParsed={logParseStatus !== 'pending'}
               logParseStatus={logParseStatus}
               user={user}
+              repoName={repoName}
               $injector={$injector}
             />
           </TabPanel>}

--- a/ui/job-view/details/tabs/autoclassify/AutoclassifyTab.jsx
+++ b/ui/job-view/details/tabs/autoclassify/AutoclassifyTab.jsx
@@ -324,7 +324,7 @@ class AutoclassifyTab extends React.Component {
   }
 
   render() {
-    const { autoclassifyStatus, user, $injector } = this.props;
+    const { autoclassifyStatus, user, $injector, repoName } = this.props;
     const {
       errorLines,
       loadStatus,
@@ -377,6 +377,7 @@ class AutoclassifyTab extends React.Component {
                 setEditable={() => this.setEditable([errorLine.id], true)}
                 setErrorLineInput={this.setErrorLineInput}
                 toggleSelect={this.toggleSelect}
+                repoName={repoName}
               />
             </li>))}
           </ul>
@@ -393,6 +394,7 @@ AutoclassifyTab.propTypes = {
   hasLogs: PropTypes.bool.isRequired,
   pinJob: PropTypes.func.isRequired,
   notify: PropTypes.func.isRequired,
+  repoName: PropTypes.string.isRequired,
   autoclassifyStatus: PropTypes.string,
   logsParsed: PropTypes.bool,
   logParseStatus: PropTypes.string,

--- a/ui/job-view/details/tabs/autoclassify/ErrorLine.jsx
+++ b/ui/job-view/details/tabs/autoclassify/ErrorLine.jsx
@@ -434,7 +434,7 @@ class ErrorLine extends React.Component {
   render() {
     const {
       errorLine, selectedJob, canClassify, isSelected, isEditable, setEditable,
-      $injector, toggleSelect,
+      $injector, toggleSelect, repoName,
     } = this.props;
     const {
       messageExpanded, showHidden, selectedOption, options, extraOptions,
@@ -442,7 +442,7 @@ class ErrorLine extends React.Component {
 
     const failureLine = errorLine.data.metadata.failure_line;
     const searchLine = errorLine.data.bug_suggestions.search;
-    const logUrl = getLogViewerUrl(selectedJob.id, this.$rootScope.repoName, errorLine.data.line_number + 1);
+    const logUrl = getLogViewerUrl(selectedJob.id, repoName, errorLine.data.line_number + 1);
     const status = this.getStatus();
 
     return (
@@ -593,6 +593,7 @@ ErrorLine.propTypes = {
   setErrorLineInput: PropTypes.func.isRequired,
   setEditable: PropTypes.func.isRequired,
   canClassify: PropTypes.bool.isRequired,
+  repoName: PropTypes.string.isRequired,
   $injector: PropTypes.object.isRequired,
   prevErrorLine: PropTypes.object,
 };


### PR DESCRIPTION
Sits on top of PR #4142

There were a few places where we were still looking to ``$rootScope`` for ``repoName``, ``filterModel`` and ``currentRepo``.  We don't need those anymore.  Though ``MainCtrl`` still needs a couple values from react for the window title.  So still need to set ``currentRepo`` and ``firstPush``.