### PR TITLE
Bug 1364045 - Don't load '@neutrinojs/jest' in production

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -119,7 +119,7 @@ module.exports = {
         patterns: ['ui/contribute.json', 'ui/revision.txt', 'ui/robots.txt'],
       },
     ],
-    '@neutrinojs/jest',
+    process.env.NODE_ENV === 'test' && '@neutrinojs/jest',
     neutrino => {
       neutrino.config
         .plugin('provide')

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 const neutrino = require('neutrino');
 
-process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.NODE_ENV = 'test';
 
 module.exports = neutrino().jest();


### PR DESCRIPTION
Since it's in `devDependencies` so is not installed during deploys.

Fixes:

`Error: Cannot find module '@neutrinojs/jest'`
https://dashboard.heroku.com/apps/treeherder-stage/activity/builds/8228fa8d-0209-43d3-8699-4e6c124b248f