### PR TITLE
Bug 1521157 - Update dataset for unit tests

### DIFF
--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -1,5 +1,7 @@
 export const uiJobsUrlBase = '/#/jobs';
 
+export const uiPushHealthBase = '/pushhealth.html';
+
 export const bzBaseUrl = 'https://bugzilla.mozilla.org/';
 
 export const hgBaseUrl = 'https://hg.mozilla.org/';
@@ -80,6 +82,11 @@ export const getPerfAnalysisUrl = function getPerfAnalysisUrl(url) {
 // This takes a plain object, rather than a URLSearchParams object.
 export const getJobsUrl = function getJobsUrl(params) {
   return `${uiJobsUrlBase}${createQueryParams(params)}`;
+};
+
+// This takes a plain object, rather than a URLSearchParams object.
+export const getPushHealthUrl = function getJobsUrl(params) {
+  return `${uiPushHealthBase}${createQueryParams(params)}`;
 };
 
 export const getCompareChooserUrl = function getCompareChooserUrl(params) {

--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -7,6 +7,7 @@ import CustomJobActions from '../CustomJobActions';
 import PushModel from '../../models/push';
 import { withPushes } from '../context/Pushes';
 import { withNotifications } from '../../shared/context/Notifications';
+import { getPushHealthUrl } from '../../helpers/url';
 
 // Trigger missing jobs is dangerous on repos other than these (see bug 1335506)
 const triggerMissingRepos = ['mozilla-inbound', 'autoland'];
@@ -227,6 +228,17 @@ class PushActionMenu extends React.PureComponent {
               href={bottomOfRangeUrl}
             >
               Set as bottom of range
+            </a>
+          </li>
+          <li className="dropdown-divider" />
+          <li>
+            <a
+              className="dropdown-item"
+              href={getPushHealthUrl({ repo: repoName, revision })}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              DEMO: Push Health (fake data)
             </a>
           </li>
         </ul>

--- a/ui/push-health/Health.jsx
+++ b/ui/push-health/Health.jsx
@@ -56,7 +56,7 @@ export default class Health extends React.Component {
         <Container fluid>
           {healthData ? (
             <div className="d-flex flex-column">
-              <h2 className="text-center">
+              <h3 className="text-center">
                 <span className={`badge badge-xl mb-3 badge-${overallResult}`}>
                   <a
                     href={getJobsUrl({ repo, revision })}
@@ -67,7 +67,7 @@ export default class Health extends React.Component {
                     {repo} - {revision}
                   </a>
                 </span>
-              </h2>
+              </h3>
               <Table size="sm">
                 <tbody>
                   {healthData.metrics.map(metric => (
@@ -77,6 +77,9 @@ export default class Health extends React.Component {
                         result={metric.result}
                         value={metric.value}
                         details={metric.details}
+                        failures={metric.failures}
+                        repo={repo}
+                        revision={revision}
                       />
                     </tr>
                   ))}

--- a/ui/push-health/Metric.jsx
+++ b/ui/push-health/Metric.jsx
@@ -5,8 +5,10 @@ import {
   faPlusSquare,
   faMinusSquare,
 } from '@fortawesome/free-regular-svg-icons';
+import { Badge } from 'reactstrap';
 
 import { resultColorMap } from './helpers';
+import TestFailure from './TestFailure';
 
 export default class Metric extends React.PureComponent {
   constructor(props) {
@@ -25,7 +27,15 @@ export default class Metric extends React.PureComponent {
 
   render() {
     const { detailsShowing } = this.state;
-    const { result, name, value, details } = this.props;
+    const {
+      result,
+      name,
+      value,
+      details,
+      failures,
+      repo,
+      revision,
+    } = this.props;
     const resultColor = resultColorMap[result];
     const expandIcon = detailsShowing ? faMinusSquare : faPlusSquare;
 
@@ -33,21 +43,40 @@ export default class Metric extends React.PureComponent {
       <td>
         <div className="d-flex flex-row">
           <div className={`bg-${resultColor} pr-2 mr-2`} />
-          <div>
-            <h3>
-              {name}
-              <span onClick={this.toggleDetails} className="btn btn-lg">
-                <FontAwesomeIcon icon={expandIcon} />
+          <div className="d-flex flex-column w-100">
+            <div className="d-flex justify-content-between w-100">
+              <div>
+                <span className="metric-name align-top font-weight-bold">
+                  {name}
+                </span>
+                <span onClick={this.toggleDetails} className="btn">
+                  <FontAwesomeIcon icon={expandIcon} />
+                </span>
+              </div>
+              <span>
+                Confidence:
+                <Badge color={resultColor} className="ml-1">
+                  {value}
+                </Badge>
               </span>
-            </h3>
+            </div>
             {detailsShowing && (
               <React.Fragment>
-                <div>Confidence: {value}/10</div>
-                {details.map(detail => (
-                  <div key={detail} className="ml-3">
-                    {detail}
-                  </div>
-                ))}
+                {failures &&
+                  failures.map(failure => (
+                    <TestFailure
+                      key={failure.testName}
+                      failure={failure}
+                      repo={repo}
+                      revision={revision}
+                    />
+                  ))}
+                {details &&
+                  details.map(detail => (
+                    <div key={detail} className="ml-3">
+                      {detail}
+                    </div>
+                  ))}
               </React.Fragment>
             )}
           </div>
@@ -58,8 +87,15 @@ export default class Metric extends React.PureComponent {
 }
 
 Metric.propTypes = {
+  repo: PropTypes.string.isRequired,
+  revision: PropTypes.string.isRequired,
   result: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   value: PropTypes.number.isRequired,
   details: PropTypes.array.isRequired,
+  failures: PropTypes.array,
+};
+
+Metric.defaultProps = {
+  failures: null,
 };

--- a/ui/push-health/Metric.jsx
+++ b/ui/push-health/Metric.jsx
@@ -5,7 +5,7 @@ import {
   faPlusSquare,
   faMinusSquare,
 } from '@fortawesome/free-regular-svg-icons';
-import { Badge } from 'reactstrap';
+import { Badge, Row, Col } from 'reactstrap';
 
 import { resultColorMap } from './helpers';
 import TestFailure from './TestFailure';
@@ -41,10 +41,10 @@ export default class Metric extends React.PureComponent {
 
     return (
       <td>
-        <div className="d-flex flex-row">
+        <Row>
           <div className={`bg-${resultColor} pr-2 mr-2`} />
-          <div className="d-flex flex-column w-100">
-            <div className="d-flex justify-content-between w-100">
+          <Col>
+            <Row className="justify-content-between">
               <div>
                 <span className="metric-name align-top font-weight-bold">
                   {name}
@@ -59,7 +59,7 @@ export default class Metric extends React.PureComponent {
                   {value}
                 </Badge>
               </span>
-            </div>
+            </Row>
             {detailsShowing && (
               <React.Fragment>
                 {failures &&
@@ -79,8 +79,8 @@ export default class Metric extends React.PureComponent {
                   ))}
               </React.Fragment>
             )}
-          </div>
-        </div>
+          </Col>
+        </Row>
       </td>
     );
   }

--- a/ui/push-health/Navigation.jsx
+++ b/ui/push-health/Navigation.jsx
@@ -12,6 +12,12 @@ export default class Navigation extends React.PureComponent {
     return (
       <Navbar dark color="dark">
         <LogoMenu menuText="Push Health" />
+        <span
+          title="This data is for UI prototyping purposes only"
+          className="text-white"
+        >
+          [---FAKE-DATA---]
+        </span>
         <Login user={user} setUser={setUser} />
       </Navbar>
     );

--- a/ui/push-health/TestFailure.jsx
+++ b/ui/push-health/TestFailure.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faStar } from '@fortawesome/free-solid-svg-icons';
+import { Badge } from 'reactstrap';
+
+import { getJobsUrl } from '../helpers/url';
+
+export default class TestFailure extends React.PureComponent {
+  render() {
+    const { failure, repo, revision } = this.props;
+    const {
+      testName,
+      jobName,
+      jobId,
+      classification,
+      failureLine,
+      confidence,
+    } = failure;
+
+    return (
+      <div className="d-flex flex-column mt-2 mb-3 ml-2">
+        <div className="d-flex border-bottom border-secondary justify-content-between">
+          <span className="font-weight-bold pull-left">{testName}</span>
+          <span>
+            Line confidence:
+            <Badge color="secondary" className="ml-2 mr-3">
+              {confidence}
+            </Badge>
+          </span>
+        </div>
+        <div className="small">
+          <a
+            className="text-dark ml-3"
+            href={getJobsUrl({ selectedJob: jobId, repo, revision })}
+          >
+            {jobName}
+          </a>
+          <span className="ml-1">
+            <FontAwesomeIcon icon={faStar} />
+            {classification}
+          </span>
+        </div>
+        <span className="small text-monospace mt-2 ml-3">{failureLine}</span>
+      </div>
+    );
+  }
+}
+
+TestFailure.propTypes = {
+  failure: PropTypes.object.isRequired,
+  repo: PropTypes.object.isRequired,
+  revision: PropTypes.object.isRequired,
+};

--- a/ui/push-health/TestFailure.jsx
+++ b/ui/push-health/TestFailure.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faStar } from '@fortawesome/free-solid-svg-icons';
-import { Badge } from 'reactstrap';
+import { Badge, Row, Col } from 'reactstrap';
 
 import { getJobsUrl } from '../helpers/url';
 
@@ -19,16 +19,16 @@ export default class TestFailure extends React.PureComponent {
     } = failure;
 
     return (
-      <div className="d-flex flex-column mt-2 mb-3 ml-2">
-        <div className="d-flex border-bottom border-secondary justify-content-between">
-          <span className="font-weight-bold pull-left">{testName}</span>
+      <Col className="mt-2 mb-3 ml-2">
+        <Row className="border-bottom border-secondary justify-content-between">
+          <span className="font-weight-bold">{testName}</span>
           <span>
             Line confidence:
             <Badge color="secondary" className="ml-2 mr-3">
               {confidence}
             </Badge>
           </span>
-        </div>
+        </Row>
         <div className="small">
           <a
             className="text-dark ml-3"
@@ -41,8 +41,8 @@ export default class TestFailure extends React.PureComponent {
             {classification}
           </span>
         </div>
-        <span className="small text-monospace mt-2 ml-3">{failureLine}</span>
-      </div>
+        <Row className="small text-monospace mt-2 ml-3">{failureLine}</Row>
+      </Col>
     );
   }
 }

--- a/ui/push-health/helpers.js
+++ b/ui/push-health/helpers.js
@@ -17,9 +17,26 @@ export const healthData = {
       name: 'Tests',
       result: 'fail',
       value: 2,
-      details: [
-        'Ran some tests that did not go so well',
-        'See [foo.bar.baz/mongo/rational/fee]',
+      failures: [
+        {
+          testName: 'dom/tests/mochitest/fetch/test_fetch_cors_sw_reroute.html',
+          jobName: 'test-linux32/opt-mochitest-browser-chrome-e10s-4',
+          jobId: 223458405,
+          classification: 'intermittent',
+          failureLine:
+            'REFTEST TEST-UNEXPECTED-FAIL | file:///builds/worker/workspace/build/tests/reftest/tests/layout/reftests/border-dotted/border-dashed-no-radius.html == file:///builds/worker/workspace/build/tests/reftest/tests/layout/reftests/border-dotted/masked.html | image comparison, max difference: 255, number of differing pixels: 54468',
+          confidence: 3,
+        },
+        {
+          testName:
+            'browser/components/extensions/test/browser/test-oop-extensions/browser_ext_pageAction_context.js',
+          jobName: 'test-linux64/debug-mochitest-plain-headless-e10s-8',
+          jobId: 223458405,
+          classification: 'intermittent',
+          failureLine:
+            "raptor-main TEST-UNEXPECTED-FAIL: test 'raptor-tp6-bing-firefox' timed out loading test page: https://www.bing.com/search?q=barack+obama",
+          confidence: 4,
+        },
       ],
     },
     {
@@ -36,7 +53,7 @@ export const healthData = {
       name: 'Performance',
       result: 'pass',
       value: 10,
-      details: [],
+      details: ['Ludicrous Speed'],
     },
   ],
 };

--- a/ui/push-health/index.jsx
+++ b/ui/push-health/index.jsx
@@ -6,6 +6,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 
 // Treeherder Styles
 import '../css/treeherder-navbar.css';
+import './pushhealth.css';
 
 import App from './App';
 

--- a/ui/push-health/pushhealth.css
+++ b/ui/push-health/pushhealth.css
@@ -1,0 +1,3 @@
+.metric-name {
+  font-size: 24px;
+}


### PR DESCRIPTION
Per a chat with Joel, here is the initial take on data we would display for failed "Tests" metric.  I'm sure this will continue to evolve.

This also adds a menu item to the push action menu to access this view.  I went back and forth on whether to include this.  Open to opinions if you think it's better NOT to have the menu item included at this time:
<img width="258" alt="screenshot 2019-01-25 10 48 24" src="https://user-images.githubusercontent.com/419924/51766238-ee7b1780-208e-11e9-956f-0612822aa545.png">

Here's the new look of the page:
<img width="1094" alt="screenshot 2019-01-25 10 50 28" src="https://user-images.githubusercontent.com/419924/51766292-0bafe600-208f-11e9-9fe8-11f5897674db.png">
