### PR TITLE
Switch front-end to use /push/ endpoint

### DIFF
--- a/tests/ui/unit/context/pushes.tests.jsx
+++ b/tests/ui/unit/context/pushes.tests.jsx
@@ -14,7 +14,7 @@ describe('Pushes context', () => {
 
   beforeEach(() => {
     fetchMock.get(
-      getProjectUrl('/resultset/?full=true&count=10', repoName),
+      getProjectUrl('/push/?full=true&count=10', repoName),
       pushListFixture,
     );
 

--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -18,7 +18,7 @@ export const deployedRevisionUrl = '/revision.txt';
 
 export const loginCallbackUrl = '/login.html';
 
-export const pushEndpoint = '/resultset/';
+export const pushEndpoint = '/push/';
 
 export const repoEndpoint = '/repository/';
 

--- a/ui/test-view/redux/modules/groups.js
+++ b/ui/test-view/redux/modules/groups.js
@@ -122,7 +122,7 @@ export const actions = {
     type: types.FETCH_COUNTS,
     meta: {
       type: 'api',
-      url: `/resultset/${pushId}/status/`,
+      url: `/push/${pushId}/status/`,
       repoName,
       method: 'GET',
     },


### PR DESCRIPTION
This somehow never got switched over.