### PR TITLE
Bug 1501984 - Fix use of class-level variables

### DIFF
--- a/ui/job-view/context/Pushes.jsx
+++ b/ui/job-view/context/Pushes.jsx
@@ -37,6 +37,7 @@ export class PushesClass extends React.Component {
     super(props);
 
     this.skipNextPageReload = false;
+    this.cachedReloadTriggerParams = this.getNewReloadTriggerParams();
 
     this.state = {
       pushList: [],
@@ -46,7 +47,6 @@ export class PushesClass extends React.Component {
       loadingPushes: true,
       oldestPushTimestamp: null,
       latestJobTimestamp: null,
-      cachedReloadTriggerParams: this.getNewReloadTriggerParams(),
       allUnclassifiedFailureCount: 0,
       filteredUnclassifiedFailureCount: 0,
     };
@@ -238,23 +238,22 @@ export class PushesClass extends React.Component {
   // is being changed by code in a specific situation as opposed to when
   // the user manually edits the URL location bar.
   handleUrlChanges = () => {
-    const { cachedReloadTriggerParams } = this.state;
     const newReloadTriggerParams = this.getNewReloadTriggerParams();
     // if we are just setting the repo to the default because none was
     // set initially, then don't reload the page.
     const defaulting =
       newReloadTriggerParams.repo === thDefaultRepo &&
-      !cachedReloadTriggerParams.repo;
+      !this.cachedReloadTriggerParams.repo;
 
     if (
       !defaulting &&
-      cachedReloadTriggerParams &&
-      !isEqual(newReloadTriggerParams, cachedReloadTriggerParams) &&
+      this.cachedReloadTriggerParams &&
+      !isEqual(newReloadTriggerParams, this.cachedReloadTriggerParams) &&
       !this.skipNextPageReload
     ) {
       window.location.reload();
     } else {
-      this.setState({ cachedReloadTriggerParams: newReloadTriggerParams });
+      this.cachedReloadTriggerParams = newReloadTriggerParams;
     }
 
     this.skipNextPageReload = false;

--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -8,20 +8,18 @@ import PushModel from '../../models/push';
 import { withPushes } from '../context/Pushes';
 import { withNotifications } from '../../shared/context/Notifications';
 
+// Trigger missing jobs is dangerous on repos other than these (see bug 1335506)
+const triggerMissingRepos = ['mozilla-inbound', 'autoland'];
+
 class PushActionMenu extends React.PureComponent {
   constructor(props) {
     super(props);
 
-    this.revision = this.props.revision;
-    this.pushId = this.props.pushId;
-    this.repoName = this.props.repoName;
-
-    // Trigger missing jobs is dangerous on repos other than these (see bug 1335506)
-    this.triggerMissingRepos = ['mozilla-inbound', 'autoland'];
+    const { revision } = this.props;
 
     this.state = {
-      topOfRangeUrl: this.getRangeChangeUrl('tochange', this.revision),
-      bottomOfRangeUrl: this.getRangeChangeUrl('fromchange', this.revision),
+      topOfRangeUrl: this.getRangeChangeUrl('tochange', revision),
+      bottomOfRangeUrl: this.getRangeChangeUrl('fromchange', revision),
       customJobActionsShowing: false,
     };
   }
@@ -42,26 +40,26 @@ class PushActionMenu extends React.PureComponent {
   }
 
   handleUrlChanges = () => {
+    const { revision } = this.props;
+
     this.setState({
-      topOfRangeUrl: this.getRangeChangeUrl('tochange', this.revision),
-      bottomOfRangeUrl: this.getRangeChangeUrl('fromchange', this.revision),
+      topOfRangeUrl: this.getRangeChangeUrl('tochange', revision),
+      bottomOfRangeUrl: this.getRangeChangeUrl('fromchange', revision),
     });
   };
 
   triggerMissingJobs = () => {
-    const { getGeckoDecisionTaskId, notify } = this.props;
+    const { getGeckoDecisionTaskId, notify, revision, pushId } = this.props;
 
     if (
       !window.confirm(
-        `This will trigger all missing jobs for revision ${
-          this.revision
-        }!\n\nClick "OK" if you want to proceed.`,
+        `This will trigger all missing jobs for revision ${revision}!\n\nClick "OK" if you want to proceed.`,
       )
     ) {
       return;
     }
 
-    getGeckoDecisionTaskId(this.pushId)
+    getGeckoDecisionTaskId(pushId)
       .then(decisionTaskID => {
         PushModel.triggerMissingJobs(decisionTaskID)
           .then(msg => {
@@ -77,13 +75,11 @@ class PushActionMenu extends React.PureComponent {
   };
 
   triggerAllTalosJobs = () => {
-    const { getGeckoDecisionTaskId, notify } = this.props;
+    const { getGeckoDecisionTaskId, notify, revision, pushId } = this.props;
 
     if (
       !window.confirm(
-        `This will trigger all Talos jobs for revision  ${
-          this.revision
-        }!\n\nClick "OK" if you want to proceed.`,
+        `This will trigger all Talos jobs for revision  ${revision}!\n\nClick "OK" if you want to proceed.`,
       )
     ) {
       return;
@@ -100,7 +96,7 @@ class PushActionMenu extends React.PureComponent {
       );
     }
 
-    getGeckoDecisionTaskId(this.pushId)
+    getGeckoDecisionTaskId(pushId)
       .then(decisionTaskID => {
         PushModel.triggerAllTalosJobs(times, decisionTaskID)
           .then(msg => {
@@ -173,7 +169,7 @@ class PushActionMenu extends React.PureComponent {
               Add new jobs
             </li>
           )}
-          {this.triggerMissingRepos.includes(repoName) && (
+          {triggerMissingRepos.includes(repoName) && (
             <li
               title={
                 isLoggedIn


### PR DESCRIPTION
For ``PushActionMenu``, we were using class variables to cache props.
I'm not sure why I did that back in February, but this corrects it.

For ``Pushes`` context, this stores the cache of ``cachedReloadTriggerParams``
in a class variable instead of the state.  State changes should be for
changes that affect what's displayed in the UI.  But this variable is not
shown in the UI.  It's used to determine whether or not to reload the
page based on certain URL params changing.  So this change saves having
to add a ``shouldComponentUpdate`` check where it's not otherwise needed.