### PR TITLE
Bug 1494750 - (Part 1) Make Treeherder backend first attempt to find an uncompressed runnable-jobs.json

### DIFF
--- a/treeherder/etl/runnable_jobs.py
+++ b/treeherder/etl/runnable_jobs.py
@@ -9,7 +9,7 @@ from treeherder.etl.common import fetch_json
 
 logger = logging.getLogger(__name__)
 
-RUNNABLE_JOBS_URL = 'https://public-artifacts.taskcluster.net/{task_id}/0/public/runnable-jobs.json.gz'
+RUNNABLE_JOBS_URL = 'https://queue.taskcluster.net/v1/task/{task_id}/runs/0/artifacts/public/runnable-jobs.json'
 TASKCLUSTER_INDEX_URL = 'https://index.taskcluster.net/v1/task/gecko.v2.%s.latest.taskgraph.decision'
 
 
@@ -26,16 +26,15 @@ def _taskcluster_runnable_jobs(project, decision_task_id):
     validate = URLValidator()
     try:
         validate(tc_graph_url)
-        # `force_gzip_encoding` works around Taskcluster not setting `Content-Encoding: gzip`:
-        # https://bugzilla.mozilla.org/show_bug.cgi?id=1423215
-        tc_graph = fetch_json(tc_graph_url, force_gzip_decompression=True)
+        tc_graph = fetch_json(tc_graph_url)
     except ValidationError:
         logger.warning('Failed to validate %s', tc_graph_url)
         return []
     except requests.exceptions.HTTPError as e:
-        logger.info('HTTPError %s when getting taskgraph at %s',
+        logger.info('HTTPError %s when getting uncompressed taskgraph at %s',
                     e.response.status_code, tc_graph_url)
-        return []
+        logger.info('Attempting to fall back to the compressed taskgraph...')
+        tc_graph = _taskcluster_runnable_jobs_gz(tc_graph_url + ".gz")
 
     for label, node in iteritems(tc_graph):
         ret.append({
@@ -53,6 +52,21 @@ def _taskcluster_runnable_jobs(project, decision_task_id):
         })
 
     return ret
+
+
+def _taskcluster_runnable_jobs_gz(tc_graph_url):
+    try:
+        # `force_gzip_encoding` works around Taskcluster not setting `Content-Encoding: gzip`:
+        # https://bugzilla.mozilla.org/show_bug.cgi?id=1423215
+        tc_graph = fetch_json(tc_graph_url, force_gzip_decompression=True)
+    except ValidationError:
+        logger.warning('Failed to validate %s', tc_graph_url)
+        return []
+    except requests.exceptions.HTTPError as e:
+        logger.info('HTTPError %s when getting taskgraph at %s',
+                    e.response.status_code, tc_graph_url)
+        return []
+    return tc_graph
 
 
 def list_runnable_jobs(project, decision_task_id=None):


### PR DESCRIPTION
At the moment, Taskcluster is only publishing runnable-jobs.json.gz, but the plan at some point is to switch that to only publishing runnable-jobs.json, with no period of both artifacts being published.

Before the tc change can go through, then, consumers like Treeherder's "Add new jobs" feature need to be updated to try finding the new artifacts and fall back to the old one.

Once enough time has passed after everything changes over and all of the old gzipped artifacts expire, the fallback can be removed.