### PR TITLE
Bug 1428031 - Heroku: Retry load_initial_data up to 5 times

### DIFF
--- a/bin/pre_deploy
+++ b/bin/pre_deploy
@@ -2,16 +2,12 @@
 # Tasks run after the Heroku buildpack compile, but prior to the deploy.
 # Failures will block the deploy unless `IGNORE_PREDEPLOY_ERRORS` is set.
 
+# Make non-zero exit codes & other errors fatal.
+set -euo pipefail
+
 if [[ -v SKIP_PREDEPLOY ]]; then
     echo "-----> PRE-DEPLOY: Warning: Skipping pre-deploy!"
     exit 0
-fi
-
-if [[ -v IGNORE_PREDEPLOY_ERRORS ]]; then
-    echo "-----> PRE-DEPLOY: Warning: Ignoring errors during pre-deploy!"
-else
-    # Make non-zero exit codes & other errors fatal.
-    set -euo pipefail
 fi
 
 echo "-----> PRE-DEPLOY: Running Django system checks..."
@@ -21,7 +17,18 @@ echo "-----> PRE-DEPLOY: Running Django migration..."
 newrelic-admin run-program ./manage.py migrate --noinput
 
 echo "-----> PRE-DEPLOY: Loading initial data..."
-newrelic-admin run-program ./manage.py load_initial_data
+# Retry load_initial_data if it fails, to work around:
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1428031
+# TODO: Look into this again when using newer MySQL and Django 2.x.
+ATTEMPTS=0
+until newrelic-admin run-program ./manage.py load_initial_data; do
+    if (( ++ATTEMPTS == 5 )); then
+        echo "Failed to load initial data after ${ATTEMPTS} attempts!"
+        exit 1
+    fi
+    echo "Retrying after 5 seconds..."
+    sleep 5
+done
 
 echo "-----> PRE-DEPLOY: Reporting deployment to New Relic..."
 # eg: "v750: Deploy 5d6b1f0"


### PR DESCRIPTION
To work around the intermittent MySQL deadlocks encountered during a small percentage of deployments. This will ensure deployments don't cause email spam to app collaborators and Heroku admins, as well as saving us from having to manually retry the release each time it occurs.

The `IGNORE_PREDEPLOY_ERRORS` option has also been removed, since it's mostly redundant with `SKIP_PREDEPLOY`.