### PR TITLE
Bug 1472542 - Use native setTimeout rather than via a polyfill

### DIFF
--- a/ui/intermittent-failures/DateRangePicker.jsx
+++ b/ui/intermittent-failures/DateRangePicker.jsx
@@ -5,7 +5,6 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 
 import { parseDate, formatDate } from 'react-day-picker/moment';
-import { setTimeout } from 'timers';
 import { Button } from 'reactstrap';
 import { ISODate } from './helpers';
 


### PR DESCRIPTION
The `timers` module is a Node.js built-in, which webpack will polyfill during the build. Using it adds `timers-browserify` to the bundle unnecessarily, given that browsers natively support `setTimeout`:
https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout

(This import was presumably copied from a react-native code example.)