### PR TITLE
Bug 1521157 - Calculate intermittents for passing jobs

### DIFF
--- a/treeherder/push_health/classification.py
+++ b/treeherder/push_health/classification.py
@@ -58,12 +58,14 @@ def get_grouped(failures):
     classified = {
         'needInvestigation': [],
         'intermittent': [],
-        'fixedByCommit': [],
     }
 
     for failure in failures:
-        if failure['confidence'] == 100:
-            classified[failure['suggestedClassification']].append(failure)
+        pass_fail_ratio = len(failure['passJobs']) / (len(failure['failJobs']) + len(failure['passJobs']))
+        is_intermittent = failure['suggestedClassification'] == 'intermittent'
+
+        if (is_intermittent and failure['confidence'] == 100) or pass_fail_ratio > .5:
+            classified['intermittent'].append(failure)
         else:
             classified['needInvestigation'].append(failure)
 

--- a/treeherder/push_health/similar_jobs.py
+++ b/treeherder/push_health/similar_jobs.py
@@ -1,0 +1,71 @@
+from itertools import groupby
+
+from django.db.models import Q
+from django.forms.models import model_to_dict
+
+from treeherder.model.models import Job
+
+job_fields = [
+    'id',
+    'machine_platform',
+    'option_collection_hash',
+    'job_type',
+    'result',
+    'failure_classification'
+]
+
+
+def set_matching_passed_jobs(failures, push):
+
+    failed_jobs = {}
+    for failure in failures:
+        jobs = {job['id']: job for job in failure['failJobs']}
+        failed_jobs.update(jobs)
+
+    # Need to OR for each type of job that failed
+    query_conditions = []
+    for job in failed_jobs.values():
+        query_conditions.append(Q(
+            option_collection_hash=job['option_collection_hash'],
+            machine_platform=job['machine_platform'],
+            job_type=job['job_type'],
+        ))
+    # ``query`` here will end up being a set of OR conditions for each combination of
+    # platform/config/job_type for the failed jobs.  This OR condition will give us a
+    # list of passing versions of those same job conditions.
+    # Said another way: ``query`` will end up being a bunch of OR conditions for each
+    # type of job we want to find that's in a "success" state.  For instance:
+    # (platform=x, config=y, job_type=z OR platform=a, config=b, job_type=c OR ...)
+    query = query_conditions.pop()
+    for condition in query_conditions:
+        query |= condition
+
+    passing_jobs = Job.objects.filter(
+        push=push,
+        result='success'
+    ).filter(query).select_related('job_type')
+
+    #
+    # Group the passing jobs into groups based on their platform, option and job_type
+    #
+    # convert from ORM objects to dicts for when we return this object
+    passing_job_dicts = [model_to_dict(job, fields=job_fields) for job in passing_jobs]
+    sorted_passing_jobs = sorted(passing_job_dicts, key=get_job_key)
+    passing_job_map = {key: list(group) for key, group in groupby(sorted_passing_jobs, get_job_key)}
+
+    #
+    # Assign matching passing jobs to the test failures
+    #
+    for failure in failures:
+        # If the passing jobs has a list matching this failure's jobs, then add them in
+        if len(failure['failJobs']):
+            # A failure will have the same job_key for all jobs in this push, so use the first one
+            job_key = get_job_key(failure['failJobs'][0])
+            if job_key in passing_job_map:
+                # This sets the ``passJobs`` key in the ``failures`` object that was passed in,
+                # which is then returned from the API.
+                failure['passJobs'] = passing_job_map[job_key]
+
+
+def get_job_key(job):
+    return '{}-{}-{}'.format(job['machine_platform'], job['option_collection_hash'], job['job_type'])

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -207,8 +207,7 @@ class PushViewSet(viewsets.ViewSet):
             return Response("No push with revision: {0}".format(revision),
                             status=HTTP_404_NOT_FOUND)
         push_health_test_failures = get_push_health_test_failures(push, REPO_GROUPS['trunk'])
-        test_result = 'fail' if (len(push_health_test_failures['needInvestigation']) +
-                                 len(push_health_test_failures['fixedByCommit'])) else 'pass'
+        test_result = 'fail' if len(push_health_test_failures['needInvestigation']) else 'pass'
 
         return Response({
             'revision': revision,

--- a/ui/push-health/Job.jsx
+++ b/ui/push-health/Job.jsx
@@ -1,0 +1,61 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faStar } from '@fortawesome/free-solid-svg-icons';
+
+import { getBtnClass } from '../helpers/job';
+import { getJobsUrl, getLogViewerUrl } from '../helpers/url';
+import logviewerIcon from '../img/logviewerIcon.png';
+
+class Job extends PureComponent {
+  render() {
+    const { job, jobName, jobSymbol, repo, revision } = this.props;
+    const { id, result, failure_classification } = job;
+
+    return (
+      <span className="mr-2" key={id}>
+        <a
+          className={`btn job-btn filter-shown btn-sm mt-1 ${getBtnClass(
+            result,
+            failure_classification,
+          )}`}
+          href={getJobsUrl({ selectedJob: job.id, repo, revision })}
+          title={jobName}
+        >
+          {jobSymbol}
+        </a>
+        {failure_classification !== 1 && <FontAwesomeIcon icon={faStar} />}
+        {job.result === 'testfailed' && (
+          <a
+            className="logviewer-btn"
+            href={getLogViewerUrl(job.id, repo)}
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Open the Log Viewer for this job"
+          >
+            <img
+              style={{ height: '18px' }}
+              alt="Logviewer"
+              src={logviewerIcon}
+              className="logviewer-icon text-dark mb-1"
+            />
+          </a>
+        )}
+      </span>
+    );
+  }
+}
+
+Job.propTypes = {
+  job: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    result: PropTypes.string.isRequired,
+    failure_classification: PropTypes.number.isRequired,
+  }).isRequired,
+  jobName: PropTypes.string.isRequired,
+  jobSymbol: PropTypes.string.isRequired,
+  repo: PropTypes.string.isRequired,
+  revision: PropTypes.string.isRequired,
+};
+
+export default Job;

--- a/ui/push-health/TestFailure.jsx
+++ b/ui/push-health/TestFailure.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Badge, Button, Row, Col, Collapse } from 'reactstrap';
 
-import logviewerIcon from '../img/logviewerIcon.png';
-import { getJobsUrl, getLogViewerUrl } from '../helpers/url';
+import Job from './Job';
 
 const classificationMap = {
   fixedByCommit: 'Fixed By Commit',
@@ -30,7 +29,8 @@ export default class TestFailure extends React.PureComponent {
       testName,
       jobName,
       jobSymbol,
-      jobs,
+      failJobs,
+      passJobs,
       logLines,
       confidence,
       platform,
@@ -61,30 +61,25 @@ export default class TestFailure extends React.PureComponent {
           <span>
             {platform} {config}:
           </span>
-          {jobs.map(job => (
-            <span className="mr-2" key={job.id}>
-              <a
-                className="text-dark ml-3 px-1 border border-secondary rounded"
-                href={getJobsUrl({ selectedJob: job.id, repo, revision })}
-                title={jobName}
-              >
-                {jobSymbol}
-              </a>
-              <a
-                className="logviewer-btn"
-                href={getLogViewerUrl(job.id, repo)}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="Open the Log Viewer for this job"
-              >
-                <img
-                  style={{ height: '18px' }}
-                  alt="Logviewer"
-                  src={logviewerIcon}
-                  className="logviewer-icon text-dark"
-                />
-              </a>
-            </span>
+          {failJobs.map(failJob => (
+            <Job
+              job={failJob}
+              jobName={jobName}
+              jobSymbol={jobSymbol}
+              repo={repo}
+              revision={revision}
+              key={failJob.id}
+            />
+          ))}
+          {passJobs.map(passJob => (
+            <Job
+              job={passJob}
+              jobName={jobName}
+              jobSymbol={jobSymbol}
+              repo={repo}
+              revision={revision}
+              key={passJob.id}
+            />
           ))}
         </div>
         {!!logLines.length &&
@@ -115,7 +110,19 @@ export default class TestFailure extends React.PureComponent {
 }
 
 TestFailure.propTypes = {
-  failure: PropTypes.object.isRequired,
+  failure: PropTypes.shape({
+    testName: PropTypes.string.isRequired,
+    jobName: PropTypes.string.isRequired,
+    jobSymbol: PropTypes.string.isRequired,
+    failJobs: PropTypes.arrayOf(PropTypes.shape({})),
+    passJobs: PropTypes.arrayOf(PropTypes.shape({})),
+    logLines: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+    confidence: PropTypes.number.isRequired,
+    platform: PropTypes.string.isRequired,
+    config: PropTypes.string.isRequired,
+    suggestedClassification: PropTypes.string.isRequired,
+    key: PropTypes.string.isRequired,
+  }).isRequired,
   repo: PropTypes.string.isRequired,
   revision: PropTypes.string.isRequired,
 };

--- a/ui/push-health/TestFailure.jsx
+++ b/ui/push-health/TestFailure.jsx
@@ -45,7 +45,7 @@ export default class TestFailure extends React.PureComponent {
         <Row className="border-bottom border-secondary justify-content-between">
           <span>{testName}</span>
           {!!confidence && (
-            <span title="Best guess at a classification">
+            <span title="Best guess at a classification" className="ml-auto">
               {classificationMap[suggestedClassification]}
               <Badge
                 color="secondary"

--- a/ui/push-health/TestFailures.jsx
+++ b/ui/push-health/TestFailures.jsx
@@ -6,7 +6,7 @@ import ClassificationGroup from './ClassificationGroup';
 export default class TestFailures extends React.PureComponent {
   render() {
     const { failures, repo, revision } = this.props;
-    const { needInvestigation, intermittent, fixedByCommit } = failures;
+    const { needInvestigation, intermittent } = failures;
     const needInvestigationLength = Object.keys(needInvestigation).length;
 
     return (
@@ -18,13 +18,6 @@ export default class TestFailures extends React.PureComponent {
           revision={revision}
           className="mb-5"
           headerColor={needInvestigationLength ? 'danger' : 'secondary'}
-        />
-        <ClassificationGroup
-          group={fixedByCommit}
-          name="Known FixedByCommit"
-          repo={repo}
-          revision={revision}
-          headerColor="secondary"
         />
         <ClassificationGroup
           group={intermittent}

--- a/ui/push-health/index.jsx
+++ b/ui/push-health/index.jsx
@@ -6,6 +6,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 
 // Treeherder Styles
 import '../css/treeherder-navbar.css';
+import '../css/treeherder-job-buttons.css';
 import './pushhealth.css';
 
 import App from './App';


### PR DESCRIPTION
This correlates matching passing jobs to the failed jobs for a given test.  So this helps you see the frequency of pass/fail for a particular test to help with determining how intermittent it is.  

The second commit implements marking a test as intermittent if it has >50% pass/fail ratio.
This second commit also removes the bucket of "FixedByCommit" because those are ones that also need investigation, so even 100% confidence in FBC tests go into "Needs Investigation".

<img width="1186" alt="Screenshot 2019-03-29 14 05 24" src="https://user-images.githubusercontent.com/419924/55262664-bda09580-522b-11e9-856c-8bc570bf1e54.png">

