### PR TITLE
Bug 1270157 - Convert the report-only CSP header to the real thing

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -156,7 +156,7 @@ To get started:
 
 ### Building the minified UI with Vagrant
 
-If you would like to view the minified production version of the UI with Vagrant, follow this step:
+If you would like to view the minified production version of the UI with Vagrant:
 
 - Run the build task (either outside or inside of the Vagrant machine):
 
@@ -164,8 +164,11 @@ If you would like to view the minified production version of the UI with Vagrant
   $ yarn build
   ```
 
-Once the build is complete, the minified version of the UI will now be accessible at
-<http://localhost:8000> (NB: port 8000, unlike above).
+- Run either Django runserver or gunicorn following the instructions in the previous section.
+
+The minified version of the UI will now be accessible at <http://localhost:8000>
+(NB: port 8000, unlike above), and will match the content used in production
+(including being served with a `Content-Security-Policy` header).
 
 ### Running the ingestion tasks
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -49,6 +49,6 @@ def test_content_security_policy_header(client):
     # So instead we request an arbitrary static asset from django-rest-framework,
     # which will be served with the same headers as our frontend HTML.
     response = client.get('/static/rest_framework/css/default.css')
-    assert response.has_header('Content-Security-Policy-Report-Only')
+    assert response.has_header('Content-Security-Policy')
     policy_regex = r"default-src 'none'; script-src 'self' 'report-sample'; .*; report-uri /api/csp-report/"
-    assert re.match(policy_regex, response['Content-Security-Policy-Report-Only'])
+    assert re.match(policy_regex, response['Content-Security-Policy'])

--- a/treeherder/middleware.py
+++ b/treeherder/middleware.py
@@ -42,7 +42,7 @@ class CustomWhiteNoise(WhiteNoiseMiddleware):
         such as API responses, or the browse-able API/auto-generated docs,
         since they are not served by the WhiteNoise middleware.
         """
-        headers['Content-Security-Policy-Report-Only'] = CSP_HEADER
+        headers['Content-Security-Policy'] = CSP_HEADER
 
     def immutable_file_test(self, path, url):
         """

--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -1,3 +1,7 @@
+// NB: Treeherder sets a Content-Security-Policy header in production, so when
+// adding new domains *for use by fetch()*, update the `connect-src` directive:
+// https://github.com/mozilla/treeherder/blob/master/treeherder/middleware.py
+
 export const uiJobsUrlBase = '/#/jobs';
 
 export const uiPushHealthBase = '/pushhealth.html';


### PR DESCRIPTION
The latest policy used in the report-only header has been working well on production (the violation reports [logged to New Relic](https://insights.newrelic.com/accounts/677903/explorer/events?eventType=CSP%20violation&duration=604800000) are only from scripts injected by browser addons), so we're ready to start enforcing the policy by using the real `Content-Security-Policy` header name.

NB: When features are added in the future, PR authors and reviewers will need to remember to update the policy if needed (for example to add domains to the `connect-src` directive). The CSP header is not enabled when using `webpack-dev-server` (it would break dev source maps and react-hot-loader) so if in doubt test locally (using `yarn build` and serving via Django runserver) or on prototype first.

See:
https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy