### PR TITLE
Bug 1517253 - Update mysqlclient from 1.3.13 to 1.4.2.post1

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -33,11 +33,6 @@ update_configs:
           # Bug 1426683
           dependency_name: "django-filter"
           version_requirement: ">=2"
-      # Django 1.11 uses internals of mysqlclient that were removed in 1.3.14.
-      # Newer mysqlclient only works with Django 2+ (bug 1517253).
-      - match:
-          dependency_name: "mysqlclient"
-          version_requirement: ">=1.3.14"
       # more-itertools 6 requires Python 3 (bug 1527336)
       - match:
           dependency_name: "more-itertools"

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -76,8 +76,8 @@ newrelic==4.14.0.115 \
     --hash=sha256:b0f2ef6c817d9b5389cb3ef0f06037abbd1c1ed1a4ae04f293dadeb0f78ea924
 
 # Required by Django
-mysqlclient==1.3.13 \
-    --hash=sha256:ff8ee1be84215e6c30a746b728c41eb0701a46ca76e343af445b35ce6250644f
+mysqlclient==1.4.2.post1 \
+    --hash=sha256:f257d250f2675d0ef99bd318906f3cfc05cef4a2f385ea695ff32a3f04b9f9a7
 
 # Required by celery
 billiard==3.3.0.23 --hash=sha256:692a2a5a55ee39a42bcb7557930e2541da85df9ea81c6e24827f63b80cd39d0b


### PR DESCRIPTION
The backwards-incompatible change has since been fixed, so the latest version now works with Django 1.11 again, avoiding the test failures seen in #4342.

https://github.com/PyMySQL/mysqlclient-python/blob/master/HISTORY.rst#whats-new-in-142