### PR TITLE
Bug 1552250 - Make autoland the default repo

### DIFF
--- a/tests/ui/unit/context/pushes_test.jsx
+++ b/tests/ui/unit/context/pushes_test.jsx
@@ -10,7 +10,7 @@ import jobListFixtureOne from '../../mock/job_list/job_1';
 import jobListFixtureTwo from '../../mock/job_list/job_2';
 
 describe('Pushes context', () => {
-  const repoName = 'mozilla-inbound';
+  const repoName = 'autoland';
 
   beforeEach(() => {
     fetchMock.mock(

--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -175,7 +175,7 @@ export const thFavicons = {
   unavailable: treeFavicon,
 };
 
-export const thDefaultRepo = 'mozilla-inbound';
+export const thDefaultRepo = 'autoland';
 
 export const thJobNavSelectors = {
   ALL_JOBS: {


### PR DESCRIPTION
Most landings these days are going to autoland rather than
mozilla-inbound, so lets default to showing autoland if no repo is
specified.