### PR TITLE
Bug 1496858 - Improve JobModel retrigger wrt decision task

### DIFF
--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -344,14 +344,9 @@ class PinBoard extends React.Component {
   };
 
   retriggerAllPinnedJobs = () => {
-    const { getGeckoDecisionTaskId, notify, repoName } = this.props;
+    const { pinnedJobs, notify, repoName } = this.props;
 
-    JobModel.retrigger(
-      Object.keys(this.props.pinnedJobs),
-      repoName,
-      getGeckoDecisionTaskId,
-      notify,
-    );
+    JobModel.retrigger(Object.values(pinnedJobs), repoName, notify);
   };
 
   render() {

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -121,8 +121,7 @@ class ActionBar extends React.PureComponent {
   };
 
   retriggerJob = jobs => {
-    const { user, repoName, getGeckoDecisionTaskId, notify } = this.props;
-    const jobIds = jobs.map(({ id }) => id);
+    const { user, repoName, notify } = this.props;
 
     if (!user.isLoggedIn) {
       return notify('Must be logged in to retrigger a job', 'danger');
@@ -136,7 +135,7 @@ class ActionBar extends React.PureComponent {
       });
     });
 
-    JobModel.retrigger(jobIds, repoName, getGeckoDecisionTaskId, notify);
+    JobModel.retrigger(jobs, repoName, notify);
   };
 
   backfillJob = () => {

--- a/ui/models/push.js
+++ b/ui/models/push.js
@@ -158,4 +158,16 @@ export default class PushModel {
       getProjectUrl(`${pushEndpoint}health/?revision=${revision}`, repoName),
     );
   }
+
+  static getDecisionTaskId(pushId) {
+    const map = PushModel.getDecisionTaskMap([pushId]);
+
+    return map[pushId];
+  }
+
+  static getDecisionTaskMap(pushIds) {
+    return getData(
+      getProjectUrl(`${pushEndpoint}decisiontask/?push_ids=${pushIds}`),
+    );
+  }
 }


### PR DESCRIPTION
This is to help with enabling retriggers in Push Health.  The way this was done before was really convoluted.  This application can be applied to any function that is currently using ``getGeckoDecisionTaskId``.  I'm just starting here since this is what I need right now.