### PR TITLE
Remove inline styles from new Perfherder/IFV components

### DIFF
--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -464,3 +464,28 @@ h4 {
 .pre {
   font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
+
+.max-width-default {
+  max-width: 1200px;
+}
+
+/* Custom widths for compare table cells */
+.table-width-lg {
+  width: 140px;
+}
+
+.table-width-md {
+  width: 100px;
+}
+
+.table-width-sm {
+  width: 50px;
+}
+
+.card-height {
+  height: 260px;
+}
+
+.dropdown-menu-height {
+  max-height: 300px;
+}

--- a/ui/intermittent-failures/Layout.jsx
+++ b/ui/intermittent-failures/Layout.jsx
@@ -36,10 +36,7 @@ const Layout = props => {
     failureMessage = graphData;
   }
   return (
-    <Container
-      fluid
-      style={{ marginBottom: '5rem', marginTop: '5rem', maxWidth: '1200px' }}
-    >
+    <Container fluid className="my-5 max-width-default">
       <Navigation updateState={updateState} tree={tree} />
       {(isFetchingGraphs || isFetchingTable) &&
         !(

--- a/ui/perfherder/CompareSelectorView.jsx
+++ b/ui/perfherder/CompareSelectorView.jsx
@@ -84,10 +84,7 @@ export default class CompareSelectorView extends React.Component {
     } = this.state;
 
     return (
-      <Container
-        fluid
-        style={{ marginBottom: '5rem', marginTop: '5rem', maxWidth: '1200px' }}
-      >
+      <Container fluid className="my-5 pt-5 max-width-default">
         <ErrorBoundary
           errorClasses={errorMessageClass}
           message={genericErrorMessage}

--- a/ui/perfherder/CompareTable.jsx
+++ b/ui/perfherder/CompareTable.jsx
@@ -36,17 +36,15 @@ export default class CompareTable extends React.Component {
             <th className="text-left">
               <span>{testName}</span>
             </th>
-            <th style={{ width: '200px' }}>Base</th>
+            <th className="table-width-lg">Base</th>
             {/* empty for less than/greater than data */}
-            <th style={{ width: '30px' }} />
-            <th style={{ width: '140px' }}>New</th>
-            <th style={{ width: '100px' }}>Delta</th>
+            <th className="table-width-sm" />
+            <th className="table-width-lg">New</th>
+            <th className="table-width-sm">Delta</th>
             {/* empty for progress bars (magnitude of difference) */}
-            <th style={{ width: '120px' }} />
-            <th style={{ width: '100px' }}>Confidence</th>
-            <th className="text-right" style={{ width: '80px' }}>
-              # Runs
-            </th>
+            <th className="table-width-lg" />
+            <th className="table-width-lg">Confidence</th>
+            <th className="text-right table-width-md"># Runs</th>
           </tr>
         </thead>
         <tbody>

--- a/ui/perfherder/SelectorCard.jsx
+++ b/ui/perfherder/SelectorCard.jsx
@@ -203,10 +203,8 @@ export default class SelectorCard extends React.Component {
     } = this.props;
     return (
       <Col sm="4" className="p-2">
-        <Card style={{ height: '260px' }}>
-          <CardHeader style={{ backgroundColor: 'lightgrey' }}>
-            {title}
-          </CardHeader>
+        <Card className="card-height">
+          <CardHeader className="bg-lightgray">{title}</CardHeader>
           <CardBody>
             <CardSubtitle className="pb-2 pt-3">Project</CardSubtitle>
             <ButtonDropdown
@@ -218,12 +216,7 @@ export default class SelectorCard extends React.Component {
                 {selectedRepo}
               </DropdownToggle>
               {projects.length > 0 && (
-                <DropdownMenu
-                  style={{
-                    overflow: 'auto',
-                    maxHeight: 300,
-                  }}
-                >
+                <DropdownMenu className="overflow-auto dropdown-menu-height">
                   {projects.map(item => (
                     <DropdownItem
                       key={item.name}


### PR DESCRIPTION
In preparation for implementation of [CSP policy](https://bugzilla.mozilla.org/show_bug.cgi?id=1270157), replace inline styles with bootstrap utility classes and custom classes.

Bootstrap doesn't appear to have width utility classes (only width controls as they pertain to the grid syntax and using a col-1 is too large for several of the compare table column contents, so I went with custom css classes).