### PR TITLE
Fix updating details if selectedJob is updated

### DIFF
--- a/ui/job-view/context/Pushes.jsx
+++ b/ui/job-view/context/Pushes.jsx
@@ -326,8 +326,16 @@ export class PushesClass extends React.Component {
       const pushJobs = acc[job.push_id] ? [...acc[job.push_id], job] : [job];
       return { ...acc, [job.push_id]: pushJobs };
     }, {});
+    // If a job is selected, and one of the jobs we just fetched is the
+    // updated version of that selected job, then send that with the event.
+    const selectedJobId = getUrlParam('selectedJob');
+    const updatedSelectedJob = selectedJobId ?
+      jobList.find(job => job.id === parseInt(selectedJobId)) : null;
 
-    window.dispatchEvent(new CustomEvent(thEvents.applyNewJobs, { detail: { jobs } }));
+    window.dispatchEvent(new CustomEvent(
+      thEvents.applyNewJobs,
+      { detail: { jobs, updatedSelectedJob } },
+    ));
   }
 
   updateUrlFromchange() {

--- a/ui/job-view/context/SelectedJob.jsx
+++ b/ui/job-view/context/SelectedJob.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import $ from 'jquery';
 
-import { thJobNavSelectors } from '../../helpers/constants';
+import { thEvents, thJobNavSelectors } from '../../helpers/constants';
 import {
   findGroupElement,
   findGroupInstance,
@@ -41,6 +41,7 @@ class SelectedJobClass extends React.Component {
     this.clearSelectedJob = this.clearSelectedJob.bind(this);
     this.changeSelectedJob = this.changeSelectedJob.bind(this);
     this.noMoreUnclassifiedFailures = this.noMoreUnclassifiedFailures.bind(this);
+    this.handleApplyNewJobs = this.handleApplyNewJobs.bind(this);
 
     // TODO: this.value needs to now get the bound versions of the functions.
     // But when we move the function binding to the constructors, we won't
@@ -59,6 +60,12 @@ class SelectedJobClass extends React.Component {
     if (jobsLoaded !== prevProps.jobsLoaded) {
       this.setSelectedJobFromQueryString();
     }
+
+    window.addEventListener(thEvents.applyNewJobs, this.handleApplyNewJobs);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener(thEvents.applyNewJobs, this.handleApplyNewJobs);
   }
 
   setValue(newState, callback) {
@@ -164,6 +171,14 @@ class SelectedJobClass extends React.Component {
       setUrlParam('selectedJob', null);
       const selected = findSelectedInstance();
       if (selected) selected.setSelected(false);
+    }
+  }
+
+  handleApplyNewJobs(event) {
+    const { updatedSelectedJob } = event.detail;
+
+    if (updatedSelectedJob) {
+      this.setSelectedJob(updatedSelectedJob);
     }
   }
 

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -56,7 +56,7 @@ class DetailsPanel extends React.Component {
   componentDidUpdate(prevProps) {
     const { selectedJob } = this.props;
 
-    if (selectedJob && (!prevProps.selectedJob || prevProps.selectedJob.id !== selectedJob.id)) {
+    if (selectedJob && (!prevProps.selectedJob || prevProps.selectedJob !== selectedJob)) {
       this.selectJob();
     }
   }

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -11,7 +11,6 @@ import { escapeId, getGroupMapKey } from '../../helpers/aggregateId';
 import { getAllUrlParams } from '../../helpers/location';
 import PushModel from '../../models/push';
 import RunnableJobModel from '../../models/runnableJob';
-import { withSelectedJob } from '../context/SelectedJob';
 import { withNotifications } from '../../shared/context/Notifications';
 import { getRevisionTitle } from '../../helpers/revision';
 import { getPercentComplete } from '../../helpers/display';
@@ -400,4 +399,4 @@ Push.propTypes = {
   isOnlyRevision: PropTypes.bool.isRequired,
 };
 
-export default withNotifications(withPushes(withSelectedJob(Push)));
+export default withNotifications(withPushes(Push));


### PR DESCRIPTION
If the ``selectedJob`` is in state ``running`` and we poll for new jobs and that job is now ``completed``, the ``DetailsPanel`` doesn't update to reflect that, even though the job field does.  This fixes that issue.