### PR TITLE
Make travis use same node version as package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - env: js-tests
       language: node_js
-      node_js: '11'
+      node_js: '11.10.1'
       cache:
         directories:
           - node_modules

--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,6 @@
   ],
   "labels": ["dependencies", "javascript"],
   "reviewers": ["sarah-clements"],
-  "semanticCommits": false
+  "semanticCommits": false,
+  "travis": { "enabled": true }
 }


### PR DESCRIPTION
Ensure node versions for package.json and travis.yml are the same (enabled support for renovate per here: https://github.com/renovatebot/renovate/blob/aeeeff59e13a71b16864079609a37e14f3f29904/website/docs/node.md#file-support)