### PR TITLE
Bug 1510280 - Reduce repeated rendering of PushJobs

### DIFF
--- a/ui/helpers/location.js
+++ b/ui/helpers/location.js
@@ -13,6 +13,10 @@ export const getUrlParam = function getUrlParam(name) {
   return getAllUrlParams().get(name);
 };
 
+export const getSelectedJobId = function getSelectedJobId() {
+  return parseInt(getUrlParam('selectedJob') || '0', 10);
+};
+
 export const getRepo = function getRepo() {
   return getUrlParam('repo') || thDefaultRepo;
 };

--- a/ui/helpers/object.js
+++ b/ui/helpers/object.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export const extendProperties = function extendProperties(dest, src) {
   /* Version of _.extend that works with property descriptors */
   if (dest !== src) {
@@ -21,3 +20,6 @@ export const extendProperties = function extendProperties(dest, src) {
   }
   return dest;
 };
+
+export const didObjectsChange = (firstObj, secondObj, fields) =>
+  fields.some(field => firstObj[field] !== secondObj[field]);

--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -7,7 +7,11 @@ import { faPlusSquare, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { thEvents } from '../../helpers/constants';
 import { withNotifications } from '../../shared/context/Notifications';
 import { formatModelError } from '../../helpers/errorMessage';
-import { getJobBtnClass, getHoverText } from '../../helpers/job';
+import {
+  getJobBtnClass,
+  getHoverText,
+  findJobInstance,
+} from '../../helpers/job';
 import { isSHAorCommit } from '../../helpers/revision';
 import { getBugUrl } from '../../helpers/url';
 import BugJobMapModel from '../../models/bugJobMap';
@@ -122,6 +126,8 @@ class PinBoard extends React.Component {
             `Classification saved for ${job.platform} ${job.job_type_name}`,
             'success',
           );
+          // update the job to show that it's now classified
+          findJobInstance(job.id).refilter();
         })
         .catch(response => {
           const message = `Error saving classification for ${job.platform} ${

--- a/ui/job-view/pushes/JobButton.jsx
+++ b/ui/job-view/pushes/JobButton.jsx
@@ -73,6 +73,12 @@ export default class JobButtonComponent extends React.Component {
     }));
   }
 
+  refilter() {
+    const { filterPlatformCb, platform } = this.props;
+
+    filterPlatformCb(platform);
+  }
+
   render() {
     const { job, resultStatus } = this.props;
     const { isSelected, isRunnableSelected } = this.state;

--- a/ui/job-view/pushes/Platform.jsx
+++ b/ui/job-view/pushes/Platform.jsx
@@ -2,7 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { thSimplePlatforms } from '../../helpers/constants';
-import { getUrlParam } from '../../helpers/location';
+import { getSelectedJobId } from '../../helpers/location';
+import { didObjectsChange } from '../../helpers/object';
 
 import JobsAndGroups from './JobsAndGroups';
 
@@ -20,21 +21,37 @@ PlatformName.propTypes = {
 };
 
 export default class Platform extends React.PureComponent {
-  static getDerivedStateFromProps(nextProps) {
-    const { filterModel, runnableVisible } = nextProps;
-    const selectedJobId = parseInt(getUrlParam('selectedJob') || '0', 10);
+  constructor(props) {
+    super(props);
 
-    return {
-      filteredPlatform: Platform.filter(
-        nextProps.platform,
-        selectedJobId,
-        filterModel,
-        runnableVisible,
-      ),
+    this.state = {
+      filteredPlatform: props.platform,
     };
   }
 
-  static filter = (platform, selectedJobId, filterModel, runnableVisible) => {
+  componentDidMount() {
+    const selectedJobId = getSelectedJobId();
+
+    this.filter(selectedJobId);
+  }
+
+  componentDidUpdate(nextProps) {
+    if (
+      didObjectsChange(nextProps, this.props, [
+        'platform',
+        'filterModel',
+        'pushGroupState',
+        'duplicateJobsVisible',
+        'groupCountsExpanded',
+        'runnableVisible',
+      ])
+    ) {
+      this.filter(getSelectedJobId());
+    }
+  }
+
+  filter = selectedJobId => {
+    const { platform, filterModel, runnableVisible } = this.props;
     const filteredPlatform = { ...platform };
 
     filteredPlatform.visible = false;
@@ -52,28 +69,11 @@ export default class Platform extends React.PureComponent {
         }
       });
     });
-    return filteredPlatform;
+    this.setState({ filteredPlatform });
   };
 
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      filteredPlatform: props.platform,
-    };
-  }
-
-  filterCb = (platform, selectedJobId) => {
-    const { filterModel, runnableVisible } = this.props;
-
-    this.setState({
-      filteredPlatform: Platform.filter(
-        platform,
-        selectedJobId,
-        filterModel,
-        runnableVisible,
-      ),
-    });
+  filterCb = selectedJobId => {
+    this.filter(selectedJobId);
   };
 
   render() {

--- a/ui/job-view/pushes/Platform.jsx
+++ b/ui/job-view/pushes/Platform.jsx
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import { thSimplePlatforms } from '../../helpers/constants';
+import { getUrlParam } from '../../helpers/location';
+
 import JobsAndGroups from './JobsAndGroups';
 
 function PlatformName(props) {
@@ -16,41 +19,105 @@ PlatformName.propTypes = {
   title: PropTypes.string.isRequired,
 };
 
-export default function Platform(props) {
-  const {
-    platform,
-    repoName,
-    filterPlatformCb,
-    filterModel,
-    pushGroupState,
-    duplicateJobsVisible,
-    groupCountsExpanded,
-  } = props;
-  const { title, groups, id } = platform;
+export default class Platform extends React.PureComponent {
+  static getDerivedStateFromProps(nextProps) {
+    const { filterModel, runnableVisible } = nextProps;
+    const selectedJobId = parseInt(getUrlParam('selectedJob') || '0', 10);
 
-  return (
-    <tr id={id} key={id}>
-      <PlatformName title={title} />
-      <JobsAndGroups
-        groups={groups}
-        repoName={repoName}
-        filterPlatformCb={filterPlatformCb}
-        platform={platform}
-        filterModel={filterModel}
-        pushGroupState={pushGroupState}
-        duplicateJobsVisible={duplicateJobsVisible}
-        groupCountsExpanded={groupCountsExpanded}
-      />
-    </tr>
-  );
+    return {
+      filteredPlatform: Platform.filter(
+        nextProps.platform,
+        selectedJobId,
+        filterModel,
+        runnableVisible,
+      ),
+    };
+  }
+
+  static filter = (platform, selectedJobId, filterModel, runnableVisible) => {
+    const filteredPlatform = { ...platform };
+
+    filteredPlatform.visible = false;
+    filteredPlatform.groups.forEach(group => {
+      group.visible = false;
+      group.jobs.forEach(job => {
+        job.visible = filterModel.showJob(job) || job.id === selectedJobId;
+        if (job.state === 'runnable') {
+          job.visible = job.visible && runnableVisible;
+        }
+        job.selected = selectedJobId ? job.id === selectedJobId : false;
+        if (job.visible) {
+          filteredPlatform.visible = true;
+          group.visible = true;
+        }
+      });
+    });
+    return filteredPlatform;
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      filteredPlatform: props.platform,
+    };
+  }
+
+  filterCb = (platform, selectedJobId) => {
+    const { filterModel, runnableVisible } = this.props;
+
+    this.setState({
+      filteredPlatform: Platform.filter(
+        platform,
+        selectedJobId,
+        filterModel,
+        runnableVisible,
+      ),
+    });
+  };
+
+  render() {
+    const {
+      repoName,
+      filterModel,
+      pushGroupState,
+      duplicateJobsVisible,
+      groupCountsExpanded,
+    } = this.props;
+    const { filteredPlatform } = this.state;
+    const suffix =
+      thSimplePlatforms.includes(filteredPlatform.name) &&
+      filteredPlatform.option === 'opt'
+        ? ''
+        : ` ${filteredPlatform.option}`;
+    const title = `${filteredPlatform.name}${suffix}`;
+
+    return filteredPlatform.visible ? (
+      <tr key={title}>
+        <PlatformName title={title} />
+        <JobsAndGroups
+          groups={filteredPlatform.groups}
+          repoName={repoName}
+          filterPlatformCb={this.filterCb}
+          platform={filteredPlatform}
+          filterModel={filterModel}
+          pushGroupState={pushGroupState}
+          duplicateJobsVisible={duplicateJobsVisible}
+          groupCountsExpanded={groupCountsExpanded}
+        />
+      </tr>
+    ) : (
+      <React.Fragment />
+    );
+  }
 }
 
 Platform.propTypes = {
   platform: PropTypes.object.isRequired,
   repoName: PropTypes.string.isRequired,
   filterModel: PropTypes.object.isRequired,
-  filterPlatformCb: PropTypes.func.isRequired,
   pushGroupState: PropTypes.string.isRequired,
   duplicateJobsVisible: PropTypes.bool.isRequired,
   groupCountsExpanded: PropTypes.bool.isRequired,
+  runnableVisible: PropTypes.bool.isRequired,
 };

--- a/ui/job-view/pushes/PushJobs.jsx
+++ b/ui/job-view/pushes/PushJobs.jsx
@@ -3,12 +3,11 @@ import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
-import { thSimplePlatforms } from '../../helpers/constants';
 import { withPinnedJobs } from '../context/PinnedJobs';
 import { withSelectedJob } from '../context/SelectedJob';
 import { getPushTableId } from '../../helpers/aggregateId';
 import { findInstance, findSelectedInstance } from '../../helpers/job';
-import { getUrlParam } from '../../helpers/location';
+import { didObjectsChange } from '../../helpers/object';
 import { getLogViewerUrl } from '../../helpers/url';
 import JobModel from '../../models/job';
 import { withPushes } from '../context/Pushes';
@@ -16,67 +15,23 @@ import { withPushes } from '../context/Pushes';
 import Platform from './Platform';
 
 class PushJobs extends React.Component {
-  static getDerivedStateFromProps(nextProps) {
-    const { filterModel, push, platforms, runnableVisible } = nextProps;
-    const selectedJobId = parseInt(getUrlParam('selectedJob'), 10);
-    const filteredPlatforms = platforms.reduce((acc, platform) => {
-      const thisPlatform = { ...platform };
-      const suffix =
-        thSimplePlatforms.includes(platform.name) && platform.option === 'opt'
-          ? ''
-          : ` ${platform.option}`;
-      thisPlatform.title = `${thisPlatform.name}${suffix}`;
-      thisPlatform.visible = true;
-      return [
-        ...acc,
-        PushJobs.filterPlatform(
-          thisPlatform,
-          selectedJobId,
-          push,
-          filterModel,
-          runnableVisible,
-        ),
-      ];
-    }, []);
-
-    return { filteredPlatforms };
-  }
-
-  static filterPlatform(
-    platform,
-    selectedJobId,
-    push,
-    filterModel,
-    runnableVisible,
-  ) {
-    platform.visible = false;
-    platform.groups.forEach(group => {
-      group.visible = false;
-      group.jobs.forEach(job => {
-        job.visible = filterModel.showJob(job) || job.id === selectedJobId;
-        if (job.state === 'runnable') {
-          job.visible = job.visible && runnableVisible;
-        }
-        job.selected = selectedJobId ? job.id === selectedJobId : false;
-        if (job.visible) {
-          platform.visible = true;
-          group.visible = true;
-        }
-      });
-    });
-    return platform;
-  }
-
   constructor(props) {
     super(props);
     const { push, repoName } = this.props;
 
     this.pushId = push.id;
     this.aggregateId = getPushTableId(repoName, this.pushId, push.revision);
+  }
 
-    this.state = {
-      filteredPlatforms: [],
-    };
+  shouldComponentUpdate(nextProps) {
+    return didObjectsChange(this.props, nextProps, [
+      'platforms',
+      'filterModel',
+      'pushGroupState',
+      'runnableVisible',
+      'duplicateJobsVisible',
+      'groupCountsExpanded',
+    ]);
   }
 
   onMouseDown = ev => {
@@ -135,53 +90,33 @@ class PushJobs extends React.Component {
     jobInstance.toggleRunnableSelected();
   };
 
-  filterPlatformCallback = (platform, selectedJobId) => {
-    const { push, filterModel, runnableVisible } = this.props;
-    const { filteredPlatforms } = this.state;
-
-    // This actually filters the platform in-place.  So we just need to
-    // trigger a re-render by giving it a new ``filteredPlatforms`` object instance.
-    PushJobs.filterPlatform(
-      platform,
-      selectedJobId,
-      push,
-      filterModel,
-      runnableVisible,
-    );
-    if (filteredPlatforms.length) {
-      this.setState({ filteredPlatforms: [...filteredPlatforms] });
-    }
-  };
-
   render() {
-    const filteredPlatforms = this.state.filteredPlatforms || [];
     const {
       repoName,
       filterModel,
       pushGroupState,
       duplicateJobsVisible,
       groupCountsExpanded,
+      runnableVisible,
+      platforms,
     } = this.props;
 
     return (
       <table id={this.aggregateId} className="table-hover">
         <tbody onMouseDown={this.onMouseDown}>
-          {filteredPlatforms ? (
-            filteredPlatforms.map(
-              platform =>
-                platform.visible && (
-                  <Platform
-                    platform={platform}
-                    repoName={repoName}
-                    key={platform.title}
-                    filterModel={filterModel}
-                    pushGroupState={pushGroupState}
-                    filterPlatformCb={this.filterPlatformCallback}
-                    duplicateJobsVisible={duplicateJobsVisible}
-                    groupCountsExpanded={groupCountsExpanded}
-                  />
-                ),
-            )
+          {platforms ? (
+            platforms.map(platform => (
+              <Platform
+                platform={platform}
+                repoName={repoName}
+                filterModel={filterModel}
+                pushGroupState={pushGroupState}
+                key={`${platform.name}${platform.option}`}
+                duplicateJobsVisible={duplicateJobsVisible}
+                groupCountsExpanded={groupCountsExpanded}
+                runnableVisible={runnableVisible}
+              />
+            ))
           ) : (
             <tr>
               <td>

--- a/ui/job-view/pushes/PushJobs.jsx
+++ b/ui/job-view/pushes/PushJobs.jsx
@@ -7,6 +7,7 @@ import { withPinnedJobs } from '../context/PinnedJobs';
 import { withSelectedJob } from '../context/SelectedJob';
 import { getPushTableId } from '../../helpers/aggregateId';
 import { findInstance, findSelectedInstance } from '../../helpers/job';
+import { getSelectedJobId } from '../../helpers/location';
 import { didObjectsChange } from '../../helpers/object';
 import { getLogViewerUrl } from '../../helpers/url';
 import JobModel from '../../models/job';
@@ -35,8 +36,9 @@ class PushJobs extends React.Component {
   }
 
   onMouseDown = ev => {
-    const { selectedJob, togglePinJob } = this.props;
+    const { togglePinJob } = this.props;
     const jobInstance = findInstance(ev.target);
+    const selectedJobId = getSelectedJobId();
 
     if (jobInstance && jobInstance.props.job) {
       const { job } = jobInstance.props;
@@ -45,7 +47,7 @@ class PushJobs extends React.Component {
         this.handleLogViewerClick(job.id);
       } else if (ev.metaKey || ev.ctrlKey) {
         // Pin job
-        if (!selectedJob) {
+        if (!selectedJobId) {
           this.selectJob(job, ev.target);
         }
         togglePinJob(job);
@@ -59,8 +61,9 @@ class PushJobs extends React.Component {
   };
 
   selectJob = (job, el) => {
-    const { setSelectedJob, selectedJob } = this.props;
-    if (selectedJob) {
+    const { setSelectedJob } = this.props;
+
+    if (getSelectedJobId()) {
       const selected = findSelectedInstance();
       if (selected) selected.setSelected(false);
     }
@@ -136,22 +139,17 @@ class PushJobs extends React.Component {
 }
 
 PushJobs.propTypes = {
-  push: PropTypes.object.isRequired,
-  platforms: PropTypes.array.isRequired,
-  repoName: PropTypes.string.isRequired,
-  filterModel: PropTypes.object.isRequired,
   togglePinJob: PropTypes.func.isRequired,
   setSelectedJob: PropTypes.func.isRequired,
-  pushGroupState: PropTypes.string.isRequired,
   toggleSelectedRunnableJob: PropTypes.func.isRequired,
+  repoName: PropTypes.string.isRequired,
+  push: PropTypes.object.isRequired,
+  pushGroupState: PropTypes.string.isRequired,
   runnableVisible: PropTypes.bool.isRequired,
   duplicateJobsVisible: PropTypes.bool.isRequired,
   groupCountsExpanded: PropTypes.bool.isRequired,
-  selectedJob: PropTypes.object,
-};
-
-PushJobs.defaultProps = {
-  selectedJob: null,
+  platforms: PropTypes.array.isRequired,
+  filterModel: PropTypes.object.isRequired,
 };
 
 export default withPushes(withSelectedJob(withPinnedJobs(PushJobs)));


### PR DESCRIPTION
Partially address [Bug 1510280](https://bugzilla.mozilla.org/show_bug.cgi?id=1510280)

This change reduces the rendering time of a 10 pushes of mozilla-inbound (unfiltered) from around 8 seconds to around 4 seconds.

The main gist of this change is to add ``shouldComponentUpdate`` and remove the ``getDerivedStateFromProps`` from ``PushJobs`` also means that we won't re-render every push when a single push has returned new jobs.  

This change also moves the filtering and re-rendering of platforms from ``PushJobs`` which holds all the platforms for a ``Push`` down to each ``Platform``, which then filters itself.  This has the advantage that if one platform needs to re-filter and render, the others don't need to.  Follow-up PRs will try to take more advantage of this.  But I didn't want to make too many changes all at once in this one.

