### PR TITLE
Fix minor Push Health layout

### DIFF
--- a/ui/push-health/Health.jsx
+++ b/ui/push-health/Health.jsx
@@ -81,7 +81,7 @@ export default class Health extends React.Component {
                     </a>
                   </span>
                 </h3>
-                <Table size="sm">
+                <Table size="sm" className="table-fixed">
                   <tbody>
                     {healthData.metrics.map(metric => (
                       <tr key={metric.name}>

--- a/ui/push-health/Metric.jsx
+++ b/ui/push-health/Metric.jsx
@@ -41,7 +41,7 @@ export default class Metric extends React.PureComponent {
 
     return (
       <td>
-        <Row>
+        <Row className="flex-nowrap">
           <div className={`bg-${resultColor} pr-2 mr-2`} />
           <Col>
             <Row className="justify-content-between">

--- a/ui/push-health/TestFailure.jsx
+++ b/ui/push-health/TestFailure.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Badge, Button, Row, Col, Collapse } from 'reactstrap';
+import { Badge, Button, Row, Col } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faRedo } from '@fortawesome/free-solid-svg-icons';
 
@@ -131,12 +131,18 @@ class TestFailure extends React.PureComponent {
               className="small text-monospace mt-2 ml-3"
               key={logLine.line_number}
             >
-              {logLine.subtest}
-              <Collapse isOpen={detailsShowing}>
-                <Row className="ml-3">
-                  <div>{logLine.message}</div>
-                </Row>
-              </Collapse>
+              {detailsShowing ? (
+                <div className="pre-wrap text-break">
+                  {logLine.subtest}
+                  <Row className="ml-3">
+                    <div>{logLine.message}</div>
+                  </Row>
+                </div>
+              ) : (
+                <div className="pre-wrap text-break">
+                  {!!logLine.subtest && logLine.subtest.substr(0, 200)}
+                </div>
+              )}
             </Row>
           ))}
         <div>

--- a/ui/push-health/pushhealth.css
+++ b/ui/push-health/pushhealth.css
@@ -5,3 +5,12 @@
 .pointable {
   cursor: pointer;
 }
+
+.pre-wrap {
+  white-space: pre-wrap;
+  max-width: 95%;
+}
+
+.table-fixed {
+  table-layout: fixed;
+}


### PR DESCRIPTION
This is mainly aimed at fixing a ``subtest`` that had a really odd and long string:

http://localhost:5000/pushhealth.html?repo=mozilla-inbound&revision=fdff2d33f119d6ea14594af60846df80c76506d2

I think it was the 34th test.  So this formats the monospaced text and prevents the table from growing too large with a hard-to-wrap string.

It also makes the ``subtest`` shorter by default to remove clutter.  Then it can be viewed by clicking  "more..."