### PR TITLE
Bug 1521157 - Check for fixed_by_commit classification

### DIFF
--- a/treeherder/push_health/classification.py
+++ b/treeherder/push_health/classification.py
@@ -1,9 +1,7 @@
 def set_classifications(failures, intermittent_history, fixed_by_commit_history):
     for failure in failures:
-        if set_intermittent(failure, intermittent_history):
-            continue
-        if set_previous_regression(failure, fixed_by_commit_history):
-            continue
+        set_intermittent(failure, intermittent_history)
+        set_previous_regression(failure, fixed_by_commit_history)
 
 
 def set_previous_regression(failure, fixed_by_commit_history):

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -11,7 +11,8 @@ from treeherder.model.models import (Push,
                                      Repository)
 from treeherder.push_health.push_health import get_push_health_test_failures
 from treeherder.webapp.api.serializers import PushSerializer
-from treeherder.webapp.api.utils import (to_datetime,
+from treeherder.webapp.api.utils import (REPO_GROUPS,
+                                         to_datetime,
                                          to_timestamp)
 
 
@@ -205,7 +206,7 @@ class PushViewSet(viewsets.ViewSet):
         except Push.DoesNotExist:
             return Response("No push with revision: {0}".format(revision),
                             status=HTTP_404_NOT_FOUND)
-        push_health_test_failures = get_push_health_test_failures(push)
+        push_health_test_failures = get_push_health_test_failures(push, REPO_GROUPS['trunk'])
 
         return Response({
             'revision': revision,

--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -238,7 +238,7 @@ class PushActionMenu extends React.PureComponent {
               target="_blank"
               rel="noopener noreferrer"
             >
-              Prototype: Push Health)
+              Prototype: Push Health
             </a>
           </li>
         </ul>


### PR DESCRIPTION
Currently, we categorize failures into "intermittent".  This adds categorizing them into "fixedByCommit"

These queries are a bit slow still, so I will introduce caching in a follow-up PR.