### PR TITLE
Bug 1548632 - Push Health - Use failed jobs for tests where they passed

### DIFF
--- a/treeherder/push_health/classification.py
+++ b/treeherder/push_health/classification.py
@@ -61,7 +61,8 @@ def get_grouped(failures):
     }
 
     for failure in failures:
-        pass_fail_ratio = len(failure['passJobs']) / (len(failure['failJobs']) + len(failure['passJobs']))
+        total_jobs = len(failure['failJobs']) + len(failure['passJobs']) + len(failure['passInFailedJobs'])
+        pass_fail_ratio = (len(failure['passJobs']) + len(failure['passInFailedJobs'])) / total_jobs
         is_intermittent = failure['suggestedClassification'] == 'intermittent'
 
         if (is_intermittent and failure['confidence'] == 100) or pass_fail_ratio > .5:

--- a/ui/push-health/TestFailure.jsx
+++ b/ui/push-health/TestFailure.jsx
@@ -46,6 +46,7 @@ class TestFailure extends React.PureComponent {
       jobSymbol,
       failJobs,
       passJobs,
+      passInFailedJobs,
       logLines,
       confidence,
       platform,
@@ -103,6 +104,24 @@ class TestFailure extends React.PureComponent {
               repo={repo}
               revision={revision}
               key={passJob.id}
+            />
+          ))}
+          {!!passInFailedJobs.length && (
+            <span
+              className="text-success mr-1"
+              title="The following jobs failed overall, but this test did not fail in them"
+            >
+              Passed in:
+            </span>
+          )}
+          {passInFailedJobs.map(passedInAFailedJob => (
+            <Job
+              job={passedInAFailedJob}
+              jobName={jobName}
+              jobSymbol={jobSymbol}
+              repo={repo}
+              revision={revision}
+              key={passedInAFailedJob.id}
             />
           ))}
         </div>


### PR DESCRIPTION
If a test fails in one job, it may pass in a retrigger, even in that new job failed
because of another test.  In this case, the job should count as a pass for this
test with regard to it being intermittent.