### PR TITLE
Bug 1493833 - Fix ESLint errors with import/no-cycle

### DIFF
--- a/tests/ui/unit/context/pushes.tests.jsx
+++ b/tests/ui/unit/context/pushes.tests.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import * as fetchMock from 'fetch-mock';
 import { mount } from 'enzyme';
 
-import { getProjectUrl } from '../../../../ui/helpers/url';
+import { getProjectUrl } from '../../../../ui/helpers/location';
 import { PushesClass } from '../../../../ui/job-view/context/Pushes';
 import FilterModel from '../../../../ui/models/filter';
 import pushListFixture from '../../mock/push_list';

--- a/tests/ui/unit/models/jobs.tests.js
+++ b/tests/ui/unit/models/jobs.tests.js
@@ -1,7 +1,7 @@
 import * as fetchMock from 'fetch-mock';
 
 import JobModel from '../../../../ui/models/job';
-import { getProjectUrl } from '../../../../ui/helpers/url';
+import { getProjectUrl } from '../../../../ui/helpers/location';
 import jobListFixtureOne from '../../mock/job_list/job_1';
 import paginatedJobListFixtureOne from '../../mock/job_list/pagination/page_1';
 import paginatedJobListFixtureTwo from '../../mock/job_list/pagination/page_2';

--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -2,6 +2,8 @@ import $ from 'jquery';
 
 import { thFailureResults, thPlatformMap } from './constants';
 import { getGroupMapKey } from './aggregateId';
+import { getAllUrlParams } from './location';
+import { uiJobsUrlBase } from './url';
 
 const btnClasses = {
   busted: 'btn-red',
@@ -190,6 +192,13 @@ export const getSearchStr = function getSearchStr(job) {
     .filter(item => typeof item !== 'undefined')
     .join(' ')
     .toLowerCase();
+};
+
+export const getJobSearchStrHref = function getJobSearchStrHref(jobSearchStr) {
+  const params = getAllUrlParams();
+  params.set('searchStr', jobSearchStr.split(' '));
+
+  return `${uiJobsUrlBase}?${params.toString()}`;
 };
 
 export const getHoverText = function getHoverText(job) {

--- a/ui/helpers/location.js
+++ b/ui/helpers/location.js
@@ -1,5 +1,5 @@
 import { thDefaultRepo } from './constants';
-import { createQueryParams } from './url';
+import { createQueryParams, getApiUrl, uiJobsUrlBase } from './url';
 
 export const getQueryString = function getQueryString() {
   return window.location.hash.split('?')[1];
@@ -34,4 +34,28 @@ export const setUrlParam = function setUrlParam(
     params.delete(field);
   }
   setLocation(params, hashPrefix);
+};
+
+export const getRepoUrl = function getRepoUrl(newRepoName) {
+  const params = getAllUrlParams();
+
+  params.delete('selectedJob');
+  params.delete('fromchange');
+  params.delete('tochange');
+  params.delete('revision');
+  params.set('repo', newRepoName);
+  return `${uiJobsUrlBase}?${params.toString()}`;
+};
+
+// Take the repoName, if passed in.  If not, then try to find it on the
+// URL.  If not there, then try m-i and hope for the best.  The caller may
+// not actually need a repo if they're trying to get a job by ``id``.
+export const getProjectUrl = function getProjectUrl(uri, repoName) {
+  const repo = repoName || getRepo();
+
+  return getApiUrl(`/project/${repo}${uri}`);
+};
+
+export const getProjectJobUrl = function getProjectJobUrl(url, jobId) {
+  return getProjectUrl(`/jobs/${jobId}${url}`);
 };

--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -1,5 +1,3 @@
-import { getAllUrlParams, getRepo } from './location';
-
 export const uiJobsUrlBase = '/#/jobs';
 
 export const bzBaseUrl = 'https://bugzilla.mozilla.org/';
@@ -79,26 +77,6 @@ export const getPerfAnalysisUrl = function getPerfAnalysisUrl(url) {
   return `https://perf-html.io/from-url/${encodeURIComponent(url)}`;
 };
 
-// Take the repoName, if passed in.  If not, then try to find it on the
-// URL.  If not there, then try m-i and hope for the best.  The caller may
-// not actually need a repo if they're trying to get a job by ``id``.
-export const getProjectUrl = function getProjectUrl(uri, repoName) {
-  const repo = repoName || getRepo();
-
-  return getApiUrl(`/project/${repo}${uri}`);
-};
-
-export const getProjectJobUrl = function getProjectJobUrl(url, jobId) {
-  return getProjectUrl(`/jobs/${jobId}${url}`);
-};
-
-export const getJobSearchStrHref = function getJobSearchStrHref(jobSearchStr) {
-  const params = getAllUrlParams();
-  params.set('searchStr', jobSearchStr.split(' '));
-
-  return `${uiJobsUrlBase}?${params.toString()}`;
-};
-
 // This takes a plain object, rather than a URLSearchParams object.
 export const getJobsUrl = function getJobsUrl(params) {
   return `${uiJobsUrlBase}${createQueryParams(params)}`;
@@ -127,15 +105,4 @@ export const createApiUrl = function createApiUrl(api, params) {
 export const bugzillaBugsApi = function bugzillaBugsApi(api, params) {
   const query = createQueryParams(params);
   return `${bzBaseUrl}rest/${api}${query}`;
-};
-
-export const getRepoUrl = function getRepoUrl(newRepoName) {
-  const params = getAllUrlParams();
-
-  params.delete('selectedJob');
-  params.delete('fromchange');
-  params.delete('tochange');
-  params.delete('revision');
-  params.set('repo', newRepoName);
-  return `${uiJobsUrlBase}?${params.toString()}`;
 };

--- a/ui/job-view/details/tabs/autoclassify/AutoclassifyTab.jsx
+++ b/ui/job-view/details/tabs/autoclassify/AutoclassifyTab.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { thEvents } from '../../../../helpers/constants';
-import { getProjectJobUrl } from '../../../../helpers/url';
+import { getProjectJobUrl } from '../../../../helpers/location';
 import TextLogErrorsModel from '../../../../models/textLogErrors';
 import { withSelectedJob } from '../../../context/SelectedJob';
 import { withPinnedJobs } from '../../../context/PinnedJobs';

--- a/ui/job-view/headerbars/ReposMenu.jsx
+++ b/ui/job-view/headerbars/ReposMenu.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { getRepoUrl } from '../../helpers/url';
+import { getRepoUrl } from '../../helpers/location';
 
 const GROUP_ORDER = [
   'development',

--- a/ui/job-view/headerbars/WatchedRepo.jsx
+++ b/ui/job-view/headerbars/WatchedRepo.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import TreeStatusModel from '../../models/treeStatus';
 import BugLinkify from '../../shared/BugLinkify';
-import { getRepoUrl } from '../../helpers/url';
+import { getRepoUrl } from '../../helpers/location';
 
 const statusInfoMap = {
   open: {

--- a/ui/models/bugJobMap.js
+++ b/ui/models/bugJobMap.js
@@ -1,5 +1,6 @@
-import { createQueryParams, getProjectUrl } from '../helpers/url';
+import { createQueryParams } from '../helpers/url';
 import { destroy, create } from '../helpers/http';
+import { getProjectUrl } from '../helpers/location';
 
 const uri = getProjectUrl('/bug-job-map/');
 

--- a/ui/models/bugSuggestions.js
+++ b/ui/models/bugSuggestions.js
@@ -1,4 +1,4 @@
-import { getProjectJobUrl } from '../helpers/url';
+import { getProjectJobUrl } from '../helpers/location';
 
 export default class BugSuggestionsModel {
   static get(jobId) {

--- a/ui/models/classification.js
+++ b/ui/models/classification.js
@@ -1,5 +1,6 @@
-import { createQueryParams, getProjectUrl } from '../helpers/url';
 import { destroy, create } from '../helpers/http';
+import { getProjectUrl } from '../helpers/location';
+import { createQueryParams } from '../helpers/url';
 
 const uri = getProjectUrl('/note/');
 

--- a/ui/models/job.js
+++ b/ui/models/job.js
@@ -1,6 +1,7 @@
 import { thPlatformMap } from '../helpers/constants';
-import { createQueryParams, getProjectUrl } from '../helpers/url';
+import { createQueryParams } from '../helpers/url';
 import { formatTaskclusterError } from '../helpers/errorMessage';
+import { getProjectUrl } from '../helpers/location';
 
 import TaskclusterModel from './taskcluster';
 

--- a/ui/models/jobLogUrl.js
+++ b/ui/models/jobLogUrl.js
@@ -1,4 +1,5 @@
-import { createQueryParams, getProjectUrl } from '../helpers/url';
+import { getProjectUrl } from '../helpers/location';
+import { createQueryParams } from '../helpers/url';
 
 const uri = getProjectUrl('/job-log-url/');
 

--- a/ui/models/perfSeries.js
+++ b/ui/models/perfSeries.js
@@ -1,6 +1,7 @@
 import queryString from 'query-string';
 
-import { getApiUrl, getProjectUrl } from '../helpers/url';
+import { getProjectUrl } from '../helpers/location';
+import { getApiUrl } from '../helpers/url';
 
 import OptionCollectionModel from './optionCollection';
 

--- a/ui/models/push.js
+++ b/ui/models/push.js
@@ -1,9 +1,9 @@
 import { slugid } from 'taskcluster-client-web';
 
 import { thMaxPushFetchSize } from '../helpers/constants';
-import { getUrlParam } from '../helpers/location';
+import { getProjectUrl, getUrlParam } from '../helpers/location';
 import taskcluster from '../helpers/taskcluster';
-import { createQueryParams, getProjectUrl, pushEndpoint } from '../helpers/url';
+import { createQueryParams, pushEndpoint } from '../helpers/url';
 
 import JobModel from './job';
 import TaskclusterModel from './taskcluster';

--- a/ui/models/runnableJob.js
+++ b/ui/models/runnableJob.js
@@ -1,4 +1,5 @@
-import { getProjectUrl, getRunnableJobsURL } from '../helpers/url';
+import { getProjectUrl } from '../helpers/location';
+import { getRunnableJobsURL } from '../helpers/url';
 import { escapeId } from '../helpers/aggregateId';
 
 import JobModel from './job';

--- a/ui/models/textLogStep.js
+++ b/ui/models/textLogStep.js
@@ -1,4 +1,4 @@
-import { getProjectJobUrl } from '../helpers/url';
+import { getProjectJobUrl } from '../helpers/location';
 
 export default class TextLogStepModel {
   static get(jobId) {

--- a/ui/perfherder/CompareSelectorView.jsx
+++ b/ui/perfherder/CompareSelectorView.jsx
@@ -7,7 +7,6 @@ import perf from '../js/perf';
 import {
   getApiUrl,
   repoEndpoint,
-  getProjectUrl,
   createQueryParams,
   pushEndpoint,
 } from '../helpers/url';
@@ -18,6 +17,7 @@ import {
   genericErrorMessage,
   errorMessageClass,
 } from '../helpers/constants';
+import { getProjectUrl } from '../helpers/location';
 import ErrorBoundary from '../shared/ErrorBoundary';
 
 import SelectorCard from './SelectorCard';

--- a/ui/perfherder/SelectorCard.jsx
+++ b/ui/perfherder/SelectorCard.jsx
@@ -19,9 +19,10 @@ import {
   InputGroupButtonDropdown,
 } from 'reactstrap';
 
-import { getProjectUrl, createQueryParams, pushEndpoint } from '../helpers/url';
+import { createQueryParams, pushEndpoint } from '../helpers/url';
 import { getData } from '../helpers/http';
 import { genericErrorMessage } from '../helpers/constants';
+import { getProjectUrl } from '../helpers/location';
 
 export default class SelectorCard extends React.Component {
   constructor(props) {

--- a/ui/shared/JobInfo.jsx
+++ b/ui/shared/JobInfo.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { getInspectTaskUrl, getJobSearchStrHref } from '../helpers/url';
-import { getSearchStr } from '../helpers/job';
+import { getInspectTaskUrl } from '../helpers/url';
+import { getSearchStr, getJobSearchStrHref } from '../helpers/job';
 import { toDateStr } from '../helpers/display';
 
 const getTimeFields = function getTimeFields(job) {

--- a/ui/test-view/redux/configureStore.js
+++ b/ui/test-view/redux/configureStore.js
@@ -8,7 +8,8 @@ import createHistory from 'history/createBrowserHistory';
 import createDebounce from 'redux-debounce';
 
 import { thPlatformMap } from '../../helpers/constants';
-import { getServiceUrl, getProjectUrl } from '../../helpers/url';
+import { getProjectUrl } from '../../helpers/location';
+import { getServiceUrl } from '../../helpers/url';
 
 import * as groupsStore from './modules/groups';
 


### PR DESCRIPTION
This really only required moving a handful of functions from ``helpers/url`` to ``helpers/location`` and then one to ``helpers/job``.  But since they were imported in so many places, it makes for a lot of noise.