### PR TITLE
Bug 1550014 Allow sorting by table column on compare subtest page

### DIFF
--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -268,6 +268,27 @@ th {
   color: #333;
 }
 
+.compare-table .subtest-header-visible .sorted-asc {
+  border-bottom-color: #333;
+  border-bottom-width: 1px;
+}
+
+.compare-table  .subtest-header-visible .sorted-desc {
+  border-top-color: #333;
+  border-top-width: 1px;
+}
+
+.compare-table .subtest-header-visible > th {
+  color: #333;
+}
+
+.compare-table .text-left span,
+.compare-table .table-width-lg span,
+.compare-table .text-right span,
+.compare-table .table-width-md span {
+  cursor: pointer;
+}
+
 .compare-table tr:hover .detail-hint {
   border-bottom: 1px dotted #777;
 }

--- a/ui/helpers/sort.js
+++ b/ui/helpers/sort.js
@@ -24,3 +24,30 @@ export const sortAlphaNum = (a, b) => {
     return rv;
   }
 };
+
+// This is a helper function for sorting an array of hashes:
+// arr.sort(sortHashes(key, dataType, desc))
+export const sortHashes = (key, dataType, desc) => {
+  return (a, b) => {
+    let result = 0;
+    let item1 = desc ? b[key] : a[key];
+    let item2 = desc ? a[key] : b[key];
+    // If a[key] or b[key] doesn't exist, they are skipped by the sorting
+    // so they need to be initialized with a default value
+    if (dataType === 'number') {
+      if (Number.isNaN(item1)) item1 = 0;
+      if (Number.isNaN(item2)) item2 = 0;
+      result = item1 - item2;
+    } else if (dataType === 'array') {
+      if (!Array.isArray(item1)) item1 = [];
+      if (!Array.isArray(item2)) item2 = [];
+      result = item1.length - item2.length;
+    } else {
+      if (typeof item1 !== 'string') item1 = '';
+      if (typeof item2 !== 'string') item2 = '';
+      if (item1 < item2) result = -1;
+      if (item1 > item2) result = 1;
+    }
+    return result;
+  };
+};

--- a/ui/intermittent-failures/helpers.js
+++ b/ui/intermittent-failures/helpers.js
@@ -76,8 +76,11 @@ export const updateQueryParams = function updateHistoryWithQueryParams(
 
 export const sortData = function sortData(data, sortBy, desc) {
   data.sort((a, b) => {
-    const item1 = desc ? b[sortBy] : a[sortBy];
-    const item2 = desc ? a[sortBy] : b[sortBy];
+    let item1 = desc ? b[sortBy] : a[sortBy];
+    let item2 = desc ? a[sortBy] : b[sortBy];
+    // This enables comparing arrays by their length
+    item1 = Array.isArray(item1) ? item1.length : item1;
+    item2 = Array.isArray(item2) ? item2.length : item2;
 
     if (item1 < item2) {
       return -1;

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -89,7 +89,7 @@ export const getTTest = function getTTest(
   return delta / stdDiffErr;
 };
 
-const numericCompare = (a, b) => {
+export const numericCompare = (a, b) => {
   if (a < b) {
     return -1;
   }


### PR DESCRIPTION
This PR is adding a simple sort function for the compare-table columns. In addition, after sorting on of the columns, the headers will be permanently visible. Similar to the intermittent failures page, after sorting ascending/descending the respective header cell will get top/bottom margins visible (UX reasons).