### PR TITLE
Bug 1526909 - Perf alerts missing color indicators

### DIFF
--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -412,6 +412,25 @@ th {
   width: 160px;
   text-align: right;
 }
+/* TODO replace with bootstrap colors */
+.bar {
+  height: 1em;
+  margin-top: 0.25em;
+  margin-bottom: 5px;
+  background-color: #bbb;
+}
+
+.bar-scale {
+  background-color: #eee;
+}
+
+.bar-improvement {
+  background-color: green;
+}
+
+.bar-regression {
+  background-color: red;
+}
 
 /* Table widths for alerts */
 td.alert-checkbox {

--- a/ui/partials/perf/alertsctrl.html
+++ b/ui/partials/perf/alertsctrl.html
@@ -150,7 +150,7 @@
         </td>
         <td class="alert-value">{{alert.prev_value|number}}</td>
         <td class="alert-comparison">
-          <span ng-class="{'compare-improvement': !alert.is_regression, 'compare-regression': alert.is_regression}">
+          <span ng-class="{'text-success': !alert.is_regression, 'text-danger': alert.is_regression}">
             <span ng-if="alert.prev_value < alert.new_value">
               &lt;
             </span>
@@ -162,6 +162,7 @@
         <td class="alert-value">{{alert.new_value|number}}</td>
         <td class="alert-pct-difference"><span class="detail-hint" uib-tooltip="Absolute difference: {{alert.amount_abs}}">{{alert.amount_pct}}%</span></td>
         <td class="alert-graphical-difference">
+          <!-- TODO replace with progress bar (in CompareTable component) and remove custom classes -->
           <div ng-if="alert.is_regression" style="margin: auto; width: 80%;"
                uib-tooltip="Relative magnitude of change (scale from 0 - 20%+)">
             <div class="bar bar-scale"


### PR DESCRIPTION
Add CSS for progress bar colors and gt and ls symbols that was erroneously removed in #4538