### PR TITLE
Add support for mozilla-esr68 repository.

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1413,5 +1413,31 @@
       "repository_group": 11,
       "description": "Fenix is not your parent's Android browser"
     }
+  },
+  {
+    "pk": 109,
+    "model": "model.repository",
+    "fields": {
+      "dvcs_type": "hg",
+      "name": "mozilla-esr68",
+      "url": "https://hg.mozilla.org/releases/mozilla-esr68",
+      "active_status": "active",
+      "codebase": "gecko",
+      "repository_group": 2,
+      "description": ""
+    }
+  },
+  {
+    "pk": 110,
+    "model": "model.repository",
+    "fields": {
+      "dvcs_type": "hg",
+      "name": "comm-esr68",
+      "url": "https://hg.mozilla.org/releases/comm-esr68",
+      "active_status": "onhold",
+      "codebase": "comm",
+      "repository_group": 8,
+      "description": ""
+    }
   }
 ]

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1076,7 +1076,7 @@
       "dvcs_type": "hg",
       "name": "mozilla-esr52",
       "url": "https://hg.mozilla.org/releases/mozilla-esr52",
-      "active_status": "active",
+      "active_status": "onhold",
       "codebase": "gecko",
       "repository_group": 2,
       "description": ""
@@ -1089,7 +1089,7 @@
       "dvcs_type": "hg",
       "name": "comm-esr52",
       "url": "https://hg.mozilla.org/releases/comm-esr52",
-      "active_status": "active",
+      "active_status": "onhold",
       "codebase": "comm",
       "repository_group": 8,
       "description": ""

--- a/ui/intermittent-failures/constants.js
+++ b/ui/intermittent-failures/constants.js
@@ -37,6 +37,7 @@ export const treeOptions = [
   'mozilla-central',
   'mozilla-inbound',
   'mozilla-esr60',
+  'mozilla-esr68',
   'autoland',
   'firefox-releases',
   'comm-central',


### PR DESCRIPTION
And disable the esr52 repositories at the same time.

This should land after the repositories have been [created](https://bugzilla.mozilla.org/show_bug.cgi?id=1555777).