### PR TITLE
Bug 1512656 - Fix unexpected group count expansion

### DIFF
--- a/ui/helpers/aggregateId.js
+++ b/ui/helpers/aggregateId.js
@@ -12,6 +12,6 @@ export const getPlatformRowId = (
 export const getPushTableId = (repoName, pushId, revision) =>
   escapeId(`${repoName}${pushId}${revision}`);
 
-export const getGroupMapKey = (grSymbol, grTier, plName, plOpt) =>
+export const getGroupMapKey = (pushId, grSymbol, grTier, plName, plOpt) =>
   // Build string key for groupMap entries
-  escapeId(`${grSymbol}${grTier}${plName}${plOpt}`);
+  escapeId(`${pushId}${grSymbol}${grTier}${plName}${plOpt}`);

--- a/ui/job-view/context/SelectedJob.jsx
+++ b/ui/job-view/context/SelectedJob.jsx
@@ -129,14 +129,15 @@ class SelectedJobClass extends React.Component {
       const selected = findSelectedInstance();
       if (selected) selected.setSelected(false);
     }
-    const group = findGroupInstance(job);
-    if (group) {
-      group.setExpanded(true);
-    }
     const newSelectedElement = findJobInstance(job.id, true);
     if (newSelectedElement) {
       newSelectedElement.setSelected(true);
     } else {
+      const group = findGroupInstance(job);
+      if (group) {
+        group.setExpanded(true);
+      }
+
       // If the job is in a group count, then the job element won't exist, but
       // its group will.  We can try scrolling to that.
       const groupEl = findGroupElement(job);


### PR DESCRIPTION
This logic in ``SelectedJob`` was primarily for page load job selection.  But the same code is used when clicking a job to select it.  So now we only expand the group if we can't find the job we're looking for.  It would of course always find the job if the user actually clicked it.

While testing, I hit a bug where it didn't expand the right group.  I realized we didn't have the right number of params in ``getGroupMapKey``.  All the callers had all 5 params, but since the func def only had 4, it was dropping the last item of ``plOpt``. and there were cases where only the ``opt`` was difference, so it picked the first group rather than the correct one.