### PR TITLE
Bug 1529191 - treeherder-client: Bump version to 5.0.0

### DIFF
--- a/treeherder/client/setup.py
+++ b/treeherder/client/setup.py
@@ -34,6 +34,10 @@ setup(name='treeherder-client',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.6',
           'Topic :: Software Development :: Libraries :: Python Modules',
       ],
       keywords='',
@@ -43,5 +47,5 @@ setup(name='treeherder-client',
       license='MPL',
       packages=['thclient'],
       zip_safe=False,
-      install_requires=['requests>=2.4.3']
+      install_requires=['requests>=2.4.3', 'six']
       )

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 
 # The Python client release process is documented here:
 # https://treeherder.readthedocs.io/common_tasks.html#releasing-a-new-version-of-the-python-client
-__version__ = '4.0.0'
+__version__ = '5.0.0'
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Changes:
* The deprecated `TreeherderClient.get_resultsets()` has been removed. Use the otherwise identical `TreeherderClient.get_pushes()` instead.
* Functionality related to submitting jobs has been removed, now that
  Treeherder's REST API no longer supports it (bug 1349182):
  - `TreeherderClient`'s constructor no longer accepts the `client_id` and `secret` arguments.
  - `TreeherderClient.post_collection()` has been removed.
  - The `TreeherderJobCollection`, `TreeherderCollection`, `TreeherderJob`, `TreeherderData` and `ValidatorMixin` classes have been removed.
  - `treeherder-client` no longer depends on the `requests-hawk` package.
* The `TreeherderClient` methods `get_products()`, `get_job_groups()`, `get_build_platforms()`, `get_job_types()`, `get_machines()` and `get_machine_platforms()` have been removed, since their associated REST API endpoints have not existed since bug 1437968.
* Support for Python 3 has been added.
* `treeherder-client` now depends on the package `six`.

Relevant commits:
* https://github.com/mozilla/treeherder/commit/5d6cb2371c7f9c4bfccc388b540bddef2fa0cbda#diff-47795f6202e468e8606477db7d0eb39b
* https://github.com/mozilla/treeherder/commit/02d3c625c70577dd90ec5fcb01db320d207d00ee#diff-47795f6202e468e8606477db7d0eb39b
* https://github.com/mozilla/treeherder/commit/c8ca4b51d53c043e6153752608be53e5cd0be427#diff-47795f6202e468e8606477db7d0eb39b
* https://github.com/mozilla/treeherder/commit/ecf4c4e33abf7abc5995a8b9f3bb811bc7c57087#diff-de0800dbf7bd186065ffc348f147df96
* https://github.com/mozilla/treeherder/commit/f6ecbdd8b680a43e03a43170ddb3f2d593b4f246#diff-8f20c700b32fc2a7be610d1089eb9eb4
* https://github.com/mozilla/treeherder/commit/4fe1fa89fb5f50059190039f419a4853364e2e51