### PR TITLE
Bug 1526764 - Make test_intermittents_commenter pass under Python 3

### DIFF
--- a/tests/intermittents_commenter/test_commenter.py
+++ b/tests/intermittents_commenter/test_commenter.py
@@ -37,7 +37,6 @@ def test_intermittents_commenter(bug_data):
                     status=200))
 
     resp = process.fetch_bug_details(bug_data['bug_id'])
-    assert responses.calls[0].request.url == url
     assert resp == content['bugs']
 
     comment_params = process.generate_bug_changes(startday, endday, alt_startday, alt_endday)

--- a/treeherder/intermittents_commenter/comment.template
+++ b/treeherder/intermittents_commenter/comment.template
@@ -21,11 +21,11 @@ This is the #{{rank}} most frequent failure this week.{% endif %}
 ** This test has failed more than 150 times in the last 21 days. It should be disabled until it can be fixed. ** {% endif %}
 
 Repository breakdown:
-{% for repository, count in repositories.iteritems() -%}
+{% for repository, count in repositories.items() -%}
 * {{repository}}: {{count}}
 {% endfor %}
 Platform breakdown:
-{% for platform, count in platforms.iteritems() -%}
+{% for platform, count in platforms.items() -%}
 * {{platform}}: {{count}}
 {% endfor %}
 For more details, see:


### PR DESCRIPTION
* Switches from `.iteritems()` to `.items()` in the Jinja template.
* Removes an assert from `test_intermittents_commenter` that is redundant (due to `match_querystring=True`) and non-deterministic across Python versions (due to the query string params being affected by dict order).