### PR TITLE
 Perherder compareChooser - remove input validation

### DIFF
--- a/ui/perfherder/SelectorCard.jsx
+++ b/ui/perfherder/SelectorCard.jsx
@@ -89,33 +89,6 @@ export default class SelectorCard extends React.Component {
     }
   };
 
-  validateInput = async value => {
-    const { updateState } = this.props;
-
-    if (value.length < 40 && value !== '') {
-      return this.setState({
-        invalidInput: 'Revision must be at least 40 characters',
-      });
-    }
-
-    if (value.length >= 40) {
-      const url = `${getProjectUrl(
-        pushEndpoint,
-        this.props.selectedRepo,
-      )}${createQueryParams({ revision: value })}`;
-      const { data, failureStatus } = await getData(url);
-
-      if (failureStatus || data.meta.count === 0) {
-        return this.setState({ invalidInput: 'Invalid revision' });
-      }
-      updateState({ disableButton: false });
-    }
-    // reset if value is valid but previous value wasn't
-    if (this.state.invalidInput) {
-      this.setState({ invalidInput: false });
-    }
-  };
-
   updateRevision = value => {
     const { updateState, revisionState } = this.props;
 
@@ -214,10 +187,9 @@ export default class SelectorCard extends React.Component {
                       updateState({
                         [revisionState]: event.target.value,
                         errorMessages: [],
-                        disableButton: true,
+                        disableButton: false,
                       })
                     }
-                    onBlur={event => this.validateInput(event.target.value)}
                     onFocus={() => this.setState({ invalidInput: false })}
                   />
                   <InputGroupButtonDropdown


### PR DESCRIPTION
During testing I found the `validateInput` wasn't working as expected. With the onBlur this function will only be called if you select "something". So if that something is the compare button, it means you have to select it twice to actually navigate (once to validate and reset disableButton, and the second to navigate). This only happens if you paste a valid revision directly into the input. Removing this entirely until I have more time to rework it (it will still show an error message if the New revision input is blank). I also might try to incorporate one of Cam's suggestion (in #4388).