### PR TITLE
Update wiki links and component in perf bug templates

### DIFF
--- a/treeherder/perf/fixtures/performance_bug_templates.yaml
+++ b/treeherder/perf/fixtures/performance_bug_templates.yaml
@@ -3,7 +3,7 @@
   fields:
     framework: 1
     keywords: perf, regression, talos-regression
-    default_component: General
+    default_component: Performance
     default_product: Testing
     cc_list: dave.hunt@gmail.com, rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com
     text: |
@@ -31,7 +31,7 @@
   fields:
     framework: 2
     keywords: regression
-    default_component: General
+    default_component: Performance
     default_product: Testing
     cc_list: dave.hunt@gmail.com, rwood@mozilla.com, nfroyd@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com
     text: |
@@ -55,7 +55,7 @@
   fields:
     framework: 3
     keywords: perf, regression
-    default_component: General
+    default_component: Performance
     default_product: Testing
     cc_list: dave.hunt@gmail.com, rwood@mozilla.com, bob@bclary.com, igoldan@mozilla.com, fstrugariu@mozilla.com
     text: |
@@ -77,7 +77,7 @@
   fields:
     framework: 4
     keywords: perf, regression
-    default_component: General
+    default_component: Performance
     default_product: Testing
     cc_list: dave.hunt@gmail.com, rwood@mozilla.com, bob@bclary.com, igoldan@mozilla.com, erahm@mozilla.com, fstrugariu@mozilla.com
     text: |
@@ -99,7 +99,7 @@
   fields:
     framework: 5
     keywords: perf, regression
-    default_component: General
+    default_component: Performance
     default_product: Testing
     cc_list: dave.hunt@gmail.com, rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com
     text: |
@@ -121,7 +121,7 @@
   fields:
     framework: 6
     keywords: perf, regression
-    default_component: General
+    default_component: Performance
     default_product: Testing
     cc_list: dave.hunt@gmail.com, rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com
     text: |
@@ -143,7 +143,7 @@
   fields:
     framework: 10
     keywords: perf, regression
-    default_component: General
+    default_component: Performance
     default_product: Testing
     cc_list: dave.hunt@gmail.com, rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com
     text: |

--- a/treeherder/perf/fixtures/performance_bug_templates.yaml
+++ b/treeherder/perf/fixtures/performance_bug_templates.yaml
@@ -19,13 +19,13 @@
 
       On the page above you can see an alert for each affected platform as well as a link to a graph showing the history of scores for this test. There is also a link to a treeherder page showing the Talos jobs in a pushlog format.
 
-      To learn more about the regressing test(s), please see: https://wiki.mozilla.org/Performance_sheriffing/Talos/Tests
+      To learn more about the regressing test(s), please see: https://wiki.mozilla.org/TestEngineering/Performance/Talos
 
-      For information on reproducing and debugging the regression, either on try or locally, see: https://wiki.mozilla.org/Performance_sheriffing/Talos/Running
+      For information on reproducing and debugging the regression, either on try or locally, see: https://wiki.mozilla.org/TestEngineering/Performance/Talos/Running
 
       *** Please let us know your plans within 3 business days, or the offending patch(es) will be backed out! ***
 
-      Our wiki page outlines the common responses and expectations: https://wiki.mozilla.org/Performance_sheriffing/Talos/RegressionBugsHandling
+      Our wiki page outlines the common responses and expectations: https://wiki.mozilla.org/TestEngineering/Performance/Talos/RegressionBugsHandling
 - model: perf.PerformanceBugTemplate
   pk: 2
   fields:
@@ -159,8 +159,8 @@
 
       On the page above you can see an alert for each affected platform as well as a link to a graph showing the history of scores for this test. There is also a link to a Treeherder page showing the Raptor jobs in a pushlog format.
 
-      To learn more about the regressing test(s) or reproducing them, please see: https://wiki.mozilla.org/Performance_sheriffing/Raptor
+      To learn more about the regressing test(s) or reproducing them, please see: https://wiki.mozilla.org/TestEngineering/Performance/Raptor
 
       *** Please let us know your plans within 3 business days, or the offending patch(es) will be backed out! ***
 
-      Our wiki page outlines the common responses and expectations: https://wiki.mozilla.org/Performance_sheriffing/Talos/RegressionBugsHandling
+      Our wiki page outlines the common responses and expectations: https://wiki.mozilla.org/TestEngineering/Performance/Talos/RegressionBugsHandling

--- a/treeherder/perf/fixtures/performance_bug_templates.yaml
+++ b/treeherder/perf/fixtures/performance_bug_templates.yaml
@@ -5,7 +5,7 @@
     keywords: perf, regression, talos-regression
     default_component: Performance
     default_product: Testing
-    cc_list: dave.hunt@gmail.com, rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com
+    cc_list: dave.hunt@gmail.com, rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, alexandru.ionescu@softvision.ro, marian.raiciof@softvision.ro
     text: |
       Talos has detected a Firefox performance regression from push:
 
@@ -33,7 +33,7 @@
     keywords: regression
     default_component: Performance
     default_product: Testing
-    cc_list: dave.hunt@gmail.com, rwood@mozilla.com, nfroyd@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com
+    cc_list: dave.hunt@gmail.com, rwood@mozilla.com, nfroyd@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, alexandru.ionescu@softvision.ro, marian.raiciof@softvision.ro
     text: |
       We have detected a build metrics regression from push:
 
@@ -57,7 +57,7 @@
     keywords: perf, regression
     default_component: Performance
     default_product: Testing
-    cc_list: dave.hunt@gmail.com, rwood@mozilla.com, bob@bclary.com, igoldan@mozilla.com, fstrugariu@mozilla.com
+    cc_list: dave.hunt@gmail.com, rwood@mozilla.com, bob@bclary.com, igoldan@mozilla.com, fstrugariu@mozilla.com, alexandru.ionescu@softvision.ro, marian.raiciof@softvision.ro
     text: |
       We have detected an autophone (Android) regression from push:
 
@@ -79,7 +79,7 @@
     keywords: perf, regression
     default_component: Performance
     default_product: Testing
-    cc_list: dave.hunt@gmail.com, rwood@mozilla.com, bob@bclary.com, igoldan@mozilla.com, erahm@mozilla.com, fstrugariu@mozilla.com
+    cc_list: dave.hunt@gmail.com, rwood@mozilla.com, bob@bclary.com, igoldan@mozilla.com, erahm@mozilla.com, fstrugariu@mozilla.com, alexandru.ionescu@softvision.ro, marian.raiciof@softvision.ro
     text: |
       We have detected an awsy regression from push:
 
@@ -101,7 +101,7 @@
     keywords: perf, regression
     default_component: Performance
     default_product: Testing
-    cc_list: dave.hunt@gmail.com, rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com
+    cc_list: dave.hunt@gmail.com, rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, alexandru.ionescu@softvision.ro, marian.raiciof@softvision.ro
     text: |
       We have detected an awfy regression from push:
 
@@ -123,7 +123,7 @@
     keywords: perf, regression
     default_component: Performance
     default_product: Testing
-    cc_list: dave.hunt@gmail.com, rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com
+    cc_list: dave.hunt@gmail.com, rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, alexandru.ionescu@softvision.ro, marian.raiciof@softvision.ro
     text: |
       We have detected a platform microbenchmarks regression from push:
 
@@ -145,7 +145,7 @@
     keywords: perf, regression
     default_component: Performance
     default_product: Testing
-    cc_list: dave.hunt@gmail.com, rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com
+    cc_list: dave.hunt@gmail.com, rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, alexandru.ionescu@softvision.ro, marian.raiciof@softvision.ro
     text: |
       Raptor has detected a Firefox performance regression from push:
 


### PR DESCRIPTION
The old wiki links redirect so this isn't urgent, just a bit of cleanup.