### PR TITLE
Add pyup ignore marker for mysqlclient 1.3.14+

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -77,7 +77,7 @@ newrelic==4.8.0.110 \
 
 # Required by Django
 mysqlclient==1.3.13 \
-    --hash=sha256:ff8ee1be84215e6c30a746b728c41eb0701a46ca76e343af445b35ce6250644f
+    --hash=sha256:ff8ee1be84215e6c30a746b728c41eb0701a46ca76e343af445b35ce6250644f  # pyup: <1.3.14 # Bug 1517253
 
 # Required by celery
 billiard==3.3.0.23 --hash=sha256:692a2a5a55ee39a42bcb7557930e2541da85df9ea81c6e24827f63b80cd39d0b  # pyup: <3.4 # Bug 1337717


### PR DESCRIPTION
Since it's not compatible with Django <2.1 - see:
https://github.com/mozilla/treeherder/pull/4342#issuecomment-444888366

Bug 1517253 is filed for updating it once we're using newer Django.

Closes #4342.