### PR TITLE
Bug 1527824 - refactor and replace usage of PushModel.getList

### DIFF
--- a/ui/helpers/http.js
+++ b/ui/helpers/http.js
@@ -1,5 +1,7 @@
 import Cookies from 'js-cookie';
 
+import { processErrorMessage } from './errorMessage';
+
 const generateHeaders = function generateHeaders() {
   return new Headers({
     'X-CSRFToken': Cookies.get('csrftoken'),
@@ -48,9 +50,14 @@ export const getData = async function getData(url) {
     .startsWith('text/html');
 
   if (contentType && failureStatus) {
-    return { data: { [failureStatus]: response.statusText }, failureStatus };
+    const errorMessage = processErrorMessage(`${failureStatus}: ${response.statusText}`, failureStatus);
+    return { data: errorMessage, failureStatus };
   }
 
-  const data = await response.json();
+  let data = await response.json();
+
+  if (failureStatus) {
+    data = processErrorMessage(data, failureStatus)
+  }
   return { data, failureStatus };
 };

--- a/ui/helpers/http.js
+++ b/ui/helpers/http.js
@@ -50,14 +50,17 @@ export const getData = async function getData(url) {
     .startsWith('text/html');
 
   if (contentType && failureStatus) {
-    const errorMessage = processErrorMessage(`${failureStatus}: ${response.statusText}`, failureStatus);
+    const errorMessage = processErrorMessage(
+      `${failureStatus}: ${response.statusText}`,
+      failureStatus,
+    );
     return { data: errorMessage, failureStatus };
   }
 
   let data = await response.json();
 
   if (failureStatus) {
-    data = processErrorMessage(data, failureStatus)
+    data = processErrorMessage(data, failureStatus);
   }
   return { data, failureStatus };
 };

--- a/ui/intermittent-failures/Layout.jsx
+++ b/ui/intermittent-failures/Layout.jsx
@@ -53,7 +53,6 @@ const Layout = props => {
         errorMessages.length > 0) && (
         <ErrorMessages
           failureMessage={failureMessage}
-          failureStatus={tableFailureStatus || graphFailureStatus}
           errorMessages={errorMessages}
         />
       )}

--- a/ui/job-view/context/Pushes.jsx
+++ b/ui/job-view/context/Pushes.jsx
@@ -216,13 +216,15 @@ export class PushesClass extends React.Component {
         }
         // We will either have a ``revision`` param, but no push for it yet,
         // or a ``fromchange`` param because we have at least 1 push already.
-          const { data, failureStatus } = await PushModel.getList(pushPollingParams);
-          if (!failureStatus) {
-            this.addPushes(data);
-            this.fetchNewJobs();
-          } else {
-            notify('Error fetching new push data', 'danger', { sticky: true });
-          }
+        const { data, failureStatus } = await PushModel.getList(
+          pushPollingParams,
+        );
+        if (!failureStatus) {
+          this.addPushes(data);
+          this.fetchNewJobs();
+        } else {
+          notify('Error fetching new push data', 'danger', { sticky: true });
+        }
       }
     }, pushPollInterval);
   };

--- a/ui/job-view/details/tabs/SimilarJobsTab.jsx
+++ b/ui/job-view/details/tabs/SimilarJobsTab.jsx
@@ -96,11 +96,9 @@ class SimilarJobsTab extends React.Component {
           this.showJobInfo(newSimilarJobs[0]);
         }
       } else {
-        notify(
-          `Error fetching similar jobs push data: ${data}`,
-          'danger',
-          { sticky: true },
-        );
+        notify(`Error fetching similar jobs push data: ${data}`, 'danger', {
+          sticky: true,
+        });
       }
     }
     this.setState({ isLoading: false });

--- a/ui/job-view/details/tabs/SimilarJobsTab.jsx
+++ b/ui/job-view/details/tabs/SimilarJobsTab.jsx
@@ -67,13 +67,13 @@ class SimilarJobsTab extends React.Component {
       const pushIds = [...new Set(newSimilarJobs.map(job => job.push_id))];
       // get pushes and revisions for the given ids
       let pushList = { results: [] };
-      const resp = await PushModel.getList({
+      const { data, failureStatus } = await PushModel.getList({
         id__in: pushIds.join(','),
         count: thMaxPushFetchSize,
       });
 
-      if (resp.ok) {
-        pushList = await resp.json();
+      if (!failureStatus) {
+        pushList = data;
         // decorate the list of jobs with their result sets
         const pushes = pushList.results.reduce(
           (acc, push) => ({ ...acc, [push.id]: push }),
@@ -97,7 +97,7 @@ class SimilarJobsTab extends React.Component {
         }
       } else {
         notify(
-          `Error fetching similar jobs push data: ${resp.message}`,
+          `Error fetching similar jobs push data: ${data}`,
           'danger',
           { sticky: true },
         );

--- a/ui/js/controllers/perf/alerts.js
+++ b/ui/js/controllers/perf/alerts.js
@@ -466,8 +466,9 @@ perf.controller('AlertsCtrl', [
             });
 
             $q.all(Object.keys(resultSetToSummaryMap).map(async repo => {
-                const { data: results } = await PushModel.getList({ repo, id__in: Object.keys(resultSetToSummaryMap[repo]).join(',') })
-                results.forEach((resultSet) => {
+                // TODO utilize failureStatus from PushModel.getList for error handling
+                const { data } = await PushModel.getList({ repo, id__in: Object.keys(resultSetToSummaryMap[repo]).join(',') });
+                data.results.forEach((resultSet) => {
                     resultSet.dateStr = dateFilter(
                         resultSet.push_timestamp * 1000, thDateFormat);
                     // want at least 14 days worth of results for relative comparisons

--- a/ui/js/controllers/perf/compare.js
+++ b/ui/js/controllers/perf/compare.js
@@ -606,18 +606,14 @@ perf.controller('CompareSubtestDistributionCtrl', ['$scope', '$stateParams', '$q
         $scope.newSubtestSignature = $stateParams.newSubtestSignature;
         $scope.dataLoading = true;
         const loadRepositories = RepositoryModel.getList();
-        const fetchAndDrawReplicateGraph = function (project, revision, subtestSignature, target) {
+        const fetchAndDrawReplicateGraph = async function (project, revision, subtestSignature, target) {
             const replicateData = {};
-
-            return PushModel.getList({ repo: project, commit_revision: revision })
-                .then(async (resp) => {
-                    const { results } = await resp.json();
-                    replicateData.resultSet = results[0];
-                    return PerfSeriesModel.getSeriesData(project, {
-                        signatures: subtestSignature,
-                        push_id: replicateData.resultSet.id,
-                    });
-                }).then((perfDatumList) => {
+            const { data } = await PushModel.getList({ repo: project, commit_revision: revision });
+            replicateData.resultSet = data.results[0];
+            return PerfSeriesModel.getSeriesData(project, {
+                signatures: subtestSignature,
+                push_id: replicateData.resultSet.id,
+            }).then((perfDatumList) => {
                     if (!perfDatumList[subtestSignature]) {
                         replicateData.replicateDataError = true;
                         return;

--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -471,23 +471,18 @@ perf.controller('GraphsCtrl', [
                 if (rev && rev.length === 12) {
                     highlightPromises = [...new Set([
                         ...highlightPromises,
-                        ...$scope.seriesList.map((series) => {
+                        ...$scope.seriesList.map(async (series) => {
                             if (series.visible) {
-                                return PushModel.getList({
+                                const { data: results, failureStatus } = await PushModel.getList({
                                     repo: series.projectName,
                                     revision: rev,
-                                }).then(async (resp) => {
-                                    if (resp.ok) {
-                                      const { results } = await resp.json();
-
-                                      if (results.length) {
+                                });
+                                    if (!failureStatus && results.length) {
                                         addHighlightedDatapoint(series, results[0].id);
                                         $scope.$apply();
-                                      }
-                                      // ignore cases where no push exists
-                                      // for revision
                                     }
-                                });
+                                    // ignore cases where no push exists
+                                    // for revision
                             }
                             return null;
                         })])];

--- a/ui/models/push.js
+++ b/ui/models/push.js
@@ -28,7 +28,7 @@ const convertDates = function convertDates(locationParams) {
 };
 
 export default class PushModel {
-  static getList(options = {}) {
+  static async getList(options = {}) {
     const transformedOptions = convertDates(options);
     const repoName = transformedOptions.repo;
     delete transformedOptions.repo;
@@ -51,7 +51,7 @@ export default class PushModel {
       // fetch the maximum number of pushes
       params.count = thMaxPushFetchSize;
     }
-    return fetch(
+    return getData(
       `${getProjectUrl(pushEndpoint, repoName)}${createQueryParams(params)}`,
     );
   }

--- a/ui/perfherder/CompareSelectorView.jsx
+++ b/ui/perfherder/CompareSelectorView.jsx
@@ -95,7 +95,6 @@ export default class CompareSelectorView extends React.Component {
                 {(failureStatus || errorMessages.length > 0) && (
                   <ErrorMessages
                     failureMessage={data}
-                    failureStatus={failureStatus}
                     errorMessages={errorMessages}
                   />
                 )}

--- a/ui/perfherder/SelectorCard.jsx
+++ b/ui/perfherder/SelectorCard.jsx
@@ -20,10 +20,8 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
 
-import { createQueryParams, pushEndpoint } from '../helpers/url';
-import { getData } from '../helpers/http';
+import PushModel from '../models/push';
 import { genericErrorMessage } from '../helpers/constants';
-import { getProjectUrl } from '../helpers/location';
 
 export default class SelectorCard extends React.Component {
   constructor(props) {
@@ -74,15 +72,8 @@ export default class SelectorCard extends React.Component {
       this.setState({ disabled: true });
     }
 
-    const url = `${getProjectUrl(
-      pushEndpoint,
-      selectedRepo,
-    )}${createQueryParams({
-      full: true,
-      count: 10,
-    })}`;
-    const { data, failureStatus } = await getData(url);
-
+    const { data, failureStatus } = await PushModel.getList({ repo: selectedRepo });
+    
     if (failureStatus) {
       updateState({ errorMessages: [genericErrorMessage] });
     } else {
@@ -156,13 +147,8 @@ export default class SelectorCard extends React.Component {
     if (!existingRevision) {
       this.setState({ validating: 'Validating...' });
 
-      const url = `${getProjectUrl(
-        pushEndpoint,
-        selectedRepo,
-      )}${createQueryParams({ commit_revision: value })}`;
-
-      const { data: revisions, failureStatus } = await getData(url);
-
+      const { data: revisions, failureStatus } = await PushModel.getList({ repo: selectedRepo, commit_revision: value });
+      
       if (failureStatus || revisions.meta.count === 0) {
         return this.setState({
           invalidRevision: 'Invalid revision',

--- a/ui/perfherder/SelectorCard.jsx
+++ b/ui/perfherder/SelectorCard.jsx
@@ -72,8 +72,10 @@ export default class SelectorCard extends React.Component {
       this.setState({ disabled: true });
     }
 
-    const { data, failureStatus } = await PushModel.getList({ repo: selectedRepo });
-    
+    const { data, failureStatus } = await PushModel.getList({
+      repo: selectedRepo,
+    });
+
     if (failureStatus) {
       updateState({ errorMessages: [genericErrorMessage] });
     } else {
@@ -147,8 +149,11 @@ export default class SelectorCard extends React.Component {
     if (!existingRevision) {
       this.setState({ validating: 'Validating...' });
 
-      const { data: revisions, failureStatus } = await PushModel.getList({ repo: selectedRepo, commit_revision: value });
-      
+      const { data: revisions, failureStatus } = await PushModel.getList({
+        repo: selectedRepo,
+        commit_revision: value,
+      });
+
       if (failureStatus || revisions.meta.count === 0) {
         return this.setState({
           invalidRevision: 'Invalid revision',

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -299,12 +299,12 @@ export const validateQueryParams = async function validateQueryParams(params) {
 
   if (
     !failureStatus &&
-    data.find(project => project.name === originalProject)
+    !data.find(project => project.name === originalProject)
   ) {
     errors.push(`Invalid project, doesn't exist ${originalProject}`);
   }
 
-  if (!failureStatus && data.find(project => project.name === newProject)) {
+  if (!failureStatus && !data.find(project => project.name === newProject)) {
     errors.push(`Invalid project, doesn't exist ${newProject}`);
   }
 

--- a/ui/push-health/Health.jsx
+++ b/ui/push-health/Health.jsx
@@ -52,13 +52,7 @@ export default class Health extends React.Component {
   };
 
   render() {
-    const {
-      healthData,
-      user,
-      repo,
-      revision,
-      failureMessage,
-    } = this.state;
+    const { healthData, user, repo, revision, failureMessage } = this.state;
     const overallResult = healthData
       ? resultColorMap[healthData.result]
       : 'none';
@@ -100,11 +94,7 @@ export default class Health extends React.Component {
               </Table>
             </div>
           )}
-          {failureMessage && (
-            <ErrorMessages
-              failureMessage={failureMessage}
-            />
-          )}
+          {failureMessage && <ErrorMessages failureMessage={failureMessage} />}
           {!failureMessage && !healthData && <Spinner />}
         </Container>
       </React.Fragment>

--- a/ui/push-health/Health.jsx
+++ b/ui/push-health/Health.jsx
@@ -22,7 +22,6 @@ export default class Health extends React.Component {
       repo: params.get('repo'),
       healthData: null,
       failureMessage: null,
-      failureStatus: null,
     };
   }
 
@@ -47,7 +46,7 @@ export default class Health extends React.Component {
     const { data, failureStatus } = await PushModel.getHealth(repo, revision);
     const newState = !failureStatus
       ? { healthData: data }
-      : { failureMessage: data, failureStatus };
+      : { failureMessage: data };
 
     this.setState(newState);
   };
@@ -59,7 +58,6 @@ export default class Health extends React.Component {
       repo,
       revision,
       failureMessage,
-      failureStatus,
     } = this.state;
     const overallResult = healthData
       ? resultColorMap[healthData.result]
@@ -105,7 +103,6 @@ export default class Health extends React.Component {
           {failureMessage && (
             <ErrorMessages
               failureMessage={failureMessage}
-              failureStatus={failureStatus}
             />
           )}
           {!failureMessage && !healthData && <Spinner />}

--- a/ui/shared/ErrorMessages.jsx
+++ b/ui/shared/ErrorMessages.jsx
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 import { Alert } from 'reactstrap';
 
 const ErrorMessages = ({ failureMessage, errorMessages }) => {
-  const messages = errorMessages.length
-    ? errorMessages
-    : [failureMessage];
+  const messages = errorMessages.length ? errorMessages : [failureMessage];
 
   return (
     <div>

--- a/ui/shared/ErrorMessages.jsx
+++ b/ui/shared/ErrorMessages.jsx
@@ -2,12 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert } from 'reactstrap';
 
-import { processErrorMessage } from '../helpers/errorMessage';
-
-const ErrorMessages = ({ failureMessage, failureStatus, errorMessages }) => {
+const ErrorMessages = ({ failureMessage, errorMessages }) => {
   const messages = errorMessages.length
     ? errorMessages
-    : [processErrorMessage(failureMessage, failureStatus)];
+    : [failureMessage];
 
   return (
     <div>
@@ -25,13 +23,11 @@ ErrorMessages.propTypes = {
     PropTypes.object,
     PropTypes.arrayOf(PropTypes.string),
   ]),
-  failureStatus: PropTypes.number,
   errorMessages: PropTypes.arrayOf(PropTypes.string),
 };
 
 ErrorMessages.defaultProps = {
   failureMessage: null,
-  failureStatus: null,
   errorMessages: [],
 };
 


### PR DESCRIPTION
This is kind of a combination of two bugs - Bug 1527834 to replace usage of `getData` in the Perfherder SelectorCard component with PushModel.getList and part of [Bug 147377](https://bugzilla.mozilla.org/show_bug.cgi?id=1473777) to replace usage of `Fetch`. Since I'm starting conversion on the compare view, I wanted to get this part of it out of the way rather than wait for one of us to convert all Fetch usage at once (which would probably result in a fairly large diff anyways). 

Cameron, there's some files of TH that I had to change so please let me know if you want some things implemented differently, or if there's some aspect of the `getData` wrapper that should be approached differently.

@ionutgoldan This will affect the subtest distribution controller.