### PR TITLE
Bug 1546463 - Tweak 'Add New Jobs (Fuzzy)' a bit

### DIFF
--- a/ui/css/treeherder-fuzzyfinder.css
+++ b/ui/css/treeherder-fuzzyfinder.css
@@ -10,3 +10,15 @@
 div.fuzzybuttons {
   margin-bottom: 3px;
 }
+
+.fuzzy-modal > div {
+  height: 95vh;
+}
+
+.fuzzy-modal .modal-body #addJobsGroup {
+  height: 30vh;
+}
+
+.fuzzy-modal .modal-body #removeJobsGroup {
+  height: 29vh;
+}

--- a/ui/job-view/pushes/FuzzyJobFinder.jsx
+++ b/ui/job-view/pushes/FuzzyJobFinder.jsx
@@ -52,8 +52,8 @@ class FuzzyJobFinder extends React.Component {
         this.setState({ fuzzySearch: ev.target.value }, () => {
           const options = {
             // http://fusejs.io/ describes the options available
-            keys: ['name'],
-            threshold: 0.3, // This seems like a good threshold to remove most false matches, lower is stricter
+            keys: ['name', 'symbol'],
+            threshold: 0.6, // This seems like a good threshold to remove most false matches, lower is stricter
             matchAllTokens: true,
             tokenize: true,
           };
@@ -204,7 +204,7 @@ class FuzzyJobFinder extends React.Component {
           toggle={this.props.toggle}
           className={this.props.className}
         >
-          <ModalHeader>Add New Jobs (Fuzzy)</ModalHeader>
+          <ModalHeader>Add New Jobs (Search)</ModalHeader>
           <ModalBody>
             <FormGroup row>
               <Col sm={10}>

--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -175,7 +175,7 @@ class PushActionMenu extends React.PureComponent {
             <li
               title={
                 isLoggedIn
-                  ? 'Add new jobs to this push via fuzzy search'
+                  ? 'Add new jobs to this push via a fuzzy search'
                   : 'Must be logged in'
               }
               className={
@@ -183,7 +183,7 @@ class PushActionMenu extends React.PureComponent {
               }
               onClick={showFuzzyJobs}
             >
-              Add new jobs (fuzzy)
+              Add new jobs (Search)
             </li>
           )}
           {triggerMissingRepos.includes(repoName) && (


### PR DESCRIPTION
This commit changes a few pieces of the fuzzy job finder modal:

Change the name from 'Add New Jobs (Fuzzy)' to 'Add New Jobs (Search)'.
This distinguishes it a bit from 'mach try fuzzy' since we don't have
fzf's search syntax.

Allow the fuzzy finder to search by job symbol instead of just job
name/label. You can now just search for 'wpt' instead of
'web-platform-test'. There's something weird with the fuzzy search
library, so searching for both the job label and the job symbol (eg
'android wpt') doesn't give any results. But you can search for 'wpt'
and then look through the list for android jobs. There's an issue filed
against fuse.js about this, so hopefully it works better in the future.

Loosen the threshold on what qualifies as a match in the fuzzy search.
The old value made it require almost an exact match to work (and was
weirdly hiding some jobs from view that should have been shown, even
with an exact match). Loosening this means that typos find things
('androd', 'tsets', etc), and those mysteriously hidden jobs aren't
being hidden anymore.

Increase the height of the fuzzy modal to take up most of the page
height. This gives the modal enough room to increase the height of the
select boxes showing runnable and selected jobs. They now can show more
than 5 jobs at a time, making it easier to select multiple jobs.