### PR TITLE
Bug 1521157 - Allow force-caching of failure history

### DIFF
--- a/treeherder/model/management/commands/cache_failure_history.py
+++ b/treeherder/model/management/commands/cache_failure_history.py
@@ -45,7 +45,8 @@ class Command(BaseCommand):
                 push_date,
                 intermittent_history_days,
                 option_map,
-                repository_ids)
+                repository_ids,
+                True)
             self.debug('Cached failure history for {}'.format(cache_key))
 
             fbc_hist, cache_key = get_history(
@@ -53,7 +54,8 @@ class Command(BaseCommand):
                 push_date,
                 fixed_by_commit_history_days,
                 option_map,
-                repository_ids)
+                repository_ids,
+                True)
             self.debug('Cached failure history for {}'.format(cache_key))
 
     def debug(self, msg):

--- a/treeherder/push_health/push_health.py
+++ b/treeherder/push_health/push_health.py
@@ -25,13 +25,13 @@ ignored_log_lines = [
 ]
 
 
-def get_history(failure_classification_id, push_date, num_days, option_map, repository_ids):
+def get_history(failure_classification_id, push_date, num_days, option_map, repository_ids, force_update=False):
     start_date = push_date - datetime.timedelta(days=num_days)
     end_date = push_date - datetime.timedelta(days=2)
     cache_key = 'failure_history:{}:{}'.format(failure_classification_id, push_date)
     previous_failures_json = cache.get(cache_key)
 
-    if not previous_failures_json:
+    if not previous_failures_json or force_update:
         failure_lines = FailureLine.objects.filter(
             job_log__job__result='testfailed',
             job_log__job__tier=1,


### PR DESCRIPTION
When the management command to update the failure history is invoked, we want to force 
updating the cache.  This is in case we change the format of the data that is stored, we can easily update it to the latest version.