### PR TITLE
Bug 1566077 - Fix retriggers throwing errors intermittently

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -150,7 +150,7 @@ module.exports = {
         neutrino.config.performance
           .hints('error')
           .maxAssetSize(2 * 1024 * 1024)
-          .maxEntrypointSize(2 * 1024 * 1024);
+          .maxEntrypointSize(2.1 * 1024 * 1024);
       }
     },
   ],

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -362,3 +362,6 @@ attrs==19.1.0 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399
 pyrsistent==0.15.4 \
     --hash=sha256:34b47fa169d6006b32e99d4b3c4031f155e6e68ebcc107d6454852e8e0ee6533
+
+django-cache-memoize==0.1.6 \
+    --hash=sha256:d239e8c37734b0a70b74f94fa33b180b3b0c82c3784beb21209bb4ab64a3e6fb


### PR DESCRIPTION
This adds some caching, so we don't have to fetch the Decision Task so often.  Both on the client/JS side as well as the back-end/Django side.  It also adds a bit of logging to give me more idea of what might be failing if this continues to fail.