### PR TITLE
Bug 1501984 - Fix menu availability on login/out

### DIFF
--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -76,11 +76,17 @@ class PushHeader extends React.Component {
   }
 
   shouldComponentUpdate(prevProps) {
-    const { jobCounts, watchState } = this.props;
+    const {
+      jobCounts: prevJobCounts,
+      watchState: prevWatchState,
+      isLoggedIn: prevIsLoggedIn,
+    } = prevProps;
+    const { jobCounts, watchState, isLoggedIn } = this.props;
 
     return (
-      !isEqual(prevProps.jobCounts, jobCounts) ||
-      prevProps.watchState !== watchState
+      !isEqual(prevJobCounts, jobCounts) ||
+      prevWatchState !== watchState ||
+      prevIsLoggedIn !== isLoggedIn
     );
   }
 


### PR DESCRIPTION
I noticed a small bug with my earlier change.  If you log in or out, the menu availability on "add new jobs", etc does not update.  This fixes that.  I also added destructuring on ``prevProps``