### PR TITLE
Bug 1512262 - Add link to filter to pushes for current user

### DIFF
--- a/ui/job-view/headerbars/FiltersMenu.jsx
+++ b/ui/job-view/headerbars/FiltersMenu.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { thAllResultStatuses } from '../../helpers/constants';
+import { getJobsUrl } from '../../helpers/url';
 import { withPinnedJobs } from '../context/PinnedJobs';
 import { withSelectedJob } from '../context/SelectedJob';
 import { withPushes } from '../context/Pushes';
@@ -17,6 +18,7 @@ function FiltersMenu(props) {
     getAllShownJobs,
     selectedJob,
     setSelectedJob,
+    user,
   } = props;
   const {
     urlParams: { resultStatus, classifiedState },
@@ -30,6 +32,7 @@ function FiltersMenu(props) {
       setSelectedJob(shownJobs[0]);
     }
   };
+  const { email } = user;
 
   return (
     <span>
@@ -104,6 +107,9 @@ function FiltersMenu(props) {
           >
             Superseded only
           </li>
+          <li title={`Show only pushes for ${email}`} className="dropdown-item">
+            <a href={getJobsUrl({ author: email })}>My pushes only</a>
+          </li>
           <li
             title="Reset to default status filters"
             className="dropdown-item"
@@ -123,6 +129,7 @@ FiltersMenu.propTypes = {
   setSelectedJob: PropTypes.func.isRequired,
   getAllShownJobs: PropTypes.func.isRequired,
   selectedJob: PropTypes.object,
+  user: PropTypes.object.isRequired,
 };
 
 FiltersMenu.defaultProps = {

--- a/ui/job-view/headerbars/PrimaryNavBar.jsx
+++ b/ui/job-view/headerbars/PrimaryNavBar.jsx
@@ -38,7 +38,7 @@ export default function PrimaryNavBar(props) {
               <InfraMenu />
               <ReposMenu repos={repos} />
               <TiersMenu filterModel={filterModel} />
-              <FiltersMenu filterModel={filterModel} />
+              <FiltersMenu filterModel={filterModel} user={user} />
               <HelpMenu />
               <Login user={user} setUser={setUser} />
             </span>


### PR DESCRIPTION
This came up in our brainstorm today and seemed trivial enough to just add it.

I'm not certain this is the right location.  It seemed right, but could possibly go under the ``Login`` menu when the user is logged in?  I'm open to suggestions.  This isn't terribly easy to discover, but adding another button to the navbar just adds that much more clutter.  