### PR TITLE
Bug 1544149 - Use markdown in the bug filer

### DIFF
--- a/tests/webapp/api/test_bugzilla.py
+++ b/tests/webapp/api/test_bugzilla.py
@@ -17,7 +17,7 @@ def test_create_bug(client, eleven_jobs_stored, activate_responses, test_user):
         requestheaders = request.headers
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
         assert requestdata['product'] == "Bugzilla"
-        assert requestdata['description'] == u"#[markdown(off)]\nFiled by: {}\n\nIntermittent Description".format(test_user.email.replace('@', " [at] "))
+        assert requestdata['description'] == u"**Filed by:** {}\nIntermittent Description".format(test_user.email.replace('@', " [at] "))
         assert requestdata['component'] == "Administration"
         assert requestdata['summary'] == u"Intermittent summary"
         assert requestdata['comment_tags'] == "treeherder"
@@ -61,7 +61,7 @@ def test_create_bug_with_unicode(client, eleven_jobs_stored, activate_responses,
         requestheaders = request.headers
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
         assert requestdata['product'] == "Bugzilla"
-        assert requestdata['description'] == u"#[markdown(off)]\nFiled by: {}\n\nIntermittent “description” string".format(test_user.email.replace('@', " [at] "))
+        assert requestdata['description'] == u"**Filed by:** {}\nIntermittent “description” string".format(test_user.email.replace('@', " [at] "))
         assert requestdata['component'] == "Administration"
         assert requestdata['summary'] == u"Intermittent “summary”"
         assert requestdata['comment_tags'] == "treeherder"
@@ -105,7 +105,7 @@ def test_create_crash_bug(client, eleven_jobs_stored, activate_responses, test_u
         requestheaders = request.headers
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
         assert requestdata['product'] == "Bugzilla"
-        assert requestdata['description'] == u"#[markdown(off)]\nFiled by: {}\n\nIntermittent Description".format(test_user.email.replace('@', " [at] "))
+        assert requestdata['description'] == u"**Filed by:** {}\nIntermittent Description".format(test_user.email.replace('@', " [at] "))
         assert requestdata['component'] == "Administration"
         assert requestdata['summary'] == u"Intermittent summary"
         assert requestdata['comment_tags'] == "treeherder"
@@ -155,7 +155,7 @@ def test_create_unauthenticated_bug(client, eleven_jobs_stored, activate_respons
         requestheaders = request.headers
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
         assert requestdata['product'] == "Bugzilla"
-        assert requestdata['description'] == u"#[markdown(off)]\nFiled by: MyName\n\nIntermittent Description"
+        assert requestdata['description'] == u"**Filed by:** MyName\nIntermittent Description"
         assert requestdata['component'] == "Administration"
         assert requestdata['summary'] == u"Intermittent summary"
         assert requestdata['comment_tags'] == "treeherder"
@@ -203,7 +203,7 @@ def test_create_bug_with_long_crash_signature(client, eleven_jobs_stored, activa
         requestheaders = request.headers
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
         assert requestdata['product'] == "Bugzilla"
-        assert requestdata['description'] == u"#[markdown(off)]\nFiled by: MyName\n\nIntermittent Description"
+        assert requestdata['description'] == u"**Filed by:** MyName\nIntermittent Description"
         assert requestdata['component'] == "Administration"
         assert requestdata['summary'] == u"Intermittent summary"
         assert requestdata['comment_tags'] == "treeherder"

--- a/treeherder/webapp/api/bugzilla.py
+++ b/treeherder/webapp/api/bugzilla.py
@@ -29,7 +29,7 @@ class BugzillaViewSet(viewsets.ViewSet):
             return Response({"failure": "Crash signature can't be more than 2048 characters."},
                             status=HTTP_400_BAD_REQUEST)
 
-        description = u"#[markdown(off)]\nFiled by: {}\n\n{}".format(
+        description = u"**Filed by:** {}\n{}".format(
             request.user.email.replace('@', " [at] "),
             params.get("comment", "")
         ).encode("utf-8")


### PR DESCRIPTION
This updates the bug filer to use markdown in the bugzilla bug
description. It adds bolded labels to the `Filed by` entry and any URLs
specified. Addtionally the comment is surrounded in a code fence so
that long lines aren't wrapped and lines that also happen to have
markdown formatting in them are ignored.

Example output:

**Filed by:** foo [@] bar.com
**Parsed log:** http://.../parsed.log.html
**Full log:** http://.../full.log.html

---

```
[task 2019-03-06T03:54:26.459Z] 03:54:26 INFO - TEST-FAIL...
[task 2019-03-06T03:54:26.460Z] 03:54:26 INFO - INFO | LeakSanitize
...
```

@sarah-clements Can you take a look this? I've tested the front-end locally and can confirm it doesn't seem to cause any errors, but I've neither confirmed that back-end tests pass nor that it properly files a bug.