### PR TITLE
Bug 1561934 - Activate comm-esr68 repository.

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1434,7 +1434,7 @@
       "dvcs_type": "hg",
       "name": "comm-esr68",
       "url": "https://hg.mozilla.org/releases/comm-esr68",
-      "active_status": "onhold",
+      "active_status": "active",
       "codebase": "comm",
       "repository_group": 8,
       "description": ""

--- a/ui/intermittent-failures/constants.js
+++ b/ui/intermittent-failures/constants.js
@@ -42,5 +42,6 @@ export const treeOptions = [
   'firefox-releases',
   'comm-central',
   'comm-esr60',
+  'comm-esr68',
   'comm-releases',
 ];


### PR DESCRIPTION
The mercurial repository is up and running now.