### PR TITLE
Bug 1513506 - Stop using --maxtasksperchild with log parser tasks

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -41,8 +41,7 @@ pulse_listener_jobs: newrelic-admin run-program ./manage.py pulse_listener_jobs
 worker_store_pulse_data: REMAP_SIGTERM=SIGQUIT newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q store_pulse_pushes,store_pulse_jobs --concurrency=3
 
 # Handles the log parsing tasks scheduled by `worker_store_pulse_data` as part of job ingestion.
-# TODO: Figure out the memory leak and remove the `--maxtasksperchild` (bug 1513506).
-worker_log_parser: REMAP_SIGTERM=SIGQUIT newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_parser,log_parser_fail,log_autoclassify,log_autoclassify_fail --maxtasksperchild=50 --concurrency=7
+worker_log_parser: REMAP_SIGTERM=SIGQUIT newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_parser,log_parser_fail,log_autoclassify,log_autoclassify_fail --concurrency=7
 
 # Tasks that don't need a dedicated worker.
 worker_misc: REMAP_SIGTERM=SIGQUIT newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q default,generate_perf_alerts,pushlog,seta_analyze_failures --concurrency=3


### PR DESCRIPTION
Since the memory leaks that made it necessary to restart the workers after they had processed 50 tasks appear to no longer occur.

![screenshot_2019-03-05 treeherder-prototype metrics heroku](https://user-images.githubusercontent.com/501702/53786241-fa21ef80-3f12-11e9-9180-e5fcb2b30e16.png)

