### PR TITLE
Bug 1451171 - Transition away from unsafe lifecycle functions

### DIFF
--- a/ui/job-view/pushes/JobButton.jsx
+++ b/ui/job-view/pushes/JobButton.jsx
@@ -7,20 +7,13 @@ export default class JobButtonComponent extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      isSelected: false,
-      isRunnableSelected: false,
-    };
-  }
-
-  componentWillMount() {
     const { job } = this.props;
-    const { id } = job;
     const urlSelectedJob = getUrlParam('selectedJob');
 
-    if (parseInt(urlSelectedJob) === id) {
-      this.setState({ isSelected: true });
-    }
+    this.state = {
+      isSelected: parseInt(urlSelectedJob) === job.id,
+      isRunnableSelected: false,
+    };
   }
 
   componentDidMount() {

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -68,11 +68,8 @@ class PushHeader extends React.PureComponent {
     this.pushDateStr = toDateStr(pushTimestamp);
   }
 
-  componentWillMount() {
-    this.triggerNewJobs = this.triggerNewJobs.bind(this);
-  }
-
   componentDidMount() {
+    this.triggerNewJobs = this.triggerNewJobs.bind(this);
     this.pinAllShownJobs = this.pinAllShownJobs.bind(this);
     this.cancelAllJobs = this.cancelAllJobs.bind(this);
   }

--- a/ui/login-callback/LoginCallback.jsx
+++ b/ui/login-callback/LoginCallback.jsx
@@ -15,9 +15,7 @@ class LoginCallback extends React.PureComponent {
     this.authService = new AuthService();
   }
 
-  async componentWillMount() {
-    let authResult;
-
+  async componentDidMount() {
     // make the user login if there is no access token
     if (!window.location.hash) {
       return webAuth.authorize();
@@ -32,7 +30,7 @@ class LoginCallback extends React.PureComponent {
     }
 
     try {
-      authResult = await parseHash({ hash: window.location.hash });
+      const authResult = await parseHash({ hash: window.location.hash });
 
       if (authResult.accessToken) {
         await this.authService.saveCredentialsFromAuthResult(authResult);
@@ -45,8 +43,12 @@ class LoginCallback extends React.PureComponent {
         }
       }
     } catch (err) {
-      return this.setState({ loginError: err.message ? err.message : err.errorDescription });
+      this.setError(err);
     }
+  }
+
+  setError(err) {
+    this.setState({ loginError: err.message ? err.message : err.errorDescription });
   }
 
   render() {

--- a/ui/test-view/ui/Groups.jsx
+++ b/ui/test-view/ui/Groups.jsx
@@ -13,7 +13,8 @@ const mapStateToProps = ({ groups }) => groups;
 
 class Groups extends React.Component {
 
-  componentWillMount() {
+  constructor(props) {
+    super(props);
     this.filterStr = new URLSearchParams(location.search).get('filter') || '';
   }
 


### PR DESCRIPTION
I didn't remove the ordering rules from ``lint.js`` for these functions.  Happy to do so, if that makes more sense.  But seems like it's correct to keep them until React 17?  :)  