### PR TITLE
Bug 1531271 - Remove unused Celery queues

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -40,7 +40,7 @@ worker_store_pulse_data: newrelic-admin run-program celery worker -A treeherder 
 
 # Handles the log parsing tasks scheduled by `worker_store_pulse_data` as part of job ingestion.
 # TODO: Figure out the memory leak and remove the `--maxtasksperchild` (bug 1513506).
-worker_log_parser: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_parser,log_parser_fail,log_store_failure_lines,log_store_failure_lines_fail,log_crossreference_error_lines,log_crossreference_error_lines_fail,log_autoclassify,log_autoclassify_fail --maxtasksperchild=50 --concurrency=7
+worker_log_parser: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_parser,log_parser_fail,log_autoclassify,log_autoclassify_fail --maxtasksperchild=50 --concurrency=7
 
 # Tasks that don't need a dedicated worker.
 worker_misc: newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q default,generate_perf_alerts,pushlog,seta_analyze_failures --concurrency=3

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -265,15 +265,8 @@ AUTH0_CLIENTID = env('AUTH0_CLIENTID', default="q8fZZFfGEmSB2c5uSI8hOkKdDGXnlo5z
 # Celery
 CELERY_QUEUES = [
     Queue('default', Exchange('default'), routing_key='default'),
-    # queue for failed jobs/logs
     Queue('log_parser', Exchange('default'), routing_key='log_parser.normal'),
     Queue('log_parser_fail', Exchange('default'), routing_key='log_parser.failures'),
-    Queue('log_store_failure_lines', Exchange('default'), routing_key='store_failure_lines.normal'),
-    Queue('log_store_failure_lines_fail', Exchange('default'), routing_key='store_failure_lines.failures'),
-    Queue('log_crossreference_error_lines', Exchange('default'),
-          routing_key='crossreference_error_lines.normal'),
-    Queue('log_crossreference_error_lines_fail', Exchange('default'),
-          routing_key='crossreference_error_lines.failures'),
     Queue('log_autoclassify', Exchange('default'), routing_key='autoclassify.normal'),
     Queue('log_autoclassify_fail', Exchange('default'), routing_key='autoclassify.failures'),
     Queue('pushlog', Exchange('default'), routing_key='pushlog'),


### PR DESCRIPTION
The `store_failure_lines*` and `crossreference_error_lines*` queues have been unused since the log parsing tasks were combined in #2544.