### PR TITLE
Fix Push Health when there are no structured log failures

### DIFF
--- a/treeherder/push_health/similar_jobs.py
+++ b/treeherder/push_health/similar_jobs.py
@@ -16,6 +16,8 @@ job_fields = [
 
 
 def set_matching_passed_jobs(failures, push):
+    if len(failures) == 0:
+        return
 
     failed_jobs = {}
     for failure in failures:


### PR DESCRIPTION
If there were no structured log failures in the push, then ``failures`` here would be empty, so we should bail out of this function.

This was the bug you mentioned in the retrigger PR.  :)