### PR TITLE
Bug 1528485 - Suppress manage.py DeprecationWarnings from dependencies

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -8,6 +8,14 @@ import warnings
 # https://docs.python.org/2.7/library/warnings.html#default-warning-filters
 warnings.simplefilter('default', DeprecationWarning)
 
+# Suppress noisy warnings from dependencies
+# Reported in https://support.newrelic.com/tickets/338064
+warnings.filterwarnings('ignore', category=DeprecationWarning, module='newrelic.api.import_hook')
+# Remove when we update to Kombu 4+ (bug 1337717)
+warnings.filterwarnings('ignore', category=DeprecationWarning, module='kombu.five')
+# https://github.com/encode/django-rest-framework/issues/6317
+warnings.filterwarnings('ignore', category=DeprecationWarning, module='markdown.util')
+
 if __name__ == "__main__":
     os.environ["DJANGO_SETTINGS_MODULE"] = "treeherder.config.settings"
 


### PR DESCRIPTION
Prevents:

```
kombu/five.py:20: DeprecationWarning: the imp module is deprecated in favour of importlib ...
markdown/util.py:453: DeprecationWarning: Using the add method to register a processor or pattern is deprecated ...
newrelic/api/import_hook.py:166: DeprecationWarning: Use importlib.util.find_spec() instead
```