### PR TITLE
Clean up the location of generated output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,9 @@ npm-error.log
 \#*
 
 # Treeherder-specific
-_build/
-build/
-treeherder/static/
+.build/
+.build-docs/
+.django-static/
 
 # Celery
 celerybeat-schedule

--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -39,6 +39,7 @@ module.exports = {
         title: 'Intermittent Failures View',
       },
     },
+    output: '.build/',
     tests: 'tests/ui/',
   },
   use: [

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,5 @@
 # Ignore generated directories.
 .*/
-_build/
-build/
-treeherder/static/
 
 # Ignore our legacy JS since it will be rewritten when converted to React.
 ui/js/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 SPHINXOPTS    = -n -W
 SPHINXBUILD   = sphinx-build
-BUILDDIR      = _build
+BUILDDIR      = .build-docs
 SOURCEDIR     = docs
 
 # User-friendly check for sphinx-build

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -5,13 +5,13 @@
 set -euo pipefail
 
 # Make the current Git revision accessible at <site-root>/revision.txt
-echo "$SOURCE_VERSION" > build/revision.txt
+echo "$SOURCE_VERSION" > .build/revision.txt
 
 # Generate gzipped versions of files that would benefit from compression, that
 # WhiteNoise can then serve in preference to the originals. This is required
 # since WhiteNoise's Django storage backend only gzips assets handled by
-# collectstatic, and so does not affect files in the `build/` directory.
-python -m whitenoise.compress build
+# collectstatic, and so does not affect files in the `.build/` directory.
+python -m whitenoise.compress .build
 
 # Remove nodejs files to reduce slug size (and avoid environment variable
 # pollution from the nodejs profile script), since they are no longer

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ copyright = u'Mozilla and other contributors'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['.build-docs']
 
 html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ filterwarnings =
     error
     ignore::ImportWarning
     ignore::PendingDeprecationWarning
-    # WhiteNoise warns if either `treeherder/static/` or `build/` do not exist at startup,
+    # WhiteNoise warns if either `.django-static/` or `.build/` do not exist at startup,
     # however this is expected when running tests since Django collectstatic and yarn build
     # (which create those directories) typically aren't run apart from during deployments.
     ignore:No directory at.*:UserWarning:whitenoise.base

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -1,8 +1,10 @@
 from __future__ import unicode_literals
 
-import os
 import re
 from datetime import timedelta
+from os.path import (abspath,
+                     dirname,
+                     join)
 
 import environ
 from celery.schedules import crontab
@@ -13,7 +15,8 @@ from kombu import (Exchange,
 from treeherder.config.utils import (connection_should_use_tls,
                                      get_tls_redis_url)
 
-PROJECT_DIR = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+# TODO: Switch to pathlib once using Python 3.
+SRC_DIR = dirname(dirname(dirname(abspath(__file__))))
 
 env = environ.Env()
 
@@ -138,7 +141,7 @@ USE_I18N = False
 USE_L10N = True
 
 # Static files (CSS, JavaScript, Images)
-STATIC_ROOT = os.path.join(PROJECT_DIR, "static")
+STATIC_ROOT = join(SRC_DIR, ".django-static")
 STATIC_URL = "/static/"
 
 # Create hashed+gzipped versions of assets during collectstatic,
@@ -386,7 +389,7 @@ REST_FRAMEWORK = {
 
 # Whitenoise
 # Files in this directory will be served by WhiteNoise at the site root.
-WHITENOISE_ROOT = os.path.join(PROJECT_DIR, "..", "build")
+WHITENOISE_ROOT = join(SRC_DIR, ".build")
 # Serve index.html for URLs ending in a trailing slash.
 WHITENOISE_INDEX_FILE = True
 # Only output the hashed filename version of static files and not the originals.


### PR DESCRIPTION
So that their purposes are clearer and it's easier to differentiate between generated content and files committed to the repository.

* Neutrino build: `build/` -> `.build/`
* Sphinx build: `_build/` -> `.build-docs/`
* Django collectstatic: `treeherder/static/` -> `.django-static/`

(The naming then aligns with `.pytest_cache/`, `.vagrant/`, `.vscode/` etc)