### PR TITLE
Bug 1270157 - Add a report-only CSP header and report collection API

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -9,6 +9,11 @@ TREEHERDER_TEST_REPOSITORY_NAME = 'test_treeherder_jobs'
 CELERY_ALWAYS_EAGER = True
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 
+# Make WhiteNoise look for static assets inside registered Django apps, rather
+# than only inside the generated staticfiles directory. This means we don't
+# have to run collectstatic for `test_content_security_policy_header` to pass.
+WHITENOISE_USE_FINDERS = True
+
 # Set a fake api key for testing bug filing
 BUGFILER_API_KEY = "12345helloworld"
 BUGFILER_API_URL = "https://thisisnotbugzilla.org"

--- a/tests/webapp/api/test_csp_report.py
+++ b/tests/webapp/api/test_csp_report.py
@@ -1,0 +1,33 @@
+import json
+
+from django.urls import reverse
+
+
+def test_valid_report(client):
+    """Tests that a correctly formed CSP violation report is accepted when unauthenticated."""
+    valid_report = {
+        'csp-report': {
+            'blocked-uri': 'https://treestatus.mozilla-releng.net/trees/mozilla-inbound',
+            'document-uri': 'http://localhost:8000/',
+            'original-policy': '...',
+            'referrer': '',
+            'violated-directive': 'connect-src'
+        }
+    }
+    response = client.post(
+        reverse('csp-report'),
+        data=json.dumps(valid_report),
+        content_type='application/csp-report',
+    )
+    assert response.status_code == 200
+
+
+def test_invalid_report(client):
+    """Test that badly formed reports are gracefully handled."""
+    invalid_report = 'bad'
+    response = client.post(
+        reverse('csp-report'),
+        data=json.dumps(invalid_report),
+        content_type='application/csp-report',
+    )
+    assert response.status_code == 400

--- a/treeherder/webapp/api/csp_report.py
+++ b/treeherder/webapp/api/csp_report.py
@@ -1,0 +1,39 @@
+import logging
+
+import newrelic.agent
+from rest_framework.parsers import JSONParser
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.status import HTTP_400_BAD_REQUEST
+from rest_framework.views import APIView
+
+logger = logging.getLogger(__name__)
+
+
+class CSPReportParser(JSONParser):
+    # Reports are submitted with a Content-Type that is not `application/json`, so we
+    # have to tell django-rest-framework that it should still parse the body as JSON:
+    # https://w3c.github.io/webappsec-csp/2/#violation-reports
+    # https://www.django-rest-framework.org/api-guide/parsers/#how-the-parser-is-determined
+    media_type = 'application/csp-report'
+
+
+class CSPReportView(APIView):
+    """
+    Accepts the Content-Security-Policy violation reports generated via the `report-uri` feature:
+    https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri
+    """
+
+    # We want to receive all CSP violation reports, including from unauthenticated users.
+    permission_classes = (AllowAny,)
+    parser_classes = (CSPReportParser,)
+
+    def post(self, request):
+        try:
+            report = request.data['csp-report']
+        except (KeyError, TypeError):
+            return Response('Invalid CSP violation report', status=HTTP_400_BAD_REQUEST)
+
+        logger.warning('CSP violation: %s', report)
+        newrelic.agent.record_custom_event('CSP violation', report)
+        return Response()

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -7,6 +7,7 @@ from rest_framework import routers
 from treeherder.webapp.api import (auth,
                                    bug,
                                    bugzilla,
+                                   csp_report,
                                    intermittents_view,
                                    job_log_url,
                                    jobs,
@@ -127,4 +128,5 @@ urlpatterns = [
     url(r'^failuresbybug/$', intermittents_view.FailuresByBug.as_view(), name='failures-by-bug'),
     url(r'^failurecount/$', intermittents_view.FailureCount.as_view(), name='failure-count'),
     url(r'^performance/summary/$', performance_data.PerformanceSummary.as_view(), name='performance-summary'),
+    url(r'^csp-report/$', csp_report.CSPReportView.as_view(), name='csp-report'),
 ]

--- a/ui/css/intermittent-failures.css
+++ b/ui/css/intermittent-failures.css
@@ -1,3 +1,4 @@
+/* If this is ever removed, remove the corresponding Content-Security-Policy header entries. */
 @import url('https://fonts.googleapis.com/css?family=Open+Sans');
 
 body {

--- a/ui/entry-perf.js
+++ b/ui/entry-perf.js
@@ -1,6 +1,7 @@
 // Webpack entry point for perf.html
 
 // Vendor Styles
+import 'angular/angular-csp.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'metrics-graphics/dist/metricsgraphics.css';
 

--- a/ui/perf.html
+++ b/ui/perf.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="perf" ng-strict-di>
+<html ng-app="perf" ng-strict-di ng-csp>
   <head>
     <meta charset="utf-8" />
     <title>Perfherder</title>


### PR DESCRIPTION
This adds a `Content-Security-Policy-Report-Only` header for static assets served by WhiteNoise (such as our frontend), which includes a first pass at a possible policy that should work for Treeherder.

The header also includes a `report-uri` directive, which points at a newly added API for collecting CSP violation reports. Reports are logged as warnings (so will appear in Papertrail) and sent to New Relic as a custom event. This will allow us to see whether the policy would block valid requests, so we can refine it prior to converting to the real (ie blocks things) `Content-Security-Policy` header.

The addition of `ng-csp` to `perf.html` is to enable AngularJS's ngCSP feature, which turns off use of `eval()` and automatic stylesheet injection, so that the policy directives `unsafe-eval` and `unsafe-inline` don't have to be used. This requires us to then manually import the AngularJS stylesheet to include the styles that would have previously been injected:
https://docs.angularjs.org/api/ng/directive/ngCsp

See:
https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only