### PR TITLE
Move attrs requirement to common.txt

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -327,5 +327,8 @@ first==2.0.1 \
     --hash=sha256:41d5b64e70507d0c3ca742d68010a76060eea8a3d863e9b5130ab11a4a91aa0e
 
 # Required by jsonschema
+attrs==18.2.0 \
+    --hash=sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb \
+    --hash=sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69
 pyrsistent==0.14.11 \
     --hash=sha256:3ca82748918eb65e2d89f222b702277099aca77e34843c5eb9d52451173970e2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -43,9 +43,6 @@ isort==4.3.10 \
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6
-attrs==18.2.0 \
-    --hash=sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb \
-    --hash=sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69
 more-itertools==6.0.0 \
     --hash=sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40
 pluggy==0.9.0 \


### PR DESCRIPTION
This fixes the deploys on Heroku when we do not use the ``dev.txt`` requirement (it's only used on Prototype).

Thanks Ed!