### PR TITLE
Bug 1507808 - Fix job details reloading for specific job

### DIFF
--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -59,10 +59,18 @@ class DetailsPanel extends React.Component {
   componentDidUpdate(prevProps) {
     const { selectedJob } = this.props;
 
-    if (
-      selectedJob &&
-      (!prevProps.selectedJob || prevProps.selectedJob !== selectedJob)
-    ) {
+    if (selectedJob && prevProps.selectedJob) {
+      const {
+        state: prevState,
+        result: prevResult,
+        failure_classification_id: prevFci,
+      } = prevProps.selectedJob;
+      const { state, result, failure_classification_id: fci } = selectedJob;
+
+      if (prevState !== state || prevResult !== result || prevFci !== fci) {
+        this.selectJob();
+      }
+    } else if (selectedJob && selectedJob !== prevProps.selectedJob) {
       this.selectJob();
     }
   }


### PR DESCRIPTION
This was happening because the specific job in question was the newest job on that page.  And we poll for that >= the timestamp of the latest job.  So each poll, that job was always returned.  That's not a problem, except that in ``DetailsPanel`` we were checking if we should reload the details panel by object (``oldjob !== newjob``) instead of the values that we care about.  This fixes it so that we just check the things that would change in the job: ``state``, ``result``, ``failure_classification_id``.

So the details will reload if any of those fields change, which is the correct thing to do.