### PR TITLE
Bug 1502147 - Add ability to collapse pushes

### DIFF
--- a/ui/job-view/App.jsx
+++ b/ui/job-view/App.jsx
@@ -32,6 +32,7 @@ const HIDDEN_URL_PARAMS = [
   'resultStatus',
   'selectedJob',
   'searchStr',
+  'collapsedPushes',
 ];
 
 const getWindowHeight = function getWindowHeight() {

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -15,8 +15,8 @@ import RunnableJobModel from '../../models/runnableJob';
 import { withNotifications } from '../../shared/context/Notifications';
 import { getRevisionTitle } from '../../helpers/revision';
 import { getPercentComplete } from '../../helpers/display';
-import { Revision } from './Revision';
 
+import { Revision } from './Revision';
 import PushHeader from './PushHeader';
 import PushJobs from './PushJobs';
 import { RevisionList } from './RevisionList';
@@ -434,12 +434,7 @@ class Push extends React.Component {
         <div className="push-body-divider" />
         {!collapsed ? (
           <div className="row push clearfix">
-            {currentRepo &&
-              <RevisionList
-                push={push}
-                repo={currentRepo}
-              />
-            }
+            {currentRepo && <RevisionList push={push} repo={currentRepo} />}
             <span className="job-list job-list-pad col-7">
               <PushJobs
                 push={push}

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -183,9 +183,10 @@ class PushHeader extends React.PureComponent {
     } else {
       collapsedPushes.add(pushId);
     }
-    setUrlParam('collapsedPushes', collapsedPushes.size
-      ? Array.from(collapsedPushes)
-      : null);
+    setUrlParam(
+      'collapsedPushes',
+      collapsedPushes.size ? Array.from(collapsedPushes) : null,
+    );
   }
 
   render() {
@@ -225,7 +226,9 @@ class PushHeader extends React.PureComponent {
             <span className="push-title-left">
               <span
                 onClick={this.togglePushCollapsed}
-                className={`fa ${collapsed ? 'fa-plus-square-o' : 'fa-minus-square-o'} mr-2 mt-2 text-muted pointable`}
+                className={`fa ${
+                  collapsed ? 'fa-plus-square-o' : 'fa-minus-square-o'
+                } mr-2 mt-2 text-muted pointable`}
                 title={`${collapsed ? 'Expand' : 'Collapse'} push data`}
               />
               <span>

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -10,6 +10,7 @@ import { withPinnedJobs } from '../context/PinnedJobs';
 import { withSelectedJob } from '../context/SelectedJob';
 import { withPushes } from '../context/Pushes';
 import { withNotifications } from '../../shared/context/Notifications';
+import { getUrlParam, setUrlParam } from '../../helpers/location';
 
 import PushActionMenu from './PushActionMenu';
 
@@ -77,6 +78,7 @@ class PushHeader extends React.PureComponent {
     this.triggerNewJobs = this.triggerNewJobs.bind(this);
     this.pinAllShownJobs = this.pinAllShownJobs.bind(this);
     this.cancelAllJobs = this.cancelAllJobs.bind(this);
+    this.togglePushCollapsed = this.togglePushCollapsed.bind(this);
   }
 
   getLinkParams() {
@@ -168,6 +170,24 @@ class PushHeader extends React.PureComponent {
     }
   }
 
+  togglePushCollapsed() {
+    const { push, collapsed } = this.props;
+    const pushId = `${push.id}`;
+    const collapsedPushesParam = getUrlParam('collapsedPushes');
+    const collapsedPushes = collapsedPushesParam
+      ? new Set(collapsedPushesParam.split(','))
+      : new Set();
+
+    if (collapsed) {
+      collapsedPushes.delete(pushId);
+    } else {
+      collapsedPushes.add(pushId);
+    }
+    setUrlParam('collapsedPushes', collapsedPushes.size
+      ? Array.from(collapsedPushes)
+      : null);
+  }
+
   render() {
     const {
       repoName,
@@ -183,6 +203,7 @@ class PushHeader extends React.PureComponent {
       cycleWatchState,
       notificationSupported,
       selectedRunnableJobs,
+      collapsed,
     } = this.props;
     const cancelJobsTitle = isLoggedIn
       ? 'Cancel all jobs'
@@ -202,6 +223,11 @@ class PushHeader extends React.PureComponent {
         <div className="push-bar">
           <span className="push-left">
             <span className="push-title-left">
+              <span
+                onClick={this.togglePushCollapsed}
+                className={`fa ${collapsed ? 'fa-plus-square-o' : 'fa-minus-square-o'} mr-2 mt-2 text-muted pointable`}
+                title={`${collapsed ? 'Expand' : 'Collapse'} push data`}
+              />
               <span>
                 <a href={revisionPushFilterUrl} title="View only this push">
                   {this.pushDateStr}{' '}
@@ -305,6 +331,7 @@ PushHeader.propTypes = {
   getAllShownJobs: PropTypes.func.isRequired,
   getGeckoDecisionTaskId: PropTypes.func.isRequired,
   selectedRunnableJobs: PropTypes.array.isRequired,
+  collapsed: PropTypes.bool.isRequired,
   notify: PropTypes.func.isRequired,
   jobCounts: PropTypes.object.isRequired,
   watchState: PropTypes.string,


### PR DESCRIPTION
This adds the ability to collapse pushes.  The collapsed pushes are persisted on the URL so that the links can be shared.

This obviously isn't the whole solution to paging and memory usage, but I still feel like this is a worthwhile feature to help reduce noise in certain circumstances.

Expanded push:
<img width="1148" alt="screenshot 2018-11-06 18 00 14" src="https://user-images.githubusercontent.com/419924/48105931-3ad05d00-e1ee-11e8-98c1-75882f95beba.png">


Collapsed push:
<img width="1155" alt="screenshot 2018-11-06 18 00 00" src="https://user-images.githubusercontent.com/419924/48105938-40c63e00-e1ee-11e8-943b-90e6dbbc6322.png">


