### PR TITLE
Bug 1505417 - Stop setting a viewport meta tag

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -93,6 +93,11 @@ module.exports = {
         // Enable source maps for `yarn build` too (but not on CI, since it doubles build times).
         production: process.env.CI ? false : 'source-map',
       },
+      html: {
+        // Disable the default viewport meta tag, since Treeherder doesn't work well at
+        // small viewport sizes, so shouldn't use `width=device-width` (see bug 1505417).
+        meta: false,
+      },
       style: {
         // Disable Neutrino's CSS modules support, since we don't use it.
         modules: false,


### PR DESCRIPTION
Previously all pages were using the following meta tag:

```
<meta name="viewport" content="width=device-width,initial-scale=1">
```

On mobile devices this causes the viewport to be set at the device screen width, which is likely to be very small. Most of Treeherder's pages do not function well under 800-900 pixels, so this meant mobile users had to enable the "Request desktop site" feature for them to be usable.

With this change we now don't set a viewport meta tag at all, which causes Firefox for Android to use a default viewport of 980 pixels (and similar other mobile browsers). This will mean they see scroll bars, however the UI will at least be usable.

See:
https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag