### PR TITLE
Restyle the failure summary's bug suggestions and add a label to hint at what they mean

### DIFF
--- a/ui/css/treeherder-details-panel.css
+++ b/ui/css/treeherder-details-panel.css
@@ -307,8 +307,14 @@ ul.failure-summary-list li .btn-xs {
   background: #ffffff;
 }
 
-.failure-summary-bugs {
-  padding: 0 0 0 18px;
+.failure-summary-bugs-title {
+  font-size: 12px;
+}
+
+.failure-summary-bugs-container {
+  margin: 0 10px;
+  padding: 10px 15px;
+  border-left: 2px solid #0004;
 }
 
 /* We override global anchor color to replicate TBPL here */
@@ -320,12 +326,15 @@ ul.failure-summary-list li .btn-xs {
   color: purple;
 }
 
-/* We override global anchor color to replicate TBPL here */
 .show-hide-more {
-  font-size: 11px;
-  padding: 0 0 0 37px;
-  color: #0000ee;
-  cursor: pointer;
+  /* Override the selector complexity of: "ul.failure-summary-list li .btn-xs" */
+  font-size: 11px !important;
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.failure-btn-file-bug {
+  margin-right: 5px;
 }
 
 /*

--- a/ui/css/treeherder-details-panel.css
+++ b/ui/css/treeherder-details-panel.css
@@ -312,7 +312,10 @@ ul.failure-summary-list li .btn-xs {
 }
 
 .failure-summary-bugs-container {
-  margin: 0 10px;
+  /* These styles don't use the bootstrap system as they are creating a vertical
+   * line underneath the bug icon. When only using bootstrap classes, this vertical line
+   * is not aligned with the bug icon. */
+  margin: 0 11px;
   padding: 10px 15px;
   border-left: 2px solid #0004;
 }
@@ -329,12 +332,6 @@ ul.failure-summary-list li .btn-xs {
 .show-hide-more {
   /* Override the selector complexity of: "ul.failure-summary-list li .btn-xs" */
   font-size: 11px !important;
-  margin-top: 5px;
-  margin-bottom: 5px;
-}
-
-.failure-btn-file-bug {
-  margin-right: 5px;
 }
 
 /*

--- a/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
@@ -45,21 +45,23 @@ export default class SuggestionsListItem extends React.Component {
           ))}
         </ul>,
       );
-    }
 
-    // All other bugs
-    if (suggestion.valid_all_others && suggestion.valid_open_recent) {
-      suggestions.push(
-        <Button
-          key="show-hide-more"
-          color="link"
-          rel="noopener"
-          onClick={this.clickShowMore}
-          className="show-hide-more"
-        >
-          Show / Hide more
-        </Button>,
-      );
+      // All other bugs
+      if (suggestion.valid_all_others) {
+        suggestions.push(
+          <Button
+            key="show-hide-more"
+            color="link"
+            rel="noopener"
+            onClick={this.clickShowMore}
+            className="bg-light px-2 py-1 btn btn-outline-secondary btn-xs show-hide-more"
+          >
+            {suggestionShowMore
+              ? 'Hide bug suggestions'
+              : 'Show more bug suggestions'}
+          </Button>,
+        );
+      }
     }
 
     if (
@@ -94,7 +96,14 @@ export default class SuggestionsListItem extends React.Component {
       );
     }
 
-    return suggestions;
+    return suggestions.length > 0 ? (
+      <div className="failure-summary-bugs-container">
+        <h4 className="failure-summary-bugs-title">
+          These bugs may be related:
+        </h4>
+        {suggestions}
+      </div>
+    ) : null;
   }
 
   render() {
@@ -104,7 +113,7 @@ export default class SuggestionsListItem extends React.Component {
       <li>
         <div>
           <Button
-            className="bg-light py-1 px-2"
+            className="bg-light py-1 px-2 failure-btn-file-bug"
             outline
             size="xs"
             onClick={() => toggleBugFiler(suggestion)}

--- a/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
@@ -22,8 +22,8 @@ export default class SuggestionsListItem extends React.Component {
     }));
   };
 
-  renderBugSuggestions() {
-    const { suggestion, selectedJobFull } = this.props;
+  render() {
+    const { suggestion, toggleBugFiler, selectedJobFull } = this.props;
     const { suggestionShowMore } = this.state;
 
     const suggestions = [];
@@ -96,19 +96,6 @@ export default class SuggestionsListItem extends React.Component {
       );
     }
 
-    return suggestions.length > 0 ? (
-      <div className="failure-summary-bugs-container">
-        <h4 className="failure-summary-bugs-title">
-          These bugs may be related:
-        </h4>
-        {suggestions}
-      </div>
-    ) : null;
-  }
-
-  render() {
-    const { suggestion, toggleBugFiler } = this.props;
-
     return (
       <li>
         <div>
@@ -123,7 +110,14 @@ export default class SuggestionsListItem extends React.Component {
           </Button>
           <span>{suggestion.search}</span>
         </div>
-        {this.renderBugSuggestions()}
+        {suggestions.length > 0 && (
+          <div className="failure-summary-bugs-container">
+            <h4 className="failure-summary-bugs-title">
+              These bugs may be related:
+            </h4>
+            {suggestions}
+          </div>
+        )}
       </li>
     );
   }

--- a/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
@@ -22,9 +22,83 @@ export default class SuggestionsListItem extends React.Component {
     }));
   };
 
-  render() {
-    const { suggestion, toggleBugFiler, selectedJobFull } = this.props;
+  renderBugSuggestions() {
+    const { suggestion, selectedJobFull } = this.props;
     const { suggestionShowMore } = this.state;
+
+    const suggestions = [];
+
+    // Open recent bugs
+    if (suggestion.valid_open_recent) {
+      suggestions.push(
+        <ul
+          className="list-unstyled failure-summary-bugs"
+          key="open-recent-bugs"
+        >
+          {suggestion.bugs.open_recent.map((bug) => (
+            <BugListItem
+              key={bug.id}
+              bug={bug}
+              suggestion={suggestion}
+              selectedJobFull={selectedJobFull}
+            />
+          ))}
+        </ul>,
+      );
+    }
+
+    // All other bugs
+    if (suggestion.valid_all_others && suggestion.valid_open_recent) {
+      suggestions.push(
+        <Button
+          key="show-hide-more"
+          color="link"
+          rel="noopener"
+          onClick={this.clickShowMore}
+          className="show-hide-more"
+        >
+          Show / Hide more
+        </Button>,
+      );
+    }
+
+    if (
+      suggestion.valid_all_others &&
+      (suggestionShowMore || !suggestion.valid_open_recent)
+    ) {
+      suggestions.push(
+        <ul className="list-unstyled failure-summary-bugs" key="all-others">
+          {suggestion.bugs.all_others.map((bug) => (
+            <BugListItem
+              key={bug.id}
+              bug={bug}
+              suggestion={suggestion}
+              bugClassName={bug.resolution !== '' ? 'strike-through' : ''}
+              title={bug.resolution !== '' ? bug.resolution : ''}
+              selectedJobFull={selectedJobFull}
+            />
+          ))}
+        </ul>,
+      );
+    }
+
+    if (
+      suggestion.bugs.too_many_open_recent ||
+      (suggestion.bugs.too_many_all_others && !suggestion.valid_open_recent)
+    ) {
+      suggestions.push(
+        <mark key="too-many">
+          Exceeded max {thBugSuggestionLimit} bug suggestions, most of which are
+          likely false positives.
+        </mark>,
+      );
+    }
+
+    return suggestions;
+  }
+
+  render() {
+    const { suggestion, toggleBugFiler } = this.props;
 
     return (
       <li>
@@ -40,57 +114,7 @@ export default class SuggestionsListItem extends React.Component {
           </Button>
           <span>{suggestion.search}</span>
         </div>
-
-        {/* <!--Open recent bugs--> */}
-        {suggestion.valid_open_recent && (
-          <ul className="list-unstyled failure-summary-bugs">
-            {suggestion.bugs.open_recent.map((bug) => (
-              <BugListItem
-                key={bug.id}
-                bug={bug}
-                suggestion={suggestion}
-                selectedJobFull={selectedJobFull}
-              />
-            ))}
-          </ul>
-        )}
-
-        {/* <!--All other bugs--> */}
-        {suggestion.valid_all_others && suggestion.valid_open_recent && (
-          <Button
-            color="link"
-            rel="noopener"
-            onClick={this.clickShowMore}
-            className="show-hide-more"
-          >
-            Show / Hide more
-          </Button>
-        )}
-
-        {suggestion.valid_all_others &&
-          (suggestionShowMore || !suggestion.valid_open_recent) && (
-            <ul className="list-unstyled failure-summary-bugs">
-              {suggestion.bugs.all_others.map((bug) => (
-                <BugListItem
-                  key={bug.id}
-                  bug={bug}
-                  suggestion={suggestion}
-                  bugClassName={bug.resolution !== '' ? 'strike-through' : ''}
-                  title={bug.resolution !== '' ? bug.resolution : ''}
-                  selectedJobFull={selectedJobFull}
-                />
-              ))}
-            </ul>
-          )}
-
-        {(suggestion.bugs.too_many_open_recent ||
-          (suggestion.bugs.too_many_all_others &&
-            !suggestion.valid_open_recent)) && (
-          <mark>
-            Exceeded max {thBugSuggestionLimit} bug suggestions, most of which
-            are likely false positives.
-          </mark>
-        )}
+        {this.renderBugSuggestions()}
       </li>
     );
   }

--- a/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
@@ -54,7 +54,7 @@ export default class SuggestionsListItem extends React.Component {
             color="link"
             rel="noopener"
             onClick={this.clickShowMore}
-            className="bg-light px-2 py-1 btn btn-outline-secondary btn-xs show-hide-more"
+            className="bg-light px-2 py-1 btn btn-outline-secondary btn-xs my-2 show-hide-more"
           >
             {suggestionShowMore
               ? 'Hide bug suggestions'
@@ -113,7 +113,7 @@ export default class SuggestionsListItem extends React.Component {
       <li>
         <div>
           <Button
-            className="bg-light py-1 px-2 failure-btn-file-bug"
+            className="bg-light py-1 px-2 mr-2"
             outline
             size="xs"
             onClick={() => toggleBugFiler(suggestion)}


### PR DESCRIPTION
Hey there!

First time contributor to this project. I've been helping folks in the Tulsa Mozilla co-working space to onboard with Mozilla Central. I work on the Firefox Profiler. I ran into confusion around what the suggested bugs mean for test failures. I took a stab at changing the UI to provide better hints for first time (and existing) users as to what is going on.

I don't see a `CONTRIBUTING.md` here, so I'm not sure the best approach here to talking about this work. I figured a good first approach would be to send in a PR with some changes. I'm happy to re-file this on Bugzilla if that's the proper channel, or continue here with my "drive-by PR".

Specifically my co-worker was confused over this test failure. He assumed that the issue was already on file. I had the exact some confusion when I was first on-boarding with the system as well.
 * https://treeherder.mozilla.org/#/jobs?repo=try&selectedJob=255506254&revision=649fbfeaaad987fa1d7e9d39242b2a7f0799ba43

<img width="854" alt="image" src="https://user-images.githubusercontent.com/1588648/60924096-f35f0c80-a265-11e9-8731-91c248f09c5f.png">

In this PR, I tried to change the UI to make it more obvious what the intent of this bug list is:

<img width="863" alt="image" src="https://user-images.githubusercontent.com/1588648/60924146-125d9e80-a266-11e9-9977-b4dd40b45493.png">

I also tested this on some other bigger failure logs:

http://localhost:5000/#/jobs?repo=autoland&group_state=expanded&author=gtatum%40mozilla.com&selectedJob=255278294

<img width="853" alt="image" src="https://user-images.githubusercontent.com/1588648/60924193-315c3080-a266-11e9-8899-c9218359d5d6.png">


