### PR TITLE
Perfherder - modify AlertSummary serializer

### DIFF
--- a/tests/webapp/api/test_performance_alertsummary_api.py
+++ b/tests/webapp/api/test_performance_alertsummary_api.py
@@ -79,6 +79,9 @@ def test_alert_summaries_get(client, test_perf_alert_summary,
         'repository',
         'push_id',
         'status',
+        'revision',
+        'push_timestamp',
+        'prev_push_revision'
     ])
     assert len(resp.json()['results'][0]['alerts']) == 1
     assert set(resp.json()['results'][0]['alerts'][0].keys()) == set([
@@ -125,6 +128,9 @@ def test_alert_summaries_get_onhold(client, test_perf_alert_summary,
         'repository',
         'push_id',
         'status',
+        'revision',
+        'push_timestamp',
+        'prev_push_revision'
     ])
     assert len(resp.json()['results'][0]['alerts']) == 1
     assert set(resp.json()['results'][0]['alerts'][0].keys()) == set([

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -259,7 +259,7 @@ class PerformanceAlertSummaryViewSet(viewsets.ModelViewSet):
     """ViewSet for the performance alert summary model"""
     queryset = PerformanceAlertSummary.objects.filter(
         repository__active_status='active').select_related(
-            'repository').prefetch_related(
+            'repository', 'push').prefetch_related(
                 'alerts',
                 'alerts__classifier',
                 'alerts__series_signature',

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -13,6 +13,7 @@ from treeherder.perf.models import (IssueTracker,
                                     PerformanceBugTemplate,
                                     PerformanceFramework,
                                     PerformanceSignature)
+from treeherder.webapp.api.utils import to_timestamp
 
 
 class PerformanceFrameworkSerializer(serializers.ModelSerializer):
@@ -120,6 +121,12 @@ class PerformanceAlertSerializer(serializers.ModelSerializer):
                   'manually_created', 'classifier', 'starred', 'classifier_email']
 
 
+class TimestampField(serializers.Field):
+
+    def to_representation(self, value):
+        return to_timestamp(value.time)
+
+
 class PerformanceAlertSummarySerializer(serializers.ModelSerializer):
     alerts = PerformanceAlertSerializer(many=True, read_only=True)
     related_alerts = PerformanceAlertSerializer(many=True, read_only=True)
@@ -127,7 +134,13 @@ class PerformanceAlertSummarySerializer(serializers.ModelSerializer):
                                               slug_field='name')
     framework = serializers.SlugRelatedField(read_only=True,
                                              slug_field='id')
-
+    revision = serializers.SlugRelatedField(read_only=True,
+                                            slug_field='revision',
+                                            source='push')
+    push_timestamp = TimestampField(source='push', read_only=True)
+    prev_push_revision = serializers.SlugRelatedField(read_only=True,
+                                                      slug_field='revision',
+                                                      source='prev_push')
     # marking these fields as readonly, the user should not be modifying them
     # (after the item is first created, where we don't use this serializer
     # class)
@@ -144,7 +157,7 @@ class PerformanceAlertSummarySerializer(serializers.ModelSerializer):
         fields = ['id', 'push_id', 'prev_push_id',
                   'created', 'repository', 'framework', 'alerts',
                   'related_alerts', 'status', 'bug_number',
-                  'issue_tracker', 'notes']
+                  'issue_tracker', 'notes', 'revision', 'push_timestamp', 'prev_push_revision']
 
 
 class PerformanceBugTemplateSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Return revision, prev_push_revision and push_timestamp; doesn't appear to affect the overall query time.

Creating this pr separately so I can continue to work on the Perfherder Alerts conversion.