### PR TITLE
Bug 1499852 - Add missing option to fix platform sort order

### DIFF
--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -205,6 +205,7 @@ export const thOptionOrder = {
   debug: 4,
   cc: 5,
   addon: 6,
+  all: 7,
 };
 
 export const thFavicons = {

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -213,8 +213,8 @@ class Push extends React.Component {
       platform.groups.sort((a, b) => a.symbol.length + a.tier - b.symbol.length - b.tier);
     });
     platforms.sort((a, b) => (
-      (platformArray.indexOf(a.name) * 100 + thOptionOrder[a.option]) -
-      (platformArray.indexOf(b.name) * 100 + thOptionOrder[b.option])
+      (platformArray.indexOf(a.name) * 100 + (thOptionOrder[a.option] || 10)) -
+      (platformArray.indexOf(b.name) * 100 + (thOptionOrder[b.option] || 10))
     ));
     return platforms;
   }


### PR DESCRIPTION
The option of "all" was missing from the map object.  This caused the calculation for sorting to use ``undefined``, which obviously didn't work well.  :)

I also added a fall-back in case another option comes our way that doesn't exist.