### PR TITLE
Bug 1501984 - Fix too much re-rendering in App for url changes

### DIFF
--- a/ui/helpers/filter.js
+++ b/ui/helpers/filter.js
@@ -60,6 +60,11 @@ export const thFilterDefaults = {
   tier: ['1', '2'],
 };
 
+export const allFilterParams = [
+  ...Object.keys(thFieldChoices),
+  ...Object.keys(thFilterDefaults),
+];
+
 // compare 2 arrays, but ignore order
 export const arraysEqual = function arraysEqual(arr1, arr2) {
   return arr1.length === arr2.length && arr1.every(v => arr2.includes(v));

--- a/ui/job-view/headerbars/PrimaryNavBar.jsx
+++ b/ui/job-view/headerbars/PrimaryNavBar.jsx
@@ -13,50 +13,52 @@ import FiltersMenu from './FiltersMenu';
 import HelpMenu from './HelpMenu';
 import SecondaryNavBar from './SecondaryNavBar';
 
-export default function PrimaryNavBar(props) {
-  const {
-    user,
-    setUser,
-    repos,
-    updateButtonClick,
-    serverChanged,
-    filterModel,
-    setCurrentRepoTreeStatus,
-    duplicateJobsVisible,
-    groupCountsExpanded,
-    toggleFieldFilterVisible,
-  } = props;
+export default class PrimaryNavBar extends React.PureComponent {
+  render() {
+    const {
+      user,
+      setUser,
+      repos,
+      updateButtonClick,
+      serverChanged,
+      filterModel,
+      setCurrentRepoTreeStatus,
+      duplicateJobsVisible,
+      groupCountsExpanded,
+      toggleFieldFilterVisible,
+    } = this.props;
 
-  return (
-    <div id="global-navbar-container">
-      <div id="th-global-top-nav-panel">
-        <nav id="th-global-navbar" className="navbar navbar-dark">
-          <div id="th-global-navbar-top">
-            <LogoMenu menuText="Treeherder" menuImage={Logo} />
-            <span className="navbar-right">
-              <NotificationsMenu />
-              <InfraMenu />
-              <ReposMenu repos={repos} />
-              <TiersMenu filterModel={filterModel} />
-              <FiltersMenu filterModel={filterModel} user={user} />
-              <HelpMenu />
-              <Login user={user} setUser={setUser} />
-            </span>
-          </div>
-          <SecondaryNavBar
-            updateButtonClick={updateButtonClick}
-            serverChanged={serverChanged}
-            filterModel={filterModel}
-            repos={repos}
-            setCurrentRepoTreeStatus={setCurrentRepoTreeStatus}
-            duplicateJobsVisible={duplicateJobsVisible}
-            groupCountsExpanded={groupCountsExpanded}
-            toggleFieldFilterVisible={toggleFieldFilterVisible}
-          />
-        </nav>
+    return (
+      <div id="global-navbar-container">
+        <div id="th-global-top-nav-panel">
+          <nav id="th-global-navbar" className="navbar navbar-dark">
+            <div id="th-global-navbar-top">
+              <LogoMenu menuText="Treeherder" menuImage={Logo} />
+              <span className="navbar-right">
+                <NotificationsMenu />
+                <InfraMenu />
+                <ReposMenu repos={repos} />
+                <TiersMenu filterModel={filterModel} />
+                <FiltersMenu filterModel={filterModel} user={user} />
+                <HelpMenu />
+                <Login user={user} setUser={setUser} />
+              </span>
+            </div>
+            <SecondaryNavBar
+              updateButtonClick={updateButtonClick}
+              serverChanged={serverChanged}
+              filterModel={filterModel}
+              repos={repos}
+              setCurrentRepoTreeStatus={setCurrentRepoTreeStatus}
+              duplicateJobsVisible={duplicateJobsVisible}
+              groupCountsExpanded={groupCountsExpanded}
+              toggleFieldFilterVisible={toggleFieldFilterVisible}
+            />
+          </nav>
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
 }
 
 PrimaryNavBar.propTypes = {

--- a/ui/job-view/headerbars/SecondaryNavBar.jsx
+++ b/ui/job-view/headerbars/SecondaryNavBar.jsx
@@ -18,7 +18,7 @@ const getSearchStrFromUrl = function getSearchStrFromUrl() {
   return searchStr ? searchStr.replace(/,/g, ' ') : '';
 };
 
-class SecondaryNavBar extends React.Component {
+class SecondaryNavBar extends React.PureComponent {
   constructor(props) {
     super(props);
 


### PR DESCRIPTION
This fixes when url changes are made that should not cause re-rendering in the ``App``.  It used to be you could add a url param of ``foo=bar`` and it would cause the page to re-render (the virtual DOM would catch most of it before actual paint, though).  This is pretty unlikely, but it meant that pertinent URL changes that should re-render SOME things are re-rendering ALL things.  ``selectedJob`` is an example.  Changing that param is still re-rendering too much, but we need this fix in before we can address it in the ``selectedJob`` context.