### PR TITLE
Bug 1504617 - Travis: Explicitly start redis-server

### DIFF
--- a/bin/travis-setup.sh
+++ b/bin/travis-setup.sh
@@ -37,6 +37,9 @@ setup_services() {
     sudo cp vagrant/mysql.cnf /etc/mysql/conf.d/treeherder.cnf
     sudo systemctl start mysql
 
+    echo '-----> Starting redis-server'
+    sudo systemctl start redis-server
+
     echo '-----> Waiting for Elasticsearch to be ready'
     while ! curl "${ELASTICSEARCH_URL}" &> /dev/null; do sleep 1; done
 }


### PR DESCRIPTION
Since the service is no longer started by default in the base Travis image as of travis-ci/travis-cookbooks#999.

Fixes:

```
ConnectionError: Error 111 connecting to localhost:6379. Connection refused.
```
(eg https://travis-ci.org/mozilla/treeherder/jobs/450605269#L880)