### PR TITLE
Bug 1532255 - Enable Celery acks_late

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -305,6 +305,12 @@ CELERY_BROKER_HEARTBEAT = None
 # default value when no task routing info is specified
 CELERY_TASK_DEFAULT_QUEUE = 'default'
 
+# Make Celery defer the acknowledgment of a task until after the task has completed,
+# to prevent data loss in the case of celery master process crashes or infra failures.
+# https://devcenter.heroku.com/articles/celery-heroku#using-acks_late
+# http://docs.celeryproject.org/en/latest/userguide/tasks.html#Task.acks_late
+CELERY_TASK_ACKS_LATE = True
+
 # Default celery time limits in seconds. The gap between the soft and hard time limit
 # is to give the New Relic agent time to report the `SoftTimeLimitExceeded` exception.
 # NB: The per-task `soft_time_limit` must always be lower than `CELERY_TASK_TIME_LIMIT`.


### PR DESCRIPTION
This makes Celery defer acknowledging a task until after the task has been completed, to prevent data loss in the case of a celery/infra issue which prevents Celery from returning any unfinished tasks back to RabbitMQ.

It effectively changes the task delivery guarantee from "at most once" to "at least once", which is fine since our tasks are now all idempotent.

See:
https://devcenter.heroku.com/articles/celery-heroku#using-acks_late
http://docs.celeryproject.org/en/latest/faq.html#should-i-use-retry-or-acks-late
http://docs.celeryproject.org/en/latest/userguide/tasks.html#Task.acks_late
http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-task_acks_late