### PR TITLE
Bug 1441938 - Use PushModel.getDecisionTask functions

### DIFF
--- a/ui/job-view/context/Pushes.jsx
+++ b/ui/job-view/context/Pushes.jsx
@@ -64,8 +64,6 @@ export class PushesClass extends React.Component {
       updateUrlFromchange: this.updateUrlFromchange,
       getNextPushes: this.getNextPushes,
       handleUrlChanges: this.handleUrlChanges,
-      getGeckoDecisionJob: this.getGeckoDecisionJob,
-      getGeckoDecisionTaskId: this.getGeckoDecisionTaskId,
     };
   }
 
@@ -151,35 +149,6 @@ export class PushesClass extends React.Component {
       setUrlParam('startdate', null);
     }
     this.fetchPushes(count).then(this.updateUrlFromchange);
-  };
-
-  getGeckoDecisionJob = pushId => {
-    const { jobMap } = this.state;
-
-    return Object.values(jobMap).find(
-      job =>
-        job.push_id === pushId &&
-        job.platform === 'gecko-decision' &&
-        job.state === 'completed' &&
-        job.job_type_symbol === 'D',
-    );
-  };
-
-  getGeckoDecisionTaskId = (pushId, repoName) => {
-    const decisionTask = this.getGeckoDecisionJob(pushId);
-    if (decisionTask) {
-      return JobModel.get(repoName, decisionTask.id).then(job => {
-        // this failure case is unlikely, but I guess you
-        // never know
-        if (!job.taskcluster_metadata) {
-          return Promise.reject('Decision task missing taskcluster metadata');
-        }
-        return job.taskcluster_metadata.task_id;
-      });
-    }
-
-    // no decision task, we fail
-    return Promise.reject('No decision task');
   };
 
   getLastModifiedJobTime = () => {
@@ -450,8 +419,6 @@ export function withPushes(Component) {
               context.recalculateUnclassifiedCounts
             }
             getNextPushes={context.getNextPushes}
-            getGeckoDecisionJob={context.getGeckoDecisionJob}
-            getGeckoDecisionTaskId={context.getGeckoDecisionTaskId}
           />
         )}
       </PushesContext.Consumer>

--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -198,14 +198,12 @@ class PinBoard extends React.Component {
   };
 
   cancelAllPinnedJobs = () => {
-    const { getGeckoDecisionTaskId, notify, repoName } = this.props;
+    const { notify, repoName, pinnedJobs } = this.props;
 
     if (
       window.confirm('This will cancel all the selected jobs. Are you sure?')
     ) {
-      const jobIds = Object.keys(this.props.pinnedJobs);
-
-      JobModel.cancel(jobIds, repoName, getGeckoDecisionTaskId, notify);
+      JobModel.cancel(Object.values(pinnedJobs), repoName, notify);
       this.unPinAll();
     }
   };
@@ -640,7 +638,6 @@ PinBoard.propTypes = {
   unPinAll: PropTypes.func.isRequired,
   setClassificationId: PropTypes.func.isRequired,
   setClassificationComment: PropTypes.func.isRequired,
-  getGeckoDecisionTaskId: PropTypes.func.isRequired,
   setSelectedJob: PropTypes.func.isRequired,
   notify: PropTypes.func.isRequired,
   repoName: PropTypes.string.isRequired,

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -12,6 +12,7 @@ import { withPushes } from '../context/Pushes';
 import { getGroupMapKey } from '../../helpers/aggregateId';
 import { getAllUrlParams, getUrlParam } from '../../helpers/location';
 import JobModel from '../../models/job';
+import PushModel from '../../models/push';
 import RunnableJobModel from '../../models/runnableJob';
 import { getRevisionTitle } from '../../helpers/revision';
 import { getPercentComplete } from '../../helpers/display';
@@ -311,10 +312,10 @@ class Push extends React.Component {
   };
 
   showRunnableJobs = async () => {
-    const { push, repoName, getGeckoDecisionTaskId, notify } = this.props;
+    const { push, repoName, notify } = this.props;
 
     try {
-      const decisionTaskId = await getGeckoDecisionTaskId(push.id, repoName);
+      const decisionTaskId = await PushModel.getDecisionTaskId(push.id, notify);
       const jobList = await RunnableJobModel.getList(repoName, {
         decision_task_id: decisionTaskId,
         push_id: push.id,
@@ -348,7 +349,7 @@ class Push extends React.Component {
   };
 
   showFuzzyJobs = async () => {
-    const { push, repoName, getGeckoDecisionTaskId, notify } = this.props;
+    const { push, repoName, notify } = this.props;
     const createRegExp = (str, opts) =>
       new RegExp(str.raw[0].replace(/\s/gm, ''), opts || '');
     const excludedJobNames = createRegExp`
@@ -361,7 +362,7 @@ class Push extends React.Component {
       test-verify|test-windows10-64-ux|toolchain|upload-generated-sources)`;
 
     try {
-      const decisionTaskId = await getGeckoDecisionTaskId(push.id, repoName);
+      const decisionTaskId = await PushModel.getDecisionTaskId(push.id, notify);
 
       notify('Fetching runnable jobs... This could take a while...');
       let fuzzyJobList = await RunnableJobModel.getList(repoName, {
@@ -542,7 +543,6 @@ Push.propTypes = {
   updateJobMap: PropTypes.func.isRequired,
   recalculateUnclassifiedCounts: PropTypes.func.isRequired,
   allUnclassifiedFailureCount: PropTypes.number.isRequired,
-  getGeckoDecisionTaskId: PropTypes.func.isRequired,
   duplicateJobsVisible: PropTypes.bool.isRequired,
   groupCountsExpanded: PropTypes.bool.isRequired,
   notify: PropTypes.func.isRequired,

--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -6,7 +6,6 @@ import { getUrlParam } from '../../helpers/location';
 import { formatTaskclusterError } from '../../helpers/errorMessage';
 import CustomJobActions from '../CustomJobActions';
 import PushModel from '../../models/push';
-import { withPushes } from '../context/Pushes';
 import { getPushHealthUrl } from '../../helpers/url';
 import { notify } from '../redux/stores/notifications';
 
@@ -51,7 +50,7 @@ class PushActionMenu extends React.PureComponent {
   };
 
   triggerMissingJobs = () => {
-    const { getGeckoDecisionTaskId, notify, revision, pushId } = this.props;
+    const { notify, revision, pushId } = this.props;
 
     if (
       !window.confirm(
@@ -61,23 +60,13 @@ class PushActionMenu extends React.PureComponent {
       return;
     }
 
-    getGeckoDecisionTaskId(pushId)
-      .then(decisionTaskID => {
-        PushModel.triggerMissingJobs(decisionTaskID)
-          .then(msg => {
-            notify(msg, 'success');
-          })
-          .catch(e => {
-            notify(formatTaskclusterError(e), 'danger', { sticky: true });
-          });
-      })
-      .catch(e => {
-        notify(formatTaskclusterError(e), 'danger', { sticky: true });
-      });
+    PushModel.triggerMissingJobs(pushId, notify).catch(e => {
+      notify(formatTaskclusterError(e), 'danger', { sticky: true });
+    });
   };
 
   triggerAllTalosJobs = () => {
-    const { getGeckoDecisionTaskId, notify, revision, pushId } = this.props;
+    const { notify, revision, pushId } = this.props;
 
     if (
       !window.confirm(
@@ -98,15 +87,9 @@ class PushActionMenu extends React.PureComponent {
       );
     }
 
-    getGeckoDecisionTaskId(pushId)
-      .then(decisionTaskID => {
-        PushModel.triggerAllTalosJobs(times, decisionTaskID)
-          .then(msg => {
-            notify(msg, 'success');
-          })
-          .catch(e => {
-            notify(formatTaskclusterError(e), 'danger', { sticky: true });
-          });
+    PushModel.triggerAllTalosJobs(times, pushId)
+      .then(msg => {
+        notify(msg, 'success');
       })
       .catch(e => {
         notify(formatTaskclusterError(e), 'danger', { sticky: true });
@@ -197,7 +180,7 @@ class PushActionMenu extends React.PureComponent {
               className={
                 isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'
               }
-              onClick={() => this.triggerMissingJobs(revision)}
+              onClick={this.triggerMissingJobs}
             >
               Trigger missing jobs
             </li>
@@ -281,11 +264,10 @@ PushActionMenu.propTypes = {
   hideRunnableJobs: PropTypes.func.isRequired,
   showRunnableJobs: PropTypes.func.isRequired,
   showFuzzyJobs: PropTypes.func.isRequired,
-  getGeckoDecisionTaskId: PropTypes.func.isRequired,
   notify: PropTypes.func.isRequired,
 };
 
 export default connect(
   null,
   { notify },
-)(withPushes(PushActionMenu));
+)(PushActionMenu);

--- a/ui/models/push.js
+++ b/ui/models/push.js
@@ -59,7 +59,9 @@ export default class PushModel {
     return fetch(getProjectUrl(`${pushEndpoint}${pk}/`, repoName));
   }
 
-  static triggerMissingJobs(decisionTaskId) {
+  static async triggerMissingJobs(pushId, notify) {
+    const decisionTaskId = await PushModel.getDecisionTaskId(pushId, notify);
+
     return TaskclusterModel.load(decisionTaskId).then(results => {
       const actionTaskId = slugid();
       const missingTestsTask = results.actions.find(
@@ -75,13 +77,17 @@ export default class PushModel {
         input: {},
         staticActionVariables: results.staticActionVariables,
       }).then(
-        () =>
-          `Request sent to trigger missing jobs via actions.json (${actionTaskId})`,
+        notify(
+          `Request sent to trigger missing jobs (${actionTaskId})`,
+          'success',
+        ),
       );
     });
   }
 
-  static triggerAllTalosJobs(times, decisionTaskId) {
+  static async triggerAllTalosJobs(times, pushId, notify) {
+    const decisionTaskId = await PushModel.getDecisionTaskId(pushId, notify);
+
     return TaskclusterModel.load(decisionTaskId).then(results => {
       const actionTaskId = slugid();
       const allTalosTask = results.actions.find(
@@ -137,15 +143,25 @@ export default class PushModel {
     );
   }
 
-  static getDecisionTaskId(pushId) {
-    const map = PushModel.getDecisionTaskMap([pushId]);
+  static async getDecisionTaskId(pushId, notify) {
+    const taskIdMap = await PushModel.getDecisionTaskMap([pushId], notify);
 
-    return map[pushId];
+    return taskIdMap[pushId];
   }
 
-  static getDecisionTaskMap(pushIds) {
-    return getData(
+  static async getDecisionTaskMap(pushIds, notify) {
+    const { data, failureStatus } = await getData(
       getProjectUrl(`${pushEndpoint}decisiontask/?push_ids=${pushIds}`),
     );
+
+    if (failureStatus) {
+      const msg = `Error getting Gecko Decision Task Ids: ${failureStatus}: ${data}`;
+
+      if (notify) {
+        notify(msg, 'danger', { sticky: true });
+      }
+      throw Error(msg);
+    }
+    return data;
   }
 }


### PR DESCRIPTION
I wanted to simplify the process of getting the decision task ID rather than searching in the existing/loaded jobs.  Since we have to do a round-trip to the server anyway.