### PR TITLE
Remove redundant error boundary in WatchedRepo

### DIFF
--- a/ui/job-view/headerbars/WatchedRepo.jsx
+++ b/ui/job-view/headerbars/WatchedRepo.jsx
@@ -53,8 +53,6 @@ export default class WatchedRepo extends React.Component {
         color: 'tree-unavailable',
         btnClass: 'btn-view-nav',
       },
-      hasBoundaryError: false,
-      boundaryError: '',
     };
   }
 
@@ -71,13 +69,6 @@ export default class WatchedRepo extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.treeStatusIntervalId);
-  }
-
-  componentDidCatch(error) {
-    this.setState({
-      hasBoundaryError: true,
-      boundaryError: error,
-    });
   }
 
   updateTreeStatus() {
@@ -102,14 +93,7 @@ export default class WatchedRepo extends React.Component {
 
   render() {
     const { repoName, unwatchRepo, repo } = this.props;
-    const {
-      status,
-      messageOfTheDay,
-      reason,
-      statusInfo,
-      hasBoundaryError,
-      boundaryError,
-    } = this.state;
+    const { status, messageOfTheDay, reason, statusInfo } = this.state;
     const watchedRepo = repo.name;
     const activeClass = watchedRepo === repoName ? 'active' : '';
     const { btnClass, icon, color } = statusInfo;
@@ -117,16 +101,6 @@ export default class WatchedRepo extends React.Component {
     const treeStatusName = TreeStatusModel.getTreeStatusName(watchedRepo);
     const changeRepoUrl = getRepoUrl(watchedRepo);
 
-    if (hasBoundaryError) {
-      return (
-        <span
-          className="btn-view-nav pl-1 pr-1 border-right"
-          title={boundaryError.toString()}
-        >
-          Error getting {watchedRepo} info
-        </span>
-      );
-    }
     return (
       <span className="btn-group">
         <a


### PR DESCRIPTION
This functionality is already covered by the outer ``ErrorBoundary``, so it's redundant.