### PR TITLE
Bug 1526657 - Make remaining .iteritems() usage Python 3 compatible

### DIFF
--- a/treeherder/services/elasticsearch/utils.py
+++ b/treeherder/services/elasticsearch/utils.py
@@ -1,4 +1,5 @@
-from six import string_types
+from six import (iteritems,
+                 string_types)
 
 
 def dict_to_op(d, index_name, doc_type, op_type='index'):
@@ -53,4 +54,4 @@ def to_dict(obj):
     ]
 
     all_fields = obj.to_dict()
-    return {k: v for k, v in all_fields.iteritems() if k in keys}
+    return {k: v for k, v in iteritems(all_fields) if k in keys}


### PR DESCRIPTION
Since this usage was added after the others were converted in #3418.

Fixes:
`AttributeError: 'dict' object has no attribute 'iteritems'`