### PR TITLE
Bug 1549556 - Add Push Health badge to PushHeader

### DIFF
--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -196,6 +196,21 @@ class PushViewSet(viewsets.ViewSet):
                             status=HTTP_404_NOT_FOUND)
         return Response(push.get_status())
 
+    @action(detail=True)
+    def health_summary(self, request, project, pk=None):
+        """
+        Return a calculated summary of the health of this push.
+        """
+
+        try:
+            push = Push.objects.get(id=pk)
+        except Push.DoesNotExist:
+            return Response("No push with id: {0}".format(pk),
+                            status=HTTP_404_NOT_FOUND)
+        push_health_test_failures = get_push_health_test_failures(push, REPO_GROUPS['trunk'])
+
+        return Response({'needInvestigation': len(push_health_test_failures['needInvestigation'])})
+
     @action(detail=False)
     def health(self, request, project):
         """

--- a/ui/job-view/App.jsx
+++ b/ui/job-view/App.jsx
@@ -21,6 +21,7 @@ import { PinnedJobs } from './context/PinnedJobs';
 import PrimaryNavBar from './headerbars/PrimaryNavBar';
 import ActiveFilters from './headerbars/ActiveFilters';
 import UpdateAvailable from './headerbars/UpdateAvailable';
+import { PUSH_HEALTH_VISIBILITY } from './headerbars/HealthMenu';
 import DetailsPanel from './details/DetailsPanel';
 import PushList from './pushes/PushList';
 import KeyboardShortcuts from './KeyboardShortcuts';
@@ -71,6 +72,8 @@ class App extends React.Component {
       groupCountsExpanded: urlParams.get('group_state') === 'expanded',
       duplicateJobsVisible: urlParams.get('duplicate_jobs') === 'visible',
       showShortCuts: false,
+      pushHealthVisibility:
+        localStorage.getItem(PUSH_HEALTH_VISIBILITY) || 'None',
     };
   }
 
@@ -100,6 +103,7 @@ class App extends React.Component {
 
     window.addEventListener('resize', this.updateDimensions, false);
     window.addEventListener('hashchange', this.handleUrlChanges, false);
+    window.addEventListener('storage', this.handleStorageEvent);
 
     // Get the current Treeherder revision and poll to notify on updates.
     this.fetchDeployedRevision().then(revision => {
@@ -141,6 +145,7 @@ class App extends React.Component {
   componentWillUnmount() {
     window.removeEventListener('resize', this.updateDimensions, false);
     window.removeEventListener('hashchange', this.handleUrlChanges, false);
+    window.removeEventListener('storage', this.handleUrlChanges, false);
 
     if (this.updateInterval) {
       clearInterval(this.updateInterval);
@@ -161,6 +166,19 @@ class App extends React.Component {
       defaultDetailsHeight,
     };
   }
+
+  handleStorageEvent = e => {
+    if (e.key === PUSH_HEALTH_VISIBILITY) {
+      this.setState({
+        pushHealthVisibility: localStorage.getItem(PUSH_HEALTH_VISIBILITY),
+      });
+    }
+  };
+
+  setPushHealthVisibility = visibility => {
+    localStorage.setItem(PUSH_HEALTH_VISIBILITY, visibility);
+    this.setState({ pushHealthVisibility: visibility });
+  };
 
   setUser = user => {
     this.setState({ user });
@@ -256,6 +274,7 @@ class App extends React.Component {
       duplicateJobsVisible,
       groupCountsExpanded,
       showShortCuts,
+      pushHealthVisibility,
     } = this.state;
 
     // SplitPane will adjust the CSS height of the top component, but not the
@@ -301,6 +320,8 @@ class App extends React.Component {
                     duplicateJobsVisible={duplicateJobsVisible}
                     groupCountsExpanded={groupCountsExpanded}
                     toggleFieldFilterVisible={this.toggleFieldFilterVisible}
+                    pushHealthVisibility={pushHealthVisibility}
+                    setPushHealthVisibility={this.setPushHealthVisibility}
                   />
                   <SplitPane
                     split="horizontal"
@@ -334,6 +355,7 @@ class App extends React.Component {
                             filterModel={filterModel}
                             duplicateJobsVisible={duplicateJobsVisible}
                             groupCountsExpanded={groupCountsExpanded}
+                            pushHealthVisibility={pushHealthVisibility}
                           />
                         </span>
                       </div>

--- a/ui/job-view/headerbars/HealthMenu.jsx
+++ b/ui/job-view/headerbars/HealthMenu.jsx
@@ -1,0 +1,55 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { Label } from 'reactstrap';
+
+export const PUSH_HEALTH_VISIBILITY = 'pushHealthVisibility';
+
+class HealthMenu extends PureComponent {
+  render() {
+    const { pushHealthVisibility, setPushHealthVisibility } = this.props;
+
+    return (
+      <span className="dropdown">
+        <span
+          id="healthLabel"
+          role="button"
+          title="Change visibility of the Push Health badge/link"
+          data-toggle="dropdown"
+          className="btn btn-view-nav btn-sm nav-menu-btn dropdown-toggle"
+        >
+          Health
+        </span>
+        <ul className="dropdown-menu checkbox-dropdown-menu" role="menu">
+          {['All', 'Try', 'None'].map(option => {
+            return (
+              <li key={option}>
+                <div>
+                  <Label
+                    title={`Add Push Health badge to ${option} repo(s)`}
+                    className="dropdown-item"
+                  >
+                    <input
+                      id="health-checkbox"
+                      type="checkbox"
+                      className="mousetrap"
+                      checked={pushHealthVisibility === option}
+                      onChange={() => setPushHealthVisibility(option)}
+                    />
+                    {option}
+                  </Label>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </span>
+    );
+  }
+}
+
+HealthMenu.propTypes = {
+  pushHealthVisibility: PropTypes.string.isRequired,
+  setPushHealthVisibility: PropTypes.func.isRequired,
+};
+
+export default HealthMenu;

--- a/ui/job-view/headerbars/HealthMenu.jsx
+++ b/ui/job-view/headerbars/HealthMenu.jsx
@@ -1,48 +1,45 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Label } from 'reactstrap';
+import { Dropdown, DropdownToggle } from 'reactstrap';
+
+import DropdownMenuItems from '../../shared/DropdownMenuItems';
 
 export const PUSH_HEALTH_VISIBILITY = 'pushHealthVisibility';
 
 class HealthMenu extends PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      dropdownOpen: false,
+    };
+  }
+
+  toggle = () => {
+    this.setState(prevState => ({
+      dropdownOpen: !prevState.dropdownOpen,
+    }));
+  };
+
   render() {
     const { pushHealthVisibility, setPushHealthVisibility } = this.props;
+    const { dropdownOpen } = this.state;
 
     return (
-      <span className="dropdown">
-        <span
-          id="healthLabel"
-          role="button"
+      <Dropdown isOpen={dropdownOpen} toggle={this.toggle}>
+        <DropdownToggle
+          caret
           title="Change visibility of the Push Health badge/link"
-          data-toggle="dropdown"
           className="btn btn-view-nav btn-sm nav-menu-btn dropdown-toggle"
         >
           Health
-        </span>
-        <ul className="dropdown-menu checkbox-dropdown-menu" role="menu">
-          {['All', 'Try', 'None'].map(option => {
-            return (
-              <li key={option}>
-                <div>
-                  <Label
-                    title={`Add Push Health badge to ${option} repo(s)`}
-                    className="dropdown-item"
-                  >
-                    <input
-                      id="health-checkbox"
-                      type="checkbox"
-                      className="mousetrap"
-                      checked={pushHealthVisibility === option}
-                      onChange={() => setPushHealthVisibility(option)}
-                    />
-                    {option}
-                  </Label>
-                </div>
-              </li>
-            );
-          })}
-        </ul>
-      </span>
+        </DropdownToggle>
+        <DropdownMenuItems
+          options={['All', 'Try', 'None']}
+          updateData={setPushHealthVisibility}
+          selectedItem={pushHealthVisibility}
+        />
+      </Dropdown>
     );
   }
 }

--- a/ui/job-view/headerbars/PrimaryNavBar.jsx
+++ b/ui/job-view/headerbars/PrimaryNavBar.jsx
@@ -13,6 +13,7 @@ import TiersMenu from './TiersMenu';
 import FiltersMenu from './FiltersMenu';
 import HelpMenu from './HelpMenu';
 import SecondaryNavBar from './SecondaryNavBar';
+import HealthMenu from './HealthMenu';
 
 export default class PrimaryNavBar extends React.Component {
   shouldComponentUpdate(prevProps) {
@@ -23,6 +24,7 @@ export default class PrimaryNavBar extends React.Component {
       serverChanged,
       groupCountsExpanded,
       duplicateJobsVisible,
+      pushHealthVisibility,
     } = this.props;
 
     return (
@@ -31,7 +33,8 @@ export default class PrimaryNavBar extends React.Component {
       !isEqual(prevProps.repos, repos) ||
       prevProps.serverChanged !== serverChanged ||
       prevProps.groupCountsExpanded !== groupCountsExpanded ||
-      prevProps.duplicateJobsVisible !== duplicateJobsVisible
+      prevProps.duplicateJobsVisible !== duplicateJobsVisible ||
+      prevProps.pushHealthVisibility !== pushHealthVisibility
     );
   }
 
@@ -47,6 +50,8 @@ export default class PrimaryNavBar extends React.Component {
       duplicateJobsVisible,
       groupCountsExpanded,
       toggleFieldFilterVisible,
+      pushHealthVisibility,
+      setPushHealthVisibility,
     } = this.props;
 
     return (
@@ -61,6 +66,10 @@ export default class PrimaryNavBar extends React.Component {
                 <ReposMenu repos={repos} />
                 <TiersMenu filterModel={filterModel} />
                 <FiltersMenu filterModel={filterModel} user={user} />
+                <HealthMenu
+                  pushHealthVisibility={pushHealthVisibility}
+                  setPushHealthVisibility={setPushHealthVisibility}
+                />
                 <HelpMenu />
                 <Login user={user} setUser={setUser} />
               </span>
@@ -93,4 +102,6 @@ PrimaryNavBar.propTypes = {
   user: PropTypes.object.isRequired,
   duplicateJobsVisible: PropTypes.bool.isRequired,
   groupCountsExpanded: PropTypes.bool.isRequired,
+  pushHealthVisibility: PropTypes.string.isRequired,
+  setPushHealthVisibility: PropTypes.func.isRequired,
 };

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -435,6 +435,7 @@ class Push extends React.Component {
       getAllShownJobs,
       groupCountsExpanded,
       isOnlyRevision,
+      pushHealthVisibility,
     } = this.props;
     const {
       fuzzyJobList,
@@ -493,6 +494,7 @@ class Push extends React.Component {
           getAllShownJobs={getAllShownJobs}
           selectedRunnableJobs={selectedRunnableJobs}
           notificationSupported={notificationSupported}
+          pushHealthVisibility={pushHealthVisibility}
         />
         <div className="push-body-divider" />
         {!collapsed ? (
@@ -544,6 +546,7 @@ Push.propTypes = {
   groupCountsExpanded: PropTypes.bool.isRequired,
   notify: PropTypes.func.isRequired,
   isOnlyRevision: PropTypes.bool.isRequired,
+  pushHealthVisibility: PropTypes.string.isRequired,
 };
 
 export default withNotifications(withPushes(Push));

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -21,6 +21,7 @@ import { withPinnedJobs } from '../context/PinnedJobs';
 import { withSelectedJob } from '../context/SelectedJob';
 import { withPushes } from '../context/Pushes';
 import { withNotifications } from '../../shared/context/Notifications';
+import PushHealthStatus from '../../shared/PushHealthStatus';
 import { getUrlParam, setUrlParam } from '../../helpers/location';
 
 import PushActionMenu from './PushActionMenu';
@@ -93,6 +94,7 @@ class PushHeader extends React.Component {
       selectedRunnableJobs: prevSelectedRunnableJobs,
       runnableVisible: prevRunnableVisible,
       collapsed: prevCollapsed,
+      pushHealthVisibility: prevPushHealthVisibility,
     } = prevProps;
     const {
       jobCounts,
@@ -101,6 +103,7 @@ class PushHeader extends React.Component {
       selectedRunnableJobs,
       runnableVisible,
       collapsed,
+      pushHealthVisibility,
     } = this.props;
 
     return (
@@ -109,7 +112,8 @@ class PushHeader extends React.Component {
       prevIsLoggedIn !== isLoggedIn ||
       prevSelectedRunnableJobs !== selectedRunnableJobs ||
       prevRunnableVisible !== runnableVisible ||
-      prevCollapsed !== collapsed
+      prevCollapsed !== collapsed ||
+      prevPushHealthVisibility !== pushHealthVisibility
     );
   }
 
@@ -237,6 +241,7 @@ class PushHeader extends React.Component {
       notificationSupported,
       selectedRunnableJobs,
       collapsed,
+      pushHealthVisibility,
     } = this.props;
     const cancelJobsTitle = isLoggedIn
       ? 'Cancel all jobs'
@@ -244,7 +249,9 @@ class PushHeader extends React.Component {
     const linkParams = this.getLinkParams();
     const revisionPushFilterUrl = getJobsUrl({ ...linkParams, revision });
     const authorPushFilterUrl = getJobsUrl({ ...linkParams, author });
-
+    const showPushHealthStatus =
+      pushHealthVisibility === 'All' ||
+      repoName === pushHealthVisibility.toLowerCase();
     const watchStateLabel = {
       none: 'Watch',
       push: 'Notifying (per-push)',
@@ -275,6 +282,14 @@ class PushHeader extends React.Component {
               <Author author={author} url={authorPushFilterUrl} />
             </span>
           </span>
+          {showPushHealthStatus && (
+            <PushHealthStatus
+              repoName={repoName}
+              pushId={pushId}
+              revision={revision}
+              jobCounts={jobCounts}
+            />
+          )}
           <PushCounts
             className="push-counts"
             pending={jobCounts.pending}
@@ -382,6 +397,7 @@ PushHeader.propTypes = {
   collapsed: PropTypes.bool.isRequired,
   notify: PropTypes.func.isRequired,
   jobCounts: PropTypes.object.isRequired,
+  pushHealthVisibility: PropTypes.string.isRequired,
   watchState: PropTypes.string,
   selectedJob: PropTypes.object,
 };

--- a/ui/job-view/pushes/PushList.jsx
+++ b/ui/job-view/pushes/PushList.jsx
@@ -35,6 +35,7 @@ class PushList extends React.Component {
       jobsLoaded,
       duplicateJobsVisible,
       groupCountsExpanded,
+      pushHealthVisibility,
     } = this.props;
     const { notificationSupported } = this.state;
     const { isLoggedIn } = user;
@@ -63,6 +64,7 @@ class PushList extends React.Component {
                 duplicateJobsVisible={duplicateJobsVisible}
                 groupCountsExpanded={groupCountsExpanded}
                 isOnlyRevision={push.revision === revision}
+                pushHealthVisibility={pushHealthVisibility}
               />
             </ErrorBoundary>
           ))}
@@ -110,6 +112,7 @@ PushList.propTypes = {
   duplicateJobsVisible: PropTypes.bool.isRequired,
   groupCountsExpanded: PropTypes.bool.isRequired,
   allUnclassifiedFailureCount: PropTypes.number.isRequired,
+  pushHealthVisibility: PropTypes.string.isRequired,
   revision: PropTypes.string,
   currentRepo: PropTypes.object,
 };

--- a/ui/models/push.js
+++ b/ui/models/push.js
@@ -131,6 +131,12 @@ export default class PushModel {
     );
   }
 
+  static getHealthSummary(repoName, pushId) {
+    return getData(
+      getProjectUrl(`${pushEndpoint}${pushId}/health_summary/`, repoName),
+    );
+  }
+
   static getDecisionTaskId(pushId) {
     const map = PushModel.getDecisionTaskMap([pushId]);
 

--- a/ui/push-health/Navigation.jsx
+++ b/ui/push-health/Navigation.jsx
@@ -1,23 +1,47 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Navbar } from 'reactstrap';
+import { Navbar, Tooltip } from 'reactstrap';
 
 import LogoMenu from '../shared/LogoMenu';
 import Login from '../shared/auth/Login';
 
 export default class Navigation extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      explainerOpen: false,
+    };
+  }
+
+  toggleExplainer = () => {
+    const { explainerOpen } = this.state;
+
+    this.setState({ explainerOpen: !explainerOpen });
+  };
+
   render() {
+    const { explainerOpen } = this.state;
     const { user, setUser } = this.props;
 
     return (
       <Navbar dark color="dark">
         <LogoMenu menuText="Push Health" />
-        <span
-          title="This data is for UI prototyping purposes only"
-          className="text-white"
-        >
+        <span id="prototype" className="text-white">
           [---PROTOTYPE---]
         </span>
+        <Tooltip
+          placement="bottom"
+          isOpen={explainerOpen}
+          target="prototype"
+          toggle={this.toggleExplainer}
+        >
+          This prototype is still in-progress. The section on `Tests` has been
+          implemented, but Linting, Coverage, Builds, etc are not. You will
+          notice in Treeherder that the status may say `OK` for a push that has
+          failed Builds or linting. These features will be updated in the weeks
+          to come.
+        </Tooltip>
         <Login user={user} setUser={setUser} />
       </Navbar>
     );

--- a/ui/push-health/Navigation.jsx
+++ b/ui/push-health/Navigation.jsx
@@ -1,47 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Navbar, Tooltip } from 'reactstrap';
+import { Navbar } from 'reactstrap';
 
 import LogoMenu from '../shared/LogoMenu';
 import Login from '../shared/auth/Login';
+import SimpleTooltip from '../shared/SimpleTooltip';
 
 export default class Navigation extends React.PureComponent {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      explainerOpen: false,
-    };
-  }
-
-  toggleExplainer = () => {
-    const { explainerOpen } = this.state;
-
-    this.setState({ explainerOpen: !explainerOpen });
-  };
-
   render() {
-    const { explainerOpen } = this.state;
     const { user, setUser } = this.props;
 
     return (
       <Navbar dark color="dark">
         <LogoMenu menuText="Push Health" />
-        <span id="prototype" className="text-white">
-          [---PROTOTYPE---]
-        </span>
-        <Tooltip
+        <SimpleTooltip
+          text="[---PROTOTYPE---]"
+          textClass="text-white"
           placement="bottom"
-          isOpen={explainerOpen}
-          target="prototype"
-          toggle={this.toggleExplainer}
-        >
-          This prototype is still in-progress. The section on `Tests` has been
-          implemented, but Linting, Coverage, Builds, etc are not. You will
-          notice in Treeherder that the status may say `OK` for a push that has
-          failed Builds or linting. These features will be updated in the weeks
-          to come.
-        </Tooltip>
+          tooltipText={
+            <div>
+              This prototype is still in-progress. The section on `Tests` has
+              been implemented, but Linting, Coverage, Builds, etc are not. You
+              will notice in Treeherder that the status may say `OK` for a push
+              that has failed Builds or linting. These features will be updated
+              in the weeks to come.
+            </div>
+          }
+        />
         <Login user={user} setUser={setUser} />
       </Navbar>
     );

--- a/ui/shared/PushHealthStatus.jsx
+++ b/ui/shared/PushHealthStatus.jsx
@@ -1,0 +1,89 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Badge } from 'reactstrap';
+
+import PushModel from '../models/push';
+import { getPushHealthUrl } from '../helpers/url';
+
+class PushHealthStatus extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      healthStatus: 'Loading...',
+      needInvestigation: 0,
+    };
+  }
+
+  async componentDidMount() {
+    await this.loadLatestStatus();
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    const { jobCounts } = this.props;
+    const { healthStatus } = this.state;
+
+    return (
+      jobCounts !== nextProps.jobCounts ||
+      healthStatus !== nextState.healthStatus
+    );
+  }
+
+  async componentDidUpdate() {
+    await this.loadLatestStatus();
+  }
+
+  async loadLatestStatus() {
+    const { repoName, pushId } = this.props;
+
+    PushModel.getHealthSummary(repoName, pushId).then(resp => {
+      const { data, error } = resp;
+      if (!error) {
+        const { needInvestigation } = data;
+        const testsNeed = needInvestigation > 1 ? 'tests need' : 'test needs';
+        const healthStatus = needInvestigation
+          ? `${needInvestigation} ${testsNeed} investigation`
+          : 'OK';
+
+        this.setState({ healthStatus, needInvestigation });
+      }
+    });
+  }
+
+  render() {
+    const { repoName, revision } = this.props;
+    const { healthStatus, needInvestigation } = this.state;
+    const color = needInvestigation ? 'danger' : 'success';
+    const extraTitle = needInvestigation
+      ? 'Count of tests that need investigation'
+      : 'Push looks good';
+
+    return (
+      <a
+        href={getPushHealthUrl({ repo: repoName, revision })}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <Badge
+          color={color}
+          title={`Push Health status for Tests only - click for details: ${extraTitle}`}
+        >
+          {healthStatus}
+        </Badge>
+      </a>
+    );
+  }
+}
+
+PushHealthStatus.propTypes = {
+  pushId: PropTypes.number.isRequired,
+  revision: PropTypes.string.isRequired,
+  repoName: PropTypes.string.isRequired,
+  jobCounts: PropTypes.shape({
+    pending: PropTypes.number.isRequired,
+    running: PropTypes.number.isRequired,
+    completed: PropTypes.number.isRequired,
+  }).isRequired,
+};
+
+export default PushHealthStatus;


### PR DESCRIPTION
This adds an opt-in to add the Push Health Status badge to each push.  It stores your selection in ``localStorage`` so it persists.  Currently, the options are "All", "Try" or "None".  If there are other specific options I should add, please let me know.

I also added a Tooltip to Push Health on the "[--PROTOTYPE--]" text to help explain its state a bit.

In Treeherder, the badge will look like:
<img width="618" alt="Screenshot 2019-05-08 16 38 14" src="https://user-images.githubusercontent.com/419924/57478399-a5bb2900-724f-11e9-806d-8ac1eb5ba2f4.png">

I left the PushActionMenu item so that you can still access Push Health without needing to activate the badge.