### PR TITLE
Fix bad revision message when no revision filter in url

### DIFF
--- a/ui/job-view/pushes/PushLoadErrors.jsx
+++ b/ui/job-view/pushes/PushLoadErrors.jsx
@@ -45,7 +45,7 @@ function PushLoadErrors(props) {
             </span>
           </div>
         )}
-      {!loadingPushes && !isRevision(revision) && currentRepo.url && (
+      {!loadingPushes && revision && !isRevision(revision) && currentRepo.url && (
         <div className="push-body unknown-message-body">
           This is an invalid or unknown revision. Please change it, or click
           <a href={`${uiJobsUrlBase}?${urlParams.toString()}`}> here</a> to


### PR DESCRIPTION
I discovered this when I was filtering on my own email.  I don't have any pushes, but it told me it was "a bad revision" which is clearly not right.  I HAD no revision specified.  So just needed to add that check.