### PR TITLE
Fix spacing around revision sha

### DIFF
--- a/ui/css/treeherder-resultsets.css
+++ b/ui/css/treeherder-resultsets.css
@@ -142,16 +142,8 @@ th-action-button .btn-push {
   color: red;
 }
 
-.revision-holder > a {
-  padding-left: 3px;
-  padding-top: 2px;
-  font: 11px 'Lucida Console', Monaco, monospace;
-}
-
-.revision-holder {
-  padding-left: 20px;
-  padding-right: 6px;
-  display: inline-block;
+.commit-sha {
+  font-size: 11px;
 }
 
 .user-push-icon {

--- a/ui/job-view/pushes/Revision.jsx
+++ b/ui/job-view/pushes/Revision.jsx
@@ -62,7 +62,7 @@ export class Revision extends React.PureComponent {
     return (
       <li>
         <span className="revision" data-tags={this.tags}>
-          <span className="pl-4 pr-1">
+          <span className="pl-4 pr-1 revision-holder">
             <span
               type="button"
               className="pointer"

--- a/ui/job-view/pushes/Revision.jsx
+++ b/ui/job-view/pushes/Revision.jsx
@@ -60,9 +60,9 @@ export class Revision extends React.PureComponent {
     const commitRevision = revision.revision;
 
     return (
-      <li className="clearfix">
+      <li>
         <span className="revision" data-tags={this.tags}>
-          <span className="revision-holder">
+          <span className="pl-4 pr-1">
             <span
               type="button"
               className="pointer"
@@ -73,6 +73,7 @@ export class Revision extends React.PureComponent {
             <a
               title={`Open revision ${commitRevision} on ${repo.url}`}
               href={repo.getRevisionHref(commitRevision)}
+              className="text-monospace commit-sha"
             >
               {commitRevision.substring(0, 12)}
             </a>


### PR DESCRIPTION
The spacing was off after ionut's addition of the clipboard copy.  I had meant to fix this before we pushed to prod.  But here it is.  :)