### PR TITLE
Fix cancel button color on ActionBar

### DIFF
--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -459,7 +459,7 @@ class ActionBar extends React.PureComponent {
                       ? 'Cancel this job'
                       : 'Must be logged in to cancel a job'
                   }
-                  className={`actionbar-nav-btn ${
+                  className={`bg-transparent border-0 actionbar-nav-btn ${
                     user.isLoggedIn ? 'hover-warning' : 'disabled'
                   }`}
                   onClick={() => this.cancelJob()}


### PR DESCRIPTION
It currently looks like this on stage: 

<img width="221" alt="Screenshot 2019-09-09 08 22 20" src="https://user-images.githubusercontent.com/419924/64543941-f8c6ea80-d2da-11e9-982c-eef71bc9b9dc.png">

This sets the border and background to invisible.