### PR TITLE
Bug 1539580 - platform 'opt' should be on top of list for operating system

### DIFF
--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -121,14 +121,14 @@ export const thAllResultStatuses = [
 ];
 
 export const thOptionOrder = {
-  opt: 0,
-  pgo: 1,
-  asan: 2,
-  tsan: 3,
-  debug: 4,
-  cc: 5,
-  addon: 6,
-  all: 7,
+  opt: 1,
+  pgo: 2,
+  asan: 3,
+  tsan: 4,
+  debug: 5,
+  cc: 6,
+  addon: 7,
+  all: 8,
 };
 
 export const thFavicons = {


### PR DESCRIPTION
The 'opt' build flavor is supposed to be shown on top for the group of platforms whose only difference is the build flavor:
https://github.com/mozilla/treeherder/blob/fa39de7925dc2dc398c22389d31fa7af79369ab5/ui/helpers/constants.js#L125

Because its value is 0, it evals to false in the if check at
https://github.com/mozilla/treeherder/blob/fa39de7925dc2dc398c22389d31fa7af79369ab5/ui/job-view/pushes/Push.jsx#L233
and 10 gets used as value instead which puts it at bottom.

Let's increase the value for each flavor so all are positive and the sort function doesn't have to become more complex.