### PR TITLE
Don't run preinstall/install/postinstall hooks during yarn install

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -9,5 +9,12 @@ ignore-engines true
 # https://github.com/yarnpkg/yarn/issues/4925
 --*.no-bin-links true
 
+# Don't run preinstall/install/postinstall hooks during yarn install, since:
+#  - most are not actually required
+#  - they often don't work with --no-bin-links (the bin scripts called may not exist)
+#  - they cause Yarn to "unplug" the package when using the "Plug and Play" feature
+#  - it's more secure to not run arbitrary code during package installation
+--ignore-scripts true
+
 # Default to saving the exact package version in package.json and not a tilde version range.
 save-exact true


### PR DESCRIPTION
Since:
- most are not actually required
- they often don't work with --no-bin-links (the bin scripts called may not exist)
- they cause Yarn to "unplug" the package when using the "Plug and Play" feature
- it's more secure to not run arbitrary code during package installation

Fixes the failures seen in #4418.