### PR TITLE
Update to recommonmark 0.5.0

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,12 +5,5 @@
 Sphinx==1.8.3
 sphinx-autobuild==0.7.1
 sphinx-rtd-theme==0.4.2
-# Installing from GitHub since the version on PyPI is 2 years old:
-# https://github.com/rtfd/recommonmark/issues/92
-# ...and we need the fix for:
-# https://github.com/rtfd/recommonmark/issues/51
-# Editable mode is required to force the latest version to be
-# installed, since Read The Docs doesn't use --upgrade and has an
-# older incompatible version of recommonmark pre-installed.
--e git+git://github.com/rtfd/recommonmark.git#egg=recommonmark
+recommonmark==0.5.0
 commonmark==0.8.1


### PR DESCRIPTION
There has finally been a new release of recommonmark, so we no longer need to install directly from its GitHub repository. This also solves the issue of constant cache churn seen on Travis (due to usage of pip editable mode).