### PR TITLE
Fix getData helper

### DIFF
--- a/ui/helpers/http.js
+++ b/ui/helpers/http.js
@@ -43,9 +43,11 @@ export const getData = async function getData(url) {
     failureStatus = response.status;
   }
 
-  const responseHeader = response.headers.get('content-type').split(';');
+  const contentType = response.headers
+    .get('content-type')
+    .startsWith('text/html');
 
-  if (responseHeader[0] === 'text/html' && failureStatus) {
+  if (contentType && failureStatus) {
     return { data: { [failureStatus]: response.statusText }, failureStatus };
   }
 

--- a/ui/helpers/http.js
+++ b/ui/helpers/http.js
@@ -43,7 +43,9 @@ export const getData = async function getData(url) {
     failureStatus = response.status;
   }
 
-  if (response.headers.get('content-type') === 'text/html' && failureStatus) {
+  const responseHeader = response.headers.get('content-type').split(';');
+
+  if (responseHeader[0] === 'text/html' && failureStatus) {
     return { data: { [failureStatus]: response.statusText }, failureStatus };
   }
 


### PR DESCRIPTION
Change response header to account for additional info such as the utf charset when checking for errors.

I've noticed that occasionally the IFV spinner would get stuck the first time loading the page for the day and found that the exact string match for the header content was insufficient since "text/html; charset=utf-8" is returned for the 503 instead of just "text/html".
