### PR TITLE
Bug 1521032: Use retrigger-multiple action to retrigger jobs.

### DIFF
--- a/ui/models/job.js
+++ b/ui/models/job.js
@@ -141,7 +141,7 @@ export default class JobModel {
         TaskclusterModel.load(decisionTaskId).then(async results => {
           const actionTaskId = slugid();
           const addNewJobsTask = results.actions.find(
-            action => action.name === 'add-new-jobs',
+            action => action.name === 'retrigger-multiple',
           );
 
           await TaskclusterModel.submit({
@@ -150,7 +150,9 @@ export default class JobModel {
             decisionTaskId,
             taskId: null,
             task: null,
-            input: { tasks: value.map(job => job.job_type_name) },
+            input: {
+              requests: [{ tasks: value.map(job => job.job_type_name) }],
+            },
             staticActionVariables: results.staticActionVariables,
           })
             .then(() =>


### PR DESCRIPTION
Some jobs (notable release jobs) should not be retriggered, but instead rerun.
Use the new `retrigger-multiple` action to allow taskgraph to make that
determination.