### PR TITLE
Perf summary api change

### DIFF
--- a/tests/webapp/api/test_performance_data_api.py
+++ b/tests/webapp/api/test_performance_data_api.py
@@ -397,7 +397,9 @@ def test_perf_summary(client, test_perf_signature, test_perf_data):
         'name': 'mysuite mytest opt e10s opt',
         'parent_signature': None,
         'job_ids': [test_perf_data[0].job_id],
-        'suite': test_perf_signature.suite
+        'suite': test_perf_signature.suite,
+        'repository_name': test_perf_signature.repository.name,
+        'repository_id': test_perf_signature.repository.id,
     }]
 
     resp1 = client.get(reverse('performance-summary') + query_params1)

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -454,6 +454,9 @@ class PerformanceSummary(generics.ListAPIView):
 
         if revision:
             data = data.filter(push__revision=revision)
+        elif interval and not startday and not endday:
+            data = data.filter(push_timestamp__gt=datetime.datetime.utcfromtimestamp(
+                                                   int(time.time() - int(interval))))
         else:
             data = data.filter(push_timestamp__gt=startday, push_timestamp__lt=endday)
 

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -461,10 +461,9 @@ class PerformanceSummary(generics.ListAPIView):
         option_collection = OptionCollection.objects.select_related('option').values('id', 'option__name')
         option_collection_map = {item['id']: item['option__name'] for item in list(option_collection)}
 
-        if all_data:
-            # add push__revision also maybe prev revision
+        if signature and all_data:
             for item in self.queryset:
-                item['data'] = data.values('value', 'job_id', 'id', 'push_id', 'push_timestamp')
+                item['data'] = data.values('value', 'job_id', 'id', 'push_id', 'push_timestamp', 'push__revision').order_by('push_timestamp')
                 item['option_name'] = option_collection_map[item['option_collection_id']]
 
         else:

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -426,9 +426,9 @@ class PerformanceSummary(generics.ListAPIView):
         signature_data = (PerformanceSignature.objects
                                               .select_related('framework', 'repository', 'platform', 'push', 'job')
                                               .filter(repository__name=repository_name))
-
-        if signature:
-            signature_data = signature_data.filter(id=signature)
+        print(signature)
+        if len(signature):
+            signature_data = signature_data.filter(id__in=list(signature))
         else:
             signature_data = signature_data.filter(parent_signature__isnull=no_subtests)
 

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -445,7 +445,7 @@ class PerformanceSummary(generics.ListAPIView):
         # TODO signature_hash is being returned for legacy support - should be removed at some point
         self.queryset = (signature_data.values('framework_id', 'id', 'lower_is_better', 'has_subtests', 'extra_options', 'suite',
                                                'signature_hash', 'platform__platform', 'test', 'option_collection_id',
-                                               'parent_signature_id'))
+                                               'parent_signature_id', 'repository_id'))
 
         signature_ids = [item['id'] for item in list(self.queryset)]
 
@@ -468,6 +468,7 @@ class PerformanceSummary(generics.ListAPIView):
             for item in self.queryset:
                 item['data'] = data.values('value', 'job_id', 'id', 'push_id', 'push_timestamp', 'push__revision').order_by('push_timestamp')
                 item['option_name'] = option_collection_map[item['option_collection_id']]
+                item['repository_name'] = repository_name
 
         else:
             grouped_values = defaultdict(list)
@@ -482,6 +483,7 @@ class PerformanceSummary(generics.ListAPIView):
                 item['values'] = grouped_values.get(item['id'], [])
                 item['job_ids'] = grouped_job_ids.get(item['id'], [])
                 item['option_name'] = option_collection_map[item['option_collection_id']]
+                item['repository_name'] = repository_name
 
         serializer = self.get_serializer(self.queryset, many=True)
         return Response(data=serializer.data)

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -426,7 +426,7 @@ class PerformanceSummary(generics.ListAPIView):
         signature_data = (PerformanceSignature.objects
                                               .select_related('framework', 'repository', 'platform', 'push', 'job')
                                               .filter(repository__name=repository_name))
-        print(signature)
+
         if len(signature):
             signature_data = signature_data.filter(id__in=list(signature))
         else:

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -11,9 +11,9 @@ from treeherder.perf.models import (IssueTracker,
                                     PerformanceAlert,
                                     PerformanceAlertSummary,
                                     PerformanceBugTemplate,
+                                    PerformanceDatum,
                                     PerformanceFramework,
-                                    PerformanceSignature,
-                                    PerformanceDatum)
+                                    PerformanceSignature)
 from treeherder.webapp.api.utils import to_timestamp
 
 
@@ -212,9 +212,11 @@ class PerformanceQueryParamsSerializer(serializers.Serializer):
 
 
 class PerformanceDatumSerializer(serializers.ModelSerializer):
+    revision = serializers.CharField(source='push__revision')
+
     class Meta:
         model = PerformanceDatum
-        fields = ['job_id', 'id', 'value', 'push_timestamp', 'push_id']
+        fields = ['job_id', 'id', 'value', 'push_timestamp', 'push_id', 'revision']
 
 
 class PerformanceSummarySerializer(serializers.ModelSerializer):
@@ -231,7 +233,7 @@ class PerformanceSummarySerializer(serializers.ModelSerializer):
     class Meta:
         model = PerformanceSignature
         fields = ['signature_id', 'framework_id', 'signature_hash', 'platform', 'test', 'suite',
-                  'lower_is_better', 'has_subtests', 'values', 'name', 'parent_signature', 'job_ids', 
+                  'lower_is_better', 'has_subtests', 'values', 'name', 'parent_signature', 'job_ids',
                   'data']
 
     def get_name(self, value):

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -196,8 +196,8 @@ class PerformanceQueryParamsSerializer(serializers.Serializer):
     all_data = serializers.BooleanField(required=False, default=False)
 
     def validate(self, data):
-        if data['revision'] is None and (data['startday'] is None or data['endday'] is None):
-            raise serializers.ValidationError('Required: revision or startday and endday.')
+        if data['revision'] is None and data['interval'] is None and (data['startday'] is None or data['endday'] is None):
+            raise serializers.ValidationError('Required: revision, startday and endday or interval.')
 
         return data
 

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -229,12 +229,13 @@ class PerformanceSummarySerializer(serializers.ModelSerializer):
     signature_id = serializers.IntegerField(source="id")
     job_ids = serializers.ListField(child=serializers.IntegerField(), default=[])
     data = PerformanceDatumSerializer(read_only=True, many=True)
+    repository_name = serializers.CharField()
 
     class Meta:
         model = PerformanceSignature
         fields = ['signature_id', 'framework_id', 'signature_hash', 'platform', 'test', 'suite',
                   'lower_is_better', 'has_subtests', 'values', 'name', 'parent_signature', 'job_ids',
-                  'data']
+                  'repository_name', 'repository_id', 'data']
 
     def get_name(self, value):
         test = value['test']

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -191,7 +191,7 @@ class PerformanceQueryParamsSerializer(serializers.Serializer):
     framework = serializers.ListField(required=False, child=serializers.IntegerField(), default=[])
     interval = serializers.IntegerField(required=False, allow_null=True, default=None)
     parent_signature = serializers.CharField(required=False, allow_null=True, default=None)
-    signature = serializers.CharField(required=False, allow_null=True, default=None)
+    signature = serializers.ListField(child=serializers.IntegerField(), required=False, allow_null=True, default=[])
     no_subtests = serializers.BooleanField(required=False)
     all_data = serializers.BooleanField(required=False, default=False)
 


### PR DESCRIPTION
I've made a few changes to the `/performance/summary/` endpoint so that if a `all_data` param is passed the data is in the same structure as it would be with the `/performance/data/` endpoint (except it also eliminates the need to call `/performance/signature/` endpoint as the Perfherder graphs view is currently doing). 