### PR TITLE
Remove leftover isort recommonmark workaround

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,6 @@ multi_line_output = 1
 force_grid_wrap = true
 line_length = 100
 known_first_party = tests
-# Required since we install recommonmark as an editable install from GitHub:
-# https://github.com/timothycrosley/isort/issues/386
-known_third_party = recommonmark
 
 [tool:pytest]
 testpaths = tests


### PR DESCRIPTION
This workaround is not required after #4440, since recommonmark is now
installed from PyPI rather than from GitHub.