### PR TITLE
Change renovate reviewer to armenzg

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
     "@uirouter/angularjs"
   ],
   "labels": ["dependencies", "javascript"],
-  "reviewers": ["sarah-clements"],
+  "reviewers": ["armenzg"],
   "semanticCommits": false,
   "travis": { "enabled": true }
 }


### PR DESCRIPTION
Changing the reviewer to Armen (thank you!) since he'll be taking a turn at handling this. We can change this in the future to team reviewers - not sure exactly what that entails but it appears that's what Ed was originally going for and renovate has added that feature in quite recently: https://github.com/mozilla/treeherder/pull/4585

FYI @camd 