### PR TITLE
Bug 1526911 - Close performance-artifact.json after opening it

### DIFF
--- a/tests/etl/test_perf_schema.py
+++ b/tests/etl/test_perf_schema.py
@@ -21,7 +21,9 @@ import pytest
                           ({'value': 1234,
                             'extraOptions': ['1', '2', '3', '4', '5', '6', '7', '8']}, {'value': 1234}, False)])
 def test_perf_schema(suite_value, test_value, expected_fail):
-    perf_schema = json.load(open('schemas/performance-artifact.json'))
+    with open('schemas/performance-artifact.json') as f:
+        perf_schema = json.load(f)
+
     datum = {
         "framework": {"name": "talos"}, "suites": [{
             "name": "basic_compositor_video",

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -487,6 +487,10 @@ class ErrorParser(ParserBase):
                     self.RE_ERR_MATCH.match(trimline) or self.RE_ERR_SEARCH.search(trimline))
 
 
+with open('schemas/performance-artifact.json') as f:
+    PERF_SCHEMA = json.load(f)
+
+
 class PerformanceParser(ParserBase):
     """a sub-parser to find generic performance data"""
 
@@ -494,7 +498,6 @@ class PerformanceParser(ParserBase):
     # regex to fail on windows logs. This is likely due to the
     # ^M character representation of the windows end of line.
     RE_PERFORMANCE = re.compile(r'.*?PERFHERDER_DATA:\s+({.*})')
-    PERF_SCHEMA = json.load(open('schemas/performance-artifact.json'))
 
     def __init__(self):
         super().__init__("performance_data")
@@ -504,7 +507,7 @@ class PerformanceParser(ParserBase):
         if match:
             try:
                 dict = json.loads(match.group(1))
-                jsonschema.validate(dict, self.PERF_SCHEMA)
+                jsonschema.validate(dict, PERF_SCHEMA)
                 self.artifact.append(dict)
             except ValueError:
                 logger.warning("Unable to parse Perfherder data from line: %s",


### PR DESCRIPTION
Fixes:

```
ResourceWarning: unclosed file <_io.TextIOWrapper name=
    'schemas/performance-artifact.json' mode='r' encoding='UTF-8'>
```