### PR TITLE
Bug 1513601 - Fix/enable ESLint 'react/button-has-type'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,6 @@ module.exports = {
     'no-shadow': 'off',
     'no-underscore-dangle': 'off',
     'prefer-promise-reject-errors': 'off',
-    'react/button-has-type': 'off',
     'react/destructuring-assignment': 'off',
     'react/forbid-prop-types': 'off',
     'react/no-access-state-in-setstate': 'off',

--- a/tests/ui/unit/react/groups.tests.jsx
+++ b/tests/ui/unit/react/groups.tests.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jest/prefer-to-have-length */
 import React from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import { mount } from 'enzyme';
@@ -35,14 +36,13 @@ describe('JobGroup component', () => {
         groupCountsExpanded={false}
       />,
     );
-    expect(jobGroup.html()).toEqual(
-      '<span class="platform-group" data-group-key="313281W-e10s1linux64debug"><span class="disabled job-group" title="Web platform tests with e10s">' +
-        '<button class="btn group-symbol">W-e10s</button>' +
-        '<span class="group-content">' +
-        '<span class="group-job-list"><button data-job-id="166315800" title="success | test-linux64/debug-web-platform-tests-reftests-e10s-1 -  (18 mins)" class="btn btn-green filter-shown job-btn btn-xs">Wr1</button></span>' +
-        '<span class="group-count-list"><button class="btn-dkgray-count btn group-btn btn-xs job-group-count filter-shown" title="2 running jobs in group">2</button>' +
-        '</span></span></span></span>',
-    );
+
+    expect(
+      jobGroup
+        .find('.job-group-count')
+        .first()
+        .text(),
+    ).toEqual('2');
   });
 
   it('should show a job and count of 2 when expanded, then re-collapsed', () => {
@@ -60,14 +60,13 @@ describe('JobGroup component', () => {
     );
     jobGroup.setState({ expanded: true });
     jobGroup.setState({ expanded: false });
-    expect(jobGroup.html()).toEqual(
-      '<span class="platform-group" data-group-key="313281W-e10s1linux64debug"><span class="disabled job-group" title="Web platform tests with e10s">' +
-        '<button class="btn group-symbol">W-e10s</button>' +
-        '<span class="group-content">' +
-        '<span class="group-job-list"><button data-job-id="166315800" title="success | test-linux64/debug-web-platform-tests-reftests-e10s-1 -  (18 mins)" class="btn btn-green filter-shown job-btn btn-xs">Wr1</button></span>' +
-        '<span class="group-count-list"><button class="btn-dkgray-count btn group-btn btn-xs job-group-count filter-shown" title="2 running jobs in group">2</button>' +
-        '</span></span></span></span>',
-    );
+
+    expect(
+      jobGroup
+        .find('.job-group-count')
+        .first()
+        .text(),
+    ).toEqual('2');
   });
 
   it('should show jobs, not counts when expanded', () => {
@@ -84,17 +83,9 @@ describe('JobGroup component', () => {
       />,
     );
     jobGroup.setState({ expanded: true });
-    expect(jobGroup.html()).toEqual(
-      '<span class="platform-group" data-group-key="313281W-e10s1linux64debug"><span class="disabled job-group" title="Web platform tests with e10s">' +
-        '<button class="btn group-symbol">W-e10s</button>' +
-        '<span class="group-content">' +
-        '<span class="group-job-list">' +
-        '<button data-job-id="166315799" title="running | test-linux64/debug-web-platform-tests-wdspec-e10s - " class="btn btn-dkgray filter-shown job-btn btn-xs">Wd</button>' +
-        '<button data-job-id="166315800" title="success | test-linux64/debug-web-platform-tests-reftests-e10s-1 -  (18 mins)" class="btn btn-green filter-shown job-btn btn-xs">Wr1</button>' +
-        '<button data-job-id="166315797" title="running | test-linux64/debug-web-platform-tests-e10s-1 - " class="btn btn-dkgray filter-shown job-btn btn-xs">wpt1</button>' +
-        '</span>' +
-        '<span class="group-count-list"></span></span></span></span>',
-    );
+
+    expect(jobGroup.find('.job-group-count').length).toEqual(0);
+    expect(jobGroup.find('.job-btn').length).toEqual(3);
   });
 
   it('should show jobs, not counts when globally expanded', () => {
@@ -112,17 +103,8 @@ describe('JobGroup component', () => {
       />,
     );
 
-    expect(jobGroup.html()).toEqual(
-      '<span class="platform-group" data-group-key="313281W-e10s1linux64debug"><span class="disabled job-group" title="Web platform tests with e10s">' +
-        '<button class="btn group-symbol">W-e10s</button>' +
-        '<span class="group-content">' +
-        '<span class="group-job-list">' +
-        '<button data-job-id="166315799" title="running | test-linux64/debug-web-platform-tests-wdspec-e10s - " class="btn btn-dkgray filter-shown job-btn btn-xs">Wd</button>' +
-        '<button data-job-id="166315800" title="success | test-linux64/debug-web-platform-tests-reftests-e10s-1 -  (18 mins)" class="btn btn-green filter-shown job-btn btn-xs">Wr1</button>' +
-        '<button data-job-id="166315797" title="running | test-linux64/debug-web-platform-tests-e10s-1 - " class="btn btn-dkgray filter-shown job-btn btn-xs">wpt1</button>' +
-        '</span>' +
-        '<span class="group-count-list"></span></span></span></span>',
-    );
+    expect(jobGroup.find('.job-btn').length).toEqual(3);
+    expect(jobGroup.find('.job-group-count').length).toEqual(0);
   });
 
   it('should hide duplicates by default', () => {
@@ -139,16 +121,8 @@ describe('JobGroup component', () => {
       />,
     );
 
-    expect(jobGroup.html()).toEqual(
-      '<span class="platform-group" data-group-key="313293SM1linux64opt"><span class="disabled job-group" title="Spidermonkey builds">' +
-        '<button class="btn group-symbol">SM</button>' +
-        '<span class="group-content"><span class="group-job-list">' +
-        '<button data-job-id="166316707" title="retry | spidermonkey-sm-msan-linux64/opt -  (0 mins)" class="btn btn-dkblue filter-shown job-btn btn-xs">msan</button>' +
-        '</span>' +
-        '<span class="group-count-list">' +
-        '<button class="btn-green-count btn group-btn btn-xs job-group-count filter-shown" title="6 success jobs in group">6</button>' +
-        '</span></span></span></span>',
-    );
+    expect(jobGroup.find('.job-group-count').length).toEqual(1);
+    expect(jobGroup.find('.job-btn').length).toEqual(1);
   });
 
   it('should show 2 duplicates when set to show duplicates', () => {
@@ -166,17 +140,8 @@ describe('JobGroup component', () => {
       />,
     );
 
-    expect(jobGroup.html()).toEqual(
-      '<span class="platform-group" data-group-key="313293SM1linux64opt"><span class="disabled job-group" title="Spidermonkey builds">' +
-        '<button class="btn group-symbol">SM</button>' +
-        '<span class="group-content"><span class="group-job-list">' +
-        '<button data-job-id="166316707" title="retry | spidermonkey-sm-msan-linux64/opt -  (0 mins)" class="btn btn-dkblue filter-shown job-btn btn-xs">msan</button>' +
-        '<button data-job-id="166321182" title="success | spidermonkey-sm-msan-linux64/opt -  (10 mins)" class="btn btn-green filter-shown job-btn btn-xs">msan</button>' +
-        '</span>' +
-        '<span class="group-count-list">' +
-        '<button class="btn-green-count btn group-btn btn-xs job-group-count filter-shown" title="5 success jobs in group">5</button>' +
-        '</span></span></span></span>',
-    );
+    expect(jobGroup.find('.job-group-count').length).toEqual(1);
+    expect(jobGroup.find('.job-btn').length).toEqual(2);
   });
 
   it('should show 2 duplicates when globally set to show duplicates', () => {
@@ -194,16 +159,7 @@ describe('JobGroup component', () => {
       />,
     );
 
-    expect(jobGroup.html()).toEqual(
-      '<span class="platform-group" data-group-key="313293SM1linux64opt"><span class="disabled job-group" title="Spidermonkey builds">' +
-        '<button class="btn group-symbol">SM</button>' +
-        '<span class="group-content"><span class="group-job-list">' +
-        '<button data-job-id="166316707" title="retry | spidermonkey-sm-msan-linux64/opt -  (0 mins)" class="btn btn-dkblue filter-shown job-btn btn-xs">msan</button>' +
-        '<button data-job-id="166321182" title="success | spidermonkey-sm-msan-linux64/opt -  (10 mins)" class="btn btn-green filter-shown job-btn btn-xs">msan</button>' +
-        '</span>' +
-        '<span class="group-count-list">' +
-        '<button class="btn-green-count btn group-btn btn-xs job-group-count filter-shown" title="5 success jobs in group">5</button>' +
-        '</span></span></span></span>',
-    );
+    expect(jobGroup.find('.job-group-count').length).toEqual(1);
+    expect(jobGroup.find('.job-btn').length).toEqual(2);
   });
 });

--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -565,6 +565,7 @@ class PinBoard extends React.Component {
                     ? 'disabled'
                     : ''
                 }`}
+                type="button"
                 title={this.saveUITitle('classification')}
                 onClick={this.save}
               >

--- a/ui/job-view/details/tabs/SimilarJobsTab.jsx
+++ b/ui/job-view/details/tabs/SimilarJobsTab.jsx
@@ -183,6 +183,7 @@ class SimilarJobsTab extends React.Component {
                       className={`btn btn-similar-jobs btn-xs ${button_class(
                         similarJob,
                       )}`}
+                      type="button"
                     >
                       {similarJob.job_type_symbol}
                       {similarJob.failure_classification_id > 1 && (
@@ -210,6 +211,7 @@ class SimilarJobsTab extends React.Component {
           {hasNextPage && (
             <button
               className="btn btn-light-bordered btn-sm link-style"
+              type="button"
               onClick={this.showNext}
             >
               Show previous jobs

--- a/ui/job-view/details/tabs/autoclassify/AutoclassifyToolbar.jsx
+++ b/ui/job-view/details/tabs/autoclassify/AutoclassifyToolbar.jsx
@@ -48,6 +48,7 @@ export default class AutoclassifyToolbar extends React.Component {
 
         <button
           className="btn btn-view-nav btn-sm nav-menu-btn"
+          type="button"
           title="Pin job for bustage"
           onClick={onPin}
         >
@@ -56,6 +57,7 @@ export default class AutoclassifyToolbar extends React.Component {
 
         <button
           className="btn btn-view-nav btn-sm nav-menu-btn"
+          type="button"
           title={this.getButtonTitle(
             hasSelection,
             'Edit selected lines',
@@ -69,6 +71,7 @@ export default class AutoclassifyToolbar extends React.Component {
 
         <button
           className="btn btn-view-nav btn-sm nav-menu-btn"
+          type="button"
           title={this.getButtonTitle(
             hasSelection,
             'Ignore selected lines',
@@ -82,6 +85,7 @@ export default class AutoclassifyToolbar extends React.Component {
 
         <button
           className="btn btn-view-nav btn-sm nav-menu-btn"
+          type="button"
           title={this.getButtonTitle(canSave, 'Save', 'Nothing selected')}
           onClick={onSave}
           disabled={!canSave}
@@ -91,6 +95,7 @@ export default class AutoclassifyToolbar extends React.Component {
 
         <button
           className="btn btn-view-nav btn-sm nav-menu-btn"
+          type="button"
           title={this.getButtonTitle(
             canSaveAll,
             'Save All',

--- a/ui/job-view/details/tabs/autoclassify/LineOption.jsx
+++ b/ui/job-view/details/tabs/autoclassify/LineOption.jsx
@@ -104,6 +104,7 @@ class LineOption extends React.Component {
                 {(!canClassify || selectedJob.id in pinnedJobs) && (
                   <button
                     className="btn btn-xs btn-light-bordered"
+                    type="button"
                     onClick={() =>
                       addBug({ id: option.bugNumber }, selectedJob)
                     }

--- a/ui/job-view/details/tabs/autoclassify/StaticLineOption.jsx
+++ b/ui/job-view/details/tabs/autoclassify/StaticLineOption.jsx
@@ -44,6 +44,7 @@ function StaticLineOption(props) {
           {(!canClassify || selectedJob.id in pinnedJobs) && (
             <button
               className="btn btn-xs btn-light-bordered"
+              type="button"
               onClick={() => addBug({ id: option.bugNumber }, selectedJob)}
               title="add to list of bugs to associate with all pinned jobs"
             >

--- a/ui/job-view/details/tabs/failureSummary/BugListItem.jsx
+++ b/ui/job-view/details/tabs/failureSummary/BugListItem.jsx
@@ -15,6 +15,7 @@ function BugListItem(props) {
     <li>
       <button
         className="btn btn-xs btn-light-bordered"
+        type="button"
         onClick={() => addBug(bug, selectedJob)}
         title="add to list of bugs to associate with all pinned jobs"
       >

--- a/ui/job-view/headerbars/ActiveFilters.jsx
+++ b/ui/job-view/headerbars/ActiveFilters.jsx
@@ -196,7 +196,7 @@ export default class ActiveFilters extends React.Component {
                   add
                 </button>
                 <button
-                  type="reset"
+                  type="button"
                   className="btn btn-light-bordered btn-sm"
                   onClick={this.clearNewFieldFilter}
                 >

--- a/ui/job-view/headerbars/FiltersMenu.jsx
+++ b/ui/job-view/headerbars/FiltersMenu.jsx
@@ -39,6 +39,7 @@ function FiltersMenu(props) {
       <span className="dropdown">
         <button
           id="filterLabel"
+          type="button"
           title="Set filters"
           data-toggle="dropdown"
           className="btn btn-view-nav nav-menu-btn dropdown-toggle"

--- a/ui/job-view/headerbars/HelpMenu.jsx
+++ b/ui/job-view/headerbars/HelpMenu.jsx
@@ -51,6 +51,7 @@ export default function HelpMenu() {
     <span id="help-menu" className="dropdown">
       <button
         id="helpLabel"
+        type="button"
         title="Treeherder help"
         aria-label="Treeherder help"
         data-toggle="dropdown"

--- a/ui/job-view/headerbars/InfraMenu.jsx
+++ b/ui/job-view/headerbars/InfraMenu.jsx
@@ -5,6 +5,7 @@ export default function InfraMenu() {
     <span className="dropdown">
       <button
         id="infraLabel"
+        type="button"
         title="Infrastructure status"
         data-toggle="dropdown"
         className="btn btn-view-nav nav-menu-btn dropdown-toggle"

--- a/ui/job-view/headerbars/NotificationsMenu.jsx
+++ b/ui/job-view/headerbars/NotificationsMenu.jsx
@@ -24,6 +24,7 @@ class NotificationsMenu extends React.Component {
       <span className="dropdown">
         <button
           id="notificationLabel"
+          type="button"
           title="Recent notifications"
           aria-label="Recent notifications"
           data-toggle="dropdown"
@@ -45,6 +46,7 @@ class NotificationsMenu extends React.Component {
             Recent notifications
             {!!storedNotifications.length && (
               <button
+                type="button"
                 className="btn btn-xs btn-light-bordered notification-dropdown-btn"
                 title="Clear all notifications"
                 onClick={clearStoredNotifications}

--- a/ui/job-view/headerbars/ReposMenu.jsx
+++ b/ui/job-view/headerbars/ReposMenu.jsx
@@ -30,6 +30,7 @@ export default function ReposMenu(props) {
       <span className="dropdown">
         <button
           id="repoLabel"
+          type="button"
           title="Watch a repo"
           data-toggle="dropdown"
           className="btn btn-view-nav nav-menu-btn dropdown-toggle"

--- a/ui/job-view/headerbars/WatchedRepo.jsx
+++ b/ui/job-view/headerbars/WatchedRepo.jsx
@@ -121,6 +121,7 @@ export default class WatchedRepo extends React.Component {
         {watchedRepo !== repoName && (
           <button
             className={`watched-repo-unwatch-btn btn btn-sm btn-view-nav ${activeClass}`}
+            type="button"
             onClick={() => unwatchRepo(watchedRepo)}
             title={`Unwatch ${watchedRepo}`}
           >

--- a/ui/job-view/pushes/JobButton.jsx
+++ b/ui/job-view/pushes/JobButton.jsx
@@ -120,7 +120,11 @@ export default class JobButtonComponent extends React.Component {
     }
 
     attributes.className = classes.join(' ');
-    return <button {...attributes}>{job_type_symbol}</button>;
+    return (
+      <button type="button" {...attributes}>
+        {job_type_symbol}
+      </button>
+    );
   }
 }
 

--- a/ui/job-view/pushes/JobCount.jsx
+++ b/ui/job-view/pushes/JobCount.jsx
@@ -9,7 +9,12 @@ export default function JobCount(props) {
   ];
 
   return (
-    <button className={classes.join(' ')} title={title} onClick={onClick}>
+    <button
+      type="button"
+      className={classes.join(' ')}
+      title={title}
+      onClick={onClick}
+    >
       {count}
     </button>
   );

--- a/ui/job-view/pushes/JobGroup.jsx
+++ b/ui/job-view/pushes/JobGroup.jsx
@@ -14,7 +14,7 @@ const GroupSymbol = function GroupSymbol(props) {
   const { symbol, tier, toggleExpanded } = props;
 
   return (
-    <button className="btn group-symbol" onClick={toggleExpanded}>
+    <button type="button" className="btn group-symbol" onClick={toggleExpanded}>
       {symbol}
       {tier !== 1 && <span className="small text-muted">[tier {tier}]</span>}
     </button>

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -243,6 +243,7 @@ class PushHeader extends React.PureComponent {
           <span className="push-buttons">
             {jobCounts.pending + jobCounts.running > 0 && (
               <button
+                type="button"
                 className="btn btn-sm btn-push watch-commit-btn"
                 disabled={!notificationSupported}
                 title={
@@ -267,6 +268,7 @@ class PushHeader extends React.PureComponent {
             </a>
             {isLoggedIn && (
               <button
+                type="button"
                 className="btn btn-sm btn-push cancel-all-jobs-btn"
                 title={cancelJobsTitle}
                 onClick={this.cancelAllJobs}
@@ -275,6 +277,7 @@ class PushHeader extends React.PureComponent {
               </button>
             )}
             <button
+              type="button"
               className="btn btn-sm btn-push pin-all-jobs-btn"
               title="Pin all available jobs in this push"
               aria-label="Pin all available jobs in this push"
@@ -284,6 +287,7 @@ class PushHeader extends React.PureComponent {
             </button>
             {!!selectedRunnableJobs.length && runnableVisible && (
               <button
+                type="button"
                 className="btn btn-sm btn-push trigger-new-jobs-btn"
                 title="Trigger new jobs"
                 onClick={this.triggerNewJobs}

--- a/ui/shared/NotificationList.jsx
+++ b/ui/shared/NotificationList.jsx
@@ -38,6 +38,7 @@ class NotificationList extends React.Component {
               )}
               {notification.sticky && (
                 <button
+                  type="button"
                   onClick={() => removeNotification(idx)}
                   className="close"
                 >

--- a/ui/shared/auth/Login.jsx
+++ b/ui/shared/auth/Login.jsx
@@ -110,6 +110,7 @@ class Login extends React.Component {
           <span className="dropdown">
             <button
               id="logoutLabel"
+              type="button"
               title={`Logged in as: ${user.email}`}
               data-toggle="dropdown"
               className="btn btn-view-nav"

--- a/ui/userguide/UserGuideBody.jsx
+++ b/ui/userguide/UserGuideBody.jsx
@@ -79,7 +79,10 @@ const UserGuideBody = function UserGuideBody() {
                   {notations.map(({ classes, explanation, text }) => (
                     <tr key={classes}>
                       <th className="superseded">
-                        <button className={`btn ug-btn ${classes}`}>
+                        <button
+                          type="button"
+                          className={`btn ug-btn ${classes}`}
+                        >
                           {text || 'Th'}
                         </button>
                       </th>


### PR DESCRIPTION
I'm not quite certain why the type of ``reset`` was flagged by the linter in ``ui/job-view/headerbars/ActiveFilters.jsx``.  But it's kind of irrelevant since this wasn't a real form that we're submitting.  So I just switched it to "button".

Also: The ``JobGroup`` tests were way too brittle.  They broke here, and I've had to update them several times when making html changes.  So this makes them test just what matters.