### PR TITLE
Bug 1530206 - Remove the now emptied store_pulse_resultsets queue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -36,8 +36,7 @@ pulse_listener_pushes: newrelic-admin run-program ./manage.py pulse_listener_pus
 pulse_listener_jobs: newrelic-admin run-program ./manage.py pulse_listener_jobs
 
 # Processes pushes/jobs from Pulse that were collected by `pulse_listener_{pushes,jobs)`.
-# TODO: Remove store_pulse_resultsets once the queue has been emptied.
-worker_store_pulse_data: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q store_pulse_pushes,store_pulse_resultsets,store_pulse_jobs --concurrency=3
+worker_store_pulse_data: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q store_pulse_pushes,store_pulse_jobs --concurrency=3
 
 # Handles the log parsing tasks scheduled by `worker_store_pulse_data` as part of job ingestion.
 # TODO: Figure out the memory leak and remove the `--maxtasksperchild` (bug 1513506).

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -280,8 +280,6 @@ CELERY_QUEUES = [
     Queue('generate_perf_alerts', Exchange('default'), routing_key='generate_perf_alerts'),
     Queue('store_pulse_jobs', Exchange('default'), routing_key='store_pulse_jobs'),
     Queue('store_pulse_pushes', Exchange('default'), routing_key='store_pulse_pushes'),
-    # TODO: Remove this queue once emptied.
-    Queue('store_pulse_resultsets', Exchange('default'), routing_key='store_pulse_resultsets'),
     Queue('seta_analyze_failures', Exchange('default'), routing_key='seta_analyze_failures'),
 ]
 

--- a/treeherder/etl/tasks/pulse_tasks.py
+++ b/treeherder/etl/tasks/pulse_tasks.py
@@ -28,15 +28,3 @@ def store_pulse_pushes(body, exchange, routing_key):
     newrelic.agent.add_custom_parameter("routing_key", routing_key)
 
     PushLoader().process(body, exchange)
-
-
-# TODO: Remove this task once the queue is empty.
-@retryable_task(name='store-pulse-resultsets', max_retries=10)
-def store_pulse_resultsets(body, exchange, routing_key):
-    """
-    Fetches the pushes pending from pulse exchanges and loads them.
-    """
-    newrelic.agent.add_custom_parameter("exchange", exchange)
-    newrelic.agent.add_custom_parameter("routing_key", routing_key)
-
-    PushLoader().process(body, exchange)


### PR DESCRIPTION
In #4709 push ingestion was changed to use a new `store_pulse_pushes` queue (since we now prefer the term "push" instead of "resultset"), with the old queue left behind to ensure any tasks in it at the time of deployment would still be run.

Now that the old queue is empty it can be removed.