### PR TITLE
Bug 1526763 - Remove `.encode()` from test_load_non_ascii_textlog_errors

### DIFF
--- a/tests/etl/test_load_artifacts.py
+++ b/tests/etl/test_load_artifacts.py
@@ -96,12 +96,12 @@ def test_load_non_ascii_textlog_errors(test_job):
                         'errors': [
                             {
                                 # non-ascii character
-                                "line": '07:51:28  WARNING - \U000000c3'.encode('utf-8'),
+                                "line": '07:51:28  WARNING - \U000000c3',
                                 "linenumber": 1587
                             },
                             {
                                 # astral character (i.e. higher than ucs2)
-                                "line": '07:51:29  WARNING - \U0001d400'.encode('utf-8'),
+                                "line": '07:51:29  WARNING - \U0001d400',
                                 "linenumber": 1588
                             }
                         ]


### PR DESCRIPTION
Since by design `.encode()` returns bytes, whereas the test should be using a string. The goal of the encode seems to have been to handle unicode correctly, however that's now achieved via the use of:
`from __future__ import unicode_literals`

Fixes the following exception under Python 3:
`TypeError: Object of type bytes is not JSON serializable`