### PR TITLE
Bug 1550273 - Remove tests from need investigation that are classified

### DIFF
--- a/tests/push_health/test_classification.py
+++ b/tests/push_health/test_classification.py
@@ -8,7 +8,7 @@ def test_intermittent_win7_reftest():
     failures = [
         {
             'testName': 'foo',
-            'failureLines': [],
+            'failJobs': [],
             'jobName': 'Foodebug-reftest',
             'platform': 'windows7-32',
             'suggestedClassification': 'New Failure',
@@ -20,18 +20,20 @@ def test_intermittent_win7_reftest():
     assert failures[0]['suggestedClassification'] == 'intermittent'
 
 
-@pytest.mark.parametrize(('history', 'confidence', 'classification'), [
-    ({'foo': {'bing': {'baz': 2}}}, 100, 'intermittent'),
-    ({'foo': {'bing': {'bee': 2}}}, 75, 'intermittent'),
-    ({'foo': {'bee': {'bee': 2}}}, 50, 'intermittent'),
-    ({'fee': {'bee': {'bee': 2}}}, 0, 'New Failure'),
+@pytest.mark.parametrize(('history', 'confidence', 'classification', 'fcid'), [
+    ({'foo': {'bing': {'baz': 2}}}, 100, 'intermittent', 1),
+    ({'foo': {'bing': {'bee': 2}}}, 75, 'intermittent', 1),
+    ({'foo': {'bee': {'bee': 2}}}, 50, 'intermittent', 1),
+    ({'fee': {'bee': {'bee': 2}}}, 0, 'New Failure', 1),
+    # no match, but job has been classified as intermittent by hand.
+    ({'fee': {'bee': {'bee': 2}}}, 100, 'intermittent', 4),
 ])
-def test_intermittent_confidence(history, confidence, classification):
+def test_intermittent_confidence(history, confidence, classification, fcid):
     """test that a failed test is classified as intermittent, confidence 100"""
     failures = [
         {
             'testName': 'foo',
-            'failureLines': [],
+            'failJobs': [{'failure_classification_id': fcid}],
             'jobName': 'bar',
             'platform': 'bing',
             'suggestedClassification': 'New Failure',

--- a/treeherder/push_health/classification.py
+++ b/treeherder/push_health/classification.py
@@ -6,7 +6,7 @@ def set_classifications(failures, intermittent_history, fixed_by_commit_history)
 
 def set_fixed_by_commit(failure, fixed_by_commit_history):
     # Not perfect, could have intermittent that is cause of fbc
-    if failure['testName'] in fixed_by_commit_history.keys():
+    if failure['testName'] in fixed_by_commit_history.keys() and not is_classified_intermittent(failure):
         failure['suggestedClassification'] = 'fixedByCommit'
         return True
     return False
@@ -37,11 +37,18 @@ def set_intermittent(failure, previous_failures):
     ):
         confidence = 50
 
+    if is_classified_intermittent(failure):
+        confidence = 100
+
     if confidence:
         failure['confidence'] = confidence
         failure['suggestedClassification'] = 'intermittent'
         return True
     return False
+
+
+def is_classified_intermittent(failure):
+    return all(job['failure_classification_id'] == 4 for job in failure['failJobs'])
 
 
 def get_log_lines(failure):


### PR DESCRIPTION
It occurred to me that, rather than being able to toggle these tests on and off based on whether all their failed jobs are classified, that it is appropriate to move them to "intermittent".  My reasoning is that if the job was classified intermittent by a sheriff or whomever, then that means it's been investigated already and judged to be intermittent.

@jmaher : What do you think?  Do you agree or am I off-base?  :)