### PR TITLE
Bug 1531759 - Modify treeherder's bugfiler to set bug type as 'defect'

### DIFF
--- a/tests/webapp/api/test_bugzilla.py
+++ b/tests/webapp/api/test_bugzilla.py
@@ -16,6 +16,7 @@ def test_create_bug(client, eleven_jobs_stored, activate_responses, test_user):
         requestdata = json.loads(request.body)
         requestheaders = request.headers
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
+        assert requestdata['type'] == "defect"
         assert requestdata['product'] == "Bugzilla"
         assert requestdata['description'] == u"**Filed by:** {}\nIntermittent Description".format(test_user.email.replace('@', " [at] "))
         assert requestdata['component'] == "Administration"
@@ -37,6 +38,7 @@ def test_create_bug(client, eleven_jobs_stored, activate_responses, test_user):
     resp = client.post(
         reverse("bugzilla-create-bug"),
         {
+            "type": "defect",
             "product": "Bugzilla",
             "component": "Administration",
             "summary": u"Intermittent summary",
@@ -60,6 +62,7 @@ def test_create_bug_with_unicode(client, eleven_jobs_stored, activate_responses,
         requestdata = json.loads(request.body)
         requestheaders = request.headers
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
+        assert requestdata['type'] == "defect"
         assert requestdata['product'] == "Bugzilla"
         assert requestdata['description'] == u"**Filed by:** {}\nIntermittent “description” string".format(test_user.email.replace('@', " [at] "))
         assert requestdata['component'] == "Administration"
@@ -81,6 +84,7 @@ def test_create_bug_with_unicode(client, eleven_jobs_stored, activate_responses,
     resp = client.post(
         reverse("bugzilla-create-bug"),
         {
+            "type": "defect",
             "product": "Bugzilla",
             "component": "Administration",
             "summary": u"Intermittent “summary”",
@@ -104,6 +108,7 @@ def test_create_crash_bug(client, eleven_jobs_stored, activate_responses, test_u
         requestdata = json.loads(request.body)
         requestheaders = request.headers
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
+        assert requestdata['type'] == "defect"
         assert requestdata['product'] == "Bugzilla"
         assert requestdata['description'] == u"**Filed by:** {}\nIntermittent Description".format(test_user.email.replace('@', " [at] "))
         assert requestdata['component'] == "Administration"
@@ -128,6 +133,7 @@ def test_create_crash_bug(client, eleven_jobs_stored, activate_responses, test_u
     resp = client.post(
         reverse("bugzilla-create-bug"),
         {
+            "type": "defect",
             "product": "Bugzilla",
             "component": "Administration",
             "summary": u"Intermittent summary",
@@ -154,6 +160,7 @@ def test_create_unauthenticated_bug(client, eleven_jobs_stored, activate_respons
         requestdata = json.loads(request.body)
         requestheaders = request.headers
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
+        assert requestdata['type'] == "defect"
         assert requestdata['product'] == "Bugzilla"
         assert requestdata['description'] == u"**Filed by:** MyName\nIntermittent Description"
         assert requestdata['component'] == "Administration"
@@ -176,6 +183,7 @@ def test_create_unauthenticated_bug(client, eleven_jobs_stored, activate_respons
     resp = client.post(
         reverse("bugzilla-create-bug"),
         {
+            "type": "defect",
             "product": "Bugzilla",
             "component": "Administration",
             "summary": u"Intermittent summary",
@@ -202,6 +210,7 @@ def test_create_bug_with_long_crash_signature(client, eleven_jobs_stored, activa
         requestdata = json.loads(request.body)
         requestheaders = request.headers
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
+        assert requestdata['type'] == "defect"
         assert requestdata['product'] == "Bugzilla"
         assert requestdata['description'] == u"**Filed by:** MyName\nIntermittent Description"
         assert requestdata['component'] == "Administration"
@@ -228,6 +237,7 @@ def test_create_bug_with_long_crash_signature(client, eleven_jobs_stored, activa
     resp = client.post(
         reverse("bugzilla-create-bug"),
         {
+            "type": "defect",
             "product": "Bugzilla",
             "component": "Administration",
             "summary": u"Intermittent summary",

--- a/treeherder/webapp/api/bugzilla.py
+++ b/treeherder/webapp/api/bugzilla.py
@@ -40,6 +40,7 @@ class BugzillaViewSet(viewsets.ViewSet):
             'Accept': 'application/json'
         }
         data = {
+            'type': "defect",
             'product': params.get("product"),
             'component': params.get("component"),
             'summary': summary,

--- a/ui/job-view/details/BugFiler.jsx
+++ b/ui/job-view/details/BugFiler.jsx
@@ -442,7 +442,6 @@ export class BugFilerClass extends React.Component {
           .filter(prodVer => prodVer.is_active)
           .slice(-1)[0];
         const payload = {
-          type: 'defect',
           product,
           component,
           summary,

--- a/ui/job-view/details/BugFiler.jsx
+++ b/ui/job-view/details/BugFiler.jsx
@@ -442,6 +442,7 @@ export class BugFilerClass extends React.Component {
           .filter(prodVer => prodVer.is_active)
           .slice(-1)[0];
         const payload = {
+          type: 'defect',
           product,
           component,
           summary,


### PR DESCRIPTION
Always use the “defect” bug type, or the bot will soon fail to file new bugs once the [Bugzilla API makes the type field mandatory](https://bugzilla.mozilla.org/show_bug.cgi?id=1562364).

## Bugzilla link

[Bug 1531759 - Modify treeherder's bugfiler to set bug type as 'defect'](https://bugzilla.mozilla.org/show_bug.cgi?id=1531759)