### PR TITLE
Bug 1466494 - Convert global lodash imports to specific imports

### DIFF
--- a/ui/helpers/autoclassify.jsx
+++ b/ui/helpers/autoclassify.jsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import countBy from 'lodash/countBy';
 import React from 'react';
 
 export const stringOverlap = function (str1, str2) {
@@ -26,7 +26,7 @@ export const stringOverlap = function (str1, str2) {
   }
 
   const tokenCounts = tokens.map(function (tokens) {
-    return _.countBy(tokens, function (x) {
+    return countBy(tokens, function (x) {
       return x;
     });
   });

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { chunk } from 'lodash';
+import chunk from 'lodash/chunk';
 
 import { thEvents, thBugSuggestionLimit } from '../../helpers/constants';
 import { withPinnedJobs } from '../context/PinnedJobs';

--- a/ui/js/controllers/perf/alerts.js
+++ b/ui/js/controllers/perf/alerts.js
@@ -1,4 +1,6 @@
-import _ from 'lodash';
+import merge from 'lodash/merge';
+import defaults from 'lodash/defaults';
+import set from 'lodash/set';
 import angular from 'angular';
 
 import perf from '../../perf';
@@ -104,7 +106,7 @@ perf.controller(
             $scope.saveChanges = function () {
                 $scope.modifying = true;
                 $scope.alertSummaryCopy.saveNotes().then(function () {
-                    _.merge(alertSummary, $scope.alertSummaryCopy);
+                    merge(alertSummary, $scope.alertSummaryCopy);
                     $scope.modifying = false;
                     $scope.error = false;
 
@@ -424,8 +426,8 @@ perf.controller('AlertsCtrl', [
             alertSummaries.forEach(function (alertSummary) {
                 // initialize summary map for this repository, if not already
                 // initialized
-                _.defaults(resultSetToSummaryMap,
-                           _.set({}, alertSummary.repository, {}));
+                defaults(resultSetToSummaryMap,
+                           set({}, alertSummary.repository, {}));
 
                 alertSummary.originalNotes = alertSummary.notes;
 
@@ -436,7 +438,7 @@ perf.controller('AlertsCtrl', [
                         const repoMap = resultSetToSummaryMap[alertSummary.repository];
                         // initialize map for this result set, if not already
                         // initialized
-                        _.defaults(repoMap, _.set({}, resultSetId, []));
+                        defaults(repoMap, set({}, resultSetId, []));
                         repoMap[resultSetId].push(alertSummary);
                     });
             });

--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import isEqual from 'lodash/isEqual';
 import difference from 'lodash/difference';
 import metricsgraphics from 'metrics-graphics';
 
@@ -285,7 +285,7 @@ perf.controller('CompareResultsCtrl', [
             if ($scope.originalRevision) {
                 const timeRange = PhCompare.getInterval($scope.originalResultSet.push_timestamp, $scope.newResultSet.push_timestamp);
                 // Optimization - if old/new branches are the same collect data in one pass
-                const resultSetIds = (_.isEqual($scope.originalProject, $scope.newProject)) ?
+                const resultSetIds = (isEqual($scope.originalProject, $scope.newProject)) ?
                       [$scope.originalResultSet.id, $scope.newResultSet.id] : [$scope.originalResultSet.id];
 
                 PhSeries.getSeriesList($scope.originalProject.name, {

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -3,7 +3,9 @@
 // to let/const won't break anything.
 
 import $ from 'jquery';
-import _ from 'lodash';
+import map from 'lodash/map';
+import sortBy from 'lodash/sortBy';
+import countBy from 'lodash/countBy';
 import remove from 'lodash/remove';
 import angular from 'angular';
 import Mousetrap from 'mousetrap';
@@ -141,7 +143,7 @@ perf.controller('GraphsCtrl', [
                 var prevResultSetId = (firstResultSetIndex > 0) ?
                     phSeries.flotSeries.resultSetData[firstResultSetIndex - 1] : null;
 
-                var retriggerNum = _.countBy(phSeries.flotSeries.resultSetData,
+                var retriggerNum = countBy(phSeries.flotSeries.resultSetData,
                     function (resultSetId) {
                         return resultSetId === dataPoint.resultSetId ? 'retrigger' : 'original';
                     });
@@ -629,7 +631,7 @@ perf.controller('GraphsCtrl', [
                         points: { show: series.visible },
                         color: series.color,
                         label: series.projectName + ' ' + series.name,
-                        data: _.map(
+                        data: map(
                             seriesData[series.signature],
                             function (dataPoint) {
                                 return [
@@ -637,12 +639,12 @@ perf.controller('GraphsCtrl', [
                                     dataPoint.value,
                                 ];
                             }),
-                        resultSetData: _.map(
+                        resultSetData: map(
                             seriesData[series.signature],
                             'push_id'),
                         thSeries: $.extend({}, series),
-                        jobIdData: _.map(seriesData[series.signature], 'job_id'),
-                        idData: _.map(seriesData[series.signature], 'id'),
+                        jobIdData: map(seriesData[series.signature], 'job_id'),
+                        idData: map(seriesData[series.signature], 'id'),
                     };
                 }).then(function () {
                     series.relatedAlertSummaries = [];
@@ -980,7 +982,7 @@ perf.controller('TestChooserCtrl', ['$scope', '$uibModalInstance',
                 remove($scope.testsToAdd, test);
             });
             // resort unselected test list
-            $scope.unselectedTestList = _.sortBy($scope.unselectedTestList,
+            $scope.unselectedTestList = sortBy($scope.unselectedTestList,
                 'name');
         };
 
@@ -1126,7 +1128,7 @@ perf.controller('TestChooserCtrl', ['$scope', '$uibModalInstance',
                             platform: $scope.selectedPlatform,
                             framework: $scope.selectedFramework.id,
                             subtests: $scope.includeSubtests ? 1 : 0 }).then(function (seriesList) {
-                                $scope.unselectedTestList = _.sortBy(
+                                $scope.unselectedTestList = sortBy(
                                     seriesList.filter(series => series.platform === $scope.selectedPlatform),
                                     'name',
                                 );

--- a/ui/js/models/perf/alerts.js
+++ b/ui/js/models/perf/alerts.js
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import sortBy from 'lodash/sortBy';
+import padStart from 'lodash/padStart';
 import capitalize from 'lodash/capitalize';
 
 import treeherder from '../../treeherder';
@@ -107,11 +108,11 @@ treeherder.factory('PhAlerts', [
         };
         AlertSummary.prototype.getTextualSummary = function (copySummary) {
             let resultStr = '';
-            const improved = _.sortBy(
+            const improved = sortBy(
                 this.alerts.filter(alert => !alert.is_regression && alert.visible),
                 'amount_pct',
             ).reverse();
-            const regressed = _.sortBy(
+            const regressed = sortBy(
                 this.alerts.filter(alert => alert.is_regression && alert.visible && !alert.isInvalid()),
                 'amount_pct',
             ).reverse();
@@ -119,7 +120,7 @@ treeherder.factory('PhAlerts', [
             const getMaximumAlertLength = alertList => Math.max(...alertList.map(alert => alert.title.length));
 
             const formatAlert = function (alert, alertList) {
-                return _.padStart(alert.amount_pct.toFixed(0), 3) + '%  ' +
+                return padStart(alert.amount_pct.toFixed(0), 3) + '%  ' +
                 (alert.title.padEnd(getMaximumAlertLength(alertList) + 5)) +
                 displayNumberFilter(alert.prev_value) + ' -> ' + displayNumberFilter(alert.new_value);
             };

--- a/ui/models/taskcluster.js
+++ b/ui/models/taskcluster.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import defaults from 'lodash/defaults';
 import jsone from 'json-e';
 import { Auth, Hooks } from 'taskcluster-client-web';
 import { satisfiesExpression } from 'taskcluster-lib-scopes';
@@ -18,7 +18,7 @@ export default class TaskclusterModel {
   static async submit({ action, actionTaskId, decisionTaskId, taskId,
                  task, input, staticActionVariables,
                }) {
-    const context = _.defaults({}, {
+    const context = defaults({}, {
       taskGroupId: decisionTaskId,
       taskId: taskId || null,
       input,


### PR DESCRIPTION
There were just a few files left that had global ``lodash`` imports.  We may still choose to convert them to native ES6, but at least this will allow tree-shaking until that time.