### PR TITLE
Bug 1583155 - Perfherder graph link fix

### DIFF
--- a/ui/perfherder/graphs/GraphTooltip.jsx
+++ b/ui/perfherder/graphs/GraphTooltip.jsx
@@ -143,8 +143,10 @@ const GraphTooltip = ({ dataPoint, testData, user, updateData, projects }) => {
                 newProject: testDetails.repository_name,
                 originalRevision: prevRevision,
                 newRevision: dataPointDetails.revision,
-                originalSignature: testDetails.signature_id,
-                newSignature: testDetails.signature_id,
+                originalSignature:
+                  testDetails.parentSignature || testDetails.signature_id,
+                newSignature:
+                  testDetails.parentSignature || testDetails.signature_id,
                 framework: testDetails.framework_id,
               })}`}
               target="_blank"

--- a/ui/perfherder/graphs/GraphsView.jsx
+++ b/ui/perfherder/graphs/GraphsView.jsx
@@ -218,6 +218,7 @@ class GraphsView extends React.Component {
         })),
         lowerIsBetter: series.lower_is_better,
         resultSetData: series.data.map(dataPoint => dataPoint.push_id),
+        parentSignature: series.parent_signature,
       };
     });
     this.setState({ colors: newColors });


### PR DESCRIPTION
Update the compare subtest link from the graph tooltip to use parent_signature if applicable (for a subtest) or signature if it's a test.