### PR TITLE
 Bug 1521157 - Improve test matching and log lines

### DIFF
--- a/treeherder/push_health/utils.py
+++ b/treeherder/push_health/utils.py
@@ -55,6 +55,23 @@ def clean_test(test_name):
     return clean_name
 
 
+def clean_config(config):
+    # We have found that pgo ~= opt for our needs, so this helps us get a
+    # more representative sample size of data.
+    if config == 'pgo':
+        config = 'opt'
+
+    return config.encode('ascii', 'ignore').decode('utf-8')
+
+
+def clean_platform(platform):
+    # This is needed because of macosx-qr
+    if platform.startswith('macosx64'):
+        platform = platform.replace('macosx64', 'osx-10-10')
+
+    return platform.encode('ascii', 'ignore').decode('utf-8')
+
+
 def is_valid_failure_line(line):
     skip_lines = ['Return code:', 'unexpected status', 'unexpected crashes', 'exit status', 'Finished in']
     return not any(skip_line in line for skip_line in skip_lines)

--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -238,7 +238,7 @@ class PushActionMenu extends React.PureComponent {
               target="_blank"
               rel="noopener noreferrer"
             >
-              DEMO: Push Health (fake data)
+              Prototype: Push Health)
             </a>
           </li>
         </ul>

--- a/ui/push-health/TestFailure.jsx
+++ b/ui/push-health/TestFailure.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faStar } from '@fortawesome/free-solid-svg-icons';
 import { Badge, Row, Col } from 'reactstrap';
 
-import { getJobsUrl } from '../helpers/url';
+import logviewerIcon from '../img/logviewerIcon.png';
+import { getJobsUrl, getLogViewerUrl } from '../helpers/url';
 
 export default class TestFailure extends React.PureComponent {
   render() {
@@ -12,10 +11,11 @@ export default class TestFailure extends React.PureComponent {
     const {
       testName,
       jobName,
-      jobId,
-      classification,
+      jobSymbol,
+      jobs,
       logLines,
       confidence,
+      platform,
       config,
     } = failure;
 
@@ -31,24 +31,39 @@ export default class TestFailure extends React.PureComponent {
           </span>
         </Row>
         <div className="small">
-          <a
-            className="text-dark ml-3 px-1 border border-secondary rounded"
-            href={getJobsUrl({ selectedJob: jobId, repo, revision })}
-          >
-            {jobName}
-          </a>
-          <span className="ml-1">{config},</span>
-          <span className="ml-1">
-            {classification !== 'not classified' && (
-              <FontAwesomeIcon icon={faStar} />
-            )}
-            <span className="ml-1">{classification}</span>
+          <span>
+            {platform} {config}:
           </span>
+          {jobs.map(job => (
+            <span className="mr-2">
+              <a
+                className="text-dark ml-3 px-1 border border-secondary rounded"
+                href={getJobsUrl({ selectedJob: job.id, repo, revision })}
+                title={jobName}
+              >
+                {jobSymbol}
+              </a>
+              <a
+                className="logviewer-btn"
+                href={getLogViewerUrl(job.id, repo)}
+                target="_blank"
+                rel="noopener noreferrer"
+                title="Open the Log Viewer for this job"
+              >
+                <img
+                  style={{ height: '18px' }}
+                  alt="Logviewer"
+                  src={logviewerIcon}
+                  className="logviewer-icon text-dark"
+                />
+              </a>
+            </span>
+          ))}
         </div>
         {!!logLines.length &&
           logLines.map(logLine => (
             <Row className="small text-monospace mt-2 ml-3" key={logLine}>
-              {logLine}
+              {logLine.subtest} {logLine.message}
             </Row>
           ))}
       </Col>


### PR DESCRIPTION
After some conversations with @jmaher I changed directions here, slightly.  Instead of fetching the ``log_lines`` for each job of each test, I print out the ``FailureLine``s, grouped by test name.  I added a link to the log so you can easily inspect further.  And when there is an identical failure, it shows both jobs for the same test failure.

I did not yet address the idea of using Serializers.  Comments in-line.