### PR TITLE
Bug 1521032 - Batch successive retrigger requests into fewer action task submissions

### DIFF
--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -345,9 +345,12 @@ class PinBoard extends React.Component {
 
   retriggerAllPinnedJobs = () => {
     const { getGeckoDecisionTaskId, notify, repoName } = this.props;
+    const jobswithcounts = Object.keys(this.props.pinnedJobs).reduce((m,e) => {
+      m[e] = (+m[e]||0)+1; return m
+    }, {});
 
     JobModel.retrigger(
-      Object.keys(this.props.pinnedJobs),
+      jobswithcounts,
       repoName,
       getGeckoDecisionTaskId,
       notify,


### PR DESCRIPTION
At the moment, if a Treeherder user mashes the 'r' key (or clicks the "retrigger" button multiple times) to request multiple retriggers on jobs, each one will go out as its own action-task request. This can quickly overwhelm the pool of workers dedicated to handling action/decision tasks, causing backlogs of decision tasks for other users, slowing down everyone else's jobs from even starting.

Treeherder can help alleviate this a bit by waiting a few seconds after each retrigger request is initiated before sending off the request. TH can batch together successive retrigger requests and submit them all in fewer action task requests.

With this PR, each time a retrigger is requested (via keyboard shortcut or on-screen button), a 5 second timer is initiated, and the requested job ID is stored in a list. 

If another retrigger is requested while that timer is requested, the old timer is removed, a new 5 second timer is started, and the newly requested job is added to that list.

If a timer successfully finishes, all of the jobs in the list are taken and batched into as few action task submissions as possible:

- All jobs are grouped by the push they're part of, because action tasks can only apply to one push at a time.
- For each push, if all jobs contained in that push have the same number of requests (eg if wpt1 and wpt2 each batch up five retrigger requests), all jobs can be submitted in a single action task (all tasks listed, and the "times" value is set to '5').
- If the numbers of requests for jobs in a push are different (eg wpt1 has 4 retriggers requested while wpt2 has 5), it will take more action tasks to finish the requests. I have it set to send one action task per unique job per push.

Some TODOs I still need to figure out or have someone figure out for/with me:

- If there are already retriggers of a job and the user requests retriggers off of each of them (eg wpt1 requests 3 retriggers and a retriggered wpt1 also requests 3), the action task will see that they have the same task name, and only create the first three retriggers. I'd need to do something to add all of the requests up over each unique instance of the job before submitting the request, or maybe just get rid of the "submit only a single action task for everything if all jobs have the same retrigger request count" case, falling back to "submit a single action task for every unique job instance".
- The five second timer is maybe too long. I'm not sure how long we should wait before we decide that it's time to send off the batched requests. Maybe two seconds is plenty? Could it be one second?
- "Add-new-jobs" and "Retrigger" action tasks have a task-defined upper limit on the "times" value. It's currently set to 100 times. While I don't imagine anyone genuinely hitting that limit on a set of batched requests, I'm pretty sure this new code will fail miserably when it submits a request with times > 100. We can just let that happen: I don't know if the "schema violation" error would get surfaced in TH, so it might just silently fail. We could try to add code so if someone requests something like 141 "times", we split that up into 100-times action tasks until we get through all of the requests. Maybe that doesn't matter, though.

Some raw numbers, assuming there are PushA and PushB, each of which runs Job1, Job2, Job3, etc:

- If the user requests five retriggers each of PushA's Job1 and PushA's Job2: The old system would submit this as ten total retrigger action tasks. The new system would submit this as one add-new-jobs action task, listing job1 and job2 with a "times" of 5.
- If the user requests five retriggers of PushA's Job1 and six retriggers of PushA's Job2: The old system would submit this as eleven total retrigger action tasks. The new system would submit this as one add-new-jobs action task listing job1 and a "times" of 5, and another add-new-jobs action task listing job2 and a "times" of 5, so two total action tasks.
- If the user requests three retriggers of PushA's Job1 and two retriggers of PushA's Job2, and also two retriggers of PushB's Job1 and two retriggers of PushB's Job2: The old system would submit this as nine total retrigger action tasks; five of them on PushA, four on PushB. The new system would submit this as one action task on PushA for Job1 (with "times": 3), another action task on PushA for Job2 (with "times": 2), then one action task on PushB for Job1 *and* Job2 (with "times": 2). So three total action tasks.
- If the user starts on PushA Job1 and presses 'r' twice before moving to the next job (r-r-next-r-r-next, etc) for Job1 through Job50: The old system would submit that as 100 action tasks. The new system (assuming the user never accidentally requested anything other than two retriggers per job) would submit them all in one action task. If any single job got more or less than two retrigger requests, it would send off 50 action tasks, one for each job with the "times" for the specified job. 

Maybe that last case could be handled better? Group all requests by their "times" value and send them off like that? (All jobs with a "times" of 1 are in one action task, "times:2" in another, "times:3" another, etc?)