### PR TITLE
Bug 1450045 - Create a shared JobInfo component

### DIFF
--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -4,8 +4,6 @@ import {
   thFailureResults,
   thPlatformMap,
 } from './constants';
-import { toDateStr } from './display';
-import { getSlaveHealthUrl, getWorkerExplorerUrl } from './url';
 import { getGroupMapKey } from './aggregateId';
 
 const btnClasses = {
@@ -178,40 +176,4 @@ export const getHoverText = function getHoverText(job) {
   const duration = Math.round((job.end_timestamp - job.start_timestamp) / 60);
 
   return `${job.job_type_name} - ${getStatus(job)} - ${duration} mins`;
-};
-
-export const getJobMachineUrl = function getJobMachineUrl(job) {
-  const { build_system_type, machine_name } = job;
-  const machineUrl = (machine_name !== 'unknown' && build_system_type === 'buildbot') ?
-    getSlaveHealthUrl(machine_name) :
-    getWorkerExplorerUrl(job.taskcluster_metadata.task_id);
-
-  return machineUrl;
-};
-
-export const getTimeFields = function getTimeFields(job) {
-  // time fields to show in detail panel, but that should be grouped together
-  const timeFields = {
-    requestTime: toDateStr(job.submit_timestamp),
-  };
-
-  // If start time is 0, then duration should be from requesttime to now
-  // If we have starttime and no endtime, then duration should be starttime to now
-  // If we have both starttime and endtime, then duration will be between those two
-  const endtime = job.end_timestamp || Date.now() / 1000;
-  const starttime = job.start_timestamp || job.submit_timestamp;
-  const duration = `${Math.round((endtime - starttime) / 60, 0)} minute(s)`;
-
-  if (job.start_timestamp) {
-    timeFields.startTime = toDateStr(job.start_timestamp);
-    timeFields.duration = duration;
-  } else {
-    timeFields.duration = `Not started (queued for ${duration})`;
-  }
-
-  if (job.end_timestamp) {
-    timeFields.endTime = toDateStr(job.end_timestamp);
-  }
-
-  return timeFields;
 };

--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -1,4 +1,3 @@
-import taskcluster from './taskcluster';
 import { getAllUrlParams, getRepo } from './location';
 
 export const uiJobsUrlBase = '/#/jobs';
@@ -34,25 +33,12 @@ export const getBugUrl = function getBugUrl(bug_id) {
   return `${bzBaseUrl}show_bug.cgi?id=${bug_id}`;
 };
 
-export const getSlaveHealthUrl = function getSlaveHealthUrl(machine_name) {
-  return `https://secure.pub.build.mozilla.org/builddata/reports/slave_health/slave.html?name=${machine_name}`;
-};
-
 export const getInspectTaskUrl = function getInspectTaskUrl(taskId) {
   return `https://tools.taskcluster.net/tasks/${taskId}`;
 };
 
 export const getReftestUrl = function getReftestUrl(logUrl) {
   return `https://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl=${logUrl}&only_show_unexpected=1`;
-};
-
-export const getWorkerExplorerUrl = async function getWorkerExplorerUrl(taskId) {
-  const queue = taskcluster.getQueue();
-  const { status } = await queue.status(taskId);
-  const { provisionerId, workerType } = status;
-  const { workerGroup, workerId } = status.runs[status.runs.length - 1];
-
-  return `https://tools.taskcluster.net/provisioners/${provisionerId}/worker-types/${workerType}/workers/${workerGroup}/${workerId}`;
 };
 
 // repoName here is necessary because this data comes from the /jobs endpoint
@@ -64,8 +50,8 @@ export const getLogViewerUrl = function getLogViewerUrl(job_id, repoName, line_n
   return line_number ? `${rv}&lineNumber=${line_number}` : rv;
 };
 
-export const getWptUrl = function getWptUrl(url, value) {
-  return `https://mozilla.github.io/wptview/#/?urls=${encodeURIComponent(url)},${encodeURIComponent(value)}`;
+export const getWptUrl = function getWptUrl(url) {
+  return `https://mozilla.github.io/wptview/#/?urls=${encodeURIComponent(url)}`;
 };
 
 export const getPerfAnalysisUrl = function getPerfAnalysisUrl(url) {

--- a/ui/job-view/CustomJobActions.jsx
+++ b/ui/job-view/CustomJobActions.jsx
@@ -14,7 +14,7 @@ import TaskclusterModel from '../models/taskcluster';
 import { withPushes } from './context/Pushes';
 import { withNotifications } from '../shared/context/Notifications';
 
-class CustomJobActions extends React.Component {
+class CustomJobActions extends React.PureComponent {
   constructor(props) {
     super(props);
 

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -15,7 +15,7 @@ import { withPinnedJobs } from '../../context/PinnedJobs';
 import { withPushes } from '../../context/Pushes';
 import { withNotifications } from '../../../shared/context/Notifications';
 
-class ActionBar extends React.Component {
+class ActionBar extends React.PureComponent {
   constructor(props) {
     super(props);
 

--- a/ui/job-view/details/summary/SummaryPanel.jsx
+++ b/ui/job-view/details/summary/SummaryPanel.jsx
@@ -1,74 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { getSearchStr, getTimeFields, getJobMachineUrl } from '../../../helpers/job';
-import { getInspectTaskUrl, getJobSearchStrHref } from '../../../helpers/url';
-
 import { withSelectedJob } from '../../context/SelectedJob';
+import JobInfo from '../../../shared/JobInfo';
 import ActionBar from './ActionBar';
 import ClassificationsPanel from './ClassificationsPanel';
 import StatusPanel from './StatusPanel';
 
-class SummaryPanel extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      machineUrl: null,
-      machineUrlStatus: '',
-    };
-  }
-
-  componentDidMount() {
-    this.setJobMachineUrl(this.props.selectedJob, null);
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    const { selectedJob } = this.props;
-    if (!selectedJob || selectedJob === prevProps.selectedJob) {
-      return;
-    }
-    this.setJobMachineUrl(selectedJob, prevState.machineUrl);
-  }
-
-  async setJobMachineUrl(selectedJob, prevMachineUrl) {
-    // If we can't get the machineUrl, then this text will be added as a suffix
-    // after the machine name to let the user know there was a problem.
-    let machineUrl = null;
-    let machineUrlStatus = '';
-
-    if ('taskcluster_metadata' in selectedJob) {
-      try {
-        machineUrl = await getJobMachineUrl(selectedJob);
-      } catch (err) {
-        machineUrlStatus = '(Load error)';
-        console.error(`Error fetching machine URL: ${err}`); // eslint-disable-line no-console
-      }
-      if (machineUrl !== prevMachineUrl) {
-        this.setState({ machineUrl, machineUrlStatus });
-      }
-    }
-  }
-
+class SummaryPanel extends React.PureComponent {
   render() {
     const {
       repoName, selectedJob, latestClassification, bugs, jobLogUrls,
-      jobDetailLoading, buildUrl, logViewerUrl, logViewerFullUrl,
+      jobDetailLoading, logViewerUrl, logViewerFullUrl,
       logParseStatus, user, currentRepo, classificationMap,
     } = this.props;
-    const { machineUrl, machineUrlStatus } = this.state;
 
-    const timeFields = getTimeFields(selectedJob);
-    const jobMachineName = selectedJob.machine_name;
-    const jobSearchStr = getSearchStr(selectedJob);
-    let iconCircleClass = null;
-
-    const buildDirectoryUrl = (selectedJob.build_system_type === 'buildbot' && !!jobLogUrls.length) ?
-      jobLogUrls[0].buildUrl : buildUrl;
-
-    if (selectedJob.job_type_description) {
-      iconCircleClass = 'fa fa-info-circle';
-    }
+    const logStatus = [{
+      title: 'Log parsing status',
+      value: !jobLogUrls.length ? 'No logs' : jobLogUrls.map(log => log.parse_status).join(', '),
+    }];
 
     return (
       <div id="summary-panel">
@@ -101,83 +51,10 @@ class SummaryPanel extends React.Component {
                   currentRepo={currentRepo}
                 />}
               <StatusPanel />
-              <div>
-                <li className="small">
-                  <label title="">Job</label>
-                  <a
-                    title="Filter jobs with this unique SHA signature"
-                    href={getJobSearchStrHref(selectedJob.signature)}
-                  >(sig)</a>:&nbsp;
-                  <a
-                    title="Filter jobs containing these keywords"
-                    href={getJobSearchStrHref(jobSearchStr)}
-                  >{jobSearchStr}</a>
-                </li>
-                {jobMachineName &&
-                  <li className="small">
-                    <label>Machine: </label>
-                    {machineUrl ? <a
-                      title="Inspect machine"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={machineUrl}
-                    >{jobMachineName}</a> :
-                    <span>{jobMachineName} {machineUrlStatus}</span>}
-                  </li>
-                }
-                {selectedJob.taskcluster_metadata &&
-                  <li className="small">
-                    <label>Task: </label>
-                    <a
-                      href={getInspectTaskUrl(selectedJob.taskcluster_metadata.task_id)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >{selectedJob.taskcluster_metadata.task_id}</a>
-                  </li>
-                }
-                <li className="small">
-                  <label>Build: </label>
-                  <a
-                    title="Open build directory in a new tab"
-                    href={buildUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >{`${selectedJob.build_architecture} ${selectedJob.build_platform} ${selectedJob.build_os || ''}`}</a>
-                  <span className={`ml-1${iconCircleClass}`} />
-                </li>
-                <li className="small">
-                  <label>Job name: </label>
-                  <a
-                    title="Open build directory in a new tab"
-                    href={buildDirectoryUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >{selectedJob.job_type_name}</a>
-                  <span className={`ml-1${iconCircleClass}`} />
-                </li>
-                {timeFields && <span>
-                  <li className="small">
-                    <label>Requested: </label>{timeFields.requestTime}
-                  </li>
-                  {timeFields.startTime && <li className="small">
-                    <label>Started: </label>{timeFields.startTime}
-                  </li>}
-                  {timeFields.endTime && <li className="small">
-                    <label>Ended: </label>{timeFields.endTime}
-                  </li>}
-                  <li className="small">
-                    <label>Duration: </label>{timeFields.duration}
-                  </li>
-                </span>}
-                {!jobLogUrls.length ?
-                  <li className="small"><label>Log parsing status: </label>No logs</li> :
-                  jobLogUrls.map(data => (
-                    <li className="small" key={data}>
-                      <label>Log parsing status: </label>{data.parse_status}
-                    </li>
-                  ))
-                }
-              </div>
+              <JobInfo
+                job={selectedJob}
+                extraFields={logStatus}
+              />
             </ul>
           </div>
         </div>
@@ -196,7 +73,6 @@ SummaryPanel.propTypes = {
   latestClassification: PropTypes.object,
   jobLogUrls: PropTypes.array,
   jobDetailLoading: PropTypes.bool,
-  buildUrl: PropTypes.string,
   logParseStatus: PropTypes.string,
   logViewerUrl: PropTypes.string,
   logViewerFullUrl: PropTypes.string,
@@ -207,7 +83,6 @@ SummaryPanel.defaultProps = {
   latestClassification: null,
   jobLogUrls: [],
   jobDetailLoading: false,
-  buildUrl: null,
   logParseStatus: 'pending',
   logViewerUrl: null,
   logViewerFullUrl: null,

--- a/ui/job-view/details/tabs/SimilarJobsTab.jsx
+++ b/ui/job-view/details/tabs/SimilarJobsTab.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { thMaxPushFetchSize } from '../../../helpers/constants';
 import { toDateStr, toShortDateStr } from '../../../helpers/display';
 import { getBtnClass, getStatus } from '../../../helpers/job';
-import { getSlaveHealthUrl, getJobsUrl } from '../../../helpers/url';
+import { getJobsUrl } from '../../../helpers/url';
 import JobModel from '../../../models/job';
 import PushModel from '../../../models/push';
 import TextLogStepModel from '../../../models/textLogStep';
@@ -213,16 +213,6 @@ class SimilarJobsTab extends React.Component {
                 <tr>
                   <th>Result</th>
                   <td>{selectedSimilarJob.result_status}</td>
-                </tr>
-                <tr>
-                  <th>Machine name</th>
-                  <td>
-                    <a
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={getSlaveHealthUrl(selectedSimilarJob.machine_name)}
-                    >{selectedSimilarJob.machine_name}</a>
-                  </td>
                 </tr>
                 <tr>
                   <th>Build</th>

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -6,7 +6,7 @@ import { thEvents } from '../../../helpers/constants';
 import { getAllUrlParams } from '../../../helpers/location';
 import { getStatus } from '../../../helpers/job';
 
-import JobDetailsTab from './JobDetailsTab';
+import JobDetails from '../../../shared/JobDetails';
 import FailureSummaryTab from './failureSummary/FailureSummaryTab';
 import PerformanceTab from './PerformanceTab';
 import AutoclassifyTab from './autoclassify/AutoclassifyTab';
@@ -145,7 +145,7 @@ class TabsPanel extends React.Component {
             </span>
           </TabList>
           <TabPanel>
-            <JobDetailsTab jobDetails={jobDetails} />
+            <JobDetails jobDetails={jobDetails} />
           </TabPanel>
           <TabPanel>
             <FailureSummaryTab

--- a/ui/models/jobLogUrl.js
+++ b/ui/models/jobLogUrl.js
@@ -3,20 +3,10 @@ import { createQueryParams, getProjectUrl } from '../helpers/url';
 const uri = getProjectUrl('/job-log-url/');
 
 export default class JobLogUrlModel {
-  constructor(data) {
-    Object.assign(this, data);
-  }
-
   // the options parameter is used to filter/limit the list of objects
   // ``signal`` is an AbortController signal.
   static getList(options, signal) {
     return fetch(`${uri}${createQueryParams(options)}`, { signal })
-      .then(resp => resp.json().then(data => (
-        data.map((elem) => {
-          const buildUrl = elem.url.slice(0, elem.url.lastIndexOf('/')) + '/';
-          elem.buildUrl = buildUrl;
-          return new JobLogUrlModel(elem);
-        })
-    )));
+      .then(resp => resp.json());
   }
 }

--- a/ui/shared/JobDetails.jsx
+++ b/ui/shared/JobDetails.jsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { getPerfAnalysisUrl, getWptUrl } from '../../../helpers/url';
+import { getPerfAnalysisUrl, getWptUrl } from '../helpers/url';
 
 const UNTITLED = 'Untitled data';
 
-export default class JobDetailsTab extends React.PureComponent {
+export default class JobDetails extends React.PureComponent {
   render() {
     const { jobDetails } = this.props;
-    const sortedDetails = jobDetails ? jobDetails.slice() : [];
-    const builderNameItem = jobDetails.findIndex(detail => detail.title === 'Buildername');
+    const sortedDetails = jobDetails.slice();
 
     sortedDetails.sort((a, b) => {
       const compareA = a.title || UNTITLED;
@@ -36,7 +35,7 @@ export default class JobDetailsTab extends React.PureComponent {
               {line.url && line.value.endsWith('raw.log') &&
                 <span> - <a
                   title={line.value}
-                  href={getWptUrl(line.url, builderNameItem ? builderNameItem.value : undefined)}
+                  href={getWptUrl(line.url)}
                 >open in test results viewer</a>
                 </span>}
               {line.url && line.value.startsWith('profile_') && line.value.endsWith('.zip') &&
@@ -60,10 +59,10 @@ export default class JobDetailsTab extends React.PureComponent {
   }
 }
 
-JobDetailsTab.propTypes = {
+JobDetails.propTypes = {
   jobDetails: PropTypes.array,
 };
 
-JobDetailsTab.defaultProps = {
+JobDetails.defaultProps = {
   jobDetails: [],
 };

--- a/ui/shared/JobInfo.jsx
+++ b/ui/shared/JobInfo.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { getInspectTaskUrl, getJobSearchStrHref } from '../helpers/url';
+import { getSearchStr } from '../helpers/job';
+import { toDateStr } from '../helpers/display';
+
+const getTimeFields = function getTimeFields(job) {
+  // time fields to show in detail panel, but that should be grouped together
+  const { end_timestamp, start_timestamp, submit_timestamp } = job;
+  const timeFields = [
+    { title: 'Requested', value: toDateStr(submit_timestamp) },
+  ];
+
+  // If start time is 0, then duration should be from requesttime to now
+  // If we have starttime and no endtime, then duration should be starttime to now
+  // If we have both starttime and endtime, then duration will be between those two
+  const endtime = end_timestamp || Date.now() / 1000;
+  const starttime = start_timestamp || submit_timestamp;
+  const duration = `${Math.round((endtime - starttime) / 60, 0)} minute(s)`;
+
+  if (start_timestamp) {
+    timeFields.push({ title: 'Started', value: toDateStr(start_timestamp) });
+  }
+  if (end_timestamp) {
+    timeFields.push({ title: 'Ended', value: toDateStr(end_timestamp) });
+  }
+  timeFields.push({
+    title: 'Duration',
+    value: start_timestamp ? duration : `Not started (queued for ${duration})`,
+  });
+
+  return timeFields;
+};
+
+export default class JobInfo extends React.PureComponent {
+  render() {
+    const { job, extraFields } = this.props;
+    const jobSearchStr = getSearchStr(job);
+    const timeFields = getTimeFields(job);
+
+    return (
+      <ul id="job-info" className="list-unstyled">
+        <li className="small">
+          <label>Job: </label>
+          <a
+            title="Filter jobs with this unique SHA signature"
+            href={getJobSearchStrHref(job.signature)}
+          >(sig)</a>:&nbsp;
+          <a
+            title="Filter jobs containing these keywords"
+            href={getJobSearchStrHref(jobSearchStr)}
+          >{jobSearchStr}</a>
+        </li>
+        {job.taskcluster_metadata &&
+          <li className="small">
+            <label>Task: </label>
+            <a
+              href={getInspectTaskUrl(job.taskcluster_metadata.task_id)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >{job.taskcluster_metadata.task_id}</a>
+          </li>
+        }
+        <li className="small">
+          <label>Build: </label>
+          <span>{`${job.build_architecture} ${job.build_platform} ${job.build_os || ''}`}</span>
+        </li>
+        <li className="small">
+          <label>Job name: </label>
+          <span>{job.job_type_name}</span>
+        </li>
+        {[...timeFields, ...extraFields].map(field => (
+          <li className="small" key={`${field.title}${field.value}`}>
+            <label>{field.title}: </label>
+            {field.url ?
+              <a
+                title={field.value}
+                href={field.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >{field.value}</a> :
+              <span>{field.value}</span>}
+          </li>
+        ))}
+      </ul>
+
+    );
+  }
+}
+
+JobInfo.propTypes = {
+  job: PropTypes.object.isRequired,
+  extraFields: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      url: PropTypes.string,
+      value: PropTypes.string,
+    }),
+  ),
+};
+
+JobInfo.defaultProps = {
+  extraFields: [],
+};


### PR DESCRIPTION
This moves the bottom-left list of details to a shared ``JobInfo`` component that can be used in the ``LogViewer`` as that gets converted.

I also removed creating the ``buildUrl`` field in the ``JobLogUrlModel``.  It can get accessed by the task inspector better.  The url it generated was a 404 anyway...   :)

Along those lines, I removed the ``machineName`` field.  iirc, that machine name is auto-generated, so really doesn't provide value.  And the user can get to it through the task inspector anyway.  But if I've gone too far, I'll revert that.  :)