### PR TITLE
Bug 1507172 - Add additional .prettierignore entries

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,17 @@
+# Ignore generated directories.
+.*/
+_build/
+build/
+treeherder/static/
+
 # Ignore our legacy JS since it will be rewritten when converted to React.
 ui/js/
+
+# Ignore Prettier-supported filetypes that we haven't yet converted to its style,
+# so that "format on save" doesn't try to format them when making unrelated changes.
+*.css
+*.html
+*.json
+*.md
+*.yaml
+*.yml


### PR DESCRIPTION
For:
* generated directories such as `build/`
* filetypes that are supported by Prettier, but that we haven't yet converted to its style (eg CSS, HTML, JSON, YAML)

These entries are not needed when running Prettier via ESLint, but help prevent the "format on save" feature of IDE prettier plugins from auto-formatting files when making unrelated changes to them.

As and when we use Prettier with more filetypes, these can be removed.