### PR TITLE
Bug 1566077 - Improve getting decision task ID

### DIFF
--- a/tests/ui/models/jobs_test.js
+++ b/tests/ui/models/jobs_test.js
@@ -1,9 +1,11 @@
 import { fetchMock } from 'fetch-mock';
 
 import JobModel from '../../../ui/models/job';
+import { decisionTaskIdCache } from '../../../ui/models/push';
 import { getApiUrl } from '../../../ui/helpers/url';
 import paginatedJobListFixtureOne from '../mock/job_list/pagination/page_1';
 import paginatedJobListFixtureTwo from '../mock/job_list/pagination/page_2';
+import { getProjectUrl } from '../../../ui/helpers/location';
 
 describe('JobModel', () => {
   afterEach(() => {
@@ -40,11 +42,39 @@ describe('JobModel', () => {
     });
   });
 
-  describe('retriggering ', () => {
+  describe('Taskcluster actions', () => {
+    const decisionTaskMap = {
+      '526443': { id: 'LVTawdmFR2-uJiWWS2NxSw', run: '0' },
+    };
+    const tcActionsUrl =
+      'https://queue.taskcluster.net/v1/task/LVTawdmFR2-uJiWWS2NxSw/artifacts/public%2Factions.json';
+    const tcTaskUrl = 'https://queue.taskcluster.net/v1/task/TASKID';
+    const decisionTaskMapUrl = getProjectUrl(
+      '/push/decisiontask/?push_ids=526443',
+      'autoland',
+    );
+    const notify = () => {};
+    const testJobs = [
+      { id: 123, push_id: 526443, job_type_name: 'foo', task_id: 'TASKID' },
+    ];
+
     beforeEach(() => {
       fetchMock.mock(
         getApiUrl('/jobs/?push_id=526443'),
         paginatedJobListFixtureOne,
+      );
+      fetchMock.mock(
+        getApiUrl('/taskclustermetadata/?job_ids=123'),
+        paginatedJobListFixtureOne,
+      );
+      fetchMock.mock(decisionTaskMapUrl, decisionTaskMap);
+      fetchMock.get(tcActionsUrl, { version: 1, actions: [{ name: 'foo' }] });
+      fetchMock.get(tcTaskUrl, {});
+
+      // Must clear the cache, because we save each time we
+      // call the API for a decision task id.
+      Object.keys(decisionTaskIdCache).forEach(
+        prop => delete decisionTaskIdCache[prop],
       );
     });
 
@@ -54,6 +84,62 @@ describe('JobModel', () => {
 
       expect(signature).toBe('2aa083621bb989d6acf1151667288d5fe9616178');
       expect(job_type_name).toBe('Gecko Decision Task');
+    });
+
+    test('retrigger uses passed-in decisionTaskMap', async () => {
+      await JobModel.retrigger(
+        testJobs,
+        'autoland',
+        notify,
+        1,
+        decisionTaskMap,
+      );
+
+      expect(fetchMock.called(decisionTaskMapUrl)).toBe(false);
+      expect(fetchMock.called(tcTaskUrl)).toBe(false);
+      expect(fetchMock.called(tcActionsUrl)).toBe(true);
+    });
+
+    test('retrigger calls for decision task when not passed-in', async () => {
+      await JobModel.retrigger(testJobs, 'autoland', notify, 1);
+
+      expect(fetchMock.called(decisionTaskMapUrl)).toBe(true);
+      expect(fetchMock.called(tcTaskUrl)).toBe(false);
+      expect(fetchMock.called(tcActionsUrl)).toBe(true);
+    });
+
+    test('cancel uses passed-in decisionTask', async () => {
+      await JobModel.cancel(testJobs, 'autoland', () => {}, decisionTaskMap);
+
+      expect(fetchMock.called(decisionTaskMapUrl)).toBe(false);
+      expect(fetchMock.called(tcTaskUrl)).toBe(true);
+      expect(fetchMock.called(tcActionsUrl)).toBe(true);
+    });
+
+    test('cancel calls for decision task when not passed-in', async () => {
+      await JobModel.cancel(testJobs, 'autoland', () => {});
+
+      expect(fetchMock.called(decisionTaskMapUrl)).toBe(true);
+      expect(fetchMock.called(tcTaskUrl)).toBe(true);
+      expect(fetchMock.called(tcActionsUrl)).toBe(true);
+    });
+
+    test('cancelAll uses passed-in decisionTask', async () => {
+      const decisionTask = { id: 'LVTawdmFR2-uJiWWS2NxSw', run: '0' };
+
+      await JobModel.cancelAll(526443, 'autoland', () => {}, decisionTask);
+
+      expect(fetchMock.called(decisionTaskMapUrl)).toBe(false);
+      expect(fetchMock.called(tcTaskUrl)).toBe(false);
+      expect(fetchMock.called(tcActionsUrl)).toBe(true);
+    });
+
+    test('cancelAll calls for decision task when not passed-in', async () => {
+      await JobModel.cancelAll(526443, 'autoland', () => {});
+
+      expect(fetchMock.called(decisionTaskMapUrl)).toBe(true);
+      expect(fetchMock.called(tcTaskUrl)).toBe(false);
+      expect(fetchMock.called(tcActionsUrl)).toBe(true);
     });
   });
 });

--- a/tests/ui/models/push_test.js
+++ b/tests/ui/models/push_test.js
@@ -9,11 +9,14 @@ describe('PushModel', () => {
   });
 
   describe('taskcluster actions', () => {
+    const decisionTaskUrl = getProjectUrl(
+      '/push/decisiontask/?push_ids=548880',
+      'autoland',
+    );
     beforeEach(() => {
-      fetchMock.mock(
-        getProjectUrl('/push/decisiontask/?push_ids=548880', 'autoland'),
-        { '548880': { id: 'U-lI3jzPTkWFplfJPz6cJA', run: '0' } },
-      );
+      fetchMock.mock(decisionTaskUrl, {
+        '548880': { id: 'U-lI3jzPTkWFplfJPz6cJA', run: '0' },
+      });
     });
 
     test('getDecisionTaskId', async () => {
@@ -26,6 +29,11 @@ describe('PushModel', () => {
         id: 'U-lI3jzPTkWFplfJPz6cJA',
         run: '0',
       });
+      expect(fetchMock.calls(decisionTaskUrl)).toHaveLength(1);
+
+      await PushModel.getDecisionTaskId(548880, () => {});
+      // on second try, it was cached.  So we still have just 1 call
+      expect(fetchMock.calls(decisionTaskUrl)).toHaveLength(1);
     });
 
     test('getDecisionTaskMap', async () => {

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -184,7 +184,6 @@ class JobsProjectViewSet(viewsets.ViewSet):
         'machine',
         'signature',
         'repository',
-        'taskcluster_metadata',
     ]
 
     _property_query_mapping = [

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -108,6 +108,7 @@ class JobsViewSet(viewsets.ReadOnlyModelViewSet):
         'job_group',
         'machine_platform',
         'signature',
+        'taskcluster_metadata',
     ]
     _query_field_names = [
         'submit_time',
@@ -128,6 +129,9 @@ class JobsViewSet(viewsets.ReadOnlyModelViewSet):
         'signature__signature',
         'state',
         'tier',
+        'taskcluster_metadata__task_id',
+        'taskcluster_metadata__retry_id',
+
     ]
     _output_field_names = [
         'failure_classification_id',
@@ -143,6 +147,8 @@ class JobsViewSet(viewsets.ReadOnlyModelViewSet):
         'signature',
         'state',
         'tier',
+        'task_id',
+        'retry_id',
         'duration',
         'platform_option',
     ]
@@ -177,7 +183,8 @@ class JobsProjectViewSet(viewsets.ViewSet):
         'machine_platform',
         'machine',
         'signature',
-        'repository'
+        'repository',
+        'taskcluster_metadata',
     ]
 
     _property_query_mapping = [
@@ -289,6 +296,9 @@ class JobsProjectViewSet(viewsets.ViewSet):
             resp["platform_option"] = platform_option
 
         try:
+            resp['task_id'] = job.taskcluster_metadata.task_id
+            resp['retry_id'] = job.taskcluster_metadata.retry_id
+            # Keep for backwards compatability
             resp['taskcluster_metadata'] = {
                 'task_id': job.taskcluster_metadata.task_id,
                 'retry_id': job.taskcluster_metadata.retry_id

--- a/ui/job-view/CustomJobActions.jsx
+++ b/ui/job-view/CustomJobActions.jsx
@@ -22,7 +22,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheckSquare } from '@fortawesome/free-regular-svg-icons';
 
 import { formatTaskclusterError } from '../helpers/errorMessage';
-import PushModel from '../models/push';
 import TaskclusterModel from '../models/taskcluster';
 
 import { notify } from './redux/stores/notifications';
@@ -46,11 +45,8 @@ class CustomJobActions extends React.PureComponent {
   }
 
   async componentDidMount() {
-    const { pushId, job, notify } = this.props;
-    const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
-      pushId,
-      notify,
-    );
+    const { pushId, job, notify, decisionTaskMap } = this.props;
+    const { id: decisionTaskId } = decisionTaskMap[pushId];
 
     TaskclusterModel.load(decisionTaskId, job).then(results => {
       const {
@@ -308,6 +304,7 @@ CustomJobActions.propTypes = {
   isLoggedIn: PropTypes.bool.isRequired,
   notify: PropTypes.func.isRequired,
   toggle: PropTypes.func.isRequired,
+  decisionTaskMap: PropTypes.object.isRequired,
   job: PropTypes.object,
 };
 
@@ -315,7 +312,11 @@ CustomJobActions.defaultProps = {
   job: null,
 };
 
+const mapStateToProps = ({ pushes: { decisionTaskMap } }) => ({
+  decisionTaskMap,
+});
+
 export default connect(
-  null,
+  mapStateToProps,
   { notify },
 )(CustomJobActions);

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -211,8 +211,7 @@ class DetailsPanel extends React.Component {
               phSeriesResult,
             ]) => {
               // This version of the job has more information than what we get in the main job list.  This
-              // is what we'll pass to the rest of the details panel.  It has extra fields like
-              // taskcluster_metadata.
+              // is what we'll pass to the rest of the details panel.
               // Don't update the job instance in the greater job field so as to not add the memory overhead
               // of all the extra fields in ``selectedJobFull``.  It's not that much for just one job, but as
               // one selects job after job, over the course of a day, it can add up.  Therefore, we keep

--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -198,12 +198,17 @@ class PinBoard extends React.Component {
   };
 
   cancelAllPinnedJobs = () => {
-    const { notify, repoName, pinnedJobs } = this.props;
+    const { notify, repoName, pinnedJobs, decisionTaskMap } = this.props;
 
     if (
       window.confirm('This will cancel all the selected jobs. Are you sure?')
     ) {
-      JobModel.cancel(Object.values(pinnedJobs), repoName, notify);
+      JobModel.cancel(
+        Object.values(pinnedJobs),
+        repoName,
+        notify,
+        decisionTaskMap,
+      );
       this.unPinAll();
     }
   };
@@ -348,10 +353,11 @@ class PinBoard extends React.Component {
     }
   };
 
-  retriggerAllPinnedJobs = () => {
-    const { pinnedJobs, notify, repoName } = this.props;
+  retriggerAllPinnedJobs = async () => {
+    const { pinnedJobs, notify, repoName, decisionTaskMap } = this.props;
+    const jobs = Object.values(pinnedJobs);
 
-    JobModel.retrigger(Object.values(pinnedJobs), repoName, notify);
+    JobModel.retrigger(jobs, repoName, notify, 1, decisionTaskMap);
   };
 
   render() {
@@ -630,6 +636,7 @@ class PinBoard extends React.Component {
 
 PinBoard.propTypes = {
   recalculateUnclassifiedCounts: PropTypes.func.isRequired,
+  decisionTaskMap: PropTypes.object.isRequired,
   classificationTypes: PropTypes.array.isRequired,
   isLoggedIn: PropTypes.bool.isRequired,
   isPinBoardVisible: PropTypes.bool.isRequired,
@@ -659,7 +666,7 @@ PinBoard.defaultProps = {
 };
 
 const mapStateToProps = ({
-  pushes: { revisionTips },
+  pushes: { revisionTips, decisionTaskMap },
   pinnedJobs: {
     isPinBoardVisible,
     pinnedJobs,
@@ -669,6 +676,7 @@ const mapStateToProps = ({
   },
 }) => ({
   revisionTips,
+  decisionTaskMap,
   isPinBoardVisible,
   pinnedJobs,
   pinnedJobBugs,

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -142,6 +142,7 @@ class PushHeader extends React.Component {
       selectedRunnableJobs,
       hideRunnableJobs,
       notify,
+      decisionTaskMap,
     } = this.props;
 
     if (
@@ -152,10 +153,7 @@ class PushHeader extends React.Component {
       return;
     }
     if (isLoggedIn) {
-      const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
-        pushId,
-        notify,
-      );
+      const { id: decisionTaskId } = decisionTaskMap[pushId];
 
       PushModel.triggerNewJobs(selectedRunnableJobs, decisionTaskId)
         .then(result => {
@@ -172,18 +170,22 @@ class PushHeader extends React.Component {
   };
 
   cancelAllJobs = () => {
-    const { notify, repoName } = this.props;
-
     if (
       window.confirm(
         'This will cancel all pending and running jobs for this push. It cannot be undone! Are you sure?',
       )
     ) {
-      const { push, isLoggedIn } = this.props;
+      const {
+        notify,
+        repoName,
+        push,
+        isLoggedIn,
+        decisionTaskMap,
+      } = this.props;
 
       if (!isLoggedIn) return;
 
-      JobModel.cancelAll(push.id, repoName, notify);
+      JobModel.cancelAll(push.id, repoName, notify, decisionTaskMap[push.id]);
     }
   };
 
@@ -407,6 +409,7 @@ PushHeader.propTypes = {
   notify: PropTypes.func.isRequired,
   jobCounts: PropTypes.object.isRequired,
   pushHealthVisibility: PropTypes.string.isRequired,
+  decisionTaskMap: PropTypes.object.isRequired,
   watchState: PropTypes.string,
 };
 
@@ -414,7 +417,11 @@ PushHeader.defaultProps = {
   watchState: 'none',
 };
 
+const mapStateToProps = ({ pushes: { decisionTaskMap } }) => ({
+  decisionTaskMap,
+});
+
 export default connect(
-  null,
+  mapStateToProps,
   { notify, setSelectedJob, pinJobs },
 )(PushHeader);

--- a/ui/models/push.js
+++ b/ui/models/push.js
@@ -28,7 +28,7 @@ const convertDates = function convertDates(locationParams) {
   return locationParams;
 };
 
-const decisionTaskIdCache = {};
+export const decisionTaskIdCache = {};
 
 export default class PushModel {
   static async getList(options = {}) {
@@ -65,11 +65,9 @@ export default class PushModel {
     return fetch(getProjectUrl(`${pushEndpoint}${pk}/`, repoName));
   }
 
-  static async triggerMissingJobs(pushId, notify) {
-    const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
-      pushId,
-      notify,
-    );
+  static async triggerMissingJobs(pushId, notify, decisionTask) {
+    const decisionTaskId =
+      decisionTask || (await PushModel.getDecisionTaskId(pushId, notify)).id;
 
     return TaskclusterModel.load(decisionTaskId).then(results => {
       const actionTaskId = slugid();
@@ -102,11 +100,9 @@ export default class PushModel {
     });
   }
 
-  static async triggerAllTalosJobs(times, pushId, notify) {
-    const { id: decisionTaskId } = await PushModel.getDecisionTaskId(
-      pushId,
-      notify,
-    );
+  static async triggerAllTalosJobs(times, pushId, notify, decisionTask) {
+    const decisionTaskId =
+      decisionTask || (await PushModel.getDecisionTaskId(pushId, notify)).id;
 
     return TaskclusterModel.load(decisionTaskId).then(results => {
       const actionTaskId = slugid();

--- a/ui/models/runnableJob.js
+++ b/ui/models/runnableJob.js
@@ -8,7 +8,8 @@ export default class RunnableJobModel {
   }
 
   static async getList(repoName, params) {
-    const uri = getRunnableJobsURL(params.decision_task_id);
+    const { push_id, decisionTask } = params;
+    const uri = getRunnableJobsURL(decisionTask);
     const rawJobs = await fetch(uri).then(response => response.json());
 
     return Object.entries(rawJobs).map(([key, value]) =>
@@ -24,8 +25,8 @@ export default class RunnableJobModel {
         signature: key,
         state: 'runnable',
         result: 'runnable',
-        push_id: params.push_id,
-        id: escapeId(params.push_id + key),
+        push_id,
+        id: escapeId(push_id + key),
       }),
     );
   }

--- a/ui/models/taskcluster.js
+++ b/ui/models/taskcluster.js
@@ -88,8 +88,8 @@ export default class TaskclusterModel {
 
     let originalTaskId;
     let originalTaskPromise = Promise.resolve(null);
-    if (job && job.taskcluster_metadata) {
-      originalTaskId = job.taskcluster_metadata.task_id;
+    if (job) {
+      originalTaskId = job.task_id;
       originalTaskPromise = fetch(
         `https://queue.taskcluster.net/v1/task/${originalTaskId}`,
       ).then(async response => response.json());

--- a/ui/shared/JobInfo.jsx
+++ b/ui/shared/JobInfo.jsx
@@ -35,7 +35,7 @@ export default class JobInfo extends React.PureComponent {
     const {
       signature,
       title,
-      taskcluster_metadata,
+      task_id,
       build_platform,
       job_type_name,
       build_architecture,
@@ -67,16 +67,16 @@ export default class JobInfo extends React.PureComponent {
             <span>{title}</span>
           )}
         </li>
-        {taskcluster_metadata && (
+        {task_id && (
           <li className="small">
             <strong>Task: </strong>
             <a
               id="taskInfo"
-              href={getInspectTaskUrl(taskcluster_metadata.task_id)}
+              href={getInspectTaskUrl(task_id)}
               target="_blank"
               rel="noopener noreferrer"
             >
-              {taskcluster_metadata.task_id}
+              {task_id}
             </a>
           </li>
         )}


### PR DESCRIPTION
This creates a ``decisionTaskMap`` which is used for all the actions interacting with Taskcluster.  Prior to this, you always needed to fetch it from the ``PushModel``.  This has proven to be slow and unreliable.  In Treeherder, we have all the decision jobs already, so this just uses what is already in memory.  

Formerly, we used to find this object from the in-memory list of jobs, but in a much more complex way.  This creates a small map of every decision task for every push that we can get wherever we need it.

I updated the ``JobModel`` so that it will use the decision task or map, if passed in.  If it wasn't, then it will try fetching it from the endpoint.  This will allow Perfherder and other apps to still get the decision task when they don't have the whole list of jobs.

Part of this was to also return the Taskcluster ``task_id`` for all jobs, so we don't need the extra call to get it.

