### PR TITLE
Bug 1562852 - fix Perherder Alerts search input

### DIFF
--- a/ui/perfherder/alerts/AlertsView.jsx
+++ b/ui/perfherder/alerts/AlertsView.jsx
@@ -87,12 +87,8 @@ export class AlertsView extends React.Component {
   };
 
   navigatePage = page => {
-    const { framework, status } = this.state;
-    this.props.$state.go('alerts', {
-      page,
-      framework: framework.id,
-      status: summaryStatusMap[status],
-    });
+    this.setState({ page }, this.fetchAlertSummaries);
+    this.props.validated.updateParams({ page });
   };
 
   getCurrentPages = () => {


### PR DESCRIPTION
Change navigatePage function to update state and params and fetch new alert summaries instead
of using angular state.go since that causes the page to re-mount on navigation (and to clear the text in the search input when navigating from page to page).