### PR TITLE
Bug 1526223 - Remove /resultset/ endpoint in favour of /push/

### DIFF
--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -41,12 +41,6 @@ project_bound_router.register(
 )
 
 project_bound_router.register(
-    r'resultset',
-    push.PushViewSet,
-    base_name='resultset',
-)
-
-project_bound_router.register(
     r'push',
     push.PushViewSet,
     base_name='push',


### PR DESCRIPTION
They are identical other than name, and we no longer use `/resultset/`.