### PR TITLE
Add more branches for the Servo repository

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -949,13 +949,13 @@
     "model": "model.repository",
     "fields": {
         "dvcs_type": "git",
-        "name": "servo",
+        "name": "servo-master",
         "url": "https://github.com/servo/servo",
         "branch": "master",
         "active_status": "active",
         "codebase": "servo",
-        "repository_group": 7,
-        "description": "The Servo Parallel Browser Engine.",
+        "repository_group": 10,
+        "description": "The Servo Parallel Browser Engine − master",
         "expire_performance_data": false
     }
 },
@@ -1271,6 +1271,36 @@
         "codebase": "ci-admin",
         "repository_group": 9,
         "description": "Administrative configuration for Firefox CI"
+    }
+},
+{
+    "pk": 99,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "servo-try",
+        "url": "https://github.com/servo/servo",
+        "branch": "try",
+        "active_status": "active",
+        "codebase": "servo",
+        "repository_group": 10,
+        "description": "The Servo Parallel Browser Engine − try",
+        "expire_performance_data": false
+    }
+},
+{
+    "pk": 100,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "servo-auto",
+        "url": "https://github.com/servo/servo",
+        "branch": "auto",
+        "active_status": "active",
+        "codebase": "servo",
+        "repository_group": 10,
+        "description": "The Servo Parallel Browser Engine − auto: testing PRs after review and before merging to master.",
+        "expire_performance_data": false
     }
 }
 ]

--- a/treeherder/model/fixtures/repository_group.json
+++ b/treeherder/model/fixtures/repository_group.json
@@ -70,5 +70,13 @@
         "name": "ci-admin",
         "description": "Administration of Firefox CI"
     }
+},
+{
+    "pk": 10,
+    "model": "model.repositorygroup",
+    "fields": {
+        "name": "servo",
+        "description": "Branches of github.com/servo/servo"
+    }
 }
 ]

--- a/ui/job-view/headerbars/ReposMenu.jsx
+++ b/ui/job-view/headerbars/ReposMenu.jsx
@@ -10,6 +10,7 @@ const GROUP_ORDER = [
   'comm-repositories',
   'qa automation tests',
   'ci-admin',
+  'servo',
   'other',
 ];
 


### PR DESCRIPTION
For Servo CI we’re starting to move to Taskcluster. Treeherder seems like a nice way to visualize which tasks have succeeded or failed. https://treeherder.mozilla.org/#/jobs?repo=servo already exists, but as far as I can tell only shows commits in / pushes to the `master` branch. Testing happens in the `auto` (and `try`) branch, before merging into `master`.