### PR TITLE
Bug 1525122 - Fix so log viewer more quickly jumps to selected line

### DIFF
--- a/ui/logviewer/App.jsx
+++ b/ui/logviewer/App.jsx
@@ -231,7 +231,6 @@ class App extends React.PureComponent {
             <div className="log-contents flex-fill">
               <LazyLog
                 url={rawLogUrl}
-                stream
                 scrollToLine={highlight ? highlight[0] : 0}
                 highlight={highlight}
                 selectableLines


### PR DESCRIPTION
Ends up this was the wrong param to use.  This caused the ``LazyLog`` to appear to scroll through the log from the beginning.

https://mozilla-frontend-infra.github.io/react-lazylog/

