### PR TITLE
Bug 1270157 - Content-Security-Policy-Report-Only Adjustments

### DIFF
--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -50,5 +50,5 @@ def test_content_security_policy_header(client):
     # which will be served with the same headers as our frontend HTML.
     response = client.get('/static/rest_framework/css/default.css')
     assert response.has_header('Content-Security-Policy-Report-Only')
-    policy_regex = r"default-src 'none'; script-src 'self'; .*; report-uri /api/csp-report/"
+    policy_regex = r"default-src 'none'; script-src 'self' 'report-sample'; .*; report-uri /api/csp-report/"
     assert re.match(policy_regex, response['Content-Security-Policy-Report-Only'])

--- a/treeherder/middleware.py
+++ b/treeherder/middleware.py
@@ -6,17 +6,21 @@ from django.utils.deprecation import MiddlewareMixin
 from whitenoise.middleware import WhiteNoiseMiddleware
 
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
-# NB: The quotes inside the strings must be single quotes.
+# NB: The quotes inside the strings must be single quotes. Also any requests that
+# redirect need to have both the original and redirected domains whitelisted.
 CSP_DIRECTIVES = [
     "default-src 'none'",
-    "script-src 'self'",
+    # 'report-sample' instructs the browser to include a sample of the violating JS to assist with debugging.
+    "script-src 'self' 'report-sample'",
     # The unsafe-inline is required for react-select's use of emotion (CSS in JS). See bug 1507903.
     # The Google entries are required for IFV's use of the Open Sans font from their CDN.
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "style-src 'self' 'unsafe-inline' 'report-sample' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
     # The `data:` is required for images that were inlined by webpack's url-loader (as an optimisation).
     "img-src 'self' data:",
-    "connect-src 'self' https://*.taskcluster.net https://treestatus.mozilla-releng.net https://bugzilla.mozilla.org https://auth.mozilla.auth0.com",
+    "connect-src 'self' https://*.taskcluster.net https://taskcluster-artifacts.net https://treestatus.mozilla-releng.net https://bugzilla.mozilla.org https://auth.mozilla.auth0.com",
+    # Required since auth0-js performs session renewals in an iframe.
+    "frame-src 'self' https://auth.mozilla.auth0.com",
     "report-uri {}".format(reverse('csp-report')),
 ]
 CSP_HEADER = '; '.join(CSP_DIRECTIVES)

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -128,5 +128,5 @@ urlpatterns = [
     url(r'^failuresbybug/$', intermittents_view.FailuresByBug.as_view(), name='failures-by-bug'),
     url(r'^failurecount/$', intermittents_view.FailureCount.as_view(), name='failure-count'),
     url(r'^performance/summary/$', performance_data.PerformanceSummary.as_view(), name='performance-summary'),
-    url(r'^csp-report/$', csp_report.CSPReportView.as_view(), name='csp-report'),
+    url(r'^csp-report/$', csp_report.csp_report_collector, name='csp-report'),
 ]


### PR DESCRIPTION
1) Makes the following changes to the initial report-only CSP header added in #4678:

   * Adds a `frame-src` directive

      Whilst the Auth0 domain is already whitelisted in `connect-src` allowing initial logins to work, Auth0.js renewals are performed in an iframe, so need both the auth0 domain and `'self'` (for the `/login.html` callback) to be permitted via `frame-src`.

   * Adds https://taskcluster-artifacts.net to `connect-src`

      Since some requests to `queue.taskcluster.net` redirect to it (eg for the "Add new jobs" feature), and for redirects both the original and new domain need whitelisting.

   * Adds `'report-sample'` to `script-src` and `style-src`, which makes the browser send JS/CSS samples for any violations of the "inline" rules, making it easier to debug collected CSP violation reports.

2) Make the CSP report collector skip CSRF checks

   Since otherwise report submissions will fail with an HTTP 403 on browsers that send the Django session cookie but not the CSRF token.

   The collector has also been rewritten to be a standard Django view rather than a django-rest-framework APIView, since the latter is more of a hindrance than a help for this use-case (particularly now we're wanting to disable CSRF checks).