### PR TITLE
Bug 1558752 - Fix alert summary checkbox on Perfherder alerts view

### DIFF
--- a/tests/ui/unit/react/alerts_test.jsx
+++ b/tests/ui/unit/react/alerts_test.jsx
@@ -306,7 +306,7 @@ test('selecting all alerts and marking them as acknowledged updates all alerts',
   const alertCheckbox2 = getByTestId('alert 69345 checkbox');
 
   fireEvent.click(summaryCheckbox);
-  expect(summaryCheckbox).toHaveProperty('checked', true);  
+  expect(summaryCheckbox).toHaveProperty('checked', true);
   expect(alertCheckbox1).toHaveProperty('checked', true);
   expect(alertCheckbox2).toHaveProperty('checked', true);
   let acknowledgeButton = await waitForElement(() => getByText('Acknowledge'));
@@ -380,57 +380,51 @@ test('selecting an alert and marking it as invalid only updates that alert', asy
   modifyAlertSpy.mockClear();
 });
 
-test('deselecting one alert only updates the selected alerts not all alerts', async () => {
+test('selecting the alert summary checkbox then deselecting one alert only updates the selected alerts', async () => {
   const { getByTestId, getByText, queryByText } = alertsViewControls();
-  
-    // select all alerts
-    const summaryCheckbox = getByTestId('alert summary 20174 checkbox');
-    const alertCheckbox1 = getByTestId('alert 69344 checkbox');
-    const alertCheckbox2 = getByTestId('alert 69345 checkbox');
 
-    fireEvent.click(summaryCheckbox);
-    expect(summaryCheckbox).toHaveProperty('checked', true);
-    expect(alertCheckbox1).toHaveProperty('checked', true);
-    expect(alertCheckbox2).toHaveProperty('checked', true);
-    
-    // deselect one alert
-    fireEvent.click(alertCheckbox1);
+  // select all alerts
+  const summaryCheckbox = getByTestId('alert summary 20174 checkbox');
+  const alertCheckbox1 = getByTestId('alert 69344 checkbox');
+  const alertCheckbox2 = getByTestId('alert 69345 checkbox');
+
+  fireEvent.click(summaryCheckbox);
+  expect(summaryCheckbox).toHaveProperty('checked', true);
+  expect(alertCheckbox1).toHaveProperty('checked', true);
+  expect(alertCheckbox2).toHaveProperty('checked', true);
+
+  // deselect one alert
+  fireEvent.click(alertCheckbox1);
+  expect(summaryCheckbox).toHaveProperty('checked', false);
+  expect(alertCheckbox1).toHaveProperty('checked', false);
+  expect(alertCheckbox2).toHaveProperty('checked', true);
+
+  let confirmingButton = await waitForElement(() => getByText('Confirming'));
+  fireEvent.click(confirmingButton);
+
+  // only the selected alert has been updated
+  expect(modifyAlertSpy).toHaveBeenCalled();
+  expect(modifyAlertSpy.mock.results).toHaveLength(1);
+  expect(modifyAlertSpy.mock.results[0].value.data.id).toEqual(69345);
+  expect(modifyAlertSpy.mock.results[0].value).toStrictEqual({
+    data: {
+      ...testAlertSummaries[0].alerts[0],
+      ...{ status: 5 },
+    },
+    failureStatus: null,
+  });
+
+  // action panel has closed and all checkboxes reset
+  confirmingButton = await waitForElementToBeRemoved(() =>
+    queryByText('Confirming'),
+  );
+  await wait(() => {
     expect(summaryCheckbox).toHaveProperty('checked', false);
     expect(alertCheckbox1).toHaveProperty('checked', false);
-    expect(alertCheckbox2).toHaveProperty('checked', true);
-    
-    // let acknowledgeButton = await waitForElement(() => getByText('Acknowledge'));
-    // fireEvent.click(acknowledgeButton);
-  
-    // only the selected alert has been updated
-    // expect(modifyAlertSpy).toHaveBeenCalled();
-    // expect(modifyAlertSpy.mock.results[0].value).toStrictEqual({
-    //   data: {
-    //     ...testAlertSummaries[0].alerts[0],
-    //     ...{ status: 4 },
-    //   },
-    //   failureStatus: null,
-    // });
-  
-    // expect(modifyAlertSpy.mock.results[1].value).toStrictEqual({
-    //   data: {
-    //     ...testAlertSummaries[0].alerts[1],
-    //     ...{ status: 4 },
-    //   },
-    //   failureStatus: null,
-    // });
-  
-    // // action panel has closed and all checkboxes reset
-    // acknowledgeButton = await waitForElementToBeRemoved(() =>
-    //   queryByText('Acknowledge'),
-    // );
-    // await wait(() => {
-    //   expect(summaryCheckbox).toHaveProperty('checked', false);
-    //   expect(alertCheckbox1).toHaveProperty('checked', false);
-    //   expect(alertCheckbox2).toHaveProperty('checked', false);
-    // });
-  
-    // modifyAlertSpy.mockClear();
+    expect(alertCheckbox2).toHaveProperty('checked', false);
+  });
+
+  modifyAlertSpy.mockClear();
 });
 
 // TODO should write tests for alert summary dropdown menu actions performed in StatusDropdown

--- a/tests/ui/unit/react/alerts_test.jsx
+++ b/tests/ui/unit/react/alerts_test.jsx
@@ -306,6 +306,7 @@ test('selecting all alerts and marking them as acknowledged updates all alerts',
   const alertCheckbox2 = getByTestId('alert 69345 checkbox');
 
   fireEvent.click(summaryCheckbox);
+  expect(summaryCheckbox).toHaveProperty('checked', true);  
   expect(alertCheckbox1).toHaveProperty('checked', true);
   expect(alertCheckbox2).toHaveProperty('checked', true);
   let acknowledgeButton = await waitForElement(() => getByText('Acknowledge'));
@@ -377,6 +378,59 @@ test('selecting an alert and marking it as invalid only updates that alert', asy
   });
 
   modifyAlertSpy.mockClear();
+});
+
+test('deselecting one alert only updates the selected alerts not all alerts', async () => {
+  const { getByTestId, getByText, queryByText } = alertsViewControls();
+  
+    // select all alerts
+    const summaryCheckbox = getByTestId('alert summary 20174 checkbox');
+    const alertCheckbox1 = getByTestId('alert 69344 checkbox');
+    const alertCheckbox2 = getByTestId('alert 69345 checkbox');
+
+    fireEvent.click(summaryCheckbox);
+    expect(summaryCheckbox).toHaveProperty('checked', true);
+    expect(alertCheckbox1).toHaveProperty('checked', true);
+    expect(alertCheckbox2).toHaveProperty('checked', true);
+    
+    // deselect one alert
+    fireEvent.click(alertCheckbox1);
+    expect(summaryCheckbox).toHaveProperty('checked', false);
+    expect(alertCheckbox1).toHaveProperty('checked', false);
+    expect(alertCheckbox2).toHaveProperty('checked', true);
+    
+    // let acknowledgeButton = await waitForElement(() => getByText('Acknowledge'));
+    // fireEvent.click(acknowledgeButton);
+  
+    // only the selected alert has been updated
+    // expect(modifyAlertSpy).toHaveBeenCalled();
+    // expect(modifyAlertSpy.mock.results[0].value).toStrictEqual({
+    //   data: {
+    //     ...testAlertSummaries[0].alerts[0],
+    //     ...{ status: 4 },
+    //   },
+    //   failureStatus: null,
+    // });
+  
+    // expect(modifyAlertSpy.mock.results[1].value).toStrictEqual({
+    //   data: {
+    //     ...testAlertSummaries[0].alerts[1],
+    //     ...{ status: 4 },
+    //   },
+    //   failureStatus: null,
+    // });
+  
+    // // action panel has closed and all checkboxes reset
+    // acknowledgeButton = await waitForElementToBeRemoved(() =>
+    //   queryByText('Acknowledge'),
+    // );
+    // await wait(() => {
+    //   expect(summaryCheckbox).toHaveProperty('checked', false);
+    //   expect(alertCheckbox1).toHaveProperty('checked', false);
+    //   expect(alertCheckbox2).toHaveProperty('checked', false);
+    // });
+  
+    // modifyAlertSpy.mockClear();
 });
 
 // TODO should write tests for alert summary dropdown menu actions performed in StatusDropdown

--- a/ui/perfherder/alerts/AlertTable.jsx
+++ b/ui/perfherder/alerts/AlertTable.jsx
@@ -36,10 +36,12 @@ export default class AlertTable extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.filters !== this.props.filters) {
+    const { filters, alertSummary } = this.props;
+
+    if (prevProps.filters !== filters) {
       this.updateFilteredAlerts();
     }
-    if (prevProps.alertSummary !== this.props.alertSummary) {
+    if (prevProps.alertSummary !== alertSummary) {
       this.processAlerts();
     }
   }
@@ -171,7 +173,12 @@ export default class AlertTable extends React.Component {
                             checked={allSelected}
                             disabled={!user.isStaff}
                             onChange={() =>
-                              this.setState({ allSelected: !allSelected })
+                              this.setState({
+                                allSelected: !allSelected,
+                                selectedAlerts: !allSelected
+                                  ? [...alertSummary.alerts]
+                                  : [],
+                              })
                             }
                           />
                           <AlertHeader
@@ -203,7 +210,6 @@ export default class AlertTable extends React.Component {
                       alertSummary={alertSummary}
                       alert={alert}
                       user={user}
-                      allSelected={allSelected}
                       updateSelectedAlerts={alerts => this.setState(alerts)}
                       selectedAlerts={selectedAlerts}
                       updateViewState={updateViewState}
@@ -253,11 +259,9 @@ export default class AlertTable extends React.Component {
                       />
                     </div>
                   )}
-                  {(allSelected || selectedAlerts.length > 0) && (
+                  {selectedAlerts.length > 0 && (
                     <AlertActionPanel
-                      selectedAlerts={
-                        allSelected ? alertSummary.alerts : selectedAlerts
-                      }
+                      selectedAlerts={selectedAlerts}
                       allSelected={allSelected}
                       alertSummaries={alertSummaries}
                       alertSummary={alertSummary}

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-did-update-set-state */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup, Input } from 'reactstrap';
@@ -27,20 +28,19 @@ export default class AlertTableRow extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { allSelected, selectedAlerts } = this.props;
-
-    if (prevProps.allSelected !== allSelected) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ checkboxSelected: allSelected });
-    }
-    // remove checkbox when an action is taken in the AlertActionPanel
-    // (it resets selectedAlerts)
-    else if (
-      prevProps.selectedAlerts !== selectedAlerts &&
-      !selectedAlerts.length
-    ) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ checkboxSelected: false });
+    const { selectedAlerts } = this.props;
+    // reset alert checkbox when an action is taken in the AlertActionPanel
+    // (it resets selectedAlerts) or an individual alert has been deselected
+    // and removed from selectedAlerts
+    if (prevProps.selectedAlerts !== selectedAlerts) {
+      if (!selectedAlerts.length) {
+        this.setState({ checkboxSelected: false });
+      } else {
+        const index = selectedAlerts.findIndex(
+          alert => alert.id === this.state.alert.id,
+        );
+        this.setState({ checkboxSelected: index !== -1 });
+      }
     }
   }
 
@@ -103,10 +103,10 @@ export default class AlertTableRow extends React.Component {
   };
 
   updateCheckbox = () => {
-    const { alert, updateSelectedAlerts, selectedAlerts } = this.props;
-    const { checkboxSelected } = this.state;
+    const { updateSelectedAlerts, selectedAlerts } = this.props;
+    const { checkboxSelected, alert } = this.state;
 
-    const index = selectedAlerts.indexOf(alert);
+    const index = selectedAlerts.findIndex(item => item.id === alert.id);
 
     if (checkboxSelected && index === -1) {
       return updateSelectedAlerts({
@@ -114,9 +114,9 @@ export default class AlertTableRow extends React.Component {
       });
     }
 
-    if (index !== -1) {
+    if (!checkboxSelected && index !== -1) {
       selectedAlerts.splice(index, 1);
-      return updateSelectedAlerts({ selectedAlerts });
+      return updateSelectedAlerts({ selectedAlerts, allSelected: false });
     }
   };
 
@@ -310,7 +310,6 @@ AlertTableRow.propTypes = {
   }).isRequired,
   updateSelectedAlerts: PropTypes.func.isRequired,
   selectedAlerts: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  allSelected: PropTypes.bool.isRequired,
   updateViewState: PropTypes.func.isRequired,
   modifyAlert: PropTypes.func,
 };

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -21,14 +21,14 @@ export default class AlertTableRow extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      alert: this.props.alert,
       starred: this.props.alert.starred,
       checkboxSelected: false,
     };
   }
 
   componentDidUpdate(prevProps) {
-    const { selectedAlerts } = this.props;
+    const { selectedAlerts, alert } = this.props;
+
     // reset alert checkbox when an action is taken in the AlertActionPanel
     // (it resets selectedAlerts) or an individual alert has been deselected
     // and removed from selectedAlerts
@@ -36,9 +36,7 @@ export default class AlertTableRow extends React.Component {
       if (!selectedAlerts.length) {
         this.setState({ checkboxSelected: false });
       } else {
-        const index = selectedAlerts.findIndex(
-          alert => alert.id === this.state.alert.id,
-        );
+        const index = selectedAlerts.findIndex(item => item.id === alert.id);
         this.setState({ checkboxSelected: index !== -1 });
       }
     }
@@ -63,7 +61,8 @@ export default class AlertTableRow extends React.Component {
   };
 
   toggleStar = async () => {
-    const { starred, alert } = this.state;
+    const { starred } = this.state;
+    const { alert } = this.props;
     const updatedStar = {
       starred: !starred,
     };
@@ -103,8 +102,8 @@ export default class AlertTableRow extends React.Component {
   };
 
   updateCheckbox = () => {
-    const { updateSelectedAlerts, selectedAlerts } = this.props;
-    const { checkboxSelected, alert } = this.state;
+    const { updateSelectedAlerts, selectedAlerts, alert } = this.props;
+    const { checkboxSelected } = this.state;
 
     const index = selectedAlerts.findIndex(item => item.id === alert.id);
 


### PR DESCRIPTION
This patch solves a bug Ionut discovered where if an alert summary checkbox is selected (to select all alerts), and then one alert is deselected, any action performed will still update all alerts because the checkbox summary alert was also not deselected. I added another test to cover this scenario and cleaned up the `AlertTableRow` file a bit.