### PR TITLE
Bug 1550014 Allow sorting by table column on compare subtest page

### DIFF
--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -277,6 +277,20 @@ th {
   color: #333;
 }
 
+.compare-table .subtest-header > th.subtest-header-visible {
+  color: #333;
+}
+
+.compare-table .sort-symbol-asc-visible {
+  border-top-color: #333;
+  border-top-width: 1px;
+}
+
+.compare-table .sort-symbol-desc-visible {
+  border-bottom-color: #333;
+  border-bottom-width: 1px;
+}
+
 .compare-table tr:hover .detail-hint {
   border-bottom: 1px dotted #777;
 }


### PR DESCRIPTION
This PR is adding a simple sort function for the compare-table columns. In addition, after sorting on of the columns, the headers will be permanently visible. Similar to the intermittent failures page, after sorting ascending/descending the respective header cell will get top/bottom margins visible (UX reasons).