### PR TITLE
Fix bad release of graphql_relay

### DIFF
--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -37,6 +37,9 @@ RUN curl -sSfL "https://storage.googleapis.com/shellcheck/shellcheck-v${SHELLCHE
 ADD . /app
 WORKDIR /app
 
+# There was a bad release of graphql_relay:
+# https://github.com/graphql-python/graphql-relay-py/issues/23
+RUN pip install https://files.pythonhosted.org/packages/5e/b0/b91fadc180544fc9e3c156d7049561fd5f1e2211d26fd29033548fd50934/graphql-relay-0.4.5.tar.gz
 # Common and dev deps installed separately to prove that common.txt works standalone
 # (given that dev.txt is not installed on Heroku)
 RUN pip install --no-cache-dir --disable-pip-version-check --require-hashes -r requirements/common.txt


### PR DESCRIPTION
Per Armen's research, this should solve the issue with the failing tests in Travis due to a missing wheel SHA in our requirements file that pip was expecting. However the linting test has failed.. I've tried running `docker-compose run backend ./runtests.sh` but I don't see any issues except for the usual src/recommonmark/ errors. Do I need to change the graphql-core dependency? https://travis-ci.org/mozilla/treeherder/jobs/559102999