### PR TITLE
Update Renovate config to set reviewer and labels

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
     "@types/react-dom",
     "@uirouter/angularjs"
   ],
-  "reviewers": ["@mozilla/treeherder-admins"],
+  "labels": ["dependencies", "javascript"],
+  "reviewers": ["sarah-clements"],
   "semanticCommits": false
 }


### PR DESCRIPTION
Unfortunately Renovate doesn't currently support setting a team alias as the reviewer (see renovatebot/renovate/issues/1908), but does support listing one or more users.

We could list both Sarah and Cameron, however GitHub doesn't cancel the other person's review once the first person has reviewed, so it seems easiest to just say that one person reviews JS dep updates (Renovate) and the other reviews Python deps (Dependabot).

I've also set labels to match the style configured for Dependabot.