### PR TITLE
Bug 1525239 - Use the browser version of js-yaml not the node version

### DIFF
--- a/ui/job-view/CustomJobActions.jsx
+++ b/ui/job-view/CustomJobActions.jsx
@@ -3,7 +3,11 @@ import Select from 'react-select';
 import PropTypes from 'prop-types';
 import Ajv from 'ajv';
 import jsonSchemaDefaults from 'json-schema-defaults';
-import jsyaml from 'js-yaml';
+// js-yaml is missing the `browser` entry from the package definition,
+// so we have to explicitly import the dist file otherwise we get the
+// node version which pulls in a number of unwanted polyfills. See:
+// https://github.com/nodeca/js-yaml/pull/462
+import jsyaml from 'js-yaml/dist/js-yaml';
 import { slugid } from 'taskcluster-client-web';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 


### PR DESCRIPTION
Doing so shaves 156KB off the minified index entrypoint (job-view), which is >10%. The reason the browser version is not used automatically is that the js-yaml package is missing the `browser` field from it's `package.json`.

See:
https://github.com/nodeca/js-yaml/pull/462
(which looks like it might be wontfix, hence adding the workaround here)