### PR TITLE
Bug 1527868 - Vagrant/Travis: Remove Elasticsearch server

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,8 +13,6 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"
   # MySQL
   config.vm.network "forwarded_port", guest: 3306, host: 3308, host_ip: "127.0.0.1"
-  # Elasticsearch
-  config.vm.network "forwarded_port", guest: 9200, host: 9201, host_ip: "127.0.0.1"
 
   if !Vagrant::Util::Platform.windows?
     # On platforms where NFS is used (ie all but Windows), we still have to use

--- a/docs/backend_tasks.md
+++ b/docs/backend_tasks.md
@@ -68,7 +68,7 @@ hidden by default. For TaskCluster, edit the task definition to include the
 
 ## Connecting to Services Running inside Vagrant
 
-Treeherder uses various services to function, eg MySQL, Elasticsearch, etc.
+Treeherder uses various services to function, eg MySQL, etc.
 At times it can be useful to connect to them from outside the Vagrant VM.
 
 The Vagrantfile defines how internal ports are mapped to the host OS' ports.
@@ -91,7 +91,7 @@ With MySQL exposed at port 3308 you can connect to it from your host OS with the
 - user: `root`
 - password: leave blank
 
-Other services running inside the VM, such as Elasticsearch, can be accessed in the same way.
+Other services running inside the VM, can be accessed in the same way.
 
 [client git log]: https://github.com/mozilla/treeherder/commits/master/treeherder/client
 [client.py]: https://github.com/mozilla/treeherder/blob/master/treeherder/client/thclient/client.py

--- a/tests/log_parser/test_store_failure_lines.py
+++ b/tests/log_parser/test_store_failure_lines.py
@@ -172,6 +172,8 @@ def test_store_error_summary_duplicate(activate_responses, test_repository, test
     assert FailureLine.objects.count() == 2
 
 
+@pytest.mark.skipif(not settings.ELASTICSEARCH_URL,
+                    reason="Requires Elasticsearch, which is not configured (bug 1527868)")
 def test_store_error_summary_elastic_search(activate_responses, test_repository,
                                             test_job, elasticsearch):
     log_path = SampleData().get_log_path("plain-chunked_errorsummary.log")

--- a/tests/model/test_search.py
+++ b/tests/model/test_search.py
@@ -1,3 +1,6 @@
+import pytest
+from django.conf import settings
+
 from treeherder.services.elasticsearch import (all_documents,
                                                count_index,
                                                es_conn,
@@ -6,6 +9,8 @@ from treeherder.services.elasticsearch.mapping import (DOC_TYPE,
                                                        INDEX_NAME)
 
 
+@pytest.mark.skipif(not settings.ELASTICSEARCH_URL,
+                    reason="Requires Elasticsearch, which is not configured (bug 1527868)")
 def test_store_none_subtest(elasticsearch):
     doc = {
         'job_guid': '1234',
@@ -24,6 +29,8 @@ def test_store_none_subtest(elasticsearch):
     assert docs[0]['_source']['subtest'] is None
 
 
+@pytest.mark.skipif(not settings.ELASTICSEARCH_URL,
+                    reason="Requires Elasticsearch, which is not configured (bug 1527868)")
 def test_store_no_subtest(elasticsearch):
     doc = {
         'job_guid': '1234',

--- a/tests/webapp/api/test_text_log_error.py
+++ b/tests/webapp/api/test_text_log_error.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.urls import reverse
 
 from tests.autoclassify.utils import (create_failure_lines,
@@ -64,9 +65,10 @@ def test_update_error_verify(client,
     assert error_line.metadata.best_classification == classified_failures[0]
     assert error_line.metadata.best_is_verified
 
-    es_line = get_document(error_line.metadata.failure_line.id)
-    assert es_line['best_classification'] == classified_failures[0].id
-    assert es_line['best_is_verified']
+    if settings.ELASTICSEARCH_URL:
+        es_line = get_document(error_line.metadata.failure_line.id)
+        assert es_line['best_classification'] == classified_failures[0].id
+        assert es_line['best_is_verified']
 
 
 def test_update_error_replace(client,
@@ -387,9 +389,10 @@ def test_update_error_verify_bug(client,
     assert error_line.metadata.best_classification == classified_failures[0]
     assert error_line.metadata.best_is_verified
 
-    es_line = get_document(error_line.metadata.failure_line.id)
-    assert es_line['best_classification'] == classified_failures[0].id
-    assert es_line['best_is_verified']
+    if settings.ELASTICSEARCH_URL:
+        es_line = get_document(error_line.metadata.failure_line.id)
+        assert es_line['best_classification'] == classified_failures[0].id
+        assert es_line['best_is_verified']
 
 
 def test_update_error_verify_new_bug(client,

--- a/treeherder/autoclassify/matchers.py
+++ b/treeherder/autoclassify/matchers.py
@@ -62,6 +62,7 @@ def elasticsearch_matcher(text_log_error):
     Uses a filtered search checking test, status, expected, and the message
     as a phrase query with non-alphabet tokens removed.
     """
+    # Note: Elasticsearch is currently disabled in all environments (see bug 1527868).
     if not settings.ELASTICSEARCH_URL:
         return []
 

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -352,7 +352,8 @@ if DEBUG:
     INSTALLED_APPS.append('debug_toolbar')
 
 # Elasticsearch
-ELASTICSEARCH_URL = env.str('ELASTICSEARCH_URL', default='')
+# Note: Elasticsearch is currently disabled in all environments (see bug 1527868).
+ELASTICSEARCH_URL = env.str('ELASTICSEARCH_URL', default=None)
 
 # Rest Framework
 REST_FRAMEWORK = {

--- a/treeherder/config/utils.py
+++ b/treeherder/config/utils.py
@@ -2,7 +2,7 @@ from furl import furl
 
 
 def connection_should_use_tls(url):
-    # Services such as RabbitMQ/Elasticsearch running on Travis do not yet have TLS
+    # Services such as RabbitMQ/MySQL running on Travis do not yet have TLS
     # certificates set up. We could try using TLS locally using self-signed certs,
     # but until Travis has support it's not overly useful.
     return furl(url).host != 'localhost'

--- a/vagrant/env.sh
+++ b/vagrant/env.sh
@@ -4,7 +4,6 @@ export PATH="${HOME}/firefox:${HOME}/python/bin:${PATH}"
 
 export BROKER_URL='amqp://guest:guest@localhost//'
 export DATABASE_URL='mysql://root@localhost/treeherder'
-export ELASTICSEARCH_URL='http://localhost:9200'
 export REDIS_URL='redis://localhost:6379'
 
 export TREEHERDER_DEBUG='True'


### PR DESCRIPTION
To ensure the CI and local environments match stage/production (where Elasticsearch is not configured) and don't run differing code-paths due to the various `ELASTICSEARCH_URL` conditionals used in auto-classify.

At such time when work on the fuzzy auto-classify matcher continues, this can be reverted.

Several tests had to be updated to make them correctly handle `ELASTICSEARCH_URL` being unset.