### PR TITLE
Bug 1526944 - add default prop in TableAverage component

### DIFF
--- a/ui/perfherder/CompareTable.jsx
+++ b/ui/perfherder/CompareTable.jsx
@@ -167,15 +167,17 @@ export default class CompareTable extends React.Component {
                 ) : null}
               </td>
               <td className="text-right">
-                <SimpleTooltip
-                  textClass="detail-hint"
-                  text={`${results.originalRuns.length} / ${
-                    results.newRuns.length
-                  }`}
-                  tooltipText={`${results.originalRuns.length} base / ${
-                    results.newRuns.length
-                  } new`}
-                />
+                {results.originalRuns && (
+                  <SimpleTooltip
+                    textClass="detail-hint"
+                    text={`${results.originalRuns.length} / ${
+                      results.newRuns.length
+                    }`}
+                    tooltipText={`${results.originalRuns.length} base / ${
+                      results.newRuns.length
+                    } new`}
+                  />
+                )}
               </td>
             </tr>
           ))}

--- a/ui/perfherder/TableAverage.jsx
+++ b/ui/perfherder/TableAverage.jsx
@@ -57,13 +57,14 @@ TableAverage.propTypes = {
   value: PropTypes.number,
   stddev: PropTypes.number,
   stddevpct: PropTypes.number,
-  replicates: PropTypes.arrayOf(PropTypes.number).isRequired,
+  replicates: PropTypes.arrayOf(PropTypes.number),
 };
 
 TableAverage.defaultProps = {
   value: PropTypes.null,
   stddev: PropTypes.null,
   stddevpct: PropTypes.null,
+  replicates: [],
 };
 
 export default TableAverage;


### PR DESCRIPTION
Found a case where the array of data supplied to the table's tooltipgraphs isn't assigned a default value of [] in the getResultsMap helper if it is in fact undefined. Added a default prop in TableAverage to account for it and conditional in the CompareTable.