### PR TITLE
Bug 1514720 - Fix ESLint 'Illegal usage of jasmine global' warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "build": "node ./node_modules/webpack/bin/webpack.js --mode production",
     "build:dev": "node ./node_modules/webpack/bin/webpack.js --mode development",
     "heroku-postbuild": "yarn build",
-    "lint": "node ./node_modules/eslint/bin/eslint.js --cache --report-unused-disable-directives --format codeframe --ext js,jsx \".*.js\" \"*.js\" ui/ tests/ui/",
+    "lint": "node ./node_modules/eslint/bin/eslint.js --cache --report-unused-disable-directives --max-warnings 0 --format codeframe --ext js,jsx \".*.js\" \"*.js\" ui/ tests/ui/",
     "start": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --mode development",
     "start:local": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --mode development --env.BACKEND=http://localhost:8000",
     "start:stage": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --mode development --env.BACKEND=https://treeherder.allizom.org",

--- a/tests/ui/unit/context/pushes.tests.jsx
+++ b/tests/ui/unit/context/pushes.tests.jsx
@@ -5,18 +5,17 @@ import { mount } from 'enzyme';
 import { getProjectUrl } from '../../../../ui/helpers/url';
 import { PushesClass } from '../../../../ui/job-view/context/Pushes';
 import FilterModel from '../../../../ui/models/filter';
-
-const { getJSONFixture } = window;
+import pushListFixture from '../../mock/push_list';
+import jobListFixtureOne from '../../mock/job_list/job_1';
+import jobListFixtureTwo from '../../mock/job_list/job_2';
 
 describe('Pushes context', () => {
   const repoName = 'mozilla-inbound';
 
   beforeEach(() => {
-    jasmine.getJSONFixtures().fixturesPath = 'base/tests/ui/mock';
-
     fetchMock.get(
       getProjectUrl('/resultset/?full=true&count=10', repoName),
-      getJSONFixture('push_list.json'),
+      pushListFixture,
     );
 
     fetchMock.get(
@@ -24,7 +23,7 @@ describe('Pushes context', () => {
         '/jobs/?return_type=list&count=2000&result_set_id=1',
         repoName,
       ),
-      getJSONFixture('job_list/job_1.json'),
+      jobListFixtureOne,
     );
 
     fetchMock.get(
@@ -32,7 +31,7 @@ describe('Pushes context', () => {
         '/jobs/?return_type=list&count=2000&result_set_id=2',
         repoName,
       ),
-      getJSONFixture('job_list/job_2.json'),
+      jobListFixtureTwo,
     );
   });
 

--- a/tests/ui/unit/models/jobs.tests.js
+++ b/tests/ui/unit/models/jobs.tests.js
@@ -2,15 +2,12 @@ import * as fetchMock from 'fetch-mock';
 
 import JobModel from '../../../../ui/models/job';
 import { getProjectUrl } from '../../../../ui/helpers/url';
-
-const { getJSONFixture } = window;
+import jobListFixtureOne from '../../mock/job_list/job_1';
+import paginatedJobListFixtureOne from '../../mock/job_list/pagination/page_1';
+import paginatedJobListFixtureTwo from '../../mock/job_list/pagination/page_2';
 
 describe('JobModel', () => {
   const repoName = 'mozilla-inbound';
-
-  beforeEach(() => {
-    jasmine.getJSONFixtures().fixturesPath = 'base/tests/ui/mock';
-  });
 
   afterEach(() => {
     fetchMock.reset();
@@ -18,10 +15,7 @@ describe('JobModel', () => {
 
   describe('getList', () => {
     beforeEach(() => {
-      fetchMock.get(
-        getProjectUrl('/jobs/'),
-        getJSONFixture('job_list/job_1.json'),
-      );
+      fetchMock.get(getProjectUrl('/jobs/'), jobListFixtureOne);
     });
 
     it('should return a promise', () => {
@@ -34,11 +28,11 @@ describe('JobModel', () => {
     beforeEach(() => {
       fetchMock.get(
         getProjectUrl('/jobs/?count=2'),
-        getJSONFixture('job_list/pagination/page_1.json'),
+        paginatedJobListFixtureOne,
       );
       fetchMock.get(
         getProjectUrl('/jobs/?count=2&offset=2'),
-        getJSONFixture('job_list/pagination/page_2.json'),
+        paginatedJobListFixtureTwo,
       );
     });
 

--- a/tests/ui/unit/react/groups.tests.jsx
+++ b/tests/ui/unit/react/groups.tests.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import cloneDeep from 'lodash/cloneDeep';
 import { mount } from 'enzyme';
 
 import { JobGroupComponent } from '../../../../ui/job-view/pushes/JobGroup';
 import FilterModel from '../../../../ui/models/filter';
-
-const { getJSONFixture } = window;
+import mappedGroupFixture from '../../mock/mappedGroup';
+import mappedGroupDupsFixture from '../../mock/mappedGroupDups';
 
 describe('JobGroup component', () => {
   let countGroup;
@@ -14,9 +15,8 @@ describe('JobGroup component', () => {
   const pushGroupState = 'collapsed';
 
   beforeEach(() => {
-    jasmine.getJSONFixtures().fixturesPath = 'base/tests/ui/mock';
-    countGroup = getJSONFixture('mappedGroup.json');
-    dupGroup = getJSONFixture('mappedGroupDups.json');
+    countGroup = cloneDeep(mappedGroupFixture);
+    dupGroup = cloneDeep(mappedGroupDupsFixture);
   });
 
   /*


### PR DESCRIPTION
### 1. Stop using jasmine-jquery JSON fixtures support

Since it's unnecessary given that we now have the ability to import JSON directly, and the current usage is causing ESLint warnings like:

```
warning: Illegal usage of jasmine global (jest/no-jasmine-globals) at tests/ui/unit/context/pushes.tests.jsx:15:5:
  13 |
  14 |   beforeEach(() => {
> 15 |     jasmine.getJSONFixtures().fixturesPath = 'base/tests/ui/mock';
     |     ^
  16 |
  17 |     fetchMock.get(
  18 |       getProjectUrl('/resultset/?full=true&count=10', repoName),
```

This means the only `jasmine-jquery` feature we're now using is the `toHaveLength` matcher, so use of `jasmine-jquery` can be dropped entirely once the tests are migrated to Jest, which supports `toHaveLength` natively.


### 2. Make ESLint warnings fatal when running yarn lint

Since otherwise any rules marked as level `warning` do not cause ESLint to exit with a non-zero exit code.