### PR TITLE
Fix deprecation warning in jest setup

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -127,7 +127,7 @@ module.exports = {
     process.env.NODE_ENV === 'test' && [
       '@neutrinojs/jest',
       {
-        setupTestFrameworkScriptFile: '<rootDir>/tests/ui/unit/test-setup.js',
+        setupFilesAfterEnv: ['<rootDir>/tests/ui/unit/test-setup.js'],
       },
     ],
     neutrino => {


### PR DESCRIPTION
Rats, I somehow missed the deprecation warning in the output when I rebased...  This fixes it.