### PR TITLE
Add browser_meta field to `performance-artifact.json`.

### DIFF
--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -146,9 +146,26 @@
       "type": "object"
     }
   },
+  "browser_meta_schema": {
+    "properties": {
+      "version": {
+        "title": "Version of the browser tested.",
+        "type": "string"
+      },
+      "name": {
+        "title": "Name of the browser tested.",
+        "type": "string"
+      },
+    },
+    "required": ["version", "name"],
+    "type": "object"
+  },
   "description": "Structure for submitting performance data as part of a job",
   "id": "https://treeherder.mozilla.org/schemas/v1/performance-artifact.json#",
   "properties": {
+    "browser_meta": {
+      "$ref": "#/definitions/browser_meta_schema"
+    },
     "framework": {
       "$ref": "#/definitions/framework_schema"
     },

--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -144,21 +144,21 @@
       },
       "required": ["name", "subtests"],
       "type": "object"
-    }
-  },
-  "browser_meta_schema": {
-    "properties": {
-      "version": {
-        "title": "Version of the browser tested.",
-        "type": "string"
-      },
-      "name": {
-        "title": "Name of the browser tested.",
-        "type": "string"
-      },
     },
-    "required": ["version", "name"],
-    "type": "object"
+    "browser_meta_schema": {
+      "properties": {
+        "name": {
+          "title": "Name of the browser tested",
+          "type": "string"
+        },
+        "version": {
+          "title": "Version of the browser tested",
+          "type": "string"
+        }
+      },
+      "required": ["name", "version"],
+      "type": "object"
+    }
   },
   "description": "Structure for submitting performance data as part of a job",
   "id": "https://treeherder.mozilla.org/schemas/v1/performance-artifact.json#",


### PR DESCRIPTION
This patch adds a browser_meta field to the `performance-artifact.json file` for perfherder data. It will hold the browser name and version used in the given test so that it can be reported in the dashboards.