### PR TITLE
Bug 1502288 - Update flake8, pycodestyle and pyflakes

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -31,9 +31,9 @@ Werkzeug==0.14.1 \
     --hash=sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b \
     --hash=sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c
 
-flake8==3.5.0 \
-    --hash=sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37 \
-    --hash=sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0
+flake8==3.6.0 \
+    --hash=sha256:c01f8a3963b3571a8e6bd7a4063359aff90749e160778e03817cd9b71c9e07d2 \
+    --hash=sha256:6a35f5b8761f45c5513e3405f110a86bea57982c3b75b766ce7b65217abe1670
 
 isort==4.3.4 \
     --hash=sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497 \
@@ -87,12 +87,13 @@ configparser==3.5.0 --hash=sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4
 mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
-pycodestyle==2.3.1 \
-    --hash=sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9 \
-    --hash=sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766  # pyup: <2.4.0 # Blocked on new release of flake8
-pyflakes==1.6.0 \
-    --hash=sha256:08bd6a50edf8cffa9fa09a463063c425ecaaf10d1eb0335a7e8b1401aef89e6f \
-    --hash=sha256:8d616a382f243dbf19b54743f280b80198be0bca3a5396f1d2e1fca6223e8805  # pyup: <2 # Blocked on new release of flake8
+pycodestyle==2.4.0 \
+    --hash=sha256:74abc4e221d393ea5ce1f129ea6903209940c1ecd29e002e8c6933c2b21026e0 \
+    --hash=sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83 \
+    --hash=sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a
+pyflakes==2.0.0 \
+    --hash=sha256:9a7662ec724d0120012f6e29d6248ae3727d821bba522a0e6b356eff19126a49 \
+    --hash=sha256:f661252913bc1dbe7fcfcbf0af0db3f42ab65aabd1a6ca68fe5d466bace94dae
 
 pytest-django==3.4.3 \
     --hash=sha256:49e9ffc856bc6a1bec1c26c5c7b7213dff7cc8bc6b64d624c4d143d04aff0bcf \

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,29 +1,15 @@
-[pycodestyle]
-exclude = .git,__pycache__,.vagrant,node_modules
-# E121,E123,E126,E226,E24,E704,W503: Ignored in default pycodestyle config:
-# https://github.com/PyCQA/pycodestyle/blob/2.2.0/pycodestyle.py#L72
-# Our additions...
-# E501: line too long
-# E129: visually indented line with same indent as next logical line
-ignore = E121,E123,E126,E129,E226,E24,E704,W503,E501
-max-line-length = 140
-
 [flake8]
-# flake8 is a combination of pyflakes & pycodestyle.
-# Unfortunately we have to mostly duplicate the above, since some tools use
-# pycodestyle's config (eg autopep8) so we can't just define everything under [flake8].
 exclude = .git,__pycache__,.vagrant,node_modules
-# The ignore list for pycodestyle above, plus our own PyFlakes additions:
-# F403: 'from module import *' used; unable to detect undefined names
-# F405: name may be undefined, or defined from star imports: module
-ignore = E121,E123,E126,E129,E226,E24,E704,W503,E501,F403,F405
-max-line-length = 140
+# E129: visually indented line with same indent as next logical line
+# E501: line too long
+extend_ignore = E129,E501
+max-line-length = 100
 
 [isort]
 skip = .git,__pycache__,.vagrant,node_modules,migrations
 multi_line_output = 1
 force_grid_wrap = true
-line_length = 140
+line_length = 100
 known_first_party = tests
 # Required since we install recommonmark as an editable install from GitHub:
 # https://github.com/timothycrosley/isort/issues/386

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,6 @@
-from treeherder.config.settings import *
+from treeherder.config.settings import *  # noqa: F403
 
-DATABASES["default"]["TEST"] = {"NAME": "test_treeherder"}
+DATABASES["default"]["TEST"] = {"NAME": "test_treeherder"}  # noqa: F405
 KEY_PREFIX = 'test'
 
 TREEHERDER_TEST_REPOSITORY_NAME = 'test_treeherder_jobs'

--- a/treeherder/intermittents_commenter/commenter.py
+++ b/treeherder/intermittents_commenter/commenter.py
@@ -199,7 +199,7 @@ class Commenter(object):
         return False
 
     def update_whiteboard(self, existing, new):
-        whiteboard = re.sub('\[stockwell.*?\]', '', existing)
+        whiteboard = re.sub(r'\[stockwell.*?\]', '', existing)
         return whiteboard + new
 
     def new_request(self):

--- a/treeherder/webapp/graphql/schema.py
+++ b/treeherder/webapp/graphql/schema.py
@@ -4,7 +4,24 @@ from graphene_django.types import DjangoObjectType
 from graphql.utils.ast_to_dict import ast_to_dict
 
 from treeherder.model import error_summary
-from treeherder.model.models import *
+from treeherder.model.models import (BuildPlatform,
+                                     FailureClassification,
+                                     FailureLine,
+                                     Group,
+                                     Job,
+                                     JobDetail,
+                                     JobGroup,
+                                     JobLog,
+                                     JobType,
+                                     Machine,
+                                     MachinePlatform,
+                                     Option,
+                                     OptionCollection,
+                                     Product,
+                                     Push,
+                                     Repository,
+                                     TextLogError,
+                                     TextLogStep)
 from treeherder.webapp.graphql.helpers import optimize
 from treeherder.webapp.graphql.types import ObjectScalar
 


### PR DESCRIPTION
http://flake8.pycqa.org/en/latest/release-notes/3.6.0.html
https://github.com/PyCQA/pycodestyle/blob/2.4.0/CHANGES.txt#L4
https://github.com/PyCQA/pyflakes/blob/2.0.0/NEWS.txt#L1

Also:
* Switches from the `ignore` setting to the new `extend_ignore`, which doesn't overwrite the default ignore list, meaning we no longer have to duplicate it ourselves.
* Remove the rarely used `[pycodestyle]` config section, since it's only used when using tools like autopep8, which should really learn to use the `[flake8]` section themselves.
* Enables the previously ignored F403 and F405 rules, adding `# noqa` entries to instances that we do not wish to fix.
* Adjust max line length down to 100, since we already disable the `E501: line too long` rule, making the length mostly redundant other than in IDEs, where it's probably good to show a warning if exceeding 100 characters.
* Fixes:
```
treeherder/intermittents_commenter/commenter.py:202:10:
  W605 invalid escape sequence '\['
treeherder/intermittents_commenter/commenter.py:202:24:
  W605 invalid escape sequence '\]'
treeherder/webapp/graphql/schema.py:7:1:
  F403 'from treeherder.model.models import *' used; unable to detect undefined names
```

Closes #4177.
Refs #3425.
Refs #3565.