### PR TITLE
Bug 1506805 - Upgrade to modern Font Awesome (Part 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "1.2.14",
+    "@fortawesome/free-brands-svg-icons": "5.7.1",
     "@fortawesome/free-regular-svg-icons": "5.7.1",
     "@fortawesome/free-solid-svg-icons": "5.7.1",
     "@fortawesome/react-fontawesome": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "react": "16.7.0",
     "react-day-picker": "7.2.4",
     "react-dom": "16.7.0",
-    "react-fontawesome": "1.6.1",
     "react-highlight-words": "0.16.0",
     "react-hot-loader": "4.6.5",
     "react-hotkeys": "1.1.4",

--- a/ui/css/treeherder-loading-overlay.css
+++ b/ui/css/treeherder-loading-overlay.css
@@ -21,7 +21,8 @@
   width: 100%;
 }
 
-.overlay > div > span {
+.overlay > div > span,
+.overlay > div > svg {
   position: absolute;
   top: 40%;
   left: 45%;

--- a/ui/css/treeherder-test-view.css
+++ b/ui/css/treeherder-test-view.css
@@ -129,10 +129,6 @@ main .progress {
   cursor: pointer;
 }
 
-.toggle-count .fa {
-  padding-right: 0.25em;
-}
-
 [disabled]:hover {
   cursor: not-allowed;
 }

--- a/ui/entry-perf.js
+++ b/ui/entry-perf.js
@@ -2,11 +2,39 @@
 
 // Vendor Styles
 import 'bootstrap/dist/css/bootstrap.min.css';
-import 'font-awesome/css/font-awesome.css';
 import 'metrics-graphics/dist/metricsgraphics.css';
 
 // Vendor JS
 import 'bootstrap';
+import { library, dom, config } from '@fortawesome/fontawesome-svg-core';
+import {
+  faArrowAltCircleRight,
+  faClock,
+  faFileCode,
+  faFileWord,
+  faStar as faStarRegular,
+} from '@fortawesome/free-regular-svg-icons';
+import {
+  faAngleDoubleLeft,
+  faAngleDoubleRight,
+  faBan,
+  faBug,
+  faCheck,
+  faChevronLeft,
+  faChevronRight,
+  faCode,
+  faExclamationCircle,
+  faExclamationTriangle,
+  faExternalLinkAlt,
+  faLevelDownAlt,
+  faPlus,
+  faQuestionCircle,
+  faSpinner,
+  faStar as faStarSolid,
+  faUser,
+} from '@fortawesome/free-solid-svg-icons';
+import { faGithub } from '@fortawesome/free-brands-svg-icons';
+
 // The official 'flot' NPM package is out of date, so we're using 'jquery.flot'
 // instead, which is identical to https://github.com/flot/flot
 import 'jquery.flot';
@@ -32,3 +60,36 @@ import './js/components/loading';
 import './js/perfapp';
 import './perfherder/CompareSelectorView';
 import './perfherder/RevisionInformation';
+
+config.showMissingIcons = true;
+
+// TODO: Remove these as Perfherder components switch to using react-fontawesome.
+library.add(
+  faAngleDoubleLeft,
+  faAngleDoubleRight,
+  faArrowAltCircleRight,
+  faBan,
+  faBug,
+  faCheck,
+  faChevronLeft,
+  faChevronRight,
+  faClock,
+  faCode,
+  faExclamationCircle,
+  faExclamationTriangle,
+  faExternalLinkAlt,
+  faFileCode,
+  faFileWord,
+  faGithub,
+  faLevelDownAlt,
+  faPlus,
+  faQuestionCircle,
+  faSpinner,
+  faStarRegular,
+  faStarSolid,
+  faUser,
+);
+
+// Replace any existing <i> or <span> tags with <svg> and set up a MutationObserver
+// to continue doing this as the DOM changes. Remove once using react-fontawesome.
+dom.watch();

--- a/ui/intermittent-failures/BugDetailsView.jsx
+++ b/ui/intermittent-failures/BugDetailsView.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Row, Col } from 'reactstrap';
 import { Link } from 'react-router-dom';
-import Icon from 'react-fontawesome';
 import ReactTable from 'react-table';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 
 import { bugDetailsEndpoint, getJobsUrl } from '../helpers/url';
 
@@ -96,13 +97,11 @@ const BugDetailsView = props => {
       header={
         <React.Fragment>
           <Row>
-            <Col xs="12">
-              <span className="pull-left">
-                <Link to={lastLocation || '/'}>
-                  <Icon name="arrow-left" className="pr-1" />
-                  back
-                </Link>
-              </span>
+            <Col xs="12" className="text-left">
+              <Link to={lastLocation || '/'}>
+                <FontAwesomeIcon icon={faArrowLeft} className="mr-1" />
+                back
+              </Link>
             </Col>
           </Row>
           {!errorMessages.length && !tableFailureStatus && !graphFailureStatus && (

--- a/ui/intermittent-failures/DropdownMenuItems.jsx
+++ b/ui/intermittent-failures/DropdownMenuItems.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import Icon from 'react-fontawesome';
 import PropTypes from 'prop-types';
 import { DropdownMenu, DropdownItem } from 'reactstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
 
 const DropdownMenuItems = ({ selectedItem, updateData, options }) => (
   <DropdownMenu>
@@ -10,9 +11,9 @@ const DropdownMenuItems = ({ selectedItem, updateData, options }) => (
         key={item}
         onClick={event => updateData(event.target.innerText)}
       >
-        <Icon
-          name="check"
-          className={`pr-1 ${selectedItem === item ? '' : 'hide'}`}
+        <FontAwesomeIcon
+          icon={faCheck}
+          className={`mr-1 ${selectedItem === item ? '' : 'hide'}`}
         />
         {item}
       </DropdownItem>

--- a/ui/intermittent-failures/Layout.jsx
+++ b/ui/intermittent-failures/Layout.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Container } from 'reactstrap';
 import PropTypes from 'prop-types';
-import Icon from 'react-fontawesome';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCog } from '@fortawesome/free-solid-svg-icons';
 
 import ErrorBoundary from '../shared/ErrorBoundary';
 import ErrorMessages from '../shared/ErrorMessages';
@@ -47,7 +48,7 @@ const Layout = props => {
           errorMessages.length > 0
         ) && (
           <div className="loading">
-            <Icon spin name="cog" size="4x" />
+            <FontAwesomeIcon icon={faCog} size="4x" spin />
           </div>
         )}
       {(tableFailureStatus ||

--- a/ui/intermittent-failures/index.jsx
+++ b/ui/intermittent-failures/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render } from 'react-dom';
 import 'bootstrap/dist/css/bootstrap.min.css';
-import 'font-awesome/css/font-awesome.css';
 import 'react-table/react-table.css';
 
 import '../css/treeherder-global.css';

--- a/ui/js/components/loading.js
+++ b/ui/js/components/loading.js
@@ -7,7 +7,7 @@ treeherder.component('loading', {
     template: `
         <div ng-if="$ctrl.data" class="overlay">
             <div>
-                <span class="fa fa-spinner fa-pulse th-spinner-lg"></span>
+                <span class="fas fa-spinner fa-pulse th-spinner-lg"></span>
             </div>        
         </div>
     `,

--- a/ui/js/controllers/perf/alerts.js
+++ b/ui/js/controllers/perf/alerts.js
@@ -552,7 +552,7 @@ perf.controller('AlertsCtrl', [
         };
 
         $scope.summaryTitle = {
-            html: '<i class="fa fa-spinner fa-pulse" aria-hidden="true"/>',
+            html: '<i class="fas fa-spinner fa-pulse" aria-hidden="true"/>',
             promise: null,
         };
 
@@ -565,7 +565,7 @@ perf.controller('AlertsCtrl', [
         };
 
         $scope.resetSummaryTitle = function () {
-            $scope.summaryTitle.html = '<i class="fa fa-spinner fa-pulse" aria-hidden="true"/>';
+            $scope.summaryTitle.html = '<i class="fas fa-spinner fa-pulse" aria-hidden="true"/>';
         };
 
         $scope.filtersUpdated = function () {

--- a/ui/login-callback/LoginCallback.jsx
+++ b/ui/login-callback/LoginCallback.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import Icon from 'react-fontawesome';
 import { hot } from 'react-hot-loader/root';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 import AuthService from '../shared/auth/AuthService';
 import { webAuth, parseHash } from '../helpers/auth';
@@ -63,7 +64,7 @@ class LoginCallback extends React.PureComponent {
       return (
         <div>
           <span>Logging in..&nbsp;</span>
-          <Icon name="spinner" spin />
+          <FontAwesomeIcon icon={faSpinner} spin />
         </div>
       );
     }
@@ -71,7 +72,7 @@ class LoginCallback extends React.PureComponent {
     return (
       <div>
         <span>Redirecting..&nbsp;</span>
-        <Icon name="spinner" spin />
+        <FontAwesomeIcon icon={faSpinner} spin />
       </div>
     );
   }

--- a/ui/login-callback/index.jsx
+++ b/ui/login-callback/index.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render } from 'react-dom';
-import 'font-awesome/css/font-awesome.css';
 
 import LoginCallback from './LoginCallback';
 import '../css/login.css';

--- a/ui/logviewer/Navigation.jsx
+++ b/ui/logviewer/Navigation.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChartBar, faFileAlt } from '@fortawesome/free-regular-svg-icons';
+import { faTree } from '@fortawesome/free-solid-svg-icons';
 
 import LogoMenu from '../shared/LogoMenu';
 
@@ -45,7 +48,10 @@ export default class Navigation extends React.PureComponent {
                 rel="noopener noreferrer"
                 href={jobUrl}
               >
-                <span className="fa fa-tree actionbtn-icon mr-1" />
+                <FontAwesomeIcon
+                  icon={faTree}
+                  className="actionbtn-icon mr-1"
+                />
                 <span>open Job</span>
               </a>
             </span>
@@ -58,7 +64,10 @@ export default class Navigation extends React.PureComponent {
               rel="noopener noreferrer"
               href={rawLogUrl}
             >
-              <span className="fa fa-file-text-o actionbtn-icon mr-1" />
+              <FontAwesomeIcon
+                icon={faFileAlt}
+                className="actionbtn-icon mr-1"
+              />
               <span>open raw log</span>
             </a>
           </span>
@@ -71,7 +80,10 @@ export default class Navigation extends React.PureComponent {
                 rel="noopener noreferrer"
                 href={reftestUrl}
               >
-                <span className="fa fa-bar-chart-o actionbtn-icon mr-1" />
+                <FontAwesomeIcon
+                  icon={faChartBar}
+                  className="actionbtn-icon mr-1"
+                />
                 <span>open analyser</span>
               </a>
             </span>

--- a/ui/logviewer/index.jsx
+++ b/ui/logviewer/index.jsx
@@ -3,7 +3,6 @@ import { render } from 'react-dom';
 
 // Vendor Styles
 import 'bootstrap/dist/css/bootstrap.min.css';
-import 'font-awesome/css/font-awesome.css';
 
 // Vendor JS
 import 'bootstrap';

--- a/ui/partials/perf/alertsctrl.html
+++ b/ui/partials/perf/alertsctrl.html
@@ -44,7 +44,7 @@
       </div>
       <div class="alert-summary-title">
         <a class="anchor" href="#/alerts?id={{alertSummary.id}}" ng-class="{'alert-summary-title-invalid': alertSummary.status==4}">
-          Alert #{{alertSummary.id}} - {{alertSummary.repository}} - {{getTitle(alertSummary)}} <span class="fa fa-external-link icon-superscript"/>
+          Alert #{{alertSummary.id}} - {{alertSummary.repository}} - {{getTitle(alertSummary)}} <span class="fas fa-external-link-alt icon-superscript"/>
         </a>
         <br/>
         {{alertSummary.resultSetMetadata.dateStr}}
@@ -121,9 +121,10 @@
         </td>
         <td class="alert-labels">
           <a ng-attr-title="{{alert.starred ? 'Starred': 'Not starred'}}"
-             ng-class="{'fa fa-star visible': alert.starred, 'fa fa-star-o': !alert.starred}"
+             ng-class="{'visible': alert.starred}"
              ng-disabled="!user.isStaff"
              ng-click="toggleStar(alert)">
+             <i ng-class="{'fas fa-star': alert.starred, 'far fa-star': !alert.starred}"></i>
           </a>
         </td>
         <td class="alert-title">
@@ -190,7 +191,7 @@
             </span>
           </span>
           <span ng-if="alert.manually_created" uib-tooltip="Sheriff-created alert">
-            <span class="fa fa-user"/>
+            <span class="fas fa-user"></span>
           </span>
         </td>
       </tr>
@@ -218,25 +219,25 @@
           <button class="btn btn-light-bordered" role="button"
                   ng-if="!allSelectedAreConfirming(alertSummary.alerts)"
                   ng-click="markAlertsConfirming(alertSummary)" title="Retriggers & backfills are pending">
-            <span class="fa fa-clock-o"></span> Confirming
+            <span class="far fa-clock"></span> Confirming
           </button>
           <button class="btn btn-light-bordered" role="button"
                   ng-click="markAlertsAcknowledged(alertSummary)" title="Acknowledge selected alerts as valid">
-            <span class="fa fa-check"></span> Acknowledge
+            <span class="fas fa-check"></span> Acknowledge
           </button>
           <button class="btn btn-light-bordered" role="button"
                   ng-click="markAlertsInvalid(alertSummary)" title="Mark selected alerts as invalid">
-            <span class="fa fa-ban"></span> Mark invalid
+            <span class="fas fa-ban"></span> Mark invalid
           </button>
           <button class="btn btn-light-bordered" role="button"
                   ng-click="markAlertsDownstream(alertSummary)"
                   title="Mark selected alerts as downstream from an alert summary on another branch">
-            <span class="fa fa-level-down"></span> Mark downstream
+            <span class="fas fa-level-down-alt"></span> Mark downstream
           </button>
           <button class="btn btn-light-bordered" role="button"
                   ng-click="reassignAlerts(alertSummary)"
                   title="Reassign selected alerts to another alert summary on the same branch">
-            <span class="fa fa-arrow-circle-o-right"></span> Reassign
+            <span class="far fa-arrow-alt-circle-right"></span> Reassign
           </button>
         </span>
       </div>

--- a/ui/partials/perf/comparerror.html
+++ b/ui/partials/perf/comparerror.html
@@ -1,6 +1,6 @@
 <div class="alert alert-danger" role="alert">
     <p ng-repeat="error in errors">
-        <span class="fa fa-warning"></span> {{error}}
+        <span class="fas fa-exclamation-triangle"></span> {{error}}
     </p>
 <p><a class="alert-link" href="#/comparechooser?originalProject={{originalProject}}&originalRevision={{originalRevision}}&newProject={{newProject}}&newRevision={{newRevision}}">Modify choice</p>
 </div>

--- a/ui/partials/perf/comparetable.html
+++ b/ui/partials/perf/comparetable.html
@@ -143,7 +143,7 @@
                not confident in a change, more are unlikely to help)
           -->
         <span ng-if="compareResult.needsMoreRuns"
-              class="fa fa-warning-sign text-warning"
+              class="fas fa-exclamation-triangle text-warning"
               uib-tooltip="More base / new runs recommended for increased confidence in comparison"
               tooltip-placement="left"
               style="cursor:default"></span>

--- a/ui/partials/perf/graphsctrl.html
+++ b/ui/partials/perf/graphsctrl.html
@@ -22,7 +22,7 @@
         </tr>
       </table>
       <button id="add-test-data-button" class="btn btn-primary-soft" ng-click="addTestData()">
-        <span class="fa fa-plus" aria-hidden="true"></span> Add <span ng-show="seriesList.length > 0">more</span> test data</button>
+        <span class="fas fa-plus" aria-hidden="true"></span> Add <span ng-show="seriesList.length > 0">more</span> test data</button>
     </div>
     <div id="data-display">
       <select ng-model="myTimerange" ng-options="timerange.text for timerange in timeranges track by timerange.value" ng-change="timeRangeChanged()">
@@ -77,9 +77,9 @@
           <button title="Nudge left"
             ng-if="user.isStaff && tooltipContent.alert"
             ng-click="nudgeAlert(tooltipContent, 'left')">
-            <span class="fa fa-angle-double-left"
+            <span class="fas fa-angle-double-left"
               ng-if="!nudgingAlert"></span>
-            <span class="fa fa-spinner fa-pulse th-spinner-lg"
+            <span class="fas fa-spinner fa-pulse th-spinner-lg"
               ng-if="nudgingAlert"></span>
           </button>
           <a id="tt-cset" ng-href="{{tooltipContent.pushlogURL}}" target="_blank" rel="noopener">
@@ -88,9 +88,9 @@
           <button title="Nudge right"
             ng-if="user.isStaff && tooltipContent.alert"
             ng-click="nudgeAlert(tooltipContent, 'right')">
-            <span class="fa fa-angle-double-right"
+            <span class="fas fa-angle-double-right"
               ng-if="!nudgingAlert"></span>
-            <span class="fa fa-spinner fa-pulse th-spinner-lg"
+            <span class="fas fa-spinner fa-pulse th-spinner-lg"
               ng-if="nudgingAlert"></span>
           </button>
           <span ng-show="tooltipContent.prevRevision && tooltipContent.revision">
@@ -98,7 +98,7 @@
           </span>
         </p>
         <p ng-if="tooltipContent.alertSummary">
-          <i class="text-warning fa fa-exclamation-circle"></i>
+          <i class="text-warning fas fa-exclamation-circle"></i>
           <a href="perf.html#/alerts?id={{tooltipContent.alertSummary.id}}">
             Alert #{{tooltipContent.alertSummary.id}}</a>
         <span class="text-muted">- {{tooltipContent.alert && (alertIsOfState(tooltipContent.alert, phAlertStatusMap.ACKNOWLEDGED) ? getAlertSummarytStatusText(tooltipContent.alertSummary) : getAlertStatusText(tooltipContent.alert))}}
@@ -123,7 +123,7 @@
             </span>
           </span>
           <span ng-if="creatingAlert">
-            Creating alert... <i class="fa fa-spinner fa-pulse"></i>
+            Creating alert... <i class="fas fa-spinner fa-pulse"></i>
           </span>
         </p>
         <p ng-hide="tooltipContent.revision">

--- a/ui/partials/perf/helpMenu.html
+++ b/ui/partials/perf/helpMenu.html
@@ -1,25 +1,26 @@
+<!--- TODO: Replace this with the React component used by jobs-view -->
 <li>
   <a class="dropdown-item" href="https://treeherder.readthedocs.io/" target="_blank" rel="noopener">
-    <span class="fa fa-file-code-o midgray"></span>
+    <span class="far fa-file-code fa-fw mr-1 midgray"></span>
     Development Documentation</a>
 </li>
 <li>
   <a class="dropdown-item" href="/docs/" target="_blank" rel="noopener">
-    <span class="fa fa-code midgray"></span>
+    <span class="fas fa-code fa-fw mr-1 midgray"></span>
     API Reference</a>
 </li>
 <li>
   <a class="dropdown-item" href="https://wiki.mozilla.org/EngineeringProductivity/Projects/Perfherder" target="_blank" rel="noopener">
-    <span class="fa fa-file-word-o midgray"></span>
+    <span class="far fa-file-word fa-fw mr-1 midgray"></span>
     Project Wiki</a>
 </li>
 <li>
   <a class="dropdown-item" href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree%20Management&component=Perfherder" target="_blank" rel="noopener">
-    <span class="fa fa-bug midgray"></span>
+    <span class="fas fa-bug fa-fw mr-1 midgray"></span>
     Report a Bug</a>
 </li>
 <li>
   <a class="dropdown-item" href="https://github.com/mozilla/treeherder" target="_blank" rel="noopener">
-    <span class="fa fa-github midgray"></span>
+    <span class="fab fa-github fa-fw mr-1 midgray"></span>
     Source</a>
 </li>

--- a/ui/partials/perf/testdatachooser.html
+++ b/ui/partials/perf/testdatachooser.html
@@ -43,10 +43,10 @@
   </div>
   <div class="btn-group-vertical">
     <button id="unselect-test" ng-click="unselectTest()" type="button" class="btn btn-xs btn-light-bordered" ng-disabled="!testsToAdd.length">
-      <span class="fa fa-chevron-left"></span>
+      <span class="fas fa-chevron-left"></span>
     </button>
     <button id="select-test" ng-click="selectTest()" type="button" class="btn btn-xs btn-light-bordered" ng-disabled="!unselectedTestList.length">
-      <span class="fa fa-chevron-right"></span>
+      <span class="fas fa-chevron-right"></span>
     </button>
   </div>
   <div class="test-list-container">
@@ -63,5 +63,5 @@
   </div>
 </div>
 <div class="modal-footer">
-  <button class="btn btn-primary-soft" ng-click="addTestData()" ng-disabled="!testsToAdd.length" ng-model="rightList"><span class="fa fa-plus" aria-hidden="true"></span> Add</button>
+  <button class="btn btn-primary-soft" ng-click="addTestData()" ng-disabled="!testsToAdd.length" ng-model="rightList"><span class="fas fa-plus" aria-hidden="true"></span> Add</button>
 </div>

--- a/ui/perf.html
+++ b/ui/perf.html
@@ -60,9 +60,7 @@
               data-toggle="dropdown"
               class="btn btn-view-nav nav-help-btn dropdown-toggle"
             >
-              <span
-                class="fa fa-question-circle lightgray nav-help-icon"
-              ></span>
+              <span class="fas fa-question-circle lightgray"></span>
             </button>
             <ul
               class="dropdown-menu nav-dropdown-menu-right icon-menu"

--- a/ui/perfherder/SelectorCard.jsx
+++ b/ui/perfherder/SelectorCard.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Icon from 'react-fontawesome';
 import {
   Col,
   Card,
@@ -18,6 +17,8 @@ import {
   InputGroup,
   InputGroupButtonDropdown,
 } from 'reactstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
 
 import { createQueryParams, pushEndpoint } from '../helpers/url';
 import { getData } from '../helpers/http';
@@ -230,9 +231,9 @@ export default class SelectorCard extends React.Component {
                         this.updateRevisions(event.target.innerText)
                       }
                     >
-                      <Icon
-                        name="check"
-                        className={`pr-1 ${
+                      <FontAwesomeIcon
+                        icon={faCheck}
+                        className={`mr-1 ${
                           selectedRepo === item.name ? '' : 'hide'
                         }`}
                       />
@@ -298,9 +299,9 @@ export default class SelectorCard extends React.Component {
                               )
                             }
                           >
-                            <Icon
-                              name="check"
-                              className={`pr-1 ${
+                            <FontAwesomeIcon
+                              icon={faCheck}
+                              className={`mr-1 ${
                                 selectedRevision === item.revision ? '' : 'hide'
                               }`}
                             />

--- a/ui/shared/auth/Login.jsx
+++ b/ui/shared/auth/Login.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
-import { faUser } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faUser } from '@fortawesome/free-solid-svg-icons';
 
 import { loggedOutUser } from '../../helpers/auth';
 import taskcluster from '../../helpers/taskcluster';

--- a/ui/test-view/index.jsx
+++ b/ui/test-view/index.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import 'bootstrap/dist/css/bootstrap.min.css';
-import 'font-awesome/css/font-awesome.css';
 
 import '../css/treeherder-test-view.css';
 import { store, actions } from './redux/store';

--- a/ui/test-view/ui/Groups.jsx
+++ b/ui/test-view/ui/Groups.jsx
@@ -10,8 +10,9 @@ import {
   Table,
   Container,
 } from 'reactstrap';
-import Icon from 'react-fontawesome';
 import { connect } from 'react-redux';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBug, faSpinner, faUnlink } from '@fortawesome/free-solid-svg-icons';
 
 import { store, actions } from '../redux/store';
 
@@ -78,10 +79,18 @@ class Groups extends React.Component {
             <Row>
               <Col md={3} sm={12} xs={12} style={{ textAlign: 'right' }}>
                 Known intermittent failure&nbsp;&nbsp;
-                <Icon name="bug" style={{ color: '#d78236' }} />
+                <FontAwesomeIcon
+                  icon={faBug}
+                  size="sm"
+                  className="classified-intermittent"
+                />
                 <br />
                 Infrastructure issue&nbsp;&nbsp;
-                <Icon name="chain-broken" style={{ color: '#db3737' }} />
+                <FontAwesomeIcon
+                  icon={faUnlink}
+                  size="sm"
+                  className="classified-infra"
+                />
               </Col>
               <Col md={6} sm={12} xs={12}>
                 <FormGroup style={{ marginBottom: 0 }}>
@@ -157,7 +166,7 @@ class Groups extends React.Component {
                   colSpan={4}
                   style={{ textAlign: 'center', paddingTop: '2rem' }}
                 >
-                  <Icon name="spinner" size="2x" spin />
+                  <FontAwesomeIcon icon={faSpinner} size="2x" spin />
                 </td>
               </tr>
             </tbody>

--- a/ui/test-view/ui/StatusNavbar.jsx
+++ b/ui/test-view/ui/StatusNavbar.jsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Navbar, Nav, Badge } from 'reactstrap';
-import Icon from 'react-fontawesome';
 import { connect } from 'react-redux';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faCheckSquare,
+  faIdCard,
+  faSquare,
+} from '@fortawesome/free-regular-svg-icons';
+import { faCode } from '@fortawesome/free-solid-svg-icons';
 
 import { store, actions } from '../redux/store';
 
@@ -41,13 +47,14 @@ class StatusNavbar extends React.Component {
       <Navbar expand>
         <Nav className="mr-auto">
           <span className="navbar-text">
-            <Icon name="code" /> Revision{' '}
+            <FontAwesomeIcon icon={faCode} size="sm" /> Revision{' '}
             <code className="push-revision">{push.revision}</code>
           </span>
 
           <span className="navbar-text">
             <span className="hidden-sm-down">&mdash;&nbsp;&nbsp;&nbsp;</span>
-            <Icon name="id-card-o" /> Author <code>{push.author}</code>
+            <FontAwesomeIcon icon={faIdCard} /> Author{' '}
+            <code>{push.author}</code>
           </span>
         </Nav>
 
@@ -60,7 +67,10 @@ class StatusNavbar extends React.Component {
           onClick={() => this.toggleHideClassified('infra')}
         >
           <Badge color="infra">
-            <Icon name={hideClassified.infra ? 'square-o' : 'check-square-o'} />
+            <FontAwesomeIcon
+              icon={hideClassified.infra ? faSquare : faCheckSquare}
+              pull="left"
+            />
             {counts.infra} Infra Tests
           </Badge>
         </span>
@@ -70,8 +80,9 @@ class StatusNavbar extends React.Component {
           onClick={() => this.toggleHideClassified('intermittent')}
         >
           <Badge color="intermittent">
-            <Icon
-              name={hideClassified.intermittent ? 'square-o' : 'check-square-o'}
+            <FontAwesomeIcon
+              icon={hideClassified.intermittent ? faSquare : faCheckSquare}
+              pull="left"
             />
             {counts.intermittent} Intermittent Tests
           </Badge>

--- a/ui/test-view/ui/Test.jsx
+++ b/ui/test-view/ui/Test.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import Icon from 'react-fontawesome';
 import { connect } from 'react-redux';
 import { Badge } from 'reactstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faBug,
+  faMinus,
+  faUnlink,
+  faStar,
+} from '@fortawesome/free-solid-svg-icons';
 
 import { store, actions } from '../redux/store';
 import { thPlatformMap } from '../../helpers/constants';
@@ -42,7 +48,10 @@ class BugCountComponent extends React.Component {
         {// TODO: Clean this up
         // eslint-disable-next-line no-nested-ternary
         this.props.test.bugs === undefined ? (
-          <Icon name="minus" title="Click to expand and fetch bugs" />
+          <FontAwesomeIcon
+            icon={faMinus}
+            title="Click to expand and fetch bugs"
+          />
         ) : Object.keys(this.props.test.bugs).length > 0 ? (
           Object.keys(this.props.test.bugs).length
         ) : (
@@ -75,14 +84,24 @@ class Platform extends React.Component {
         return;
       case 'intermittent':
         return (
-          <Icon name="bug" className="classified classified-intermittent" />
+          <FontAwesomeIcon
+            icon={faBug}
+            size="sm"
+            className="classified classified-intermittent"
+          />
         );
       case 'infra':
         return (
-          <Icon name="chain-broken" className="classified classified-infra" />
+          <FontAwesomeIcon
+            icon={faUnlink}
+            size="sm"
+            className="classified classified-infra"
+          />
         );
       default:
-        return <Icon name="star" className="classified" />;
+        return (
+          <FontAwesomeIcon icon={faStar} size="sm" className="classified" />
+        );
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7718,7 +7718,7 @@ prompts@^2.0.1:
     kleur "^3.0.0"
     sisteransi "^1.0.0"
 
-prop-types@15.6.2, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@15.6.2, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
@@ -7924,13 +7924,6 @@ react-dom@16.7.0, react-dom@^16.6.3:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.12.0"
-
-react-fontawesome@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/react-fontawesome/-/react-fontawesome-1.6.1.tgz#eddce17e7dc731aa09fd4a186688a61793a16c5c"
-  integrity sha1-7dzhfn3HMaoJ/UoYZoimF5OhbFw=
-  dependencies:
-    prop-types "^15.5.6"
 
 react-highlight-words@0.16.0:
   version "0.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -742,6 +742,13 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.14"
 
+"@fortawesome/free-brands-svg-icons@5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.7.1.tgz#20711fe4d6a459161d052171169baa175b90fca1"
+  integrity sha512-YU+np8UJGjHUmzfGS5yyK0wWR0QHbx5lTFRSylBfEkm8QXvOkRxB03sUhOSIWVXU7iPiePuqrsglQRgxoG4nrw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.14"
+
 "@fortawesome/free-regular-svg-icons@5.7.1":
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.7.1.tgz#eab182769eef910f961ed4c3a581ebd9934b4b38"


### PR DESCRIPTION
This continues on the work in #4475 of switching to Font Awesome v5 and using the React version over the manual CSS classes approach, since we're currently using a mixture of 3 different Font Awesome packages which isn't ideal since their stylesheets are not compatible with each other.

Before:
* Login callback / Test view / Intermittent failures view:
  - Legacy `react-fontawesome`
* Logviewer:
  - Font Awesome v4 web fonts
* Perfherder:
  - combination of Font Awesome v4 web fonts and legacy `react-fontawesome`

After:
* Login callback / Test view / Intermittent failures view / Logviewer / User guide:
  - Modern `react-fontawesome` (`@fortawesome/react-fontawesome`)
* Perfherder:
  - combination of Font Awesome v5 SVG+JS and modern `react-fontawesome`

Unchanged:
* Push health / shared login component:
  - Modern `react-fontawesome` (`@fortawesome/react-fontawesome`)
* Job view / User guide:
  - Font Awesome v4 web fonts
 
As and when Perfherder components are re-written in React they can switch over to `react-fontawesome`, which will be much easier now (since using the same version of Font Awesome and SVG+JS not web fonts).

The final other pieces are job-view and userguide, however I've split that out to simplify review / mean we can get this merged sooner, unblocking the use of react-fontawesome during the Perfherder conversion.

Relevant docs:
* https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4
* https://github.com/FortAwesome/react-fontawesome#usage

Note: The CSS changes replacing padding with margins is due to the new version using SVG rather than webfonts, which affects the way layout is calculated.