### PR TITLE
Bug 1501682 - Poll for new jobs on all pushes at once

### DIFF
--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -246,6 +246,7 @@ export const thEvents = {
   deleteClassification: 'delete-classification-EVT',
   openLogviewer: 'open-logviewer-EVT',
   autoclassifyIgnore: 'ac-ignore-EVT',
+  applyNewJobs: 'apply-new-jobs-EVT',
 };
 
 export const phCompareDefaultOriginalRepo = 'mozilla-central';

--- a/ui/job-view/pushes/JobGroup.jsx
+++ b/ui/job-view/pushes/JobGroup.jsx
@@ -9,19 +9,17 @@ import { getUrlParam } from '../../helpers/location';
 import JobButton from './JobButton';
 import JobCount from './JobCount';
 
-class GroupSymbol extends React.PureComponent {
-  render() {
-    const { symbol, tier, toggleExpanded } = this.props;
+const GroupSymbol = function (props) {
+  const { symbol, tier, toggleExpanded } = props;
 
-    return (
-      <button
-        className="btn group-symbol"
-        onClick={toggleExpanded}
-      >{symbol}{tier !== 1 && <span className="small text-muted">[tier {tier}]</span>}
-      </button>
-    );
-  }
-}
+  return (
+    <button
+      className="btn group-symbol"
+      onClick={toggleExpanded}
+    >{symbol}{tier !== 1 && <span className="small text-muted">[tier {tier}]</span>}
+    </button>
+  );
+};
 
 GroupSymbol.propTypes = {
   symbol: PropTypes.string.isRequired,


### PR DESCRIPTION
This PR switches polling for jobs from each ``Push`` to the ``Pushes`` context.  Then it sends an event with the new jobs, and each ``Push`` listens to that event.

I am experimenting with the idea of fetching the jobs in the ``Pushes`` context, or possibly ``PushList`` and passing that to each ``Push`` as a prop.  But there are issues with re-rendering too much.  So for now, this is a smaller change that simply updates the jobs each push already fetched.

I briefly looked into switching to GraphQL for fetching these jobs, but it will involve changing the way we parse the jobs data.  I think it is worth exploring in a separate PR.