### PR TITLE
Bug 1525368: Update ci-{admin,config} repository paths.

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1253,7 +1253,7 @@
     "fields": {
       "dvcs_type": "hg",
       "name": "ci-admin",
-      "url": "https://hg.mozilla.org/build/ci-admin",
+      "url": "https://hg.mozilla.org/ci/ci-admin",
       "active_status": "active",
       "codebase": "ci-admin",
       "repository_group": 9,
@@ -1266,7 +1266,7 @@
     "fields": {
       "dvcs_type": "hg",
       "name": "ci-configuration",
-      "url": "https://hg.mozilla.org/build/ci-configuration",
+      "url": "https://hg.mozilla.org/ci/ci-configuration",
       "active_status": "active",
       "codebase": "ci-admin",
       "repository_group": 9,

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1359,5 +1359,31 @@
       "description": "Tools for defining graphs fo taskclutser tasks",
       "is_try_repo": true
     }
+  },
+  {
+    "pk": 105,
+    "model": "model.repository",
+    "fields": {
+      "dvcs_type": "hg",
+      "name": "ci-admin-try",
+      "url": "https://hg.mozilla.org/ci/ci-admin-try",
+      "active_status": "active",
+      "codebase": "ci-admin",
+      "repository_group": 9,
+      "description": "Administrative scripts for Firefox CI"
+    }
+  },
+  {
+    "pk": 106,
+    "model": "model.repository",
+    "fields": {
+      "dvcs_type": "hg",
+      "name": "ci-configuration-try",
+      "url": "https://hg.mozilla.org/ci/ci-configuration-try",
+      "active_status": "active",
+      "codebase": "ci-admin",
+      "repository_group": 9,
+      "description": "Administrative configuration for Firefox CI"
+    }
   }
 ]


### PR DESCRIPTION
This needs to be deployed after the move [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1525368) takes place.