### PR TITLE
Bug 1526339 - fix noise metric for subtests view 

### DIFF
--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -473,7 +473,6 @@ perf.controller('CompareSubtestResultsCtrl', [
             const cmap = getCounterMap(noiseMetricTitle, $scope.oldStddevVariance, $scope.newStddevVariance);
             if (!cmap.isEmpty) {
                 createNoiseMetric(cmap, testName, $scope.compareResults)
-                $scope.titles[noiseMetricTitle] = $scope.platformList[0] + ': ' + testName + ' : ' + noiseMetricTitle;
             }
 
             // call $apply explicitly so we don't have to worry about when promises

--- a/ui/perfherder/CompareTable.jsx
+++ b/ui/perfherder/CompareTable.jsx
@@ -28,9 +28,9 @@ export default class CompareTable extends React.Component {
     )}% ${improvement ? 'better' : 'worse'})`;
 
   render() {
-    const { data, testName, title } = this.props;
+    const { data, testName } = this.props;
     return (
-      <Table sz="small" className="compare-table mb-0" key={title || testName}>
+      <Table sz="small" className="compare-table mb-0" key={testName}>
         <thead>
           <tr className="subtest-header bg-lightgray">
             <th className="text-left">
@@ -188,10 +188,8 @@ export default class CompareTable extends React.Component {
 CompareTable.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape({})),
   testName: PropTypes.string.isRequired,
-  title: PropTypes.shape({}),
 };
 
 CompareTable.defaultProps = {
   data: null,
-  title: null,
 };


### PR DESCRIPTION
There was a bug in the subtests controller that was breaking the view when 'test metric' was included in the data. I consolidated duplicate logic in the test metric (should have done this right away as per Cam's suggestion in #4538, rather than waiting till I start converting this file next week). I think that helper function will get folded into a component to be used by both views, so leaving it in the compare.js file for now.

While there, I removed the 'title' prop that wasn't being used by the subtests view and isn't necessary and removed the redundant variable `noiseMetricTestName`.