### PR TITLE
Bug 1480166 - Use class fields to avoid bind() calls in App and /headerbars

### DIFF
--- a/ui/job-view/App.jsx
+++ b/ui/job-view/App.jsx
@@ -70,8 +70,6 @@ class App extends React.Component {
       duplicateJobsVisible: urlParams.get('duplicate_jobs') === 'visible',
       showShortCuts: false,
     };
-
-    this.setUser = this.setUser.bind(this);
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -162,9 +160,9 @@ class App extends React.Component {
     };
   }
 
-  setUser(user) {
+  setUser = user => {
     this.setState({ user });
-  }
+  };
 
   setCurrentRepoTreeStatus = status => {
     const link = document.head.querySelector('link[rel="shortcut icon"]');

--- a/ui/job-view/headerbars/ActiveFilters.jsx
+++ b/ui/job-view/headerbars/ActiveFilters.jsx
@@ -23,25 +23,18 @@ export default class ActiveFilters extends React.Component {
     return { fieldChoices };
   }
 
-  componentDidMount() {
-    this.addNewFieldFilter = this.addNewFieldFilter.bind(this);
-    this.setNewFilterValue = this.setNewFilterValue.bind(this);
-    this.setNewFilterField = this.setNewFilterField.bind(this);
-    this.clearNewFieldFilter = this.clearNewFieldFilter.bind(this);
-  }
-
-  setNewFilterField(field) {
+  setNewFilterField = field => {
     const { fieldChoices } = this.state;
     this.setState({
       newFilterField: field,
       newFilterMatchType: fieldChoices[field].matchType,
       newFilterChoices: fieldChoices[field].choices,
     });
-  }
+  };
 
-  setNewFilterValue(value) {
+  setNewFilterValue = value => {
     this.setState({ newFilterValue: value });
-  }
+  };
 
   getFilterValue(field, value) {
     const { fieldChoices } = this.state;
@@ -53,7 +46,7 @@ export default class ActiveFilters extends React.Component {
       : value;
   }
 
-  addNewFieldFilter() {
+  addNewFieldFilter = () => {
     const { filterModel } = this.props;
     const { newFilterField, newFilterValue } = this.state;
 
@@ -61,10 +54,10 @@ export default class ActiveFilters extends React.Component {
       filterModel.addFilter(newFilterField, newFilterValue);
       this.clearNewFieldFilter();
     }
-  }
+  };
 
   // Clear the values and close the input form group
-  clearNewFieldFilter() {
+  clearNewFieldFilter = () => {
     this.setState({
       newFilterField: '',
       newFilterMatchType: '',
@@ -72,7 +65,7 @@ export default class ActiveFilters extends React.Component {
       newFilterChoices: [],
     });
     this.props.toggleFieldFilterVisible();
-  }
+  };
 
   render() {
     const { isFieldFilterVisible, filterModel, filterBarFilters } = this.props;

--- a/ui/job-view/headerbars/SecondaryNavBar.jsx
+++ b/ui/job-view/headerbars/SecondaryNavBar.jsx
@@ -36,14 +36,6 @@ class SecondaryNavBar extends React.Component {
   }
 
   componentDidMount() {
-    this.toggleGroupState = this.toggleGroupState.bind(this);
-    this.toggleUnclassifiedFailures = this.toggleUnclassifiedFailures.bind(
-      this,
-    );
-    this.clearFilterBox = this.clearFilterBox.bind(this);
-    this.unwatchRepo = this.unwatchRepo.bind(this);
-    this.handleUrlChanges = this.handleUrlChanges.bind(this);
-
     window.addEventListener('hashchange', this.handleUrlChanges, false);
     this.loadWatchedRepos();
   }
@@ -56,13 +48,13 @@ class SecondaryNavBar extends React.Component {
     this.setState({ searchQueryStr: ev.target.value });
   }
 
-  handleUrlChanges() {
+  handleUrlChanges = () => {
     this.setState({
       searchQueryStr: getSearchStrFromUrl(),
     });
-  }
+  };
 
-  search(ev) {
+  search = ev => {
     const { filterModel } = this.props;
     const { value } = ev.target;
 
@@ -74,9 +66,9 @@ class SecondaryNavBar extends React.Component {
       }
       ev.target.parentElement.focus();
     }
-  }
+  };
 
-  isFilterOn(filter) {
+  isFilterOn = filter => {
     const { filterModel } = this.props;
     const { resultStatus } = filterModel.urlParams;
 
@@ -84,13 +76,13 @@ class SecondaryNavBar extends React.Component {
       return thFilterGroups[filter].some(val => resultStatus.includes(val));
     }
     return resultStatus.includes(filter);
-  }
+  };
 
   /**
    * Handle toggling one of the individual result status filter chicklets
    * on the nav bar
    */
-  toggleResultStatusFilterChicklet(filter) {
+  toggleResultStatusFilterChicklet = filter => {
     const { filterModel } = this.props;
     const filterValues =
       filter in thFilterGroups
@@ -98,39 +90,39 @@ class SecondaryNavBar extends React.Component {
         : [filter];
 
     filterModel.toggleResultStatuses(filterValues);
-  }
+  };
 
-  toggleShowDuplicateJobs() {
+  toggleShowDuplicateJobs = () => {
     const { duplicateJobsVisible } = this.props;
     const duplicateJobs = duplicateJobsVisible ? null : 'visible';
 
     setUrlParam('duplicate_jobs', duplicateJobs);
-  }
+  };
 
-  toggleGroupState() {
+  toggleGroupState = () => {
     const { groupCountsExpanded } = this.props;
     const groupState = groupCountsExpanded ? null : 'expanded';
 
     setUrlParam('group_state', groupState);
-  }
+  };
 
-  toggleUnclassifiedFailures() {
+  toggleUnclassifiedFailures = () => {
     const { filterModel } = this.props;
 
     filterModel.toggleUnclassifiedFailures();
-  }
+  };
 
-  clearFilterBox() {
+  clearFilterBox = () => {
     const { filterModel } = this.props;
 
     filterModel.removeFilter('searchStr');
-  }
+  };
 
-  unwatchRepo(name) {
+  unwatchRepo = name => {
     const { watchedRepoNames } = this.state;
 
     this.saveWatchedRepos(watchedRepoNames.filter(repo => repo !== name));
-  }
+  };
 
   loadWatchedRepos() {
     const { repoName } = this.state;

--- a/ui/job-view/headerbars/WatchedRepo.jsx
+++ b/ui/job-view/headerbars/WatchedRepo.jsx
@@ -57,8 +57,6 @@ export default class WatchedRepo extends React.Component {
   }
 
   componentDidMount() {
-    this.updateTreeStatus = this.updateTreeStatus.bind(this);
-
     this.updateTreeStatus();
     // update the TreeStatus every 2 minutes
     this.treeStatusIntervalId = setInterval(
@@ -71,7 +69,7 @@ export default class WatchedRepo extends React.Component {
     clearInterval(this.treeStatusIntervalId);
   }
 
-  updateTreeStatus() {
+  updateTreeStatus = () => {
     const { repo, repoName, setCurrentRepoTreeStatus } = this.props;
     const watchedRepoName = repo.name;
 
@@ -89,7 +87,7 @@ export default class WatchedRepo extends React.Component {
         statusInfo: statusInfoMap[treeStatus.status],
       });
     });
-  }
+  };
 
   render() {
     const { repoName, unwatchRepo, repo } = this.props;

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -52,7 +52,7 @@ class Push extends React.Component {
     }
 
     window.addEventListener(thEvents.applyNewJobs, this.handleApplyNewJobs);
-    window.addEventListener('hashchange', this.handleUrlChange);
+    window.addEventListener('hashchange', this.handleUrlChanges);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -61,7 +61,7 @@ class Push extends React.Component {
 
   componentWillUnmount() {
     window.removeEventListener(thEvents.applyNewJobs, this.handleApplyNewJobs);
-    window.removeEventListener('hashchange', this.handleUrlChange);
+    window.removeEventListener('hashchange', this.handleUrlChanges);
   }
 
   getJobCount(jobList) {
@@ -105,7 +105,7 @@ class Push extends React.Component {
     )}`;
   }
 
-  handleUrlChange = () => {
+  handleUrlChanges = () => {
     const { push } = this.props;
     const collapsedPushes = getUrlParam('collapsedPushes') || '';
 


### PR DESCRIPTION
This is the rest of them in ``/job-view``.

And one cleanup, found a function named incorrectly.