### PR TITLE
Bug 1364045 - Convert the groups unit tests to Jest

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -128,6 +128,8 @@ module.exports = {
       '@neutrinojs/jest',
       {
         setupFilesAfterEnv: ['<rootDir>/tests/ui/unit/test-setup.js'],
+        // For more info, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1523376#c3
+        browser: true,
       },
     ],
     neutrino => {

--- a/tests/ui/unit/react/groups_test.jsx
+++ b/tests/ui/unit/react/groups_test.jsx
@@ -45,7 +45,7 @@ describe('JobGroup component', () => {
     ).toEqual('2');
   });
 
-  it('should show a job and count of 2 when expanded, then re-collapsed', () => {
+  test('should show a job and count of 2 when expanded, then re-collapsed', () => {
     const jobGroup = mount(
       <JobGroupComponent
         repoName={repoName}
@@ -69,7 +69,7 @@ describe('JobGroup component', () => {
     ).toEqual('2');
   });
 
-  it('should show jobs, not counts when expanded', () => {
+  test('should show jobs, not counts when expanded', () => {
     const jobGroup = mount(
       <JobGroupComponent
         repoName={repoName}
@@ -88,7 +88,7 @@ describe('JobGroup component', () => {
     expect(jobGroup.find('.job-btn').length).toEqual(3);
   });
 
-  it('should show jobs, not counts when globally expanded', () => {
+  test('should show jobs, not counts when globally expanded', () => {
     const groupCountsExpanded = true;
     const jobGroup = mount(
       <JobGroupComponent
@@ -107,7 +107,7 @@ describe('JobGroup component', () => {
     expect(jobGroup.find('.job-group-count').length).toEqual(0);
   });
 
-  it('should hide duplicates by default', () => {
+  test('should hide duplicates by default', () => {
     const jobGroup = mount(
       <JobGroupComponent
         repoName={repoName}
@@ -125,7 +125,7 @@ describe('JobGroup component', () => {
     expect(jobGroup.find('.job-btn').length).toEqual(1);
   });
 
-  it('should show 2 duplicates when set to show duplicates', () => {
+  test('should show 2 duplicates when set to show duplicates', () => {
     const duplicateJobsVisible = true;
     const jobGroup = mount(
       <JobGroupComponent
@@ -144,7 +144,7 @@ describe('JobGroup component', () => {
     expect(jobGroup.find('.job-btn').length).toEqual(2);
   });
 
-  it('should show 2 duplicates when globally set to show duplicates', () => {
+  test('should show 2 duplicates when globally set to show duplicates', () => {
     const duplicateJobsVisible = true;
     const jobGroup = mount(
       <JobGroupComponent

--- a/ui/job-view/pushes/JobButton.jsx
+++ b/ui/job-view/pushes/JobButton.jsx
@@ -33,12 +33,12 @@ export default class JobButtonComponent extends React.Component {
    * shallow compare would allow.
    */
   shouldComponentUpdate(nextProps, nextState) {
-    const { visible, status, failureClassificationId } = this.props;
+    const { visible, resultStatus, failureClassificationId } = this.props;
     const { isSelected, isRunnableSelected } = this.state;
 
     return (
       visible !== nextProps.visible ||
-      status !== nextProps.status ||
+      resultStatus !== nextProps.resultStatus ||
       failureClassificationId !== nextProps.failureClassificationId ||
       isSelected !== nextState.isSelected ||
       isRunnableSelected !== nextState.isRunnableSelected
@@ -69,7 +69,7 @@ export default class JobButtonComponent extends React.Component {
   }
 
   render() {
-    const { job } = this.props;
+    const { job, resultStatus } = this.props;
     const { isSelected, isRunnableSelected } = this.state;
     const {
       state,
@@ -81,16 +81,12 @@ export default class JobButtonComponent extends React.Component {
       visible,
       id,
       job_type_symbol,
-      result,
     } = job;
 
     if (!visible) return null;
-    const resultStatus = state === 'completed' ? result : state;
     const runnable = state === 'runnable';
     const btnClass = getBtnClass(resultStatus, failure_classification_id);
-    // TODO: This is broken (bug 1504713)
-    // eslint-disable-next-line no-restricted-globals
-    let title = `${resultStatus} | ${job_type_name} - ${status}`;
+    let title = `${resultStatus} | ${job_type_name}`;
 
     if (state === 'completed') {
       const duration = Math.round((end_timestamp - start_timestamp) / 60);
@@ -133,7 +129,7 @@ JobButtonComponent.propTypes = {
   filterModel: PropTypes.object.isRequired,
   repoName: PropTypes.string.isRequired,
   visible: PropTypes.bool.isRequired,
-  status: PropTypes.string.isRequired,
+  resultStatus: PropTypes.string.isRequired,
   platform: PropTypes.object.isRequired,
   filterPlatformCb: PropTypes.func.isRequired,
   failureClassificationId: PropTypes.number, // runnable jobs won't have this

--- a/ui/job-view/pushes/JobGroup.jsx
+++ b/ui/job-view/pushes/JobGroup.jsx
@@ -150,7 +150,7 @@ export class JobGroupComponent extends React.Component {
                   job={job}
                   filterModel={filterModel}
                   visible={job.visible}
-                  status={getStatus(job)}
+                  resultStatus={getStatus(job)}
                   failureClassificationId={job.failure_classification_id}
                   repoName={repoName}
                   filterPlatformCb={filterPlatformCb}

--- a/ui/job-view/pushes/JobsAndGroups.jsx
+++ b/ui/job-view/pushes/JobsAndGroups.jsx
@@ -45,7 +45,7 @@ export default class JobsAndGroups extends React.Component {
               filterModel={filterModel}
               repoName={repoName}
               visible={job.visible}
-              status={getStatus(job)}
+              resultStatus={getStatus(job)}
               failureClassificationId={job.failure_classification_id}
               filterPlatformCb={filterPlatformCb}
               platform={platform}


### PR DESCRIPTION
--WIP:
Trying to get these tests working with Jest is hitting an error with ``taskcluster-client-web``.  Talked to Dustin, and it appears to be an issue with the version of ``hawk`` that's getting installed with their package.  

Filed upstream bug https://bugzilla.mozilla.org/show_bug.cgi?id=1523376 to hopefully address this.