### PR TITLE
Bug 1527020 - Travis: Use Python 3.6.8 instead of 3.7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,8 @@ matrix:
 
     - env: python3-main
       language: python
-      python: '3.7.2'
+      # Python 3.7 is blocked on Celery/kombu support
+      python: '3.6.8'
       cache:
         directories:
           - ${HOME}/venv
@@ -91,7 +92,8 @@ matrix:
 
     - env: python3-tests-selenium
       language: python
-      python: '3.7.2'
+      # Python 3.7 is blocked on Celery/kombu support
+      python: '3.6.8'
       cache:
         directories:
           - ${HOME}/venv


### PR DESCRIPTION
Since Celery/kombu don't yet support Python 3.7:
https://github.com/celery/celery/issues/4500

This isn't seen in tests due to bug 1349362.