### PR TITLE
Bug 1510240 - Fix updating details panel when changing jobs

### DIFF
--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -61,13 +61,22 @@ class DetailsPanel extends React.Component {
 
     if (selectedJob && prevProps.selectedJob) {
       const {
+        id: prevId,
         state: prevState,
         result: prevResult,
         failure_classification_id: prevFci,
       } = prevProps.selectedJob;
-      const { state, result, failure_classification_id: fci } = selectedJob;
+      const { id, state, result, failure_classification_id: fci } = selectedJob;
 
-      if (prevState !== state || prevResult !== result || prevFci !== fci) {
+      // Check the id in case the user switched to a new job.
+      // But also check some of the fields of the selected job,
+      // in case they have changed due to polling.
+      if (
+        prevId !== id ||
+        prevState !== state ||
+        prevResult !== result ||
+        prevFci !== fci
+      ) {
         this.selectJob();
       }
     } else if (selectedJob && selectedJob !== prevProps.selectedJob) {


### PR DESCRIPTION
Embarrassing I missed this...  We were only updating ``DetailsPanel`` if the ``result``, ``state``, or ``failure_classification_id`` changed.  But that meant it didn't update if switching between jobs that had those values the same.  [facepalm...]  Now we also check the ``id``.  The other fields ARE important to check, in case the selected job got an update due to polling.