### PR TITLE
Bug 1340216 - Make pulse_listener_{pushes,jobs} report to New Relic

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -28,4 +28,6 @@ shutdown_timeout = 15
 # The agent doesn't annotate Django management commands by default:
 # https://docs.newrelic.com/docs/agents/python-agent/supported-features/python-background-tasks#django
 # List finite-duration commands here to enable their annotation by the agent.
+# For infinite duration commands (such as `pulse_listener_*`) see:
+# https://docs.newrelic.com/docs/agents/python-agent/supported-features/python-background-tasks#wrapping
 instrumentation.scripts.django_admin = check cycle_data load_initial_data migrate update_bugscache run_intermittents_commenter

--- a/treeherder/services/pulse/consumers.py
+++ b/treeherder/services/pulse/consumers.py
@@ -1,5 +1,6 @@
 import logging
 
+import newrelic.agent
 from kombu import (Exchange,
                    Queue)
 from kombu.mixins import ConsumerMixin
@@ -92,6 +93,7 @@ class PulseConsumer(ConsumerMixin):
 class JobConsumer(PulseConsumer):
     queue_suffix = "jobs"
 
+    @newrelic.agent.background_task(name='pulse-listener-jobs.on_message', group='Pulse Listener')
     def on_message(self, body, message):
         exchange = message.delivery_info['exchange']
         routing_key = message.delivery_info['routing_key']
@@ -106,6 +108,7 @@ class JobConsumer(PulseConsumer):
 class PushConsumer(PulseConsumer):
     queue_suffix = "resultsets"
 
+    @newrelic.agent.background_task(name='pulse-listener-pushes.on_message', group='Pulse Listener')
     def on_message(self, body, message):
         exchange = message.delivery_info['exchange']
         routing_key = message.delivery_info['routing_key']


### PR DESCRIPTION
Since these Django management commands are infinite duration (they run continuously listening for Pulse messages), they cannot be added to the list of Django management commands in `newrelic.ini` that are automatically tracked by the New Relic Python agent.

Instead, we need to wrap the finite duration function within the Pulse listener command that represents a discrete unit of work that New Relic can report as an individual non-web transaction.

See:
https://docs.newrelic.com/docs/agents/python-agent/supported-features/python-background-tasks#wrapping