### PR TITLE
Remove unused redux-thunk dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "reactstrap": "6.5.0",
     "redux": "4.0.1",
     "redux-debounce": "1.0.1",
-    "redux-thunk": "2.3.0",
     "taskcluster-client-web": "8.1.0",
     "taskcluster-lib-scopes": "10.0.1",
     "webpack": "4.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6806,11 +6806,6 @@ redux-debounce@1.0.1:
     lodash.debounce "^4.0.6"
     lodash.mapvalues "^4.3.0"
 
-redux-thunk@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
-  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
-
 redux@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"


### PR DESCRIPTION
The last usage was removed in #4107 ([bug 1485226](https://bugzilla.mozilla.org/show_bug.cgi?id=1485226)).