### PR TITLE
Bug 1557235 - Provide 2 decimals for 0% regressions

### DIFF
--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -434,8 +434,14 @@ export const getTextualSummary = (alerts, alertSummary, copySummary = null) => {
 
   const formatAlert = (alert, alertList) => {
     const numFormat = '0,0.00';
+    let amountPct;
 
-    const amountPct = alert.amount_pct.toFixed(0).padStart(3);
+    if (alert.amount_pct.toFixed(0) === '0') {
+      // have extra fraction digits when rounding ends up with 0%
+      amountPct = alert.amount_pct.toFixed(2);
+    } else {
+      amountPct = alert.amount_pct.toFixed(0).padStart(4);
+    }
     const title = alert.title.padEnd(getMaximumAlertLength(alertList) + 5);
     const prevValue = numeral(alert.prev_value).format(numFormat);
     const newValue = numeral(alert.new_value).format(numFormat);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1557235

The template forms we use for filing Bugzilla tickets approximate percentages without any decimals. This is nice most of the times, as the report is readable.

Still, there are cases when we need to leverage 2 decimals for extra precision.
More precisely, when we have alerts which end up approximated to 0%.

E.g.:

for Perfherder alerts like

6.8% Base Content JS linux64-shippable opt
5.45% Base Content JS windows10-64-shippable-qr opt
0.21% Base Content JS windows7-32-shippable opt
we would get a report like

7% Base Content JS linux64-shippable opt
5% Base Content JS windows10-64-shippable-qr opt
0.21% Base Content JS windows7-32-shippable opt