### PR TITLE
Bug 1557038 - Add Test Isolation to Job Action, r=camd.

### DIFF
--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 
 import { thFailureResults, thPlatformMap } from './constants';
 import { getGroupMapKey } from './aggregateId';
-import { getAllUrlParams } from './location';
+import { getAllUrlParams, getRepo } from './location';
 import { uiJobsUrlBase } from './url';
 
 const btnClasses = {
@@ -78,6 +78,16 @@ export const isPerfTest = function isPerfTest(job) {
 };
 
 export const isTestIsolatable = function isTestIsolatable(job) {
+  const isolatableRepos = [
+    'autoland',
+    'mozilla-central',
+    'mozilla-inbound',
+    'try',
+  ];
+  const repoName = getRepo();
+  if (!isolatableRepos.includes(repoName)) {
+    return false;
+  }
   if (job.job_type_name.toLowerCase().includes('jsreftest')) {
     return false;
   }

--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -77,6 +77,20 @@ export const isPerfTest = function isPerfTest(job) {
   );
 };
 
+export const isTestIsolatable = function isTestIsolatable(job) {
+  if (job.job_type_name.toLowerCase().includes('jsreftest')) {
+    return false;
+  }
+  return [job.job_group_name, job.job_type_name].some(
+    name =>
+      !name.toLowerCase().includes('source-test') &&
+      (name.toLowerCase().includes('crashtest') ||
+        name.toLowerCase().includes('mochitest') ||
+        name.toLowerCase().includes('reftest') ||
+        name.toLowerCase().includes('xpcshell')),
+  );
+};
+
 export const isClassified = function isClassified(job) {
   return !thUnclassifiedIds.includes(job.failure_classification_id);
 };

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -14,7 +14,7 @@ import {
 
 import { thEvents } from '../../../helpers/constants';
 import { formatTaskclusterError } from '../../../helpers/errorMessage';
-import { isReftest, isPerfTest } from '../../../helpers/job';
+import { isReftest, isPerfTest, isTestIsolatable } from '../../../helpers/job';
 import { getInspectTaskUrl, getReftestUrl } from '../../../helpers/url';
 import JobModel from '../../../models/job';
 import TaskclusterModel from '../../../models/taskcluster';
@@ -190,6 +190,94 @@ class ActionBar extends React.PureComponent {
       );
     } else {
       notify('Unable to backfill this job type!', 'danger', { sticky: true });
+    }
+  };
+
+  isolateJob = () => {
+    const { user, selectedJob, getGeckoDecisionTaskId, notify } = this.props;
+
+    if (!isTestIsolatable(selectedJob)) {
+      return;
+    }
+
+    if (!user.isLoggedIn) {
+      notify('Must be logged in to isolate a job', 'danger');
+
+      return;
+    }
+
+    if (!selectedJob.id) {
+      notify('Job not yet loaded for isolation', 'warning');
+
+      return;
+    }
+
+    if (selectedJob.state !== 'completed') {
+      notify('Job not yet completed. Try again later.', 'warning');
+
+      return;
+    }
+
+    if (
+      selectedJob.build_system_type === 'taskcluster' ||
+      selectedJob.reason.startsWith('Created by BBB for task')
+    ) {
+      getGeckoDecisionTaskId(selectedJob.push_id).then(decisionTaskId =>
+        TaskclusterModel.load(decisionTaskId, selectedJob).then(results => {
+          const isolationtask = results.actions.find(
+            result => result.name === 'isolate-test-failures',
+          );
+
+          if (!isolationtask) {
+            notify(
+              'Request to isolate job via actions.json failed could not find action.',
+              'danger',
+              { sticky: true },
+            );
+            return;
+          }
+
+          let times = 1;
+          let response = null;
+          do {
+            response = window.prompt(
+              'Enter number of times (1..100) to run isolation jobs: ',
+              times,
+            );
+            if (response == null) {
+              break;
+            }
+            times = parseInt(response, 10);
+          } while (Number.isNaN(times) || times < 1 || times > 100);
+
+          if (response === null) {
+            notify('Request to isolate job via actions.json aborted.');
+            return;
+          }
+
+          return TaskclusterModel.submit({
+            action: isolationtask,
+            decisionTaskId,
+            taskId: results.originalTaskId,
+            input: { times },
+            staticActionVariables: results.staticActionVariables,
+          }).then(
+            () => {
+              notify(
+                'Request sent to isolate-test-failures job via actions.json',
+                'success',
+              );
+            },
+            e => {
+              // The full message is too large to fit in a Treeherder
+              // notification box.
+              notify(formatTaskclusterError(e), 'danger', { sticky: true });
+            },
+          );
+        }),
+      );
+    } else {
+      notify('Unable to isolate this job type!', 'danger', { sticky: true });
     }
   };
 
@@ -425,6 +513,16 @@ class ActionBar extends React.PureComponent {
                           onClick={this.createGeckoProfile}
                         >
                           Create Gecko Profile
+                        </Button>
+                      </li>
+                    )}
+                    {isTestIsolatable(selectedJob) && (
+                      <li>
+                        <Button
+                          className="dropdown-item py-2"
+                          onClick={this.isolateJob}
+                        >
+                          Run Isolation Tests
                         </Button>
                       </li>
                     )}


### PR DESCRIPTION
@camd: This is a combination of the original pull request with fixes for the lint errors and two additional changes to prevent test isolation from being available to jsreftests and to increase the maximum 'times' to 100.