### PR TITLE
Add tests for Perfherder's compare table using react-testing-library

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "eslint-plugin-react": "7.12.4",
     "fetch-mock": "7.3.0",
     "jest": "24.1.0",
+    "jest-dom": "3.1.1",
     "node-fetch": "1.7.3",
     "prettier": "1.16.4",
     "react-testing-library": "5.8.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "node-fetch": "1.7.3",
     "prettier": "1.16.4",
     "react-testing-library": "5.8.0",
-    "webpack-dev-server": "3.2.0"    
+    "webpack-dev-server": "3.2.0"
   },
   "scripts": {
     "build": "node ./node_modules/webpack/bin/webpack.js --mode production",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "jest": "24.1.0",
     "node-fetch": "1.7.3",
     "prettier": "1.16.4",
-    "webpack-dev-server": "3.2.0"
+    "react-testing-library": "5.8.0",
+    "webpack-dev-server": "3.2.0"    
   },
   "scripts": {
     "build": "node ./node_modules/webpack/bin/webpack.js --mode production",

--- a/tests/ui/unit/react/compare_table_test.jsx
+++ b/tests/ui/unit/react/compare_table_test.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import {
+  render,
+  cleanup,
+  fireEvent,
+  waitForElement,
+} from 'react-testing-library';
+
+import CompareTableControls from '../../../../ui/perfherder/CompareTableControls';
+import { filterText } from '../../../../ui/perfherder/constants';
+
+// TODO addtional tests:
+// 1) that the table is receiving the correct data structure after data
+// is transformed in compare and comparesubtests views (Map containing objects with arrays as props)
+// 2) if filterByFramework is true, frameworks returns a list
+// 3) if a new framework is selected, results are updated
+
+// TODO replace with mock data performance/summary API that is transformed
+// by getResultsMap in compareView and comparesubtests view
+const result = [
+  {
+    className: 'danger',
+    confidence: 5.057234137528269,
+    confidenceText: 'high',
+    confidenceTextLong:
+      "Result of running t-test on base versus new result distribution: A value of 'high' indicates more confidence that there is a significant change, however you should check the historical record for the test by looking at the graph to be more sure (some noisy tests can provide inconsistent results).",
+    delta: 3.9191666666666265,
+    deltaPercentage: 2.23249676019764,
+    frameworkId: 1,
+    isComplete: 1,
+    isConfident: false,
+    isEmpty: false,
+    isImprovement: false,
+    isMeaningful: true,
+    isNoiseMetric: true,
+    isRegression: true,
+    links: [],
+    magnitude: 11.162483800988202,
+    name: 'linux64',
+    needsMoreRuns: false,
+    newIsBetter: false,
+    newRuns: [],
+  },
+  {
+    className: 'danger',
+    confidence: 5.057234137528269,
+    confidenceText: 'high',
+    confidenceTextLong:
+      "Result of running t-test on base versus new result distribution: A value of 'high' indicates more confidence that there is a significant change, however you should check the historical record for the test by looking at the graph to be more sure (some noisy tests can provide inconsistent results).",
+    delta: 3.9191666666666265,
+    deltaPercentage: 2.23249676019764,
+    frameworkId: 1,
+    isComplete: 1,
+    isConfident: true,
+    isEmpty: false,
+    isImprovement: false,
+    isMeaningful: true,
+    isNoiseMetric: false,
+    isRegression: true,
+    links: [],
+    magnitude: 11.162483800988202,
+    name: 'osx-10-10',
+    needsMoreRuns: false,
+    newIsBetter: false,
+    newRuns: [],
+  },
+];
+
+const results = new Map([['a11yr pgo e10s stylo', result]]);
+
+afterEach(cleanup);
+
+const compareTableControls = () =>
+  render(<CompareTableControls compareResults={results} filterOptions={{}} />);
+
+test('toggle buttons should filter results by selected filter', async () => {
+  const { getByText } = compareTableControls();
+
+  const result1 = await waitForElement(() => getByText(result[0].name));
+  const result2 = await waitForElement(() => getByText(result[1].name));
+
+  // default - no filters selected
+  expect(result1).toBeInTheDocument();
+  expect(result2).toBeInTheDocument();
+
+  // one filter selected
+  const showImportant = getByText(filterText.showImportant);
+  fireEvent.click(showImportant);
+
+  // active prop is treated as as a classname rather than an attribute
+  // (toHaveAttribute), such as disabled
+  expect(showImportant).toHaveClass('active');
+  expect(result1).toBeInTheDocument();
+  expect(result2).toBeInTheDocument();
+
+  // two filters selected
+  const hideUncertain = getByText(filterText.hideUncertain);
+  fireEvent.click(hideUncertain);
+
+  expect(hideUncertain).toHaveClass('active');
+  expect(result1).not.toBeInTheDocument();
+  expect(result2).toBeInTheDocument();
+});
+
+test('text input filter results should differ when filter button(s) are selected', async () => {
+  const { getByText, getByPlaceholderText } = compareTableControls();
+
+  const result1 = await waitForElement(() => getByText(result[0].name));
+  const result2 = await waitForElement(() => getByText(result[1].name));
+
+  const filterInput = await waitForElement(() =>
+    getByPlaceholderText(filterText.inputPlaceholder),
+  );
+  const filterButton = await waitForElement(() => getByText('filter'));
+
+  fireEvent.change(filterInput, { target: { value: 'linux' } });
+  fireEvent.click(filterButton);
+
+  expect(filterInput.value).toBe('linux');
+  expect(result1).toBeInTheDocument();
+  expect(result2).not.toBeInTheDocument();
+
+  const hideUncertain = getByText(filterText.hideUncertain);
+  fireEvent.click(hideUncertain);
+
+  expect(hideUncertain).toHaveClass('active');
+  expect(result1).not.toBeInTheDocument();
+  expect(result2).not.toBeInTheDocument();
+});

--- a/tests/ui/unit/test-setup.js
+++ b/tests/ui/unit/test-setup.js
@@ -1,5 +1,6 @@
 // Entry point for Jest tests
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import 'jest-dom/extend-expect';
 
 configure({ adapter: new Adapter() });

--- a/ui/perfherder/CompareTableControls.jsx
+++ b/ui/perfherder/CompareTableControls.jsx
@@ -9,6 +9,7 @@ import SimpleTooltip from '../shared/SimpleTooltip';
 import DropdownButton from './DropdownButton';
 import InputFilter from './InputFilter';
 import CompareTable from './CompareTable';
+import { filterText } from './constants';
 
 export default class CompareTableControls extends React.Component {
   constructor(props) {
@@ -175,7 +176,7 @@ export default class CompareTableControls extends React.Component {
                   onClick={() => this.updateFilter('hideUncomparable')}
                   active={hideUncomparable}
                 >
-                  Hide uncomparable results
+                  {filterText.hideUncomparable}
                 </Button>
               }
               tooltipText="At least 1 result for old and new revision"
@@ -190,7 +191,7 @@ export default class CompareTableControls extends React.Component {
                   onClick={() => this.updateFilter('showImportant')}
                   active={showImportant}
                 >
-                  Show only important changes
+                  {filterText.showImportant}
                 </Button>
               }
               tooltipText="Non-trivial changes (2%+)"
@@ -205,7 +206,7 @@ export default class CompareTableControls extends React.Component {
                   onClick={() => this.updateFilter('hideUncertain')}
                   active={hideUncertain}
                 >
-                  Hide uncertain results
+                  {filterText.hideUncertain}
                 </Button>
               }
               tooltipText="At least 6 datapoints OR 2+ datapoints and a large difference"
@@ -220,7 +221,7 @@ export default class CompareTableControls extends React.Component {
                   onClick={() => this.updateFilter('showNoise')}
                   active={showNoise}
                 >
-                  Show only noise
+                  {filterText.showNoise}
                 </Button>
               }
               tooltipText="Display Noise Metric to compare noisy tests at a platform level"

--- a/ui/perfherder/InputFilter.jsx
+++ b/ui/perfherder/InputFilter.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { InputGroup, InputGroupAddon, Input, Button } from 'reactstrap';
 
+import { filterText } from './constants';
+
 export default class InputFilter extends React.Component {
   constructor(props) {
     super(props);
@@ -34,7 +36,7 @@ export default class InputFilter extends React.Component {
     return (
       <InputGroup>
         <Input
-          placeholder="linux tp5o"
+          placeholder={filterText.inputPlaceholder}
           onChange={this.updateInput}
           value={input}
           onKeyPress={this.handleKeyPress}

--- a/ui/perfherder/constants.js
+++ b/ui/perfherder/constants.js
@@ -8,3 +8,11 @@ export const endpoints = {
 };
 
 export const noiseMetricTitle = 'noise metric';
+
+export const filterText = {
+  showImportant: 'Show only important changes',
+  hideUncertain: 'Hide uncertain results',
+  showNoise: 'Show only noise',
+  hideUncomparable: 'Hide uncomparable results',
+  inputPlaceholder: 'linux tp5o',
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2561,6 +2561,21 @@ css-what@2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^2.2.3:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
+
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
@@ -4770,6 +4785,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
+
 indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
@@ -5360,6 +5380,20 @@ jest-docblock@^24.0.0:
   integrity sha512-KfAKZ4SN7CFOZpWg4i7g7MSlY0M+mq7K0aMqENaG2vHuhC9fc3vkpU/iNN9sOus7v3h3Y48uEjqz3+Gdn2iptA==
   dependencies:
     detect-newline "^2.1.0"
+
+jest-dom@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/jest-dom/-/jest-dom-3.1.1.tgz#5671014f6834471895cdde3fbf7e9f58cc3f2c95"
+  integrity sha512-7CnQHQsyfAa7lofrfvChgYIlIrIfr90UczutjA2AuBlNGOCzCCt/x9T/fHftg3P3IJlBQvBWT+TfZ+lsen/4+A==
+  dependencies:
+    chalk "^2.4.1"
+    css "^2.2.3"
+    css.escape "^1.5.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    lodash "^4.17.11"
+    pretty-format "^24.0.0"
+    redent "^2.0.0"
 
 jest-each@^24.0.0:
   version "24.0.0"
@@ -7943,6 +7977,14 @@ recast@~0.11.12:
     private "~0.1.5"
     source-map "~0.5.0"
 
+redent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
+  integrity sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=
+  dependencies:
+    indent-string "^3.0.0"
+    strip-indent "^2.0.0"
+
 redux-debounce@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/redux-debounce/-/redux-debounce-1.0.1.tgz#76a70953fbb3f89e9fd40c390674aceef400d105"
@@ -8552,7 +8594,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
@@ -8845,6 +8887,11 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
 strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -643,7 +643,7 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.1.5", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1":
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
   integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
@@ -898,6 +898,11 @@
     babel-merge "^2.0.1"
     deepmerge "^1.5.2"
     webpack-manifest-plugin "^2.0.4"
+
+"@sheerun/mutationobserver-shim@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
+  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
 
 "@types/angular@*", "@types/angular@^1.6.39":
   version "1.6.54"
@@ -3122,6 +3127,16 @@ dom-serializer@0, dom-serializer@~0.1.0:
   dependencies:
     domelementtype "^1.3.0"
     entities "^1.1.1"
+
+dom-testing-library@^3.13.1:
+  version "3.16.5"
+  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-3.16.5.tgz#8c71f127c6b4ee48115660798040291b59dfc894"
+  integrity sha512-t3OaTcDdsAqtAZNeZ13KnOJmt+2HaDJqYWyf0iBRzbG6GwrNtpF0122Ygu/qkerIwcnHMX1ihwZVx/DhaLpmTw==
+  dependencies:
+    "@babel/runtime" "^7.1.5"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    pretty-format "^24.0.0"
+    wait-for-expect "^1.1.0"
 
 dom-walk@^0.1.0:
   version "0.1.1"
@@ -7754,6 +7769,14 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.8.2"
     scheduler "^0.13.2"
 
+react-testing-library@5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-5.8.0.tgz#b5163758b1ddfd2e15c3cd2790562a527a1bb0a5"
+  integrity sha512-cYOX8aUKea5ojFVXkhLbNEAq86nYqBlhKulJI/0v8JfwWyQm+kbyNKFfyci6b2qI4KUEvBYZKWx+zZWeYrYOOA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    dom-testing-library "^3.13.1"
+
 react-transition-group@^2.2.1, react-transition-group@^2.3.1:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.3.tgz#26de363cab19e5c88ae5dbae105c706cf953bb92"
@@ -9388,6 +9411,11 @@ w3c-hr-time@^1.0.1:
   integrity sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
   dependencies:
     browser-process-hrtime "^0.1.2"
+
+wait-for-expect@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.1.0.tgz#6607375c3f79d32add35cd2c87ce13f351a3d453"
+  integrity sha512-vQDokqxyMyknfX3luCDn16bSaRcOyH6gGuUXMIbxBLeTo6nWuEWYqMTT9a+44FmW8c2m6TRWBdNvBBjA1hwEKg==
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
This is only testing the filtering buttons and filter input logic and does not include a thorough set of test cases (I'm wondering if this should be done as some sort of separate unit test with just the filtering functions or if this is sufficient - thoughts?). More to come when I work on the compare view and compare subtest views. 

![screen shot 2019-02-15 at 1 05 39 pm](https://user-images.githubusercontent.com/19615783/52884310-6edae880-3122-11e9-8c9f-77eb11d41af0.png)

If you'd like these tests organized differently (broken out into additional tests), lmk.

FYI @ionutgoldan this is what testing components would look like using this library and jest utlities.