### PR TITLE
Bug 1581497 The graph-tooltip is unaligned with its datapoint

### DIFF
--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -449,10 +449,63 @@ li.pagination-active.active > button {
   border-left-color: #b87e17;
 }
 
-@media only screen and (min-width: 1700px) {
+@media only screen and (min-width: 1600px) and (max-width: 1740px) {
   .custom-col-xxl-auto {
     flex: 0 0 auto;
     width: auto;
-    max-width: 100%;
+    max-width: 80%;
+  }
+}
+
+@media only screen and (min-width: 1500px) and (max-width: 1599px) {
+  .custom-col-xxl-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 75%;
+  }
+}
+
+@media only screen and (min-width: 1400px) and (max-width: 1499px) {
+  .custom-col-xxl-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 70%;
+  }
+}
+
+@media only screen and (min-width: 1000px) and (max-width: 1399px) {
+  .custom-col-xxl-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 65%;
+  }
+}
+
+@media only screen and (max-width: 999px) {
+  .custom-col-xxl-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 90%;
+  }
+  .graph-container svg {
+    max-width: 1350px;
+  }
+  .graph-container {
+    width: 1350px !important;
+  }
+  .graph-chooser {
+    max-width: 1499px;
+    width: max-content;
+  }
+  .graph-legend {
+    max-width: 1499px;
+    width: max-content;
+  }
+  .graph-legend-card {
+    min-width: 170px;
+    max-width: max-content;
+  }
+  .inline {
+    display: inline-block;
   }
 }

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -38,6 +38,7 @@ class GraphsContainer extends React.Component {
       showTooltip: false,
       lockTooltip: false,
       dataPoint: this.props.selectedDataPoint,
+      chartWidth: 1350 - (1700 - window.screen.availWidth),
     };
   }
 
@@ -151,7 +152,7 @@ class GraphsContainer extends React.Component {
   };
 
   getTooltipPosition = (point, yOffset = 15) => ({
-    left: point.x - (280 / 2) * (1 + point.x / 1350),
+    left: point.x - 280 / 2,
     top: point.y - yOffset,
   });
 
@@ -240,6 +241,7 @@ class GraphsContainer extends React.Component {
       showTooltip,
       lockTooltip,
       dataPoint,
+      chartWidth,
     } = this.state;
 
     const highlightPoints = !!highlights.length;
@@ -282,12 +284,12 @@ class GraphsContainer extends React.Component {
           <div className="tip" />
         </div>
         <Row>
-          <Col className="p-0 col-md-auto">
+          <Col className="graph-container-top p-0 col-md-auto">
             <VictoryChart
               padding={chartPadding}
-              width={1350}
+              width={chartWidth}
               height={150}
-              style={{ parent: { maxHeight: '150px', maxWidth: '1350px' } }}
+              style={{ parent: { maxHeight: '150px', maxWidth: toString(chartWidth).concat('px') } }}
               scale={{ x: 'time', y: 'linear' }}
               domainPadding={{ y: 30 }}
               containerComponent={
@@ -322,12 +324,12 @@ class GraphsContainer extends React.Component {
         </Row>
 
         <Row>
-          <Col className="p-0 col-md-auto">
+          <Col className="graph-container-bottom p-0 col-md-auto">
             <VictoryChart
               padding={chartPadding}
-              width={1350}
+              width={chartWidth}
               height={400}
-              style={{ parent: { maxHeight: '400px', maxWidth: '1350px' } }}
+              style={{ parent: { maxHeight: '400px', maxWidth: toString(chartWidth).concat('px') } }}
               scale={{ x: 'time', y: 'linear' }}
               domainPadding={{ y: 40 }}
               containerComponent={

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -151,7 +151,7 @@ class GraphsContainer extends React.Component {
   };
 
   getTooltipPosition = (point, yOffset = 15) => ({
-    left: point.x - 280 / 2,
+    left: point.x - (280 / 2) * (1 + point.x / 1350),
     top: point.y - yOffset,
   });
 

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -38,7 +38,6 @@ class GraphsContainer extends React.Component {
       showTooltip: false,
       lockTooltip: false,
       dataPoint: this.props.selectedDataPoint,
-      chartWidth: 1350 - (1700 - window.screen.availWidth),
     };
   }
 
@@ -284,18 +283,19 @@ class GraphsContainer extends React.Component {
           <div className="tip" />
         </div>
         <Row>
-          <Col className="graph-container-top p-0 col-md-auto">
+          <Col className="graph-container p-0 col-md-auto">
             <VictoryChart
               padding={chartPadding}
-              width={chartWidth}
+              width={1350}
               height={150}
-              style={{ parent: { maxHeight: '150px', maxWidth: toString(chartWidth).concat('px') } }}
+              style={{ parent: { maxHeight: '150px', maxWidth: '1350px' } }}
               scale={{ x: 'time', y: 'linear' }}
               domainPadding={{ y: 30 }}
               containerComponent={
                 <VictoryBrushContainer
                   brushDomain={zoom}
                   onBrushDomainChange={this.updateZoom}
+                  responsive={false}
                 />
               }
             >
@@ -324,12 +324,12 @@ class GraphsContainer extends React.Component {
         </Row>
 
         <Row>
-          <Col className="graph-container-bottom p-0 col-md-auto">
+          <Col className="graph-container p-0 col-md-auto">
             <VictoryChart
               padding={chartPadding}
-              width={chartWidth}
+              width={1350}
               height={400}
-              style={{ parent: { maxHeight: '400px', maxWidth: toString(chartWidth).concat('px') } }}
+              style={{ parent: { maxHeight: '400px', maxWidth: '1350px' } }}
               scale={{ x: 'time', y: 'linear' }}
               domainPadding={{ y: 40 }}
               containerComponent={
@@ -338,6 +338,7 @@ class GraphsContainer extends React.Component {
                   onSelection={(points, bounds) => this.updateZoom(bounds)}
                   allowPan={false}
                   allowZoom={false}
+                  responsive={false}
                 />
               }
             >

--- a/ui/perfherder/graphs/GraphsView.jsx
+++ b/ui/perfherder/graphs/GraphsView.jsx
@@ -366,7 +366,7 @@ class GraphsView extends React.Component {
             </Container>
           )}
 
-          <Row className="justify-content-center">
+          <Row className="justify-content-start container-fluid">
             <Col
               className={`ml-2 ${testData.length ? 'graph-chooser' : 'col-12'}`}
             >
@@ -374,6 +374,7 @@ class GraphsView extends React.Component {
                 {testData.length > 0 &&
                   testData.map(series => (
                     <div
+                      className={`inline`}
                       key={`${series.name} ${series.repository_name} ${series.platform}`}
                     >
                       <LegendCard


### PR DESCRIPTION
For some reason the half width of tooltip if not enough to align with the datapoint. Looks like for the left-most datapoint the alignment difference is almost insignificant but it increases with point.x, so I applied a formula that depends on point.x / (related to) graph with.
It's not ideal, but seems to be somewhere close to reality.