### PR TITLE
Make job details panel close button visible again

### DIFF
--- a/ui/css/treeherder-details-panel.css
+++ b/ui/css/treeherder-details-panel.css
@@ -121,6 +121,11 @@ div#details-panel-content .details-panel-navbar > ul.tab-headers > li {
 .details-panel-close-btn {
   padding-top: 3px;
   font-size: 12px;
+  color: unset; /* reset from bootstrap button class */
+}
+
+.details-panel-close-btn:hover {
+  color: unset; /* reset from bootstrap button class */
 }
 
 .perf-job-selected {


### PR DESCRIPTION
It looks like bootstrap's default button class (now?) sets the
default button color to dark grey, which is really hard to see against
the background of the job details panel. Fix this by resetting
the color to the default of the containing class.