### PR TITLE
Bug 1581227 - Fix cycle_data failure due to invalid  continuation byte

### DIFF
--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -156,9 +156,6 @@ class Command(BaseCommand):
 
     def get_logger(self, is_debug):
         logger = logging.getLogger('cycle_data')
-        logger.setLevel(
-            logging.WARNING if is_debug else logging.CRITICAL)
-        logger.propagate = False
 
         console_handler = logging.StreamHandler()
         console_handler.setLevel(logging.WARNING)

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -422,6 +422,7 @@ class JobManager(models.Manager):
         jobs_cycled = 0
         while True:
             jobs_chunk = list(self.filter(repository=repository, submit_time__lt=jobs_max_timestamp)
+                                  .order_by('id')
                                   .values_list('guid', flat=True)[:chunk_size])
 
             if not jobs_chunk:
@@ -430,7 +431,7 @@ class JobManager(models.Manager):
 
             # Remove ORM entries for these jobs that don't currently have a
             # foreign key relation
-            lines = FailureLine.objects.filter(job_guid__in=jobs_chunk)
+            lines = FailureLine.objects.filter(job_guid__in=jobs_chunk).only('id')
 
             if settings.ELASTICSEARCH_URL:
                 # To delete the data from elasticsearch we need the document


### PR DESCRIPTION
This change will allow us to delete FailureLine records, even if they have an invalid continuation byte.

I also had it order deletion by ``id`` so it gets the oldest records first.

This removes part of a change that @ionutgoldan introduced to limit the logging to only ``CRITICAL`` for ``cycle_data``.  But I think we want to log the ``cycle_data`` activity so it is search-able in Papertrail.  But I value your input on this, @ionutgoldan, in case there was a strong argument to keep these lines.  :)