### PR TITLE
Bug 1505417 - Remove viewport meta tag for Perfherder too

### DIFF
--- a/ui/perf.html
+++ b/ui/perf.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="utf-8">
     <title>Perfherder</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link id="favicon" type="image/png" rel="shortcut icon" href="img/line_chart.png">
     <style>
       [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {


### PR DESCRIPTION
The Perfherder equivalent of #4262 since the changes there only affected auto-generated HTML, but Perfherder still uses its own custom HTML template (until the React conversion is finished).