### PR TITLE
Bug 1528601 - Surface 'BytesWarning's and make them fail the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
         - source ./bin/travis-setup.sh python_env docs
       script:
         - pip check
-        - python lints/queuelint.py
+        - python -3 -bb lints/queuelint.py
         - flake8 --show-source
         - isort --check-only --diff --quiet
         - git grep -El '^#!/.+\b(bash|sh)\b' | xargs shellcheck
@@ -48,10 +48,12 @@ matrix:
         # Several security features in settings.py (eg setting HSTS headers) are conditional on
         # 'https://' being in the site URL. In addition, we override the test environment's debug
         # value so the tests pass. The real environment variable will be checked during deployment.
-        - SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' ./manage.py check --deploy --fail-level WARNING
-        # Using Python 2's `-3` mode to surface DeprecationWarnings for Python 3 incompatibilities:
+        - SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' python -3 -bb ./manage.py check --deploy --fail-level WARNING
+        # Using Python's `-3` mode to surface DeprecationWarnings for Python 3 incompatibilities:
         # https://docs.python.org/2/using/cmdline.html#cmdoption-3
-        - python -3 -m pytest tests/ --runslow --ignore=tests/selenium/
+        # Using `-bb` mode to surface BytesWarnings:
+        # https://docs.python.org/2/using/cmdline.html#cmdoption-b
+        - python -3 -bb -m pytest tests/ --runslow --ignore=tests/selenium/
 
     - env: python2-tests-selenium
       language: python
@@ -67,9 +69,7 @@ matrix:
         # Run in `before_script` to prevent the selenium tests from still being run if the UI build fails.
         - yarn build
       script:
-        # Using Python 2's `-3` mode to surface DeprecationWarnings for Python 3 incompatibilities:
-        # https://docs.python.org/2/using/cmdline.html#cmdoption-3
-        - python -3 -m pytest tests/selenium/ --driver Firefox
+        - python -3 -bb -m pytest tests/selenium/
 
     - env: python3-main
       language: python
@@ -84,11 +84,11 @@ matrix:
         - mysql -u root -e 'create database test_treeherder;'
       script:
         - pip check
-        - python lints/queuelint.py
+        - python -bb lints/queuelint.py
         - flake8 --show-source
         - isort --check-only --diff --quiet
-        - SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' ./manage.py check --deploy --fail-level WARNING
-        - pytest tests/ --runslow --ignore=tests/selenium/
+        - SITE_URL='https://treeherder.dev' TREEHERDER_DEBUG='False' python -bb ./manage.py check --deploy --fail-level WARNING
+        - python -bb -m pytest tests/ --runslow --ignore=tests/selenium/
 
     - env: python3-tests-selenium
       language: python
@@ -105,7 +105,7 @@ matrix:
         # Run in `before_script` to prevent the selenium tests from still being run if the UI build fails.
         - yarn build
       script:
-        - pytest tests/selenium/ --driver Firefox
+        - python -bb -m pytest tests/selenium/
 
 notifications:
   email:

--- a/runtests.sh
+++ b/runtests.sh
@@ -7,7 +7,7 @@ echo "Running pip check"
 pip check
 
 echo "Checking CELERY_QUEUES matches Procfile"
-./lints/queuelint.py
+python -3 -bb ./lints/queuelint.py
 
 echo "Running flake8"
 flake8 || { echo "flake8 errors found!"; exit 1; }
@@ -21,7 +21,7 @@ git grep -El '^#!/.+\b(bash|sh)\b' | xargs shellcheck
 
 echo "Running Django system checks"
 # See .travis.yml for explanation of the environment variable overriding.
-SITE_URL="https://treeherder.dev" TREEHERDER_DEBUG="False" ./manage.py check --deploy --fail-level WARNING
+SITE_URL="https://treeherder.dev" TREEHERDER_DEBUG="False" python -3 -bb ./manage.py check --deploy --fail-level WARNING
 
 echo "Running Python tests"
-pytest --driver Firefox tests/
+python -3 -bb -m pytest tests/


### PR DESCRIPTION
Invalid comparisons between bytes and strings will now cause the tests to fail, making it easier to spot bugs that would appear under Python 3.

If there are any false positives in the future, the errors can be suppressed using `filterwarnings` in `setup.cfg`.

See:
https://docs.python.org/3.6/using/cmdline.html#cmdoption-b
https://docs.python.org/3.6/library/exceptions.html#BytesWarning