### PR TITLE
Bug 1514668 - Use shared LogoMenu across IFV and Perfherder

### DIFF
--- a/tests/selenium/pages/base.py
+++ b/tests/selenium/pages/base.py
@@ -14,7 +14,7 @@ class Base(Page):
         _root_locator = (By.ID, 'th-global-navbar')
         _app_menu_locator = (By.ID, 'th-logo')
         _app_logo_locator = (By.CSS_SELECTOR, '#th-logo img')
-        _switch_app_locator = (By.CSS_SELECTOR, '#th-logo + ul > li a')
+        _switch_app_locator = (By.CSS_SELECTOR, '#th-logo + div > button a')
 
         @property
         def active_app(self):

--- a/tests/selenium/pages/base.py
+++ b/tests/selenium/pages/base.py
@@ -14,7 +14,7 @@ class Base(Page):
         _root_locator = (By.ID, 'th-global-navbar')
         _app_menu_locator = (By.ID, 'th-logo')
         _app_logo_locator = (By.CSS_SELECTOR, '#th-logo img')
-        _switch_app_locator = (By.CSS_SELECTOR, '#th-logo + div > button a')
+        _switch_app_locator = (By.CSS_SELECTOR, '#th-logo + div > a')
 
         @property
         def active_app(self):

--- a/ui/intermittent-failures/Navigation.jsx
+++ b/ui/intermittent-failures/Navigation.jsx
@@ -8,6 +8,8 @@ import {
   DropdownToggle,
 } from 'reactstrap';
 
+import LogoMenu from '../shared/LogoMenu';
+
 import DropdownMenuItems from './DropdownMenuItems';
 import { treeOptions } from './constants';
 
@@ -25,7 +27,7 @@ export default class Navigation extends React.Component {
     const { updateState, tree } = this.props;
     return (
       <Navbar expand fixed="top" className="top-navbar">
-        <span className="lightorange">Intermittent Failures View </span>
+        <LogoMenu menuText="Intermittent Failures View" />
         <Collapse isOpen={this.state.isOpen} navbar>
           <Nav navbar />
           <UncontrolledDropdown>

--- a/ui/intermittent-failures/Navigation.jsx
+++ b/ui/intermittent-failures/Navigation.jsx
@@ -27,7 +27,10 @@ export default class Navigation extends React.Component {
     const { updateState, tree } = this.props;
     return (
       <Navbar expand fixed="top" className="top-navbar">
-        <LogoMenu menuText="Intermittent Failures View" />
+        <LogoMenu
+          menuText="Intermittent Failures View"
+          colorClass="lightorange"
+        />
         <Collapse isOpen={this.state.isOpen} navbar>
           <Nav navbar />
           <UncontrolledDropdown>

--- a/ui/intermittent-failures/index.jsx
+++ b/ui/intermittent-failures/index.jsx
@@ -5,6 +5,7 @@ import 'font-awesome/css/font-awesome.css';
 import 'react-table/react-table.css';
 
 import '../css/treeherder-global.css';
+import '../css/treeherder-navbar.css';
 import '../css/intermittent-failures.css';
 import App from './App';
 

--- a/ui/js/perf.js
+++ b/ui/js/perf.js
@@ -6,6 +6,7 @@ import 'ng-text-truncate-2';
 import { react2angular } from 'react2angular/index.es2015';
 
 import Login from '../shared/auth/Login';
+import LogoMenu from '../shared/LogoMenu';
 
 import treeherderModule from './treeherder';
 
@@ -18,5 +19,6 @@ const perf = angular.module('perf', [
 ]);
 
 perf.component('login', react2angular(Login, ['user', 'setUser'], []));
+perf.component('logoMenu', react2angular(LogoMenu, ['menuText'], []));
 
 export default perf;

--- a/ui/perf.html
+++ b/ui/perf.html
@@ -14,17 +14,7 @@
   <nav id="th-global-navbar" class="navbar navbar-inverse" role="navigation" ng-cloak>
     <div id="th-global-navbar-top" class="navbar navbar-collapse">
       <span class="navbar-left">
-        <span class="dropdown">
-          <button id="th-logo"
-                  title="Treeherder services" role="button"
-                  class="btn btn-view-nav dropdown-toggle"
-                  data-toggle="dropdown">Perfherder
-          </button>
-          <ul class="dropdown-menu" role="menu" aria-labelledby="perf-logo">
-            <li><a href="/#/jobs?repo=mozilla-inbound" class="dropdown-item">Treeherder</a></li>
-            <li><a href="/intermittent-failures.html/" class="dropdown-item">Intermittent Failures View</a></li>
-          </ul>
-        </span>
+        <logo-menu menu-text="'Perfherder'"></logo-menu>
         <a ng-class="{active: $state.includes('graphs')}" class="btn btn-view-nav" ui-sref="graphs">Graphs</a>
         <a ng-class="{active: $state.current.name.startsWith('compare')}" class="btn btn-view-nav" ui-sref="comparechooser">Compare</a>
         <a ng-class="{active: $state.current.name.indexOf('alerts') >= 0}" class="btn btn-view-nav" ui-sref="alerts({id: null, status: null, framework: null, filter: null, hideImprovements: null, hideDwnToInv: 1})">Alerts</a>

--- a/ui/perf.html
+++ b/ui/perf.html
@@ -22,6 +22,7 @@
           </button>
           <ul class="dropdown-menu" role="menu" aria-labelledby="perf-logo">
             <li><a href="/#/jobs?repo=mozilla-inbound" class="dropdown-item">Treeherder</a></li>
+            <li><a href="/intermittent-failures.html/" class="dropdown-item">Intermittent Failures View</a></li>
           </ul>
         </span>
         <a ng-class="{active: $state.includes('graphs')}" class="btn btn-view-nav" ui-sref="graphs">Graphs</a>

--- a/ui/shared/LogoMenu.jsx
+++ b/ui/shared/LogoMenu.jsx
@@ -1,39 +1,64 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {
+  ButtonDropdown,
+  DropdownToggle,
+  DropdownMenu,
+  DropdownItem,
+} from 'reactstrap';
 
 const choices = [
   { url: '/', text: 'Treeherder' },
   { url: '/perf.html', text: 'Perfherder' },
-  { url: '/intermittent-failures.html', text: 'Intermittent Failures' },
+  { url: '/intermittent-failures.html', text: 'Intermittent Failures View' },
 ];
 
-export default function LogoMenu(props) {
-  const { menuText, menuImage } = props;
+export default class LogoMenu extends React.Component {
+  constructor(props) {
+    super(props);
 
-  const menuChoices = choices.filter(choice => choice.text !== menuText);
+    this.toggle = this.toggle.bind(this);
+    this.state = {
+      dropdownOpen: false,
+    };
+  }
 
-  return (
-    <span className="dropdown">
-      <button
-        id="th-logo"
-        title="Treeherder services"
-        data-toggle="dropdown"
-        className="btn btn-view-nav dropdown-toggle"
-        type="button"
-      >
-        <img src={menuImage} alt={menuText} />
-      </button>
-      <ul className="dropdown-menu" role="menu" aria-labelledby="th-logo">
-        {menuChoices.map(choice => (
-          <li key={choice.text}>
-            <a href={choice.url} className="dropdown-item">
-              {choice.text}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </span>
-  );
+  toggle() {
+    this.setState({
+      dropdownOpen: !this.state.dropdownOpen,
+    });
+  }
+
+  render() {
+    const { menuText, menuImage } = this.props;
+
+    const menuChoices = choices.filter(choice => choice.text !== menuText);
+    return (
+      <ButtonDropdown isOpen={this.state.dropdownOpen} toggle={this.toggle}>
+        <DropdownToggle
+          className="btn-view-nav"
+          id="th-logo"
+          caret
+          title="Treeherder services"
+        >
+          {menuImage ? (
+            <img src={menuImage} alt={menuText} />
+          ) : (
+            <span className="lightorange">{menuText}</span>
+          )}
+        </DropdownToggle>
+        <DropdownMenu>
+          {menuChoices.map(choice => (
+            <DropdownItem key={choice.text}>
+              <a href={choice.url} className="dropdown-item">
+                {choice.text}
+              </a>
+            </DropdownItem>
+          ))}
+        </DropdownMenu>
+      </ButtonDropdown>
+    );
+  }
 }
 
 LogoMenu.propTypes = {

--- a/ui/shared/LogoMenu.jsx
+++ b/ui/shared/LogoMenu.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  ButtonDropdown,
+  UncontrolledDropdown,
   DropdownToggle,
   DropdownMenu,
   DropdownItem,
@@ -13,28 +13,13 @@ const choices = [
   { url: '/intermittent-failures.html', text: 'Intermittent Failures View' },
 ];
 
-export default class LogoMenu extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.toggle = this.toggle.bind(this);
-    this.state = {
-      dropdownOpen: false,
-    };
-  }
-
-  toggle() {
-    this.setState({
-      dropdownOpen: !this.state.dropdownOpen,
-    });
-  }
-
+export default class LogoMenu extends React.PureComponent {
   render() {
     const { menuText, menuImage, colorClass } = this.props;
 
     const menuChoices = choices.filter(choice => choice.text !== menuText);
     return (
-      <ButtonDropdown isOpen={this.state.dropdownOpen} toggle={this.toggle}>
+      <UncontrolledDropdown>
         <DropdownToggle
           className="btn-view-nav"
           id="th-logo"
@@ -54,7 +39,7 @@ export default class LogoMenu extends React.Component {
             </DropdownItem>
           ))}
         </DropdownMenu>
-      </ButtonDropdown>
+      </UncontrolledDropdown>
     );
   }
 }

--- a/ui/shared/LogoMenu.jsx
+++ b/ui/shared/LogoMenu.jsx
@@ -30,7 +30,7 @@ export default class LogoMenu extends React.Component {
   }
 
   render() {
-    const { menuText, menuImage } = this.props;
+    const { menuText, menuImage, colorClass } = this.props;
 
     const menuChoices = choices.filter(choice => choice.text !== menuText);
     return (
@@ -44,15 +44,13 @@ export default class LogoMenu extends React.Component {
           {menuImage ? (
             <img src={menuImage} alt={menuText} />
           ) : (
-            <span className="lightorange">{menuText}</span>
+            <span className={colorClass}>{menuText}</span>
           )}
         </DropdownToggle>
         <DropdownMenu>
           {menuChoices.map(choice => (
-            <DropdownItem key={choice.text}>
-              <a href={choice.url} className="dropdown-item">
-                {choice.text}
-              </a>
+            <DropdownItem key={choice.text} tag="a" href={choice.url}>
+              {choice.text}
             </DropdownItem>
           ))}
         </DropdownMenu>
@@ -64,8 +62,10 @@ export default class LogoMenu extends React.Component {
 LogoMenu.propTypes = {
   menuText: PropTypes.string.isRequired,
   menuImage: PropTypes.string,
+  colorClass: PropTypes.string,
 };
 
 LogoMenu.defaultProps = {
   menuImage: null,
+  colorClass: 'white',
 };


### PR DESCRIPTION
This ensures consistency between all the apps.  

We converted ``LogoMenu`` to Reactstrap, rather than generic Bootstrap and added its use to IFV.
I had to tweak the Selenium tests and ``LogoMenu`` itself a bit to get the tests working.

Closes #4380.