### PR TITLE
Vagrant: Update pip to 19.02

### DIFF
--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -18,7 +18,7 @@ cd "$SRC_DIR"
 ELASTICSEARCH_VERSION="6.2.4"
 GECKODRIVER_VERSION="0.24.0"
 PYTHON_VERSION="$(sed 's/python-//' runtime.txt)"
-PIP_VERSION="18.0"
+PIP_VERSION="19.0.2"
 # Keep in sync with the version pre-installed on Travis.
 # https://github.com/travis-ci/travis-cookbooks/blob/9595f0a5316a2bc9b15f1e8a07e58cd07b97167c/cookbooks/travis_build_environment/attributes/default.rb#L267-L270
 SHELLCHECK_VERSION="0.6.0"


### PR DESCRIPTION
Since the Travis pre-installed pip is already v19.x.

See:
https://pip.pypa.io/en/stable/news/