### PR TITLE
Perfherder - change comparesubtests url to use signature id

### DIFF
--- a/ui/partials/perf/graphsctrl.html
+++ b/ui/partials/perf/graphsctrl.html
@@ -94,7 +94,7 @@
               ng-if="nudgingAlert"></span>
           </button>
           <span ng-show="tooltipContent.prevRevision && tooltipContent.revision">
-            (<span ng-if="tooltipContent.jobId"><a id="tt-cset" ng-href="{{tooltipContent.revision | getRevisionUrl:tooltipContent.project.name}}&selectedJob={{tooltipContent.jobId}}&group_state=expanded" target="_blank" rel="noopener">job</a>, </span><a ng-href="#/comparesubtest?originalProject={{tooltipContent.project.name}}&newProject={{tooltipContent.project.name}}&originalRevision={{tooltipContent.prevRevision}}&newRevision={{tooltipContent.revision}}&originalSignature={{selectedDataPoint.signature}}&newSignature={{selectedDataPoint.signature}}&framework={{selectedDataPoint.frameworkId}}" target="_blank" rel="noopener">compare</a>)
+            (<span ng-if="tooltipContent.jobId"><a id="tt-cset" ng-href="{{tooltipContent.revision | getRevisionUrl:tooltipContent.project.name}}&selectedJob={{tooltipContent.jobId}}&group_state=expanded" target="_blank" rel="noopener">job</a>, </span><a ng-href="#/comparesubtest?originalProject={{tooltipContent.project.name}}&newProject={{tooltipContent.project.name}}&originalRevision={{tooltipContent.prevRevision}}&newRevision={{tooltipContent.revision}}&originalSignature={{selectedDataPoint.signatureId}}&newSignature={{selectedDataPoint.signatureId}}&framework={{selectedDataPoint.frameworkId}}" target="_blank" rel="noopener">compare</a>)
           </span>
         </p>
         <p ng-if="tooltipContent.alertSummary">

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -382,7 +382,6 @@ export const getGraphsURL = (
 
 export const getSubtestsURL = (alert, alertSummary) => {
   const endpoint = '#/comparesubtest';
-
   const urlParameters = {
     framework: alertSummary.framework,
     originalProject: alertSummary.repository,

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -338,6 +338,8 @@ export const getGraphsLink = function getGraphsLink(
 };
 
 // old PhAlerts' inner workings
+// TODO change all usage of signature_hash to signature.id
+// for originalSignature and newSignature query params
 const Alert = (alertData, optionCollectionMap) => ({
   ...alertData,
   title: getSeriesName(alertData.series_signature, optionCollectionMap, {
@@ -380,12 +382,13 @@ export const getGraphsURL = (
 
 export const getSubtestsURL = (alert, alertSummary) => {
   const endpoint = '#/comparesubtest';
+
   const urlParameters = {
     framework: alertSummary.framework,
     originalProject: alertSummary.repository,
-    originalSignature: alert.series_signature.signature_hash,
+    originalSignature: alert.series_signature.id,
     newProject: alertSummary.repository,
-    newSignature: alert.series_signature.signature_hash,
+    newSignature: alert.series_signature.id,
   };
   if (alertSummary.prevResultSetMetadata) {
     urlParameters.originalRevision =


### PR DESCRIPTION
Fixing a bug caused by the change to using signature_id instead of signature_hash in the `comparesubtest` view in #4414. I had neglected to make changes to the `comparesubtests` urls used in the Alerts view and Graph view tooltip.