### PR TITLE
Add another (try-taskcluster) branch for the Servo repository

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1302,5 +1302,20 @@
         "description": "The Servo Parallel Browser Engine − auto: testing PRs after review and before merging to master.",
         "expire_performance_data": false
     }
+},
+{
+    "pk": 101,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "servo-try-taskcluster",
+        "url": "https://github.com/servo/servo",
+        "branch": "try-taskcluster",
+        "active_status": "active",
+        "codebase": "servo",
+        "repository_group": 10,
+        "description": "The Servo Parallel Browser Engine − try, Taskcluster only",
+        "expire_performance_data": false
+    }
 }
 ]


### PR DESCRIPTION
Same as https://github.com/mozilla/treeherder/pull/4249, but it turns out I need yet another branch to mess with while working on Taskcluster integration without disrupting the existing Buildbot CI.