### PR TITLE
Bug 1519573 - Add Perfherder compareChooser input validation

### DIFF
--- a/ui/perfherder/CompareSelectorView.jsx
+++ b/ui/perfherder/CompareSelectorView.jsx
@@ -12,7 +12,6 @@ import {
   genericErrorMessage,
   errorMessageClass,
 } from '../helpers/constants';
-import { getProjectUrl } from '../helpers/location';
 import ErrorBoundary from '../shared/ErrorBoundary';
 
 import SelectorCard from './SelectorCard';

--- a/ui/perfherder/CompareSelectorView.jsx
+++ b/ui/perfherder/CompareSelectorView.jsx
@@ -4,12 +4,7 @@ import { react2angular } from 'react2angular/index.es2015';
 import { Container, Col, Row, Button } from 'reactstrap';
 
 import perf from '../js/perf';
-import {
-  getApiUrl,
-  repoEndpoint,
-  createQueryParams,
-  pushEndpoint,
-} from '../helpers/url';
+import { getApiUrl, repoEndpoint } from '../helpers/url';
 import { getData } from '../helpers/http';
 import ErrorMessages from '../shared/ErrorMessages';
 import {
@@ -26,108 +21,24 @@ import SelectorCard from './SelectorCard';
 export default class CompareSelectorView extends React.Component {
   constructor(props) {
     super(props);
-
+    this.queryParams = this.props.$stateParams;
     this.state = {
       projects: [],
       failureStatus: null,
-      originalProject: 'mozilla-central',
-      newProject: 'try',
-      originalRevision: '',
-      newRevision: '',
+      originalProject: this.queryParams.originalProject || 'mozilla-central',
+      newProject: this.queryParams.newProject || 'try',
+      originalRevision: this.queryParams.originalRevision || '',
+      newRevision: this.queryParams.newRevision || '',
       errorMessages: [],
       disableButton: true,
+      missingRevision: false,
     };
   }
 
   async componentDidMount() {
     const { data, failureStatus } = await getData(getApiUrl(repoEndpoint));
     this.setState({ projects: data, failureStatus });
-    this.validateQueryParams();
   }
-
-  validateQueryParams = () => {
-    const {
-      originalProject,
-      newProject,
-      originalRevision,
-      newRevision,
-    } = this.props.$stateParams;
-
-    const { errorMessages } = this.state;
-
-    // reset
-    if (errorMessages.length > 0) {
-      this.setState({ errorMessages: [] });
-    }
-
-    if (originalProject) {
-      this.validateProject('originalProject', originalProject);
-    }
-
-    if (newProject) {
-      this.validateProject('newProject', newProject);
-    }
-
-    if (newRevision) {
-      this.validateRevision(
-        'newRevision',
-        newRevision,
-        newProject || this.state.newProject,
-      );
-    }
-
-    if (originalRevision) {
-      this.validateRevision(
-        'originalRevision',
-        originalRevision,
-        originalProject || this.state.originalProject,
-      );
-    }
-
-    if (errorMessages.length === 0) {
-      this.setState({ disableButton: false });
-    }
-  };
-
-  validateProject = (projectName, project) => {
-    const { projects, errorMessages } = this.state;
-    let updates = {};
-    const validProject = projects.find(item => item.name === project);
-
-    if (validProject) {
-      updates = { [projectName]: project };
-    } else {
-      updates = {
-        errorMessages: [
-          ...errorMessages,
-          `${projectName} must be a valid project.`,
-        ],
-      };
-    }
-    this.setState(updates);
-  };
-
-  validateRevision = async (revisionName, revision, project) => {
-    const { errorMessages } = this.state;
-    let updates = {};
-
-    const url = `${getProjectUrl(pushEndpoint, project)}${createQueryParams({
-      revision,
-    })}`;
-    const { data, failureStatus } = await getData(url);
-
-    if (failureStatus || data.meta.count === 0) {
-      updates = {
-        errorMessages: [
-          ...errorMessages,
-          `${revisionName} must be a valid revision.`,
-        ],
-      };
-    } else {
-      updates = { [revisionName]: revision };
-    }
-    this.setState(updates);
-  };
 
   submitData = () => {
     const {
@@ -139,7 +50,7 @@ export default class CompareSelectorView extends React.Component {
     const { $state } = this.props;
 
     if (newRevision === '') {
-      return this.setState({ errorMessages: ['New revision is required'] });
+      return this.setState({ missingRevision: 'Revision is required' });
     }
 
     if (originalRevision !== '') {
@@ -170,7 +81,9 @@ export default class CompareSelectorView extends React.Component {
       failureStatus,
       errorMessages,
       disableButton,
+      missingRevision,
     } = this.state;
+
     return (
       <Container
         fluid
@@ -192,29 +105,34 @@ export default class CompareSelectorView extends React.Component {
                 )}
               </Col>
             </Row>
-            <Row className="justify-content-center">
-              <SelectorCard
-                projects={projects}
-                updateState={updates => this.setState(updates)}
-                selectedRepo={originalProject}
-                title="Base"
-                checkbox
-                text="By default, Perfherder will compare against performance data gathered over the last 2 days from when new revision was pushed"
-                projectState="originalProject"
-                revisionState="originalRevision"
-                selectedRevision={originalRevision}
-                queryParam={this.props.$stateParams.originalRevision}
-              />
-              <SelectorCard
-                projects={projects}
-                updateState={updates => this.setState(updates)}
-                selectedRepo={newProject}
-                title="New"
-                projectState="newProject"
-                revisionState="newRevision"
-                selectedRevision={newRevision}
-              />
-            </Row>
+            {projects.length > 0 && (
+              <Row className="justify-content-center">
+                <SelectorCard
+                  projects={projects}
+                  updateState={updates => this.setState(updates)}
+                  selectedRepo={originalProject}
+                  title="Base"
+                  checkbox
+                  text="By default, Perfherder will compare against performance data gathered over the last 2 days from when new revision was pushed"
+                  projectState="originalProject"
+                  revisionState="originalRevision"
+                  selectedRevision={originalRevision}
+                  queryParam={this.props.$stateParams.originalRevision}
+                  errorMessages={errorMessages}
+                />
+                <SelectorCard
+                  projects={projects}
+                  updateState={updates => this.setState(updates)}
+                  selectedRepo={newProject}
+                  title="New"
+                  projectState="newProject"
+                  revisionState="newRevision"
+                  selectedRevision={newRevision}
+                  errorMessages={errorMessages}
+                  missingRevision={missingRevision}
+                />
+              </Row>
+            )}
             <Row className="justify-content-center">
               <Col sm="8" className="text-right px-1">
                 <Button

--- a/ui/perfherder/SelectorCard.jsx
+++ b/ui/perfherder/SelectorCard.jsx
@@ -102,6 +102,9 @@ export default class SelectorCard extends React.Component {
 
   updateRevisions = selectedRepo => {
     const { updateState, projectState } = this.props;
+    // reset invalidProject from query param validation
+    // in case user resets project via dropdown instead
+    // of updating the query param
     if (this.state.invalidProject) {
       this.setState({ invalidProject: false });
     }


### PR DESCRIPTION
Add improved input validation back to selectorCard component and move query param validation to selectorCard

Tested locally... tried as many different combinations of interactions as I could think of. Let me know if I've missed something.

## Notes
- I had to remove the input validation in #4390 because the behavior was not right. This pr replaces the onBlur with onChange and adds validation back in.
- Other improvements to the validation include adding a 'validating...' message and using the new bootstrap `valid` prop to show when a revision has been validated (only occurs when a user pastes in a revision, pastes in a revision and then selects another project/repo, or uses the newRevision or originalRevision query params). The lack of this information has resulted in confusion for the user (@wlach brought this to my attention).
- I've decided to let the selectorCard handle validation of all inputs - including those passed in as props, such as query params. This deleted some duplicate data fetches to verify revisions and made the user messages consistent
- I know there's a lot going on here... renamed a few things to (hopefully) make it clearer