### PR TITLE
Bug 1573162 - Patch to prevent UI from breaking in Perfherder

### DIFF
--- a/ui/js/controllers/perf/graphs.js
+++ b/ui/js/controllers/perf/graphs.js
@@ -634,7 +634,7 @@ perf.controller('GraphsCtrl', [
                     series.flotSeries = {
                         lines: { show: false },
                         points: { show: series.visible },
-                        color: series.color[1],
+                        color: series.color ? series.color[1] : '#6c757d',
                         label: series.projectName + ' ' + series.name,
                         data: map(
                             seriesData[series.signature],

--- a/ui/perfherder/graphs/TestCard.jsx
+++ b/ui/perfherder/graphs/TestCard.jsx
@@ -39,7 +39,7 @@ export class TestContainer extends React.Component {
         </span>
         <div
           className={`${
-            checked ? series.color[0] : 'border-secondary'
+            checked && series.color ? series.color[0] : 'border-secondary'
           } graph-legend-card p-3`}
         >
           <p


### PR DESCRIPTION
If more tests are added than colors are provided, show the excess as grey. More improvements to come in pr #5286 