### PR TITLE
Bug 1521157 - Create a prototype for the Push Health View

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -30,6 +30,10 @@ module.exports = {
         entry: 'test-view/index.jsx',
         title: 'Treeherder Test View',
       },
+      pushhealth: {
+        entry: 'push-health/index.jsx',
+        title: 'Push Health',
+      },
       perf: {
         entry: 'entry-perf.js',
         template: 'ui/perf.html',

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "d3": "5.7.0"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "1.2.12",
+    "@fortawesome/free-regular-svg-icons": "5.6.3",
+    "@fortawesome/free-solid-svg-icons": "5.6.3",
+    "@fortawesome/react-fontawesome": "0.1.4",
     "@neutrinojs/copy": "9.0.0-rc.0",
     "@neutrinojs/react": "9.0.0-rc.0",
     "@types/angular": "*",

--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -93,11 +93,7 @@ label.dropdown-item {
 }
 
 .nav-user-icon {
-  display: inline-block;
-  margin-right: 4px;
-  padding: 3px 4px;
-  vertical-align: text-bottom;
-  border-radius: 1px;
+  padding: 1px 3px 2px 4px;
   background: linear-gradient(#44adf3, #287cc2);
 }
 
@@ -105,10 +101,6 @@ label.dropdown-item {
   margin: 0 auto;
   font-size: 12px;
   color: #fff;
-}
-
-.nav-user-name {
-  display: inline-block;
 }
 
 .nav-login-btn {

--- a/ui/push-health/App.jsx
+++ b/ui/push-health/App.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { hot } from 'react-hot-loader/root';
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
+
+import NotFound from './NotFound';
+import Health from './Health';
+
+function hasProps(search) {
+  const params = new URLSearchParams(search);
+
+  return params.get('repo') && params.get('revision');
+}
+
+const App = () => (
+  <BrowserRouter>
+    <div>
+      <div>
+        <Switch>
+          <Route
+            exact
+            path="/pushhealth.html"
+            render={props =>
+              hasProps(props.location.search) ? (
+                <Health {...props} />
+              ) : (
+                <NotFound {...props} />
+              )
+            }
+          />
+          <Route name="notfound" component={NotFound} />
+        </Switch>
+      </div>
+    </div>
+  </BrowserRouter>
+);
+
+App.propTypes = {
+  location: PropTypes.object,
+};
+
+App.defaultProps = {
+  location: null,
+};
+
+export default hot(App);

--- a/ui/push-health/Health.jsx
+++ b/ui/push-health/Health.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Table, Container } from 'reactstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+
+import { getJobsUrl } from '../helpers/url';
+
+import { healthData, resultColorMap } from './helpers';
+import Metric from './Metric';
+import Navigation from './Navigation';
+
+export default class Health extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const params = new URLSearchParams(props.location.search);
+
+    this.state = {
+      user: { isLoggedIn: false },
+      revision: params.get('revision'),
+      repo: params.get('repo'),
+      healthData: null,
+    };
+  }
+
+  componentDidMount() {
+    // Get the test data
+    this.updatePushHealth();
+
+    // Update the tests every two minutes.
+    this.testTimerId = setInterval(() => this.updatePushHealth(), 120000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.testTimerId);
+  }
+
+  setUser = user => {
+    this.setState({ user });
+  };
+
+  updatePushHealth = () => {
+    this.setState({ healthData });
+  };
+
+  render() {
+    const { healthData, user, repo, revision } = this.state;
+    const overallResult = healthData
+      ? resultColorMap[healthData.result]
+      : 'none';
+
+    return (
+      <React.Fragment>
+        <Navigation user={user} setUser={this.setUser} />
+        <Container fluid>
+          {healthData ? (
+            <div className="d-flex flex-column">
+              <h2 className="text-center">
+                <span className={`badge badge-xl mb-3 badge-${overallResult}`}>
+                  <a
+                    href={getJobsUrl({ repo, revision })}
+                    className="text-white"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {repo} - {revision}
+                  </a>
+                </span>
+              </h2>
+              <Table size="sm">
+                <tbody>
+                  {healthData.metrics.map(metric => (
+                    <tr key={metric.name}>
+                      <Metric
+                        name={metric.name}
+                        result={metric.result}
+                        value={metric.value}
+                        details={metric.details}
+                      />
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            </div>
+          ) : (
+            <div>
+              <FontAwesomeIcon icon={faSpinner} size="2x" spin />
+            </div>
+          )}
+        </Container>
+      </React.Fragment>
+    );
+  }
+}
+
+Health.propTypes = {
+  location: PropTypes.object.isRequired,
+};

--- a/ui/push-health/Metric.jsx
+++ b/ui/push-health/Metric.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faPlusSquare,
+  faMinusSquare,
+} from '@fortawesome/free-regular-svg-icons';
+
+import { resultColorMap } from './helpers';
+
+export default class Metric extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    const { result } = this.props;
+
+    this.state = {
+      detailsShowing: result !== 'pass',
+    };
+  }
+
+  toggleDetails = () => {
+    this.setState({ detailsShowing: !this.state.detailsShowing });
+  };
+
+  render() {
+    const { detailsShowing } = this.state;
+    const { result, name, value, details } = this.props;
+    const resultColor = resultColorMap[result];
+    const expandIcon = detailsShowing ? faMinusSquare : faPlusSquare;
+
+    return (
+      <td>
+        <div className="d-flex flex-row">
+          <div className={`bg-${resultColor} pr-2 mr-2`} />
+          <div>
+            <h3>
+              {name}
+              <span onClick={this.toggleDetails} className="btn btn-lg">
+                <FontAwesomeIcon icon={expandIcon} />
+              </span>
+            </h3>
+            {detailsShowing && (
+              <React.Fragment>
+                <div>Confidence: {value}/10</div>
+                {details.map(detail => (
+                  <div key={detail} className="ml-3">
+                    {detail}
+                  </div>
+                ))}
+              </React.Fragment>
+            )}
+          </div>
+        </div>
+      </td>
+    );
+  }
+}
+
+Metric.propTypes = {
+  result: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.number.isRequired,
+  details: PropTypes.array.isRequired,
+};

--- a/ui/push-health/Navigation.jsx
+++ b/ui/push-health/Navigation.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Navbar } from 'reactstrap';
+
+import LogoMenu from '../shared/LogoMenu';
+import Login from '../shared/auth/Login';
+
+export default class Navigation extends React.PureComponent {
+  render() {
+    const { user, setUser } = this.props;
+
+    return (
+      <Navbar dark color="dark">
+        <LogoMenu menuText="Push Health" />
+        <Login user={user} setUser={setUser} />
+      </Navbar>
+    );
+  }
+}
+
+Navigation.propTypes = {
+  user: PropTypes.object.isRequired,
+  setUser: PropTypes.func.isRequired,
+};

--- a/ui/push-health/NotFound.jsx
+++ b/ui/push-health/NotFound.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Container, Row, Col, Alert } from 'reactstrap';
+
+const NotFound = () => (
+  <Container fluid style={{ marginTop: 40 }}>
+    <Row>
+      <Col>
+        <Alert color="danger">
+          Missing required URL parameters of <code>repo</code> and{' '}
+          <code>revision</code>.
+        </Alert>
+      </Col>
+    </Row>
+  </Container>
+);
+
+export default NotFound;

--- a/ui/push-health/helpers.js
+++ b/ui/push-health/helpers.js
@@ -1,0 +1,49 @@
+export const healthData = {
+  result: 'fail', // This is a tri-state of pass/fail/indeterminate.  Reflects the worst metric state.
+  metrics: [
+    {
+      name: 'Builds',
+      result: 'pass',
+      value: 10,
+      details: ['Wow, everything passed!'],
+    },
+    {
+      name: 'Linting',
+      result: 'pass',
+      value: 10,
+      details: ['Gosh, this code is really nicely formatted.'],
+    },
+    {
+      name: 'Tests',
+      result: 'fail',
+      value: 2,
+      details: [
+        'Ran some tests that did not go so well',
+        'See [foo.bar.baz/mongo/rational/fee]',
+      ],
+    },
+    {
+      name: 'Coverage',
+      result: 'indeterminate',
+      value: 5,
+      details: [
+        'Covered 42% of the tests that are needed for feature ``foo``.',
+        'Covered 100% of the tests that are needed for feature ``bar``.',
+        'The ratio of people to cake is too many...',
+      ],
+    },
+    {
+      name: 'Performance',
+      result: 'pass',
+      value: 10,
+      details: [],
+    },
+  ],
+};
+
+export const resultColorMap = {
+  pass: 'success',
+  fail: 'danger',
+  indeterminate: 'warning',
+  none: 'default',
+};

--- a/ui/push-health/index.jsx
+++ b/ui/push-health/index.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+// Vendor Styles
+import 'bootstrap/dist/css/bootstrap.min.css';
+
+// Treeherder Styles
+import '../css/treeherder-navbar.css';
+
+import App from './App';
+
+render(<App />, document.getElementById('root'));

--- a/ui/shared/auth/Login.jsx
+++ b/ui/shared/auth/Login.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import { faUser } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { loggedOutUser } from '../../helpers/auth';
 import taskcluster from '../../helpers/taskcluster';
@@ -116,12 +118,10 @@ class Login extends React.Component {
               className="btn btn-view-nav"
             >
               <div className="dropdown-toggle">
-                <div className="nav-user-icon">
-                  <span className="fa fa-user pull-left" />
-                </div>
-                <div className="nav-user-name">
-                  <span>{user.fullName}</span>
-                </div>
+                <span className="nav-user-icon mr-1 rounded">
+                  <FontAwesomeIcon icon={faUser} size="xs" />
+                </span>
+                <span>{user.fullName}</span>
               </div>
             </button>
             <ul

--- a/yarn.lock
+++ b/yarn.lock
@@ -721,6 +721,40 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
   integrity sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==
 
+"@fortawesome/fontawesome-common-types@^0.2.12":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.12.tgz#42baa71f97ca06faeb0b6718fa5ed20c5eefdf07"
+  integrity sha512-ISLNpEx6fhJTYYkvBeo/4DHeL5EIA+VybJoOOnH67m6uXt6V6VFizdEN4qchHagNIeZfzI0LnA22gk0wbVPv/g==
+
+"@fortawesome/fontawesome-svg-core@1.2.12":
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.12.tgz#9732617b1e484435f6946645d7f9ad248f12c437"
+  integrity sha512-cqTfa3vZ+Z9UYQnmLfCOwyLnf0Xcoxkmm/BSaI29Yikzu9zIeD4es7lBZMDqLOXYSEQC+rCr8caxFlGJcJVA+w==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.12"
+
+"@fortawesome/free-regular-svg-icons@5.6.3":
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.6.3.tgz#b0a44d665c347b56d064a37962e81e8d8a8f2624"
+  integrity sha512-G6pFCyDaR+R67m1dFHATdeUk5acMglyK7Ney7lZ1QQOusRldhLTPGTnY3LZZ3+WBa3VUz6FwcHRRLNevkIYnIA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.12"
+
+"@fortawesome/free-solid-svg-icons@5.6.3":
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.6.3.tgz#1d7f6669ccd6a1ea673699e41f7e32c81401a260"
+  integrity sha512-ld8Gfp1KrncOpFRheThUDlD6/Ro9ZJGqfCEMXlO/x1Cg7ltLc5iYDG7yxDowLcmFY2BGSmxIIU3ZMW5FVTrfwQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.12"
+
+"@fortawesome/react-fontawesome@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.4.tgz#18d61d9b583ca289a61aa7dccc05bd164d6bc9ad"
+  integrity sha512-GwmxQ+TK7PEdfSwvxtGnMCqrfEm0/HbRHArbUudsYiy9KzVCwndxa2KMcfyTQ8El0vROrq8gOOff09RF1oQe8g==
+  dependencies:
+    humps "^2.0.1"
+    prop-types "^15.5.10"
+
 "@mattiasbuelens/web-streams-polyfill@^0.2.0":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@mattiasbuelens/web-streams-polyfill/-/web-streams-polyfill-0.2.1.tgz#d7c4aa94f98084ec0787be084d47167d62ea5f67"
@@ -4883,6 +4917,11 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+humps@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
+  integrity sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=
 
 iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"


### PR DESCRIPTION
Here is the beginning of the prototype for the Push Health View.  It only has dummy data for now.  I'm sure the format will evolve as we start creating the API to give us some real data.

The bar at the top may be a bit obnoxious.  :)  It display red/yellow/green, based on the worst ``result``.  Perhaps a badge on the left or right that says, "pass", "fail", "indeterminate" would also work.  Or perhaps just the color bars on the left for each metric is enough.

<img width="1002" alt="screenshot 2019-01-18 12 07 22" src="https://user-images.githubusercontent.com/419924/51410551-d862d980-1b19-11e9-937b-551dad03dd14.png">

I'm considering adding markdown support for the details items.  I'd like to support links there, but we could have a "url" field in the details, too.  They're just strings at the moment.