### PR TITLE
Bug 1559146 - fix disappearing pagination in Perfherder alerts view

### DIFF
--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -420,31 +420,12 @@ button:disabled {
   stroke: #ffffff;
 }
 
-/* The paginator in angular1-ui-bootstrap4 always tries to put chevrons
-   for the prev/next buttons, but they look all messed up sizing wise.
-   The paginator SHOULD show the text of Next/Previous, but it's not, so this
-   is a work-around.*/
-li.page-item .material-icons {
-  font-size: 0;
-}
-
-li.pagination-prev .material-icons::before {
-  content: 'Previous';
-  font-size: 14px;
-  font-style: normal;
-}
-
-li.pagination-next .material-icons::before {
-  content: 'Next';
-  font-size: 14px;
-  font-style: normal;
-}
-
-.pagination {
-  margin: 20px 0;
-}
-
 /* for use with global max-width-default style */
 .max-width-row-text {
   max-width: 1194px;
+}
+
+li.pagination-active.active > button {
+  background-color: lightgray !Important;
+  border-color: lightgray !Important;
 }

--- a/ui/perfherder/alerts/AlertsView.jsx
+++ b/ui/perfherder/alerts/AlertsView.jsx
@@ -178,7 +178,7 @@ export class AlertsView extends React.Component {
         ...updates,
         ...{
           alertSummaries: update ? alertSummaries : summary.results,
-          count: update ? count : Math.round(summary.count / 10),
+          count: update ? count : Math.ceil(summary.count / 10),
         },
       };
     } else {
@@ -279,13 +279,17 @@ export class AlertsView extends React.Component {
                     />
                   </PaginationItem>
                 )}
-                {pageNums.map(page => (
-                  <PaginationItem key={page}>
+                {pageNums.map(num => (
+                  <PaginationItem
+                    key={num}
+                    active={num === page}
+                    className="text-info pagination-active"
+                  >
                     <PaginationLink
                       className="text-info"
-                      onClick={() => this.navigatePage(page)}
+                      onClick={() => this.navigatePage(num)}
                     >
-                      {page}
+                      {num}
                     </PaginationLink>
                   </PaginationItem>
                 ))}


### PR DESCRIPTION
I realized in my last pr #5065 I didn't address the issue with the disappearing pagination, and the culprit was the use of Math.round. I also added active prop (and a CSS style to match the color) to easily denote active page to avoid confusion and remove unused styles.