### PR TITLE
Bug 1563884 - Stop sending 'credentials: same-origin' to /user requests

### DIFF
--- a/ui/models/user.js
+++ b/ui/models/user.js
@@ -9,7 +9,6 @@ export default class UserModel {
   }
 
   static get() {
-    // TODO: The credentials param can be removed in July once Firefox 62 ships and it is the default.
     return fetch(`${uri}`).then(resp =>
       resp.json().then(data => (data.length > 0 ? new UserModel(data[0]) : {})),
     );

--- a/ui/models/user.js
+++ b/ui/models/user.js
@@ -10,7 +10,7 @@ export default class UserModel {
 
   static get() {
     // TODO: The credentials param can be removed in July once Firefox 62 ships and it is the default.
-    return fetch(`${uri}`, { credentials: 'same-origin' }).then(resp =>
+    return fetch(`${uri}`).then(resp =>
       resp.json().then(data => (data.length > 0 ? new UserModel(data[0]) : {})),
     );
   }


### PR DESCRIPTION
Totally untested by me, but the default has been same-origin since Firefox 61 or 62, and similar timeline for Chrome.