### PR TITLE
Bug 1567868 - Fix canceling more than one job from the pinboard

### DIFF
--- a/treeherder/webapp/api/refdata.py
+++ b/treeherder/webapp/api/refdata.py
@@ -40,6 +40,17 @@ class FailureClassificationViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.FailureClassification.objects.exclude(name="intermittent needs filing")
     serializer_class = th_serializers.FailureClassificationSerializer
 
+
+class TaskclusterMetadataViewSet(viewsets.ReadOnlyModelViewSet):
+
+    """ViewSet for the refdata TaskclusterMetadata model"""
+    serializer_class = th_serializers.TaskclusterMetadataSerializer
+
+    def get_queryset(self):
+        job_ids = self.request.query_params.get('job_ids', '').split(',')
+        return models.TaskclusterMetadata.objects.filter(job_id__in=job_ids)
+
+
 #############################
 # User profiles
 #############################

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -45,6 +45,13 @@ class RepositorySerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class TaskclusterMetadataSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = models.TaskclusterMetadata
+        fields = '__all__'
+
+
 class JobSerializer(serializers.ModelSerializer):
 
     def to_representation(self, job):

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -94,6 +94,8 @@ tle_router.register(r'text-log-error',
 # refdata endpoints:
 default_router = routers.DefaultRouter()
 default_router.register(r'repository', refdata.RepositoryViewSet)
+default_router.register(r'taskclustermetadata', refdata.TaskclusterMetadataViewSet,
+                        base_name='taskclustermetadata')
 default_router.register(r'optioncollectionhash', refdata.OptionCollectionHashViewSet,
                         base_name='optioncollectionhash')
 default_router.register(r'failureclassification', refdata.FailureClassificationViewSet)


### PR DESCRIPTION
The issue here was that, for canceling, you need the decision task ID for the job.  But that data does not come down with the greater list of jobs in the job-view.  It only comes when you get an individual job (the currently selected one).

So the most efficient way to get this info was to create an endpoint for the ``taskclustermetadata``.  I call this with the list of job ids when the attempt to cancel happens in the ``JobModel``.

I didn't create a JS model for ``taskclustermetadata`` as it seemed overkill.  But I'll do that if you feel like it's worth it for parity with the others.