### PR TITLE
Bug 1500056 - update endday in bugdetails view

### DIFF
--- a/ui/intermittent-failures/DateOptions.jsx
+++ b/ui/intermittent-failures/DateOptions.jsx
@@ -39,7 +39,8 @@ export default class DateOptions extends React.Component {
       from = 120;
     }
     const startday = ISODate(moment().utc().subtract(from, 'days'));
-    this.props.updateState({ startday });
+    const endday = ISODate(moment().utc());
+    this.props.updateState({ startday, endday });
   }
 
   render() {


### PR DESCRIPTION
Update `endday` with current date when selecting a date option (i.e. 'last 7 days'). Tested it locally.