### PR TITLE
Bug 1582652 - perfherder graph links fix

### DIFF
--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -54,10 +54,11 @@ export default class AlertTableRow extends React.Component {
       phTimeRanges
         .map(time => time.value)
         .find(
-          value => Date.now() / 1000.0 - alertSummary.push_timestamp < value,
+          value => Date.now() / 1000.0 - alertSummary.push_timestamp <= value,
         ),
     );
-    return timeRange;
+    // default value of one year, for one a push_timestamp exceeds the one year value slightly
+    return timeRange || 31536000;
   };
 
   toggleStar = async () => {


### PR DESCRIPTION
add a default value for when push timestamps exceed the max one year value