### PR TITLE
Bug 1561059 - Allow Fuzzy Job Finder to store/use presets

### DIFF
--- a/ui/css/treeherder-fuzzyfinder.css
+++ b/ui/css/treeherder-fuzzyfinder.css
@@ -2,6 +2,14 @@
  * Fuzzy runnable job finder
  */
 
+.fuzzy-modal #preset-group > * {
+  margin: 1px;
+}
+
+.fuzzy-modal #preset-group label {
+  margin-top: 5px;
+}
+
 .fuzzy-modal .modal-body #addJobsGroup option.selected::before {
   content: '• ';
   color: red;
@@ -16,9 +24,13 @@ div.fuzzybuttons {
 }
 
 .fuzzy-modal .modal-body #addJobsGroup {
-  height: 30vh;
+  height: 28vh;
 }
 
 .fuzzy-modal .modal-body #removeJobsGroup {
-  height: 29vh;
+  height: 28vh;
+}
+
+.fuzzy-modal #save-presets {
+  float: right !important;
 }


### PR DESCRIPTION
I'm not gonna have time to work on this much in the near future, but I thought I'd put what I had up somewhere if someone else wants to pick it up.

This adds the ability to store presets in your browser's localStorage via the Fuzzy Jobs Finder.

It could use a lot of finishing touches: 
It uses window.confirm and window.prompt to ask the user for preset names when it should probably use a nested reactstrap modal.
It doesn't really do any checking for preset names beyond checking if a name is already in use. If you cancel the prompts, it saves a preset named `null`. 
Using localStorage is convenient, but it can easily get blown away and then you lose your carefully crafted presets. It might do better being saved in the user's profile within Treeherder.

New appearance of the Fuzzy Job Finder:
![AddNewJobsPreset1](https://user-images.githubusercontent.com/172215/60698524-9a2d5c80-9ea4-11e9-9587-3e78f5777ce2.png)

Filter jobs like usual and add them to the selection:
![AddNewJobsPreset2](https://user-images.githubusercontent.com/172215/60698536-ac0eff80-9ea4-11e9-8240-64a7cdd35fa2.png)

Click the new "Save Selected Jobs as Preset" button and give the preset a name:
![AddNewJobsPreset3](https://user-images.githubusercontent.com/172215/60698564-c8ab3780-9ea4-11e9-9996-fe2545dfea09.png)

It's now saved as a preset. The next time you want to select those jobs, you can choose the preset from the dropdown at the top of the modal and click "Add to Selection":
![AddNewJobsPreset4](https://user-images.githubusercontent.com/172215/60698588-ee384100-9ea4-11e9-946c-9396c0084ea5.png)

All of the jobs saved in the preset should now be added to the selected jobs list and you're ready to click the "Trigger (X) New Jobs" button like usual.