### PR TITLE
Bug 1521157 - Group by classifications

### DIFF
--- a/tests/push_health/test_classification.py
+++ b/tests/push_health/test_classification.py
@@ -17,13 +17,13 @@ def test_intermittent_win7_reftest():
     ]
     set_classifications(failures, {}, {})
 
-    assert failures[0]['suggestedClassification'] == 'Intermittent'
+    assert failures[0]['suggestedClassification'] == 'intermittent'
 
 
 @pytest.mark.parametrize(('history', 'confidence', 'classification'), [
-    ({'foo': {'bing': {'baz': 2}}}, 100, 'Intermittent'),
-    ({'foo': {'bing': {'bee': 2}}}, 75, 'Intermittent'),
-    ({'foo': {'bee': {'bee': 2}}}, 50, 'Intermittent'),
+    ({'foo': {'bing': {'baz': 2}}}, 100, 'intermittent'),
+    ({'foo': {'bing': {'bee': 2}}}, 75, 'intermittent'),
+    ({'foo': {'bee': {'bee': 2}}}, 50, 'intermittent'),
     ({'fee': {'bee': {'bee': 2}}}, 0, 'New Failure'),
 ])
 def test_intermittent_confidence(history, confidence, classification):

--- a/treeherder/push_health/classification.py
+++ b/treeherder/push_health/classification.py
@@ -9,7 +9,7 @@ def set_classifications(failures, intermittent_history, fixed_by_commit_history)
 def set_previous_regression(failure, fixed_by_commit_history):
     # Not perfect, could have intermittent that is cause of fbc
     if failure['testName'] in fixed_by_commit_history.keys():
-        failure['suggestedClassification'] = 'previousregression'
+        failure['suggestedClassification'] = 'previousRegression'
         return True
     return False
 
@@ -41,7 +41,7 @@ def set_intermittent(failure, previous_failures):
 
     if confidence:
         failure['confidence'] = confidence
-        failure['suggestedClassification'] = 'Intermittent'
+        failure['suggestedClassification'] = 'intermittent'
         return True
     return False
 
@@ -54,3 +54,19 @@ def get_log_lines(failure):
         if len(parts) == 3:
             messages.append(parts[2].strip())
     return messages
+
+
+def get_grouped(failures):
+    classified = {
+        'needInvestigation': [],
+        'intermittent': [],
+        'previousRegression': [],
+    }
+
+    for failure in failures:
+        if failure['confidence'] == 100:
+            classified[failure['suggestedClassification']].append(failure)
+        else:
+            classified['needInvestigation'].append(failure)
+
+    return classified

--- a/treeherder/push_health/push_health.py
+++ b/treeherder/push_health/push_health.py
@@ -6,7 +6,8 @@ from django.forms.models import model_to_dict
 from treeherder.model.models import (FailureLine,
                                      OptionCollection,
                                      Repository)
-from treeherder.push_health.classification import set_classifications
+from treeherder.push_health.classification import (get_grouped,
+                                                   set_classifications)
 from treeherder.push_health.filter import filter_failure
 from treeherder.push_health.utils import (clean_config,
                                           clean_platform,
@@ -121,4 +122,4 @@ def get_push_health_test_failures(push):
         intermittent_history,
         {},  # TODO: Use fbc history
     )
-    return filtered_push_failures
+    return get_grouped(filtered_push_failures)

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -229,7 +229,6 @@ class PushViewSet(viewsets.ViewSet):
                     'result': 'fail',
                     'value': 2,
                     'failures': push_health_test_failures,
-                    'details': [],
                 },
                 {
                     'name': 'Coverage',

--- a/ui/push-health/ClassificationGroup.jsx
+++ b/ui/push-health/ClassificationGroup.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faPlusSquare,
+  faMinusSquare,
+} from '@fortawesome/free-regular-svg-icons';
+import { Row, Collapse } from 'reactstrap';
+
+import TestFailure from './TestFailure';
+
+export default class ClassificationGroup extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      detailsShowing: props.expanded,
+    };
+  }
+
+  toggleDetails = () => {
+    this.setState(prevState => ({ detailsShowing: !prevState.detailsShowing }));
+  };
+
+  render() {
+    const { detailsShowing } = this.state;
+    const { group, name, repo, revision, className, headerColor } = this.props;
+    const expandIcon = detailsShowing ? faMinusSquare : faPlusSquare;
+
+    return (
+      <Row className={`justify-content-between ${className}`}>
+        <h4 className="w-100" onClick={this.toggleDetails}>
+          <span className={`pointable badge badge-${headerColor} w-100`}>
+            {name} : {Object.keys(group).length}
+            <FontAwesomeIcon icon={expandIcon} className="ml-1" />
+          </span>
+        </h4>
+        <Collapse isOpen={detailsShowing}>
+          <div>
+            {group &&
+              group.map(failure => (
+                <TestFailure
+                  key={failure.key}
+                  failure={failure}
+                  repo={repo}
+                  revision={revision}
+                />
+              ))}
+          </div>
+        </Collapse>
+      </Row>
+    );
+  }
+}
+
+ClassificationGroup.propTypes = {
+  group: PropTypes.array.isRequired,
+  name: PropTypes.string.isRequired,
+  repo: PropTypes.string.isRequired,
+  revision: PropTypes.string.isRequired,
+  expanded: PropTypes.bool,
+  className: PropTypes.string,
+  headerColor: PropTypes.string,
+};
+
+ClassificationGroup.defaultProps = {
+  expanded: true,
+  className: '',
+  headerColor: '',
+};

--- a/ui/push-health/Metric.jsx
+++ b/ui/push-health/Metric.jsx
@@ -8,7 +8,7 @@ import {
 import { Badge, Row, Col, Collapse, Card, CardBody } from 'reactstrap';
 
 import { resultColorMap } from './helpers';
-import TestFailure from './TestFailure';
+import TestFailures from './TestFailures';
 
 export default class Metric extends React.PureComponent {
   constructor(props) {
@@ -63,15 +63,13 @@ export default class Metric extends React.PureComponent {
             <Collapse isOpen={detailsShowing}>
               <Card>
                 <CardBody>
-                  {failures &&
-                    failures.map(failure => (
-                      <TestFailure
-                        key={failure.key}
-                        failure={failure}
-                        repo={repo}
-                        revision={revision}
-                      />
-                    ))}
+                  {name === 'Tests' && (
+                    <TestFailures
+                      failures={failures}
+                      repo={repo}
+                      revision={revision}
+                    />
+                  )}
                   {details &&
                     details.map(detail => (
                       <div key={detail} className="ml-3">
@@ -94,10 +92,11 @@ Metric.propTypes = {
   result: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   value: PropTypes.number.isRequired,
-  details: PropTypes.array.isRequired,
-  failures: PropTypes.array,
+  details: PropTypes.array,
+  failures: PropTypes.object,
 };
 
 Metric.defaultProps = {
+  details: null,
   failures: null,
 };

--- a/ui/push-health/TestFailure.jsx
+++ b/ui/push-health/TestFailure.jsx
@@ -22,7 +22,7 @@ export default class TestFailure extends React.PureComponent {
     return (
       <Col className="mt-2 mb-3 ml-2">
         <Row className="border-bottom border-secondary justify-content-between">
-          <span className="font-weight-bold">{testName}</span>
+          <span>{testName}</span>
           <span>
             Line confidence:
             <Badge color="secondary" className="ml-2 mr-3">

--- a/ui/push-health/TestFailures.jsx
+++ b/ui/push-health/TestFailures.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import ClassificationGroup from './ClassificationGroup';
+
+export default class TestFailures extends React.PureComponent {
+  render() {
+    const { failures, repo, revision } = this.props;
+    const { needInvestigation, intermittent, previousRegression } = failures;
+    const needInvestigationLength = Object.keys(needInvestigation).length;
+
+    return (
+      <div className="border-bottom border-secondary">
+        <ClassificationGroup
+          group={needInvestigation}
+          name="Need Investigation"
+          repo={repo}
+          revision={revision}
+          className="mb-5"
+          headerColor={needInvestigationLength ? 'danger' : 'secondary'}
+        />
+        <ClassificationGroup
+          group={previousRegression}
+          name="Known FixedByCommit"
+          repo={repo}
+          revision={revision}
+          headerColor="secondary"
+        />
+        <ClassificationGroup
+          group={intermittent}
+          name="Known Intermittent"
+          repo={repo}
+          revision={revision}
+          className="mb-5"
+          headerColor="secondary"
+          expanded={false}
+        />
+      </div>
+    );
+  }
+}
+
+TestFailures.propTypes = {
+  failures: PropTypes.object.isRequired,
+  repo: PropTypes.string.isRequired,
+  revision: PropTypes.string.isRequired,
+};

--- a/ui/push-health/pushhealth.css
+++ b/ui/push-health/pushhealth.css
@@ -1,3 +1,7 @@
 .metric-name {
   font-size: 24px;
 }
+
+.pointable {
+  cursor: pointer;
+}


### PR DESCRIPTION
This PR will group test failures into the groups to which we have calculated they belong.  So, "intermittent", "previousRegression", or "needInvestigation".  It defaults to the first two being collapsed in the UI.

<img width="1110" alt="Screenshot 2019-03-21 16 40 09" src="https://user-images.githubusercontent.com/419924/54791641-0b981680-4bf8-11e9-8e59-47c193bf7cb4.png">
