### PR TITLE
Bug 1503576 - New Relic: Instrument cycle_data & update_bugscache

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -28,4 +28,4 @@ shutdown_timeout = 15
 # The agent doesn't annotate Django management commands by default:
 # https://docs.newrelic.com/docs/agents/python-agent/supported-features/python-background-tasks#django
 # List finite-duration commands here to enable their annotation by the agent.
-instrumentation.scripts.django_admin = check migrate load_initial_data
+instrumentation.scripts.django_admin = check cycle_data load_initial_data migrate update_bugscache


### PR DESCRIPTION
Since we now run them as Django management commands (rather than scheduled Celery tasks), which New Relic only instruments if explicitly instructed.