### PR TITLE
Bug 1582731 - Perfherder graph change

### DIFF
--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -11,7 +11,7 @@ import {
   VictoryAxis,
   VictoryBrushContainer,
   VictoryScatter,
-  VictorySelectionContainer,
+  createContainer,
 } from 'victory';
 import moment from 'moment';
 import debounce from 'lodash/debounce';
@@ -22,6 +22,8 @@ import { faTimes, faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 import SimpleTooltip from '../../shared/SimpleTooltip';
 
 import GraphTooltip from './GraphTooltip';
+
+const VictoryZoomSelectionContainer = createContainer('zoom', 'selection');
 
 class GraphsContainer extends React.Component {
   constructor(props) {
@@ -203,7 +205,7 @@ class GraphsContainer extends React.Component {
   // doesn't work with this callback, which is why a class property is used instead)
   setLeftPadding = (tick, index, ticks) => {
     const highestTickLength = ticks[ticks.length - 1].toString();
-    const newLeftPadding = highestTickLength.length * 8 + 10;
+    const newLeftPadding = highestTickLength.length * 8 + 16;
     this.leftChartPadding =
       this.leftChartPadding > newLeftPadding
         ? this.leftChartPadding
@@ -341,11 +343,13 @@ class GraphsContainer extends React.Component {
               height={400}
               style={{ parent: { maxHeight: '400px', maxWidth: '1350px' } }}
               scale={{ x: 'time', y: 'linear' }}
-              domain={zoom}
               domainPadding={{ y: 40 }}
               containerComponent={
-                <VictorySelectionContainer
+                <VictoryZoomSelectionContainer
+                  zoomDomain={zoom}
                   onSelection={(points, bounds) => this.updateZoom(bounds)}
+                  allowPan={false}
+                  allowZoom={false}
                 />
               }
             >
@@ -423,7 +427,7 @@ class GraphsContainer extends React.Component {
                 tickFormat={this.setLeftPadding}
               />
               <VictoryAxis
-                tickCount={8}
+                tickCount={6}
                 tickFormat={x => moment.utc(x).format('MMM DD hh:mm')}
                 style={axisStyle}
                 fixLabelOverlap

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -17,9 +17,7 @@ import moment from 'moment';
 import debounce from 'lodash/debounce';
 import last from 'lodash/last';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes, faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
-
-import SimpleTooltip from '../../shared/SimpleTooltip';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
 import GraphTooltip from './GraphTooltip';
 
@@ -320,18 +318,6 @@ class GraphsContainer extends React.Component {
                 />
               ))}
             </VictoryChart>
-          </Col>
-          <Col className="p-0 col-md-auto">
-            <SimpleTooltip
-              text={
-                <FontAwesomeIcon
-                  className="pointer text-secondary"
-                  icon={faQuestionCircle}
-                  size="sm"
-                />
-              }
-              tooltipText="The bottom graph has mouse zoom enabled. When there's a large amount of data points, use the overview graph's selection marquee to narrow the x and y range before zooming with the mouse."
-            />
           </Col>
         </Row>
 


### PR DESCRIPTION
In my initial pr friday #5390 I switched to the Selection Zoom container but I hadn't noticed that this new container makes the datapoints overflow it's parent container due to something strange having to do with the `domain` prop. I've found a solution which creates a combined zoom and selection container, so the `zoomDomain` prop is updated but I can disable the mouse zoom features the sheriffs don't want.

tldr; fixed overflowing container due to zoom feature change.