### PR TITLE
Bug 1572283 - Fix filtering link by job data

### DIFF
--- a/ui/shared/JobInfo.jsx
+++ b/ui/shared/JobInfo.jsx
@@ -30,7 +30,6 @@ export default class JobInfo extends React.PureComponent {
   render() {
     const { job, extraFields, showJobFilters } = this.props;
     const {
-      searchStr,
       signature,
       title,
       taskcluster_metadata,
@@ -56,9 +55,9 @@ export default class JobInfo extends React.PureComponent {
               :&nbsp;
               <a
                 title="Filter jobs containing these keywords"
-                href={getJobSearchStrHref(searchStr)}
+                href={getJobSearchStrHref(title)}
               >
-                {searchStr}
+                {title}
               </a>
             </React.Fragment>
           ) : (

--- a/ui/shared/JobInfo.jsx
+++ b/ui/shared/JobInfo.jsx
@@ -8,6 +8,7 @@ import { toDateStr } from '../helpers/display';
 const getTimeFields = function getTimeFields(job) {
   // time fields to show in detail panel, but that should be grouped together
   const { end_timestamp, start_timestamp, submit_timestamp, duration } = job;
+  const durationStr = `${duration} minute${duration > 1 ? 's' : ''}`;
   const timeFields = [
     { title: 'Requested', value: toDateStr(submit_timestamp) },
   ];
@@ -20,7 +21,9 @@ const getTimeFields = function getTimeFields(job) {
   }
   timeFields.push({
     title: 'Duration',
-    value: start_timestamp ? duration : `Not started (queued for ${duration})`,
+    value: start_timestamp
+      ? durationStr
+      : `Not started (queued for ${durationStr})`,
   });
 
   return timeFields;


### PR DESCRIPTION
This fixes two bugs.  The ``job.searchStr`` is what is internally searched in the job, but it needs to be split in the ``JobInfo`` for each link.

The second bug is just cosmetic, but was in same file, so easy to fix at the same time.