### PR TITLE
Dependabot: Add ignored_updates entry for more-itertools

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -38,3 +38,7 @@ update_configs:
       - match:
           dependency_name: "mysqlclient"
           version_requirement: ">=1.3.14"
+      # more-itertools 6 requires Python 3 (bug 1527336)
+      - match:
+          dependency_name: "more-itertools"
+          version_requirement: ">=6"


### PR DESCRIPTION
Since it requires Python 3:
https://github.com/erikrose/more-itertools/releases/tag/6.0.0

Bug 1527336 has been filed to update it once we're using Python 3.

Closes #4626.