### PR TITLE
Show 'open in Firefox Profiler' links for profiles with a .json extension

### DIFF
--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -80,7 +80,7 @@ export const getLogViewerUrl = function getLogViewerUrl(
 };
 
 export const getPerfAnalysisUrl = function getPerfAnalysisUrl(url) {
-  return `https://perf-html.io/from-url/${encodeURIComponent(url)}`;
+  return `https://profiler.firefox.com/from-url/${encodeURIComponent(url)}`;
 };
 
 // This takes a plain object, rather than a URLSearchParams object.

--- a/ui/shared/JobDetails.jsx
+++ b/ui/shared/JobDetails.jsx
@@ -38,12 +38,13 @@ export default class JobDetails extends React.PureComponent {
               )}
               {line.url &&
                 line.value.startsWith('profile_') &&
-                line.value.endsWith('.zip') && (
+                (line.value.endsWith('.zip') ||
+                  line.value.endsWith('.json')) && (
                   <span>
                     {' '}
                     -{' '}
                     <a title={line.value} href={getPerfAnalysisUrl(line.url)}>
-                      open in perf-html.io
+                      open in Firefox Profiler
                     </a>
                   </span>
                 )}


### PR DESCRIPTION
- When a test job uploads a single profile, it's a json file, so relax the extension check
- perf.html has been renamed to 'Firefox Profiler' and 'perf-html.io' moved to 'profiler.firefox.com'