### PR TITLE
Bug 1530502 - Force perf alert API to treat is_regression as optional

### DIFF
--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -67,6 +67,11 @@ class PerformanceAlertSerializer(serializers.ModelSerializer):
         queryset=User.objects.all())
     classifier_email = serializers.SerializerMethodField()
 
+    # Force `is_regression` to be an optional field, even when using PUT, since in
+    # Django 2.1 BooleanField no longer has an implicit `blank=True` on the model.
+    # TODO: Switch to using PATCH instead in the UI and the API tests.
+    is_regression = serializers.BooleanField(required=False)
+
     # express quantities in terms of decimals to save space
     amount_abs = PerformanceDecimalField(read_only=True)
     amount_pct = PerformanceDecimalField(read_only=True)


### PR DESCRIPTION
When using django-rest-framework's `ModelSerializer`, automatic validation rules are created for different types of API requests. Since `PUT` requests are meant to be for full updates of an object, these automatic validation rules for such requests are configured to enforce all non-optional fields.

The `is_regression` field doesn't have a `default`, and so would normally be treated as required for `PUT`s, except that in Django prior to 2.1 `BooleanField`s had an implicit `blank=True` set within Django, meaning django-rest-framework's validator treated them as optional.

As such, the current performance alert API implementation has been able to use `PUT`s for partial updates (updates where only some fields are specified), even though it really should have been using `PATCH` instead.

However this approach fails under Django 2.1 (due to `BooleanField` no longer having the implicit `blank=True`) meaning we have to override the automatic serializer configuration for `is_regression` to add `required=False`.

This PR is a no-op under Django 2.0 - which can be confirmed by running:

```py
# Inside `./manage.py shell_plus`
from treeherder.webapp.api.performance_serializers import PerformanceAlertSerializer
print(PerformanceAlertSerializer())
```

...and then checking the output before and after contains:

```py
    is_regression = BooleanField(required=False)
```

Long term the performance alert API (and consumers) should be adjusted to use `PATCH` instead.