### PR TITLE
Bug 1517264 - Treat wrench jobs as reftests.

### DIFF
--- a/tests/ui/unit/react/bugfiler.tests.jsx
+++ b/tests/ui/unit/react/bugfiler.tests.jsx
@@ -15,6 +15,7 @@ describe('BugFiler', () => {
   const selectedJob = {
     job_group_name: 'Mochitests executed by TaskCluster',
     job_type_name: 'test-linux64/debug-mochitest-browser-chrome-10',
+    job_type_symbol: 'bc10',
   };
   const suggestions = [
     { search: 'ShutdownLeaks | process() called before end of test suite' },

--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -54,8 +54,10 @@ export const getJobBtnClass = function getJobBtnClass(job) {
 };
 
 export const isReftest = function isReftest(job) {
-  return [job.job_group_name, job.job_type_name].some(name =>
-    name.toLowerCase().includes('reftest'),
+  return (
+    [job.job_group_name, job.job_type_name].some(name =>
+      name.toLowerCase().includes('reftest'),
+    ) || job.job_type_symbol.includes('wrench')
   );
 };
 


### PR DESCRIPTION
Wrench jobs are a job type for the standalone WebRender test suite, and
run reftests as part of the job. Having reftest-ish things like the
reftest analyzer links for these jobs is desirable.