### PR TITLE
Bug 1526743 - Make log parsing Python 3 compatible

### DIFF
--- a/tests/e2e/test_job_ingestion.py
+++ b/tests/e2e/test_job_ingestion.py
@@ -4,7 +4,6 @@ import json
 import pytest
 from django.forms import model_to_dict
 from mock import MagicMock
-from six import PY3
 
 from tests.test_utils import add_log_response
 from treeherder.client.thclient import client
@@ -54,7 +53,6 @@ def check_job_log(test_repository, job_guid, parse_status):
     assert job_logs[0].status == parse_status
 
 
-@pytest.mark.xfail(PY3, reason='Python 3: a bytes-like object is required, not str (bug 1526743)')
 def test_store_job_with_unparsed_log(test_repository, failure_classifications,
                                      push_stored, monkeypatch, activate_responses):
     """
@@ -99,7 +97,6 @@ def test_store_job_with_unparsed_log(test_repository, failure_classifications,
     assert len(get_error_summary(Job.objects.get(id=1))) == 2
 
 
-@pytest.mark.xfail(PY3, reason='Python 3: a bytes-like object is required, not str (bug 1526743)')
 def test_store_job_pending_to_completed_with_unparsed_log(test_repository, push_stored,
                                                           failure_classifications,
                                                           activate_responses):

--- a/tests/log_parser/test_job_artifact_builder.py
+++ b/tests/log_parser/test_job_artifact_builder.py
@@ -21,22 +21,18 @@ def do_test(log):
     lpc = ArtifactBuilderCollection(url, builders=builder)
     lpc.parse()
     act = lpc.artifacts[builder.name]
-    exp = test_utils.load_exp("{0}.jobartifact.json".format(log))
 
-    # :: Uncomment to create the ``exp`` files, if you're making a lot of them
+    # :: Uncomment to create the ``exp`` files
     # import json
     # from tests.sampledata import SampleData
     # with open(SampleData().get_log_path("{0}.jobartifact.json".format(log)), "w") as f:
     #     f.write(json.dumps(act, indent=2))
 
-    # assert act == exp, diff(exp, act)
+    exp = test_utils.load_exp("{0}.jobartifact.json".format(log))
 
-    # if you want to gather results for a new test, use this
     assert len(act) == len(exp)
     for index, artifact in act.items():
         assert artifact == exp[index]
-
-    # assert act == exp#, json.dumps(act, indent=2)
 
 
 def test_crashtest_passing():

--- a/tests/log_parser/test_job_artifact_builder.py
+++ b/tests/log_parser/test_job_artifact_builder.py
@@ -1,13 +1,9 @@
-import pytest
 import responses
-from six import PY3
 
 from tests import test_utils
 from tests.test_utils import add_log_response
 from treeherder.log_parser.artifactbuildercollection import ArtifactBuilderCollection
 from treeherder.log_parser.artifactbuilders import BuildbotJobArtifactBuilder
-
-pytestmark = pytest.mark.xfail(PY3, reason='Python 3: a bytes-like object is required, not str (bug 1526743)')
 
 
 @responses.activate

--- a/tests/log_parser/test_log_view_artifact_builder.py
+++ b/tests/log_parser/test_log_view_artifact_builder.py
@@ -24,19 +24,16 @@ def do_test(log):
     lpc = ArtifactBuilderCollection(url, builders=builder)
     lpc.parse()
     act = lpc.artifacts[builder.name]
-    exp = test_utils.load_exp("{0}.logview.json".format(log))
 
-    # :: Uncomment to create the ``exp`` files, if you're making a lot of them
+    # :: Uncomment to create the ``exp`` files
     # import json
     # from tests.sampledata import SampleData
     # with open(SampleData().get_log_path("{0}.logview.json".format(log)), "w") as f:
     #     f.write(json.dumps(act, indent=2))
 
-    assert act == exp  # , diff(exp, act)
+    exp = test_utils.load_exp("{0}.logview.json".format(log))
 
-    # :: Use this assert when creating new tests and you want to get the actual
-    # returned artifact:
-    # assert act == exp, json.dumps(act, indent=2)
+    assert act == exp
 
 
 def test_crashtest_passing():

--- a/tests/log_parser/test_log_view_artifact_builder.py
+++ b/tests/log_parser/test_log_view_artifact_builder.py
@@ -1,6 +1,5 @@
 import pytest
 import responses
-from six import PY3
 
 from tests import test_utils
 from tests.test_utils import add_log_response
@@ -8,8 +7,6 @@ from treeherder.log_parser.artifactbuildercollection import ArtifactBuilderColle
 from treeherder.log_parser.artifactbuilders import BuildbotLogViewArtifactBuilder
 
 slow = pytest.mark.slow
-
-pytestmark = pytest.mark.xfail(PY3, reason='Python 3: a bytes-like object is required, not str (bug 1526743)')
 
 
 @responses.activate

--- a/tests/log_parser/test_performance_artifact_builder.py
+++ b/tests/log_parser/test_performance_artifact_builder.py
@@ -1,7 +1,5 @@
-import pytest
 import responses
 from jsonschema import validate
-from six import PY3
 
 from tests.test_utils import add_log_response
 from treeherder.etl.perf import PERFHERDER_SCHEMA
@@ -9,7 +7,6 @@ from treeherder.log_parser.artifactbuildercollection import ArtifactBuilderColle
 from treeherder.log_parser.artifactbuilders import BuildbotPerformanceDataArtifactBuilder
 
 
-@pytest.mark.xfail(PY3, reason='Python 3: a bytes-like object is required, not str (bug 1526743)')
 @responses.activate
 def test_performance_log_parsing():
     """

--- a/tests/log_parser/test_tasks.py
+++ b/tests/log_parser/test_tasks.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import pytest
-from six import PY3
 
 from tests.test_utils import add_log_response
 from treeherder.etl.jobs import store_job_data
@@ -28,7 +27,6 @@ def jobs_with_local_log(activate_responses):
     return [job]
 
 
-@pytest.mark.xfail(PY3, reason='Python 3: a bytes-like object is required, not str (bug 1526743)')
 def test_parse_log(test_repository, failure_classifications, jobs_with_local_log, sample_push):
     """
     check that 2 job_artifacts get inserted when running a parse_log task for
@@ -49,7 +47,6 @@ def test_parse_log(test_repository, failure_classifications, jobs_with_local_log
     print(JobDetail.objects.count() == 4)
 
 
-@pytest.mark.xfail(PY3, reason='Python 3: a bytes-like object is required, not str (bug 1526743)')
 def test_create_error_summary(failure_classifications,
                               jobs_with_local_log, sample_push,
                               test_repository):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -187,7 +187,7 @@ def load_exp(filename):
     development.
     """
     path = SampleData().get_log_path(filename)
-    with open(path, "a+") as f:
+    with open(path) as f:
         try:
             return json.load(f)
         except ValueError:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -181,18 +181,10 @@ def verify_superseded(expected_superseded_job_guids):
 def load_exp(filename):
     """
     Load in an expected result json and return as an obj.
-
-    If the file doesn't exist, it will be created, but the test will
-    fail, due to no content.  This is to make it easier during test
-    development.
     """
     path = SampleData().get_log_path(filename)
     with open(path) as f:
-        try:
-            return json.load(f)
-        except ValueError:
-            # if it's not parse-able, return an empty dict
-            return {}
+        return json.load(f)
 
 
 def create_generic_job(guid, repository, push_id, generic_reference_data):

--- a/treeherder/log_parser/artifactbuildercollection.py
+++ b/treeherder/log_parser/artifactbuildercollection.py
@@ -1,5 +1,3 @@
-from contextlib import closing
-
 import newrelic.agent
 
 from treeherder.etl.common import make_request
@@ -87,7 +85,7 @@ BuildbotPerformanceDataArtifactBuilder
         Stream lines from the gzip file and run each parser against it,
         building the ``artifact`` as we go.
         """
-        with closing(make_request(self.url, stream=True)) as response:
+        with make_request(self.url, stream=True) as response:
             # Temporary annotation of log size to help set thresholds in bug 1295997.
             newrelic.agent.add_custom_parameter(
                 'unstructured_log_size',


### PR DESCRIPTION
1. **Explicitly `.decode()` streamed log lines**

   Since the `request` package's `iter_lines()` returns bytes by default:
   http://docs.python-requests.org/en/master/user/advanced/#streaming-requests

   We cannot pass `decode_unicode=True` to `iter_lines()` since it splits on Unicode newlines (which can exist in test message output), so instead we manually `.decode()` each line before parsing it.

   Fixes the following exception under Python 3:
   `TypeError: a bytes-like object is required, not 'str'`

   The test utility `load_exp()` had to be modified to no longer use append mode when opening the expected output JSON files, in order to fix:
   `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`


2. **Remove no longer required use of `contextlib.closing()`**

   Since `requests` has native support for being used as a context manager as of v2.18.0:
   kennethreitz/requests#4137

3. **Clean up log parsing test utilities**

   Previously any exceptions raised whilst loading the expected output JSON fixtures were suppressed, which made debugging the Python 3 test failures harder than needs be.

   The reason failures were suppressed was to allow the test to continue far enough that the actual output could be saved to the fixture when creating new tests. However reordering `do_test()` has the same effect without the need for the `load_exp()` try-except handling.