### PR TITLE
Bug 1553924 - iterate over gecko decision task runs for list of available jobs, don't assume first run has created it

### DIFF
--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -30,8 +30,11 @@ export const repoEndpoint = '/repository/';
 
 export const perfSummaryEndpoint = 'performance/summary/';
 
-export const getRunnableJobsURL = function getRunnableJobsURL(decisionTaskId) {
-  return `https://queue.taskcluster.net/v1/task/${decisionTaskId}/runs/0/artifacts/public/runnable-jobs.json`;
+export const getRunnableJobsURL = function getRunnableJobsURL(
+  decisionTaskId,
+  runNumber,
+) {
+  return `https://queue.taskcluster.net/v1/task/${decisionTaskId}/runs/${runNumber}/artifacts/public/runnable-jobs.json`;
 };
 
 export const getUserSessionUrl = function getUserSessionUrl(oidcProvider) {

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -319,6 +319,13 @@ class Push extends React.Component {
         push_id: push.id,
       });
 
+      if (jobList === undefined) {
+        notify(
+          `Error fetching runnable jobs: No job list found for any run of gecko decision task`,
+          'danger',
+        );
+        return;
+      }
       if (jobList.length === 0) {
         notify('No new jobs available');
       }
@@ -366,6 +373,13 @@ class Push extends React.Component {
       let fuzzyJobList = await RunnableJobModel.getList(repoName, {
         decision_task_id: decisionTaskId,
       });
+      if (fuzzyJobList === undefined) {
+        notify(
+          `Error fetching runnable jobs: No job list found for any run of gecko decision task`,
+          'danger',
+        );
+        return;
+      }
       fuzzyJobList = [
         ...new Set(
           fuzzyJobList.map(job => {


### PR DESCRIPTION
urls for testing:

decision task failed, no runnable-jobs.json artifact:
https://treeherder.mozilla.org/#/jobs?repo=try&searchStr=gecko%2Cdecision%2Ctask&revision=90e724cf39afaa055a5fbba7a5fbc24878b1efa4&selectedJob=247993591

decision task failed, has a runnable-jobs.json artifact:
https://treeherder.mozilla.org/#/jobs?repo=autoland&resultStatus=success%2Ctestfailed%2Cbusted%2Cexception%2Cretry%2Cusercancel%2Crunnable&revision=4f539454545731865881e379b8849830dbedcfc3&selectedJob=247821833

normal push with runnable-jobs.json artifact:
https://treeherder.mozilla.org/#/jobs?repo=autoland&resultStatus=success%2Ctestfailed%2Cbusted%2Cexception%2Cretry%2Cusercancel%2Crunnable&group_state=expanded&revision=06fd76912201276f6212687eba91ff75facefdf9