### PR TITLE
Bug 1453837 - Use correct value for id token expiry in auth tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,6 @@ filterwarnings =
     # however this is expected when running tests since Django collectstatic and yarn build
     # (which create those directories) typically aren't run apart from during deployments.
     ignore:No directory at.*:UserWarning:whitenoise.base
-    # `python2 -3` mode warning that's a real bug. Remove once bug 1453837 is fixed.
-    ignore:comparing unequal types not supported in 3.x:DeprecationWarning:treeherder.auth.backends
     # Hide `python2 -3` mode warnings that are false positives
     ignore:Overriding __eq__ blocks inheritance of __hash__ in 3.x:DeprecationWarning
     ignore:sys.exc_clear\(\) not supported in 3.x; use except clauses:DeprecationWarning

--- a/treeherder/auth/backends.py
+++ b/treeherder/auth/backends.py
@@ -84,6 +84,35 @@ class AuthBackend(object):
             raise AuthenticationFailed("Unrecognized identity")
 
     def _get_user_info(self, request):
+        """
+        Extracts the user info payload from the Id Token.
+
+        Example return value:
+
+        {
+            "at_hash": "<HASH>",
+            "aud": "<HASH>",
+            "email_verified": true,
+            "email": "fsurname@mozilla.com",
+            "exp": 1551259495,
+            "family_name": "Surname",
+            "given_name": "Firstname",
+            "https://sso.mozilla.com/claim/groups": [
+                "all_scm_level_1",
+                "all_scm_level_2",
+                "all_scm_level_3",
+                # ...
+            ],
+            "iat": 1550654695,
+            "iss": "https://auth.mozilla.auth0.com/",
+            "name": "Firstname Surname",
+            "nickname": "Firstname Surname",
+            "nonce": "<HASH>",
+            "picture": "<GRAVATAR_URL>",
+            "sub": "ad|Mozilla-LDAP|fsurname",
+            "updated_at": "2019-02-20T09:24:55.449Z",
+        }
+        """
         access_token = self._get_token_auth_header(request)
         id_token = request.META.get("HTTP_IDTOKEN")
 
@@ -134,6 +163,7 @@ class AuthBackend(object):
         try:
             user = User.objects.get(username=username)
 
+            # TODO: This should be performed even in the `ObjectDoesNotExist` case.
             accesstoken_exp_in_ms = self._get_accesstoken_expiry(request)
             # Per http://openid.net/specs/openid-connect-core-1_0.html#IDToken, exp is given in seconds
             idtoken_exp_in_ms = user_info['exp'] * 1000


### PR DESCRIPTION
The id token payload contains an `exp` property, which is an integer representing the number of seconds past the epoch at which the id token expires:
https://openid.net/specs/openid-connect-core-1_0.html#IDToken

However the mocked value in our authentication tests was the string `'500'`, which is neither the correct data type, nor a timestamp. This meant that during tests only, the `min(accesstoken_exp_in_ms, idtoken_exp_in_ms)` in `AuthBackend.authenticate()` was comparing an int and a string, which under Python 3 results in:

`TypeError: '<' not supported between instances of 'str' and 'int'`

A later bug/PR will refactor the auth backend to fix issues unrelated to Python 3 compatibility and add more test coverage.