### PR TITLE
Vagrant: Fix error during dist-upgrade due to conf file prompt

### DIFF
--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -52,7 +52,7 @@ fi
 
 echo '-----> Installing/updating APT packages'
 sudo -E apt-get -yqq update
-sudo -E apt-get -yqq dist-upgrade
+sudo -E apt-get -yqq -o 'Dpkg::Options::=--force-confnew' dist-upgrade
 # libdbus-glib-1-2, libgtk-3.0 and libxt6 are required by Firefox
 # gcc and libmysqlclient-dev are required by mysqlclient
 # openjdk-8-jre-headless is required by Elasticsearch


### PR DESCRIPTION
Recent Ubuntu package updates mean that a clean Vagrant provision was failing due to dpkg wanting an answer to the "which version of the config file would you like to keep" question, which fails when apt-get is run non-interactively.

To avoid such prompts we have to force dpkg to always pick one of the config file conflict resolution options -- in this case I've chosen to always use the new version of the config file (via `--force-confnew`), since we don't customise any system config files, so overwriting any existing ones is fine.

Fixes:

```
default: Setting up ubuntu-release-upgrader-core (1:18.04.30) ...
default: Configuration file '/etc/update-manager/release-upgrades'
default:  ==> Modified (by you or by a script) since installation.
default:  ==> Package distributor has shipped an updated version.
default:    What would you like to do about it ?  Your options are:
default:     Y or I  : install the package maintainer's version
default:     N or O  : keep your currently-installed version
default:       D     : show the differences between the versions
default:       Z     : start a shell to examine the situation
default:  The default action is to keep your current version.
default: *** release-upgrades (Y/I/N/O/D/Z) [default=N] ?
default: Configuration file '/etc/update-manager/release-upgrades'
default:  ==> Modified (by you or by a script) since installation.
default:  ==> Package distributor has shipped an updated version.
default:    What would you like to do about it ?  Your options are:
default:     Y or I  : install the package maintainer's version
default:     N or O  : keep your currently-installed version
default:       D     : show the differences between the versions
default:       Z     : start a shell to examine the situation
default:  The default action is to keep your current version.
default: *** release-upgrades (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package ubuntu-release-upgrader-core (--configure):
default:  end of file on stdin at conffile prompt
default: dpkg: dependency problems prevent configuration of update-manager-core:
default:  update-manager-core depends on ubuntu-release-upgrader-core (>= 1:18.04.9); however:
default:   Package ubuntu-release-upgrader-core is not configured yet.
default:
default: dpkg: error processing package update-manager-core (--configure):
default:  dependency problems - leaving unconfigured
default: dpkg: dependency problems prevent configuration of update-notifier-common:
default:  update-notifier-common depends on update-manager-core (>= 1:17.04.2); however:
default:   Package update-manager-core is not configured yet.
default:
default: dpkg: error processing package update-notifier-common (--configure):
default:  dependency problems - leaving unconfigured
default: Processing triggers for libc-bin (2.27-3ubuntu1) ...
default: No apport report written because the error message indicates its a followup error from a previous failure.
default: No apport report written because the error message indicates its a followup error from a previous failure.
default: Processing triggers for initramfs-tools (0.130ubuntu3.6) ...
default: update-initramfs: Generating /boot/initrd.img-4.15.0-29-generic
default: Errors were encountered while processing:
default:  ubuntu-release-upgrader-core
default:  update-manager-core
default:  update-notifier-common
```