### PR TITLE
Increase maxEntrypointSize to avoid failures from duplicate deps

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -155,7 +155,7 @@ module.exports = {
         neutrino.config.performance
           .hints('error')
           .maxAssetSize(2 * 1024 * 1024)
-          .maxEntrypointSize(1.72 * 1024 * 1024);
+          .maxEntrypointSize(1.75 * 1024 * 1024);
       }
     },
   ],


### PR DESCRIPTION
The current perfherder entrypoint size is right on the threshold, which causes failures when something marginally increases the bundle size (such as the duplicate deps that occur after a React update PR prior to the lockfile maintenance PR cleaning them up).