### PR TITLE
Bug 1527336 - Update more-itertools from 5.0.0 to 6.0.0

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -33,7 +33,3 @@ update_configs:
           # Bug 1426683
           dependency_name: "django-filter"
           version_requirement: ">=2"
-      # more-itertools 6 requires Python 3 (bug 1527336)
-      - match:
-          dependency_name: "more-itertools"
-          version_requirement: ">=6"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -47,10 +47,8 @@ atomicwrites==1.3.0 \
 attrs==18.2.0 \
     --hash=sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb \
     --hash=sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69
-more-itertools==5.0.0 \
-    --hash=sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc \
-    --hash=sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9 \
-    --hash=sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4
+more-itertools==6.0.0 \
+    --hash=sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40
 pathlib2==2.3.3; python_version < '3.6' \
     --hash=sha256:5887121d7f7df3603bca2f710e7219f3eca0eb69e0b7cc6e0a022e155ac931a7 \
     --hash=sha256:25199318e8cc3c25dcb45cbe084cc061051336d5a9ea2a12448d3d8cb748f742


### PR DESCRIPTION
The new version has dropped support for Python 2, so this was previously blocked on bug 1330474.

Changes:
https://github.com/erikrose/more-itertools/blob/6.0.0/docs/versions.rst#600