### PR TITLE
Bug 1306707 - Search for push without startswith when 40 chars

### DIFF
--- a/tests/webapp/api/test_push_api.py
+++ b/tests/webapp/api/test_push_api.py
@@ -1,4 +1,3 @@
-import copy
 import datetime
 import json
 
@@ -122,36 +121,6 @@ def test_push_list_single_long_revision(client, eleven_jobs_stored, test_reposit
             u'revisions_long_revision': u'45f8637cb9f78f19cb8463ff174e81756805d8cf'
         },
         u'repository': test_repository.name}
-    )
-
-
-def test_push_list_single_long_revision_stored_long(client, sample_push, test_repository):
-    """
-    test retrieving a push list with store long revision, filtered by a single long revision
-    """
-    long_revision = "21fb3eed1b5f3456789012345678901234567890"
-
-    # store a push with long revision
-    push = copy.deepcopy(sample_push[0])
-    push["revisions"][0]["revision"] = long_revision
-    store_push_data(test_repository, [push])
-
-    resp = client.get(
-        reverse("push-list", kwargs={"project": test_repository.name}),
-        {"revision": long_revision}
-    )
-    assert resp.status_code == 200
-    results = resp.json()['results']
-    meta = resp.json()['meta']
-    assert len(results) == 1
-    assert set([ph["revision"] for ph in results]) == {sample_push[0]['revision']}
-    assert(meta == {
-        'count': 1,
-        'revision': long_revision,
-        'filter_params': {
-            'revisions_long_revision': long_revision
-        },
-        'repository': test_repository.name}
     )
 
 

--- a/treeherder/etl/job_loader.py
+++ b/treeherder/etl/job_loader.py
@@ -72,7 +72,10 @@ class JobLoader(object):
         filter_kwargs = {'repository': repository, revision_field: revision}
 
         if revision_field == 'revision__startswith':
-            newrelic.agent.record_exception(params={'error': 'Revision < 40 chars', 'job': pulse_job})
+            newrelic.agent.record_custom_event(
+                'short_revision_job_loader',
+                {'error': 'Revision <40 chars', 'revision': revision, 'job': pulse_job}
+            )
 
         if not Push.objects.filter(**filter_kwargs).exists():
             raise MissingPushException(

--- a/treeherder/etl/jobs.py
+++ b/treeherder/etl/jobs.py
@@ -445,12 +445,12 @@ def store_job_data(repository, data):
             # job consumer, then the data will always be vetted with a
             # JSON schema before we get to this point.
             job = datum['job']
+            revision = datum['revision']
             superseded = datum.get('superseded', [])
 
-            # TODO: Stop using startswith for improved performance as part of bug 1306707.
-            push_id = Push.objects.values_list('id', flat=True).get(
-                repository=repository,
-                revision__startswith=datum['revision'])
+            revision_field = 'revision__startswith' if len(revision) < 40 else 'revision'
+            filter_kwargs = {'repository': repository, revision_field: revision}
+            push_id = Push.objects.values_list('id', flat=True).get(**filter_kwargs)
 
             # load job
             job_guid = _load_job(repository, job, push_id)

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -78,7 +78,9 @@ class PushViewSet(viewsets.ViewSet):
             elif param == 'revision':
                 # revision can be either the revision of the push itself, or
                 # any of the commits it refers to
-                pushes = pushes.filter(commits__revision__startswith=value)
+                revision_field = 'commits__revision__startswith' if len(value) < 40 else 'commits__revision'
+                filter_kwargs = {revision_field: value}
+                pushes = pushes.filter(**filter_kwargs)
                 rev_key = "revisions_long_revision" \
                           if len(meta['revision']) == 40 else "revisions_short_revision"
                 filter_params.update({rev_key: meta['revision']})

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -1,5 +1,6 @@
 import datetime
 
+import newrelic.agent
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -50,20 +51,27 @@ class PushViewSet(viewsets.ViewSet):
 
         for (param, value) in iteritems(meta):
             if param == 'fromchange':
+                revision_field = 'revision__startswith' if len(value) < 40 else 'revision'
+                filter_kwargs = {revision_field: value}
                 frompush_time = Push.objects.values_list('time', flat=True).get(
-                    repository=repository, revision__startswith=value)
+                    **filter_kwargs)
                 pushes = pushes.filter(time__gte=frompush_time)
                 filter_params.update({
                     "push_timestamp__gte": to_timestamp(frompush_time)
                 })
+                self.report_if_short_revision(param, value)
 
             elif param == 'tochange':
+                revision_field = 'revision__startswith' if len(value) < 40 else 'revision'
+                filter_kwargs = {revision_field: value}
                 topush_time = Push.objects.values_list('time', flat=True).get(
-                    repository=repository, revision__startswith=value)
+                    **filter_kwargs)
                 pushes = pushes.filter(time__lte=topush_time)
                 filter_params.update({
                     "push_timestamp__lte": to_timestamp(topush_time)
                 })
+                self.report_if_short_revision(param, value)
+
             elif param == 'startdate':
                 pushes = pushes.filter(time__gte=to_datetime(value))
                 filter_params.update({
@@ -78,12 +86,13 @@ class PushViewSet(viewsets.ViewSet):
             elif param == 'revision':
                 # revision can be either the revision of the push itself, or
                 # any of the commits it refers to
-                revision_field = 'commits__revision__startswith' if len(value) < 40 else 'commits__revision'
+                revision_field = 'revision__startswith' if len(value) < 40 else 'revision'
                 filter_kwargs = {revision_field: value}
                 pushes = pushes.filter(**filter_kwargs)
                 rev_key = "revisions_long_revision" \
                           if len(meta['revision']) == 40 else "revisions_short_revision"
                 filter_params.update({rev_key: meta['revision']})
+                self.report_if_short_revision(param, value)
 
         for param in ['push_timestamp__lt', 'push_timestamp__lte',
                       'push_timestamp__gt', 'push_timestamp__gte']:
@@ -259,3 +268,11 @@ class PushViewSet(viewsets.ViewSet):
                 },
             ],
         })
+
+    # TODO: Remove when we no longer support short revisions: Bug 1306707
+    def report_if_short_revision(self, param, revision):
+        if len(revision) < 40:
+            newrelic.agent.record_custom_event(
+                'short_revision_push_api',
+                {'error': 'Revision <40 chars', 'param': param, 'revision': revision}
+            )


### PR DESCRIPTION
Check ``revision`` length to see if we don't need the ``__startswith`` for finding it.  If we DO need that, then report to New Relic that we hit a revision <40 chars.