### PR TITLE
Fix window scroll-height

### DIFF
--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -37,7 +37,7 @@ a {
   cursor: pointer;
 }
 
-job-view {
+.height-minus-navbars {
   height: calc(100% - 63px);
 }
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,6 +7,6 @@
         <link id="favicon" type="image/png" rel="shortcut icon" href="img/tree_open.png">
     </head>
     <body>
-        <job-view />
+        <job-view className="d-flex flex-column h-100" />
     </body>
 </html>

--- a/ui/job-view/JobView.jsx
+++ b/ui/job-view/JobView.jsx
@@ -241,7 +241,7 @@ class JobView extends React.Component {
     ), []);
 
     return (
-      <div id="global-container" className="d-flex flex-column h-100">
+      <div id="global-container" className="height-minus-navbars">
         <Notifications>
           <Pushes filterModel={filterModel}>
             <PinnedJobs>


### PR DESCRIPTION
When I changed the ``index.html`` for the on-screen overlay of the shortcuts, I changed the hierarchy of elements.  This ended up with the ``CSS`` for ``height: calc()`` in the wrong place.