### PR TITLE
Disable patch level checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    patch: off


### PR DESCRIPTION
In order to not fail automatic tests when auto-deploying to master.

About:
https://docs.codecov.io/docs/commit-status#section-patch-status