### PR TITLE
Bug 1526682 - Remove Python 3 incompatible usage of filter()

### DIFF
--- a/tests/webapp/api/test_performance_alerts_api.py
+++ b/tests/webapp/api/test_performance_alerts_api.py
@@ -2,6 +2,7 @@ import copy
 
 import pytest
 from django.urls import reverse
+from first import first
 
 from treeherder.model.models import Push
 from treeherder.perf.models import (PerformanceAlert,
@@ -441,8 +442,8 @@ def link_alert_summary_in_perf_data(test_perf_data, test_perf_alert,
                                     perf_datum_id):
     assert perf_datum_id > 0
 
-    perf_datum = filter(lambda tpd: tpd.id == perf_datum_id, test_perf_data)[0]
-    prev_perf_datum = filter(lambda tpd: tpd.id == perf_datum_id-1, test_perf_data)[0]
+    perf_datum = first(test_perf_data, key=lambda tpd: tpd.id == perf_datum_id)
+    prev_perf_datum = first(test_perf_data, key=lambda tpd: tpd.id == perf_datum_id-1)
 
     # adjust relations
     alert_summary = test_perf_alert.summary


### PR DESCRIPTION
Python 3's `filter()` now return iterators rather than list/..., so must be cast back to a `list()` if used in contexts where an iterator is not supported. However in this case `first` fulfils the goal more cleanly.

Fixes:
`TypeError: 'filter' object is not subscriptable`