### PR TITLE
Fix btnClass being applied incorrectly to jobs and counts

### DIFF
--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -201,7 +201,6 @@ export const addAggregateFields = function addAggregateFields(job) {
     platform_option,
     signature,
     duration,
-    failure_classification_id,
     submit_timestamp,
     start_timestamp,
     end_timestamp,
@@ -235,7 +234,6 @@ export const addAggregateFields = function addAggregateFields(job) {
   }
 
   job.hoverText = `${job_type_name} - ${job.resultStatus} - ${job.duration} mins`;
-  job.btnClass = getBtnClass(job.resultStatus, failure_classification_id);
   return job;
 };
 

--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -7,7 +7,7 @@ import { faPlusSquare, faTimes } from '@fortawesome/free-solid-svg-icons';
 
 import { thEvents } from '../../helpers/constants';
 import { formatModelError } from '../../helpers/errorMessage';
-import { findJobInstance } from '../../helpers/job';
+import { findJobInstance, getBtnClass } from '../../helpers/job';
 import { isSHAorCommit } from '../../helpers/revision';
 import { getBugUrl } from '../../helpers/url';
 import BugJobMapModel from '../../models/bugJobMap';
@@ -383,7 +383,10 @@ class PinBoard extends React.Component {
               {Object.values(pinnedJobs).map(job => (
                 <span className="btn-group" key={job.id}>
                   <span
-                    className={`btn pinned-job ${job.btnClass} ${
+                    className={`btn pinned-job ${getBtnClass(
+                      job.resultStatus,
+                      job.failure_classification_id,
+                    )} ${
                       selectedJobId === job.id
                         ? 'btn-lg selected-job'
                         : 'btn-xs'

--- a/ui/job-view/details/tabs/SimilarJobsTab.jsx
+++ b/ui/job-view/details/tabs/SimilarJobsTab.jsx
@@ -6,7 +6,7 @@ import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 import { thMaxPushFetchSize } from '../../../helpers/constants';
 import { toDateStr, toShortDateStr } from '../../../helpers/display';
-import { addAggregateFields } from '../../../helpers/job';
+import { addAggregateFields, getBtnClass } from '../../../helpers/job';
 import { getJobsUrl } from '../../../helpers/url';
 import JobModel from '../../../models/job';
 import PushModel from '../../../models/push';
@@ -185,7 +185,10 @@ class SimilarJobsTab extends React.Component {
                 >
                   <td>
                     <button
-                      className={`btn btn-similar-jobs btn-xs ${similarJob.btnClass}`}
+                      className={`btn btn-similar-jobs btn-xs ${getBtnClass(
+                        similarJob.resultStatus,
+                        similarJob.failure_classification_id,
+                      )}`}
                       type="button"
                     >
                       {similarJob.job_type_symbol}

--- a/ui/job-view/pushes/JobButton.jsx
+++ b/ui/job-view/pushes/JobButton.jsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faStar as faStarRegular } from '@fortawesome/free-regular-svg-icons';
 import { faStar as faStarSolid } from '@fortawesome/free-solid-svg-icons';
 
-import { findJobInstance } from '../../helpers/job';
+import { getBtnClass, findJobInstance } from '../../helpers/job';
 import { getSelectedJobId, getUrlParam } from '../../helpers/location';
 
 export default class JobButtonComponent extends React.Component {
@@ -88,11 +88,12 @@ export default class JobButtonComponent extends React.Component {
       visible,
       id,
       job_type_symbol,
-      btnClass,
+      resultStatus,
     } = job;
 
     if (!visible) return null;
     const runnable = state === 'runnable';
+    const btnClass = getBtnClass(resultStatus, failure_classification_id);
     let classifiedIcon = null;
 
     if (failure_classification_id > 1) {

--- a/ui/job-view/pushes/JobGroup.jsx
+++ b/ui/job-view/pushes/JobGroup.jsx
@@ -4,6 +4,7 @@ import countBy from 'lodash/countBy';
 
 import { thFailureResults } from '../../helpers/constants';
 import { getSelectedJobId, getUrlParam } from '../../helpers/location';
+import { getBtnClass } from '../../helpers/job';
 
 import JobButton from './JobButton';
 import JobCount from './JobCount';
@@ -71,7 +72,8 @@ export class JobGroupComponent extends React.Component {
       const stateCounts = {};
       const typeSymbolCounts = countBy(jobs, 'job_type_symbol');
       jobs.forEach(job => {
-        const { resultStatus, visible, btnClass } = job;
+        const { resultStatus, visible } = job;
+        const btnClass = getBtnClass(resultStatus);
         if (!visible) return;
 
         let countInfo = {


### PR DESCRIPTION
I had tried to optimize setting the ``btnClass`` on jobs and group counts, but it ended up not having the right updates when things changed.  So this goes back to how it was, getting the class on the fly.