### PR TITLE
Bug 1526763 - Explicitly convert encoded task IDs back to a string

### DIFF
--- a/treeherder/etl/job_loader.py
+++ b/treeherder/etl/job_loader.py
@@ -140,7 +140,9 @@ class JobLoader(object):
         # https://bugzilla.mozilla.org/show_bug.cgi?id=1323110#c7
         try:
             (decoded_task_id, retry_id) = job_guid.split('/')
-            real_task_id = slugid.encode(uuid.UUID(decoded_task_id))
+            # Using `.decode('ascii')` to match the `slugid.encode()` implementation:
+            # https://github.com/taskcluster/slugid.py/blob/v1.0.7/slugid/slugid.py#L22
+            real_task_id = slugid.encode(uuid.UUID(decoded_task_id)).decode('ascii')
             x["job"].update({
                 "taskcluster_task_id": real_task_id,
                 "taskcluster_retry_id": int(retry_id)


### PR DESCRIPTION
Since `slugid.encode()` internally uses `base64.b64encode()` which returns bytes under Python 3:
https://docs.python.org/3/library/base64.html#base64.b64encode

Fixes the following exception during `test_job_transformation`:
`TypeError: Object of type bytes is not JSON serializable`