### PR TITLE
Use Markdown code block for log body submitted by bug filer

### DIFF
--- a/ui/job-view/details/BugFiler.jsx
+++ b/ui/job-view/details/BugFiler.jsx
@@ -411,8 +411,9 @@ export class BugFilerClass extends React.Component {
       })
       .join('\n');
 
-    // Join that with the comment separated with a hard rule.
-    const descriptionStrings = `${logLinks}\n\n---\n\n${comment}`;
+    // Join that with the comment (log body) separated with a horizontal rule.
+    // Also wrap the comment with a code block.
+    const descriptionStrings = `${logLinks}\n\n---\n\n\`\`\`${comment}\`\`\``;
 
     const keywords = isIntermittent ? ['intermittent-failure'] : [];
     keywords.push('regression');

--- a/ui/job-view/details/BugFiler.jsx
+++ b/ui/job-view/details/BugFiler.jsx
@@ -413,7 +413,7 @@ export class BugFilerClass extends React.Component {
 
     // Join that with the comment (log body) separated with a horizontal rule.
     // Also wrap the comment with a code block.
-    const descriptionStrings = `${logLinks}\n\n---\n\n\`\`\`${comment}\`\`\``;
+    const descriptionStrings = `${logLinks}\n\n---\n\n\`\`\`\n${comment}\n\`\`\``;
 
     const keywords = isIntermittent ? ['intermittent-failure'] : [];
     keywords.push('regression');


### PR DESCRIPTION
The bug filer bot makes use of Markdown in Bugzilla comments since #4888 was deployed, but the log body is not wrapped with a [code block](https://help.github.com/en/articles/creating-and-highlighting-code-blocks). In [Bug 1547098](https://bugzilla.mozilla.org/show_bug.cgi?id=1547098) @EricRahm says it was a mistake, so here’s a PR to start using a code block assuming `comment` here only contains a log body.