### PR TITLE
Bug 1572255 - Fix set top and bottom of range links

### DIFF
--- a/tests/ui/job-view/PushList_test.jsx
+++ b/tests/ui/job-view/PushList_test.jsx
@@ -70,7 +70,7 @@ describe('PushList', () => {
     });
     fetchMock.get(
       getProjectUrl(
-        '/push/?full=true&count=10&fromchange=ba9c692786e95143b8df3f4b3e9b504dfbc589a0',
+        '/push/?full=true&count=100&fromchange=ba9c692786e95143b8df3f4b3e9b504dfbc589a0',
         repoName,
       ),
       {

--- a/tests/ui/job-view/stores/pushes_test.jsx
+++ b/tests/ui/job-view/stores/pushes_test.jsx
@@ -82,7 +82,7 @@ describe('Pushes Redux store', () => {
   test('should add new push and jobs when polling', async () => {
     fetchMock.get(
       getProjectUrl(
-        '/push/?full=true&count=10&fromchange=ba9c692786e95143b8df3f4b3e9b504dfbc589a0',
+        '/push/?full=true&count=100&fromchange=ba9c692786e95143b8df3f4b3e9b504dfbc589a0',
         repoName,
       ),
       pollPushListFixture,
@@ -188,7 +188,7 @@ describe('Pushes Redux store', () => {
   test('should fetch a new set of pushes with updateRange', async () => {
     fetchMock.get(
       getProjectUrl(
-        '/push/?full=true&count=10&fromchange=9692347caff487cdcd889489b8e89a825fe6bbd1',
+        '/push/?full=true&count=100&fromchange=9692347caff487cdcd889489b8e89a825fe6bbd1',
         repoName,
       ),
       pushListFromChangeFixture,

--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -8,6 +8,7 @@ import CustomJobActions from '../CustomJobActions';
 import PushModel from '../../models/push';
 import { getPushHealthUrl } from '../../helpers/url';
 import { notify } from '../redux/stores/notifications';
+import { thEvents } from '../../helpers/constants';
 
 // Trigger missing jobs is dangerous on repos other than these (see bug 1335506)
 const triggerMissingRepos = ['mozilla-inbound', 'autoland'];
@@ -27,10 +28,12 @@ class PushActionMenu extends React.PureComponent {
 
   componentDidMount() {
     window.addEventListener('hashchange', this.handleUrlChanges, false);
+    window.addEventListener(thEvents.filtersUpdated, this.handleUrlChanges);
   }
 
   componentWillUnmount() {
     window.removeEventListener('hashchange', this.handleUrlChanges, false);
+    window.removeEventListener(thEvents.filtersUpdated, this.handleUrlChanges);
   }
 
   getRangeChangeUrl(param, revision) {

--- a/ui/models/push.js
+++ b/ui/models/push.js
@@ -44,7 +44,8 @@ export default class PushModel {
     }
     if (
       params.count > thMaxPushFetchSize ||
-      transformedOptions.push_timestamp__gte
+      transformedOptions.push_timestamp__gte ||
+      transformedOptions.fromchange
     ) {
       // fetch the maximum number of pushes
       params.count = thMaxPushFetchSize;


### PR DESCRIPTION
Just need to update on "get X more" pushes because we silently update the URL so as not to kick off a cascade of unwanted renders.

This also fixes the error where we only fetched up to 10 pushes, even if the ``fromchange`` param is set.  It should then get the max pushes allowed.