### PR TITLE
Bug 1565364 - Fix Retriggers

### DIFF
--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -269,10 +269,10 @@ class PushViewSet(viewsets.ViewSet):
         Return the decision task ids for the pushes.
         """
         push_ids = request.query_params.getlist('push_ids')
-        job_type = JobType.objects.get(name='Gecko Decision Task')
+        job_types = JobType.objects.filter(name__contains='Decision Task')
         decision_jobs = Job.objects.filter(
             push_id__in=push_ids,
-            job_type=job_type,
+            job_type__in=job_types,
             result='success',
         ).select_related('taskcluster_metadata')
 

--- a/ui/job-view/CustomJobActions.jsx
+++ b/ui/job-view/CustomJobActions.jsx
@@ -47,7 +47,10 @@ class CustomJobActions extends React.PureComponent {
 
   async componentDidMount() {
     const { pushId, job, notify } = this.props;
-    const decisionTaskId = await PushModel.getDecisionTaskId(pushId, notify);
+    const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
+      pushId,
+      notify,
+    );
 
     TaskclusterModel.load(decisionTaskId, job).then(results => {
       const {

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -82,7 +82,7 @@ class ActionBar extends React.PureComponent {
       return notify('Must be logged in to create a gecko profile', 'danger');
     }
 
-    const decisionTaskId = await PushModel.getDecisionTaskId(
+    const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
       selectedJob.push_id,
       notify,
     );
@@ -164,7 +164,7 @@ class ActionBar extends React.PureComponent {
       selectedJob.build_system_type === 'taskcluster' ||
       selectedJob.reason.startsWith('Created by BBB for task')
     ) {
-      const decisionTaskId = await PushModel.getDecisionTaskId(
+      const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
         selectedJob.push_id,
         notify,
       );
@@ -197,7 +197,7 @@ class ActionBar extends React.PureComponent {
 
   isolateJob = async () => {
     const { user, selectedJob, notify } = this.props;
-    const decisionTaskId = await PushModel.getDecisionTaskId(
+    const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
       selectedJob.push_id,
       notify,
     );
@@ -328,7 +328,7 @@ class ActionBar extends React.PureComponent {
     }
 
     const job = await JobModel.get(repoName, jobId);
-    const decisionTaskId = await PushModel.getDecisionTaskId(
+    const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
       job.push_id,
       notify,
     );

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -315,7 +315,10 @@ class Push extends React.PureComponent {
     const { push, repoName, notify } = this.props;
 
     try {
-      const decisionTaskId = await PushModel.getDecisionTaskId(push.id, notify);
+      const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
+        push.id,
+        notify,
+      );
       const jobList = await RunnableJobModel.getList(repoName, {
         decision_task_id: decisionTaskId,
         push_id: push.id,
@@ -362,7 +365,10 @@ class Push extends React.PureComponent {
       test-verify|test-windows10-64-ux|toolchain|upload-generated-sources)`;
 
     try {
-      const decisionTaskId = await PushModel.getDecisionTaskId(push.id, notify);
+      const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
+        push.id,
+        notify,
+      );
 
       notify('Fetching runnable jobs... This could take a while...');
       let fuzzyJobList = await RunnableJobModel.getList(repoName, {

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -148,7 +148,10 @@ class PushHeader extends React.Component {
       return;
     }
     if (isLoggedIn) {
-      const decisionTaskId = await PushModel.getDecisionTaskId(pushId, notify);
+      const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
+        pushId,
+        notify,
+      );
 
       PushModel.triggerNewJobs(selectedRunnableJobs, decisionTaskId)
         .then(result => {

--- a/ui/models/job.js
+++ b/ui/models/job.js
@@ -125,7 +125,7 @@ export default class JobModel {
       const uniquePerPushJobs = groupBy(jobs, job => job.push_id);
 
       for (const [key, value] of Object.entries(uniquePerPushJobs)) {
-        const decisionTaskId = taskIdMap[key];
+        const decisionTaskId = taskIdMap[key].id;
 
         TaskclusterModel.load(decisionTaskId).then(async results => {
           const actionTaskId = slugid();
@@ -175,7 +175,10 @@ export default class JobModel {
   }
 
   static async cancelAll(pushId, repoName, notify) {
-    const decisionTaskId = await PushModel.getDecisionTaskId(pushId, notify);
+    const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
+      pushId,
+      notify,
+    );
     const results = await TaskclusterModel.load(decisionTaskId);
     const cancelAllTask = results.actions.find(
       result => result.name === 'cancel-all',
@@ -212,7 +215,7 @@ export default class JobModel {
 
       /* eslint-disable no-await-in-loop */
       for (const job of jobs) {
-        const decisionTaskId = taskIdMap[job.push_id];
+        const decisionTaskId = taskIdMap[job.push_id].id;
         const results = await TaskclusterModel.load(decisionTaskId, job);
         const cancelTask = results.actions.find(
           result => result.name === 'cancel',

--- a/ui/models/push.js
+++ b/ui/models/push.js
@@ -60,7 +60,10 @@ export default class PushModel {
   }
 
   static async triggerMissingJobs(pushId, notify) {
-    const decisionTaskId = await PushModel.getDecisionTaskId(pushId, notify);
+    const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
+      pushId,
+      notify,
+    );
 
     return TaskclusterModel.load(decisionTaskId).then(results => {
       const actionTaskId = slugid();
@@ -86,7 +89,10 @@ export default class PushModel {
   }
 
   static async triggerAllTalosJobs(times, pushId, notify) {
-    const decisionTaskId = await PushModel.getDecisionTaskId(pushId, notify);
+    const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
+      pushId,
+      notify,
+    );
 
     return TaskclusterModel.load(decisionTaskId).then(results => {
       const actionTaskId = slugid();


### PR DESCRIPTION
I broke retriggers when I fixed add-new-jobs in commit 3b5665fa7144a1b7604c5bf1d0f5dc97f972264f.

These need tests and I will add them after Armen's pulse data ingestion changes land.  Otherwise, the test data to ingest would have to be re-written.  [Bug 1565667](https://bugzilla.mozilla.org/show_bug.cgi?id=1565667)

The second commit fixes the Treeherder side of having retriggers and add new jobs work on NSS repos.  Hopefully this is generic enough, but not too generic to work for any other repo.  Now NSS has to generate the required artifacts in their decision tasks.