### PR TITLE
Bug 1506856 - fix IFV bug details count

### DIFF
--- a/ui/intermittent-failures/BugDetailsView.jsx
+++ b/ui/intermittent-failures/BugDetailsView.jsx
@@ -95,9 +95,9 @@ const BugDetailsView = (props) => {
             <Row>
               <Col xs="4" className="mx-auto"><p className="text-secondary text-center">{summary}</p></Col>
             </Row>}
-            {tableData && tableData.count &&
+            {tableData.length > 0 &&
             <Row>
-              <Col xs="12" className="mx-auto"><p className="text-secondary">{tableData.count} total failures</p></Col>
+              <Col xs="12" className="mx-auto"><p className="text-secondary">{tableData.length} total failures</p></Col>
             </Row>}
           </React.Fragment>}
         </React.Fragment>


### PR DESCRIPTION
Since the failuresbybug API changed to deliver all results with no pagination (and the
associated meta went away) for the table sorting in #4178, the bug count needed to be changed to tableData.length from tableData.count