### PR TITLE
Bug 1554136 - Fix error when classifying many jobs on the same platform

### DIFF
--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -128,7 +128,11 @@ class PinBoard extends React.Component {
             'success',
           );
           // update the job to show that it's now classified
-          findJobInstance(job.id).refilter();
+          const jobInstance = findJobInstance(job.id);
+
+          if (jobInstance) {
+            jobInstance.refilter();
+          }
         })
         .catch(response => {
           const message = `Error saving classification for ${job.platform} ${


### PR DESCRIPTION
I just needed to add a check before calling ``refilter``.  Because if another job in the same platform was classified, a race condition could cause this job to have already been removed from the DOM.