### PR TITLE
 Bug 1583488 - Perfherder legend links fix 

### DIFF
--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -117,7 +117,7 @@ const LegendCard = ({
         <p
           className={subtitleStyle}
           onClick={() => addTestData('addRelatedPlatform')}
-          title="Add related platforms"
+          title="Add related platforms and branches"
           type="button"
         >
           {series.platform}

--- a/ui/perfherder/graphs/TestDataModal.jsx
+++ b/ui/perfherder/graphs/TestDataModal.jsx
@@ -150,18 +150,24 @@ export default class TestDataModal extends React.Component {
     const relatedProjects = thPerformanceBranches.filter(
       repository_name => repository_name !== relatedSeries.repository_name,
     );
+
     const requests = relatedProjects.map(projectName =>
       PerfSeriesModel.getSeriesList(projectName, params),
     );
 
     const responses = await Promise.all(requests);
-    // eslint-disable-next-line func-names
-    const relatedTests = responses.flatMap(function(item) {
-      if (!item.failureStatus) {
-        return item.data;
-      }
-      errorMessages.push(item.data);
-    });
+    const relatedTests = responses
+      .flatMap(item => {
+        if (!item.failureStatus) {
+          return item.data;
+        }
+        errorMessages.push(item.data);
+      })
+      .filter(
+        item =>
+          item.name === relatedSeries.name &&
+          item.platform === relatedSeries.platform,
+      );
 
     this.setState({
       relatedTests,
@@ -208,7 +214,6 @@ export default class TestDataModal extends React.Component {
     } else if (option === 'addRelatedConfigs') {
       this.addRelatedConfigs(params);
     } else if (option === 'addRelatedBranches') {
-      params.id = relatedSeries.signature_id;
       this.addRelatedBranches(params);
     }
   };

--- a/ui/perfherder/graphs/TestDataModal.jsx
+++ b/ui/perfherder/graphs/TestDataModal.jsx
@@ -101,13 +101,12 @@ export default class TestDataModal extends React.Component {
     const updates = processResponse(response, 'relatedTests', errorMessages);
 
     if (updates.relatedTests.length) {
-      const tests =
-        updates.relatedTests.filter(
-          series =>
-            series.platform === relatedSeries.platform &&
-            series.testName === relatedSeries.test &&
-            series.name !== relatedSeries.name,
-        ) || [];
+      const tests = updates.relatedTests.filter(
+        series =>
+          series.platform === relatedSeries.platform &&
+          series.testName === relatedSeries.test &&
+          series.name !== relatedSeries.name,
+      );
 
       updates.relatedTests = tests;
     }
@@ -117,35 +116,9 @@ export default class TestDataModal extends React.Component {
     this.setState(updates);
   };
 
-  addRelatedPlatforms = async params => {
+  addRelatedBranches = async (params, samePlatform = true) => {
     const { relatedSeries } = this.props.options;
-    const { errorMessages, repository_name } = this.state;
-
-    const response = await PerfSeriesModel.getSeriesList(
-      repository_name.name,
-      params,
-    );
-    const updates = processResponse(response, 'relatedTests', errorMessages);
-
-    if (updates.relatedTests.length) {
-      const tests =
-        updates.relatedTests.filter(
-          series =>
-            series.platform !== relatedSeries.platform &&
-            series.name === relatedSeries.name,
-        ) || [];
-
-      updates.relatedTests = tests;
-    }
-    updates.showNoRelatedTests = updates.relatedTests.length === 0;
-    updates.loading = false;
-
-    this.setState(updates);
-  };
-
-  addRelatedBranches = async params => {
-    const { relatedSeries } = this.props.options;
-    const errorMessages = [];
+    const { errorMessages } = this.state;
 
     const relatedProjects = thPerformanceBranches.filter(
       repository_name => repository_name !== relatedSeries.repository_name,
@@ -166,7 +139,9 @@ export default class TestDataModal extends React.Component {
       .filter(
         item =>
           item.name === relatedSeries.name &&
-          item.platform === relatedSeries.platform,
+          (samePlatform
+            ? item.platform === relatedSeries.platform
+            : item.platform !== relatedSeries.platform),
       );
 
     this.setState({
@@ -210,7 +185,7 @@ export default class TestDataModal extends React.Component {
 
     params.framework = relatedSeries.framework_id;
     if (option === 'addRelatedPlatform') {
-      this.addRelatedPlatforms(params);
+      this.addRelatedBranches(params, false);
     } else if (option === 'addRelatedConfigs') {
       this.addRelatedConfigs(params);
     } else if (option === 'addRelatedBranches') {
@@ -249,7 +224,12 @@ export default class TestDataModal extends React.Component {
 
   closeModal = () => {
     this.setState(
-      { relatedTests: [], filteredData: [], showNoRelatedTests: false },
+      {
+        relatedTests: [],
+        filteredData: [],
+        showNoRelatedTests: false,
+        filterText: '',
+      },
       this.props.toggle,
     );
   };
@@ -265,7 +245,7 @@ export default class TestDataModal extends React.Component {
     }));
 
     getTestData(displayedTestParams);
-    this.setState({ selectedTests: [] });
+    this.setState({ selectedTests: [], filterText: '' });
     this.closeModal();
   };
 


### PR DESCRIPTION
I had misunderstood Ionut's comments about how this logic should work on a previous pr so this now works so that:
- "Add related branches" text button returns results for same test and platform with the two related branches (autoland and mozilla-inbound) if applicable

- "Add related platforms" text button returns results for same test for the two above related branches and all platforms if applicable. This label has also been renamed to make it clearer its fetched related branches AND platforms.

I've combined two functions into one since they now do almost the same thing.