### PR TITLE
Move auth folder to shared folder

### DIFF
--- a/neutrino-custom/base.js
+++ b/neutrino-custom/base.js
@@ -71,7 +71,7 @@ module.exports = neutrino => {
         .end();
     neutrino.config
         .entry('login')
-        .add(path.join(UI, 'entry-login.jsx'))
+        .add(path.join(UI, 'login-callback', 'index.jsx'))
         .end();
     neutrino.config
         .entry('userguide')
@@ -190,14 +190,14 @@ module.exports = neutrino => {
             title: 'Treeherder Login',
             meta: [
                 {
-                    "name": "description",
-                    "content": "Treeherder Login"
+                    name: 'description',
+                    content: 'Treeherder Login',
                 },
                 {
-                    "name": "author",
-                    "content": "Mozilla Treeherder"
-                }
-            ]
+                    name: 'author',
+                    content: 'Mozilla Treeherder',
+                },
+            ],
         });
 
     neutrino.config

--- a/ui/entry-perf.js
+++ b/ui/entry-perf.js
@@ -23,7 +23,7 @@ import './css/treeherder-loading-overlay.css';
 import './js/perf';
 
 // React UI
-import './shared/Login';
+import './shared/auth/Login';
 
 // Perf JS
 import './js/filters';

--- a/ui/helpers/auth.js
+++ b/ui/helpers/auth.js
@@ -1,7 +1,7 @@
 import { fromNow } from 'taskcluster-client-web';
 import { WebAuth } from 'auth0-js';
 
-import { loginCallbackUrl } from '../../helpers/url';
+import { loginCallbackUrl } from './url';
 
 export const webAuth = new WebAuth({
   clientID: 'q8fZZFfGEmSB2c5uSI8hOkKdDGXnlo5z',

--- a/ui/job-view/headerbars/PrimaryNavBar.jsx
+++ b/ui/job-view/headerbars/PrimaryNavBar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Login from '../../shared/Login';
+import Login from '../../shared/auth/Login';
 import LogoMenu from './LogoMenu';
 import NotificationsMenu from './NotificationsMenu';
 import InfraMenu from './InfraMenu';

--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -6,7 +6,7 @@ import 'ng-text-truncate-2';
 import LocalStorageModule from 'angular-local-storage';
 import { react2angular } from 'react2angular/index.es2015';
 
-import Login from '../shared/Login';
+import Login from '../shared/auth/Login';
 import treeherderModule from './treeherder';
 
 const perf = angular.module('perf', [

--- a/ui/login-callback/LoginCallback.jsx
+++ b/ui/login-callback/LoginCallback.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import Icon from 'react-fontawesome';
 
-import AuthService from './AuthService';
-import { webAuth, parseHash } from './auth-utils';
+import AuthService from '../shared/auth/AuthService';
+import { webAuth, parseHash } from '../helpers/auth';
 
 class LoginCallback extends React.PureComponent {
   constructor(props) {

--- a/ui/login-callback/index.jsx
+++ b/ui/login-callback/index.jsx
@@ -3,8 +3,8 @@ import { render } from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
 import 'font-awesome/css/font-awesome.css';
 
-import LoginCallback from './js/auth/LoginCallback';
-import './css/login.css';
+import LoginCallback from './LoginCallback';
+import '../css/login.css';
 
 const load = () => render((
   <AppContainer>
@@ -13,7 +13,7 @@ const load = () => render((
 ), document.getElementById('root'));
 
 if (module.hot) {
-  module.hot.accept('./js/auth/LoginCallback', load);
+  module.hot.accept('./LoginCallback', load);
 }
 
 load();

--- a/ui/shared/auth/AuthService.js
+++ b/ui/shared/auth/AuthService.js
@@ -1,4 +1,4 @@
-import { userSessionFromAuthResult, renew, loggedOutUser } from './auth-utils';
+import { userSessionFromAuthResult, renew, loggedOutUser } from '../../helpers/auth';
 import taskcluster from '../../helpers/taskcluster';
 import { getApiUrl } from '../../helpers/url';
 import UserModel from '../../models/user';

--- a/ui/shared/auth/Login.jsx
+++ b/ui/shared/auth/Login.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 
-import AuthService from '../js/auth/AuthService';
-import { loggedOutUser } from '../js/auth/auth-utils';
-import taskcluster from '../helpers/taskcluster';
-import { getApiUrl, loginCallbackUrl } from '../helpers/url';
-import UserModel from '../models/user';
-import { withNotifications } from './context/Notifications';
+import AuthService from './AuthService';
+import { loggedOutUser } from '../../helpers/auth';
+import taskcluster from '../../helpers/taskcluster';
+import { getApiUrl, loginCallbackUrl } from '../../helpers/url';
+import UserModel from '../../models/user';
+import { withNotifications } from '../context/Notifications';
 
 /**
  * This component handles logging in to Taskcluster Authentication


### PR DESCRIPTION
This moves the auth code out of the ``/js`` folder:
1. Moved ``auth-utils`` into the ``/helpers`` folder
2. Moved the ``LoginCallback`` to its own app folder like the other apps.  And followed the pattern of the other apps with an ``index.jsx``.
