### PR TITLE
Bug 1573462 - Job and group name keeps capitalizations

### DIFF
--- a/tests/ui/job-view/Filtering_test.jsx
+++ b/tests/ui/job-view/Filtering_test.jsx
@@ -224,7 +224,7 @@ describe('Filtering', () => {
         getByTitle('Filter jobs containing these keywords'),
       );
       expect(keywordLink.getAttribute('href')).toBe(
-        '/#/jobs?repo=autoland&selectedJob=259537372&searchStr=gecko%2Cdecision%2Ctask%2Copt%2Cgecko%2Cdecision%2Ctask%2C%28d%29',
+        '/#/jobs?repo=autoland&selectedJob=259537372&searchStr=Gecko%2CDecision%2CTask%2Copt%2CGecko%2CDecision%2CTask%2C%28D%29',
       );
     });
   });

--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -196,8 +196,7 @@ export const addAggregateFields = function addAggregateFields(job) {
     `${symbolInfo}(${job_type_symbol})`,
   ]
     .filter(item => typeof item !== 'undefined')
-    .join(' ')
-    .toLowerCase();
+    .join(' ');
   job.searchStr = `${job.title} ${signature}`;
 
   if (!duration) {


### PR DESCRIPTION
I didn't need to make this lower case here.  The ``FilterModel`` makes everything lowercase while filtering anyway.