### PR TITLE
Bug 1555864 - Fix bugfiler's use of bugzilla's product/component search

### DIFF
--- a/tests/ui/unit/react/bugfiler_test.jsx
+++ b/tests/ui/unit/react/bugfiler_test.jsx
@@ -54,7 +54,7 @@ describe('BugFiler', () => {
     );
 
     fetchMock.mock(
-      `${bzBaseUrl}rest/prod_comp_search/firefox%20::%20search?limit=5`,
+      `${bzBaseUrl}rest/prod_comp_search/find/firefox%20::%20search?limit=5`,
       {
         products: [
           { product: 'Firefox' },

--- a/ui/job-view/details/BugFiler.jsx
+++ b/ui/job-view/details/BugFiler.jsx
@@ -233,7 +233,7 @@ export class BugFilerClass extends React.Component {
 
     if (productSearch) {
       const resp = await fetch(
-        `${bzBaseUrl}rest/prod_comp_search/${productSearch}?limit=5`,
+        `${bzBaseUrl}rest/prod_comp_search/find/${productSearch}?limit=5`,
       );
       const data = await resp.json();
       const products = data.products.filter(


### PR DESCRIPTION
Bugfiler uses an apparently undocumented bugzilla api to search for
product/component pairs, and bugzilla recently moved the api endpoint,
breaking the bug filer. This patch points to the correct endpoint.