### PR TITLE
Update Neutrino to 9.0.0-rc.0

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -47,9 +47,6 @@ module.exports = {
       '@neutrinojs/eslint',
       {
         eslint: {
-          // Treat ESLint errors as warnings so they don't block the webpack build.
-          // Remove if/when changed in @neutrinojs/eslint.
-          emitWarning: true,
           // We manage our lint config in .eslintrc.js instead of here.
           useEslintrc: true,
         },
@@ -61,8 +58,6 @@ module.exports = {
         devServer: {
           historyApiFallback: false,
           open: !process.env.MOZ_HEADLESS,
-          // Remove when enabled by default (https://github.com/neutrinojs/neutrino/issues/1131).
-          overlay: true,
           proxy: {
             // Proxy any paths not recognised by webpack to the specified backend.
             '*': {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "d3": "5.7.0"
   },
   "dependencies": {
-    "@neutrinojs/copy": "9.0.0-beta.1",
-    "@neutrinojs/react": "9.0.0-beta.1",
+    "@neutrinojs/copy": "9.0.0-rc.0",
+    "@neutrinojs/react": "9.0.0-rc.0",
     "@types/angular": "*",
     "@types/prop-types": "*",
     "@types/react": "*",
@@ -42,7 +42,7 @@
     "metrics-graphics": "2.15.6",
     "moment": "2.22.2",
     "mousetrap": "1.6.2",
-    "neutrino": "9.0.0-beta.1",
+    "neutrino": "9.0.0-rc.0",
     "ng-text-truncate-2": "1.0.1",
     "numeral": "2.0.6",
     "popper.js": "1.14.5",
@@ -73,7 +73,7 @@
     "webpack-cli": "3.1.2"
   },
   "devDependencies": {
-    "@neutrinojs/eslint": "9.0.0-beta.1",
+    "@neutrinojs/eslint": "9.0.0-rc.0",
     "angular-mocks": "1.7.5",
     "enzyme": "3.7.0",
     "enzyme-adapter-react-16": "1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@^7.0.0-beta.49", "@babel/core@^7.1.2":
+"@babel/core@^7.0.0-beta.49", "@babel/core@^7.1.6":
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.1.6.tgz#3733cbee4317429bc87c62b29cf8587dba7baeb3"
   integrity sha512-Hz6PJT6e44iUNpAn8AoyAs6B3bl60g7MJQaI0rZEar6ECzh6+srYO1xlIdssio34mPaUtAb1y+XlkkSJzok3yw==
@@ -576,7 +576,7 @@
     "@babel/helper-regex" "^7.0.0"
     regexpu-core "^4.1.3"
 
-"@babel/preset-env@^7.1.0":
+"@babel/preset-env@^7.1.6":
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.1.6.tgz#a0bf4b96b6bfcf6e000afc5b72b4abe7cc13ae97"
   integrity sha512-YIBfpJNQMBkb6MCkjz/A9J76SNCSuGVamOVBgoUkLzpJD/z8ghHi9I42LQ4pulVX68N/MmImz6ZTixt7Azgexw==
@@ -728,114 +728,114 @@
   dependencies:
     "@types/whatwg-streams" "^0.0.7"
 
-"@neutrinojs/clean@9.0.0-beta.1":
-  version "9.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@neutrinojs/clean/-/clean-9.0.0-beta.1.tgz#237f5b1e4fadc154d3b429fc5099cb09ee97d647"
-  integrity sha512-gpPZRIMy0+tRNRhJ78ITfuzslAguiwNZRNMg1ejPFy2eWEmSYF+BwDMQVMgxWtkXFr51GtHlBaduO3wj6xWTPQ==
+"@neutrinojs/clean@9.0.0-rc.0":
+  version "9.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@neutrinojs/clean/-/clean-9.0.0-rc.0.tgz#a7a7cf4141a554dcbc5b79c8d5d86dbc2eb0b2f3"
+  integrity sha512-RU6AwsWeSBfsfPgH30pRec2+YS7wS9jAOZuAPl8BZFYQBfmuWfPRebXEhoz1gWUCJw5825l4u3oVelFd44A8DA==
   dependencies:
-    clean-webpack-plugin "^0.1.19"
+    clean-webpack-plugin "^1.0.0"
 
-"@neutrinojs/compile-loader@9.0.0-beta.1":
-  version "9.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@neutrinojs/compile-loader/-/compile-loader-9.0.0-beta.1.tgz#e895cea6354426b79254cb38edccf1a14bc77d9f"
-  integrity sha512-Ia/w6+fvk20Lp5t6RmiSmhN6HDnX8KqjlftBSXwjJOyf8B90UTQKWWgBaxGjczdeZUNeagG5KUhoEMlCzs9QwQ==
+"@neutrinojs/compile-loader@9.0.0-rc.0":
+  version "9.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@neutrinojs/compile-loader/-/compile-loader-9.0.0-rc.0.tgz#201bfe0df030e8772760cf0222fbb8916c46cc87"
+  integrity sha512-1Zzt4SbLbJURTxBL+rH/Wy1DTYm6tqvvCdge7Q2EX9FQBQvtScdqnQSiyJF2QDMJK4Q4JmHElPjOktvUHrf2Zw==
   dependencies:
-    "@babel/core" "^7.1.2"
+    "@babel/core" "^7.1.6"
     babel-loader "^8.0.4"
-    babel-merge "^2.0.1"
 
-"@neutrinojs/copy@9.0.0-beta.1":
-  version "9.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@neutrinojs/copy/-/copy-9.0.0-beta.1.tgz#c5fe0df0da3a6fc13370f8dc71c67d9ab2d5044b"
-  integrity sha512-buzayN6dqlxU+RTS9pQd4/EibGKRAVJZAig19kfVMT7oBDCxNxL1XDhmDBZfNdgrDzz8Id1575TKfrkPXf6Bog==
+"@neutrinojs/copy@9.0.0-rc.0":
+  version "9.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@neutrinojs/copy/-/copy-9.0.0-rc.0.tgz#9463e6557338a8433afff58fbaba206d38f2039b"
+  integrity sha512-/Ucrl+jHi1lCbVtQ9tVPijLgP/vEjxWSORjTE9DF22BsyVv0HUPcWiWBj+Ahv3ZFS7B2gmMx6CK056OK+uqMmg==
   dependencies:
-    copy-webpack-plugin "^4.5.3"
+    copy-webpack-plugin "^4.6.0"
 
-"@neutrinojs/dev-server@9.0.0-beta.1":
-  version "9.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@neutrinojs/dev-server/-/dev-server-9.0.0-beta.1.tgz#e0aae24c8cdf73651c1c3c26593dfd37341ab8bc"
-  integrity sha512-oqUsA4gAfurYml8FUt55vgFAjzrH7gVTK0wXaTkbIjEqc15mvqd8Xq9i+Hfngf1fbB1x8FOnubYaudvcx3kWNg==
+"@neutrinojs/dev-server@9.0.0-rc.0":
+  version "9.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@neutrinojs/dev-server/-/dev-server-9.0.0-rc.0.tgz#398033327fe7ec8d16a43ab7d3659ccb791a0acc"
+  integrity sha512-m6xTvCYfCdxZSvIP+Tm1vMiXH0q11y3rMwnk6i7dGkzmA6mc76tNOPLy4jJkuXNdjMdjo1ZcT4oi0cw8IZNF/Q==
 
-"@neutrinojs/eslint@9.0.0-beta.1":
-  version "9.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@neutrinojs/eslint/-/eslint-9.0.0-beta.1.tgz#80c4ab7a47e58faac8d7ed4e0cd5ffda7b0463e0"
-  integrity sha512-QuNkLneRKbRBXFhhyOLgTTsnuveyKs8jkCXahwppamUl7PSDdJG8hVxufyHHwI2AkliRwZrZrVm8ngzAkB41KQ==
+"@neutrinojs/eslint@9.0.0-rc.0":
+  version "9.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@neutrinojs/eslint/-/eslint-9.0.0-rc.0.tgz#dce10e2fb788b64d00d93267d1d1253eeb7a8450"
+  integrity sha512-OBMDWhXMOPkd/OABruTHjhEf6THyIkHOR69giOFjYnBWZesFjKiZiWHGB6USEQ/DNzfLyS8S7iq1sMggQHSD+w==
   dependencies:
     babel-eslint "^10.0.1"
     eslint-loader "^2.1.1"
-    eslint-plugin-babel "^5.2.1"
+    eslint-plugin-babel "^5.3.0"
     lodash.pick "^4.4.0"
 
-"@neutrinojs/font-loader@9.0.0-beta.1":
-  version "9.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@neutrinojs/font-loader/-/font-loader-9.0.0-beta.1.tgz#85b1a01fb095b39fd2b86c7892af946883c75120"
-  integrity sha512-Arj7IZvlyg0az4xTwNWFS1dq/y7+8oGUMXpQfVdODb5qn1gVkgKEBLKdyrd5+Gbugn1r+ydWqTeDMTaX5YFm6w==
+"@neutrinojs/font-loader@9.0.0-rc.0":
+  version "9.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@neutrinojs/font-loader/-/font-loader-9.0.0-rc.0.tgz#bf288764c09beb2f047f444f11265c5d946cdea9"
+  integrity sha512-J9IttpWuFu8cEorl/8zrL6wbAHqWpejwlHEA6xlZp9vxX9QQXRzGVb8SCfc5TH6XvHlOnPSNuLdo+UbkpB/Z5Q==
   dependencies:
     file-loader "^2.0.0"
 
-"@neutrinojs/html-loader@9.0.0-beta.1":
-  version "9.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@neutrinojs/html-loader/-/html-loader-9.0.0-beta.1.tgz#599350d7b4d9c937d4ac633d770a5edb9fbc0f37"
-  integrity sha512-CsUFY1f9KzvzJKlWdVaOpDOnlN/0vNXJT+RyhvQf6BT6LPAINIsqqwqsnrUpq4StIy3FGKsJdlDRem3cCiMZBw==
+"@neutrinojs/html-loader@9.0.0-rc.0":
+  version "9.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@neutrinojs/html-loader/-/html-loader-9.0.0-rc.0.tgz#85b28517da001a70fd4e52cabf0b048b47dadbf3"
+  integrity sha512-OIzDJ26EEWGdyxRdoDs4bL5y8QEgVRLCnITxrFLdVXGySKP5YOqXwKF1r53+MTwxiflvbYPx86vosURDROmAgQ==
   dependencies:
     html-loader "^0.5.5"
 
-"@neutrinojs/html-template@9.0.0-beta.1":
-  version "9.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@neutrinojs/html-template/-/html-template-9.0.0-beta.1.tgz#72c32adb79ab416346638e45162ba31e27417b2a"
-  integrity sha512-6rqUMNkGCxRBbKLiVqk8k5t/P4mjWTBdssRWYiuoKuPg1YdnUMVaQYDUDxqTMzB7W9NANuCh+n+WpFRQ9+iv6Q==
+"@neutrinojs/html-template@9.0.0-rc.0":
+  version "9.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@neutrinojs/html-template/-/html-template-9.0.0-rc.0.tgz#53bbeb48804168dca539b63edc7c54d213473f28"
+  integrity sha512-rLHCEBUJePVsvdvzmCAcumuz1xWut7C6JVb3zqODnXcwCQdmxycwl2udDPvF3MxXbyXm8Ctr2ncwsOumVMUo2A==
   dependencies:
-    html-webpack-plugin "4.0.0-beta.2"
+    html-webpack-plugin "4.0.0-beta.4"
 
-"@neutrinojs/image-loader@9.0.0-beta.1":
-  version "9.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@neutrinojs/image-loader/-/image-loader-9.0.0-beta.1.tgz#e374289ceb0151afd723f056381dd6d2022585f0"
-  integrity sha512-Y07KALoy/7rxUUDoitZK7L0l+xFVe3yxLDKZJEkYr4AcSRnhWgqayTMk9NHOw4M7HQ0+w4qv2ypKuyeXHKtegw==
+"@neutrinojs/image-loader@9.0.0-rc.0":
+  version "9.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@neutrinojs/image-loader/-/image-loader-9.0.0-rc.0.tgz#bbb3c446a4e12410c7875947751b4231b9dbdff1"
+  integrity sha512-WTOE2zESwQKVZcncC457GV5U41qsGDFg0nIWNh/y3vWUtnflpEO2/GPauY439/YFI1xYTyGAWrh0QVa7GopD4A==
   dependencies:
     file-loader "^2.0.0"
     url-loader "^1.1.2"
 
-"@neutrinojs/react@9.0.0-beta.1":
-  version "9.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@neutrinojs/react/-/react-9.0.0-beta.1.tgz#cc333881a94459cada740e0d015399d1e724a85d"
-  integrity sha512-qOxtX0glocjd3iTrZgL8ZAixUJS+9rdwTmYOCt/dAiTXGvcKB3L94Gx63BMG7T2zA19qtHG1dUpj3Q4kc0vkWg==
+"@neutrinojs/react@9.0.0-rc.0":
+  version "9.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@neutrinojs/react/-/react-9.0.0-rc.0.tgz#5c73369794066b0f1b6910ce0faa7a839acf1c49"
+  integrity sha512-6Q8U2UwPWVRqlqVv90pa8OT0Al9Fyqx5SIM+UAF2ZIOWTTsR1sBOnruZlauBSwL8qvf7BWGivvK55PErqkP0Jg==
   dependencies:
-    "@babel/core" "^7.1.2"
+    "@babel/core" "^7.1.6"
     "@babel/plugin-proposal-class-properties" "^7.1.0"
     "@babel/preset-react" "^7.0.0"
-    "@neutrinojs/compile-loader" "9.0.0-beta.1"
-    "@neutrinojs/web" "9.0.0-beta.1"
+    "@neutrinojs/web" "9.0.0-rc.0"
+    babel-merge "^2.0.1"
+    babel-plugin-transform-react-remove-prop-types "^0.4.20"
     deepmerge "^1.5.2"
     eslint-plugin-react "^7.11.1"
 
-"@neutrinojs/style-loader@9.0.0-beta.1":
-  version "9.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@neutrinojs/style-loader/-/style-loader-9.0.0-beta.1.tgz#7d002ae506825bd7652166868388f5ea203c124b"
-  integrity sha512-FHp4KRy7ifs1/LHwbTA1keMySL8bR9nBvKN5u/f4T1QpIxJz4MZiunlbYRTDfiIjIOmFB2cEupfxb7WFXabeiQ==
+"@neutrinojs/style-loader@9.0.0-rc.0":
+  version "9.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@neutrinojs/style-loader/-/style-loader-9.0.0-rc.0.tgz#62753918c2a0647a0a8c6cd929971d1e15d8693b"
+  integrity sha512-u6VgqP71w1E+KyTodBJfevkdlTJ9sozhw9AqHW9/pumgrpjjCZLu0WEBiqDUjzfWopLIcQB0fBfcO8s5uTRUkQ==
   dependencies:
-    css-loader "^1.0.0"
+    css-loader "^1.0.1"
     deepmerge "^1.5.2"
-    mini-css-extract-plugin "^0.4.4"
+    mini-css-extract-plugin "^0.4.5"
     style-loader "^0.23.1"
 
-"@neutrinojs/web@9.0.0-beta.1":
-  version "9.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@neutrinojs/web/-/web-9.0.0-beta.1.tgz#01d35630e3b902f5d242f22199a1c4e3e64f7ec6"
-  integrity sha512-owH9zZLHohCJkI0tsf9ZNCcD7rRH529AznKjnNIZBfUnV6rNkBK6R/k8ZN1+cJtq9OMS8gxu3zWtcWmLyVeHnQ==
+"@neutrinojs/web@9.0.0-rc.0":
+  version "9.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@neutrinojs/web/-/web-9.0.0-rc.0.tgz#c032b9c02de56b2d12948168c001736ce8e76df4"
+  integrity sha512-Kni293aDjICr1bAe5NIAtclyY3U71b1wtTVKt0MTlMH2IOxPJsBMDS9gOPkCTE21We1GeMrE6hR6iN254sgncA==
   dependencies:
-    "@babel/core" "^7.1.2"
+    "@babel/core" "^7.1.6"
     "@babel/plugin-syntax-dynamic-import" "^7.0.0"
-    "@babel/preset-env" "^7.1.0"
-    "@neutrinojs/clean" "9.0.0-beta.1"
-    "@neutrinojs/compile-loader" "9.0.0-beta.1"
-    "@neutrinojs/dev-server" "9.0.0-beta.1"
-    "@neutrinojs/font-loader" "9.0.0-beta.1"
-    "@neutrinojs/html-loader" "9.0.0-beta.1"
-    "@neutrinojs/html-template" "9.0.0-beta.1"
-    "@neutrinojs/image-loader" "9.0.0-beta.1"
-    "@neutrinojs/style-loader" "9.0.0-beta.1"
+    "@babel/preset-env" "^7.1.6"
+    "@neutrinojs/clean" "9.0.0-rc.0"
+    "@neutrinojs/compile-loader" "9.0.0-rc.0"
+    "@neutrinojs/dev-server" "9.0.0-rc.0"
+    "@neutrinojs/font-loader" "9.0.0-rc.0"
+    "@neutrinojs/html-loader" "9.0.0-rc.0"
+    "@neutrinojs/html-template" "9.0.0-rc.0"
+    "@neutrinojs/image-loader" "9.0.0-rc.0"
+    "@neutrinojs/style-loader" "9.0.0-rc.0"
+    babel-merge "^2.0.1"
     deepmerge "^1.5.2"
-    terser-webpack-plugin "^1.1.0"
     webpack-manifest-plugin "^2.0.4"
 
 "@types/angular@*", "@types/angular@^1.6.39":
@@ -1444,6 +1444,11 @@ babel-plugin-syntax-jsx@^6.18.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
+babel-plugin-transform-react-remove-prop-types@^0.4.20:
+  version "0.4.20"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.20.tgz#688bdea1e27ea0023775dea817fa2d3f8df8802b"
+  integrity sha512-bWQ8e7LsgdFpyHU/RabjDAjVhL7KLAJXEt0nb0LANFje8YAGA8RlZv88a72aCswOxELWULkYuJqfFoKgs58Tng==
+
 babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
@@ -1977,10 +1982,10 @@ clean-css@4.2.x:
   dependencies:
     source-map "~0.6.0"
 
-clean-webpack-plugin@^0.1.19:
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-0.1.19.tgz#ceda8bb96b00fe168e9b080272960d20fdcadd6d"
-  integrity sha512-M1Li5yLHECcN2MahoreuODul5LkjohJGFxLPTjl3j1ttKrF5rgjZET1SJduuqxLAuT1gAPOdkhg03qcaaU1KeA==
+clean-webpack-plugin@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-1.0.0.tgz#f184b9c26d12983d639828e0548ae2080e84b6a7"
+  integrity sha512-+f96f52UIET4tOFBbCqezx7KH+w7lz/p4fA1FEjf0hC6ugxqwZedBtENzekN2FnmoTF/bn1LrlkvebOsDZuXKw==
   dependencies:
     rimraf "^2.6.1"
 
@@ -2205,7 +2210,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-webpack-plugin@^4.5.3:
+copy-webpack-plugin@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-4.6.0.tgz#e7f40dd8a68477d405dd1b7a854aae324b158bae"
   integrity sha512-Y+SQCF+0NoWQryez2zXn5J5knmr9z/9qSQt7fbL78u83rxmigOy8X5+BFn8CFSuX+nKT8gpYwJX68ekqtQt6ZA==
@@ -2331,7 +2336,7 @@ css-in-js-utils@^2.0.0:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
 
-css-loader@^1.0.0:
+css-loader@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-1.0.1.tgz#6885bb5233b35ec47b006057da01cc640b6b79fe"
   integrity sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==
@@ -3243,7 +3248,7 @@ eslint-module-utils@^2.2.0:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
-eslint-plugin-babel@^5.2.1:
+eslint-plugin-babel@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-5.3.0.tgz#2e7f251ccc249326da760c1a4c948a91c32d0023"
   integrity sha512-HPuNzSPE75O+SnxHIafbW5QB45r2w78fxqwK3HmjqIUoPfPzVrq6rD+CINU3yzoDSzEhUkX07VUphbF73Lth/w==
@@ -4184,10 +4189,10 @@ html-minifier@^3.5.20, html-minifier@^3.5.8:
     relateurl "0.2.x"
     uglify-js "3.4.x"
 
-html-webpack-plugin@4.0.0-beta.2:
-  version "4.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.2.tgz#c3a212448ee198a17dacd06525678ee12f917420"
-  integrity sha512-153QgkvYPOc1X5/v1GFPcq7GTinNheGA1lMZUGRMFkwIQ4kegGna+wQ0ByJ8uNgw4u1aEg9FtsSKs4AzsYMi9g==
+html-webpack-plugin@4.0.0-beta.4:
+  version "4.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.4.tgz#4a996abc66ccccad2816998741dad2589858716c"
+  integrity sha512-5JDvn5zoNxcfnbuciyBbHTtUkOXfoVdO4g0Ma2ibVHruEvtx2g5wFgRjl/bAHrnF4EzGlCFn168cOnmMGg9NtA==
   dependencies:
     html-minifier "^3.5.20"
     loader-utils "^1.1.0"
@@ -5311,7 +5316,7 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
-mini-css-extract-plugin@^0.4.4:
+mini-css-extract-plugin@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.5.tgz#c99e9e78d54f3fa775633aee5933aeaa4e80719a"
   integrity sha512-dqBanNfktnp2hwL2YguV9Jh91PFX7gu7nRLs4TGsbAfAG6WOtlynFRYzwDwmmeSb5uIwHo9nx1ta0f7vAZVp2w==
@@ -5531,16 +5536,16 @@ neo-async@^2.5.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
   integrity sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==
 
-neutrino@9.0.0-beta.1:
-  version "9.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/neutrino/-/neutrino-9.0.0-beta.1.tgz#3db3545511309de3f671ee8f4fb4a2e3fcaeb557"
-  integrity sha512-kN5q/d7TnWZPmDsgi7dq4pN+tNHrMjwGALjVD1xV3TWiGp7Lw+bzkdUqGWPIXEnVP7p1gQDaOJaGq6L/JzpIfg==
+neutrino@9.0.0-rc.0:
+  version "9.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/neutrino/-/neutrino-9.0.0-rc.0.tgz#7fc5d1c55779778f2f9e46ee4c7fd9fa356fc789"
+  integrity sha512-2CvArWrHLgmLTPVY4GIjWpmzPXqb/YWyDISwJ7uwA9X38zzaIRuSxtdPSMLJWk6CskiLM2qGBXUY5L1NKGBzdg==
   dependencies:
     deepmerge "^1.5.2"
     is-plain-object "^2.0.4"
     lodash.clonedeep "^4.5.0"
-    webpack-chain "^5.0.0"
-    yargs-parser "^11.0.0"
+    webpack-chain "^5.0.1"
+    yargs-parser "^11.1.1"
 
 ng-text-truncate-2@1.0.1:
   version "1.0.1"
@@ -8150,7 +8155,7 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webpack-chain@^5.0.0:
+webpack-chain@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/webpack-chain/-/webpack-chain-5.0.1.tgz#549ec483f1bd6699ad4305b7892869cd619c1b62"
   integrity sha512-RiMJSZ5bxURnRl1hLOjslWD9aqqBRjwLUFvYR1Nq7dxka4fYw/mLPS0X641qJd3f4SLuiZ7k8WSiss8XgTTl1w==
@@ -8402,7 +8407,7 @@ yargs-parser@^10.1.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs-parser@^11.0.0, yargs-parser@^11.1.1:
+yargs-parser@^11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
   integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==


### PR DESCRIPTION
* React prop-types are now stripped from the bundle in production (since they are only used by React in development), reducing bundle size.
* react-hot-loader's Babel plugin is now enabled in production too, which is the first piece for fixing bug 1507906.
* `@neutrinojs/eslint` now configures `emitWarning` itself, so our customising is no longer required.
* `@neutrinojs/devServer` now enabled `overlay` itself, so we do not need to do so manually.

Full changelog:
https://github.com/neutrinojs/neutrino/compare/1c082ac...e9c21b8