### PR TITLE
Bug 1530602 - Adjust Content-Security-Policy to fix ajv.compile()

### DIFF
--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -50,5 +50,5 @@ def test_content_security_policy_header(client):
     # which will be served with the same headers as our frontend HTML.
     response = client.get('/static/rest_framework/css/default.css')
     assert response.has_header('Content-Security-Policy')
-    policy_regex = r"default-src 'none'; script-src 'self' 'report-sample'; .*; report-uri /api/csp-report/"
+    policy_regex = r"default-src 'none'; script-src 'self' 'unsafe-eval' 'report-sample'; .*; report-uri /api/csp-report/"
     assert re.match(policy_regex, response['Content-Security-Policy'])

--- a/treeherder/middleware.py
+++ b/treeherder/middleware.py
@@ -10,8 +10,9 @@ from whitenoise.middleware import WhiteNoiseMiddleware
 # redirect need to have both the original and redirected domains whitelisted.
 CSP_DIRECTIVES = [
     "default-src 'none'",
+    # The unsafe-eval is required for Custom Action's use of `ajv`. See bug 1530607.
     # 'report-sample' instructs the browser to include a sample of the violating JS to assist with debugging.
-    "script-src 'self' 'report-sample'",
+    "script-src 'self' 'unsafe-eval' 'report-sample'",
     # The unsafe-inline is required for react-select's use of emotion (CSS in JS). See bug 1507903.
     # The Google entries are required for IFV's use of the Open Sans font from their CDN.
     "style-src 'self' 'unsafe-inline' 'report-sample' https://fonts.googleapis.com",


### PR DESCRIPTION
Unfortunately the "Custom Actions" usage of `ajv.compile()` requires that the `script-src` CSP directive contain `'unsafe-eval'`, otherwise the whole feature breaks.

Using `'unsafe-eval'` defeats much of the point of CSP, so it should be removed as soon as possible. Bug 1530607 is filed to track.

CC @helfi92 