### PR TITLE
Add test for generating production build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,15 @@ matrix:
         - yarn format:check
         - yarn test
 
+    - env: test-prod-build
+      language: node_js
+      # The Node version here must be kept in sync with that in `package.json`.
+      node_js: '11'
+      install:
+        - yarn install --prod --frozen-lockfile
+      script:
+        - yarn build
+
     - env: python-linters
       language: minimal
       install:


### PR DESCRIPTION
Up until now we were not testing the same code path that Heroku follows to
generate the front-end build.

Heroku runs the `yarn install` command under `NODE_ENV=production` which causes
only the production dependencies to be installed. In the case of
[PR 5283](#5283), we moved `neutrino`
from `dependencies` to `devDependencies` and went unnoticed until Heroku tried to deploy
the change. See output [1].

This change adds one more entry for Travis where we only install the production dependencies
before running `yarn build`.

[1]
```shell
2019-08-16 19:34:49 -----> Build
2019-08-16 19:34:49        Detected both "build" and "heroku-postbuild" scripts
2019-08-16 19:34:49        Running heroku-postbuild (yarn)
2019-08-16 19:34:50        yarn run v1.17.3
2019-08-16 19:34:50        $ yarn build
2019-08-16 19:34:50        $ node ./node_modules/webpack/bin/webpack.js --mode production
/tmp/build_375161ca12e2f192c2c9b1caab8276cd/node_modules/webpack-cli/bin/cli.js:93
				throw err;
				^
Error: Cannot find module 'neutrino'
```