### PR TITLE
Bug 1514668 - Fix perfherder navbar layout with bootstrap

### DIFF
--- a/ui/perf.html
+++ b/ui/perf.html
@@ -13,7 +13,7 @@
 <body>
   <nav id="th-global-navbar" class="navbar navbar-inverse" role="navigation" ng-cloak>
     <div id="th-global-navbar-top" class="navbar navbar-collapse">
-      <span class="navbar-left">
+      <span class="navbar-left d-flex">
         <logo-menu menu-text="'Perfherder'"></logo-menu>
         <a ng-class="{active: $state.includes('graphs')}" class="btn btn-view-nav" ui-sref="graphs">Graphs</a>
         <a ng-class="{active: $state.current.name.startsWith('compare')}" class="btn btn-view-nav" ui-sref="comparechooser">Compare</a>


### PR DESCRIPTION
This fixes how the ``LogoMenu`` is laid out with the rest of the Perfherder navbar.  I didn't notice this before merge.  It may be that the branch wasn't up-to-date with the latest bootstrap or some other change.  So when it got rebased, they didn't play well together.  Anyway, here's the easy-fix.  :)