### PR TITLE
Bug 1453967 - Ensure arguments passed to hashlib update() are bytes

### DIFF
--- a/tests/etl/test_job_ingestion.py
+++ b/tests/etl/test_job_ingestion.py
@@ -17,6 +17,11 @@ def test_ingest_single_sample_job(test_repository, failure_classifications,
     """Process a single job structure in the job_data.txt file"""
     job_data = sample_data.job_data[:1]
     test_utils.do_job_ingestion(test_repository, job_data, sample_push)
+    assert Job.objects.count() == 1
+    job = Job.objects.get(id=1)
+    # Ensure we don't inadvertently change the way we generate job-related hashes.
+    assert job.option_collection_hash == '32faaecac742100f7753f0c1d0aa0add01b4046b'
+    assert job.signature.signature == '4dabe44cc898e585228c43ea21337a9b00f5ddf7'
 
 
 def test_ingest_all_sample_jobs(test_repository, failure_classifications,

--- a/tests/etl/test_perf_data_adapters.py
+++ b/tests/etl/test_perf_data_adapters.py
@@ -236,6 +236,8 @@ def test_load_generic_data(test_repository,
 
     summary_signature = PerformanceSignature.objects.get(
         suite=perf_datum['suites'][0]['name'], test='')
+    # Ensure we don't inadvertently change the way we generate signature hashes.
+    assert summary_signature.signature_hash == 'f451f0c9000a7f99e5dc2f05792bfdb0e11d0cac'
     subtest_signatures = PerformanceSignature.objects.filter(
         parent_signature=summary_signature).values_list('signature_hash', flat=True)
     assert len(subtest_signatures) == 3

--- a/treeherder/etl/jobs.py
+++ b/treeherder/etl/jobs.py
@@ -155,7 +155,7 @@ def _load_job(repository, job_datum, push_id):
              machine_platform.architecture,
              job_group.name, job_group.symbol, job_type.name,
              job_type.symbol, option_collection_hash,
-             reference_data_name])))
+             reference_data_name])).encode('utf-8'))
     signature_hash = sh.hexdigest()
 
     # Should be the buildername in the case of buildbot (if not provided

--- a/treeherder/etl/perf.py
+++ b/treeherder/etl/perf.py
@@ -31,7 +31,7 @@ def _get_signature_hash(signature_properties):
     signature_prop_values.extend(str_values)
 
     sha = sha1()
-    sha.update(''.join(map(str, sorted(signature_prop_values))))
+    sha.update(''.join(map(str, sorted(signature_prop_values))).encode('utf-8'))
 
     return sha.hexdigest()
 

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -347,7 +347,7 @@ class OptionCollection(models.Model):
         options = sorted(list(options))
         sha_hash = sha1()
         # equivalent to loop over the options and call sha_hash.update()
-        sha_hash.update(''.join(options))
+        sha_hash.update(''.join(options).encode('utf-8'))
         return sha_hash.hexdigest()
 
     class Meta:


### PR DESCRIPTION
Since Python 3's hashlib's `.update()` must be passed bytes not unicode:
https://docs.python.org/3/library/hashlib.html#hash-algorithms
https://docs.python.org/3/library/hashlib.html#hashlib.hash.update

Fixes:
`TypeError: Unicode-objects must be encoded before hashing`

Additional test assertions have also been added to ensure the generated hashes did not change as a result of this. ([travis run prior to the code change](https://travis-ci.org/mozilla/treeherder/jobs/490914050))