### PR TITLE
Bug 1572516 - increase max length of perfherder extraOptions

### DIFF
--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -80,7 +80,7 @@
           "title": "Extra options used in running suite",
           "items": {
             "type": "string",
-            "maxLength": 45
+            "maxLength": 100
           },
           "uniqueItems": true,
           "maxItems": 8


### PR DESCRIPTION
One of the options provided is based on the cloud instance type. In EC2, these
are pretty short, but in GCP they can be longer, and that length is required to
fully specify custom machine types, as we are likely to use in Firefox CI.