### PR TITLE
Bug 1395254 - Consume Taskcluster jobs from standard queue exchanges

### DIFF
--- a/docs/infrastructure/troubleshooting.md
+++ b/docs/infrastructure/troubleshooting.md
@@ -167,7 +167,7 @@ If new pushes or CI job results are not appearing in Treeherder's UI:
    it suggests that Treeherder's `pulse_listener_{pushes,jobs}` dynos have stopped
    consuming Pulse events, and so might need [restarting].
 3. Failing that, it's possible the issue might lie in the services that send events to
-   those Pulse exchanges, such as `taskcluster-treeherder`, `taskcluster-github` or
+   those Pulse exchanges, such as `taskcluster-github` or
    the Taskcluster systems upstream of those. Ask for help in the IRC channel
    `#taskcluster`.
 

--- a/docs/pulseload.md
+++ b/docs/pulseload.md
@@ -2,7 +2,7 @@
 
 For ingestion from **Pulse** exchanges, on your local machine, you can choose
 to ingest from any exchange you like. Some exchanges will be registered in
-`settings.py` for use by the Treeherder servers. You can use those to get the
+`sources.py` for use by the Treeherder servers. You can use those to get the
 same data as Treeherder. Or you can specify your own and experiment with
 posting your own data.
 
@@ -32,8 +32,7 @@ string would be:
 
 ### 3. Read Pushes
 
-On the **host machine**, set your Pulse config environment variable, so that it's available
-for docker-compose to use:
+On your localhost set your Pulse config environment variable:
 
 ```bash
 export PULSE_URL="amqp://foo:bar@pulse.mozilla.org:5671/?ssl=1"
@@ -99,23 +98,18 @@ push_sources = [
 
 #### Jobs
 
-Job Exchanges and Projects are defined in `job_sources`, however can
-also be configured in the environment like so:
-
-`PULSE_JOB_SOURCES` defines a list of exchanges with projects.
+Job Exchanges and Projects are defined in `job_sources`, however, it can
+also be configured in the environment by using the `PULSE_JOB_SOURCES` environment variables.
+This defines a list of exchanges with projects.
 
 ```bash
-export PULSE_JOB_SOURCES="exchange/taskcluster-treeherder/v1/jobs.mozilla-central:mozilla-inbound",
+export PULSE_JOB_SOURCES="exchange/taskcluster-queue/v1/task-pending.#,exchange/taskcluster-queue/v1/task-completed.#",
 ```
 
-In this example we've defined one exchange:
+In this example we've defined two exchanges:
 
-- `exchange/taskcluster-treeherder/v1/jobs`
-
-The taskcluster-treeherder exchange defines two projects:
-
-- `mozilla-central`
-- `mozilla-inbound`
+- `exchange/taskcluster-queue/v1/task-pending`
+- `exchange/taskcluster-queue/v1/task-completed`
 
 When Jobs are read from Pulse and added to Treeherder's celery queue we generate a routing key by prepending `#.` to each project key.
 

--- a/docs/submitting_data.md
+++ b/docs/submitting_data.md
@@ -122,7 +122,7 @@ import yaml
 import jsonschema
 
 with open('schemas/text-log-summary-artifact.yml') as f:
-    schema = yaml.load(f)
+    schema = yaml.load(f, Loader=yaml.FullLoader)
 
 jsonschema.validate(data, schema)
 ```

--- a/misc/compare_pushes.py
+++ b/misc/compare_pushes.py
@@ -1,0 +1,99 @@
+""" Script to compare two pushes from different Treeherder instances"""
+import logging
+import pprint
+import uuid
+
+import slugid
+
+from deepdiff import DeepDiff
+from thclient import TreeherderClient
+
+logging.basicConfig()
+logger = logging.getLogger(__name__).setLevel(logging.DEBUG)
+
+
+def remove_some_attributes(job, remote_job):
+    # I belive these differences are expected since they are dependant to when the data
+    # was inserted inside of the database
+    del job["build_platform_id"]
+    del job["id"]
+    del job["job_group_id"]
+    del job["job_type_id"]
+    del job["last_modified"]
+    del job["push_id"]
+    del job["result_set_id"]
+    del remote_job["build_platform_id"]
+    del remote_job["id"]
+    del remote_job["job_group_id"]
+    del remote_job["job_type_id"]
+    del remote_job["last_modified"]
+    del remote_job["push_id"]
+    del remote_job["result_set_id"]
+
+    if job.get("end_timestamp"):
+        del job["end_timestamp"]
+        del job["start_timestamp"]
+        del remote_job["end_timestamp"]
+        del remote_job["start_timestamp"]
+
+    if job.get("failure_classification_id"):
+        del job["failure_classification_id"]
+        del remote_job["failure_classification_id"]
+
+
+def print_url_to_taskcluster(job_guid):
+    job_guid = job["job_guid"]
+    (decoded_task_id, retry_id) = job_guid.split("/")
+    # As of slugid v2, slugid.encode() returns a string not bytestring under Python 3.
+    taskId = slugid.encode(uuid.UUID(decoded_task_id))
+    print("https://taskcluster-ui.herokuapp.com/tasks/{}".format(taskId))
+
+
+if __name__ == "__main__":
+    # XXX: This script should take arguments instead being hardcoded
+    # http://localhost:5000/#/jobs?repo=mozilla-central&revision=eb7f4d56f54b3283fc15983ee859b5e62fcb9f3b
+    local = TreeherderClient(server_url="http://localhost:8000")
+    local_jobs = local.get_jobs("mozilla-central", push_id=8717, count=None)
+
+    # https://treeherder.mozilla.org/#/jobs?repo=mozilla-central&revision=eb7f4d56f54b3283fc15983ee859b5e62fcb9f3b
+    remote = TreeherderClient("https://treeherder.mozilla.org")
+    remote_jobs = remote.get_jobs("mozilla-central", push_id=516192, count=None)
+
+    remote_dict = {}
+    for job in remote_jobs:
+        remote_dict[job["job_guid"]] = job
+
+    local_dict = {}
+    local_not_found = []
+    for job in local_jobs:
+        remote_job = remote_dict.get(job["job_guid"])
+        if remote_job is None:
+            local_not_found.append(job)
+        else:
+            # You can use this value in a url with &selectedJob=
+            jobId = job["id"]
+            remove_some_attributes(job, remote_job)
+
+            differences = DeepDiff(job, remote_dict[job["job_guid"]])
+            if differences:
+                pprint.pprint(differences)
+                print(jobId)
+            else:
+                # Delete jobs that don"t have any differences
+                del remote_dict[job["job_guid"]]
+
+    print("We have found: {} jobs on the local instance.".format(len(local_jobs)))
+    print("We have found: {} jobs on the remote instance.".format(len(remote_jobs)))
+
+    if remote_dict:
+        print("There are the first 10 remote jobs we do not have locally. Follow the link to investigate.")
+        for job in list(remote_dict.values())[0:10]:
+            print_url_to_taskcluster(job["job_guid"])
+
+    if local_not_found:
+        print("Number of jobs not found locally: {} jobs".format(len(local_not_found)))
+        for job in local_not_found:
+            print_url_to_taskcluster(job["job_guid"])
+
+    if remote_dict is None and local_not_found is None:
+        print("We have not found any differences between the two pushes!! :D")

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -229,7 +229,30 @@ idna==2.8 \
     --hash=sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407
 
 # required for taskcluster
-slugid==2.0.0 --hash=sha256:aec8b0e01c4ad32e38e12d609eab3ec912fd129aaf6b2ded0199b56a5f8fd67c --hash=sha256:a950d98b72691178bdd4d6c52743c4a2aa039207cf7a97d71060a111ff9ba297
+slugid==2.0.0 \
+    --hash=sha256:aec8b0e01c4ad32e38e12d609eab3ec912fd129aaf6b2ded0199b56a5f8fd67c \
+    --hash=sha256:a950d98b72691178bdd4d6c52743c4a2aa039207cf7a97d71060a111ff9ba297
+
+taskcluster==7.0.1 \
+    --hash=sha256:97e19674738515e6891f4d7928280aecb2686def8b9d72a15477d7297f34c18c
+
+aiohttp==3.5.4 \
+    --hash=sha256:00d198585474299c9c3b4f1d5de1a576cc230d562abc5e4a0e81d71a20a6ca55
+
+mohawk==1.0.0 \
+    --hash=sha256:fca4e34d8f5492f1c33141c98b96e168a089e5692ce65fb747e4bb613f5fe552
+
+async-timeout==3.0.1 \
+    --hash=sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3
+
+multidict==4.5.2 \
+    --hash=sha256:c18498c50c59263841862ea0501da9f2b3659c00db54abfbf823a80787fde8ce
+
+yarl==1.3.0 \
+    --hash=sha256:024ecdc12bc02b321bc66b41327f930d1c2c543fa9a561b39861da9388ba7aa9
+
+taskcluster-urls==11.0.0 \
+    --hash=sha256:2aceab7cf5b1948bc197f2e5e50c371aa48181ccd490b8bada00f1e3baf0c5cc
 
 graphene-django==2.3.2 \
     --hash=sha256:7720a459da5bc99fba251f697c4d41858612bf1a36096326af86739dd31705f3 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -148,3 +148,7 @@ zope.deprecation==4.4.0 \
     --hash=sha256:0d453338f04bacf91bbfba545d8bcdf529aa829e67b705eac8c1a7fdce66e2df
 zope.proxy==4.3.2 \
     --hash=sha256:ab6d6975d9c51c13cac828ff03168de21fb562b0664c59bcdc4a4b10f39a5b17
+
+# To test async code
+pytest-asyncio==0.10.0 \
+    --hash=sha256:d734718e25cfc32d2bf78d346e99d33724deeba774cc4afdf491530c6184b63b

--- a/schemas/pulse-job.yml
+++ b/schemas/pulse-job.yml
@@ -14,8 +14,18 @@ properties:
     pattern: '^[A-Za-z0-9/+-]+$'
     minLength: 1
     maxLength: 50
-  retryId:
-    title: 'Retry ID'
+  realTaskId:
+    title: 'Real task ID'
+    description: |
+      On a follow PR we will replace taskId with realTaskId and have a jobGuid instead of the
+      current taskId
+    type: 'string'
+    # From TaskCluster https://github.com/taskcluster/taskcluster/blob/master/services/queue/schemas/constants.yml
+    pattern: '^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$'
+    minLength: 1
+    maxLength: 50
+  runId:
+    title: 'Run ID'
     description: |
       The infrastructure retry iteration on this job.  The number of times this
       job has been retried by the infrastructure.
@@ -376,11 +386,6 @@ properties:
   extra:
     type: 'object'
     description: Extra information that Treeherder reads on a best-effort basis
-  version:
-    type: 'integer'
-    description: Message version
-    enum:
-      - 1
 
 additionalProperties: false
 required:
@@ -390,7 +395,6 @@ required:
   - display
   - state
   - jobKind
-  - version
 
 definitions:
   machine:

--- a/schemas/task-treeherder-config.yml
+++ b/schemas/task-treeherder-config.yml
@@ -1,0 +1,134 @@
+$schema: 'http://json-schema.org/draft-07/schema#'
+title: 'Treeherder Configuration'
+description: |
+  Definition of the Treeherder configuration data that can be contained within
+  a task definition under task.extra.treeherder.  This information is useful for
+  determining job properties to report to Treeherder.
+type: object
+properties:
+  reason:
+    description: |
+      Examples include:
+      - scheduled
+      - scheduler
+      - Self-serve: Rebuilt by foo@example.com
+      - Self-serve: Requested by foo@example.com
+      - The Nightly scheduler named 'mozilla-inbound periodic' triggered this build
+      - unknown
+    type: 'string'
+    minLength: 1
+    maxLength: 125
+  tier:
+    type: 'integer'
+    description: |
+      Tiers are used for classifying jobs according to the Sheriffing policy.
+      These jobs can be hidden based on exclusion profiles within Treeherder and
+      display of these jobs toggled by UI settings.
+
+      By default jobs which do not specify a tier will be classified as Tier 1.
+    minimum: 1
+    maximum: 3
+  jobKind:
+    type: 'string'
+    description: |
+      jobKind specifies the type of task that should be reported to Treeherder.
+      The jobKind could cause Treeherder to display/treat the task differently.
+      For instance, tasks with a jobKind of 'build' will be reported as red when
+      the task fails, 'test' as orange, and any jobs not specifying jobKind or
+      'other' will be red.
+    default: 'other'
+    enum:
+      - build
+      - test
+      - other
+  machine:
+    type: 'object'
+    properties:
+      platform:
+        type: 'string'
+        description: |
+          The platform specified here maps to platforms that Treeherder recognizes.
+          Jobs with the same platform will be displayed within the same row on
+          Treeherder and obey any ordering that is defined'.
+
+          If no build platform is specified, the workerType specified for the job
+          will be used.
+        pattern: '^[A-Za-z0-9_-]+$'
+        minLength: 1
+        maxLength: 50
+      os:
+        type: 'string'
+        pattern: '^[A-Za-z0-9_-]+$'
+        minLength: 1
+        maxLength: 25
+      architecture:
+        type: 'string'
+        pattern: '^[A-Za-z0-9_-]+$'
+        minLength: 1
+        maxLength: 25
+    additionalProperties: false
+    required: [platform]
+  labels:
+    title: 'labels'
+    description: |
+      Labels are a dimension of a platform.  The values here can vary wildly,
+      so most strings are valid for this.  The list of labels that are used
+      is malleable going forward.
+
+      These were formerly known as "Collection" calling labels now so they
+      can be understood to be just strings that denotes a characteristic of the job.
+
+      These labels will be used for grouping jobs with a particular job platform.
+      For instance, a job with the label "debug" will be put into the debug platform
+      on Treeherder.  By default, if no label is specified, the job will be classified
+      as "opt"
+
+      Some examples of labels that have been used:
+        opt    Optimize Compiler GCC optimize flags
+        debug  Debug flags passed in
+        pgo    Profile Guided Optimization - Like opt, but runs with profiling, then builds again using that profiling
+        asan   Address Sanitizer
+        tsan   Thread Sanitizer Build
+    type: 'array'
+    uniqueItems: false
+    items:
+      type: 'string'
+      minLength: 1
+      maxLength: 50
+      pattern: '^[A-Za-z0-9_-]+$'
+  symbol:
+    title: 'symbol'
+    description: |
+      This is the symbol that will appear in a Treeherder resultset for a
+      given push.  This symbol could be something such as "B" or a number representing
+      the current chunk.
+    type: 'string'
+    minLength: 0
+    maxLength: 25
+  groupName:
+    title: 'group name'
+    type: 'string'
+    minLength: 1
+    maxLength: 100
+  groupSymbol:
+    title: 'group symbol'
+    description: |
+      Group Symbol is the symbol that job symbols will be grouped under.  This
+      is useful if there is a particular group of jobs that should be displayed
+      together.  For example, a test suite named "Media Tests" with the group symbol
+      of "ME" would have all jobs with that group symbol appear as
+      ME(symbol 1, symbol 2, ...).
+    type: 'string'
+    minLength: 1
+    maxLength: 25
+  productName:
+    description: |
+      Examples include:
+      -  'firefox'
+      -  'taskcluster'
+      -  'xulrunner'
+    type: 'string'
+    minLength: 1
+    maxLength: 125
+required: [symbol]
+additionalProperties: true

--- a/tests/etl/test_job_loader.py
+++ b/tests/etl/test_job_loader.py
@@ -1,9 +1,11 @@
 import copy
 
 import pytest
+import responses
 
 from treeherder.etl.exceptions import MissingPushException
 from treeherder.etl.job_loader import JobLoader
+from treeherder.etl.taskcluster_pulse.handler import handleMessage
 from treeherder.model.models import (Job,
                                      JobDetail,
                                      JobLog,
@@ -35,12 +37,65 @@ def transformed_pulse_jobs(sample_data, test_repository):
     return jobs
 
 
+def mock_artifact(taskId, runId, artifactName):
+    # Mock artifact with empty body
+    baseUrl = "https://queue.taskcluster.net/v1/task/{taskId}/runs/{runId}/artifacts/{artifactName}"
+    responses.add(
+        responses.GET,
+        baseUrl.format(taskId=taskId, runId=runId, artifactName=artifactName),
+        body="",
+        content_type='text/plain',
+        status=200)
+
+
+@pytest.fixture
+async def new_pulse_jobs(sample_data, test_repository, push_stored):
+    revision = push_stored[0]["revisions"][0]["revision"]
+    pulseMessages = copy.deepcopy(sample_data.taskcluster_pulse_messages)
+    tasks = copy.deepcopy(sample_data.taskcluster_tasks)
+    jobs = []
+    # Over here we transform the Pulse messages into the intermediary taskcluster-treeherder
+    # generated messages
+    for message in list(pulseMessages.values()):
+        taskId = message["payload"]["status"]["taskId"]
+        task = tasks[taskId]
+        # If we pass task to handleMessage we won't hit the network
+        taskRuns = await handleMessage(message, task)
+        # handleMessage returns [] when it is a task that is not meant for Treeherder
+        for run in reversed(taskRuns):
+            mock_artifact(taskId, run["runId"], "public/logs/live_backing.log")
+            run["origin"]["project"] = test_repository.name
+            run["origin"]["revision"] = revision
+            jobs.append(run)
+    return jobs
+
+
+@pytest.fixture
+def new_transformed_jobs(sample_data, test_repository, push_stored):
+    revision = push_stored[0]["revisions"][0]["revision"]
+    jobs = copy.deepcopy(sample_data.taskcluster_transformed_jobs)
+    for job in jobs.values():
+        job["revision"] = revision
+    return jobs
+
+
 def test_job_transformation(pulse_jobs, transformed_pulse_jobs):
     import json
     jl = JobLoader()
     for idx, pulse_job in enumerate(pulse_jobs):
         assert jl._is_valid_job(pulse_job)
         assert transformed_pulse_jobs[idx] == json.loads(json.dumps(jl.transform(pulse_job)))
+
+
+@responses.activate
+def test_new_job_transformation(new_pulse_jobs, new_transformed_jobs, failure_classifications):
+    jl = JobLoader()
+    for message in new_pulse_jobs:
+        taskId = message["realTaskId"]
+        transformed_job = jl.process_job(message)
+        # Not all messages from Taskcluster will be processed
+        if transformed_job:
+            assert new_transformed_jobs[taskId] == transformed_job
 
 
 def test_ingest_pulse_jobs(pulse_jobs, test_repository, push_stored,

--- a/tests/etl/test_job_schema.py
+++ b/tests/etl/test_job_schema.py
@@ -1,7 +1,7 @@
 import jsonschema
 import pytest
 
-from treeherder.etl.schema import job_json_schema
+from treeherder.etl.schema import get_json_schema
 
 # The test data in this file are a representative sample-set from
 # production Treeherder
@@ -16,7 +16,7 @@ def test_group_symbols(sample_data, group_symbol):
     job["origin"]["project"] = "proj"
     job["origin"]["revision"] = "1234567890123456789012345678901234567890"
     job["display"]["groupSymbol"] = group_symbol
-    jsonschema.validate(job, job_json_schema)
+    jsonschema.validate(job, get_json_schema("pulse-job.yml"))
 
 
 @pytest.mark.parametrize("job_symbol", ['1.1g', '1g', '20', 'A', 'GBI10', 'en-US-1'])
@@ -28,4 +28,4 @@ def test_job_symbols(sample_data, job_symbol):
     job["origin"]["project"] = "proj"
     job["origin"]["revision"] = "1234567890123456789012345678901234567890"
     job["display"]["jobSymbol"] = job_symbol
-    jsonschema.validate(job, job_json_schema)
+    jsonschema.validate(job, get_json_schema("pulse-job.yml"))

--- a/tests/sample_data/pulse_consumer/job_data.json
+++ b/tests/sample_data/pulse_consumer/job_data.json
@@ -42,8 +42,6 @@
     "timeCompleted": "2014-12-19T18:39:57-08:00",
 
     "labels": ["debug"],
-    "version": 1,
-
     "logs": [
       {
         "url": "http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/tinderbox-builds/mozilla-inbound-linux64/mozilla-inbound_linux64_spidermonkey-warnaserr-bm57-build1-build352.txt.gz",
@@ -68,7 +66,7 @@
 
   {
     "taskId": "5c909b6d-143a-4a9f-942f-594bfadc399e/0",
-    "retryId": 0,
+    "runId": 0,
     "origin": {
       "kind": "hg.mozilla.org",
       "project": "set by test",
@@ -102,13 +100,12 @@
     "timeScheduled": "2014-12-19T16:39:57-08:00",
     "timeStarted": "2014-12-19T17:39:57-08:00",
     "timeCompleted": "2014-12-19T18:39:57-08:00",
-    "labels": ["debug"],
-    "version": 1
+    "labels": ["debug"]
   },
 
   {
     "taskId": "5c909b6d-143a-4a9f-942f-594bfadc399e/1",
-    "retryId": 1,
+    "runId": 1,
     "origin": {
       "kind": "hg.mozilla.org",
       "project": "set by test",
@@ -142,13 +139,12 @@
     "timeScheduled": "2014-12-19T16:39:57-08:00",
     "timeStarted": "2014-12-19T17:39:57-08:00",
     "timeCompleted": "2014-12-19T18:39:57-08:00",
-    "labels": ["debug"],
-    "version": 1
+    "labels": ["debug"]
   },
 
   {
     "taskId": "66c4b325-0bb7-43ba-b631-f7a120103329/0",
-    "retryId": 0,
+    "runId": 0,
     "isRetried": true,
     "origin": {
       "kind": "hg.mozilla.org",
@@ -189,8 +185,6 @@
     "timeScheduled": "2014-12-19T16:39:57-08:00",
     "timeStarted": "2014-12-19T17:39:57-08:00",
     "timeCompleted": "2014-12-19T18:39:57-08:00",
-
-    "version": 1,
 
     "logs": [
       {
@@ -243,7 +237,7 @@
   },
   {
     "taskId": "6c8cd566-df63-4102-a0bd-0603ddad8743/3",
-    "retryId": 3,
+    "runId": 3,
     "origin": {
       "kind": "hg.mozilla.org",
       "project": "set by test",
@@ -283,8 +277,6 @@
     "timeScheduled": "2014-12-19T16:39:57-08:00",
     "timeStarted": "2014-12-19T17:39:57-08:00",
     "timeCompleted": "2014-12-19T18:39:57-08:00",
-
-    "version": 1,
 
     "logs": [
       {

--- a/tests/sample_data/pulse_consumer/taskcluster_pulse_messages.json
+++ b/tests/sample_data/pulse_consumer/taskcluster_pulse_messages.json
@@ -1,0 +1,2640 @@
+{
+  "A35mWTRuQmyj88yMnIF0fA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:51.402Z",
+        "expires": "2020-06-25T19:13:51.402Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.316Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "A35mWTRuQmyj88yMnIF0fA",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.A35mWTRuQmyj88yMnIF0fA.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "A3dJ8bDIQRKzHiZBhM0c5Q": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:55.010Z",
+        "expires": "2020-06-25T19:13:55.010Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.337Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "A3dJ8bDIQRKzHiZBhM0c5Q",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.A3dJ8bDIQRKzHiZBhM0c5Q.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "A47ePPIaRFOWxw8oVOvmCA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:52.809Z",
+        "expires": "2020-06-25T19:13:52.809Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.325Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "A47ePPIaRFOWxw8oVOvmCA",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.A47ePPIaRFOWxw8oVOvmCA.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "A4AV9EXXREGCV-hVKT0blQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:04.633Z",
+        "expires": "2020-06-25T19:14:04.633Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.321Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "A4AV9EXXREGCV-hVKT0blQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.A4AV9EXXREGCV-hVKT0blQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "ADfskOGaS7KUj0AuUb324A": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:59.107Z",
+        "expires": "2020-06-25T19:13:59.107Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.499Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "ADfskOGaS7KUj0AuUb324A",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.ADfskOGaS7KUj0AuUb324A.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "AcUWtRf7QB-4XQS8nSTilg": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:58.734Z",
+        "expires": "2020-06-25T19:13:58.734Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.598Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "AcUWtRf7QB-4XQS8nSTilg",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.AcUWtRf7QB-4XQS8nSTilg.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "Ai-bmuTzS7eRBYFhSPnZ1w": {
+    "exchange": "exchange/taskcluster-queue/v1/task-running",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:58.650Z",
+        "expires": "2020-06-25T19:13:58.650Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.193Z",
+            "started": "2019-06-26T19:36:11.066Z",
+            "state": "running",
+            "takenUntil": "2019-06-26T19:56:10.992Z",
+            "workerGroup": "us-west-1",
+            "workerId": "i-0429b6e2c0ac7474d"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "running",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "Ai-bmuTzS7eRBYFhSPnZ1w",
+        "workerType": "gecko-t-linux-large"
+      },
+      "takenUntil": "2019-06-26T19:56:10.992Z",
+      "version": 1,
+      "workerGroup": "us-west-1",
+      "workerId": "i-0429b6e2c0ac7474d"
+    },
+    "routes": "primary.Ai-bmuTzS7eRBYFhSPnZ1w.0.us-west-1.i-0429b6e2c0ac7474d.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "AlcvKmrGS8e9FXrFTYnhpA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:55.428Z",
+        "expires": "2020-06-25T19:13:55.428Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.307Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "AlcvKmrGS8e9FXrFTYnhpA",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.AlcvKmrGS8e9FXrFTYnhpA.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "ApotNgqaQh6OGDW8TMSWlQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:51.072Z",
+        "expires": "2020-06-25T19:13:51.072Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.699Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "ApotNgqaQh6OGDW8TMSWlQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.ApotNgqaQh6OGDW8TMSWlQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "AqMhSaDqSAG7nfjfxjKLZA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:50.958Z",
+        "expires": "2020-06-25T19:13:50.958Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.697Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "AqMhSaDqSAG7nfjfxjKLZA",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.AqMhSaDqSAG7nfjfxjKLZA.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "AseHcKjPRhi-NBsvwH54gw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:51.304Z",
+        "expires": "2020-06-25T19:13:51.304Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.460Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "AseHcKjPRhi-NBsvwH54gw",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.AseHcKjPRhi-NBsvwH54gw.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "B3EheQ-IQ5aPzw34KS_a6g": {
+    "exchange": "exchange/taskcluster-queue/v1/task-completed",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T18:07:13.543Z",
+        "expires": "2020-06-25T18:07:13.543Z",
+        "provisionerId": "releng-hardware",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "resolved": "2019-06-26T19:36:10.521Z",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:26:10.905Z",
+            "started": "2019-06-26T19:27:48.307Z",
+            "state": "completed",
+            "takenUntil": "2019-06-26T19:47:48.234Z",
+            "workerGroup": "mdc2",
+            "workerId": "t-mojave-r7-153"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "completed",
+        "taskGroupId": "EJAo7mQyRqS-jmzebhceFA",
+        "taskId": "B3EheQ-IQ5aPzw34KS_a6g",
+        "workerType": "gecko-t-osx-1014"
+      },
+      "version": 1,
+      "workerGroup": "mdc2",
+      "workerId": "t-mojave-r7-153"
+    },
+    "routes": "primary.B3EheQ-IQ5aPzw34KS_a6g.0.mdc2.t-mojave-r7-153.releng-hardware.gecko-t-osx-1014.gecko-level-3.EJAo7mQyRqS-jmzebhceFA._"
+  },
+  "BFqlkKMaTVqv3ROSlUT6kQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:56.048Z",
+        "expires": "2020-06-25T19:13:56.048Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.318Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "BFqlkKMaTVqv3ROSlUT6kQ",
+        "workerType": "gecko-t-linux-xlarge"
+      },
+      "version": 1
+    },
+    "routes": "primary.BFqlkKMaTVqv3ROSlUT6kQ.0._._.aws-provisioner-v1.gecko-t-linux-xlarge.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "BHejD_RvTW2HR2THXfwDAQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:03.313Z",
+        "expires": "2020-06-25T19:14:03.313Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.748Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "BHejD_RvTW2HR2THXfwDAQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.BHejD_RvTW2HR2THXfwDAQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "BXWMaUV7TCunBcJQELbZqw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:01.506Z",
+        "expires": "2020-06-25T19:14:01.506Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.554Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "BXWMaUV7TCunBcJQELbZqw",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.BXWMaUV7TCunBcJQELbZqw.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "BZuYb2PTTQ-opGzxvZvA9A": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:56.160Z",
+        "expires": "2020-06-25T19:13:56.160Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.545Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "BZuYb2PTTQ-opGzxvZvA9A",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.BZuYb2PTTQ-opGzxvZvA9A.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "BdHfGUHPTLm0IKz47oNJlA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:58.716Z",
+        "expires": "2020-06-25T19:13:58.716Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.313Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "BdHfGUHPTLm0IKz47oNJlA",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.BdHfGUHPTLm0IKz47oNJlA.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "BdHy_4vQSA2ZQoxXc-6ieA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:51.194Z",
+        "expires": "2020-06-25T19:13:51.194Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.306Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "BdHy_4vQSA2ZQoxXc-6ieA",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.BdHy_4vQSA2ZQoxXc-6ieA.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "BfEK00F_TSm20TD799GdMw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:05.356Z",
+        "expires": "2020-06-25T19:14:05.356Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.386Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "BfEK00F_TSm20TD799GdMw",
+        "workerType": "gecko-t-linux-xlarge"
+      },
+      "version": 1
+    },
+    "routes": "primary.BfEK00F_TSm20TD799GdMw.0._._.aws-provisioner-v1.gecko-t-linux-xlarge.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "Bg8h-Ct_SPSrEEYuvPAYSQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:54.997Z",
+        "expires": "2020-06-25T19:13:54.997Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.775Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "Bg8h-Ct_SPSrEEYuvPAYSQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.Bg8h-Ct_SPSrEEYuvPAYSQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "BpnQqda2Q0izXw4k0RUT6w": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:55.682Z",
+        "expires": "2020-06-25T19:13:55.682Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.255Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "BpnQqda2Q0izXw4k0RUT6w",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.BpnQqda2Q0izXw4k0RUT6w.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "CBO2K8XGQEaNpX1BkwJmNw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:51.316Z",
+        "expires": "2020-06-25T19:13:51.316Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.414Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "CBO2K8XGQEaNpX1BkwJmNw",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.CBO2K8XGQEaNpX1BkwJmNw.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "CER7YmG9QmCd-R66vfWkVQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-running",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:34:53.754Z",
+        "expires": "2019-07-24T19:34:53.754Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:34:54.106Z",
+            "started": "2019-06-26T19:36:08.719Z",
+            "state": "running",
+            "takenUntil": "2019-06-26T19:56:08.645Z",
+            "workerGroup": "us-west-1",
+            "workerId": "i-0da13f5d4e5576fd5"
+          }
+        ],
+        "schedulerId": "gecko-level-1",
+        "state": "running",
+        "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "taskId": "CER7YmG9QmCd-R66vfWkVQ",
+        "workerType": "gecko-1-decision"
+      },
+      "takenUntil": "2019-06-26T19:56:08.645Z",
+      "version": 1,
+      "workerGroup": "us-west-1",
+      "workerId": "i-0da13f5d4e5576fd5"
+    },
+    "routes": "primary.CER7YmG9QmCd-R66vfWkVQ.0.us-west-1.i-0da13f5d4e5576fd5.aws-provisioner-v1.gecko-1-decision.gecko-level-1.VQg1HZ5yS0ixZvsnHLWuFw._"
+  },
+  "DPCuZCk-SWC6SeftAbytzw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:03.391Z",
+        "expires": "2020-06-25T19:14:03.391Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.837Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "DPCuZCk-SWC6SeftAbytzw",
+        "workerType": "gecko-t-linux-xlarge"
+      },
+      "version": 1
+    },
+    "routes": "primary.DPCuZCk-SWC6SeftAbytzw.0._._.aws-provisioner-v1.gecko-t-linux-xlarge.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "D_6WScWhTLysuSIkbqfjsg": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:51.128Z",
+        "expires": "2020-06-25T19:13:51.128Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.355Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "D_6WScWhTLysuSIkbqfjsg",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.D_6WScWhTLysuSIkbqfjsg.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "DxhjVp-uQtGhRLm1w0xdiA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:51.045Z",
+        "expires": "2020-06-25T19:13:51.045Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.310Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "DxhjVp-uQtGhRLm1w0xdiA",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.DxhjVp-uQtGhRLm1w0xdiA.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "ENXQRjSMRWyWK_zAEYEoXg": {
+    "exchange": "exchange/taskcluster-queue/v1/task-completed",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T18:24:26.509Z",
+        "expires": "2020-06-25T18:24:26.509Z",
+        "provisionerId": "releng-hardware",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "resolved": "2019-06-26T19:36:06.546Z",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:02:34.936Z",
+            "started": "2019-06-26T19:02:35.542Z",
+            "state": "completed",
+            "takenUntil": "2019-06-26T19:39:35.717Z",
+            "workerGroup": "mdc2",
+            "workerId": "t-yosemite-r7-098"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "completed",
+        "taskGroupId": "HkX-TbGXQaSX4ucqGMQNBA",
+        "taskId": "ENXQRjSMRWyWK_zAEYEoXg",
+        "workerType": "gecko-t-osx-1010"
+      },
+      "version": 1,
+      "workerGroup": "mdc2",
+      "workerId": "t-yosemite-r7-098"
+    },
+    "routes": "primary.ENXQRjSMRWyWK_zAEYEoXg.0.mdc2.t-yosemite-r7-098.releng-hardware.gecko-t-osx-1010.gecko-level-3.HkX-TbGXQaSX4ucqGMQNBA._"
+  },
+  "EvNqsyBISNCH8mwfDVRnSQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-running",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:34:51.217Z",
+        "expires": "2019-07-24T19:34:51.217Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:34:51.541Z",
+            "started": "2019-06-26T19:36:04.733Z",
+            "state": "running",
+            "takenUntil": "2019-06-26T19:56:04.658Z",
+            "workerGroup": "us-west-2",
+            "workerId": "i-062aa60828009efec"
+          }
+        ],
+        "schedulerId": "gecko-level-1",
+        "state": "running",
+        "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "taskId": "EvNqsyBISNCH8mwfDVRnSQ",
+        "workerType": "gecko-1-decision"
+      },
+      "takenUntil": "2019-06-26T19:56:04.658Z",
+      "version": 1,
+      "workerGroup": "us-west-2",
+      "workerId": "i-062aa60828009efec"
+    },
+    "routes": "primary.EvNqsyBISNCH8mwfDVRnSQ.0.us-west-2.i-062aa60828009efec.aws-provisioner-v1.gecko-1-decision.gecko-level-1.VQg1HZ5yS0ixZvsnHLWuFw._"
+  },
+  "F93bme7iSP2k0TsCwqSBVw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:05.949Z",
+        "expires": "2020-06-25T19:14:05.949Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.594Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "F93bme7iSP2k0TsCwqSBVw",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.F93bme7iSP2k0TsCwqSBVw.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "FgjNkrvXS0WDDJJUpVXZsA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:53.207Z",
+        "expires": "2020-06-25T19:13:53.207Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.592Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "FgjNkrvXS0WDDJJUpVXZsA",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.FgjNkrvXS0WDDJJUpVXZsA.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "Fj3fDgrvRXitCVX2RiJUaw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:51.164Z",
+        "expires": "2020-06-25T19:13:51.164Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.584Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "Fj3fDgrvRXitCVX2RiJUaw",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.Fj3fDgrvRXitCVX2RiJUaw.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "FkHz3gGPSVmL6YJOupYBXw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:52.148Z",
+        "expires": "2020-06-25T19:13:52.148Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.583Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "FkHz3gGPSVmL6YJOupYBXw",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.FkHz3gGPSVmL6YJOupYBXw.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "FsgLMdKwRzWJAwUhYy2g0Q": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:00.578Z",
+        "expires": "2020-06-25T19:14:00.578Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.581Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "FsgLMdKwRzWJAwUhYy2g0Q",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.FsgLMdKwRzWJAwUhYy2g0Q.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "GTFxZJWzSKSNc_XElgtWHQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:57.328Z",
+        "expires": "2020-06-25T19:13:57.328Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.849Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "GTFxZJWzSKSNc_XElgtWHQ",
+        "workerType": "gecko-t-linux-xlarge"
+      },
+      "version": 1
+    },
+    "routes": "primary.GTFxZJWzSKSNc_XElgtWHQ.0._._.aws-provisioner-v1.gecko-t-linux-xlarge.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "GWxTc8p_RUa5_Xo4RtMiCA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-completed",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T18:24:27.418Z",
+        "expires": "2020-06-25T18:24:27.418Z",
+        "provisionerId": "terraform-packet",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "resolved": "2019-06-26T19:36:08.596Z",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:00:43.251Z",
+            "started": "2019-06-26T19:16:36.554Z",
+            "state": "completed",
+            "takenUntil": "2019-06-26T19:52:00.203Z",
+            "workerGroup": "packet-sjc1",
+            "workerId": "machine-39"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "completed",
+        "taskGroupId": "HkX-TbGXQaSX4ucqGMQNBA",
+        "taskId": "GWxTc8p_RUa5_Xo4RtMiCA",
+        "workerType": "gecko-t-linux"
+      },
+      "version": 1,
+      "workerGroup": "packet-sjc1",
+      "workerId": "machine-39"
+    },
+    "routes": "primary.GWxTc8p_RUa5_Xo4RtMiCA.0.packet-sjc1.machine-39.terraform-packet.gecko-t-linux.gecko-level-3.HkX-TbGXQaSX4ucqGMQNBA._"
+  },
+  "HsvD9YlDQKaoP4AQsuGeJw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-completed",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T18:24:28.261Z",
+        "expires": "2020-06-25T18:24:28.261Z",
+        "provisionerId": "releng-hardware",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "resolved": "2019-06-26T19:36:07.747Z",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:02:35.164Z",
+            "started": "2019-06-26T19:02:35.860Z",
+            "state": "completed",
+            "takenUntil": "2019-06-26T19:39:36.047Z",
+            "workerGroup": "mdc2",
+            "workerId": "t-yosemite-r7-123"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "completed",
+        "taskGroupId": "HkX-TbGXQaSX4ucqGMQNBA",
+        "taskId": "HsvD9YlDQKaoP4AQsuGeJw",
+        "workerType": "gecko-t-osx-1010"
+      },
+      "version": 1,
+      "workerGroup": "mdc2",
+      "workerId": "t-yosemite-r7-123"
+    },
+    "routes": "primary.HsvD9YlDQKaoP4AQsuGeJw.0.mdc2.t-yosemite-r7-123.releng-hardware.gecko-t-osx-1010.gecko-level-3.HkX-TbGXQaSX4ucqGMQNBA._"
+  },
+  "JKDqO-yySta79-Y92Dq2yQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:54.963Z",
+        "expires": "2020-06-25T19:13:54.963Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.585Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "JKDqO-yySta79-Y92Dq2yQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.JKDqO-yySta79-Y92Dq2yQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "JM6eV6S-R5-Dy08gjoBHrQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:54.670Z",
+        "expires": "2020-06-25T19:13:54.670Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.661Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "JM6eV6S-R5-Dy08gjoBHrQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.JM6eV6S-R5-Dy08gjoBHrQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "K2IZ74mWQfiEn2U6XnVLPQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:50.368Z",
+        "expires": "2020-06-25T19:13:50.368Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.830Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "K2IZ74mWQfiEn2U6XnVLPQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.K2IZ74mWQfiEn2U6XnVLPQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "K5R8rkgARZWMvH4JpmSPrQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:03.581Z",
+        "expires": "2020-06-25T19:14:03.581Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.831Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "K5R8rkgARZWMvH4JpmSPrQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.K5R8rkgARZWMvH4JpmSPrQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "KYZKwkbvRc-qPE22g286yQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-completed",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T18:49:29.995Z",
+        "expires": "2019-07-10T18:49:29.995Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "resolved": "2019-06-26T19:36:04.986Z",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:20:15.078Z",
+            "started": "2019-06-26T19:23:49.524Z",
+            "state": "completed",
+            "takenUntil": "2019-06-26T19:43:49.453Z",
+            "workerGroup": "us-east-1",
+            "workerId": "i-06c2c7e06fc36c6c5"
+          }
+        ],
+        "schedulerId": "gecko-level-1",
+        "state": "completed",
+        "taskGroupId": "CjxziyApQDCcPUMhKFiIGg",
+        "taskId": "KYZKwkbvRc-qPE22g286yQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1,
+      "workerGroup": "us-east-1",
+      "workerId": "i-06c2c7e06fc36c6c5"
+    },
+    "routes": "primary.KYZKwkbvRc-qPE22g286yQ.0.us-east-1.i-06c2c7e06fc36c6c5.aws-provisioner-v1.gecko-t-linux-large.gecko-level-1.CjxziyApQDCcPUMhKFiIGg._"
+  },
+  "KnBj0KLcTjuyNaTxt5LVqw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-running",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:34:52.437Z",
+        "expires": "2019-07-24T19:34:52.437Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:34:52.778Z",
+            "started": "2019-06-26T19:36:05.562Z",
+            "state": "running",
+            "takenUntil": "2019-06-26T19:56:05.473Z",
+            "workerGroup": "us-west-1",
+            "workerId": "i-019077061bddb4fe7"
+          }
+        ],
+        "schedulerId": "gecko-level-1",
+        "state": "running",
+        "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "taskId": "KnBj0KLcTjuyNaTxt5LVqw",
+        "workerType": "gecko-1-decision"
+      },
+      "takenUntil": "2019-06-26T19:56:05.473Z",
+      "version": 1,
+      "workerGroup": "us-west-1",
+      "workerId": "i-019077061bddb4fe7"
+    },
+    "routes": "primary.KnBj0KLcTjuyNaTxt5LVqw.0.us-west-1.i-019077061bddb4fe7.aws-provisioner-v1.gecko-1-decision.gecko-level-1.VQg1HZ5yS0ixZvsnHLWuFw._"
+  },
+  "LBJoI2wUTNCteg-5CnaYZQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-completed",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T18:07:24.073Z",
+        "expires": "2020-06-25T18:07:24.073Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "resolved": "2019-06-26T19:36:09.038Z",
+            "runId": 0,
+            "scheduled": "2019-06-26T18:45:37.148Z",
+            "started": "2019-06-26T18:48:50.697Z",
+            "state": "completed",
+            "takenUntil": "2019-06-26T19:55:01.752Z",
+            "workerGroup": "us-west-1",
+            "workerId": "i-0b63c3556524f5295"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "completed",
+        "taskGroupId": "EJAo7mQyRqS-jmzebhceFA",
+        "taskId": "LBJoI2wUTNCteg-5CnaYZQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1,
+      "workerGroup": "us-west-1",
+      "workerId": "i-0b63c3556524f5295"
+    },
+    "routes": "primary.LBJoI2wUTNCteg-5CnaYZQ.0.us-west-1.i-0b63c3556524f5295.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.EJAo7mQyRqS-jmzebhceFA._"
+  },
+  "LWArw4t5QaCHiHsEJo6hFA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-running",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:34:52.581Z",
+        "expires": "2019-07-24T19:34:52.581Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:34:52.962Z",
+            "started": "2019-06-26T19:36:07.062Z",
+            "state": "running",
+            "takenUntil": "2019-06-26T19:56:06.990Z",
+            "workerGroup": "us-west-1",
+            "workerId": "i-0be69dc84b0354bde"
+          }
+        ],
+        "schedulerId": "gecko-level-1",
+        "state": "running",
+        "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "taskId": "LWArw4t5QaCHiHsEJo6hFA",
+        "workerType": "gecko-1-decision"
+      },
+      "takenUntil": "2019-06-26T19:56:06.990Z",
+      "version": 1,
+      "workerGroup": "us-west-1",
+      "workerId": "i-0be69dc84b0354bde"
+    },
+    "routes": "primary.LWArw4t5QaCHiHsEJo6hFA.0.us-west-1.i-0be69dc84b0354bde.aws-provisioner-v1.gecko-1-decision.gecko-level-1.VQg1HZ5yS0ixZvsnHLWuFw._"
+  },
+  "MrYMxyDDSwWXJey-uo4T3g": {
+    "exchange": "exchange/taskcluster-queue/v1/task-completed",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T18:07:24.130Z",
+        "expires": "2020-06-25T18:07:24.130Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "resolved": "2019-06-26T19:36:04.439Z",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:18:08.175Z",
+            "started": "2019-06-26T19:18:08.696Z",
+            "state": "completed",
+            "takenUntil": "2019-06-26T19:55:08.710Z",
+            "workerGroup": "us-west-1",
+            "workerId": "i-08b6fd26055d2603e"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "completed",
+        "taskGroupId": "EJAo7mQyRqS-jmzebhceFA",
+        "taskId": "MrYMxyDDSwWXJey-uo4T3g",
+        "workerType": "gecko-t-win10-64-gpu"
+      },
+      "version": 1,
+      "workerGroup": "us-west-1",
+      "workerId": "i-08b6fd26055d2603e"
+    },
+    "routes": "primary.MrYMxyDDSwWXJey-uo4T3g.0.us-west-1.i-08b6fd26055d2603e.aws-provisioner-v1.gecko-t-win10-64-gpu.gecko-level-3.EJAo7mQyRqS-jmzebhceFA._"
+  },
+  "NWz-q9MoSL-WMfO7kiwhtg": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:53.397Z",
+        "expires": "2020-06-25T19:13:53.397Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.615Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "NWz-q9MoSL-WMfO7kiwhtg",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.NWz-q9MoSL-WMfO7kiwhtg.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "OiZYxvi5RfKol0A4SBbvOw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-completed",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T18:53:21.527Z",
+        "expires": "2020-06-25T18:53:21.527Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "resolved": "2019-06-26T19:36:07.112Z",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:14:05.165Z",
+            "started": "2019-06-26T19:14:05.561Z",
+            "state": "completed",
+            "takenUntil": "2019-06-26T19:49:28.461Z",
+            "workerGroup": "us-east-1",
+            "workerId": "i-0d0f91277e3f902cc"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "completed",
+        "taskGroupId": "Vo0j4wv3RFai2uA5IGZ1Cw",
+        "taskId": "OiZYxvi5RfKol0A4SBbvOw",
+        "workerType": "gecko-t-linux-xlarge"
+      },
+      "version": 1,
+      "workerGroup": "us-east-1",
+      "workerId": "i-0d0f91277e3f902cc"
+    },
+    "routes": "primary.OiZYxvi5RfKol0A4SBbvOw.0.us-east-1.i-0d0f91277e3f902cc.aws-provisioner-v1.gecko-t-linux-xlarge.gecko-level-3.Vo0j4wv3RFai2uA5IGZ1Cw._"
+  },
+  "PCVDCxY9QM-lEgaGhrCPrw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-completed",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T17:59:19.096Z",
+        "expires": "2019-07-10T17:59:19.096Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "resolved": "2019-06-26T19:36:10.069Z",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:03:30.162Z",
+            "started": "2019-06-26T19:03:30.706Z",
+            "state": "completed",
+            "takenUntil": "2019-06-26T19:40:32.187Z",
+            "workerGroup": "us-west-1",
+            "workerId": "i-0bd696849d1151857"
+          }
+        ],
+        "schedulerId": "gecko-level-1",
+        "state": "completed",
+        "taskGroupId": "EiRNaGPeQjCB0ceF-A-Kdw",
+        "taskId": "PCVDCxY9QM-lEgaGhrCPrw",
+        "workerType": "gecko-t-win10-64"
+      },
+      "version": 1,
+      "workerGroup": "us-west-1",
+      "workerId": "i-0bd696849d1151857"
+    },
+    "routes": "primary.PCVDCxY9QM-lEgaGhrCPrw.0.us-west-1.i-0bd696849d1151857.aws-provisioner-v1.gecko-t-win10-64.gecko-level-1.EiRNaGPeQjCB0ceF-A-Kdw._"
+  },
+  "Pr3zPNMqS8CAY6hHB_lwow": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:01.910Z",
+        "expires": "2020-06-25T19:14:01.910Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.796Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "Pr3zPNMqS8CAY6hHB_lwow",
+        "workerType": "gecko-t-linux-xlarge"
+      },
+      "version": 1
+    },
+    "routes": "primary.Pr3zPNMqS8CAY6hHB_lwow.0._._.aws-provisioner-v1.gecko-t-linux-xlarge.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "Q5dgajTmQaG3bW8xf8mWRw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:01.491Z",
+        "expires": "2020-06-25T19:14:01.491Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.609Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "Q5dgajTmQaG3bW8xf8mWRw",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.Q5dgajTmQaG3bW8xf8mWRw.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "QDGdgQTQRC2xZNR3Zs_IhA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-completed",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T17:59:20.986Z",
+        "expires": "2019-07-10T17:59:20.986Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "resolved": "2019-06-26T19:36:05.940Z",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:03:30.262Z",
+            "started": "2019-06-26T19:03:30.714Z",
+            "state": "completed",
+            "takenUntil": "2019-06-26T19:40:31.671Z",
+            "workerGroup": "us-west-2",
+            "workerId": "i-0de7ae42ffc13af93"
+          }
+        ],
+        "schedulerId": "gecko-level-1",
+        "state": "completed",
+        "taskGroupId": "EiRNaGPeQjCB0ceF-A-Kdw",
+        "taskId": "QDGdgQTQRC2xZNR3Zs_IhA",
+        "workerType": "gecko-t-win10-64"
+      },
+      "version": 1,
+      "workerGroup": "us-west-2",
+      "workerId": "i-0de7ae42ffc13af93"
+    },
+    "routes": "primary.QDGdgQTQRC2xZNR3Zs_IhA.0.us-west-2.i-0de7ae42ffc13af93.aws-provisioner-v1.gecko-t-win10-64.gecko-level-1.EiRNaGPeQjCB0ceF-A-Kdw._"
+  },
+  "QUhTaNzmR-SnLuVMscnSYA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-running",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:34:53.568Z",
+        "expires": "2019-07-24T19:34:53.568Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:34:53.892Z",
+            "started": "2019-06-26T19:36:08.714Z",
+            "state": "running",
+            "takenUntil": "2019-06-26T19:56:08.643Z",
+            "workerGroup": "us-west-1",
+            "workerId": "i-0da13f5d4e5576fd5"
+          }
+        ],
+        "schedulerId": "gecko-level-1",
+        "state": "running",
+        "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "taskId": "QUhTaNzmR-SnLuVMscnSYA",
+        "workerType": "gecko-1-decision"
+      },
+      "takenUntil": "2019-06-26T19:56:08.643Z",
+      "version": 1,
+      "workerGroup": "us-west-1",
+      "workerId": "i-0da13f5d4e5576fd5"
+    },
+    "routes": "primary.QUhTaNzmR-SnLuVMscnSYA.0.us-west-1.i-0da13f5d4e5576fd5.aws-provisioner-v1.gecko-1-decision.gecko-level-1.VQg1HZ5yS0ixZvsnHLWuFw._"
+  },
+  "QbJceuUbQF-SAHp_tuN4bg": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:00.049Z",
+        "expires": "2020-06-25T19:14:00.049Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.602Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "QbJceuUbQF-SAHp_tuN4bg",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.QbJceuUbQF-SAHp_tuN4bg.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "TNBQvfFkR0KoVFz_7QIkIw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:58.681Z",
+        "expires": "2020-06-25T19:13:58.681Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.506Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "TNBQvfFkR0KoVFz_7QIkIw",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.TNBQvfFkR0KoVFz_7QIkIw.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "TacsT1-FSMia0IGkYP-cTQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:04.882Z",
+        "expires": "2020-06-25T19:14:04.882Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.543Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "TacsT1-FSMia0IGkYP-cTQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.TacsT1-FSMia0IGkYP-cTQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "TbO_k663R3St6hBFE92StQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:06.786Z",
+        "expires": "2020-06-25T19:14:06.786Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.244Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "TbO_k663R3St6hBFE92StQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.TbO_k663R3St6hBFE92StQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "TwPxQPQiQLC0jwp0Crf4sw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:50.881Z",
+        "expires": "2020-06-25T19:13:50.881Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.271Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "TwPxQPQiQLC0jwp0Crf4sw",
+        "workerType": "gecko-t-linux-xlarge"
+      },
+      "version": 1
+    },
+    "routes": "primary.TwPxQPQiQLC0jwp0Crf4sw.0._._.aws-provisioner-v1.gecko-t-linux-xlarge.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "UAEeps8wSMmoL4r0MdjlXA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-running",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:01.375Z",
+        "expires": "2020-06-25T19:14:01.375Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.212Z",
+            "started": "2019-06-26T19:36:11.065Z",
+            "state": "running",
+            "takenUntil": "2019-06-26T19:56:10.993Z",
+            "workerGroup": "us-west-2",
+            "workerId": "i-07dbb95ac410df8f7"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "running",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "UAEeps8wSMmoL4r0MdjlXA",
+        "workerType": "gecko-t-linux-large"
+      },
+      "takenUntil": "2019-06-26T19:56:10.993Z",
+      "version": 1,
+      "workerGroup": "us-west-2",
+      "workerId": "i-07dbb95ac410df8f7"
+    },
+    "routes": "primary.UAEeps8wSMmoL4r0MdjlXA.0.us-west-2.i-07dbb95ac410df8f7.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "UWjPMpssTgq0kA7hj9QtJw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:53.237Z",
+        "expires": "2020-06-25T19:13:53.237Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.496Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "UWjPMpssTgq0kA7hj9QtJw",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.UWjPMpssTgq0kA7hj9QtJw.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "UZ37gpDqTRS1pBNnp0Spsg": {
+    "exchange": "exchange/taskcluster-queue/v1/task-completed",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T18:24:20.696Z",
+        "expires": "2020-06-25T18:24:20.696Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "resolved": "2019-06-26T19:36:08.133Z",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:12:27.722Z",
+            "started": "2019-06-26T19:12:28.309Z",
+            "state": "completed",
+            "takenUntil": "2019-06-26T19:47:52.065Z",
+            "workerGroup": "us-west-2",
+            "workerId": "i-0d6489faaf7371ecb"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "completed",
+        "taskGroupId": "HkX-TbGXQaSX4ucqGMQNBA",
+        "taskId": "UZ37gpDqTRS1pBNnp0Spsg",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1,
+      "workerGroup": "us-west-2",
+      "workerId": "i-0d6489faaf7371ecb"
+    },
+    "routes": "primary.UZ37gpDqTRS1pBNnp0Spsg.0.us-west-2.i-0d6489faaf7371ecb.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.HkX-TbGXQaSX4ucqGMQNBA._"
+  },
+  "UoGLhHlwT4mH3h3ukcm_Ig": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:02.299Z",
+        "expires": "2020-06-25T19:14:02.299Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.676Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "UoGLhHlwT4mH3h3ukcm_Ig",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.UoGLhHlwT4mH3h3ukcm_Ig.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "UxS4jt6lQdyUYnPcmN-z-w": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:50.335Z",
+        "expires": "2020-06-25T19:13:50.335Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.380Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "UxS4jt6lQdyUYnPcmN-z-w",
+        "workerType": "gecko-t-linux-xlarge"
+      },
+      "version": 1
+    },
+    "routes": "primary.UxS4jt6lQdyUYnPcmN-z-w.0._._.aws-provisioner-v1.gecko-t-linux-xlarge.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "VGU4RUKFScaK8eBikMi9IQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:57.321Z",
+        "expires": "2020-06-25T19:13:57.321Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.475Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "VGU4RUKFScaK8eBikMi9IQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.VGU4RUKFScaK8eBikMi9IQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "VqbRb6bZSlywWOQN62tk-g": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:00.780Z",
+        "expires": "2020-06-25T19:14:00.780Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.485Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "VqbRb6bZSlywWOQN62tk-g",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.VqbRb6bZSlywWOQN62tk-g.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "VspVGZYjSAqqsg6CGgv-rw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:51.089Z",
+        "expires": "2020-06-25T19:13:51.089Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.412Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "VspVGZYjSAqqsg6CGgv-rw",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.VspVGZYjSAqqsg6CGgv-rw.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "WkFYxflwT76VzWNc6hryiQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:59.334Z",
+        "expires": "2020-06-25T19:13:59.334Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.434Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "WkFYxflwT76VzWNc6hryiQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.WkFYxflwT76VzWNc6hryiQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "XOw2FYEdSb2hwS_lj2bDAg": {
+    "exchange": "exchange/taskcluster-queue/v1/task-running",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:34:51.304Z",
+        "expires": "2019-07-24T19:34:51.304Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:34:51.645Z",
+            "started": "2019-06-26T19:36:05.551Z",
+            "state": "running",
+            "takenUntil": "2019-06-26T19:56:05.471Z",
+            "workerGroup": "us-west-1",
+            "workerId": "i-019077061bddb4fe7"
+          }
+        ],
+        "schedulerId": "gecko-level-1",
+        "state": "running",
+        "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "taskId": "XOw2FYEdSb2hwS_lj2bDAg",
+        "workerType": "gecko-1-decision"
+      },
+      "takenUntil": "2019-06-26T19:56:05.471Z",
+      "version": 1,
+      "workerGroup": "us-west-1",
+      "workerId": "i-019077061bddb4fe7"
+    },
+    "routes": "primary.XOw2FYEdSb2hwS_lj2bDAg.0.us-west-1.i-019077061bddb4fe7.aws-provisioner-v1.gecko-1-decision.gecko-level-1.VQg1HZ5yS0ixZvsnHLWuFw._"
+  },
+  "XQdfjjACRJCmpqKjLxLRXA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:54.967Z",
+        "expires": "2020-06-25T19:13:54.967Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.418Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "XQdfjjACRJCmpqKjLxLRXA",
+        "workerType": "gecko-t-linux-xlarge"
+      },
+      "version": 1
+    },
+    "routes": "primary.XQdfjjACRJCmpqKjLxLRXA.0._._.aws-provisioner-v1.gecko-t-linux-xlarge.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "XiZuJW7MQ-GrC7iV81YWdw": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:03.175Z",
+        "expires": "2020-06-25T19:14:03.175Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.351Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "XiZuJW7MQ-GrC7iV81YWdw",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.XiZuJW7MQ-GrC7iV81YWdw.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "Xxznj5R9QCS-7iqptegltQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:52.515Z",
+        "expires": "2020-06-25T19:13:52.515Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.362Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "Xxznj5R9QCS-7iqptegltQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.Xxznj5R9QCS-7iqptegltQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "Y32tr9w0Tlu67dz74wiCyg": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:57.583Z",
+        "expires": "2020-06-25T19:13:57.583Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.359Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "Y32tr9w0Tlu67dz74wiCyg",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.Y32tr9w0Tlu67dz74wiCyg.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "Y6Zdr078RvemM_nabfiE3A": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:51.713Z",
+        "expires": "2020-06-25T19:13:51.713Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.398Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "Y6Zdr078RvemM_nabfiE3A",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.Y6Zdr078RvemM_nabfiE3A.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "YUU6v89vRd669kauRLNk5g": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:53.839Z",
+        "expires": "2020-06-25T19:13:53.839Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.343Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "YUU6v89vRd669kauRLNk5g",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.YUU6v89vRd669kauRLNk5g.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "YYCniY1ITuGl0fRNghknlQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:51.319Z",
+        "expires": "2020-06-25T19:13:51.319Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.635Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "YYCniY1ITuGl0fRNghknlQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.YYCniY1ITuGl0fRNghknlQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "YgnJMukTS0efJHzTI5_AnA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:00.375Z",
+        "expires": "2020-06-25T19:14:00.375Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.400Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "YgnJMukTS0efJHzTI5_AnA",
+        "workerType": "gecko-t-linux-xlarge"
+      },
+      "version": 1
+    },
+    "routes": "primary.YgnJMukTS0efJHzTI5_AnA.0._._.aws-provisioner-v1.gecko-t-linux-xlarge.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "ZPrilAZcSimdmLj9flM24w": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:58.724Z",
+        "expires": "2020-06-25T19:13:58.724Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.392Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "ZPrilAZcSimdmLj9flM24w",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.ZPrilAZcSimdmLj9flM24w.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "ZnJOMTOcRwCZG09VY4InxQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:55.325Z",
+        "expires": "2020-06-25T19:13:55.325Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.489Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "ZnJOMTOcRwCZG09VY4InxQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.ZnJOMTOcRwCZG09VY4InxQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "ZyNAZZR0SmOcgqC_k_wqsQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-completed",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:47.872Z",
+        "expires": "2020-06-25T19:13:47.872Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "resolved": "2019-06-26T19:36:06.809Z",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:14:55.917Z",
+            "started": "2019-06-26T19:14:56.370Z",
+            "state": "completed",
+            "takenUntil": "2019-06-26T19:50:20.078Z",
+            "workerGroup": "us-west-2",
+            "workerId": "i-01e55895145a2d19c"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "completed",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "ZyNAZZR0SmOcgqC_k_wqsQ",
+        "workerType": "gecko-3-b-linux"
+      },
+      "version": 1,
+      "workerGroup": "us-west-2",
+      "workerId": "i-01e55895145a2d19c"
+    },
+    "routes": "primary.ZyNAZZR0SmOcgqC_k_wqsQ.0.us-west-2.i-01e55895145a2d19c.aws-provisioner-v1.gecko-3-b-linux.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "a1uUehQvSciykK6DUUNQbQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:51.060Z",
+        "expires": "2020-06-25T19:13:51.060Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.365Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "a1uUehQvSciykK6DUUNQbQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.a1uUehQvSciykK6DUUNQbQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "a5UF8fEyQw-fx_32Qo-WjQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-running",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T18:24:21.426Z",
+        "expires": "2020-06-25T18:24:21.426Z",
+        "provisionerId": "proj-autophone",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:13:37.621Z",
+            "started": "2019-06-26T19:36:09.832Z",
+            "state": "running",
+            "takenUntil": "2019-06-26T19:56:09.761Z",
+            "workerGroup": "bitbar",
+            "workerId": "pixel2-44"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "running",
+        "taskGroupId": "HkX-TbGXQaSX4ucqGMQNBA",
+        "taskId": "a5UF8fEyQw-fx_32Qo-WjQ",
+        "workerType": "gecko-t-bitbar-gw-perf-p2"
+      },
+      "takenUntil": "2019-06-26T19:56:09.761Z",
+      "version": 1,
+      "workerGroup": "bitbar",
+      "workerId": "pixel2-44"
+    },
+    "routes": "primary.a5UF8fEyQw-fx_32Qo-WjQ.0.bitbar.pixel2-44.proj-autophone.gecko-t-bitbar-gw-perf-p2.gecko-level-3.HkX-TbGXQaSX4ucqGMQNBA._"
+  },
+  "aNf8J_ctQp6IjWJTxCAPbQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:01.381Z",
+        "expires": "2020-06-25T19:14:01.381Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.395Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "aNf8J_ctQp6IjWJTxCAPbQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.aNf8J_ctQp6IjWJTxCAPbQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "aNlE6teASbGqtSK4XSeMkg": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:01.728Z",
+        "expires": "2020-06-25T19:14:01.728Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.332Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "aNlE6teASbGqtSK4XSeMkg",
+        "workerType": "gecko-t-linux-xlarge"
+      },
+      "version": 1
+    },
+    "routes": "primary.aNlE6teASbGqtSK4XSeMkg.0._._.aws-provisioner-v1.gecko-t-linux-xlarge.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "ac7vsMLASl6XS1O_VzlLXQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:56.844Z",
+        "expires": "2020-06-25T19:13:56.844Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.329Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "ac7vsMLASl6XS1O_VzlLXQ",
+        "workerType": "gecko-t-linux-xlarge"
+      },
+      "version": 1
+    },
+    "routes": "primary.ac7vsMLASl6XS1O_VzlLXQ.0._._.aws-provisioner-v1.gecko-t-linux-xlarge.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "aeWDjRcUQhudU4axBiCQ8A": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:50.117Z",
+        "expires": "2020-06-25T19:13:50.117Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.327Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "aeWDjRcUQhudU4axBiCQ8A",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.aeWDjRcUQhudU4axBiCQ8A.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "b0DpnSIQQymnTTSXxRWmmg": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:51.395Z",
+        "expires": "2020-06-25T19:13:51.395Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.518Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "b0DpnSIQQymnTTSXxRWmmg",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.b0DpnSIQQymnTTSXxRWmmg.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "ba34BnYgT_mv1g5BvrlXnQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:14:04.804Z",
+        "expires": "2020-06-25T19:14:04.804Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.718Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "ba34BnYgT_mv1g5BvrlXnQ",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.ba34BnYgT_mv1g5BvrlXnQ.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "c9SSXwx3TnKm7MnNEit0OA": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:51.441Z",
+        "expires": "2020-06-25T19:13:51.441Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.473Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "c9SSXwx3TnKm7MnNEit0OA",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.c9SSXwx3TnKm7MnNEit0OA.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "dUcobAuPTEqHok4rpJl1Dg": {
+    "exchange": "exchange/taskcluster-queue/v1/task-pending",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:13:57.869Z",
+        "expires": "2020-06-25T19:13:57.869Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:36:10.716Z",
+            "state": "pending"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "pending",
+        "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+        "taskId": "dUcobAuPTEqHok4rpJl1Dg",
+        "workerType": "gecko-t-linux-large"
+      },
+      "version": 1
+    },
+    "routes": "primary.dUcobAuPTEqHok4rpJl1Dg.0._._.aws-provisioner-v1.gecko-t-linux-large.gecko-level-3.XrWNyFwpT2in-wLY9frb-w._"
+  },
+  "eokGh4-OSbOqAzVhJypYPg": {
+    "exchange": "exchange/taskcluster-queue/v1/task-completed",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T18:21:52.288Z",
+        "expires": "2020-06-25T18:21:52.288Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "resolved": "2019-06-26T19:36:06.943Z",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:14:22.604Z",
+            "started": "2019-06-26T19:14:22.989Z",
+            "state": "completed",
+            "takenUntil": "2019-06-26T19:51:24.156Z",
+            "workerGroup": "eu-central-1",
+            "workerId": "i-09f5a2a05cb655f08"
+          }
+        ],
+        "schedulerId": "gecko-level-3",
+        "state": "completed",
+        "taskGroupId": "UuixJvjhQU6rf9aGtGo9Wg",
+        "taskId": "eokGh4-OSbOqAzVhJypYPg",
+        "workerType": "gecko-t-win7-32"
+      },
+      "version": 1,
+      "workerGroup": "eu-central-1",
+      "workerId": "i-09f5a2a05cb655f08"
+    },
+    "routes": "primary.eokGh4-OSbOqAzVhJypYPg.0.eu-central-1.i-09f5a2a05cb655f08.aws-provisioner-v1.gecko-t-win7-32.gecko-level-3.UuixJvjhQU6rf9aGtGo9Wg._"
+  },
+  "eugCBPRNRD-zyP_I9Jcn1w": {
+    "exchange": "exchange/taskcluster-queue/v1/task-running",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:34:52.653Z",
+        "expires": "2019-07-24T19:34:52.653Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:34:52.968Z",
+            "started": "2019-06-26T19:36:07.061Z",
+            "state": "running",
+            "takenUntil": "2019-06-26T19:56:06.988Z",
+            "workerGroup": "us-west-1",
+            "workerId": "i-0be69dc84b0354bde"
+          }
+        ],
+        "schedulerId": "gecko-level-1",
+        "state": "running",
+        "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "taskId": "eugCBPRNRD-zyP_I9Jcn1w",
+        "workerType": "gecko-1-decision"
+      },
+      "takenUntil": "2019-06-26T19:56:06.988Z",
+      "version": 1,
+      "workerGroup": "us-west-1",
+      "workerId": "i-0be69dc84b0354bde"
+    },
+    "routes": "primary.eugCBPRNRD-zyP_I9Jcn1w.0.us-west-1.i-0be69dc84b0354bde.aws-provisioner-v1.gecko-1-decision.gecko-level-1.VQg1HZ5yS0ixZvsnHLWuFw._"
+  },
+  "fu4duSjBRte-V6y_oQ_BrQ": {
+    "exchange": "exchange/taskcluster-queue/v1/task-running",
+    "payload": {
+      "runId": 0,
+      "status": {
+        "deadline": "2019-06-27T19:34:50.888Z",
+        "expires": "2019-07-24T19:34:50.888Z",
+        "provisionerId": "aws-provisioner-v1",
+        "retriesLeft": 5,
+        "runs": [
+          {
+            "reasonCreated": "scheduled",
+            "runId": 0,
+            "scheduled": "2019-06-26T19:34:51.210Z",
+            "started": "2019-06-26T19:36:04.735Z",
+            "state": "running",
+            "takenUntil": "2019-06-26T19:56:04.660Z",
+            "workerGroup": "us-west-2",
+            "workerId": "i-062aa60828009efec"
+          }
+        ],
+        "schedulerId": "gecko-level-1",
+        "state": "running",
+        "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "taskId": "fu4duSjBRte-V6y_oQ_BrQ",
+        "workerType": "gecko-1-decision"
+      },
+      "takenUntil": "2019-06-26T19:56:04.660Z",
+      "version": 1,
+      "workerGroup": "us-west-2",
+      "workerId": "i-062aa60828009efec"
+    },
+    "routes": "primary.fu4duSjBRte-V6y_oQ_BrQ.0.us-west-2.i-062aa60828009efec.aws-provisioner-v1.gecko-1-decision.gecko-level-1.VQg1HZ5yS0ixZvsnHLWuFw._"
+  }
+}

--- a/tests/sample_data/pulse_consumer/taskcluster_tasks.json
+++ b/tests/sample_data/pulse_consumer/taskcluster_tasks.json
@@ -1,0 +1,12739 @@
+{
+  "A35mWTRuQmyj88yMnIF0fA": {
+    "created": "2019-06-26T19:13:51.402Z",
+    "deadline": "2019-06-27T19:13:51.402Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:51.402Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 1
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-a11y",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests without e10s",
+        "groupSymbol": "M-1proc",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "a11y",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Mochitest a11y run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-mochitest-a11y-1proc",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:51.402Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:51.402Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:51.402Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-a11y",
+        "--disable-e10s",
+        "--allow-software-gl-layers",
+        "--enable-webrender",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "false",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "a11y",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.08ebb5cd87414d33497e"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.08ebb5cd87414d33497e"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-mochitest-a11y-1proc",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "A3dJ8bDIQRKzHiZBhM0c5Q": {
+    "created": "2019-06-26T19:13:55.010Z",
+    "deadline": "2019-06-27T19:13:55.010Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:55.010Z",
+    "extra": {
+      "chunks": {
+        "current": 13,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-browser-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "bc13",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest browser-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-13",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:55.010Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:55.010Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:55.010Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-browser-chrome-chunked",
+        "--total-chunk=16",
+        "--this-chunk=13",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "browser",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.ab24bc45dca9600e59fc"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.ab24bc45dca9600e59fc"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-browser-chrome-e10s-13",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "A47ePPIaRFOWxw8oVOvmCA": {
+    "created": "2019-06-26T19:13:52.809Z",
+    "deadline": "2019-06-27T19:13:52.809Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:52.809Z",
+    "extra": {
+      "chunks": {
+        "current": 2,
+        "total": 3
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-media",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests with socket process",
+        "groupSymbol": "M-spi",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "mda2",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Mochitest media run with socket process enabled ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-mochitest-media-spi-e10s-2",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:52.809Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:52.809Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:52.809Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-media",
+        "--setpref=\"media.peerconnection.mtransport_process=true\"",
+        "--setpref=\"network.process.enabled=true\"",
+        "--allow-software-gl-layers",
+        "--enable-webrender",
+        "--total-chunk=3",
+        "--this-chunk=2",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.9b893027c3f91c317569"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.9b893027c3f91c317569"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-mochitest-media-spi-e10s-2",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "A4AV9EXXREGCV-hVKT0blQ": {
+    "created": "2019-06-26T19:14:04.633Z",
+    "deadline": "2019-06-27T19:14:04.633Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:04.633Z",
+    "extra": {
+      "chunks": {
+        "current": 5,
+        "total": 6
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "xpcshell",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Xpcshell tests",
+        "groupSymbol": "X",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "X5",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "xpcshell test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-xpcshell-e10s-5",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:04.633Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:04.633Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:04.633Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--xpcshell-suite=xpcshell",
+        "--enable-webrender",
+        "--total-chunk=6",
+        "--this-chunk=5",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.92e90b7c49144817e627"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.92e90b7c49144817e627"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-xpcshell-e10s-5",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "ADfskOGaS7KUj0AuUb324A": {
+    "created": "2019-06-26T19:13:59.107Z",
+    "deadline": "2019-06-27T19:13:59.107Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:59.107Z",
+    "extra": {
+      "chunks": {
+        "current": 2,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-browser-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "bc2",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest browser-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-2",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:59.107Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:59.107Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:59.107Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-browser-chrome-chunked",
+        "--total-chunk=16",
+        "--this-chunk=2",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "browser",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.bf7eb29b94d7714b45a9"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.bf7eb29b94d7714b45a9"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-browser-chrome-e10s-2",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "AcUWtRf7QB-4XQS8nSTilg": {
+    "created": "2019-06-26T19:13:58.734Z",
+    "deadline": "2019-06-27T19:13:58.734Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:58.734Z",
+    "extra": {
+      "chunks": {
+        "current": 3,
+        "total": 6
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "xpcshell",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Xpcshell tests",
+        "groupSymbol": "X",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "X3",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "xpcshell test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-xpcshell-e10s-3",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:58.734Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:58.734Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:58.734Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--xpcshell-suite=xpcshell",
+        "--total-chunk=6",
+        "--this-chunk=3",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.adff7c9469f3c744cb0d"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.adff7c9469f3c744cb0d"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-xpcshell-e10s-3",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "Ai-bmuTzS7eRBYFhSPnZ1w": {
+    "created": "2019-06-26T19:13:58.650Z",
+    "deadline": "2019-06-27T19:13:58.650Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:58.650Z",
+    "extra": {
+      "chunks": {
+        "current": 7,
+        "total": 12
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-devtools-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "dt7",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest devtools-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-devtools-chrome-e10s-7",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:58.650Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:58.650Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:58.650Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-devtools-chrome-chunked",
+        "--total-chunk=12",
+        "--this-chunk=7",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "chrome",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.1056f136139b114cdde0"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.1056f136139b114cdde0"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-devtools-chrome-e10s-7",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "AlcvKmrGS8e9FXrFTYnhpA": {
+    "created": "2019-06-26T19:13:55.428Z",
+    "deadline": "2019-06-27T19:13:55.428Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:55.428Z",
+    "extra": {
+      "chunks": {
+        "current": 14,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-browser-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "bc14",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest browser-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-14",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:55.428Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:55.428Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:55.428Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-browser-chrome-chunked",
+        "--total-chunk=16",
+        "--this-chunk=14",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "browser",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.35c180189c365aba1c9f"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.35c180189c365aba1c9f"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-browser-chrome-e10s-14",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "ApotNgqaQh6OGDW8TMSWlQ": {
+    "created": "2019-06-26T19:13:51.072Z",
+    "deadline": "2019-06-27T19:13:51.072Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:51.072Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 1
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "firefox-ui-functional-local",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Firefox functional tests (local)",
+        "groupSymbol": "Fxfn-l",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "en-US",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Firefox-ui-tests functional run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-firefox-ui-functional-local-e10s",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:51.072Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:51.072Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:51.072Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--tag",
+        "local",
+        "--allow-software-gl-layers",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "firefox_ui_tests/taskcluster.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "firefox_ui_tests/functional.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.105d1d71befe3d451a28"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.105d1d71befe3d451a28"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-firefox-ui-functional-local-e10s",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "AqMhSaDqSAG7nfjfxjKLZA": {
+    "created": "2019-06-26T19:13:50.958Z",
+    "deadline": "2019-06-27T19:13:50.958Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:50.958Z",
+    "extra": {
+      "chunks": {
+        "current": 2,
+        "total": 12
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-devtools-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "dt2",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest devtools-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-devtools-chrome-e10s-2",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:50.958Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:50.958Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:50.958Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-devtools-chrome-chunked",
+        "--total-chunk=12",
+        "--this-chunk=2",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "chrome",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.b64c5141bbc1fce620bb"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.b64c5141bbc1fce620bb"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-devtools-chrome-e10s-2",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "AseHcKjPRhi-NBsvwH54gw": {
+    "created": "2019-06-26T19:13:51.304Z",
+    "deadline": "2019-06-27T19:13:51.304Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:51.304Z",
+    "extra": {
+      "chunks": {
+        "current": 2,
+        "total": 6
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "xpcshell",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Xpcshell tests",
+        "groupSymbol": "X",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "X2",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "xpcshell test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-xpcshell-e10s-2",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:51.304Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:51.304Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:51.304Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--xpcshell-suite=xpcshell",
+        "--enable-webrender",
+        "--total-chunk=6",
+        "--this-chunk=2",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.e7524edb38455e2992e3"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.e7524edb38455e2992e3"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-xpcshell-e10s-2",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "B3EheQ-IQ5aPzw34KS_a6g": {
+    "created": "2019-06-26T18:07:13.543Z",
+    "deadline": "2019-06-27T18:07:13.543Z",
+    "dependencies": ["TzMuMosKQpuBq4eIRzpjHw"],
+    "expires": "2020-06-25T18:07:13.543Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 1
+      },
+      "index": {
+        "rank": 1561572308
+      },
+      "parent": "EJAo7mQyRqS-jmzebhceFA",
+      "suite": "raptor",
+      "treeherder": {
+        "collection": {
+          "opt": true
+        },
+        "groupName": "Raptor performance tests on Firefox",
+        "groupSymbol": "Rap",
+        "jobKind": "test",
+        "machine": {
+          "platform": "macosx1014-64-shippable"
+        },
+        "symbol": "tp6-7",
+        "tier": 1
+      },
+      "treeherder-platform": "macosx1014-64-shippable/opt"
+    },
+    "metadata": {
+      "description": "Raptor tp6-7 on Firefox ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=918d7c84da371bda26460fb4b50f161d32107880))",
+      "name": "test-macosx1014-64-shippable/opt-raptor-tp6-7-firefox-e10s",
+      "owner": "malexandru@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/918d7c84da371bda26460fb4b50f161d32107880/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": [
+        {
+          "name": "public/logs",
+          "path": "logs",
+          "type": "directory"
+        },
+        {
+          "name": "public/test_info",
+          "path": "build/blobber_upload_dir",
+          "type": "directory"
+        }
+      ],
+      "command": [
+        [
+          "/usr/local/bin/python2",
+          "-u",
+          "mozharness/scripts/raptor_script.py",
+          "--cfg",
+          "mozharness/configs/raptor/mac_config.py",
+          "--test=raptor-tp6-7",
+          "--download-symbols",
+          "ondemand",
+          "--test=raptor-tp6-7"
+        ]
+      ],
+      "env": {
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/TzMuMosKQpuBq4eIRzpjHw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/TzMuMosKQpuBq4eIRzpjHw/artifacts/public/build/target.dmg\"}",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "918d7c84da371bda26460fb4b50f161d32107880",
+        "IDLEIZER_DISABLE_SHUTDOWN": "true",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US.UTF-8",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_HIDE_RESULTS_TABLE": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_NO_REMOTE": "1",
+        "NO_FAIL_ON_TEST_ERRORS": "1",
+        "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+        "SCCACHE_DISABLE": "1",
+        "SHELL": "/bin/bash",
+        "XPCOM_DEBUG_BREAK": "warn",
+        "XPC_FLAGS": "0x0",
+        "XPC_SERVICE_NAME": "0"
+      },
+      "maxRunTime": 1800,
+      "mounts": [
+        {
+          "content": {
+            "artifact": "public/build/mozharness.zip",
+            "taskId": "TzMuMosKQpuBq4eIRzpjHw"
+          },
+          "directory": ".",
+          "format": "zip"
+        }
+      ],
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.ad4d17939e66b6b24091"
+    },
+    "priority": "low",
+    "provisionerId": "releng-hardware",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.918d7c84da371bda26460fb4b50f161d32107880.88554",
+      "coalesce.v1.autoland.ad4d17939e66b6b24091"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [],
+    "tags": {
+      "createdForUser": "malexandru@mozilla.com",
+      "kind": "test",
+      "label": "test-macosx1014-64-shippable/opt-raptor-tp6-7-firefox-e10s",
+      "os": "macosx",
+      "retrigger": "true",
+      "test-type": "raptor",
+      "worker-implementation": "generic-worker"
+    },
+    "taskGroupId": "EJAo7mQyRqS-jmzebhceFA",
+    "workerType": "gecko-t-osx-1014"
+  },
+  "BFqlkKMaTVqv3ROSlUT6kQ": {
+    "created": "2019-06-26T19:13:56.048Z",
+    "deadline": "2019-06-27T19:13:56.048Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:56.048Z",
+    "extra": {
+      "chunks": {
+        "current": 7,
+        "total": 18
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "web-platform-tests",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Web platform tests",
+        "groupSymbol": "W",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "wpt7",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-web-platform-tests-e10s-7",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:56.048Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:56.048Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:56.048Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--test-type=testharness",
+        "--allow-software-gl-layers",
+        "--total-chunk=18",
+        "--this-chunk=7",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 7200,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.e8a55860fd9342477326"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.e8a55860fd9342477326"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-web-platform-tests-e10s-7",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-xlarge"
+  },
+  "BHejD_RvTW2HR2THXfwDAQ": {
+    "created": "2019-06-26T19:14:03.313Z",
+    "deadline": "2019-06-27T19:14:03.313Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:03.313Z",
+    "extra": {
+      "chunks": {
+        "current": 11,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-plain-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "11",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest plain run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-e10s-11",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:03.313Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:03.313Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:03.313Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-plain-chunked",
+        "--total-chunk=16",
+        "--this-chunk=11",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.865676786fd009ca052d"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.865676786fd009ca052d"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-e10s-11",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "BXWMaUV7TCunBcJQELbZqw": {
+    "created": "2019-06-26T19:14:01.506Z",
+    "deadline": "2019-06-27T19:14:01.506Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:01.506Z",
+    "extra": {
+      "chunks": {
+        "current": 6,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-browser-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "bc6",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest browser-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-6",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:01.506Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:01.506Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:01.506Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-browser-chrome-chunked",
+        "--total-chunk=16",
+        "--this-chunk=6",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "browser",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.1b164a1cee7ae76f4c16"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.1b164a1cee7ae76f4c16"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-browser-chrome-e10s-6",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "BZuYb2PTTQ-opGzxvZvA9A": {
+    "created": "2019-06-26T19:13:56.160Z",
+    "deadline": "2019-06-27T19:13:56.160Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:56.160Z",
+    "extra": {
+      "chunks": {
+        "current": 14,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-plain-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "14",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Mochitest plain run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-mochitest-e10s-14",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:56.160Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:56.160Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:56.160Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-plain-chunked",
+        "--enable-webrender",
+        "--total-chunk=16",
+        "--this-chunk=14",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.50be16cedff97918eb4b"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.50be16cedff97918eb4b"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-mochitest-e10s-14",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "BdHfGUHPTLm0IKz47oNJlA": {
+    "created": "2019-06-26T19:13:58.716Z",
+    "deadline": "2019-06-27T19:13:58.716Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:58.716Z",
+    "extra": {
+      "chunks": {
+        "current": 2,
+        "total": 3
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-media",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests with socket process",
+        "groupSymbol": "M-spi",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "mda2",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest media run with socket process enabled ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-media-spi-e10s-2",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:58.716Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:58.716Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:58.716Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-media",
+        "--setpref=\"media.peerconnection.mtransport_process=true\"",
+        "--setpref=\"network.process.enabled=true\"",
+        "--allow-software-gl-layers",
+        "--total-chunk=3",
+        "--this-chunk=2",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.1ad6c8e66f1c96c17832"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.1ad6c8e66f1c96c17832"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-media-spi-e10s-2",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "BdHy_4vQSA2ZQoxXc-6ieA": {
+    "created": "2019-06-26T19:13:51.194Z",
+    "deadline": "2019-06-27T19:13:51.194Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:51.194Z",
+    "extra": {
+      "chunks": {
+        "current": 5,
+        "total": 8
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "reftest",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Reftests",
+        "groupSymbol": "R",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "R5",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Reftest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-reftest-e10s-5",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:51.194Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:51.194Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:51.194Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--reftest-suite=reftest",
+        "--allow-software-gl-layers",
+        "--total-chunk=8",
+        "--this-chunk=5",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.03fe3223e5bf21b256c4"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.03fe3223e5bf21b256c4"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-reftest-e10s-5",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "reftest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "BfEK00F_TSm20TD799GdMw": {
+    "created": "2019-06-26T19:14:05.356Z",
+    "deadline": "2019-06-27T19:14:05.356Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:05.356Z",
+    "extra": {
+      "chunks": {
+        "current": 3,
+        "total": 4
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "web-platform-tests-reftests",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Web platform tests",
+        "groupSymbol": "W",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "Wr3",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Web platform reftest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-web-platform-tests-reftests-e10s-3",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:05.356Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:05.356Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:05.356Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--test-type=reftest",
+        "--allow-software-gl-layers",
+        "--total-chunk=4",
+        "--this-chunk=3",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.32d4be2dc8b86b3dad36"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.32d4be2dc8b86b3dad36"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-web-platform-tests-reftests-e10s-3",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-xlarge"
+  },
+  "Bg8h-Ct_SPSrEEYuvPAYSQ": {
+    "created": "2019-06-26T19:13:54.997Z",
+    "deadline": "2019-06-27T19:13:54.997Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:54.997Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 3
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-media",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests with socket process",
+        "groupSymbol": "M-spi",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "mda1",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest media run with socket process enabled ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-media-spi-e10s-1",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:54.997Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:54.997Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:54.997Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-media",
+        "--setpref=\"media.peerconnection.mtransport_process=true\"",
+        "--setpref=\"network.process.enabled=true\"",
+        "--allow-software-gl-layers",
+        "--total-chunk=3",
+        "--this-chunk=1",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.a9cc27c1e81cf4a04a7c"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.a9cc27c1e81cf4a04a7c"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-media-spi-e10s-1",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "BpnQqda2Q0izXw4k0RUT6w": {
+    "created": "2019-06-26T19:13:55.682Z",
+    "deadline": "2019-06-27T19:13:55.682Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:55.682Z",
+    "extra": {
+      "chunks": {
+        "current": 4,
+        "total": 8
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "reftest-no-accel",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Reftests",
+        "groupSymbol": "R",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "Ru4",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Reftest not accelerated run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-reftest-no-accel-e10s-4",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:55.682Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:55.682Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:55.682Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--reftest-suite=reftest-no-accel",
+        "--allow-software-gl-layers",
+        "--total-chunk=8",
+        "--this-chunk=4",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.b87f180d978e1bd5986a"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.b87f180d978e1bd5986a"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-reftest-no-accel-e10s-4",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "reftest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "CBO2K8XGQEaNpX1BkwJmNw": {
+    "created": "2019-06-26T19:13:51.316Z",
+    "deadline": "2019-06-27T19:13:51.316Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:51.316Z",
+    "extra": {
+      "chunks": {
+        "current": 3,
+        "total": 3
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-media",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests with socket process",
+        "groupSymbol": "M-spi",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "mda3",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Mochitest media run with socket process enabled ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-mochitest-media-spi-e10s-3",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:51.316Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:51.316Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:51.316Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-media",
+        "--setpref=\"media.peerconnection.mtransport_process=true\"",
+        "--setpref=\"network.process.enabled=true\"",
+        "--allow-software-gl-layers",
+        "--enable-webrender",
+        "--total-chunk=3",
+        "--this-chunk=3",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.44230ab257487aa20074"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.44230ab257487aa20074"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-mochitest-media-spi-e10s-3",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "CER7YmG9QmCd-R66vfWkVQ": {
+    "created": "2019-06-26T19:34:53.754Z",
+    "deadline": "2019-06-27T19:34:53.754Z",
+    "dependencies": [],
+    "expires": "2019-07-24T19:34:53.754Z",
+    "extra": {
+      "action": {
+        "context": {
+          "clientId": "mozilla-auth0/ad|Mozilla-LDAP|mshal",
+          "input": {
+            "requests": [
+              {
+                "tasks": ["test-linux64-shippable/opt-talos-g4-e10s"],
+                "times": 1
+              }
+            ]
+          },
+          "parameters": {
+            "app_version": "69.0a1",
+            "base_repository": "https://hg.mozilla.org/mozilla-unified",
+            "build_date": 1561510107,
+            "build_number": 1,
+            "do_not_optimize": [],
+            "existing_tasks": {},
+            "filters": ["target_tasks_method"],
+            "head_ref": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "head_repository": "https://hg.mozilla.org/try",
+            "head_rev": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "hg_branch": "default",
+            "level": "1",
+            "message": "try: -b o -p linux64-shippable -u none -t all",
+            "moz_build_date": "20190626004827",
+            "next_version": null,
+            "optimize_target_tasks": true,
+            "owner": "mshal@mozilla.com",
+            "phabricator_diff": null,
+            "project": "try",
+            "pushdate": 1561510107,
+            "pushlog_id": "381863",
+            "release_enable_emefree": false,
+            "release_enable_partners": false,
+            "release_eta": "",
+            "release_history": {},
+            "release_partner_build_number": 1,
+            "release_partner_config": {},
+            "release_partners": [],
+            "release_product": null,
+            "release_type": "",
+            "required_signoffs": [],
+            "signoff_urls": {},
+            "target_tasks_method": "try_tasks",
+            "tasks_for": "hg-push",
+            "try_mode": "try_option_syntax",
+            "try_options": {
+              "artifact": false,
+              "build_types": "o",
+              "env": null,
+              "include_nightly": false,
+              "interactive": false,
+              "jobs": null,
+              "no_retry": false,
+              "notifications": null,
+              "platforms": "linux64-shippable",
+              "profile": false,
+              "raptor": "none",
+              "raptor_trigger_tests": 1,
+              "tag": null,
+              "talos": "all",
+              "talos_trigger_tests": 1,
+              "taskcluster_worker": false,
+              "trigger_tests": 1,
+              "unittests": "none"
+            },
+            "try_task_config": null,
+            "version": "69.0a1"
+          },
+          "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+          "taskId": null
+        },
+        "name": "retrigger-multiple"
+      },
+      "parent": "VQg1HZ5yS0ixZvsnHLWuFw",
+      "tasks_for": "action",
+      "treeherder": {
+        "groupName": "action-callback",
+        "groupSymbol": "AC",
+        "machine": {
+          "platform": "gecko-decision"
+        },
+        "symbol": "rt"
+      }
+    },
+    "metadata": {
+      "description": "Create a clone of the task.\n\nAction triggered by clientID `mozilla-auth0/ad|Mozilla-LDAP|mshal`\n",
+      "name": "Action: Retrigger",
+      "owner": "mozilla-taskcluster-maintenance@mozilla.com",
+      "source": "https://hg.mozilla.org/try/raw-file/cfe6ae48816614025c458223c66ca2a87b673408/.taskcluster.yml"
+    },
+    "payload": {
+      "artifacts": {
+        "public": {
+          "expires": "2019-07-24T19:34:53.754Z",
+          "path": "/builds/worker/artifacts",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "level-1-checkouts-sparse-v2": "/builds/worker/checkouts"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--gecko-checkout=/builds/worker/checkouts/gecko",
+        "--gecko-sparse-profile=build/sparse-profiles/taskgraph",
+        "--",
+        "bash",
+        "-cx",
+        "cd /builds/worker/checkouts/gecko && ln -s /builds/worker/artifacts artifacts && ./mach --log-no-times taskgraph action-callback\n"
+      ],
+      "env": {
+        "ACTION_CALLBACK": "retrigger-multiple",
+        "ACTION_INPUT": "{\"requests\":[{\"tasks\":[\"test-linux64-shippable/opt-talos-g4-e10s\"],\"times\":1}]}",
+        "ACTION_PARAMETERS": "{\"app_version\":\"69.0a1\",\"base_repository\":\"https://hg.mozilla.org/mozilla-unified\",\"build_date\":1561510107,\"build_number\":1,\"do_not_optimize\":[],\"existing_tasks\":{},\"filters\":[\"target_tasks_method\"],\"head_ref\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"head_repository\":\"https://hg.mozilla.org/try\",\"head_rev\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"hg_branch\":\"default\",\"level\":\"1\",\"message\":\"try: -b o -p linux64-shippable -u none -t all\",\"moz_build_date\":\"20190626004827\",\"next_version\":null,\"optimize_target_tasks\":true,\"owner\":\"mshal@mozilla.com\",\"phabricator_diff\":null,\"project\":\"try\",\"pushdate\":1561510107,\"pushlog_id\":\"381863\",\"release_enable_emefree\":false,\"release_enable_partners\":false,\"release_eta\":\"\",\"release_history\":{},\"release_partner_build_number\":1,\"release_partner_config\":{},\"release_partners\":[],\"release_product\":null,\"release_type\":\"\",\"required_signoffs\":[],\"signoff_urls\":{},\"target_tasks_method\":\"try_tasks\",\"tasks_for\":\"hg-push\",\"try_mode\":\"try_option_syntax\",\"try_options\":{\"artifact\":false,\"build_types\":\"o\",\"env\":null,\"include_nightly\":false,\"interactive\":false,\"jobs\":null,\"no_retry\":false,\"notifications\":null,\"platforms\":\"linux64-shippable\",\"profile\":false,\"raptor\":\"none\",\"raptor_trigger_tests\":1,\"tag\":null,\"talos\":\"all\",\"talos_trigger_tests\":1,\"taskcluster_worker\":false,\"trigger_tests\":1,\"unittests\":\"none\"},\"try_task_config\":null,\"version\":\"69.0a1\"}",
+        "ACTION_TASK_GROUP_ID": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "ACTION_TASK_ID": "null",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REF": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+        "GECKO_HEAD_REV": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+        "TASKCLUSTER_PROXY_URL": "http://taskcluster",
+        "TASKCLUSTER_ROOT_URL": "https://taskcluster.net"
+      },
+      "features": {
+        "chainOfTrust": true,
+        "taskclusterProxy": true
+      },
+      "image": "taskcluster/decision:2.2.0@sha256:0e9689e94605eb8395f5b49141a48148416b0d825f6f7be04c29642d1a85ee3d",
+      "maxRunTime": 1800
+    },
+    "priority": "very-low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.try.cfe6ae48816614025c458223c66ca2a87b673408.381863",
+      "index.gecko.v2.try.pushlog-id.381863.actions.CER7YmG9QmCd-R66vfWkVQ"
+    ],
+    "schedulerId": "gecko-level-1",
+    "scopes": ["assume:repo:hg.mozilla.org/try:action:generic"],
+    "tags": {
+      "createdForUser": "mozilla-taskcluster-maintenance@mozilla.com",
+      "kind": "action-callback"
+    },
+    "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+    "workerType": "gecko-1-decision"
+  },
+  "DPCuZCk-SWC6SeftAbytzw": {
+    "created": "2019-06-26T19:14:03.391Z",
+    "deadline": "2019-06-27T19:14:03.391Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:03.391Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 1
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "gtest",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "GTest",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "GTests run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-gtest-1proc",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:03.391Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:03.391Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:03.391Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--gtest-suite=gtest",
+        "--disable-e10s",
+        "--allow-software-gl-layers",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "false",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.d9b544541dfb1793336f"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.d9b544541dfb1793336f"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-gtest-1proc",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-xlarge"
+  },
+  "D_6WScWhTLysuSIkbqfjsg": {
+    "created": "2019-06-26T19:13:51.128Z",
+    "deadline": "2019-06-27T19:13:51.128Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:51.128Z",
+    "extra": {
+      "chunks": {
+        "current": 4,
+        "total": 8
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "reftest",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Reftests",
+        "groupSymbol": "R",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "R4",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Reftest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-reftest-e10s-4",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:51.128Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:51.128Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:51.128Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--reftest-suite=reftest",
+        "--allow-software-gl-layers",
+        "--enable-webrender",
+        "--total-chunk=8",
+        "--this-chunk=4",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.6e8d5bc961d49d83df32"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.6e8d5bc961d49d83df32"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-reftest-e10s-4",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "reftest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "DxhjVp-uQtGhRLm1w0xdiA": {
+    "created": "2019-06-26T19:13:51.045Z",
+    "deadline": "2019-06-27T19:13:51.045Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:51.045Z",
+    "extra": {
+      "chunks": {
+        "current": 3,
+        "total": 6
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "xpcshell",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Xpcshell tests",
+        "groupSymbol": "X",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "X3",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "xpcshell test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-xpcshell-e10s-3",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:51.045Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:51.045Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:51.045Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--xpcshell-suite=xpcshell",
+        "--enable-webrender",
+        "--total-chunk=6",
+        "--this-chunk=3",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.7100b655700515b1e264"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.7100b655700515b1e264"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-xpcshell-e10s-3",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "ENXQRjSMRWyWK_zAEYEoXg": {
+    "created": "2019-06-26T18:24:26.509Z",
+    "deadline": "2019-06-27T18:24:26.509Z",
+    "dependencies": ["QzpBepRjShOI-CoIkWlytA"],
+    "expires": "2020-06-25T18:24:26.509Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 2
+      },
+      "index": {
+        "rank": 1561573344
+      },
+      "parent": "HkX-TbGXQaSX4ucqGMQNBA",
+      "suite": "mochitest-media",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests with socket process",
+        "groupSymbol": "M-spi",
+        "jobKind": "test",
+        "machine": {
+          "platform": "macosx1010-64"
+        },
+        "symbol": "mda1",
+        "tier": 1
+      },
+      "treeherder-platform": "macosx1010-64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest media run with socket process enabled ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=b437ae030825a8ea9fa7a632b1fcb9becbe11f69))",
+      "name": "test-macosx1010-64/debug-mochitest-media-spi-e10s-1",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/b437ae030825a8ea9fa7a632b1fcb9becbe11f69/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": [
+        {
+          "name": "public/logs",
+          "path": "logs",
+          "type": "directory"
+        },
+        {
+          "name": "public/test_info",
+          "path": "build/blobber_upload_dir",
+          "type": "directory"
+        }
+      ],
+      "command": [
+        [
+          "/usr/bin/python2.7",
+          "-u",
+          "mozharness/scripts/desktop_unittest.py",
+          "--cfg",
+          "mozharness/configs/unittests/mac_unittest.py",
+          "--mochitest-suite=mochitest-media",
+          "--setpref=\"media.peerconnection.mtransport_process=true\"",
+          "--setpref=\"network.process.enabled=true\"",
+          "--download-symbols",
+          "true",
+          "--mochitest-suite=mochitest-media",
+          "--setpref=\"media.peerconnection.mtransport_process=true\"",
+          "--setpref=\"network.process.enabled=true\"",
+          "--total-chunk=2",
+          "--this-chunk=1"
+        ]
+      ],
+      "env": {
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QzpBepRjShOI-CoIkWlytA/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QzpBepRjShOI-CoIkWlytA/artifacts/public/build/target.dmg\"}",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "b437ae030825a8ea9fa7a632b1fcb9becbe11f69",
+        "IDLEIZER_DISABLE_SHUTDOWN": "true",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US.UTF-8",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_HIDE_RESULTS_TABLE": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_NO_REMOTE": "1",
+        "NO_FAIL_ON_TEST_ERRORS": "1",
+        "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+        "SCCACHE_DISABLE": "1",
+        "SHELL": "/bin/bash",
+        "XPCOM_DEBUG_BREAK": "warn",
+        "XPC_FLAGS": "0x0",
+        "XPC_SERVICE_NAME": "0"
+      },
+      "maxRunTime": 5400,
+      "mounts": [
+        {
+          "content": {
+            "artifact": "public/build/mozharness.zip",
+            "taskId": "QzpBepRjShOI-CoIkWlytA"
+          },
+          "directory": ".",
+          "format": "zip"
+        }
+      ],
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.c42fa0c7003c082ea4b6"
+    },
+    "priority": "low",
+    "provisionerId": "releng-hardware",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.b437ae030825a8ea9fa7a632b1fcb9becbe11f69.88560",
+      "coalesce.v1.autoland.c42fa0c7003c082ea4b6"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-macosx1010-64/debug-mochitest-media-spi-e10s-1",
+      "os": "macosx",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "generic-worker"
+    },
+    "taskGroupId": "HkX-TbGXQaSX4ucqGMQNBA",
+    "workerType": "gecko-t-osx-1010"
+  },
+  "EvNqsyBISNCH8mwfDVRnSQ": {
+    "created": "2019-06-26T19:34:51.217Z",
+    "deadline": "2019-06-27T19:34:51.217Z",
+    "dependencies": [],
+    "expires": "2019-07-24T19:34:51.217Z",
+    "extra": {
+      "action": {
+        "context": {
+          "clientId": "mozilla-auth0/ad|Mozilla-LDAP|mshal",
+          "input": {
+            "requests": [
+              {
+                "tasks": ["test-linux64-shippable/opt-talos-g1-e10s"],
+                "times": 1
+              }
+            ]
+          },
+          "parameters": {
+            "app_version": "69.0a1",
+            "base_repository": "https://hg.mozilla.org/mozilla-unified",
+            "build_date": 1561510107,
+            "build_number": 1,
+            "do_not_optimize": [],
+            "existing_tasks": {},
+            "filters": ["target_tasks_method"],
+            "head_ref": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "head_repository": "https://hg.mozilla.org/try",
+            "head_rev": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "hg_branch": "default",
+            "level": "1",
+            "message": "try: -b o -p linux64-shippable -u none -t all",
+            "moz_build_date": "20190626004827",
+            "next_version": null,
+            "optimize_target_tasks": true,
+            "owner": "mshal@mozilla.com",
+            "phabricator_diff": null,
+            "project": "try",
+            "pushdate": 1561510107,
+            "pushlog_id": "381863",
+            "release_enable_emefree": false,
+            "release_enable_partners": false,
+            "release_eta": "",
+            "release_history": {},
+            "release_partner_build_number": 1,
+            "release_partner_config": {},
+            "release_partners": [],
+            "release_product": null,
+            "release_type": "",
+            "required_signoffs": [],
+            "signoff_urls": {},
+            "target_tasks_method": "try_tasks",
+            "tasks_for": "hg-push",
+            "try_mode": "try_option_syntax",
+            "try_options": {
+              "artifact": false,
+              "build_types": "o",
+              "env": null,
+              "include_nightly": false,
+              "interactive": false,
+              "jobs": null,
+              "no_retry": false,
+              "notifications": null,
+              "platforms": "linux64-shippable",
+              "profile": false,
+              "raptor": "none",
+              "raptor_trigger_tests": 1,
+              "tag": null,
+              "talos": "all",
+              "talos_trigger_tests": 1,
+              "taskcluster_worker": false,
+              "trigger_tests": 1,
+              "unittests": "none"
+            },
+            "try_task_config": null,
+            "version": "69.0a1"
+          },
+          "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+          "taskId": null
+        },
+        "name": "retrigger-multiple"
+      },
+      "parent": "VQg1HZ5yS0ixZvsnHLWuFw",
+      "tasks_for": "action",
+      "treeherder": {
+        "groupName": "action-callback",
+        "groupSymbol": "AC",
+        "machine": {
+          "platform": "gecko-decision"
+        },
+        "symbol": "rt"
+      }
+    },
+    "metadata": {
+      "description": "Create a clone of the task.\n\nAction triggered by clientID `mozilla-auth0/ad|Mozilla-LDAP|mshal`\n",
+      "name": "Action: Retrigger",
+      "owner": "mozilla-taskcluster-maintenance@mozilla.com",
+      "source": "https://hg.mozilla.org/try/raw-file/cfe6ae48816614025c458223c66ca2a87b673408/.taskcluster.yml"
+    },
+    "payload": {
+      "artifacts": {
+        "public": {
+          "expires": "2019-07-24T19:34:51.217Z",
+          "path": "/builds/worker/artifacts",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "level-1-checkouts-sparse-v2": "/builds/worker/checkouts"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--gecko-checkout=/builds/worker/checkouts/gecko",
+        "--gecko-sparse-profile=build/sparse-profiles/taskgraph",
+        "--",
+        "bash",
+        "-cx",
+        "cd /builds/worker/checkouts/gecko && ln -s /builds/worker/artifacts artifacts && ./mach --log-no-times taskgraph action-callback\n"
+      ],
+      "env": {
+        "ACTION_CALLBACK": "retrigger-multiple",
+        "ACTION_INPUT": "{\"requests\":[{\"tasks\":[\"test-linux64-shippable/opt-talos-g1-e10s\"],\"times\":1}]}",
+        "ACTION_PARAMETERS": "{\"app_version\":\"69.0a1\",\"base_repository\":\"https://hg.mozilla.org/mozilla-unified\",\"build_date\":1561510107,\"build_number\":1,\"do_not_optimize\":[],\"existing_tasks\":{},\"filters\":[\"target_tasks_method\"],\"head_ref\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"head_repository\":\"https://hg.mozilla.org/try\",\"head_rev\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"hg_branch\":\"default\",\"level\":\"1\",\"message\":\"try: -b o -p linux64-shippable -u none -t all\",\"moz_build_date\":\"20190626004827\",\"next_version\":null,\"optimize_target_tasks\":true,\"owner\":\"mshal@mozilla.com\",\"phabricator_diff\":null,\"project\":\"try\",\"pushdate\":1561510107,\"pushlog_id\":\"381863\",\"release_enable_emefree\":false,\"release_enable_partners\":false,\"release_eta\":\"\",\"release_history\":{},\"release_partner_build_number\":1,\"release_partner_config\":{},\"release_partners\":[],\"release_product\":null,\"release_type\":\"\",\"required_signoffs\":[],\"signoff_urls\":{},\"target_tasks_method\":\"try_tasks\",\"tasks_for\":\"hg-push\",\"try_mode\":\"try_option_syntax\",\"try_options\":{\"artifact\":false,\"build_types\":\"o\",\"env\":null,\"include_nightly\":false,\"interactive\":false,\"jobs\":null,\"no_retry\":false,\"notifications\":null,\"platforms\":\"linux64-shippable\",\"profile\":false,\"raptor\":\"none\",\"raptor_trigger_tests\":1,\"tag\":null,\"talos\":\"all\",\"talos_trigger_tests\":1,\"taskcluster_worker\":false,\"trigger_tests\":1,\"unittests\":\"none\"},\"try_task_config\":null,\"version\":\"69.0a1\"}",
+        "ACTION_TASK_GROUP_ID": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "ACTION_TASK_ID": "null",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REF": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+        "GECKO_HEAD_REV": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+        "TASKCLUSTER_PROXY_URL": "http://taskcluster",
+        "TASKCLUSTER_ROOT_URL": "https://taskcluster.net"
+      },
+      "features": {
+        "chainOfTrust": true,
+        "taskclusterProxy": true
+      },
+      "image": "taskcluster/decision:2.2.0@sha256:0e9689e94605eb8395f5b49141a48148416b0d825f6f7be04c29642d1a85ee3d",
+      "maxRunTime": 1800
+    },
+    "priority": "very-low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.try.cfe6ae48816614025c458223c66ca2a87b673408.381863",
+      "index.gecko.v2.try.pushlog-id.381863.actions.EvNqsyBISNCH8mwfDVRnSQ"
+    ],
+    "schedulerId": "gecko-level-1",
+    "scopes": ["assume:repo:hg.mozilla.org/try:action:generic"],
+    "tags": {
+      "createdForUser": "mozilla-taskcluster-maintenance@mozilla.com",
+      "kind": "action-callback"
+    },
+    "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+    "workerType": "gecko-1-decision"
+  },
+  "F93bme7iSP2k0TsCwqSBVw": {
+    "created": "2019-06-26T19:14:05.949Z",
+    "deadline": "2019-06-27T19:14:05.949Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:05.949Z",
+    "extra": {
+      "chunks": {
+        "current": 9,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-browser-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "bc9",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest browser-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-9",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:05.949Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:05.949Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:05.949Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-browser-chrome-chunked",
+        "--total-chunk=16",
+        "--this-chunk=9",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "browser",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.fe873621a0d30d31d91c"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.fe873621a0d30d31d91c"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-browser-chrome-e10s-9",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "FgjNkrvXS0WDDJJUpVXZsA": {
+    "created": "2019-06-26T19:13:53.207Z",
+    "deadline": "2019-06-27T19:13:53.207Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:53.207Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 8
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "reftest",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Reftests",
+        "groupSymbol": "R",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "R1",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Reftest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-reftest-e10s-1",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:53.207Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:53.207Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:53.207Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--reftest-suite=reftest",
+        "--allow-software-gl-layers",
+        "--total-chunk=8",
+        "--this-chunk=1",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.1f4694c535a4d5b2098d"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.1f4694c535a4d5b2098d"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-reftest-e10s-1",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "reftest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "Fj3fDgrvRXitCVX2RiJUaw": {
+    "created": "2019-06-26T19:13:51.164Z",
+    "deadline": "2019-06-27T19:13:51.164Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:51.164Z",
+    "extra": {
+      "chunks": {
+        "current": 4,
+        "total": 6
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "xpcshell",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Xpcshell tests",
+        "groupSymbol": "X",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "X4",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "xpcshell test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-xpcshell-e10s-4",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:51.164Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:51.164Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:51.164Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--xpcshell-suite=xpcshell",
+        "--enable-webrender",
+        "--total-chunk=6",
+        "--this-chunk=4",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.4aeb28c93a8aa571a954"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.4aeb28c93a8aa571a954"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-xpcshell-e10s-4",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "FkHz3gGPSVmL6YJOupYBXw": {
+    "created": "2019-06-26T19:13:52.148Z",
+    "deadline": "2019-06-27T19:13:52.148Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:52.148Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 1
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "crashtest",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Reftests",
+        "groupSymbol": "R",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "C",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Crashtest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-crashtest-e10s",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:52.148Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:52.148Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:52.148Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--reftest-suite=crashtest",
+        "--allow-software-gl-layers",
+        "--enable-webrender",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.0477d0cf4fd78f415d7b"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.0477d0cf4fd78f415d7b"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-crashtest-e10s",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "FsgLMdKwRzWJAwUhYy2g0Q": {
+    "created": "2019-06-26T19:14:00.578Z",
+    "deadline": "2019-06-27T19:14:00.578Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:00.578Z",
+    "extra": {
+      "chunks": {
+        "current": 2,
+        "total": 3
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-chrome",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests without e10s",
+        "groupSymbol": "M-1proc",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "c2",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-chrome-1proc-2",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:00.578Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:00.578Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:00.578Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-chrome",
+        "--disable-e10s",
+        "--allow-software-gl-layers",
+        "--total-chunk=3",
+        "--this-chunk=2",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "false",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "chrome",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.76541ef3d67aef1d40ba"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.76541ef3d67aef1d40ba"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-chrome-1proc-2",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "GTFxZJWzSKSNc_XElgtWHQ": {
+    "created": "2019-06-26T19:13:57.328Z",
+    "deadline": "2019-06-27T19:13:57.328Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:57.328Z",
+    "extra": {
+      "chunks": {
+        "current": 16,
+        "total": 18
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "web-platform-tests",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Web platform tests",
+        "groupSymbol": "W",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "wpt16",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-web-platform-tests-e10s-16",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:57.328Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:57.328Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:57.328Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--test-type=testharness",
+        "--allow-software-gl-layers",
+        "--total-chunk=18",
+        "--this-chunk=16",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 7200,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.675a7ba8ee7383ab1fd0"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.675a7ba8ee7383ab1fd0"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-web-platform-tests-e10s-16",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-xlarge"
+  },
+  "GWxTc8p_RUa5_Xo4RtMiCA": {
+    "created": "2019-06-26T18:24:27.418Z",
+    "deadline": "2019-06-27T18:24:27.418Z",
+    "dependencies": ["B14JB_8CRN-3yAVaNUzqoA", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T18:24:27.418Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 4
+      },
+      "index": {
+        "rank": 0
+      },
+      "parent": "HkX-TbGXQaSX4ucqGMQNBA",
+      "suite": "mochitest-plain-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "android-em-7-0-x86_64"
+        },
+        "symbol": "1",
+        "tier": 2
+      },
+      "treeherder-platform": "android-em-7-0-x86_64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest plain run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=b437ae030825a8ea9fa7a632b1fcb9becbe11f69))",
+      "name": "test-android-em-7.0-x86_64/debug-mochitest-e10s-1",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/b437ae030825a8ea9fa7a632b1fcb9becbe11f69/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T18:24:27.418Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T18:24:27.418Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T18:24:27.418Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        },
+        "privileged": true
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--test-suite=mochitest-plain",
+        "--total-chunk=4",
+        "--this-chunk=1",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/B14JB_8CRN-3yAVaNUzqoA/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/B14JB_8CRN-3yAVaNUzqoA/artifacts/public/build/geckoview-androidTest.apk\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "b437ae030825a8ea9fa7a632b1fcb9becbe11f69",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_ACTIONS": "get-secrets",
+        "MOZHARNESS_CONFIG": "android/android_common.py android/androidx86_7_0.py",
+        "MOZHARNESS_SCRIPT": "android_emulator_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/B14JB_8CRN-3yAVaNUzqoA/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/B14JB_8CRN-3yAVaNUzqoA/artifacts/public/build/geckoview-androidTest.apk",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 7200,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.c459dfd60738a257b917"
+    },
+    "priority": "low",
+    "provisionerId": "terraform-packet",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.b437ae030825a8ea9fa7a632b1fcb9becbe11f69.88560",
+      "coalesce.v1.autoland.c459dfd60738a257b917"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "project:releng:services/tooltool/api/download/internal",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:capability:privileged",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-android-em-7.0-x86_64/debug-mochitest-e10s-1",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "HkX-TbGXQaSX4ucqGMQNBA",
+    "workerType": "gecko-t-linux"
+  },
+  "HsvD9YlDQKaoP4AQsuGeJw": {
+    "created": "2019-06-26T18:24:28.261Z",
+    "deadline": "2019-06-27T18:24:28.261Z",
+    "dependencies": ["QzpBepRjShOI-CoIkWlytA"],
+    "expires": "2020-06-25T18:24:28.261Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 2
+      },
+      "index": {
+        "rank": 1561573344
+      },
+      "parent": "HkX-TbGXQaSX4ucqGMQNBA",
+      "suite": "mochitest-media",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "macosx1010-64"
+        },
+        "symbol": "mda1",
+        "tier": 1
+      },
+      "treeherder-platform": "macosx1010-64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest media run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=b437ae030825a8ea9fa7a632b1fcb9becbe11f69))",
+      "name": "test-macosx1010-64/debug-mochitest-media-e10s-1",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/b437ae030825a8ea9fa7a632b1fcb9becbe11f69/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": [
+        {
+          "name": "public/logs",
+          "path": "logs",
+          "type": "directory"
+        },
+        {
+          "name": "public/test_info",
+          "path": "build/blobber_upload_dir",
+          "type": "directory"
+        }
+      ],
+      "command": [
+        [
+          "/usr/bin/python2.7",
+          "-u",
+          "mozharness/scripts/desktop_unittest.py",
+          "--cfg",
+          "mozharness/configs/unittests/mac_unittest.py",
+          "--mochitest-suite=mochitest-media",
+          "--download-symbols",
+          "true",
+          "--mochitest-suite=mochitest-media",
+          "--total-chunk=2",
+          "--this-chunk=1"
+        ]
+      ],
+      "env": {
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QzpBepRjShOI-CoIkWlytA/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QzpBepRjShOI-CoIkWlytA/artifacts/public/build/target.dmg\"}",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "b437ae030825a8ea9fa7a632b1fcb9becbe11f69",
+        "IDLEIZER_DISABLE_SHUTDOWN": "true",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US.UTF-8",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_HIDE_RESULTS_TABLE": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_NO_REMOTE": "1",
+        "NO_FAIL_ON_TEST_ERRORS": "1",
+        "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+        "SCCACHE_DISABLE": "1",
+        "SHELL": "/bin/bash",
+        "XPCOM_DEBUG_BREAK": "warn",
+        "XPC_FLAGS": "0x0",
+        "XPC_SERVICE_NAME": "0"
+      },
+      "maxRunTime": 5400,
+      "mounts": [
+        {
+          "content": {
+            "artifact": "public/build/mozharness.zip",
+            "taskId": "QzpBepRjShOI-CoIkWlytA"
+          },
+          "directory": ".",
+          "format": "zip"
+        }
+      ],
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.19568861619e0354f724"
+    },
+    "priority": "low",
+    "provisionerId": "releng-hardware",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.b437ae030825a8ea9fa7a632b1fcb9becbe11f69.88560",
+      "coalesce.v1.autoland.19568861619e0354f724"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-macosx1010-64/debug-mochitest-media-e10s-1",
+      "os": "macosx",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "generic-worker"
+    },
+    "taskGroupId": "HkX-TbGXQaSX4ucqGMQNBA",
+    "workerType": "gecko-t-osx-1010"
+  },
+  "JKDqO-yySta79-Y92Dq2yQ": {
+    "created": "2019-06-26T19:13:54.963Z",
+    "deadline": "2019-06-27T19:13:54.963Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:54.963Z",
+    "extra": {
+      "chunks": {
+        "current": 10,
+        "total": 12
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-devtools-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "dt10",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest devtools-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-devtools-chrome-e10s-10",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:54.963Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:54.963Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:54.963Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-devtools-chrome-chunked",
+        "--total-chunk=12",
+        "--this-chunk=10",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "chrome",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.8d13822dc1ab9c259668"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.8d13822dc1ab9c259668"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-devtools-chrome-e10s-10",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "JM6eV6S-R5-Dy08gjoBHrQ": {
+    "created": "2019-06-26T19:13:54.670Z",
+    "deadline": "2019-06-27T19:13:54.670Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:54.670Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 3
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-media",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "mda1",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Mochitest media run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-mochitest-media-e10s-1",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:54.670Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:54.670Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:54.670Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-media",
+        "--allow-software-gl-layers",
+        "--enable-webrender",
+        "--total-chunk=3",
+        "--this-chunk=1",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.a295d5ecc028d10fa696"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.a295d5ecc028d10fa696"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-mochitest-media-e10s-1",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "K2IZ74mWQfiEn2U6XnVLPQ": {
+    "created": "2019-06-26T19:13:50.368Z",
+    "deadline": "2019-06-27T19:13:50.368Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:50.368Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-plain-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "1",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest plain run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-e10s-1",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:50.368Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:50.368Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:50.368Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-plain-chunked",
+        "--total-chunk=16",
+        "--this-chunk=1",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.5e99165554f02cbf4160"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.5e99165554f02cbf4160"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-e10s-1",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "K5R8rkgARZWMvH4JpmSPrQ": {
+    "created": "2019-06-26T19:14:03.581Z",
+    "deadline": "2019-06-27T19:14:03.581Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:03.581Z",
+    "extra": {
+      "chunks": {
+        "current": 3,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-plain-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "3",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest plain run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-e10s-3",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:03.581Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:03.581Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:03.581Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-plain-chunked",
+        "--total-chunk=16",
+        "--this-chunk=3",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.0079298d985e376f799e"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.0079298d985e376f799e"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-e10s-3",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "KYZKwkbvRc-qPE22g286yQ": {
+    "created": "2019-06-26T18:49:29.995Z",
+    "deadline": "2019-06-27T18:49:29.995Z",
+    "dependencies": ["MSjjBczERqG4wgnsX5e_dA", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2019-07-10T18:49:29.995Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 1
+      },
+      "index": {
+        "rank": 1561574819
+      },
+      "parent": "CjxziyApQDCcPUMhKFiIGg",
+      "suite": "mochitest-webgl1-core",
+      "treeherder": {
+        "collection": {
+          "opt": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "gl1c",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/opt"
+    },
+    "metadata": {
+      "description": "Mochitest webgl1-core run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=e9802fad44ec8c8ccf3326cf7c75967576db855b))",
+      "name": "test-linux64-qr/opt-mochitest-webgl1-core-e10s",
+      "owner": "cbrewster@mozilla.com",
+      "source": "https://hg.mozilla.org/try/file/e9802fad44ec8c8ccf3326cf7c75967576db855b/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2019-07-10T18:49:29.995Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2019-07-10T18:49:29.995Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2019-07-10T18:49:29.995Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-1-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-1-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-webgl1-core",
+        "--enable-webrender",
+        "--download-symbols=ondemand"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/MSjjBczERqG4wgnsX5e_dA/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/MSjjBczERqG4wgnsX5e_dA/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+        "GECKO_HEAD_REV": "e9802fad44ec8c8ccf3326cf7c75967576db855b",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/MSjjBczERqG4wgnsX5e_dA/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/MSjjBczERqG4wgnsX5e_dA/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "1",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "TRY_COMMIT_MSG": "",
+        "TRY_SELECTOR": "fuzzy",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      }
+    },
+    "priority": "very-low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.try.e9802fad44ec8c8ccf3326cf7c75967576db855b.382341"
+    ],
+    "schedulerId": "gecko-level-1",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-1-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-1-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "cbrewster@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/opt-mochitest-webgl1-core-e10s",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "CjxziyApQDCcPUMhKFiIGg",
+    "workerType": "gecko-t-linux-large"
+  },
+  "KnBj0KLcTjuyNaTxt5LVqw": {
+    "created": "2019-06-26T19:34:52.437Z",
+    "deadline": "2019-06-27T19:34:52.437Z",
+    "dependencies": [],
+    "expires": "2019-07-24T19:34:52.437Z",
+    "extra": {
+      "action": {
+        "context": {
+          "clientId": "mozilla-auth0/ad|Mozilla-LDAP|mshal",
+          "input": {
+            "requests": [
+              {
+                "tasks": ["test-linux64-shippable/opt-talos-g3-e10s"],
+                "times": 1
+              }
+            ]
+          },
+          "parameters": {
+            "app_version": "69.0a1",
+            "base_repository": "https://hg.mozilla.org/mozilla-unified",
+            "build_date": 1561510107,
+            "build_number": 1,
+            "do_not_optimize": [],
+            "existing_tasks": {},
+            "filters": ["target_tasks_method"],
+            "head_ref": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "head_repository": "https://hg.mozilla.org/try",
+            "head_rev": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "hg_branch": "default",
+            "level": "1",
+            "message": "try: -b o -p linux64-shippable -u none -t all",
+            "moz_build_date": "20190626004827",
+            "next_version": null,
+            "optimize_target_tasks": true,
+            "owner": "mshal@mozilla.com",
+            "phabricator_diff": null,
+            "project": "try",
+            "pushdate": 1561510107,
+            "pushlog_id": "381863",
+            "release_enable_emefree": false,
+            "release_enable_partners": false,
+            "release_eta": "",
+            "release_history": {},
+            "release_partner_build_number": 1,
+            "release_partner_config": {},
+            "release_partners": [],
+            "release_product": null,
+            "release_type": "",
+            "required_signoffs": [],
+            "signoff_urls": {},
+            "target_tasks_method": "try_tasks",
+            "tasks_for": "hg-push",
+            "try_mode": "try_option_syntax",
+            "try_options": {
+              "artifact": false,
+              "build_types": "o",
+              "env": null,
+              "include_nightly": false,
+              "interactive": false,
+              "jobs": null,
+              "no_retry": false,
+              "notifications": null,
+              "platforms": "linux64-shippable",
+              "profile": false,
+              "raptor": "none",
+              "raptor_trigger_tests": 1,
+              "tag": null,
+              "talos": "all",
+              "talos_trigger_tests": 1,
+              "taskcluster_worker": false,
+              "trigger_tests": 1,
+              "unittests": "none"
+            },
+            "try_task_config": null,
+            "version": "69.0a1"
+          },
+          "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+          "taskId": null
+        },
+        "name": "retrigger-multiple"
+      },
+      "parent": "VQg1HZ5yS0ixZvsnHLWuFw",
+      "tasks_for": "action",
+      "treeherder": {
+        "groupName": "action-callback",
+        "groupSymbol": "AC",
+        "machine": {
+          "platform": "gecko-decision"
+        },
+        "symbol": "rt"
+      }
+    },
+    "metadata": {
+      "description": "Create a clone of the task.\n\nAction triggered by clientID `mozilla-auth0/ad|Mozilla-LDAP|mshal`\n",
+      "name": "Action: Retrigger",
+      "owner": "mozilla-taskcluster-maintenance@mozilla.com",
+      "source": "https://hg.mozilla.org/try/raw-file/cfe6ae48816614025c458223c66ca2a87b673408/.taskcluster.yml"
+    },
+    "payload": {
+      "artifacts": {
+        "public": {
+          "expires": "2019-07-24T19:34:52.437Z",
+          "path": "/builds/worker/artifacts",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "level-1-checkouts-sparse-v2": "/builds/worker/checkouts"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--gecko-checkout=/builds/worker/checkouts/gecko",
+        "--gecko-sparse-profile=build/sparse-profiles/taskgraph",
+        "--",
+        "bash",
+        "-cx",
+        "cd /builds/worker/checkouts/gecko && ln -s /builds/worker/artifacts artifacts && ./mach --log-no-times taskgraph action-callback\n"
+      ],
+      "env": {
+        "ACTION_CALLBACK": "retrigger-multiple",
+        "ACTION_INPUT": "{\"requests\":[{\"tasks\":[\"test-linux64-shippable/opt-talos-g3-e10s\"],\"times\":1}]}",
+        "ACTION_PARAMETERS": "{\"app_version\":\"69.0a1\",\"base_repository\":\"https://hg.mozilla.org/mozilla-unified\",\"build_date\":1561510107,\"build_number\":1,\"do_not_optimize\":[],\"existing_tasks\":{},\"filters\":[\"target_tasks_method\"],\"head_ref\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"head_repository\":\"https://hg.mozilla.org/try\",\"head_rev\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"hg_branch\":\"default\",\"level\":\"1\",\"message\":\"try: -b o -p linux64-shippable -u none -t all\",\"moz_build_date\":\"20190626004827\",\"next_version\":null,\"optimize_target_tasks\":true,\"owner\":\"mshal@mozilla.com\",\"phabricator_diff\":null,\"project\":\"try\",\"pushdate\":1561510107,\"pushlog_id\":\"381863\",\"release_enable_emefree\":false,\"release_enable_partners\":false,\"release_eta\":\"\",\"release_history\":{},\"release_partner_build_number\":1,\"release_partner_config\":{},\"release_partners\":[],\"release_product\":null,\"release_type\":\"\",\"required_signoffs\":[],\"signoff_urls\":{},\"target_tasks_method\":\"try_tasks\",\"tasks_for\":\"hg-push\",\"try_mode\":\"try_option_syntax\",\"try_options\":{\"artifact\":false,\"build_types\":\"o\",\"env\":null,\"include_nightly\":false,\"interactive\":false,\"jobs\":null,\"no_retry\":false,\"notifications\":null,\"platforms\":\"linux64-shippable\",\"profile\":false,\"raptor\":\"none\",\"raptor_trigger_tests\":1,\"tag\":null,\"talos\":\"all\",\"talos_trigger_tests\":1,\"taskcluster_worker\":false,\"trigger_tests\":1,\"unittests\":\"none\"},\"try_task_config\":null,\"version\":\"69.0a1\"}",
+        "ACTION_TASK_GROUP_ID": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "ACTION_TASK_ID": "null",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REF": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+        "GECKO_HEAD_REV": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+        "TASKCLUSTER_PROXY_URL": "http://taskcluster",
+        "TASKCLUSTER_ROOT_URL": "https://taskcluster.net"
+      },
+      "features": {
+        "chainOfTrust": true,
+        "taskclusterProxy": true
+      },
+      "image": "taskcluster/decision:2.2.0@sha256:0e9689e94605eb8395f5b49141a48148416b0d825f6f7be04c29642d1a85ee3d",
+      "maxRunTime": 1800
+    },
+    "priority": "very-low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.try.cfe6ae48816614025c458223c66ca2a87b673408.381863",
+      "index.gecko.v2.try.pushlog-id.381863.actions.KnBj0KLcTjuyNaTxt5LVqw"
+    ],
+    "schedulerId": "gecko-level-1",
+    "scopes": ["assume:repo:hg.mozilla.org/try:action:generic"],
+    "tags": {
+      "createdForUser": "mozilla-taskcluster-maintenance@mozilla.com",
+      "kind": "action-callback"
+    },
+    "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+    "workerType": "gecko-1-decision"
+  },
+  "LBJoI2wUTNCteg-5CnaYZQ": {
+    "created": "2019-06-26T18:07:24.073Z",
+    "deadline": "2019-06-27T18:07:24.073Z",
+    "dependencies": ["ZGIou44NSL22KimFgzFS0w", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T18:07:24.073Z",
+    "extra": {
+      "chunks": {
+        "current": 8,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561572308
+      },
+      "parent": "EJAo7mQyRqS-jmzebhceFA",
+      "suite": "mochitest-browser-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "bc8",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest browser-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=918d7c84da371bda26460fb4b50f161d32107880))",
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-8",
+      "owner": "malexandru@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/918d7c84da371bda26460fb4b50f161d32107880/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T18:07:24.073Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T18:07:24.073Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T18:07:24.073Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-browser-chrome-chunked",
+        "--total-chunk=16",
+        "--this-chunk=8",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZGIou44NSL22KimFgzFS0w/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZGIou44NSL22KimFgzFS0w/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "918d7c84da371bda26460fb4b50f161d32107880",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "browser",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZGIou44NSL22KimFgzFS0w/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZGIou44NSL22KimFgzFS0w/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.e3d4e7a40813d5cb6edb"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.918d7c84da371bda26460fb4b50f161d32107880.88554",
+      "coalesce.v1.autoland.e3d4e7a40813d5cb6edb"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "malexandru@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-browser-chrome-e10s-8",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "EJAo7mQyRqS-jmzebhceFA",
+    "workerType": "gecko-t-linux-large"
+  },
+  "LWArw4t5QaCHiHsEJo6hFA": {
+    "created": "2019-06-26T19:34:52.581Z",
+    "deadline": "2019-06-27T19:34:52.581Z",
+    "dependencies": [],
+    "expires": "2019-07-24T19:34:52.581Z",
+    "extra": {
+      "action": {
+        "context": {
+          "clientId": "mozilla-auth0/ad|Mozilla-LDAP|mshal",
+          "input": {
+            "requests": [
+              {
+                "tasks": ["test-linux64-shippable/opt-talos-g3-e10s"],
+                "times": 1
+              }
+            ]
+          },
+          "parameters": {
+            "app_version": "69.0a1",
+            "base_repository": "https://hg.mozilla.org/mozilla-unified",
+            "build_date": 1561510107,
+            "build_number": 1,
+            "do_not_optimize": [],
+            "existing_tasks": {},
+            "filters": ["target_tasks_method"],
+            "head_ref": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "head_repository": "https://hg.mozilla.org/try",
+            "head_rev": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "hg_branch": "default",
+            "level": "1",
+            "message": "try: -b o -p linux64-shippable -u none -t all",
+            "moz_build_date": "20190626004827",
+            "next_version": null,
+            "optimize_target_tasks": true,
+            "owner": "mshal@mozilla.com",
+            "phabricator_diff": null,
+            "project": "try",
+            "pushdate": 1561510107,
+            "pushlog_id": "381863",
+            "release_enable_emefree": false,
+            "release_enable_partners": false,
+            "release_eta": "",
+            "release_history": {},
+            "release_partner_build_number": 1,
+            "release_partner_config": {},
+            "release_partners": [],
+            "release_product": null,
+            "release_type": "",
+            "required_signoffs": [],
+            "signoff_urls": {},
+            "target_tasks_method": "try_tasks",
+            "tasks_for": "hg-push",
+            "try_mode": "try_option_syntax",
+            "try_options": {
+              "artifact": false,
+              "build_types": "o",
+              "env": null,
+              "include_nightly": false,
+              "interactive": false,
+              "jobs": null,
+              "no_retry": false,
+              "notifications": null,
+              "platforms": "linux64-shippable",
+              "profile": false,
+              "raptor": "none",
+              "raptor_trigger_tests": 1,
+              "tag": null,
+              "talos": "all",
+              "talos_trigger_tests": 1,
+              "taskcluster_worker": false,
+              "trigger_tests": 1,
+              "unittests": "none"
+            },
+            "try_task_config": null,
+            "version": "69.0a1"
+          },
+          "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+          "taskId": null
+        },
+        "name": "retrigger-multiple"
+      },
+      "parent": "VQg1HZ5yS0ixZvsnHLWuFw",
+      "tasks_for": "action",
+      "treeherder": {
+        "groupName": "action-callback",
+        "groupSymbol": "AC",
+        "machine": {
+          "platform": "gecko-decision"
+        },
+        "symbol": "rt"
+      }
+    },
+    "metadata": {
+      "description": "Create a clone of the task.\n\nAction triggered by clientID `mozilla-auth0/ad|Mozilla-LDAP|mshal`\n",
+      "name": "Action: Retrigger",
+      "owner": "mozilla-taskcluster-maintenance@mozilla.com",
+      "source": "https://hg.mozilla.org/try/raw-file/cfe6ae48816614025c458223c66ca2a87b673408/.taskcluster.yml"
+    },
+    "payload": {
+      "artifacts": {
+        "public": {
+          "expires": "2019-07-24T19:34:52.581Z",
+          "path": "/builds/worker/artifacts",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "level-1-checkouts-sparse-v2": "/builds/worker/checkouts"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--gecko-checkout=/builds/worker/checkouts/gecko",
+        "--gecko-sparse-profile=build/sparse-profiles/taskgraph",
+        "--",
+        "bash",
+        "-cx",
+        "cd /builds/worker/checkouts/gecko && ln -s /builds/worker/artifacts artifacts && ./mach --log-no-times taskgraph action-callback\n"
+      ],
+      "env": {
+        "ACTION_CALLBACK": "retrigger-multiple",
+        "ACTION_INPUT": "{\"requests\":[{\"tasks\":[\"test-linux64-shippable/opt-talos-g3-e10s\"],\"times\":1}]}",
+        "ACTION_PARAMETERS": "{\"app_version\":\"69.0a1\",\"base_repository\":\"https://hg.mozilla.org/mozilla-unified\",\"build_date\":1561510107,\"build_number\":1,\"do_not_optimize\":[],\"existing_tasks\":{},\"filters\":[\"target_tasks_method\"],\"head_ref\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"head_repository\":\"https://hg.mozilla.org/try\",\"head_rev\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"hg_branch\":\"default\",\"level\":\"1\",\"message\":\"try: -b o -p linux64-shippable -u none -t all\",\"moz_build_date\":\"20190626004827\",\"next_version\":null,\"optimize_target_tasks\":true,\"owner\":\"mshal@mozilla.com\",\"phabricator_diff\":null,\"project\":\"try\",\"pushdate\":1561510107,\"pushlog_id\":\"381863\",\"release_enable_emefree\":false,\"release_enable_partners\":false,\"release_eta\":\"\",\"release_history\":{},\"release_partner_build_number\":1,\"release_partner_config\":{},\"release_partners\":[],\"release_product\":null,\"release_type\":\"\",\"required_signoffs\":[],\"signoff_urls\":{},\"target_tasks_method\":\"try_tasks\",\"tasks_for\":\"hg-push\",\"try_mode\":\"try_option_syntax\",\"try_options\":{\"artifact\":false,\"build_types\":\"o\",\"env\":null,\"include_nightly\":false,\"interactive\":false,\"jobs\":null,\"no_retry\":false,\"notifications\":null,\"platforms\":\"linux64-shippable\",\"profile\":false,\"raptor\":\"none\",\"raptor_trigger_tests\":1,\"tag\":null,\"talos\":\"all\",\"talos_trigger_tests\":1,\"taskcluster_worker\":false,\"trigger_tests\":1,\"unittests\":\"none\"},\"try_task_config\":null,\"version\":\"69.0a1\"}",
+        "ACTION_TASK_GROUP_ID": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "ACTION_TASK_ID": "null",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REF": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+        "GECKO_HEAD_REV": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+        "TASKCLUSTER_PROXY_URL": "http://taskcluster",
+        "TASKCLUSTER_ROOT_URL": "https://taskcluster.net"
+      },
+      "features": {
+        "chainOfTrust": true,
+        "taskclusterProxy": true
+      },
+      "image": "taskcluster/decision:2.2.0@sha256:0e9689e94605eb8395f5b49141a48148416b0d825f6f7be04c29642d1a85ee3d",
+      "maxRunTime": 1800
+    },
+    "priority": "very-low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.try.cfe6ae48816614025c458223c66ca2a87b673408.381863",
+      "index.gecko.v2.try.pushlog-id.381863.actions.LWArw4t5QaCHiHsEJo6hFA"
+    ],
+    "schedulerId": "gecko-level-1",
+    "scopes": ["assume:repo:hg.mozilla.org/try:action:generic"],
+    "tags": {
+      "createdForUser": "mozilla-taskcluster-maintenance@mozilla.com",
+      "kind": "action-callback"
+    },
+    "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+    "workerType": "gecko-1-decision"
+  },
+  "MrYMxyDDSwWXJey-uo4T3g": {
+    "created": "2019-06-26T18:07:24.130Z",
+    "deadline": "2019-06-27T18:07:24.130Z",
+    "dependencies": ["aAJvMkEkSkOyC-zR34O4ZA"],
+    "expires": "2020-06-25T18:07:24.130Z",
+    "extra": {
+      "chunks": {
+        "current": 4,
+        "total": 4
+      },
+      "index": {
+        "rank": 1561572308
+      },
+      "parent": "EJAo7mQyRqS-jmzebhceFA",
+      "suite": "mochitest-webgl2-ext",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "windows10-64"
+        },
+        "symbol": "gl2e4",
+        "tier": 1
+      },
+      "treeherder-platform": "windows10-64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest webgl2-ext run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=918d7c84da371bda26460fb4b50f161d32107880))",
+      "name": "test-windows10-64/debug-mochitest-webgl2-ext-e10s-4",
+      "owner": "malexandru@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/918d7c84da371bda26460fb4b50f161d32107880/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": [
+        {
+          "name": "public/logs",
+          "path": "logs",
+          "type": "directory"
+        },
+        {
+          "name": "public/test_info",
+          "path": "build/blobber_upload_dir",
+          "type": "directory"
+        }
+      ],
+      "command": [
+        "c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\desktop_unittest.py --cfg mozharness\\configs\\unittests\\win_unittest.py --mochitest-suite=mochitest-webgl2-ext --download-symbols true --mochitest-suite=mochitest-webgl2-ext --total-chunk=4 --this-chunk=4"
+      ],
+      "env": {
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/aAJvMkEkSkOyC-zR34O4ZA/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/aAJvMkEkSkOyC-zR34O4ZA/artifacts/public/build/target.zip\"}",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "918d7c84da371bda26460fb4b50f161d32107880",
+        "MOZ_AUTOMATION": "1",
+        "SCCACHE_DISABLE": "1"
+      },
+      "maxRunTime": 5400,
+      "mounts": [
+        {
+          "content": {
+            "artifact": "public/build/mozharness.zip",
+            "taskId": "aAJvMkEkSkOyC-zR34O4ZA"
+          },
+          "directory": ".",
+          "format": "zip"
+        }
+      ],
+      "onExitStatus": {
+        "retry": [1073807364, 3221225786]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.9a435591e74c387568d3"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.918d7c84da371bda26460fb4b50f161d32107880.88554",
+      "coalesce.v1.autoland.9a435591e74c387568d3"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [],
+    "tags": {
+      "createdForUser": "malexandru@mozilla.com",
+      "kind": "test",
+      "label": "test-windows10-64/debug-mochitest-webgl2-ext-e10s-4",
+      "os": "windows",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "generic-worker"
+    },
+    "taskGroupId": "EJAo7mQyRqS-jmzebhceFA",
+    "workerType": "gecko-t-win10-64-gpu"
+  },
+  "NWz-q9MoSL-WMfO7kiwhtg": {
+    "created": "2019-06-26T19:13:53.397Z",
+    "deadline": "2019-06-27T19:13:53.397Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:53.397Z",
+    "extra": {
+      "chunks": {
+        "current": 4,
+        "total": 12
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-devtools-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "dt4",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest devtools-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-devtools-chrome-e10s-4",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:53.397Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:53.397Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:53.397Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-devtools-chrome-chunked",
+        "--total-chunk=12",
+        "--this-chunk=4",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "chrome",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.c9d7a6a0020f0cde940b"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.c9d7a6a0020f0cde940b"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-devtools-chrome-e10s-4",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "OiZYxvi5RfKol0A4SBbvOw": {
+    "created": "2019-06-26T18:53:21.527Z",
+    "deadline": "2019-06-27T18:53:21.527Z",
+    "dependencies": ["FLRWu3KeQO-3YxkSvo_Neg", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T18:53:21.527Z",
+    "extra": {
+      "chunks": {
+        "current": 2,
+        "total": 8
+      },
+      "index": {
+        "rank": 1561575086
+      },
+      "parent": "Vo0j4wv3RFai2uA5IGZ1Cw",
+      "suite": "geckoview-junit",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "jobKind": "test",
+        "machine": {
+          "platform": "android-em-4-3-armv7-api16"
+        },
+        "symbol": "gv-junit2",
+        "tier": 1
+      },
+      "treeherder-platform": "android-em-4-3-armv7-api16/debug"
+    },
+    "metadata": {
+      "description": "Geckoview junit run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=mozilla-inbound&revision=ba32151f8fc12c08e67647293a7dc43403a18639))",
+      "name": "test-android-em-4.3-arm7-api-16/debug-geckoview-junit-e10s-2",
+      "owner": "longsonr@gmail.com",
+      "source": "https://hg.mozilla.org/integration/mozilla-inbound/file/ba32151f8fc12c08e67647293a7dc43403a18639/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T18:53:21.527Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T18:53:21.527Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T18:53:21.527Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--test-suite=geckoview-junit",
+        "--total-chunk=8",
+        "--this-chunk=2",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/FLRWu3KeQO-3YxkSvo_Neg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/FLRWu3KeQO-3YxkSvo_Neg/artifacts/public/build/geckoview-androidTest.apk\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/mozilla-inbound",
+        "GECKO_HEAD_REV": "ba32151f8fc12c08e67647293a7dc43403a18639",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_ACTIONS": "get-secrets",
+        "MOZHARNESS_CONFIG": "android/android_common.py android/androidarm_4_3_junit.py",
+        "MOZHARNESS_SCRIPT": "android_emulator_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/FLRWu3KeQO-3YxkSvo_Neg/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/FLRWu3KeQO-3YxkSvo_Neg/artifacts/public/build/geckoview-androidTest.apk",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/mozilla-inbound.609e619f93d12bddbbf4"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.mozilla-inbound.ba32151f8fc12c08e67647293a7dc43403a18639.113528",
+      "coalesce.v1.mozilla-inbound.609e619f93d12bddbbf4"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "project:releng:services/tooltool/api/download/internal",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "longsonr@gmail.com",
+      "kind": "test",
+      "label": "test-android-em-4.3-arm7-api-16/debug-geckoview-junit-e10s-2",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "Vo0j4wv3RFai2uA5IGZ1Cw",
+    "workerType": "gecko-t-linux-xlarge"
+  },
+  "PCVDCxY9QM-lEgaGhrCPrw": {
+    "created": "2019-06-26T17:59:19.096Z",
+    "deadline": "2019-06-27T17:59:19.096Z",
+    "dependencies": ["A_9OoPyPRGKKk8tygRUIcw"],
+    "expires": "2019-07-10T17:59:19.096Z",
+    "extra": {
+      "chunks": {
+        "current": 2,
+        "total": 7
+      },
+      "index": {
+        "rank": 1561571806
+      },
+      "parent": "EiRNaGPeQjCB0ceF-A-Kdw",
+      "suite": "mochitest-browser-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "windows10-64"
+        },
+        "symbol": "bc2",
+        "tier": 1
+      },
+      "treeherder-platform": "windows10-64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest browser-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=ea0152de5560eefdb0fbcb69437ffd0db05ae95b))",
+      "name": "test-windows10-64/debug-mochitest-browser-chrome-e10s-2",
+      "owner": "ralderete@mozilla.com",
+      "source": "https://hg.mozilla.org/try/file/ea0152de5560eefdb0fbcb69437ffd0db05ae95b/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": [
+        {
+          "name": "public/logs",
+          "path": "logs",
+          "type": "directory"
+        },
+        {
+          "name": "public/test_info",
+          "path": "build/blobber_upload_dir",
+          "type": "directory"
+        }
+      ],
+      "command": [
+        "c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\desktop_unittest.py --cfg mozharness\\configs\\unittests\\win_unittest.py --mochitest-suite=mochitest-browser-chrome-chunked --download-symbols true --mochitest-suite=mochitest-browser-chrome-chunked --total-chunk=7 --this-chunk=2"
+      ],
+      "env": {
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/A_9OoPyPRGKKk8tygRUIcw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/A_9OoPyPRGKKk8tygRUIcw/artifacts/public/build/target.zip\"}",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+        "GECKO_HEAD_REV": "ea0152de5560eefdb0fbcb69437ffd0db05ae95b",
+        "MOZ_AUTOMATION": "1",
+        "SCCACHE_DISABLE": "1",
+        "TRY_COMMIT_MSG": "try: -b do -p all -u autophone-crashtest-dom-media,autophone-crashtest-dom-media-tests,autophone-mochitest-dom-media,autophone-mochitest-dom-media-tests,cppunit,crashtest,crashtest-e10s,gtest,mochitest-bc,mochitest-e10s-bc,mochitest-media,mochitest-media-1,mochitest-media-2,mochitest-media-3,mochitest-media-e10s,test-verify-e10s,web-platform-tests -t none"
+      },
+      "maxRunTime": 3600,
+      "mounts": [
+        {
+          "content": {
+            "artifact": "public/build/mozharness.zip",
+            "taskId": "A_9OoPyPRGKKk8tygRUIcw"
+          },
+          "directory": ".",
+          "format": "zip"
+        }
+      ],
+      "onExitStatus": {
+        "retry": [1073807364, 3221225786]
+      }
+    },
+    "priority": "very-low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.try.ea0152de5560eefdb0fbcb69437ffd0db05ae95b.382323"
+    ],
+    "schedulerId": "gecko-level-1",
+    "scopes": [],
+    "tags": {
+      "createdForUser": "ralderete@mozilla.com",
+      "kind": "test",
+      "label": "test-windows10-64/debug-mochitest-browser-chrome-e10s-2",
+      "os": "windows",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "generic-worker"
+    },
+    "taskGroupId": "EiRNaGPeQjCB0ceF-A-Kdw",
+    "workerType": "gecko-t-win10-64"
+  },
+  "Pr3zPNMqS8CAY6hHB_lwow": {
+    "created": "2019-06-26T19:14:01.910Z",
+    "deadline": "2019-06-27T19:14:01.910Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:01.910Z",
+    "extra": {
+      "chunks": {
+        "current": 3,
+        "total": 6
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "web-platform-tests-reftests",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Web platform tests",
+        "groupSymbol": "W",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "Wr3",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Web platform reftest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-web-platform-tests-reftests-e10s-3",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:01.910Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:01.910Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:01.910Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--test-type=reftest",
+        "--allow-software-gl-layers",
+        "--enable-webrender",
+        "--total-chunk=6",
+        "--this-chunk=3",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.349db14f679fa2cd0459"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.349db14f679fa2cd0459"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-web-platform-tests-reftests-e10s-3",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-xlarge"
+  },
+  "Q5dgajTmQaG3bW8xf8mWRw": {
+    "created": "2019-06-26T19:14:01.491Z",
+    "deadline": "2019-06-27T19:14:01.491Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:01.491Z",
+    "extra": {
+      "chunks": {
+        "current": 16,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-browser-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "bc16",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest browser-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-16",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:01.491Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:01.491Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:01.491Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-browser-chrome-chunked",
+        "--total-chunk=16",
+        "--this-chunk=16",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "browser",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.4587c6b29c078a490d24"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.4587c6b29c078a490d24"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-browser-chrome-e10s-16",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "QDGdgQTQRC2xZNR3Zs_IhA": {
+    "created": "2019-06-26T17:59:20.986Z",
+    "deadline": "2019-06-27T17:59:20.986Z",
+    "dependencies": ["A_9OoPyPRGKKk8tygRUIcw"],
+    "expires": "2019-07-10T17:59:20.986Z",
+    "extra": {
+      "chunks": {
+        "current": 4,
+        "total": 5
+      },
+      "index": {
+        "rank": 1561571806
+      },
+      "parent": "EiRNaGPeQjCB0ceF-A-Kdw",
+      "suite": "web-platform-tests-reftests",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Web platform tests",
+        "groupSymbol": "W",
+        "jobKind": "test",
+        "machine": {
+          "platform": "windows10-64"
+        },
+        "symbol": "Wr4",
+        "tier": 1
+      },
+      "treeherder-platform": "windows10-64/debug"
+    },
+    "metadata": {
+      "description": "Web platform reftest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=ea0152de5560eefdb0fbcb69437ffd0db05ae95b))",
+      "name": "test-windows10-64/debug-web-platform-tests-reftests-e10s-4",
+      "owner": "ralderete@mozilla.com",
+      "source": "https://hg.mozilla.org/try/file/ea0152de5560eefdb0fbcb69437ffd0db05ae95b/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": [
+        {
+          "name": "public/logs",
+          "path": "logs",
+          "type": "directory"
+        },
+        {
+          "name": "public/test_info",
+          "path": "build/blobber_upload_dir",
+          "type": "directory"
+        }
+      ],
+      "command": [
+        "c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=reftest --download-symbols true --test-type=reftest --total-chunk=5 --this-chunk=4"
+      ],
+      "env": {
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/A_9OoPyPRGKKk8tygRUIcw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/A_9OoPyPRGKKk8tygRUIcw/artifacts/public/build/target.zip\"}",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+        "GECKO_HEAD_REV": "ea0152de5560eefdb0fbcb69437ffd0db05ae95b",
+        "MOZ_AUTOMATION": "1",
+        "SCCACHE_DISABLE": "1",
+        "TRY_COMMIT_MSG": "try: -b do -p all -u autophone-crashtest-dom-media,autophone-crashtest-dom-media-tests,autophone-mochitest-dom-media,autophone-mochitest-dom-media-tests,cppunit,crashtest,crashtest-e10s,gtest,mochitest-bc,mochitest-e10s-bc,mochitest-media,mochitest-media-1,mochitest-media-2,mochitest-media-3,mochitest-media-e10s,test-verify-e10s,web-platform-tests -t none"
+      },
+      "maxRunTime": 5400,
+      "mounts": [
+        {
+          "content": {
+            "artifact": "public/build/mozharness.zip",
+            "taskId": "A_9OoPyPRGKKk8tygRUIcw"
+          },
+          "directory": ".",
+          "format": "zip"
+        }
+      ],
+      "onExitStatus": {
+        "retry": [1073807364, 3221225786]
+      }
+    },
+    "priority": "very-low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.try.ea0152de5560eefdb0fbcb69437ffd0db05ae95b.382323"
+    ],
+    "schedulerId": "gecko-level-1",
+    "scopes": [],
+    "tags": {
+      "createdForUser": "ralderete@mozilla.com",
+      "kind": "test",
+      "label": "test-windows10-64/debug-web-platform-tests-reftests-e10s-4",
+      "os": "windows",
+      "retrigger": "true",
+      "worker-implementation": "generic-worker"
+    },
+    "taskGroupId": "EiRNaGPeQjCB0ceF-A-Kdw",
+    "workerType": "gecko-t-win10-64"
+  },
+  "QUhTaNzmR-SnLuVMscnSYA": {
+    "created": "2019-06-26T19:34:53.568Z",
+    "deadline": "2019-06-27T19:34:53.568Z",
+    "dependencies": [],
+    "expires": "2019-07-24T19:34:53.568Z",
+    "extra": {
+      "action": {
+        "context": {
+          "clientId": "mozilla-auth0/ad|Mozilla-LDAP|mshal",
+          "input": {
+            "requests": [
+              {
+                "tasks": ["test-linux64-shippable/opt-talos-g4-e10s"],
+                "times": 1
+              }
+            ]
+          },
+          "parameters": {
+            "app_version": "69.0a1",
+            "base_repository": "https://hg.mozilla.org/mozilla-unified",
+            "build_date": 1561510107,
+            "build_number": 1,
+            "do_not_optimize": [],
+            "existing_tasks": {},
+            "filters": ["target_tasks_method"],
+            "head_ref": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "head_repository": "https://hg.mozilla.org/try",
+            "head_rev": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "hg_branch": "default",
+            "level": "1",
+            "message": "try: -b o -p linux64-shippable -u none -t all",
+            "moz_build_date": "20190626004827",
+            "next_version": null,
+            "optimize_target_tasks": true,
+            "owner": "mshal@mozilla.com",
+            "phabricator_diff": null,
+            "project": "try",
+            "pushdate": 1561510107,
+            "pushlog_id": "381863",
+            "release_enable_emefree": false,
+            "release_enable_partners": false,
+            "release_eta": "",
+            "release_history": {},
+            "release_partner_build_number": 1,
+            "release_partner_config": {},
+            "release_partners": [],
+            "release_product": null,
+            "release_type": "",
+            "required_signoffs": [],
+            "signoff_urls": {},
+            "target_tasks_method": "try_tasks",
+            "tasks_for": "hg-push",
+            "try_mode": "try_option_syntax",
+            "try_options": {
+              "artifact": false,
+              "build_types": "o",
+              "env": null,
+              "include_nightly": false,
+              "interactive": false,
+              "jobs": null,
+              "no_retry": false,
+              "notifications": null,
+              "platforms": "linux64-shippable",
+              "profile": false,
+              "raptor": "none",
+              "raptor_trigger_tests": 1,
+              "tag": null,
+              "talos": "all",
+              "talos_trigger_tests": 1,
+              "taskcluster_worker": false,
+              "trigger_tests": 1,
+              "unittests": "none"
+            },
+            "try_task_config": null,
+            "version": "69.0a1"
+          },
+          "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+          "taskId": null
+        },
+        "name": "retrigger-multiple"
+      },
+      "parent": "VQg1HZ5yS0ixZvsnHLWuFw",
+      "tasks_for": "action",
+      "treeherder": {
+        "groupName": "action-callback",
+        "groupSymbol": "AC",
+        "machine": {
+          "platform": "gecko-decision"
+        },
+        "symbol": "rt"
+      }
+    },
+    "metadata": {
+      "description": "Create a clone of the task.\n\nAction triggered by clientID `mozilla-auth0/ad|Mozilla-LDAP|mshal`\n",
+      "name": "Action: Retrigger",
+      "owner": "mozilla-taskcluster-maintenance@mozilla.com",
+      "source": "https://hg.mozilla.org/try/raw-file/cfe6ae48816614025c458223c66ca2a87b673408/.taskcluster.yml"
+    },
+    "payload": {
+      "artifacts": {
+        "public": {
+          "expires": "2019-07-24T19:34:53.568Z",
+          "path": "/builds/worker/artifacts",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "level-1-checkouts-sparse-v2": "/builds/worker/checkouts"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--gecko-checkout=/builds/worker/checkouts/gecko",
+        "--gecko-sparse-profile=build/sparse-profiles/taskgraph",
+        "--",
+        "bash",
+        "-cx",
+        "cd /builds/worker/checkouts/gecko && ln -s /builds/worker/artifacts artifacts && ./mach --log-no-times taskgraph action-callback\n"
+      ],
+      "env": {
+        "ACTION_CALLBACK": "retrigger-multiple",
+        "ACTION_INPUT": "{\"requests\":[{\"tasks\":[\"test-linux64-shippable/opt-talos-g4-e10s\"],\"times\":1}]}",
+        "ACTION_PARAMETERS": "{\"app_version\":\"69.0a1\",\"base_repository\":\"https://hg.mozilla.org/mozilla-unified\",\"build_date\":1561510107,\"build_number\":1,\"do_not_optimize\":[],\"existing_tasks\":{},\"filters\":[\"target_tasks_method\"],\"head_ref\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"head_repository\":\"https://hg.mozilla.org/try\",\"head_rev\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"hg_branch\":\"default\",\"level\":\"1\",\"message\":\"try: -b o -p linux64-shippable -u none -t all\",\"moz_build_date\":\"20190626004827\",\"next_version\":null,\"optimize_target_tasks\":true,\"owner\":\"mshal@mozilla.com\",\"phabricator_diff\":null,\"project\":\"try\",\"pushdate\":1561510107,\"pushlog_id\":\"381863\",\"release_enable_emefree\":false,\"release_enable_partners\":false,\"release_eta\":\"\",\"release_history\":{},\"release_partner_build_number\":1,\"release_partner_config\":{},\"release_partners\":[],\"release_product\":null,\"release_type\":\"\",\"required_signoffs\":[],\"signoff_urls\":{},\"target_tasks_method\":\"try_tasks\",\"tasks_for\":\"hg-push\",\"try_mode\":\"try_option_syntax\",\"try_options\":{\"artifact\":false,\"build_types\":\"o\",\"env\":null,\"include_nightly\":false,\"interactive\":false,\"jobs\":null,\"no_retry\":false,\"notifications\":null,\"platforms\":\"linux64-shippable\",\"profile\":false,\"raptor\":\"none\",\"raptor_trigger_tests\":1,\"tag\":null,\"talos\":\"all\",\"talos_trigger_tests\":1,\"taskcluster_worker\":false,\"trigger_tests\":1,\"unittests\":\"none\"},\"try_task_config\":null,\"version\":\"69.0a1\"}",
+        "ACTION_TASK_GROUP_ID": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "ACTION_TASK_ID": "null",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REF": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+        "GECKO_HEAD_REV": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+        "TASKCLUSTER_PROXY_URL": "http://taskcluster",
+        "TASKCLUSTER_ROOT_URL": "https://taskcluster.net"
+      },
+      "features": {
+        "chainOfTrust": true,
+        "taskclusterProxy": true
+      },
+      "image": "taskcluster/decision:2.2.0@sha256:0e9689e94605eb8395f5b49141a48148416b0d825f6f7be04c29642d1a85ee3d",
+      "maxRunTime": 1800
+    },
+    "priority": "very-low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.try.cfe6ae48816614025c458223c66ca2a87b673408.381863",
+      "index.gecko.v2.try.pushlog-id.381863.actions.QUhTaNzmR-SnLuVMscnSYA"
+    ],
+    "schedulerId": "gecko-level-1",
+    "scopes": ["assume:repo:hg.mozilla.org/try:action:generic"],
+    "tags": {
+      "createdForUser": "mozilla-taskcluster-maintenance@mozilla.com",
+      "kind": "action-callback"
+    },
+    "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+    "workerType": "gecko-1-decision"
+  },
+  "QbJceuUbQF-SAHp_tuN4bg": {
+    "created": "2019-06-26T19:14:00.049Z",
+    "deadline": "2019-06-27T19:14:00.049Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:00.049Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 3
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-chrome",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests without e10s",
+        "groupSymbol": "M-1proc",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "c1",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-chrome-1proc-1",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:00.049Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:00.049Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:00.049Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-chrome",
+        "--disable-e10s",
+        "--allow-software-gl-layers",
+        "--total-chunk=3",
+        "--this-chunk=1",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "false",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "chrome",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.133ca057e6b7cfbf2d27"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.133ca057e6b7cfbf2d27"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-chrome-1proc-1",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "TNBQvfFkR0KoVFz_7QIkIw": {
+    "created": "2019-06-26T19:13:58.681Z",
+    "deadline": "2019-06-27T19:13:58.681Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:58.681Z",
+    "extra": {
+      "chunks": {
+        "current": 16,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-plain-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "16",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Mochitest plain run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-mochitest-e10s-16",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:58.681Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:58.681Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:58.681Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-plain-chunked",
+        "--enable-webrender",
+        "--total-chunk=16",
+        "--this-chunk=16",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.2d43ab255a9f2a36d1a6"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.2d43ab255a9f2a36d1a6"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-mochitest-e10s-16",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "TacsT1-FSMia0IGkYP-cTQ": {
+    "created": "2019-06-26T19:14:04.882Z",
+    "deadline": "2019-06-27T19:14:04.882Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:04.882Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-plain-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "1",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Mochitest plain run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-mochitest-e10s-1",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:04.882Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:04.882Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:04.882Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-plain-chunked",
+        "--enable-webrender",
+        "--total-chunk=16",
+        "--this-chunk=1",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.d26e152f113468c9f53b"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.d26e152f113468c9f53b"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-mochitest-e10s-1",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "TbO_k663R3St6hBFE92StQ": {
+    "created": "2019-06-26T19:14:06.786Z",
+    "deadline": "2019-06-27T19:14:06.786Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:06.786Z",
+    "extra": {
+      "chunks": {
+        "current": 3,
+        "total": 8
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "reftest-no-accel",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Reftests",
+        "groupSymbol": "R",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "Ru3",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Reftest not accelerated run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-reftest-no-accel-e10s-3",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:06.786Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:06.786Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:06.786Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--reftest-suite=reftest-no-accel",
+        "--allow-software-gl-layers",
+        "--total-chunk=8",
+        "--this-chunk=3",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.e736ef048a55a02fae78"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.e736ef048a55a02fae78"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-reftest-no-accel-e10s-3",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "reftest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "TwPxQPQiQLC0jwp0Crf4sw": {
+    "created": "2019-06-26T19:13:50.881Z",
+    "deadline": "2019-06-27T19:13:50.881Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:50.881Z",
+    "extra": {
+      "chunks": {
+        "current": 2,
+        "total": 18
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "web-platform-tests",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Web platform tests",
+        "groupSymbol": "W",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "wpt2",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-web-platform-tests-e10s-2",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:50.881Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:50.881Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:50.881Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--test-type=testharness",
+        "--allow-software-gl-layers",
+        "--total-chunk=18",
+        "--this-chunk=2",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 7200,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.384f67863a1634580671"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.384f67863a1634580671"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-web-platform-tests-e10s-2",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-xlarge"
+  },
+  "UAEeps8wSMmoL4r0MdjlXA": {
+    "created": "2019-06-26T19:14:01.375Z",
+    "deadline": "2019-06-27T19:14:01.375Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:01.375Z",
+    "extra": {
+      "chunks": {
+        "current": 2,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-plain-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "2",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Mochitest plain run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-mochitest-e10s-2",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:01.375Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:01.375Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:01.375Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-plain-chunked",
+        "--enable-webrender",
+        "--total-chunk=16",
+        "--this-chunk=2",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.381bea4740c49350f041"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.381bea4740c49350f041"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-mochitest-e10s-2",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "UWjPMpssTgq0kA7hj9QtJw": {
+    "created": "2019-06-26T19:13:53.237Z",
+    "deadline": "2019-06-27T19:13:53.237Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:53.237Z",
+    "extra": {
+      "chunks": {
+        "current": 3,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-browser-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "bc3",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest browser-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-3",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:53.237Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:53.237Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:53.237Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-browser-chrome-chunked",
+        "--total-chunk=16",
+        "--this-chunk=3",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "browser",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.60ef765174e49ad5b4f3"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.60ef765174e49ad5b4f3"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-browser-chrome-e10s-3",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "UZ37gpDqTRS1pBNnp0Spsg": {
+    "created": "2019-06-26T18:24:20.696Z",
+    "deadline": "2019-06-27T18:24:20.696Z",
+    "dependencies": ["cMWIUhU_R32z113lhaeHTw", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T18:24:20.696Z",
+    "extra": {
+      "chunks": {
+        "current": 16,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561573344
+      },
+      "parent": "HkX-TbGXQaSX4ucqGMQNBA",
+      "suite": "mochitest-browser-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "asan": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "bc16",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/asan"
+    },
+    "metadata": {
+      "description": "Mochitest browser-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=b437ae030825a8ea9fa7a632b1fcb9becbe11f69))",
+      "name": "test-linux64-asan/opt-mochitest-browser-chrome-e10s-16",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/b437ae030825a8ea9fa7a632b1fcb9becbe11f69/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T18:24:20.696Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T18:24:20.696Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T18:24:20.696Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-browser-chrome-chunked",
+        "--total-chunk=16",
+        "--this-chunk=16"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/cMWIUhU_R32z113lhaeHTw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/cMWIUhU_R32z113lhaeHTw/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "b437ae030825a8ea9fa7a632b1fcb9becbe11f69",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "browser",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/cMWIUhU_R32z113lhaeHTw/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/cMWIUhU_R32z113lhaeHTw/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.007933f74ad412a1a5d3"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.b437ae030825a8ea9fa7a632b1fcb9becbe11f69.88560",
+      "coalesce.v1.autoland.007933f74ad412a1a5d3"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-asan/opt-mochitest-browser-chrome-e10s-16",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "HkX-TbGXQaSX4ucqGMQNBA",
+    "workerType": "gecko-t-linux-large"
+  },
+  "UoGLhHlwT4mH3h3ukcm_Ig": {
+    "created": "2019-06-26T19:14:02.299Z",
+    "deadline": "2019-06-27T19:14:02.299Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:02.299Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 1
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "marionette",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "Mn",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Marionette unittest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-marionette-e10s",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:02.299Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:02.299Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:02.299Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--allow-software-gl-layers",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "marionette/prod_config.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "marionette.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.cc1ea3570a578dff9a69"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.cc1ea3570a578dff9a69"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-marionette-e10s",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "UxS4jt6lQdyUYnPcmN-z-w": {
+    "created": "2019-06-26T19:13:50.335Z",
+    "deadline": "2019-06-27T19:13:50.335Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:50.335Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 4
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "web-platform-tests-reftests",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Web platform tests",
+        "groupSymbol": "W",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "Wr1",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Web platform reftest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-web-platform-tests-reftests-e10s-1",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:50.335Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:50.335Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:50.335Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--test-type=reftest",
+        "--allow-software-gl-layers",
+        "--total-chunk=4",
+        "--this-chunk=1",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.29fbb18f807c48f36551"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.29fbb18f807c48f36551"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-web-platform-tests-reftests-e10s-1",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-xlarge"
+  },
+  "VGU4RUKFScaK8eBikMi9IQ": {
+    "created": "2019-06-26T19:13:57.321Z",
+    "deadline": "2019-06-27T19:13:57.321Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:57.321Z",
+    "extra": {
+      "chunks": {
+        "current": 15,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-browser-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "bc15",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest browser-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-15",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:57.321Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:57.321Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:57.321Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-browser-chrome-chunked",
+        "--total-chunk=16",
+        "--this-chunk=15",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "browser",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.7857d0e99b8b4db40337"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.7857d0e99b8b4db40337"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-browser-chrome-e10s-15",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "VqbRb6bZSlywWOQN62tk-g": {
+    "created": "2019-06-26T19:14:00.780Z",
+    "deadline": "2019-06-27T19:14:00.780Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:00.780Z",
+    "extra": {
+      "chunks": {
+        "current": 14,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-plain-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "14",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest plain run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-e10s-14",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:00.780Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:00.780Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:00.780Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-plain-chunked",
+        "--total-chunk=16",
+        "--this-chunk=14",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.e4b7852df2949a725787"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.e4b7852df2949a725787"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-e10s-14",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "VspVGZYjSAqqsg6CGgv-rw": {
+    "created": "2019-06-26T19:13:51.089Z",
+    "deadline": "2019-06-27T19:13:51.089Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:51.089Z",
+    "extra": {
+      "chunks": {
+        "current": 2,
+        "total": 8
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "reftest",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Reftests",
+        "groupSymbol": "R",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "R2",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Reftest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-reftest-e10s-2",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:51.089Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:51.089Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:51.089Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--reftest-suite=reftest",
+        "--allow-software-gl-layers",
+        "--enable-webrender",
+        "--total-chunk=8",
+        "--this-chunk=2",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.9f16f2fb24d6f1c37ec7"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.9f16f2fb24d6f1c37ec7"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-reftest-e10s-2",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "reftest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "WkFYxflwT76VzWNc6hryiQ": {
+    "created": "2019-06-26T19:13:59.334Z",
+    "deadline": "2019-06-27T19:13:59.334Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:59.334Z",
+    "extra": {
+      "chunks": {
+        "current": 2,
+        "total": 8
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "reftest-no-accel",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Reftests",
+        "groupSymbol": "R",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "Ru2",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Reftest not accelerated run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-reftest-no-accel-e10s-2",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:59.334Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:59.334Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:59.334Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--reftest-suite=reftest-no-accel",
+        "--allow-software-gl-layers",
+        "--total-chunk=8",
+        "--this-chunk=2",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.ba7e668539117283fcb8"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.ba7e668539117283fcb8"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-reftest-no-accel-e10s-2",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "reftest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "XOw2FYEdSb2hwS_lj2bDAg": {
+    "created": "2019-06-26T19:34:51.304Z",
+    "deadline": "2019-06-27T19:34:51.304Z",
+    "dependencies": [],
+    "expires": "2019-07-24T19:34:51.304Z",
+    "extra": {
+      "action": {
+        "context": {
+          "clientId": "mozilla-auth0/ad|Mozilla-LDAP|mshal",
+          "input": {
+            "requests": [
+              {
+                "tasks": ["test-linux64-shippable/opt-talos-g1-e10s"],
+                "times": 1
+              }
+            ]
+          },
+          "parameters": {
+            "app_version": "69.0a1",
+            "base_repository": "https://hg.mozilla.org/mozilla-unified",
+            "build_date": 1561510107,
+            "build_number": 1,
+            "do_not_optimize": [],
+            "existing_tasks": {},
+            "filters": ["target_tasks_method"],
+            "head_ref": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "head_repository": "https://hg.mozilla.org/try",
+            "head_rev": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "hg_branch": "default",
+            "level": "1",
+            "message": "try: -b o -p linux64-shippable -u none -t all",
+            "moz_build_date": "20190626004827",
+            "next_version": null,
+            "optimize_target_tasks": true,
+            "owner": "mshal@mozilla.com",
+            "phabricator_diff": null,
+            "project": "try",
+            "pushdate": 1561510107,
+            "pushlog_id": "381863",
+            "release_enable_emefree": false,
+            "release_enable_partners": false,
+            "release_eta": "",
+            "release_history": {},
+            "release_partner_build_number": 1,
+            "release_partner_config": {},
+            "release_partners": [],
+            "release_product": null,
+            "release_type": "",
+            "required_signoffs": [],
+            "signoff_urls": {},
+            "target_tasks_method": "try_tasks",
+            "tasks_for": "hg-push",
+            "try_mode": "try_option_syntax",
+            "try_options": {
+              "artifact": false,
+              "build_types": "o",
+              "env": null,
+              "include_nightly": false,
+              "interactive": false,
+              "jobs": null,
+              "no_retry": false,
+              "notifications": null,
+              "platforms": "linux64-shippable",
+              "profile": false,
+              "raptor": "none",
+              "raptor_trigger_tests": 1,
+              "tag": null,
+              "talos": "all",
+              "talos_trigger_tests": 1,
+              "taskcluster_worker": false,
+              "trigger_tests": 1,
+              "unittests": "none"
+            },
+            "try_task_config": null,
+            "version": "69.0a1"
+          },
+          "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+          "taskId": null
+        },
+        "name": "retrigger-multiple"
+      },
+      "parent": "VQg1HZ5yS0ixZvsnHLWuFw",
+      "tasks_for": "action",
+      "treeherder": {
+        "groupName": "action-callback",
+        "groupSymbol": "AC",
+        "machine": {
+          "platform": "gecko-decision"
+        },
+        "symbol": "rt"
+      }
+    },
+    "metadata": {
+      "description": "Create a clone of the task.\n\nAction triggered by clientID `mozilla-auth0/ad|Mozilla-LDAP|mshal`\n",
+      "name": "Action: Retrigger",
+      "owner": "mozilla-taskcluster-maintenance@mozilla.com",
+      "source": "https://hg.mozilla.org/try/raw-file/cfe6ae48816614025c458223c66ca2a87b673408/.taskcluster.yml"
+    },
+    "payload": {
+      "artifacts": {
+        "public": {
+          "expires": "2019-07-24T19:34:51.304Z",
+          "path": "/builds/worker/artifacts",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "level-1-checkouts-sparse-v2": "/builds/worker/checkouts"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--gecko-checkout=/builds/worker/checkouts/gecko",
+        "--gecko-sparse-profile=build/sparse-profiles/taskgraph",
+        "--",
+        "bash",
+        "-cx",
+        "cd /builds/worker/checkouts/gecko && ln -s /builds/worker/artifacts artifacts && ./mach --log-no-times taskgraph action-callback\n"
+      ],
+      "env": {
+        "ACTION_CALLBACK": "retrigger-multiple",
+        "ACTION_INPUT": "{\"requests\":[{\"tasks\":[\"test-linux64-shippable/opt-talos-g1-e10s\"],\"times\":1}]}",
+        "ACTION_PARAMETERS": "{\"app_version\":\"69.0a1\",\"base_repository\":\"https://hg.mozilla.org/mozilla-unified\",\"build_date\":1561510107,\"build_number\":1,\"do_not_optimize\":[],\"existing_tasks\":{},\"filters\":[\"target_tasks_method\"],\"head_ref\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"head_repository\":\"https://hg.mozilla.org/try\",\"head_rev\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"hg_branch\":\"default\",\"level\":\"1\",\"message\":\"try: -b o -p linux64-shippable -u none -t all\",\"moz_build_date\":\"20190626004827\",\"next_version\":null,\"optimize_target_tasks\":true,\"owner\":\"mshal@mozilla.com\",\"phabricator_diff\":null,\"project\":\"try\",\"pushdate\":1561510107,\"pushlog_id\":\"381863\",\"release_enable_emefree\":false,\"release_enable_partners\":false,\"release_eta\":\"\",\"release_history\":{},\"release_partner_build_number\":1,\"release_partner_config\":{},\"release_partners\":[],\"release_product\":null,\"release_type\":\"\",\"required_signoffs\":[],\"signoff_urls\":{},\"target_tasks_method\":\"try_tasks\",\"tasks_for\":\"hg-push\",\"try_mode\":\"try_option_syntax\",\"try_options\":{\"artifact\":false,\"build_types\":\"o\",\"env\":null,\"include_nightly\":false,\"interactive\":false,\"jobs\":null,\"no_retry\":false,\"notifications\":null,\"platforms\":\"linux64-shippable\",\"profile\":false,\"raptor\":\"none\",\"raptor_trigger_tests\":1,\"tag\":null,\"talos\":\"all\",\"talos_trigger_tests\":1,\"taskcluster_worker\":false,\"trigger_tests\":1,\"unittests\":\"none\"},\"try_task_config\":null,\"version\":\"69.0a1\"}",
+        "ACTION_TASK_GROUP_ID": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "ACTION_TASK_ID": "null",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REF": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+        "GECKO_HEAD_REV": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+        "TASKCLUSTER_PROXY_URL": "http://taskcluster",
+        "TASKCLUSTER_ROOT_URL": "https://taskcluster.net"
+      },
+      "features": {
+        "chainOfTrust": true,
+        "taskclusterProxy": true
+      },
+      "image": "taskcluster/decision:2.2.0@sha256:0e9689e94605eb8395f5b49141a48148416b0d825f6f7be04c29642d1a85ee3d",
+      "maxRunTime": 1800
+    },
+    "priority": "very-low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.try.cfe6ae48816614025c458223c66ca2a87b673408.381863",
+      "index.gecko.v2.try.pushlog-id.381863.actions.XOw2FYEdSb2hwS_lj2bDAg"
+    ],
+    "schedulerId": "gecko-level-1",
+    "scopes": ["assume:repo:hg.mozilla.org/try:action:generic"],
+    "tags": {
+      "createdForUser": "mozilla-taskcluster-maintenance@mozilla.com",
+      "kind": "action-callback"
+    },
+    "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+    "workerType": "gecko-1-decision"
+  },
+  "XQdfjjACRJCmpqKjLxLRXA": {
+    "created": "2019-06-26T19:13:54.967Z",
+    "deadline": "2019-06-27T19:13:54.967Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:54.967Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 2
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "web-platform-tests-wdspec",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Web platform tests",
+        "groupSymbol": "W",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "Wd1",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Web platform webdriver-spec run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-web-platform-tests-wdspec-e10s-1",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:54.967Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:54.967Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:54.967Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--test-type=wdspec",
+        "--allow-software-gl-layers",
+        "--total-chunk=2",
+        "--this-chunk=1",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.e52a528f7a27226364f1"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.e52a528f7a27226364f1"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-web-platform-tests-wdspec-e10s-1",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-xlarge"
+  },
+  "XiZuJW7MQ-GrC7iV81YWdw": {
+    "created": "2019-06-26T19:14:03.175Z",
+    "deadline": "2019-06-27T19:14:03.175Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:03.175Z",
+    "extra": {
+      "chunks": {
+        "current": 7,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-plain-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "7",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest plain run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-e10s-7",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:03.175Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:03.175Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:03.175Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-plain-chunked",
+        "--total-chunk=16",
+        "--this-chunk=7",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.bca49d80cff53b647f3b"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.bca49d80cff53b647f3b"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-e10s-7",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "Xxznj5R9QCS-7iqptegltQ": {
+    "created": "2019-06-26T19:13:52.515Z",
+    "deadline": "2019-06-27T19:13:52.515Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:52.515Z",
+    "extra": {
+      "chunks": {
+        "current": 3,
+        "total": 3
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-media",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "mda3",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest media run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-media-e10s-3",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:52.515Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:52.515Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:52.515Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-media",
+        "--allow-software-gl-layers",
+        "--total-chunk=3",
+        "--this-chunk=3",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.08d648608ec7b3089c0a"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.08d648608ec7b3089c0a"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-media-e10s-3",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "Y32tr9w0Tlu67dz74wiCyg": {
+    "created": "2019-06-26T19:13:57.583Z",
+    "deadline": "2019-06-27T19:13:57.583Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:57.583Z",
+    "extra": {
+      "chunks": {
+        "current": 2,
+        "total": 3
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-chrome",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests without e10s",
+        "groupSymbol": "M-1proc",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "c2",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Mochitest chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-mochitest-chrome-1proc-2",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:57.583Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:57.583Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:57.583Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-chrome",
+        "--disable-e10s",
+        "--allow-software-gl-layers",
+        "--enable-webrender",
+        "--total-chunk=3",
+        "--this-chunk=2",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "false",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "chrome",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.c230a4e0267ec0a33b03"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.c230a4e0267ec0a33b03"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-mochitest-chrome-1proc-2",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "Y6Zdr078RvemM_nabfiE3A": {
+    "created": "2019-06-26T19:13:51.713Z",
+    "deadline": "2019-06-27T19:13:51.713Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:51.713Z",
+    "extra": {
+      "chunks": {
+        "current": 10,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-plain-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "10",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Mochitest plain run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-mochitest-e10s-10",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:51.713Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:51.713Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:51.713Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-plain-chunked",
+        "--enable-webrender",
+        "--total-chunk=16",
+        "--this-chunk=10",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.97c4def85d324d45708d"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.97c4def85d324d45708d"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-mochitest-e10s-10",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "YUU6v89vRd669kauRLNk5g": {
+    "created": "2019-06-26T19:13:53.839Z",
+    "deadline": "2019-06-27T19:13:53.839Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:53.839Z",
+    "extra": {
+      "chunks": {
+        "current": 5,
+        "total": 8
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "reftest-no-accel",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Reftests",
+        "groupSymbol": "R",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "Ru5",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Reftest not accelerated run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-reftest-no-accel-e10s-5",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:53.839Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:53.839Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:53.839Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--reftest-suite=reftest-no-accel",
+        "--allow-software-gl-layers",
+        "--total-chunk=8",
+        "--this-chunk=5",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.c511cbd3ae8ece905685"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.c511cbd3ae8ece905685"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-reftest-no-accel-e10s-5",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "reftest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "YYCniY1ITuGl0fRNghknlQ": {
+    "created": "2019-06-26T19:13:51.319Z",
+    "deadline": "2019-06-27T19:13:51.319Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:51.319Z",
+    "extra": {
+      "chunks": {
+        "current": 9,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-plain-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "9",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest plain run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-e10s-9",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:51.319Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:51.319Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:51.319Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-plain-chunked",
+        "--total-chunk=16",
+        "--this-chunk=9",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.2aefbb372aa8a455faca"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.2aefbb372aa8a455faca"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-e10s-9",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "YgnJMukTS0efJHzTI5_AnA": {
+    "created": "2019-06-26T19:14:00.375Z",
+    "deadline": "2019-06-27T19:14:00.375Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:00.375Z",
+    "extra": {
+      "chunks": {
+        "current": 5,
+        "total": 6
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "web-platform-tests-reftests",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Web platform tests",
+        "groupSymbol": "W",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "Wr5",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Web platform reftest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-web-platform-tests-reftests-e10s-5",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:00.375Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:00.375Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:00.375Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--test-type=reftest",
+        "--allow-software-gl-layers",
+        "--enable-webrender",
+        "--total-chunk=6",
+        "--this-chunk=5",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.8104304cf1c7f79089b0"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.8104304cf1c7f79089b0"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-web-platform-tests-reftests-e10s-5",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-xlarge"
+  },
+  "ZPrilAZcSimdmLj9flM24w": {
+    "created": "2019-06-26T19:13:58.724Z",
+    "deadline": "2019-06-27T19:13:58.724Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:58.724Z",
+    "extra": {
+      "chunks": {
+        "current": 15,
+        "total": 16
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-plain-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "15",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Mochitest plain run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-mochitest-e10s-15",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:58.724Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:58.724Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:58.724Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-plain-chunked",
+        "--enable-webrender",
+        "--total-chunk=16",
+        "--this-chunk=15",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "plain",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.b483514f571eaeeebf4e"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.b483514f571eaeeebf4e"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-mochitest-e10s-15",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "ZnJOMTOcRwCZG09VY4InxQ": {
+    "created": "2019-06-26T19:13:55.325Z",
+    "deadline": "2019-06-27T19:13:55.325Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:55.325Z",
+    "extra": {
+      "chunks": {
+        "current": 3,
+        "total": 3
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-chrome",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests without e10s",
+        "groupSymbol": "M-1proc",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "c3",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-chrome-1proc-3",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:55.325Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:55.325Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:55.325Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-chrome",
+        "--disable-e10s",
+        "--allow-software-gl-layers",
+        "--total-chunk=3",
+        "--this-chunk=3",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "false",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "chrome",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.7b076938a02b32ad3bf7"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.7b076938a02b32ad3bf7"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-chrome-1proc-3",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "ZyNAZZR0SmOcgqC_k_wqsQ": {
+    "created": "2019-06-26T19:13:47.872Z",
+    "deadline": "2019-06-27T19:13:47.872Z",
+    "dependencies": [
+      "AD0107vYSUCmAH0cGCpjJg",
+      "BM6FRhN-QXCTcuOGUAHWXQ",
+      "DFPNoMezRqyzIc7gTrcNUg",
+      "DFPUyyHLRzOCI5dgCs9KMg",
+      "EQdpwH8CQWmlvk1Yd38h6g",
+      "LH8bxGRATeeAY_BiEN_c6w",
+      "OVHeuiB-QyqFT39RWLNNbA",
+      "a0yJRHtkQzW-tp7nzieXSA",
+      "aoAqZjlVQQ2qz3aO_H-boQ",
+      "XrWNyFwpT2in-wLY9frb-w"
+    ],
+    "expires": "2020-06-25T19:13:47.872Z",
+    "extra": {
+      "chainOfTrust": {
+        "inputs": {
+          "docker-image": "aoAqZjlVQQ2qz3aO_H-boQ"
+        }
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "jobKind": "build",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "B",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Linux64 Debug ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "build-linux64/debug",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/build"
+    },
+    "payload": {
+      "artifacts": {
+        "public/build": {
+          "expires": "2020-06-25T19:13:47.872Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/logs": {
+          "expires": "2020-06-25T19:13:47.872Z",
+          "path": "/builds/worker/logs/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-autoland-build-linux64-debug-workspace-v3-8be03508dc6d71e4397d": "/builds/worker/workspace",
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--gecko-checkout=/builds/worker/workspace/build/src",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/workspace/build/src/taskcluster/scripts/builder/build-linux.sh"
+      ],
+      "env": {
+        "EXTRA_MOZHARNESS_CONFIG": "{\"mozconfig_variant\": \"debug\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/workspace/build/src",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MH_BRANCH": "autoland",
+        "MH_BUILD_POOL": "taskcluster",
+        "MH_CUSTOM_BUILD_VARIANT_CFG": "debug",
+        "MOZHARNESS_ACTIONS": "get-secrets build check-test",
+        "MOZHARNESS_CONFIG": "builds/releng_base_firefox.py builds/releng_base_linux_64_builds.py",
+        "MOZHARNESS_SCRIPT": "mozharness/scripts/fx_desktop_build.py",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_BUILD_DATE": "20190626191141",
+        "MOZ_DISABLE_FULL_SYMBOLS": "1",
+        "MOZ_SCM_LEVEL": "3",
+        "MOZ_SOURCE_CHANGESET": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "MOZ_SOURCE_REPO": "https://hg.mozilla.org/integration/autoland",
+        "MOZ_TOOLCHAINS": "public/build/binutils.tar.xz@DFPNoMezRqyzIc7gTrcNUg public/build/clang.tar.xz@OVHeuiB-QyqFT39RWLNNbA public/build/cbindgen.tar.xz@BM6FRhN-QXCTcuOGUAHWXQ public/build/sccache.tar.xz@EQdpwH8CQWmlvk1Yd38h6g public/build/rustc.tar.xz@a0yJRHtkQzW-tp7nzieXSA public/build/rust-size.tar.xz@AD0107vYSUCmAH0cGCpjJg public/build/nasm.tar.bz2@LH8bxGRATeeAY_BiEN_c6w public/build/node.tar.xz@DFPUyyHLRzOCI5dgCs9KMg",
+        "NEED_XVFB": "true",
+        "PYTHONUNBUFFERED": "1",
+        "SCCACHE_IDLE_TIMEOUT": "0",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "USE_SCCACHE": "1"
+      },
+      "features": {
+        "chainOfTrust": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "aoAqZjlVQQ2qz3aO_H-boQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      }
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "index.gecko.v2.autoland.latest.firefox.linux64-debug",
+      "index.gecko.v2.autoland.pushdate.2019.06.26.20190626191141.firefox.linux64-debug",
+      "index.gecko.v2.autoland.pushlog-id.88565.firefox.linux64-debug",
+      "index.gecko.v2.autoland.revision.219d38523a321229f7f48aca6592f76b993fb1aa.firefox.linux64-debug",
+      "index.gecko.v2.trunk.revision.219d38523a321229f7f48aca6592f76b993fb1aa.firefox.linux64-debug",
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/releng/gecko/build/level-3/*",
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "assume:project:taskcluster:gecko:level-3-sccache-buckets",
+      "docker-worker:cache:gecko-level-3-autoland-build-linux64-debug-workspace-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "build",
+      "label": "build-linux64/debug",
+      "os": "linux",
+      "retrigger": "false",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-3-b-linux"
+  },
+  "a1uUehQvSciykK6DUUNQbQ": {
+    "created": "2019-06-26T19:13:51.060Z",
+    "deadline": "2019-06-27T19:13:51.060Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:51.060Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 8
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "reftest-no-accel",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Reftests",
+        "groupSymbol": "R",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "Ru1",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Reftest not accelerated run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-reftest-no-accel-e10s-1",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:51.060Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:51.060Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:51.060Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--reftest-suite=reftest-no-accel",
+        "--allow-software-gl-layers",
+        "--total-chunk=8",
+        "--this-chunk=1",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.1ac9c51f6999be4ea20b"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.1ac9c51f6999be4ea20b"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-reftest-no-accel-e10s-1",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "reftest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "a5UF8fEyQw-fx_32Qo-WjQ": {
+    "created": "2019-06-26T18:24:21.426Z",
+    "deadline": "2019-06-27T18:24:21.426Z",
+    "dependencies": ["QCwzJEcIT4O72_0bRcDcCg"],
+    "expires": "2020-06-25T18:24:21.426Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 1
+      },
+      "index": {
+        "rank": 1561573344
+      },
+      "parent": "HkX-TbGXQaSX4ucqGMQNBA",
+      "suite": "raptor",
+      "treeherder": {
+        "collection": {
+          "opt": true
+        },
+        "groupName": "Raptor performance tests on Firefox",
+        "groupSymbol": "Rap",
+        "jobKind": "test",
+        "machine": {
+          "platform": "android-hw-p2-8-0-android-aarch64"
+        },
+        "symbol": "tp6m-c-3",
+        "tier": 1
+      },
+      "treeherder-platform": "android-hw-p2-8-0-android-aarch64/opt"
+    },
+    "metadata": {
+      "description": "Raptor tp6m-3 cold page-load on Geckoview Example ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=b437ae030825a8ea9fa7a632b1fcb9becbe11f69))",
+      "name": "test-android-hw-p2-8-0-android-aarch64/opt-raptor-tp6m-3-geckoview-cold-e10s",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/b437ae030825a8ea9fa7a632b1fcb9becbe11f69/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": [
+        {
+          "name": "public/test/",
+          "path": "artifacts/public",
+          "type": "directory"
+        },
+        {
+          "name": "public/logs/",
+          "path": "workspace/logs",
+          "type": "directory"
+        },
+        {
+          "name": "public/test_info/",
+          "path": "workspace/build/blobber_upload_dir",
+          "type": "directory"
+        }
+      ],
+      "command": [
+        [
+          "/builds/taskcluster/script.py",
+          "bash",
+          "./test-linux.sh",
+          "--cfg",
+          "mozharness/configs/raptor/android_hw_config.py",
+          "--test=raptor-tp6m-cold-3",
+          "--app=geckoview",
+          "--binary=org.mozilla.geckoview_example",
+          "--activity=org.mozilla.geckoview_example.GeckoViewActivity",
+          "--download-symbols",
+          "ondemand",
+          "--test=raptor-tp6m-cold-3",
+          "--app=geckoview",
+          "--binary=org.mozilla.geckoview_example",
+          "--activity=org.mozilla.geckoview_example.GeckoViewActivity"
+        ]
+      ],
+      "env": {
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QCwzJEcIT4O72_0bRcDcCg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QCwzJEcIT4O72_0bRcDcCg/artifacts/public/build/geckoview_example.apk\"}",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "b437ae030825a8ea9fa7a632b1fcb9becbe11f69",
+        "MOZHARNESS_CONFIG": "raptor/android_hw_config.py",
+        "MOZHARNESS_SCRIPT": "raptor_script.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/QCwzJEcIT4O72_0bRcDcCg/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/QCwzJEcIT4O72_0bRcDcCg/artifacts/public/build/geckoview_example.apk",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_HIDE_RESULTS_TABLE": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_NO_REMOTE": "1",
+        "NEED_XVFB": "false",
+        "NO_FAIL_ON_TEST_ERRORS": "1",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_WORKER_TYPE": "t-bitbar-gw-perf-p2",
+        "XPCOM_DEBUG_BREAK": "warn"
+      },
+      "maxRunTime": 2700,
+      "mounts": [
+        {
+          "content": {
+            "url": "https://hg.mozilla.org/integration/autoland/raw-file/b437ae030825a8ea9fa7a632b1fcb9becbe11f69/taskcluster/scripts/tester/test-linux.sh"
+          },
+          "file": "test-linux.sh"
+        }
+      ],
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.789042ece47bcaf1e2a8"
+    },
+    "priority": "low",
+    "provisionerId": "proj-autophone",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.b437ae030825a8ea9fa7a632b1fcb9becbe11f69.88560",
+      "coalesce.v1.autoland.789042ece47bcaf1e2a8"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-android-hw-p2-8-0-android-aarch64/opt-raptor-tp6m-3-geckoview-cold-e10s",
+      "os": "linux-bitbar",
+      "retrigger": "true",
+      "test-type": "raptor",
+      "worker-implementation": "generic-worker"
+    },
+    "taskGroupId": "HkX-TbGXQaSX4ucqGMQNBA",
+    "workerType": "gecko-t-bitbar-gw-perf-p2"
+  },
+  "aNf8J_ctQp6IjWJTxCAPbQ": {
+    "created": "2019-06-26T19:14:01.381Z",
+    "deadline": "2019-06-27T19:14:01.381Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:01.381Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 0
+      },
+      "index": {
+        "rank": 0
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "test-verify",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "TV",
+        "tier": 2
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Extra verification of tests modified on this push ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-test-verify-e10s",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:01.381Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:01.381Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:01.381Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--verify",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 10800,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.7fd14669228cc4f23ae1"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.7fd14669228cc4f23ae1"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-test-verify-e10s",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "aNlE6teASbGqtSK4XSeMkg": {
+    "created": "2019-06-26T19:14:01.728Z",
+    "deadline": "2019-06-27T19:14:01.728Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:01.728Z",
+    "extra": {
+      "chunks": {
+        "current": 4,
+        "total": 18
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "web-platform-tests",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Web platform tests",
+        "groupSymbol": "W",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "wpt4",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-web-platform-tests-e10s-4",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:01.728Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:01.728Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:01.728Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--test-type=testharness",
+        "--allow-software-gl-layers",
+        "--total-chunk=18",
+        "--this-chunk=4",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 7200,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.cf19c8108d2acc38c3b1"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.cf19c8108d2acc38c3b1"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-web-platform-tests-e10s-4",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-xlarge"
+  },
+  "ac7vsMLASl6XS1O_VzlLXQ": {
+    "created": "2019-06-26T19:13:56.844Z",
+    "deadline": "2019-06-27T19:13:56.844Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:56.844Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 6
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "web-platform-tests-reftests",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Web platform tests",
+        "groupSymbol": "W",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "Wr1",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Web platform reftest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-web-platform-tests-reftests-e10s-1",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:56.844Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:56.844Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:56.844Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--test-type=reftest",
+        "--allow-software-gl-layers",
+        "--enable-webrender",
+        "--total-chunk=6",
+        "--this-chunk=1",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.df06f8c4996f4c0d3fb9"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.df06f8c4996f4c0d3fb9"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-web-platform-tests-reftests-e10s-1",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-xlarge"
+  },
+  "aeWDjRcUQhudU4axBiCQ8A": {
+    "created": "2019-06-26T19:13:50.117Z",
+    "deadline": "2019-06-27T19:13:50.117Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:50.117Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 1
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-a11y",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests without e10s",
+        "groupSymbol": "M-1proc",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "a11y",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest a11y run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-a11y-1proc",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:50.117Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:50.117Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:50.117Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-a11y",
+        "--disable-e10s",
+        "--allow-software-gl-layers",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "false",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "a11y",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.24bd26243798268c511d"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.24bd26243798268c511d"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-a11y-1proc",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "b0DpnSIQQymnTTSXxRWmmg": {
+    "created": "2019-06-26T19:13:51.395Z",
+    "deadline": "2019-06-27T19:13:51.395Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:51.395Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 8
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "reftest",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Reftests",
+        "groupSymbol": "R",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64-qr"
+        },
+        "symbol": "R1",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64-qr/debug"
+    },
+    "metadata": {
+      "description": "Reftest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64-qr/debug-reftest-e10s-1",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:51.395Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:51.395Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:51.395Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--reftest-suite=reftest",
+        "--allow-software-gl-layers",
+        "--enable-webrender",
+        "--total-chunk=8",
+        "--this-chunk=1",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.986a62716761ba66ff54"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.986a62716761ba66ff54"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64-qr/debug-reftest-e10s-1",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "reftest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "ba34BnYgT_mv1g5BvrlXnQ": {
+    "created": "2019-06-26T19:14:04.804Z",
+    "deadline": "2019-06-27T19:14:04.804Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:14:04.804Z",
+    "extra": {
+      "chunks": {
+        "current": 7,
+        "total": 8
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "reftest",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Reftests",
+        "groupSymbol": "R",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "R7",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Reftest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-reftest-e10s-7",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:14:04.804Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:14:04.804Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:14:04.804Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--reftest-suite=reftest",
+        "--allow-software-gl-layers",
+        "--total-chunk=8",
+        "--this-chunk=7",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 3600,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.d896485eb6209c6477ae"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.d896485eb6209c6477ae"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-reftest-e10s-7",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "reftest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "c9SSXwx3TnKm7MnNEit0OA": {
+    "created": "2019-06-26T19:13:51.441Z",
+    "deadline": "2019-06-27T19:13:51.441Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:51.441Z",
+    "extra": {
+      "chunks": {
+        "current": 5,
+        "total": 6
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "xpcshell",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Xpcshell tests",
+        "groupSymbol": "X",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "X5",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "xpcshell test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-xpcshell-e10s-5",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:51.441Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:51.441Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:51.441Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--xpcshell-suite=xpcshell",
+        "--total-chunk=6",
+        "--this-chunk=5",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "false",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.d5dcf606c4dc37503690"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.d5dcf606c4dc37503690"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-xpcshell-e10s-5",
+      "os": "linux",
+      "retrigger": "true",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "dUcobAuPTEqHok4rpJl1Dg": {
+    "created": "2019-06-26T19:13:57.869Z",
+    "deadline": "2019-06-27T19:13:57.869Z",
+    "dependencies": ["ZyNAZZR0SmOcgqC_k_wqsQ", "fwecfu9zRiyF2tPxq29EAQ"],
+    "expires": "2020-06-25T19:13:57.869Z",
+    "extra": {
+      "chunks": {
+        "current": 9,
+        "total": 12
+      },
+      "index": {
+        "rank": 1561576301
+      },
+      "parent": "XrWNyFwpT2in-wLY9frb-w",
+      "suite": "mochitest-devtools-chrome-chunked",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Mochitests",
+        "groupSymbol": "M",
+        "jobKind": "test",
+        "machine": {
+          "platform": "linux64"
+        },
+        "symbol": "dt9",
+        "tier": 1
+      },
+      "treeherder-platform": "linux64/debug"
+    },
+    "metadata": {
+      "description": "Mochitest devtools-chrome run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=219d38523a321229f7f48aca6592f76b993fb1aa))",
+      "name": "test-linux64/debug-mochitest-devtools-chrome-e10s-9",
+      "owner": "jmuizelaar@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/219d38523a321229f7f48aca6592f76b993fb1aa/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": {
+        "public/logs/": {
+          "expires": "2020-06-25T19:13:57.869Z",
+          "path": "/builds/worker/workspace/logs/",
+          "type": "directory"
+        },
+        "public/test": {
+          "expires": "2020-06-25T19:13:57.869Z",
+          "path": "/builds/worker/artifacts/",
+          "type": "directory"
+        },
+        "public/test_info/": {
+          "expires": "2020-06-25T19:13:57.869Z",
+          "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "gecko-level-3-checkouts-v3-8be03508dc6d71e4397d": "/builds/worker/checkouts",
+        "gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d": "/builds/worker/tooltool-cache"
+      },
+      "capabilities": {
+        "devices": {
+          "loopbackVideo": true
+        }
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--fetch-hgfingerprint",
+        "--",
+        "/builds/worker/bin/test-linux.sh",
+        "--mochitest-suite=mochitest-devtools-chrome-chunked",
+        "--total-chunk=12",
+        "--this-chunk=9",
+        "--download-symbols=true"
+      ],
+      "env": {
+        "ENABLE_E10S": "true",
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2\"}",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "219d38523a321229f7f48aca6592f76b993fb1aa",
+        "GECKO_PATH": "/builds/worker/checkouts/gecko",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOCHITEST_FLAVOR": "chrome",
+        "MOZHARNESS_CONFIG": "unittests/linux_unittest.py remove_executables.py",
+        "MOZHARNESS_SCRIPT": "desktop_unittest.py",
+        "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/mozharness.zip",
+        "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/artifacts/public/build/target.tar.bz2",
+        "MOZ_AUTOMATION": "1",
+        "MOZ_NODE_PATH": "/usr/local/bin/node",
+        "MOZ_SCM_LEVEL": "3",
+        "NEED_COMPIZ": "true",
+        "NEED_PULSEAUDIO": "true",
+        "NEED_WINDOW_MANAGER": "true",
+        "SCCACHE_DISABLE": "1",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+        "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+        "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+        "WORKING_DIR": "/builds/worker"
+      },
+      "features": {
+        "allowPtrace": true,
+        "taskclusterProxy": true
+      },
+      "image": {
+        "path": "public/image.tar.zst",
+        "taskId": "fwecfu9zRiyF2tPxq29EAQ",
+        "type": "task-image"
+      },
+      "maxRunTime": 5400,
+      "onExitStatus": {
+        "purgeCaches": [72],
+        "retry": [4, 72]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.7ceadd913366803a8855"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.219d38523a321229f7f48aca6592f76b993fb1aa.88565",
+      "coalesce.v1.autoland.7ceadd913366803a8855"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [
+      "secrets:get:project/taskcluster/gecko/hgfingerprint",
+      "secrets:get:project/taskcluster/gecko/hgmointernal",
+      "project:releng:services/tooltool/api/download/public",
+      "docker-worker:feature:allowPtrace",
+      "docker-worker:capability:device:loopbackVideo",
+      "docker-worker:cache:gecko-level-3-checkouts-v3-8be03508dc6d71e4397d",
+      "docker-worker:cache:gecko-level-3-tooltool-cache-v3-8be03508dc6d71e4397d"
+    ],
+    "tags": {
+      "createdForUser": "jmuizelaar@mozilla.com",
+      "kind": "test",
+      "label": "test-linux64/debug-mochitest-devtools-chrome-e10s-9",
+      "os": "linux",
+      "retrigger": "true",
+      "test-type": "mochitest",
+      "worker-implementation": "docker-worker"
+    },
+    "taskGroupId": "XrWNyFwpT2in-wLY9frb-w",
+    "workerType": "gecko-t-linux-large"
+  },
+  "eokGh4-OSbOqAzVhJypYPg": {
+    "created": "2019-06-26T18:21:52.288Z",
+    "deadline": "2019-06-27T18:21:52.288Z",
+    "dependencies": ["RmvYzniIRNWDSw_9rjU2aQ"],
+    "expires": "2020-06-25T18:21:52.288Z",
+    "extra": {
+      "chunks": {
+        "current": 1,
+        "total": 1
+      },
+      "index": {
+        "rank": 1561573180
+      },
+      "parent": "UuixJvjhQU6rf9aGtGo9Wg",
+      "suite": "crashtest",
+      "treeherder": {
+        "collection": {
+          "debug": true
+        },
+        "groupName": "Reftests",
+        "groupSymbol": "R",
+        "jobKind": "test",
+        "machine": {
+          "platform": "windows7-32"
+        },
+        "symbol": "C",
+        "tier": 1
+      },
+      "treeherder-platform": "windows7-32/debug"
+    },
+    "metadata": {
+      "description": "Crashtest run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=44932f2396663a7e44434a9c562c1089ebd4422b))",
+      "name": "test-windows7-32/debug-crashtest-e10s",
+      "owner": "npierron@mozilla.com",
+      "source": "https://hg.mozilla.org/integration/autoland/file/44932f2396663a7e44434a9c562c1089ebd4422b/taskcluster/ci/test"
+    },
+    "payload": {
+      "artifacts": [
+        {
+          "name": "public/logs",
+          "path": "logs",
+          "type": "directory"
+        },
+        {
+          "name": "public/test_info",
+          "path": "build/blobber_upload_dir",
+          "type": "directory"
+        }
+      ],
+      "command": [
+        "c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\desktop_unittest.py --cfg mozharness\\configs\\unittests\\win_unittest.py --reftest-suite=crashtest --download-symbols true --reftest-suite=crashtest"
+      ],
+      "env": {
+        "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RmvYzniIRNWDSw_9rjU2aQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RmvYzniIRNWDSw_9rjU2aQ/artifacts/public/build/target.zip\"}",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+        "GECKO_HEAD_REV": "44932f2396663a7e44434a9c562c1089ebd4422b",
+        "MOZ_AUTOMATION": "1",
+        "SCCACHE_DISABLE": "1"
+      },
+      "maxRunTime": 3600,
+      "mounts": [
+        {
+          "content": {
+            "artifact": "public/build/mozharness.zip",
+            "taskId": "RmvYzniIRNWDSw_9rjU2aQ"
+          },
+          "directory": ".",
+          "format": "zip"
+        }
+      ],
+      "onExitStatus": {
+        "retry": [1073807364, 3221225786]
+      },
+      "supersederUrl": "https://coalesce.mozilla-releng.net/v1/list/3600/5/autoland.0a7e947614b84c1371ae"
+    },
+    "priority": "low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.autoland.44932f2396663a7e44434a9c562c1089ebd4422b.88557",
+      "coalesce.v1.autoland.0a7e947614b84c1371ae"
+    ],
+    "schedulerId": "gecko-level-3",
+    "scopes": [],
+    "tags": {
+      "createdForUser": "npierron@mozilla.com",
+      "kind": "test",
+      "label": "test-windows7-32/debug-crashtest-e10s",
+      "os": "windows",
+      "retrigger": "true",
+      "worker-implementation": "generic-worker"
+    },
+    "taskGroupId": "UuixJvjhQU6rf9aGtGo9Wg",
+    "workerType": "gecko-t-win7-32"
+  },
+  "eugCBPRNRD-zyP_I9Jcn1w": {
+    "created": "2019-06-26T19:34:52.653Z",
+    "deadline": "2019-06-27T19:34:52.653Z",
+    "dependencies": [],
+    "expires": "2019-07-24T19:34:52.653Z",
+    "extra": {
+      "action": {
+        "context": {
+          "clientId": "mozilla-auth0/ad|Mozilla-LDAP|mshal",
+          "input": {
+            "requests": [
+              {
+                "tasks": ["test-linux64-shippable/opt-talos-g3-e10s"],
+                "times": 1
+              }
+            ]
+          },
+          "parameters": {
+            "app_version": "69.0a1",
+            "base_repository": "https://hg.mozilla.org/mozilla-unified",
+            "build_date": 1561510107,
+            "build_number": 1,
+            "do_not_optimize": [],
+            "existing_tasks": {},
+            "filters": ["target_tasks_method"],
+            "head_ref": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "head_repository": "https://hg.mozilla.org/try",
+            "head_rev": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "hg_branch": "default",
+            "level": "1",
+            "message": "try: -b o -p linux64-shippable -u none -t all",
+            "moz_build_date": "20190626004827",
+            "next_version": null,
+            "optimize_target_tasks": true,
+            "owner": "mshal@mozilla.com",
+            "phabricator_diff": null,
+            "project": "try",
+            "pushdate": 1561510107,
+            "pushlog_id": "381863",
+            "release_enable_emefree": false,
+            "release_enable_partners": false,
+            "release_eta": "",
+            "release_history": {},
+            "release_partner_build_number": 1,
+            "release_partner_config": {},
+            "release_partners": [],
+            "release_product": null,
+            "release_type": "",
+            "required_signoffs": [],
+            "signoff_urls": {},
+            "target_tasks_method": "try_tasks",
+            "tasks_for": "hg-push",
+            "try_mode": "try_option_syntax",
+            "try_options": {
+              "artifact": false,
+              "build_types": "o",
+              "env": null,
+              "include_nightly": false,
+              "interactive": false,
+              "jobs": null,
+              "no_retry": false,
+              "notifications": null,
+              "platforms": "linux64-shippable",
+              "profile": false,
+              "raptor": "none",
+              "raptor_trigger_tests": 1,
+              "tag": null,
+              "talos": "all",
+              "talos_trigger_tests": 1,
+              "taskcluster_worker": false,
+              "trigger_tests": 1,
+              "unittests": "none"
+            },
+            "try_task_config": null,
+            "version": "69.0a1"
+          },
+          "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+          "taskId": null
+        },
+        "name": "retrigger-multiple"
+      },
+      "parent": "VQg1HZ5yS0ixZvsnHLWuFw",
+      "tasks_for": "action",
+      "treeherder": {
+        "groupName": "action-callback",
+        "groupSymbol": "AC",
+        "machine": {
+          "platform": "gecko-decision"
+        },
+        "symbol": "rt"
+      }
+    },
+    "metadata": {
+      "description": "Create a clone of the task.\n\nAction triggered by clientID `mozilla-auth0/ad|Mozilla-LDAP|mshal`\n",
+      "name": "Action: Retrigger",
+      "owner": "mozilla-taskcluster-maintenance@mozilla.com",
+      "source": "https://hg.mozilla.org/try/raw-file/cfe6ae48816614025c458223c66ca2a87b673408/.taskcluster.yml"
+    },
+    "payload": {
+      "artifacts": {
+        "public": {
+          "expires": "2019-07-24T19:34:52.653Z",
+          "path": "/builds/worker/artifacts",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "level-1-checkouts-sparse-v2": "/builds/worker/checkouts"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--gecko-checkout=/builds/worker/checkouts/gecko",
+        "--gecko-sparse-profile=build/sparse-profiles/taskgraph",
+        "--",
+        "bash",
+        "-cx",
+        "cd /builds/worker/checkouts/gecko && ln -s /builds/worker/artifacts artifacts && ./mach --log-no-times taskgraph action-callback\n"
+      ],
+      "env": {
+        "ACTION_CALLBACK": "retrigger-multiple",
+        "ACTION_INPUT": "{\"requests\":[{\"tasks\":[\"test-linux64-shippable/opt-talos-g3-e10s\"],\"times\":1}]}",
+        "ACTION_PARAMETERS": "{\"app_version\":\"69.0a1\",\"base_repository\":\"https://hg.mozilla.org/mozilla-unified\",\"build_date\":1561510107,\"build_number\":1,\"do_not_optimize\":[],\"existing_tasks\":{},\"filters\":[\"target_tasks_method\"],\"head_ref\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"head_repository\":\"https://hg.mozilla.org/try\",\"head_rev\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"hg_branch\":\"default\",\"level\":\"1\",\"message\":\"try: -b o -p linux64-shippable -u none -t all\",\"moz_build_date\":\"20190626004827\",\"next_version\":null,\"optimize_target_tasks\":true,\"owner\":\"mshal@mozilla.com\",\"phabricator_diff\":null,\"project\":\"try\",\"pushdate\":1561510107,\"pushlog_id\":\"381863\",\"release_enable_emefree\":false,\"release_enable_partners\":false,\"release_eta\":\"\",\"release_history\":{},\"release_partner_build_number\":1,\"release_partner_config\":{},\"release_partners\":[],\"release_product\":null,\"release_type\":\"\",\"required_signoffs\":[],\"signoff_urls\":{},\"target_tasks_method\":\"try_tasks\",\"tasks_for\":\"hg-push\",\"try_mode\":\"try_option_syntax\",\"try_options\":{\"artifact\":false,\"build_types\":\"o\",\"env\":null,\"include_nightly\":false,\"interactive\":false,\"jobs\":null,\"no_retry\":false,\"notifications\":null,\"platforms\":\"linux64-shippable\",\"profile\":false,\"raptor\":\"none\",\"raptor_trigger_tests\":1,\"tag\":null,\"talos\":\"all\",\"talos_trigger_tests\":1,\"taskcluster_worker\":false,\"trigger_tests\":1,\"unittests\":\"none\"},\"try_task_config\":null,\"version\":\"69.0a1\"}",
+        "ACTION_TASK_GROUP_ID": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "ACTION_TASK_ID": "null",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REF": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+        "GECKO_HEAD_REV": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+        "TASKCLUSTER_PROXY_URL": "http://taskcluster",
+        "TASKCLUSTER_ROOT_URL": "https://taskcluster.net"
+      },
+      "features": {
+        "chainOfTrust": true,
+        "taskclusterProxy": true
+      },
+      "image": "taskcluster/decision:2.2.0@sha256:0e9689e94605eb8395f5b49141a48148416b0d825f6f7be04c29642d1a85ee3d",
+      "maxRunTime": 1800
+    },
+    "priority": "very-low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.try.cfe6ae48816614025c458223c66ca2a87b673408.381863",
+      "index.gecko.v2.try.pushlog-id.381863.actions.eugCBPRNRD-zyP_I9Jcn1w"
+    ],
+    "schedulerId": "gecko-level-1",
+    "scopes": ["assume:repo:hg.mozilla.org/try:action:generic"],
+    "tags": {
+      "createdForUser": "mozilla-taskcluster-maintenance@mozilla.com",
+      "kind": "action-callback"
+    },
+    "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+    "workerType": "gecko-1-decision"
+  },
+  "fu4duSjBRte-V6y_oQ_BrQ": {
+    "created": "2019-06-26T19:34:50.888Z",
+    "deadline": "2019-06-27T19:34:50.888Z",
+    "dependencies": [],
+    "expires": "2019-07-24T19:34:50.888Z",
+    "extra": {
+      "action": {
+        "context": {
+          "clientId": "mozilla-auth0/ad|Mozilla-LDAP|mshal",
+          "input": {
+            "requests": [
+              {
+                "tasks": ["test-linux64-shippable/opt-talos-g1-e10s"],
+                "times": 1
+              }
+            ]
+          },
+          "parameters": {
+            "app_version": "69.0a1",
+            "base_repository": "https://hg.mozilla.org/mozilla-unified",
+            "build_date": 1561510107,
+            "build_number": 1,
+            "do_not_optimize": [],
+            "existing_tasks": {},
+            "filters": ["target_tasks_method"],
+            "head_ref": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "head_repository": "https://hg.mozilla.org/try",
+            "head_rev": "cfe6ae48816614025c458223c66ca2a87b673408",
+            "hg_branch": "default",
+            "level": "1",
+            "message": "try: -b o -p linux64-shippable -u none -t all",
+            "moz_build_date": "20190626004827",
+            "next_version": null,
+            "optimize_target_tasks": true,
+            "owner": "mshal@mozilla.com",
+            "phabricator_diff": null,
+            "project": "try",
+            "pushdate": 1561510107,
+            "pushlog_id": "381863",
+            "release_enable_emefree": false,
+            "release_enable_partners": false,
+            "release_eta": "",
+            "release_history": {},
+            "release_partner_build_number": 1,
+            "release_partner_config": {},
+            "release_partners": [],
+            "release_product": null,
+            "release_type": "",
+            "required_signoffs": [],
+            "signoff_urls": {},
+            "target_tasks_method": "try_tasks",
+            "tasks_for": "hg-push",
+            "try_mode": "try_option_syntax",
+            "try_options": {
+              "artifact": false,
+              "build_types": "o",
+              "env": null,
+              "include_nightly": false,
+              "interactive": false,
+              "jobs": null,
+              "no_retry": false,
+              "notifications": null,
+              "platforms": "linux64-shippable",
+              "profile": false,
+              "raptor": "none",
+              "raptor_trigger_tests": 1,
+              "tag": null,
+              "talos": "all",
+              "talos_trigger_tests": 1,
+              "taskcluster_worker": false,
+              "trigger_tests": 1,
+              "unittests": "none"
+            },
+            "try_task_config": null,
+            "version": "69.0a1"
+          },
+          "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+          "taskId": null
+        },
+        "name": "retrigger-multiple"
+      },
+      "parent": "VQg1HZ5yS0ixZvsnHLWuFw",
+      "tasks_for": "action",
+      "treeherder": {
+        "groupName": "action-callback",
+        "groupSymbol": "AC",
+        "machine": {
+          "platform": "gecko-decision"
+        },
+        "symbol": "rt"
+      }
+    },
+    "metadata": {
+      "description": "Create a clone of the task.\n\nAction triggered by clientID `mozilla-auth0/ad|Mozilla-LDAP|mshal`\n",
+      "name": "Action: Retrigger",
+      "owner": "mozilla-taskcluster-maintenance@mozilla.com",
+      "source": "https://hg.mozilla.org/try/raw-file/cfe6ae48816614025c458223c66ca2a87b673408/.taskcluster.yml"
+    },
+    "payload": {
+      "artifacts": {
+        "public": {
+          "expires": "2019-07-24T19:34:50.888Z",
+          "path": "/builds/worker/artifacts",
+          "type": "directory"
+        }
+      },
+      "cache": {
+        "level-1-checkouts-sparse-v2": "/builds/worker/checkouts"
+      },
+      "command": [
+        "/builds/worker/bin/run-task",
+        "--gecko-checkout=/builds/worker/checkouts/gecko",
+        "--gecko-sparse-profile=build/sparse-profiles/taskgraph",
+        "--",
+        "bash",
+        "-cx",
+        "cd /builds/worker/checkouts/gecko && ln -s /builds/worker/artifacts artifacts && ./mach --log-no-times taskgraph action-callback\n"
+      ],
+      "env": {
+        "ACTION_CALLBACK": "retrigger-multiple",
+        "ACTION_INPUT": "{\"requests\":[{\"tasks\":[\"test-linux64-shippable/opt-talos-g1-e10s\"],\"times\":1}]}",
+        "ACTION_PARAMETERS": "{\"app_version\":\"69.0a1\",\"base_repository\":\"https://hg.mozilla.org/mozilla-unified\",\"build_date\":1561510107,\"build_number\":1,\"do_not_optimize\":[],\"existing_tasks\":{},\"filters\":[\"target_tasks_method\"],\"head_ref\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"head_repository\":\"https://hg.mozilla.org/try\",\"head_rev\":\"cfe6ae48816614025c458223c66ca2a87b673408\",\"hg_branch\":\"default\",\"level\":\"1\",\"message\":\"try: -b o -p linux64-shippable -u none -t all\",\"moz_build_date\":\"20190626004827\",\"next_version\":null,\"optimize_target_tasks\":true,\"owner\":\"mshal@mozilla.com\",\"phabricator_diff\":null,\"project\":\"try\",\"pushdate\":1561510107,\"pushlog_id\":\"381863\",\"release_enable_emefree\":false,\"release_enable_partners\":false,\"release_eta\":\"\",\"release_history\":{},\"release_partner_build_number\":1,\"release_partner_config\":{},\"release_partners\":[],\"release_product\":null,\"release_type\":\"\",\"required_signoffs\":[],\"signoff_urls\":{},\"target_tasks_method\":\"try_tasks\",\"tasks_for\":\"hg-push\",\"try_mode\":\"try_option_syntax\",\"try_options\":{\"artifact\":false,\"build_types\":\"o\",\"env\":null,\"include_nightly\":false,\"interactive\":false,\"jobs\":null,\"no_retry\":false,\"notifications\":null,\"platforms\":\"linux64-shippable\",\"profile\":false,\"raptor\":\"none\",\"raptor_trigger_tests\":1,\"tag\":null,\"talos\":\"all\",\"talos_trigger_tests\":1,\"taskcluster_worker\":false,\"trigger_tests\":1,\"unittests\":\"none\"},\"try_task_config\":null,\"version\":\"69.0a1\"}",
+        "ACTION_TASK_GROUP_ID": "VQg1HZ5yS0ixZvsnHLWuFw",
+        "ACTION_TASK_ID": "null",
+        "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+        "GECKO_HEAD_REF": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+        "GECKO_HEAD_REV": "cfe6ae48816614025c458223c66ca2a87b673408",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+        "TASKCLUSTER_PROXY_URL": "http://taskcluster",
+        "TASKCLUSTER_ROOT_URL": "https://taskcluster.net"
+      },
+      "features": {
+        "chainOfTrust": true,
+        "taskclusterProxy": true
+      },
+      "image": "taskcluster/decision:2.2.0@sha256:0e9689e94605eb8395f5b49141a48148416b0d825f6f7be04c29642d1a85ee3d",
+      "maxRunTime": 1800
+    },
+    "priority": "very-low",
+    "provisionerId": "aws-provisioner-v1",
+    "requires": "all-completed",
+    "retries": 5,
+    "routes": [
+      "tc-treeherder.v2.try.cfe6ae48816614025c458223c66ca2a87b673408.381863",
+      "index.gecko.v2.try.pushlog-id.381863.actions.fu4duSjBRte-V6y_oQ_BrQ"
+    ],
+    "schedulerId": "gecko-level-1",
+    "scopes": ["assume:repo:hg.mozilla.org/try:action:generic"],
+    "tags": {
+      "createdForUser": "mozilla-taskcluster-maintenance@mozilla.com",
+      "kind": "action-callback"
+    },
+    "taskGroupId": "VQg1HZ5yS0ixZvsnHLWuFw",
+    "workerType": "gecko-1-decision"
+  }
+}

--- a/tests/sample_data/pulse_consumer/taskcluster_transformed_jobs.json
+++ b/tests/sample_data/pulse_consumer/taskcluster_transformed_jobs.json
@@ -1,0 +1,4303 @@
+{
+  "A35mWTRuQmyj88yMnIF0fA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "037e6659-346e-426c-a3f3-cc8c9c81747c/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests without e10s",
+      "group_symbol": "M-1proc",
+      "job_guid": "037e6659-346e-426c-a3f3-cc8c9c81747c/0",
+      "job_symbol": "a11y",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-mochitest-a11y-1proc",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576431,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "A35mWTRuQmyj88yMnIF0fA",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "A3dJ8bDIQRKzHiZBhM0c5Q": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "037749f1-b0c8-4112-b31e-264184cd1ce5/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "037749f1-b0c8-4112-b31e-264184cd1ce5/0",
+      "job_symbol": "bc13",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-13",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576435,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "A3dJ8bDIQRKzHiZBhM0c5Q",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "A47ePPIaRFOWxw8oVOvmCA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "038ede3c-f21a-4453-96c7-0f2854ebe608/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests with socket process",
+      "group_symbol": "M-spi",
+      "job_guid": "038ede3c-f21a-4453-96c7-0f2854ebe608/0",
+      "job_symbol": "mda2",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-mochitest-media-spi-e10s-2",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576432,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "A47ePPIaRFOWxw8oVOvmCA",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "A4AV9EXXREGCV-hVKT0blQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "038015f4-45d7-4441-8257-e855293d1b95/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Xpcshell tests",
+      "group_symbol": "X",
+      "job_guid": "038015f4-45d7-4441-8257-e855293d1b95/0",
+      "job_symbol": "X5",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-xpcshell-e10s-5",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576444,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "A4AV9EXXREGCV-hVKT0blQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "ADfskOGaS7KUj0AuUb324A": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "0037ec90-e19a-4bb2-948f-402e51bdf6e0/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "0037ec90-e19a-4bb2-948f-402e51bdf6e0/0",
+      "job_symbol": "bc2",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-2",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576439,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "ADfskOGaS7KUj0AuUb324A",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "AcUWtRf7QB-4XQS8nSTilg": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "01c516b5-17fb-401f-b85d-04bc9d24e296/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Xpcshell tests",
+      "group_symbol": "X",
+      "job_guid": "01c516b5-17fb-401f-b85d-04bc9d24e296/0",
+      "job_symbol": "X3",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-xpcshell-e10s-3",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576438,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "AcUWtRf7QB-4XQS8nSTilg",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "Ai-bmuTzS7eRBYFhSPnZ1w": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "022f9b9a-e4f3-4bb7-9105-816148f9d9d7/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "022f9b9a-e4f3-4bb7-9105-816148f9d9d7/0",
+      "job_symbol": "dt7",
+      "log_references": [],
+      "machine": "i-0429b6e2c0ac7474d",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-devtools-chrome-e10s-7",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "start_timestamp": 1561577771,
+      "state": "running",
+      "submit_timestamp": 1561576438,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "Ai-bmuTzS7eRBYFhSPnZ1w",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "AlcvKmrGS8e9FXrFTYnhpA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "02572f2a-6ac6-4bc7-bd15-7ac54d89e1a4/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "02572f2a-6ac6-4bc7-bd15-7ac54d89e1a4/0",
+      "job_symbol": "bc14",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-14",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576435,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "AlcvKmrGS8e9FXrFTYnhpA",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "ApotNgqaQh6OGDW8TMSWlQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "029a2d36-0a9a-421e-8e18-35bc4cc49695/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Firefox functional tests (local)",
+      "group_symbol": "Fxfn-l",
+      "job_guid": "029a2d36-0a9a-421e-8e18-35bc4cc49695/0",
+      "job_symbol": "en-US",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-firefox-ui-functional-local-e10s",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576431,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "ApotNgqaQh6OGDW8TMSWlQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "AqMhSaDqSAG7nfjfxjKLZA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "02a32149-a0ea-4801-bb9d-f8dfc6328b64/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "02a32149-a0ea-4801-bb9d-f8dfc6328b64/0",
+      "job_symbol": "dt2",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-devtools-chrome-e10s-2",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576430,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "AqMhSaDqSAG7nfjfxjKLZA",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "AseHcKjPRhi-NBsvwH54gw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "02c78770-a8cf-4618-be34-1b2fc07e7883/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Xpcshell tests",
+      "group_symbol": "X",
+      "job_guid": "02c78770-a8cf-4618-be34-1b2fc07e7883/0",
+      "job_symbol": "X2",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-xpcshell-e10s-2",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576431,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "AseHcKjPRhi-NBsvwH54gw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "B3EheQ-IQ5aPzw34KS_a6g": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "07712179-0f88-4396-8fcf-0df8292fdaea/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "macosx1014-64-shippable"
+      },
+      "build_system_type": "taskcluster",
+      "end_timestamp": 1561577770,
+      "group_name": "Raptor performance tests on Firefox",
+      "group_symbol": "Rap",
+      "job_guid": "07712179-0f88-4396-8fcf-0df8292fdaea/0",
+      "job_symbol": "tp6-7",
+      "log_references": [
+        {
+          "name": "builds-4h",
+          "parse_status": "pending",
+          "url": "https://queue.taskcluster.net/v1/task/B3EheQ-IQ5aPzw34KS_a6g/runs/0/artifacts/public/logs/live_backing.log"
+        }
+      ],
+      "machine": "t-mojave-r7-153",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "macosx1014-64-shippable"
+      },
+      "name": "test-macosx1014-64-shippable/opt-raptor-tp6-7-firefox-e10s",
+      "option_collection": {
+        "opt": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "success",
+      "start_timestamp": 1561577268,
+      "state": "completed",
+      "submit_timestamp": 1561572433,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "B3EheQ-IQ5aPzw34KS_a6g",
+      "tier": 1,
+      "who": "malexandru@mozilla.com"
+    },
+    "revision": "918d7c84da371bda26460fb4b50f161d32107880",
+    "superseded": []
+  },
+  "BFqlkKMaTVqv3ROSlUT6kQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "045aa590-a31a-4d5a-afdd-13929544fa91/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Web platform tests",
+      "group_symbol": "W",
+      "job_guid": "045aa590-a31a-4d5a-afdd-13929544fa91/0",
+      "job_symbol": "wpt7",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-web-platform-tests-e10s-7",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576436,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "BFqlkKMaTVqv3ROSlUT6kQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "BHejD_RvTW2HR2THXfwDAQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "0477a30f-f46f-4d6d-8747-64c75dfc0301/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "0477a30f-f46f-4d6d-8747-64c75dfc0301/0",
+      "job_symbol": "11",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-e10s-11",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576443,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "BHejD_RvTW2HR2THXfwDAQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "BXWMaUV7TCunBcJQELbZqw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "05758c69-457b-4c2b-a705-c25010b6d9ab/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "05758c69-457b-4c2b-a705-c25010b6d9ab/0",
+      "job_symbol": "bc6",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-6",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576441,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "BXWMaUV7TCunBcJQELbZqw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "BZuYb2PTTQ-opGzxvZvA9A": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "059b986f-63d3-4d0f-a8a4-6cf1bd9bc0f4/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "059b986f-63d3-4d0f-a8a4-6cf1bd9bc0f4/0",
+      "job_symbol": "14",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-mochitest-e10s-14",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576436,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "BZuYb2PTTQ-opGzxvZvA9A",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "BdHfGUHPTLm0IKz47oNJlA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "05d1df19-41cf-4cb9-b420-acf8ee834994/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests with socket process",
+      "group_symbol": "M-spi",
+      "job_guid": "05d1df19-41cf-4cb9-b420-acf8ee834994/0",
+      "job_symbol": "mda2",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-media-spi-e10s-2",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576438,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "BdHfGUHPTLm0IKz47oNJlA",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "BdHy_4vQSA2ZQoxXc-6ieA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "05d1f2ff-8bd0-480d-9942-8c5773eea278/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Reftests",
+      "group_symbol": "R",
+      "job_guid": "05d1f2ff-8bd0-480d-9942-8c5773eea278/0",
+      "job_symbol": "R5",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-reftest-e10s-5",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576431,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "BdHy_4vQSA2ZQoxXc-6ieA",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "BfEK00F_TSm20TD799GdMw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "05f10ad3-417f-4d29-b6d1-30fbf7d19d33/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Web platform tests",
+      "group_symbol": "W",
+      "job_guid": "05f10ad3-417f-4d29-b6d1-30fbf7d19d33/0",
+      "job_symbol": "Wr3",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-web-platform-tests-reftests-e10s-3",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576445,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "BfEK00F_TSm20TD799GdMw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "Bg8h-Ct_SPSrEEYuvPAYSQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "060f21f8-2b7f-48f4-ab10-462ebcf01849/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests with socket process",
+      "group_symbol": "M-spi",
+      "job_guid": "060f21f8-2b7f-48f4-ab10-462ebcf01849/0",
+      "job_symbol": "mda1",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-media-spi-e10s-1",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576434,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "Bg8h-Ct_SPSrEEYuvPAYSQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "BpnQqda2Q0izXw4k0RUT6w": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "0699d0a9-d6b6-4348-b35f-0e24d11513eb/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Reftests",
+      "group_symbol": "R",
+      "job_guid": "0699d0a9-d6b6-4348-b35f-0e24d11513eb/0",
+      "job_symbol": "Ru4",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-reftest-no-accel-e10s-4",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576435,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "BpnQqda2Q0izXw4k0RUT6w",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "CBO2K8XGQEaNpX1BkwJmNw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "0813b62b-c5c6-4046-8da5-7d4193026637/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests with socket process",
+      "group_symbol": "M-spi",
+      "job_guid": "0813b62b-c5c6-4046-8da5-7d4193026637/0",
+      "job_symbol": "mda3",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-mochitest-media-spi-e10s-3",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576431,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "CBO2K8XGQEaNpX1BkwJmNw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "CER7YmG9QmCd-R66vfWkVQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "08447b62-61bd-4260-9df9-1ebabdf5a455/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "action-callback",
+      "group_symbol": "AC",
+      "job_guid": "08447b62-61bd-4260-9df9-1ebabdf5a455/0",
+      "job_symbol": "rt",
+      "log_references": [],
+      "machine": "i-0da13f5d4e5576fd5",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "name": "Action: Retrigger",
+      "option_collection": {
+        "opt": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "start_timestamp": 1561577768,
+      "state": "running",
+      "submit_timestamp": 1561577693,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "CER7YmG9QmCd-R66vfWkVQ",
+      "tier": 1,
+      "who": "mozilla-taskcluster-maintenance@mozilla.com"
+    },
+    "revision": "cfe6ae48816614025c458223c66ca2a87b673408",
+    "superseded": []
+  },
+  "DPCuZCk-SWC6SeftAbytzw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "0cf0ae64-293e-4960-ba49-e7ed01bcadcf/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "unknown",
+      "group_symbol": "?",
+      "job_guid": "0cf0ae64-293e-4960-ba49-e7ed01bcadcf/0",
+      "job_symbol": "GTest",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-gtest-1proc",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576443,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "DPCuZCk-SWC6SeftAbytzw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "D_6WScWhTLysuSIkbqfjsg": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "0ffe9649-c5a1-4cbc-acb9-22246ea7e3b2/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Reftests",
+      "group_symbol": "R",
+      "job_guid": "0ffe9649-c5a1-4cbc-acb9-22246ea7e3b2/0",
+      "job_symbol": "R4",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-reftest-e10s-4",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576431,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "D_6WScWhTLysuSIkbqfjsg",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "DxhjVp-uQtGhRLm1w0xdiA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "0f186356-9fae-42d1-a144-b9b5c34c5d88/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Xpcshell tests",
+      "group_symbol": "X",
+      "job_guid": "0f186356-9fae-42d1-a144-b9b5c34c5d88/0",
+      "job_symbol": "X3",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-xpcshell-e10s-3",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576431,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "DxhjVp-uQtGhRLm1w0xdiA",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "ENXQRjSMRWyWK_zAEYEoXg": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "10d5d046-348c-456c-962b-fcc01181285e/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "macosx1010-64"
+      },
+      "build_system_type": "taskcluster",
+      "end_timestamp": 1561577766,
+      "group_name": "Mochitests with socket process",
+      "group_symbol": "M-spi",
+      "job_guid": "10d5d046-348c-456c-962b-fcc01181285e/0",
+      "job_symbol": "mda1",
+      "log_references": [
+        {
+          "name": "builds-4h",
+          "parse_status": "pending",
+          "url": "https://queue.taskcluster.net/v1/task/ENXQRjSMRWyWK_zAEYEoXg/runs/0/artifacts/public/logs/live_backing.log"
+        }
+      ],
+      "machine": "t-yosemite-r7-098",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "macosx1010-64"
+      },
+      "name": "test-macosx1010-64/debug-mochitest-media-spi-e10s-1",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "success",
+      "start_timestamp": 1561575755,
+      "state": "completed",
+      "submit_timestamp": 1561573466,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "ENXQRjSMRWyWK_zAEYEoXg",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "b437ae030825a8ea9fa7a632b1fcb9becbe11f69",
+    "superseded": []
+  },
+  "EvNqsyBISNCH8mwfDVRnSQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "12f36ab3-2048-48d0-87f2-6c1f0d546749/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "action-callback",
+      "group_symbol": "AC",
+      "job_guid": "12f36ab3-2048-48d0-87f2-6c1f0d546749/0",
+      "job_symbol": "rt",
+      "log_references": [],
+      "machine": "i-062aa60828009efec",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "name": "Action: Retrigger",
+      "option_collection": {
+        "opt": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "start_timestamp": 1561577764,
+      "state": "running",
+      "submit_timestamp": 1561577691,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "EvNqsyBISNCH8mwfDVRnSQ",
+      "tier": 1,
+      "who": "mozilla-taskcluster-maintenance@mozilla.com"
+    },
+    "revision": "cfe6ae48816614025c458223c66ca2a87b673408",
+    "superseded": []
+  },
+  "F93bme7iSP2k0TsCwqSBVw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "17dddb99-eee2-48fd-a4d1-3b02c2a48157/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "17dddb99-eee2-48fd-a4d1-3b02c2a48157/0",
+      "job_symbol": "bc9",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-9",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576445,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "F93bme7iSP2k0TsCwqSBVw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "FgjNkrvXS0WDDJJUpVXZsA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "1608cd92-bbd7-4b45-830c-9254a555d9b0/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Reftests",
+      "group_symbol": "R",
+      "job_guid": "1608cd92-bbd7-4b45-830c-9254a555d9b0/0",
+      "job_symbol": "R1",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-reftest-e10s-1",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576433,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "FgjNkrvXS0WDDJJUpVXZsA",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "Fj3fDgrvRXitCVX2RiJUaw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "163ddf0e-0aef-4578-ad09-55f64622546b/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Xpcshell tests",
+      "group_symbol": "X",
+      "job_guid": "163ddf0e-0aef-4578-ad09-55f64622546b/0",
+      "job_symbol": "X4",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-xpcshell-e10s-4",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576431,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "Fj3fDgrvRXitCVX2RiJUaw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "FkHz3gGPSVmL6YJOupYBXw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "1641f3de-018f-4959-8be9-824eba96015f/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Reftests",
+      "group_symbol": "R",
+      "job_guid": "1641f3de-018f-4959-8be9-824eba96015f/0",
+      "job_symbol": "C",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-crashtest-e10s",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576432,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "FkHz3gGPSVmL6YJOupYBXw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "FsgLMdKwRzWJAwUhYy2g0Q": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "16c80b31-d2b0-4735-8903-0521632da0d1/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests without e10s",
+      "group_symbol": "M-1proc",
+      "job_guid": "16c80b31-d2b0-4735-8903-0521632da0d1/0",
+      "job_symbol": "c2",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-chrome-1proc-2",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576440,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "FsgLMdKwRzWJAwUhYy2g0Q",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "GTFxZJWzSKSNc_XElgtWHQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "19317164-95b3-48a4-8d73-f5c4960b561d/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Web platform tests",
+      "group_symbol": "W",
+      "job_guid": "19317164-95b3-48a4-8d73-f5c4960b561d/0",
+      "job_symbol": "wpt16",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-web-platform-tests-e10s-16",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576437,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "GTFxZJWzSKSNc_XElgtWHQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "GWxTc8p_RUa5_Xo4RtMiCA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "196c5373-ca7f-4546-b9fd-7a3846d32208/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "android-em-7-0-x86_64"
+      },
+      "build_system_type": "taskcluster",
+      "end_timestamp": 1561577768,
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "196c5373-ca7f-4546-b9fd-7a3846d32208/0",
+      "job_symbol": "1",
+      "log_references": [
+        {
+          "name": "builds-4h",
+          "parse_status": "pending",
+          "url": "https://queue.taskcluster.net/v1/task/GWxTc8p_RUa5_Xo4RtMiCA/runs/0/artifacts/public/logs/live_backing.log"
+        }
+      ],
+      "machine": "machine-39",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "android-em-7-0-x86_64"
+      },
+      "name": "test-android-em-7.0-x86_64/debug-mochitest-e10s-1",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "success",
+      "start_timestamp": 1561576596,
+      "state": "completed",
+      "submit_timestamp": 1561573467,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "GWxTc8p_RUa5_Xo4RtMiCA",
+      "tier": 2,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "b437ae030825a8ea9fa7a632b1fcb9becbe11f69",
+    "superseded": []
+  },
+  "HsvD9YlDQKaoP4AQsuGeJw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "1ecbc3f5-8943-40a6-a83f-8010b2e19e27/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "macosx1010-64"
+      },
+      "build_system_type": "taskcluster",
+      "end_timestamp": 1561577767,
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "1ecbc3f5-8943-40a6-a83f-8010b2e19e27/0",
+      "job_symbol": "mda1",
+      "log_references": [
+        {
+          "name": "builds-4h",
+          "parse_status": "pending",
+          "url": "https://queue.taskcluster.net/v1/task/HsvD9YlDQKaoP4AQsuGeJw/runs/0/artifacts/public/logs/live_backing.log"
+        }
+      ],
+      "machine": "t-yosemite-r7-123",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "macosx1010-64"
+      },
+      "name": "test-macosx1010-64/debug-mochitest-media-e10s-1",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "success",
+      "start_timestamp": 1561575755,
+      "state": "completed",
+      "submit_timestamp": 1561573468,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "HsvD9YlDQKaoP4AQsuGeJw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "b437ae030825a8ea9fa7a632b1fcb9becbe11f69",
+    "superseded": []
+  },
+  "JKDqO-yySta79-Y92Dq2yQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "24a0ea3b-ecb2-4ad6-bbf7-e63dd83ab6c9/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "24a0ea3b-ecb2-4ad6-bbf7-e63dd83ab6c9/0",
+      "job_symbol": "dt10",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-devtools-chrome-e10s-10",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576434,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "JKDqO-yySta79-Y92Dq2yQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "JM6eV6S-R5-Dy08gjoBHrQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "24ce9e57-a4be-479f-83cb-4f208e8047ad/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "24ce9e57-a4be-479f-83cb-4f208e8047ad/0",
+      "job_symbol": "mda1",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-mochitest-media-e10s-1",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576434,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "JM6eV6S-R5-Dy08gjoBHrQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "K2IZ74mWQfiEn2U6XnVLPQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "2b6219ef-8996-41f8-849f-653a5e754b3d/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "2b6219ef-8996-41f8-849f-653a5e754b3d/0",
+      "job_symbol": "1",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-e10s-1",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576430,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "K2IZ74mWQfiEn2U6XnVLPQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "K5R8rkgARZWMvH4JpmSPrQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "2b947cae-4800-4595-8cbc-7e09a6648fad/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "2b947cae-4800-4595-8cbc-7e09a6648fad/0",
+      "job_symbol": "3",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-e10s-3",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576443,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "K5R8rkgARZWMvH4JpmSPrQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "KYZKwkbvRc-qPE22g286yQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "29864ac2-46ef-45cf-aa3c-4db6836f3ac9/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "end_timestamp": 1561577764,
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "29864ac2-46ef-45cf-aa3c-4db6836f3ac9/0",
+      "job_symbol": "gl1c",
+      "log_references": [
+        {
+          "name": "builds-4h",
+          "parse_status": "pending",
+          "url": "https://queue.taskcluster.net/v1/task/KYZKwkbvRc-qPE22g286yQ/runs/0/artifacts/public/logs/live_backing.log"
+        }
+      ],
+      "machine": "i-06c2c7e06fc36c6c5",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/opt-mochitest-webgl1-core-e10s",
+      "option_collection": {
+        "opt": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "success",
+      "start_timestamp": 1561577029,
+      "state": "completed",
+      "submit_timestamp": 1561574969,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "KYZKwkbvRc-qPE22g286yQ",
+      "tier": 1,
+      "who": "cbrewster@mozilla.com"
+    },
+    "revision": "e9802fad44ec8c8ccf3326cf7c75967576db855b",
+    "superseded": []
+  },
+  "KnBj0KLcTjuyNaTxt5LVqw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "2a7063d0-a2dc-4e3b-b235-a4f1b792d5ab/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "action-callback",
+      "group_symbol": "AC",
+      "job_guid": "2a7063d0-a2dc-4e3b-b235-a4f1b792d5ab/0",
+      "job_symbol": "rt",
+      "log_references": [],
+      "machine": "i-019077061bddb4fe7",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "name": "Action: Retrigger",
+      "option_collection": {
+        "opt": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "start_timestamp": 1561577765,
+      "state": "running",
+      "submit_timestamp": 1561577692,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "KnBj0KLcTjuyNaTxt5LVqw",
+      "tier": 1,
+      "who": "mozilla-taskcluster-maintenance@mozilla.com"
+    },
+    "revision": "cfe6ae48816614025c458223c66ca2a87b673408",
+    "superseded": []
+  },
+  "LBJoI2wUTNCteg-5CnaYZQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "2c126823-6c14-4cd0-ad7a-0fb90a769865/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "end_timestamp": 1561577769,
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "2c126823-6c14-4cd0-ad7a-0fb90a769865/0",
+      "job_symbol": "bc8",
+      "log_references": [
+        {
+          "name": "builds-4h",
+          "parse_status": "pending",
+          "url": "https://queue.taskcluster.net/v1/task/LBJoI2wUTNCteg-5CnaYZQ/runs/0/artifacts/public/logs/live_backing.log"
+        }
+      ],
+      "machine": "i-0b63c3556524f5295",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-8",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "success",
+      "start_timestamp": 1561574930,
+      "state": "completed",
+      "submit_timestamp": 1561572444,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "LBJoI2wUTNCteg-5CnaYZQ",
+      "tier": 1,
+      "who": "malexandru@mozilla.com"
+    },
+    "revision": "918d7c84da371bda26460fb4b50f161d32107880",
+    "superseded": []
+  },
+  "LWArw4t5QaCHiHsEJo6hFA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "2d602bc3-8b79-41a0-8788-7b04268ea114/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "action-callback",
+      "group_symbol": "AC",
+      "job_guid": "2d602bc3-8b79-41a0-8788-7b04268ea114/0",
+      "job_symbol": "rt",
+      "log_references": [],
+      "machine": "i-0be69dc84b0354bde",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "name": "Action: Retrigger",
+      "option_collection": {
+        "opt": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "start_timestamp": 1561577767,
+      "state": "running",
+      "submit_timestamp": 1561577692,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "LWArw4t5QaCHiHsEJo6hFA",
+      "tier": 1,
+      "who": "mozilla-taskcluster-maintenance@mozilla.com"
+    },
+    "revision": "cfe6ae48816614025c458223c66ca2a87b673408",
+    "superseded": []
+  },
+  "MrYMxyDDSwWXJey-uo4T3g": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "32b60cc7-20c3-4b05-9725-ecbeba8e13de/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "windows10-64"
+      },
+      "build_system_type": "taskcluster",
+      "end_timestamp": 1561577764,
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "32b60cc7-20c3-4b05-9725-ecbeba8e13de/0",
+      "job_symbol": "gl2e4",
+      "log_references": [
+        {
+          "name": "builds-4h",
+          "parse_status": "pending",
+          "url": "https://queue.taskcluster.net/v1/task/MrYMxyDDSwWXJey-uo4T3g/runs/0/artifacts/public/logs/live_backing.log"
+        }
+      ],
+      "machine": "i-08b6fd26055d2603e",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "windows10-64"
+      },
+      "name": "test-windows10-64/debug-mochitest-webgl2-ext-e10s-4",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "success",
+      "start_timestamp": 1561576688,
+      "state": "completed",
+      "submit_timestamp": 1561572444,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "MrYMxyDDSwWXJey-uo4T3g",
+      "tier": 1,
+      "who": "malexandru@mozilla.com"
+    },
+    "revision": "918d7c84da371bda26460fb4b50f161d32107880",
+    "superseded": []
+  },
+  "NWz-q9MoSL-WMfO7kiwhtg": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "356cfeab-d328-48bf-9631-f3bb922c21b6/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "356cfeab-d328-48bf-9631-f3bb922c21b6/0",
+      "job_symbol": "dt4",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-devtools-chrome-e10s-4",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576433,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "NWz-q9MoSL-WMfO7kiwhtg",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "OiZYxvi5RfKol0A4SBbvOw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "3a2658c6-f8b9-45f2-a897-40384816ef3b/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "android-em-4-3-armv7-api16"
+      },
+      "build_system_type": "taskcluster",
+      "end_timestamp": 1561577767,
+      "group_name": "unknown",
+      "group_symbol": "?",
+      "job_guid": "3a2658c6-f8b9-45f2-a897-40384816ef3b/0",
+      "job_symbol": "gv-junit2",
+      "log_references": [
+        {
+          "name": "builds-4h",
+          "parse_status": "pending",
+          "url": "https://queue.taskcluster.net/v1/task/OiZYxvi5RfKol0A4SBbvOw/runs/0/artifacts/public/logs/live_backing.log"
+        }
+      ],
+      "machine": "i-0d0f91277e3f902cc",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "android-em-4-3-armv7-api16"
+      },
+      "name": "test-android-em-4.3-arm7-api-16/debug-geckoview-junit-e10s-2",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "success",
+      "start_timestamp": 1561576445,
+      "state": "completed",
+      "submit_timestamp": 1561575201,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "OiZYxvi5RfKol0A4SBbvOw",
+      "tier": 1,
+      "who": "longsonr@gmail.com"
+    },
+    "revision": "ba32151f8fc12c08e67647293a7dc43403a18639",
+    "superseded": []
+  },
+  "PCVDCxY9QM-lEgaGhrCPrw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "3c25430b-163d-40cf-a512-068686b08faf/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "windows10-64"
+      },
+      "build_system_type": "taskcluster",
+      "end_timestamp": 1561577770,
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "3c25430b-163d-40cf-a512-068686b08faf/0",
+      "job_symbol": "bc2",
+      "log_references": [
+        {
+          "name": "builds-4h",
+          "parse_status": "pending",
+          "url": "https://queue.taskcluster.net/v1/task/PCVDCxY9QM-lEgaGhrCPrw/runs/0/artifacts/public/logs/live_backing.log"
+        }
+      ],
+      "machine": "i-0bd696849d1151857",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "windows10-64"
+      },
+      "name": "test-windows10-64/debug-mochitest-browser-chrome-e10s-2",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "success",
+      "start_timestamp": 1561575810,
+      "state": "completed",
+      "submit_timestamp": 1561571959,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "PCVDCxY9QM-lEgaGhrCPrw",
+      "tier": 1,
+      "who": "ralderete@mozilla.com"
+    },
+    "revision": "ea0152de5560eefdb0fbcb69437ffd0db05ae95b",
+    "superseded": []
+  },
+  "Pr3zPNMqS8CAY6hHB_lwow": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "3ebdf33c-d32a-4bc0-8063-a84707f970a3/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Web platform tests",
+      "group_symbol": "W",
+      "job_guid": "3ebdf33c-d32a-4bc0-8063-a84707f970a3/0",
+      "job_symbol": "Wr3",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-web-platform-tests-reftests-e10s-3",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576441,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "Pr3zPNMqS8CAY6hHB_lwow",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "Q5dgajTmQaG3bW8xf8mWRw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "4397606a-34e6-41a1-b76d-6f317fc99647/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "4397606a-34e6-41a1-b76d-6f317fc99647/0",
+      "job_symbol": "bc16",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-16",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576441,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "Q5dgajTmQaG3bW8xf8mWRw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "QDGdgQTQRC2xZNR3Zs_IhA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "40319d81-04d0-442d-b164-d47766cfc884/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "windows10-64"
+      },
+      "build_system_type": "taskcluster",
+      "end_timestamp": 1561577765,
+      "group_name": "Web platform tests",
+      "group_symbol": "W",
+      "job_guid": "40319d81-04d0-442d-b164-d47766cfc884/0",
+      "job_symbol": "Wr4",
+      "log_references": [
+        {
+          "name": "builds-4h",
+          "parse_status": "pending",
+          "url": "https://queue.taskcluster.net/v1/task/QDGdgQTQRC2xZNR3Zs_IhA/runs/0/artifacts/public/logs/live_backing.log"
+        }
+      ],
+      "machine": "i-0de7ae42ffc13af93",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "windows10-64"
+      },
+      "name": "test-windows10-64/debug-web-platform-tests-reftests-e10s-4",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "success",
+      "start_timestamp": 1561575810,
+      "state": "completed",
+      "submit_timestamp": 1561571960,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "QDGdgQTQRC2xZNR3Zs_IhA",
+      "tier": 1,
+      "who": "ralderete@mozilla.com"
+    },
+    "revision": "ea0152de5560eefdb0fbcb69437ffd0db05ae95b",
+    "superseded": []
+  },
+  "QUhTaNzmR-SnLuVMscnSYA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "41485368-dce6-47e4-a72e-e54cb1c9d260/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "action-callback",
+      "group_symbol": "AC",
+      "job_guid": "41485368-dce6-47e4-a72e-e54cb1c9d260/0",
+      "job_symbol": "rt",
+      "log_references": [],
+      "machine": "i-0da13f5d4e5576fd5",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "name": "Action: Retrigger",
+      "option_collection": {
+        "opt": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "start_timestamp": 1561577768,
+      "state": "running",
+      "submit_timestamp": 1561577693,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "QUhTaNzmR-SnLuVMscnSYA",
+      "tier": 1,
+      "who": "mozilla-taskcluster-maintenance@mozilla.com"
+    },
+    "revision": "cfe6ae48816614025c458223c66ca2a87b673408",
+    "superseded": []
+  },
+  "QbJceuUbQF-SAHp_tuN4bg": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "41b25c7a-e51b-405f-9200-7a7fb6e3786e/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests without e10s",
+      "group_symbol": "M-1proc",
+      "job_guid": "41b25c7a-e51b-405f-9200-7a7fb6e3786e/0",
+      "job_symbol": "c1",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-chrome-1proc-1",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576440,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "QbJceuUbQF-SAHp_tuN4bg",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "TNBQvfFkR0KoVFz_7QIkIw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "4cd050bd-f164-4742-a854-5cffed022423/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "4cd050bd-f164-4742-a854-5cffed022423/0",
+      "job_symbol": "16",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-mochitest-e10s-16",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576438,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "TNBQvfFkR0KoVFz_7QIkIw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "TacsT1-FSMia0IGkYP-cTQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "4da72c4f-5f85-48c8-9ad0-81a460ff9c4d/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "4da72c4f-5f85-48c8-9ad0-81a460ff9c4d/0",
+      "job_symbol": "1",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-mochitest-e10s-1",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576444,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "TacsT1-FSMia0IGkYP-cTQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "TbO_k663R3St6hBFE92StQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "4db3bf93-aeb7-4774-adea-104513dd92b5/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Reftests",
+      "group_symbol": "R",
+      "job_guid": "4db3bf93-aeb7-4774-adea-104513dd92b5/0",
+      "job_symbol": "Ru3",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-reftest-no-accel-e10s-3",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576446,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "TbO_k663R3St6hBFE92StQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "TwPxQPQiQLC0jwp0Crf4sw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "4f03f140-f422-40b0-b48f-0a740ab7f8b3/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Web platform tests",
+      "group_symbol": "W",
+      "job_guid": "4f03f140-f422-40b0-b48f-0a740ab7f8b3/0",
+      "job_symbol": "wpt2",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-web-platform-tests-e10s-2",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576430,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "TwPxQPQiQLC0jwp0Crf4sw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "UAEeps8wSMmoL4r0MdjlXA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "50011ea6-cf30-48c9-a82f-8af431d8e55c/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "50011ea6-cf30-48c9-a82f-8af431d8e55c/0",
+      "job_symbol": "2",
+      "log_references": [],
+      "machine": "i-07dbb95ac410df8f7",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-mochitest-e10s-2",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "start_timestamp": 1561577771,
+      "state": "running",
+      "submit_timestamp": 1561576441,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "UAEeps8wSMmoL4r0MdjlXA",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "UWjPMpssTgq0kA7hj9QtJw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "5168cf32-9b2c-4e0a-b490-0ee18fd42d27/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "5168cf32-9b2c-4e0a-b490-0ee18fd42d27/0",
+      "job_symbol": "bc3",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-3",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576433,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "UWjPMpssTgq0kA7hj9QtJw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "UZ37gpDqTRS1pBNnp0Spsg": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "519dfb82-90ea-4d14-b5a4-1367a744a9b2/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "end_timestamp": 1561577768,
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "519dfb82-90ea-4d14-b5a4-1367a744a9b2/0",
+      "job_symbol": "bc16",
+      "log_references": [
+        {
+          "name": "builds-4h",
+          "parse_status": "pending",
+          "url": "https://queue.taskcluster.net/v1/task/UZ37gpDqTRS1pBNnp0Spsg/runs/0/artifacts/public/logs/live_backing.log"
+        }
+      ],
+      "machine": "i-0d6489faaf7371ecb",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64-asan/opt-mochitest-browser-chrome-e10s-16",
+      "option_collection": {
+        "asan": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "success",
+      "start_timestamp": 1561576348,
+      "state": "completed",
+      "submit_timestamp": 1561573460,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "UZ37gpDqTRS1pBNnp0Spsg",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "b437ae030825a8ea9fa7a632b1fcb9becbe11f69",
+    "superseded": []
+  },
+  "UoGLhHlwT4mH3h3ukcm_Ig": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "52818b84-7970-4f89-87de-1dee91c9bf22/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "unknown",
+      "group_symbol": "?",
+      "job_guid": "52818b84-7970-4f89-87de-1dee91c9bf22/0",
+      "job_symbol": "Mn",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-marionette-e10s",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576442,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "UoGLhHlwT4mH3h3ukcm_Ig",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "UxS4jt6lQdyUYnPcmN-z-w": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "5314b88e-dea5-41dc-9462-73dc98dfb3fb/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Web platform tests",
+      "group_symbol": "W",
+      "job_guid": "5314b88e-dea5-41dc-9462-73dc98dfb3fb/0",
+      "job_symbol": "Wr1",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-web-platform-tests-reftests-e10s-1",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576430,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "UxS4jt6lQdyUYnPcmN-z-w",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "VGU4RUKFScaK8eBikMi9IQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "54653845-4285-49c6-8af1-e06290c8bd21/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "54653845-4285-49c6-8af1-e06290c8bd21/0",
+      "job_symbol": "bc15",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-browser-chrome-e10s-15",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576437,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "VGU4RUKFScaK8eBikMi9IQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "VqbRb6bZSlywWOQN62tk-g": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "56a6d16f-a6d9-4a5c-b058-e40deb6b64fa/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "56a6d16f-a6d9-4a5c-b058-e40deb6b64fa/0",
+      "job_symbol": "14",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-e10s-14",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576440,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "VqbRb6bZSlywWOQN62tk-g",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "VspVGZYjSAqqsg6CGgv-rw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "56ca5519-9623-480a-aab2-0e821a0bfeaf/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Reftests",
+      "group_symbol": "R",
+      "job_guid": "56ca5519-9623-480a-aab2-0e821a0bfeaf/0",
+      "job_symbol": "R2",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-reftest-e10s-2",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576431,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "VspVGZYjSAqqsg6CGgv-rw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "WkFYxflwT76VzWNc6hryiQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "5a4158c5-f970-4fbe-95cd-635cea1af289/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Reftests",
+      "group_symbol": "R",
+      "job_guid": "5a4158c5-f970-4fbe-95cd-635cea1af289/0",
+      "job_symbol": "Ru2",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-reftest-no-accel-e10s-2",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576439,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "WkFYxflwT76VzWNc6hryiQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "XOw2FYEdSb2hwS_lj2bDAg": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "5cec3615-811d-49bd-a1c1-2fe58f66c302/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "action-callback",
+      "group_symbol": "AC",
+      "job_guid": "5cec3615-811d-49bd-a1c1-2fe58f66c302/0",
+      "job_symbol": "rt",
+      "log_references": [],
+      "machine": "i-019077061bddb4fe7",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "name": "Action: Retrigger",
+      "option_collection": {
+        "opt": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "start_timestamp": 1561577765,
+      "state": "running",
+      "submit_timestamp": 1561577691,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "XOw2FYEdSb2hwS_lj2bDAg",
+      "tier": 1,
+      "who": "mozilla-taskcluster-maintenance@mozilla.com"
+    },
+    "revision": "cfe6ae48816614025c458223c66ca2a87b673408",
+    "superseded": []
+  },
+  "XQdfjjACRJCmpqKjLxLRXA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "5d075f8e-3002-4490-a6a6-a2a32f12d15c/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Web platform tests",
+      "group_symbol": "W",
+      "job_guid": "5d075f8e-3002-4490-a6a6-a2a32f12d15c/0",
+      "job_symbol": "Wd1",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-web-platform-tests-wdspec-e10s-1",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576434,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "XQdfjjACRJCmpqKjLxLRXA",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "XiZuJW7MQ-GrC7iV81YWdw": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "5e266e25-6ecc-43e1-ab0b-b895f3561677/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "5e266e25-6ecc-43e1-ab0b-b895f3561677/0",
+      "job_symbol": "7",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-e10s-7",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576443,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "XiZuJW7MQ-GrC7iV81YWdw",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "Xxznj5R9QCS-7iqptegltQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "5f1ce78f-947d-4024-beee-2aa9b5e825b5/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "5f1ce78f-947d-4024-beee-2aa9b5e825b5/0",
+      "job_symbol": "mda3",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-media-e10s-3",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576432,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "Xxznj5R9QCS-7iqptegltQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "Y32tr9w0Tlu67dz74wiCyg": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "637dadaf-dc34-4e5b-baed-dcfbe30882ca/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests without e10s",
+      "group_symbol": "M-1proc",
+      "job_guid": "637dadaf-dc34-4e5b-baed-dcfbe30882ca/0",
+      "job_symbol": "c2",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-mochitest-chrome-1proc-2",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576437,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "Y32tr9w0Tlu67dz74wiCyg",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "Y6Zdr078RvemM_nabfiE3A": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "63a65daf-4efc-46f7-a633-f9da6df884dc/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "63a65daf-4efc-46f7-a633-f9da6df884dc/0",
+      "job_symbol": "10",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-mochitest-e10s-10",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576431,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "Y6Zdr078RvemM_nabfiE3A",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "YUU6v89vRd669kauRLNk5g": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "61453abf-cf6f-45de-baf6-46ae44b364e6/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Reftests",
+      "group_symbol": "R",
+      "job_guid": "61453abf-cf6f-45de-baf6-46ae44b364e6/0",
+      "job_symbol": "Ru5",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-reftest-no-accel-e10s-5",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576433,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "YUU6v89vRd669kauRLNk5g",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "YYCniY1ITuGl0fRNghknlQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "6180a789-8d48-4ee1-a5d1-f44d82192795/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "6180a789-8d48-4ee1-a5d1-f44d82192795/0",
+      "job_symbol": "9",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-e10s-9",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576431,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "YYCniY1ITuGl0fRNghknlQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "YgnJMukTS0efJHzTI5_AnA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "6209c932-e913-4b47-9f24-7cd3239fc09c/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Web platform tests",
+      "group_symbol": "W",
+      "job_guid": "6209c932-e913-4b47-9f24-7cd3239fc09c/0",
+      "job_symbol": "Wr5",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-web-platform-tests-reftests-e10s-5",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576440,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "YgnJMukTS0efJHzTI5_AnA",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "ZPrilAZcSimdmLj9flM24w": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "64fae294-065c-4a29-9d98-b8fd7e5336e3/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "64fae294-065c-4a29-9d98-b8fd7e5336e3/0",
+      "job_symbol": "15",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-mochitest-e10s-15",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576438,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "ZPrilAZcSimdmLj9flM24w",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "ZnJOMTOcRwCZG09VY4InxQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "66724e31-339c-4700-991b-4f55638227c5/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests without e10s",
+      "group_symbol": "M-1proc",
+      "job_guid": "66724e31-339c-4700-991b-4f55638227c5/0",
+      "job_symbol": "c3",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-chrome-1proc-3",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576435,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "ZnJOMTOcRwCZG09VY4InxQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "ZyNAZZR0SmOcgqC_k_wqsQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "67234065-9474-4a63-9c82-a0bf93fc2ab1/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "end_timestamp": 1561577766,
+      "group_name": "unknown",
+      "group_symbol": "?",
+      "job_guid": "67234065-9474-4a63-9c82-a0bf93fc2ab1/0",
+      "job_symbol": "B",
+      "log_references": [
+        {
+          "name": "builds-4h",
+          "parse_status": "pending",
+          "url": "https://queue.taskcluster.net/v1/task/ZyNAZZR0SmOcgqC_k_wqsQ/runs/0/artifacts/public/logs/live_backing.log"
+        }
+      ],
+      "machine": "i-01e55895145a2d19c",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "build-linux64/debug",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "success",
+      "start_timestamp": 1561576496,
+      "state": "completed",
+      "submit_timestamp": 1561576427,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "ZyNAZZR0SmOcgqC_k_wqsQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "a1uUehQvSciykK6DUUNQbQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "6b5b947a-142f-49c8-b290-ae835143506d/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Reftests",
+      "group_symbol": "R",
+      "job_guid": "6b5b947a-142f-49c8-b290-ae835143506d/0",
+      "job_symbol": "Ru1",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-reftest-no-accel-e10s-1",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576431,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "a1uUehQvSciykK6DUUNQbQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "a5UF8fEyQw-fx_32Qo-WjQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "6b9505f1-f132-430f-9fc7-fdf6428f968d/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "android-hw-p2-8-0-android-aarch64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Raptor performance tests on Firefox",
+      "group_symbol": "Rap",
+      "job_guid": "6b9505f1-f132-430f-9fc7-fdf6428f968d/0",
+      "job_symbol": "tp6m-c-3",
+      "log_references": [],
+      "machine": "pixel2-44",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "android-hw-p2-8-0-android-aarch64"
+      },
+      "name": "test-android-hw-p2-8-0-android-aarch64/opt-raptor-tp6m-3-geckoview-cold-e10s",
+      "option_collection": {
+        "opt": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "start_timestamp": 1561577769,
+      "state": "running",
+      "submit_timestamp": 1561573461,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "a5UF8fEyQw-fx_32Qo-WjQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "b437ae030825a8ea9fa7a632b1fcb9becbe11f69",
+    "superseded": []
+  },
+  "aNf8J_ctQp6IjWJTxCAPbQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "68d7fc27-f72d-429e-888d-6253c4200f6d/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "unknown",
+      "group_symbol": "?",
+      "job_guid": "68d7fc27-f72d-429e-888d-6253c4200f6d/0",
+      "job_symbol": "TV",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-test-verify-e10s",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576441,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "aNf8J_ctQp6IjWJTxCAPbQ",
+      "tier": 2,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "aNlE6teASbGqtSK4XSeMkg": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "68d944ea-d780-49b1-aab5-22b85d278c92/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Web platform tests",
+      "group_symbol": "W",
+      "job_guid": "68d944ea-d780-49b1-aab5-22b85d278c92/0",
+      "job_symbol": "wpt4",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-web-platform-tests-e10s-4",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576441,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "aNlE6teASbGqtSK4XSeMkg",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "ac7vsMLASl6XS1O_VzlLXQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "69ceefb0-c2c0-4a5e-974b-53bf57394b5d/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Web platform tests",
+      "group_symbol": "W",
+      "job_guid": "69ceefb0-c2c0-4a5e-974b-53bf57394b5d/0",
+      "job_symbol": "Wr1",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-web-platform-tests-reftests-e10s-1",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576436,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "ac7vsMLASl6XS1O_VzlLXQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "aeWDjRcUQhudU4axBiCQ8A": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "69e5838d-1714-421b-9d53-86b1062090f0/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests without e10s",
+      "group_symbol": "M-1proc",
+      "job_guid": "69e5838d-1714-421b-9d53-86b1062090f0/0",
+      "job_symbol": "a11y",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-a11y-1proc",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576430,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "aeWDjRcUQhudU4axBiCQ8A",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "b0DpnSIQQymnTTSXxRWmmg": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "6f40e99d-2210-4329-a74d-3497c515a69a/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Reftests",
+      "group_symbol": "R",
+      "job_guid": "6f40e99d-2210-4329-a74d-3497c515a69a/0",
+      "job_symbol": "R1",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64-qr"
+      },
+      "name": "test-linux64-qr/debug-reftest-e10s-1",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576431,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "b0DpnSIQQymnTTSXxRWmmg",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "ba34BnYgT_mv1g5BvrlXnQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "6dadf806-7620-4ff9-afd6-0e41beb9579d/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Reftests",
+      "group_symbol": "R",
+      "job_guid": "6dadf806-7620-4ff9-afd6-0e41beb9579d/0",
+      "job_symbol": "R7",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-reftest-e10s-7",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576444,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "ba34BnYgT_mv1g5BvrlXnQ",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "c9SSXwx3TnKm7MnNEit0OA": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "73d4925f-0c77-4e72-a6ec-c9cd122b7438/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Xpcshell tests",
+      "group_symbol": "X",
+      "job_guid": "73d4925f-0c77-4e72-a6ec-c9cd122b7438/0",
+      "job_symbol": "X5",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-xpcshell-e10s-5",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576431,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "c9SSXwx3TnKm7MnNEit0OA",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "dUcobAuPTEqHok4rpJl1Dg": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "7547286c-0b8f-4c4a-87a2-4e2ba499750e/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "Mochitests",
+      "group_symbol": "M",
+      "job_guid": "7547286c-0b8f-4c4a-87a2-4e2ba499750e/0",
+      "job_symbol": "dt9",
+      "log_references": [],
+      "machine": "unknown",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "linux64"
+      },
+      "name": "test-linux64/debug-mochitest-devtools-chrome-e10s-9",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "state": "pending",
+      "submit_timestamp": 1561576437,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "dUcobAuPTEqHok4rpJl1Dg",
+      "tier": 1,
+      "who": "jmuizelaar@mozilla.com"
+    },
+    "revision": "219d38523a321229f7f48aca6592f76b993fb1aa",
+    "superseded": []
+  },
+  "eokGh4-OSbOqAzVhJypYPg": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "7a890687-8f8e-49b3-aa03-3561272a583e/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "windows7-32"
+      },
+      "build_system_type": "taskcluster",
+      "end_timestamp": 1561577766,
+      "group_name": "Reftests",
+      "group_symbol": "R",
+      "job_guid": "7a890687-8f8e-49b3-aa03-3561272a583e/0",
+      "job_symbol": "C",
+      "log_references": [
+        {
+          "name": "builds-4h",
+          "parse_status": "pending",
+          "url": "https://queue.taskcluster.net/v1/task/eokGh4-OSbOqAzVhJypYPg/runs/0/artifacts/public/logs/live_backing.log"
+        }
+      ],
+      "machine": "i-09f5a2a05cb655f08",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "windows7-32"
+      },
+      "name": "test-windows7-32/debug-crashtest-e10s",
+      "option_collection": {
+        "debug": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "success",
+      "start_timestamp": 1561576462,
+      "state": "completed",
+      "submit_timestamp": 1561573312,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "eokGh4-OSbOqAzVhJypYPg",
+      "tier": 1,
+      "who": "npierron@mozilla.com"
+    },
+    "revision": "44932f2396663a7e44434a9c562c1089ebd4422b",
+    "superseded": []
+  },
+  "eugCBPRNRD-zyP_I9Jcn1w": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "7ae80204-f44d-443f-b3c8-ffc8f49727d7/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "action-callback",
+      "group_symbol": "AC",
+      "job_guid": "7ae80204-f44d-443f-b3c8-ffc8f49727d7/0",
+      "job_symbol": "rt",
+      "log_references": [],
+      "machine": "i-0be69dc84b0354bde",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "name": "Action: Retrigger",
+      "option_collection": {
+        "opt": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "start_timestamp": 1561577767,
+      "state": "running",
+      "submit_timestamp": 1561577692,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "eugCBPRNRD-zyP_I9Jcn1w",
+      "tier": 1,
+      "who": "mozilla-taskcluster-maintenance@mozilla.com"
+    },
+    "revision": "cfe6ae48816614025c458223c66ca2a87b673408",
+    "superseded": []
+  },
+  "fu4duSjBRte-V6y_oQ_BrQ": {
+    "job": {
+      "artifacts": [
+        {
+          "blob": {
+            "job_details": []
+          },
+          "job_guid": "7eee1db9-28c1-46d7-be57-acbfa10fc1ad/0",
+          "name": "Job Info",
+          "type": "json"
+        }
+      ],
+      "build_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "build_system_type": "taskcluster",
+      "group_name": "action-callback",
+      "group_symbol": "AC",
+      "job_guid": "7eee1db9-28c1-46d7-be57-acbfa10fc1ad/0",
+      "job_symbol": "rt",
+      "log_references": [],
+      "machine": "i-062aa60828009efec",
+      "machine_platform": {
+        "architecture": "-",
+        "os_name": "-",
+        "platform": "gecko-decision"
+      },
+      "name": "Action: Retrigger",
+      "option_collection": {
+        "opt": true
+      },
+      "product_name": "unknown",
+      "reason": "scheduled",
+      "result": "unknown",
+      "start_timestamp": 1561577764,
+      "state": "running",
+      "submit_timestamp": 1561577690,
+      "taskcluster_retry_id": 0,
+      "taskcluster_task_id": "fu4duSjBRte-V6y_oQ_BrQ",
+      "tier": 1,
+      "who": "mozilla-taskcluster-maintenance@mozilla.com"
+    },
+    "revision": "cfe6ae48816614025c458223c66ca2a87b673408",
+    "superseded": []
+  }
+}

--- a/tests/sampledata.py
+++ b/tests/sampledata.py
@@ -31,6 +31,18 @@ class SampleData:
                   os.path.dirname(__file__))) as f:
             self.text_log_summary = json.load(f)
 
+        with open("{0}/sample_data/pulse_consumer/taskcluster_pulse_messages.json".format(
+                  os.path.dirname(__file__))) as f:
+            self.taskcluster_pulse_messages = json.load(f)
+
+        with open("{0}/sample_data/pulse_consumer/taskcluster_tasks.json".format(
+                  os.path.dirname(__file__))) as f:
+            self.taskcluster_tasks = json.load(f)
+
+        with open("{0}/sample_data/pulse_consumer/taskcluster_transformed_jobs.json".format(
+                  os.path.dirname(__file__))) as f:
+            self.taskcluster_transformed_jobs = json.load(f)
+
         with open("{0}/sample_data/pulse_consumer/job_data.json".format(
                   os.path.dirname(__file__))) as f:
             self.pulse_jobs = json.load(f)

--- a/tests/services/pulse/test_consumers.py
+++ b/tests/services/pulse/test_consumers.py
@@ -8,7 +8,7 @@ from .utils import create_and_destroy_exchange
 
 def test_bind_to(pulse_connection, pulse_exchange):
     job_consumer = JobConsumer(pulse_connection)
-    exchange = pulse_exchange("exchange/taskcluster-treeherder/v1/jobs", create_exchange=True)
+    exchange = pulse_exchange("exchange/taskcluster-queue/v1/task-running", create_exchange=True)
     routing_key = "test_routing_key"
 
     binding = bind_to(job_consumer, exchange, routing_key)
@@ -28,7 +28,7 @@ def test_bind_to(pulse_connection, pulse_exchange):
 
 def test_prepare_consumer(pulse_connection, pulse_exchange):
     # create the exchange in the local RabbitMQ instance
-    job_exchange = "exchange/taskcluster-treeherder/v1/jobs"
+    job_exchange = "exchange/taskcluster-queue/v1/task-running"
     with create_and_destroy_exchange(pulse_connection, job_exchange):
         job_consumer = prepare_consumer(
             pulse_connection,
@@ -42,7 +42,7 @@ def test_prepare_consumer(pulse_connection, pulse_exchange):
 
     queue = job_consumer.consumers[0]["queues"]
     assert queue.routing_key == "foo.test_project"
-    assert queue.exchange.name == "exchange/taskcluster-treeherder/v1/jobs"
+    assert queue.exchange.name == "exchange/taskcluster-queue/v1/task-running"
 
     push_exchange = "exchange/taskcluster-github/v1/push"
     with create_and_destroy_exchange(pulse_connection, push_exchange):

--- a/tests/test_worker/test_pulse_tasks.py
+++ b/tests/test_worker/test_pulse_tasks.py
@@ -37,18 +37,3 @@ def test_retry_missing_revision_succeeds(sample_data, sample_push,
     assert Job.objects.count() == 1
     assert Job.objects.values()[0]["guid"] == job["taskId"]
     assert thread_data.retries == 1
-
-
-def test_retry_missing_revision_never_succeeds(sample_data, test_repository,
-                                               mock_log_parser, monkeypatch):
-    """
-    Ensure that when the missing push exists after a retry, that the job
-    is then ingested.
-    """
-    job = sample_data.pulse_jobs[0]
-    job["origin"]["project"] = test_repository.name
-
-    with pytest.raises(MissingPushException):
-        store_pulse_jobs.delay(job, "foo", "bar")
-
-    assert Job.objects.count() == 0

--- a/treeherder/etl/jobs.py
+++ b/treeherder/etl/jobs.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import os
 import time
@@ -372,7 +373,7 @@ def _schedule_log_parsing(job, job_logs, result):
                            args=[job.id, job_log_ids, priority])
 
 
-def store_job_data(repository, data):
+def store_job_data(repository, originalData):
     """
     Store job data instances into jobs db
 
@@ -429,6 +430,7 @@ def store_job_data(repository, data):
     ]
 
     """
+    data = copy.deepcopy(originalData)
     # Ensure that we have job data to process
     if not data:
         return

--- a/treeherder/etl/management/commands/ingest_push_and_tasks.py
+++ b/treeherder/etl/management/commands/ingest_push_and_tasks.py
@@ -1,0 +1,142 @@
+import asyncio
+import logging
+
+import aiohttp
+import taskcluster
+import taskcluster.aio
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from treeherder.etl.job_loader import JobLoader
+from treeherder.etl.pushlog import HgPushlogProcess
+from treeherder.etl.taskcluster_pulse.handler import (EXCHANGE_EVENT_MAP,
+                                                      handleMessage)
+from treeherder.model.models import Repository
+
+logger = logging.getLogger(__name__)
+rootUrl = "https://taskcluster.net"
+options = {"rootUrl": rootUrl}
+loop = asyncio.get_event_loop()
+# Limiting the connection pool just in case we have too many
+conn = aiohttp.TCPConnector(limit=10)
+# Remove default timeout limit of 5 minutes
+timeout = aiohttp.ClientTimeout(total=0)
+session = taskcluster.aio.createSession(loop=loop, connector=conn, timeout=timeout)
+asyncQueue = taskcluster.aio.Queue(options, session=session)
+
+stateToExchange = {}
+for key, value in EXCHANGE_EVENT_MAP.items():
+    stateToExchange[value] = key
+
+
+async def handleTaskId(taskId):
+    results = await asyncio.gather(asyncQueue.status(taskId), asyncQueue.task(taskId))
+    await handleTask({
+        "status": results[0]["status"],
+        "task": results[1],
+    })
+
+
+async def handleTask(task):
+    taskId = task["status"]["taskId"]
+    runs = task["status"]["runs"]
+    # If we iterate in order of the runs, we will not be able to mark older runs as
+    # "retry" instead of exception
+    for run in reversed(runs):
+        message = {
+            "exchange": stateToExchange[run["state"]],
+            "payload": {
+                "status": {
+                    "taskId": taskId,
+                    "runs": runs,
+                },
+                "runId": run["runId"],
+            }
+        }
+        try:
+            taskRuns = await handleMessage(message, task["task"])
+            if taskRuns:
+                for run in taskRuns:
+                    logger.info("Loading into DB:\t%s/%s", taskId, run["runId"])
+                    # XXX: This seems our current bottleneck
+                    JobLoader().process_job(run)
+        except Exception as e:
+            logger.exception(e)
+
+
+async def fetchGroupTasks(taskGroupId):
+    tasks = []
+    query = {}
+    continuationToken = ""
+    while True:
+        if continuationToken:
+            query = {"continuationToken": continuationToken}
+        response = await asyncQueue.listTaskGroup(taskGroupId, query=query)
+        tasks.extend(response['tasks'])
+        continuationToken = response.get('continuationToken')
+        if continuationToken is None:
+            break
+        logger.info('Requesting more tasks. %s tasks so far...', len(tasks))
+    return tasks
+
+
+async def processTasks(taskGroupId):
+    tasks = await fetchGroupTasks(taskGroupId)
+    asyncTasks = []
+    logger.info("We have %s tasks to process", len(tasks))
+    for task in tasks:
+        asyncTasks.append(asyncio.create_task(handleTask(task)))
+
+    await asyncio.gather(*asyncTasks)
+
+
+class Command(BaseCommand):
+    """Management command to ingest data from a single push."""
+    help = "Ingests a single push and tasks into Treeherder"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--project",
+            help="repository to query"
+        )
+        parser.add_argument(
+            "--changeset",
+            nargs="?",
+            help="changeset to import"
+        )
+        parser.add_argument(
+            "--task-id",
+            dest="taskId",
+            nargs="?",
+            help="taskId to ingest"
+        )
+
+    def handle(self, *args, **options):
+        taskId = options["taskId"]
+        if taskId:
+            loop.run_until_complete(handleTaskId(taskId))
+        else:
+            project = options["project"]
+            changeset = options["changeset"]
+
+            # get reference to repo
+            repo = Repository.objects.get(name=project, active_status='active')
+            fetch_push_id = None
+
+            # make sure all tasks are run synchronously / immediately
+            settings.CELERY_TASK_ALWAYS_EAGER = True
+
+            # get hg pushlog
+            pushlog_url = '%s/json-pushes/?full=1&version=2' % repo.url
+
+            # ingest this particular revision for this project
+            process = HgPushlogProcess()
+            # Use the actual push SHA, in case the changeset specified was a tag
+            # or branch name (eg tip). HgPushlogProcess returns the full SHA.
+            process.run(pushlog_url, project, changeset=changeset, last_push_id=fetch_push_id)
+
+            # XXX: Need logic to get from project/revision to taskGroupId
+            taskGroupId = 'ZYnMSfwCS5Cc_Wi_e-ZlSA'
+            logger.info("## START ##")
+            loop.run_until_complete(processTasks(taskGroupId))
+            logger.info("## END ##")

--- a/treeherder/etl/management/commands/update_pulse_test_fixtures.py
+++ b/treeherder/etl/management/commands/update_pulse_test_fixtures.py
@@ -1,0 +1,69 @@
+import json
+import logging
+import os
+
+from django.core.management.base import BaseCommand
+
+from treeherder.etl.job_loader import JobLoader
+from treeherder.etl.taskcluster_pulse.handler import (fetchTask,
+                                                      handleMessage)
+from treeherder.services.pulse import (UpdateJobFixtures,
+                                       job_sources,
+                                       prepare_consumer,
+                                       pulse_conn)
+
+logger = logging.getLogger(__name__)
+tests_path = os.path.join('tests', 'sample_data', 'pulse_consumer')
+
+
+class Command(BaseCommand):
+    """
+    Management command to read jobs from Pulse and store it as test fixtures
+    """
+    help = "Read jobs and store it as test fixtures."
+
+    def handle(self, *args, **options):
+        UpdateJobFixtures.maxMessages = 100
+        self.stdout.write("The Pulse consumer will consume {number} messages".format(number=UpdateJobFixtures.maxMessages))
+        with pulse_conn as connection:
+            consumer = prepare_consumer(
+                connection,
+                UpdateJobFixtures,
+                job_sources,
+                lambda key: "#.{}".format(key),
+            )
+
+            try:
+                consumer.run()
+            except Exception:
+                tc_messages = {}
+                tc_tasks = {}
+                th_jobs = {}
+                jl = JobLoader()
+
+                for message in consumer.messages:
+                    taskId = message["payload"]["status"]["taskId"]
+                    task = fetchTask(taskId)
+                    runs = handleMessage(message, task)
+                    for run in runs:
+                        try:
+                            th_jobs[taskId] = jl.transform(run)
+                            tc_messages[taskId] = message
+                            tc_tasks[taskId] = task
+                        except Exception:
+                            logger.info('Issue validating this message: %s', run)
+                logger.info("Updating Taskcluster jobs: %s entries", len(tc_messages))
+                with open(os.path.join(tests_path, 'taskcluster_pulse_messages.json'), 'w') as fh:
+                    # Write new line at the end to satisfy prettier
+                    fh.write(json.dumps(tc_messages, sort_keys=True, indent=2) + "\n")
+
+                logger.info("Updating Taskcluster task: %s entries", len(tc_tasks))
+                with open(os.path.join(tests_path, 'taskcluster_tasks.json'), 'w') as fh:
+                    # Write new line at the end to satisfy prettier
+                    fh.write(json.dumps(tc_tasks, sort_keys=True, indent=2) + "\n")
+
+                logger.info("Updating transformed messages: %s entries", len(th_jobs))
+                with open(os.path.join(tests_path, 'taskcluster_transformed_jobs.json'), 'w') as fh:
+                    # Write new line at the end to satisfy prettier
+                    fh.write(json.dumps(th_jobs, sort_keys=True, indent=2) + "\n")
+                self.stdout.write("Pulse Job listening stopped...")

--- a/treeherder/etl/schema.py
+++ b/treeherder/etl/schema.py
@@ -10,8 +10,5 @@ def get_json_schema(filename):
     """
     file_path = os.path.join("schemas", filename)
     with open(file_path) as f:
-        schema = yaml.load(f)
+        schema = yaml.load(f, Loader=yaml.FullLoader)
     return schema
-
-
-job_json_schema = get_json_schema("pulse-job.yml")

--- a/treeherder/etl/taskcluster_pulse/handler.py
+++ b/treeherder/etl/taskcluster_pulse/handler.py
@@ -1,0 +1,340 @@
+# Code imported from https://github.com/taskcluster/taskcluster/blob/32629c562f8d6f5a6b608a3141a8ee2e0984619f/services/treeherder/src/handler.js
+import asyncio
+import logging
+import os
+
+import jsonschema
+import slugid
+import taskcluster
+import taskcluster.aio
+import taskcluster_urls
+
+from treeherder.etl.schema import get_json_schema
+from treeherder.etl.taskcluster_pulse.parse_route import parseRoute
+
+logger = logging.getLogger(__name__)
+root_url = "https://taskcluster.net"
+options = {"rootUrl": root_url}
+loop = asyncio.get_event_loop()
+session = taskcluster.aio.createSession(loop=loop)
+asyncQueue = taskcluster.aio.Queue(options, session=session)
+
+
+# Build a mapping from exchange name to task status
+EXCHANGE_EVENT_MAP = {
+    "exchange/taskcluster-queue/v1/task-pending": "pending",
+    "exchange/taskcluster-queue/v1/task-running": "running",
+    "exchange/taskcluster-queue/v1/task-completed": "completed",
+    "exchange/taskcluster-queue/v1/task-failed": "failed",
+    "exchange/taskcluster-queue/v1/task-exception": "exception",
+}
+
+
+class PulseHandlerError(Exception):
+    """Base error"""
+    pass
+
+
+def stateFromRun(jobRun):
+    return "completed" if jobRun["state"] in ("exception", "failed") else jobRun["state"]
+
+
+def resultFromRun(jobRun):
+    RUN_TO_RESULT = {
+        "completed": "success",
+        "failed": "fail",
+    }
+    state = jobRun["state"]
+    if state in list(RUN_TO_RESULT.keys()):
+        return RUN_TO_RESULT[state]
+    elif state == "exception":
+        reasonResolved = jobRun.get("reasonResolved")
+        if reasonResolved in ["canceled", "superseded"]:
+            return reasonResolved
+        return "exception"
+    else:
+        return "unknown"
+
+
+# Creates a log entry for Treeherder to retrieve and parse.  This log is
+# displayed on the Treeherder Log Viewer once parsed.
+def createLogReference(taskId, runId):
+    logUrl = taskcluster_urls.api(
+        root_url,
+        "queue",
+        "v1",
+        "task/{taskId}/runs/{runId}/artifacts/public/logs/live_backing.log"
+    ).format(taskId=taskId, runId=runId)
+    return {
+        # XXX: This is a magical name see 1147958 which enables the log viewer.
+        "name": "builds-4h",
+        "url": logUrl,
+    }
+
+
+# Filters the task routes for the treeherder specific route.  Once found,
+# the route is parsed into distinct parts used for constructing the
+# Treeherder job message.
+# TODO: Refactor https://bugzilla.mozilla.org/show_bug.cgi?id=1560596
+def parseRouteInfo(prefix, taskId, routes, task):
+    matchingRoutes = list(filter(lambda route: route.split(".")[0] == "tc-treeherder", routes))
+
+    if len(matchingRoutes) != 1:
+        raise PulseHandlerError(
+            "Could not determine Treeherder route. Either there is no route, " +
+            "or more than one matching route exists." +
+            "Task ID: {taskId} Routes: {routes}".format(taskId=taskId, routes=routes)
+        )
+
+    parsedRoute = parseRoute(matchingRoutes[0])
+
+    return parsedRoute
+
+
+def validateTask(task):
+    treeherderMetadata = task.get("extra", {}).get("treeherder")
+    if not treeherderMetadata:
+        logger.debug("Task metadata is missing Treeherder job configuration.")
+        return False
+    try:
+        jsonschema.validate(treeherderMetadata, get_json_schema("task-treeherder-config.yml"))
+    except (jsonschema.ValidationError, jsonschema.SchemaError) as e:
+        logger.error("JSON Schema validation error during Taskcluser message ingestion: %s", e)
+        return False
+    return True
+
+
+# Listens for Task event messages and invokes the appropriate handler
+# for the type of message received.
+# Only messages that contain the properly formatted routing key and contains
+# treeherder job information in task.extra.treeherder are accepted
+# This will generate a list of messages that need to be ingested by Treeherder
+async def handleMessage(message, taskDefinition=None):
+    taskId = message["payload"]["status"]["taskId"]
+    task = (await asyncQueue.task(taskId)) if not taskDefinition else taskDefinition
+    try:
+        parsedRoute = parseRouteInfo("tc-treeherder", taskId, task["routes"], task)
+    except PulseHandlerError as e:
+        logger.warning("%s", str(e))
+        return None
+    logger.debug("Message received for task %s with route %s", taskId, str(task["routes"])[0:100])
+
+    # Validation failures are common and logged, so do nothing more.
+    if not validateTask(task):
+        return None
+
+    taskType = EXCHANGE_EVENT_MAP.get(message["exchange"])
+    jobs = []
+
+    # Originally this code was only within the "pending" case, however, in order to support
+    # ingesting all tasks at once which might not have "pending" case
+    # If the job is an automatic rerun we mark the previous run as "retry"
+    # This will only work if the previous run has not yet been processed by Treeherder
+    # since _remove_existing_jobs() will prevent it
+    if message["payload"]["runId"] > 0:
+        jobs.append(await handleTaskRerun(parsedRoute, task, message["payload"]))
+
+    if not taskType:
+        raise Exception("Unknown exchange: {exchange}".format(exchange=message["exchange"]))
+    elif taskType == "pending":
+        jobs.append(handleTaskPending(parsedRoute, task, message["payload"]))
+    elif taskType == "running":
+        jobs.append(handleTaskRunning(parsedRoute, task, message["payload"]))
+    elif taskType in ("completed", "failed"):
+        jobs.append(await handleTaskCompleted(parsedRoute, task, message["payload"]))
+    elif taskType == "exception":
+        jobs.append(await handleTaskException(parsedRoute, task, message["payload"]))
+
+    return jobs
+
+
+# Builds the basic Treeherder job message that's universal for all
+# messsage types.
+#
+# Specific handlers for each message type will add/remove information necessary
+# for the type of task event..
+def buildMessage(pushInfo, task, runId, message):
+    taskId = message["status"]["taskId"]
+    jobRun = message["status"]["runs"][runId]
+    treeherderConfig = task["extra"]["treeherder"]
+
+    job = {
+      "buildSystem": "taskcluster",
+      "owner": task["metadata"]["owner"],
+      "taskId": "{taskId}/{runId}".format(taskId=slugid.decode(taskId), runId=runId),
+      # TODO: In a follow up we will use the right name - bug 1560596
+      "realTaskId": taskId,
+      "runId": runId,
+      "isRetried": False,
+      "display": {
+        # jobSymbols could be an integer (i.e. Chunk ID) but need to be strings
+        # for treeherder
+        "jobSymbol": str(treeherderConfig["symbol"]),
+        "groupSymbol": treeherderConfig.get("groupSymbol", "?"),
+        # Maximum job name length is 100 chars...
+        "jobName": task["metadata"]["name"][0:99],
+      },
+      "state": stateFromRun(jobRun),
+      "result": resultFromRun(jobRun),
+      "tier": treeherderConfig.get("tier", 1),
+      "timeScheduled": task["created"],
+      "jobKind": treeherderConfig.get("jobKind", "other"),
+      "reason": treeherderConfig.get("reason", "scheduled"),
+      "jobInfo": {
+        "links": [],
+        "summary": task["metadata"]["description"],
+      },
+    }
+
+    job["origin"] = {
+      "kind": pushInfo["origin"],
+      "project": pushInfo["project"],
+      "revision": pushInfo["revision"],
+    }
+
+    if pushInfo["origin"] == "hg.mozilla.org":
+        job["origin"]["pushLogID"] = pushInfo["id"]
+    else:
+        job["origin"]["pullRequestID"] = pushInfo["id"]
+        job["origin"]["owner"] = pushInfo["owner"]
+
+    # Transform "collection" into an array of labels if task doesn't
+    # define "labels".
+    labels = treeherderConfig.get("labels", [])
+    if not labels:
+        if not treeherderConfig.get("collection"):
+            labels = ["opt"]
+        else:
+            labels = list(treeherderConfig["collection"].keys())
+
+    job["labels"] = labels
+
+    machine = treeherderConfig.get("machine", {})
+    job["buildMachine"] = {
+      "name": jobRun.get("workerId", "unknown"),
+      "platform": machine.get("platform", task["workerType"]),
+      "os": machine.get("os", "-"),
+      "architecture": machine.get("architecture", "-"),
+    }
+
+    if treeherderConfig.get("productName"):
+        job["productName"] = treeherderConfig["productName"]
+
+    if treeherderConfig.get("groupName"):
+        job["display"]["groupName"] = treeherderConfig["groupName"]
+
+    return job
+
+
+def handleTaskPending(pushInfo, task, message):
+    return buildMessage(pushInfo, task, message["runId"], message)
+
+
+async def handleTaskRerun(pushInfo, task, message):
+    job = buildMessage(pushInfo, task, message["runId"]-1, message)
+    job["state"] = "completed"
+    job["result"] = "fail"
+    job["isRetried"] = True
+    # reruns often have no logs, so in the interest of not linking to a 404'ing artifact,
+    # don't include a link
+    job["logs"] = []
+    job = await addArtifactUploadedLinks(
+        message["status"]["taskId"],
+        message["runId"]-1,
+        job)
+    return job
+
+
+def handleTaskRunning(pushInfo, task, message):
+    job = buildMessage(pushInfo, task, message["runId"], message)
+    job["timeStarted"] = message["status"]["runs"][message["runId"]]["started"]
+    return job
+
+
+async def handleTaskCompleted(pushInfo, task, message):
+    jobRun = message["status"]["runs"][message["runId"]]
+    job = buildMessage(pushInfo, task, message["runId"], message)
+
+    job["timeStarted"] = jobRun["started"]
+    job["timeCompleted"] = jobRun["resolved"]
+    job["logs"] = [createLogReference(message["status"]["taskId"], jobRun["runId"])]
+    job = await addArtifactUploadedLinks(
+        message["status"]["taskId"],
+        message["runId"],
+        job)
+    return job
+
+
+async def handleTaskException(pushInfo, task, message):
+    jobRun = message["status"]["runs"][message["runId"]]
+    # Do not report runs that were created as an exception.  Such cases
+    # are deadline-exceeded
+    if jobRun["reasonCreated"] == "exception":
+        return
+
+    job = buildMessage(pushInfo, task, message["runId"], message)
+    job["timeStarted"] = jobRun["started"]
+    job["timeCompleted"] = jobRun["resolved"]
+    # exceptions generally have no logs, so in the interest of not linking to a 404'ing artifact,
+    # don't include a link
+    job["logs"] = []
+    job = await addArtifactUploadedLinks(
+        message["status"]["taskId"],
+        message["runId"],
+        job)
+    return job
+
+
+async def fetchArtifacts(taskId, runId):
+    res = await asyncQueue.listArtifacts(taskId, runId)
+    artifacts = res["artifacts"]
+
+    continuationToken = res.get("continuationToken")
+    while continuationToken is not None:
+        continuation = {
+          "continuationToken": res["continuationToken"]
+        }
+
+        try:
+            res = await asyncQueue.listArtifacts(taskId, runId, continuation)
+        except Exception:
+            break
+
+        artifacts = artifacts.concat(res["artifacts"])
+        continuationToken = res.get("continuationToken")
+
+    return artifacts
+
+
+async def addArtifactUploadedLinks(taskId, runId, job):
+    artifacts = []
+    try:
+        artifacts = await fetchArtifacts(taskId, runId)
+    except Exception:
+        logger.warning("Artifacts could not be found for task: %s run: %s", taskId, runId)
+        return job
+
+    seen = {}
+    links = []
+    for artifact in artifacts:
+        name = os.path.basename(artifact["name"])
+        if not seen.get(name):
+            seen[name] = [artifact["name"]]
+        else:
+            seen[name].append(artifact["name"])
+            name = "{name} ({length})".format(name=name, length=len(seen[name])-1)
+
+        links.append({
+            "label": "artifact uploaded",
+            "linkText": name,
+            "url": taskcluster_urls.api(
+                root_url,
+                "queue",
+                "v1",
+                "task/{taskId}/runs/{runId}/artifacts/{artifact_name}".format(
+                    taskId=taskId, runId=runId, artifact_name=artifact["name"]
+                )),
+        })
+
+    job["jobInfo"]["links"] = links
+    return job

--- a/treeherder/etl/taskcluster_pulse/parse_route.py
+++ b/treeherder/etl/taskcluster_pulse/parse_route.py
@@ -1,0 +1,39 @@
+# Code imported from https://github.com/taskcluster/taskcluster/blob/32629c562f8d6f5a6b608a3141a8ee2e0984619f/services/treeherder/src/util/route_parser.js
+
+
+# A Taskcluster routing key will be in the form:
+# treeherder.<version>.<user/project>|<project>.<revision>.<pushLogId/pullRequestId>
+# [0] Routing key prefix used for listening to only treeherder relevant messages
+# [1] Routing key version
+# [2] In the form of user/project for github repos and just project for hg.mozilla.org
+# [3] Top level revision for the push
+# [4] Pull Request ID (github) or Push Log ID (hg.mozilla.org) of the push
+#     Note: pushes on a branch on Github would not have a PR ID
+# Function extracted from
+# https://github.com/taskcluster/taskcluster/blob/32629c562f8d6f5a6b608a3141a8ee2e0984619f/services/treeherder/src/util/route_parser.js
+def parseRoute(route):
+    id = None
+    parsedRoute = route.split('.')
+    parsedProject = None
+    pushInfo = {
+      "destination": parsedRoute[0],
+      "revision": parsedRoute[3],
+    }
+
+    project = parsedRoute[2]
+    if len(project.split('/')) == 2:
+        [owner, parsedProject] = project.split('/')
+        pushInfo.owner = owner
+        pushInfo.origin = 'github.com'
+    else:
+        parsedProject = project
+        pushInfo["origin"] = 'hg.mozilla.org'
+
+    pushInfo["project"] = parsedProject
+
+    if len(parsedRoute) == 5:
+        id = parsedRoute[4]
+
+    pushInfo["id"] = int(id) if id else None
+
+    return pushInfo

--- a/treeherder/etl/tasks/pulse_tasks.py
+++ b/treeherder/etl/tasks/pulse_tasks.py
@@ -2,6 +2,7 @@
 This module contains tasks related to pulse job ingestion
 """
 import asyncio
+
 import newrelic.agent
 
 from treeherder.etl.job_loader import JobLoader

--- a/treeherder/etl/tasks/pulse_tasks.py
+++ b/treeherder/etl/tasks/pulse_tasks.py
@@ -1,6 +1,7 @@
 """
 This module contains tasks related to pulse job ingestion
 """
+import asyncio
 import newrelic.agent
 
 from treeherder.etl.job_loader import JobLoader
@@ -14,13 +15,14 @@ def store_pulse_jobs(pulse_job, exchange, routing_key):
     """
     Fetches the jobs pending from pulse exchanges and loads them.
     """
+    loop = asyncio.get_event_loop()
     newrelic.agent.add_custom_parameter("exchange", exchange)
     newrelic.agent.add_custom_parameter("routing_key", routing_key)
     # handleMessage expects messages in this format
-    runs = handleMessage({
+    runs = loop.run_until_complete(handleMessage({
         "exchange": exchange,
         "payload": pulse_job,
-    })
+    }))
     for run in runs:
         JobLoader().process_job(run)
 

--- a/treeherder/etl/tasks/pulse_tasks.py
+++ b/treeherder/etl/tasks/pulse_tasks.py
@@ -5,6 +5,7 @@ import newrelic.agent
 
 from treeherder.etl.job_loader import JobLoader
 from treeherder.etl.push_loader import PushLoader
+from treeherder.etl.taskcluster_pulse.handler import handleMessage
 from treeherder.workers.task import retryable_task
 
 
@@ -15,8 +16,13 @@ def store_pulse_jobs(pulse_job, exchange, routing_key):
     """
     newrelic.agent.add_custom_parameter("exchange", exchange)
     newrelic.agent.add_custom_parameter("routing_key", routing_key)
-
-    JobLoader().process_job(pulse_job)
+    # handleMessage expects messages in this format
+    runs = handleMessage({
+        "exchange": exchange,
+        "payload": pulse_job,
+    })
+    for run in runs:
+        JobLoader().process_job(run)
 
 
 @retryable_task(name='store-pulse-pushes', max_retries=10)

--- a/treeherder/services/pulse/__init__.py
+++ b/treeherder/services/pulse/__init__.py
@@ -1,6 +1,7 @@
 from .connection import pulse_conn
 from .consumers import (JobConsumer,
                         PushConsumer,
+                        UpdateJobFixtures,
                         prepare_consumer)
 from .sources import (job_sources,
                       push_sources)
@@ -8,6 +9,7 @@ from .sources import (job_sources,
 __all__ = [
     "JobConsumer",
     "PushConsumer",
+    "UpdateJobFixtures",
     "job_sources",
     "prepare_consumer",
     "pulse_conn",

--- a/treeherder/services/pulse/consumers.py
+++ b/treeherder/services/pulse/consumers.py
@@ -105,6 +105,30 @@ class JobConsumer(PulseConsumer):
         message.ack()
 
 
+class UpdateJobFixtures(PulseConsumer):
+    processedMessages = 0
+    maxMessages = 5
+    # This is the name of your queue on Pulse Guardian
+    queue_suffix = "foo"
+    messages = []
+
+    def on_message(self, body, message):
+        exchange = message.delivery_info['exchange']
+        routing_key = message.delivery_info['routing_key']
+        logger.debug('received job message from %s', exchange)
+        # handleMessage expects messages in this format
+        self.messages.append({
+            "exchange": exchange,
+            "routes": routing_key,
+            "payload": body,
+        })
+        message.ack()
+        self.processedMessages += 1
+        self.close()
+        if self.processedMessages > self.maxMessages:
+            raise Exception('We have processed {} and need to store them'.format(self.processedMessages))
+
+
 class PushConsumer(PulseConsumer):
     queue_suffix = "resultsets"
 

--- a/treeherder/services/pulse/sources.py
+++ b/treeherder/services/pulse/sources.py
@@ -18,8 +18,11 @@ env = environ.Env()
 job_sources = env.list(
     "PULSE_JOB_SOURCES",
     default=[
-        "exchange/taskcluster-treeherder/v1/jobs.#",
-        # ... other CI systems
+        "exchange/taskcluster-queue/v1/task-pending.#",
+        "exchange/taskcluster-queue/v1/task-running.#",
+        "exchange/taskcluster-queue/v1/task-completed.#",
+        "exchange/taskcluster-queue/v1/task-failed.#",
+        "exchange/taskcluster-queue/v1/task-exception.#",
     ],
 )
 


### PR DESCRIPTION
Currently, Treeherder consumes Pulse messages from an intermediary service called `taskcluster-treeherder`.
Such service needs to be shut down and its functionality imported into Treeherder.

In order to do this we need to switch to the standard Taskcluster exchanges as defined in here:
https://docs.taskcluster.net/docs/reference/platform/queue/exchanges

On a first pass we are only including the code from `taskcluster-treeherder` without changing
much of Treeherder's code. We will still have an intermediary data structure representing
what `taskcluster-treeherder` was emitting, however, we will stop consuming data directly
from it and be able to shut it down.

Following this work would be to get rid of the intermediary job representation which will
clean up a bunch of code and some old tests.