### PR TITLE
Bug 1526766 - Fix bug-job-map job_id error handling under Python 3

### DIFF
--- a/treeherder/webapp/api/bug.py
+++ b/treeherder/webapp/api/bug.py
@@ -56,7 +56,9 @@ class BugJobMapViewSet(viewsets.ViewSet):
 
     def list(self, request, project):
         try:
-            job_ids = map(int, request.query_params.getlist('job_id'))
+            # Casting to list since Python 3's `map` returns an iterator,
+            # which would hide any ValueError until used by the ORM below.
+            job_ids = list(map(int, request.query_params.getlist('job_id')))
         except ValueError:
             return Response({"message": "Valid job_id required"},
                             status=400)


### PR DESCRIPTION
Python 3's `map()` returns an iterator rather than a list/..., which delays any `ValueError` until point of use, which is after the try-catch. As such it must be explicitly cast to a list to force its evaluation.

Prevents the following exception in `test_bug_job_map_bad_job_id`:
`ValueError: invalid literal for int() with base 10: 'aaaa'`