### PR TITLE
Fixes Bug 1537890

### DIFF
--- a/tests/ui/helpers/helpers_test.js
+++ b/tests/ui/helpers/helpers_test.js
@@ -1,4 +1,4 @@
-import { displayNumber } from '../../../ui/perfherder/helpers';
+import { displayNumber, formatNumber } from '../../../ui/perfherder/helpers';
 import { getRevisionUrl } from '../../../ui/helpers/url';
 
 describe('getRevisionUrl helper', () => {
@@ -15,5 +15,14 @@ describe('displayNumber helper', () => {
     expect(displayNumber('123123123.53222')).toEqual('123123123.53');
     expect(displayNumber(1 / 0)).toEqual('Infinity');
     expect(displayNumber(Number.NaN)).toEqual('N/A');
+  });
+});
+
+describe('formatNumber helper', () => {
+  test('returns expected values', () => {
+    expect(formatNumber('9873.3321')).toEqual('9,873.33');
+    expect(formatNumber('123123123.53222')).toEqual('123,123,123.53');
+    expect(formatNumber(1 / 0)).toEqual('∞');
+    expect(formatNumber('a string')).toEqual('NaN');
   });
 });

--- a/tests/ui/helpers/helpers_test.js
+++ b/tests/ui/helpers/helpers_test.js
@@ -1,4 +1,4 @@
-import { displayNumber, formatNumber } from '../../../ui/perfherder/helpers';
+import { displayNumber } from '../../../ui/perfherder/helpers';
 import { getRevisionUrl } from '../../../ui/helpers/url';
 
 describe('getRevisionUrl helper', () => {
@@ -15,14 +15,5 @@ describe('displayNumber helper', () => {
     expect(displayNumber('123123123.53222')).toEqual('123123123.53');
     expect(displayNumber(1 / 0)).toEqual('Infinity');
     expect(displayNumber(Number.NaN)).toEqual('N/A');
-  });
-});
-
-describe('formatNumber helper', () => {
-  test('returns expected values', () => {
-    expect(formatNumber('9873.3321')).toEqual('9,873.33');
-    expect(formatNumber('123123123.53222')).toEqual('123,123,123.53');
-    expect(formatNumber(1 / 0)).toEqual('∞');
-    expect(formatNumber('a string')).toEqual('NaN');
   });
 });

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -255,7 +255,6 @@ h1 {
 
 .compare-table td,
 th {
-  text-align: center;
   cursor: default;
 }
 

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -244,7 +244,6 @@ h1 {
   position: relative;
   left: -5px;
 }
-
 .compare-form .input-group-btn button:hover {
   background-color: darkgrey;
 }

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -12,7 +12,7 @@ import {
 import { faStar as faStarRegular } from '@fortawesome/free-regular-svg-icons';
 
 import { createQueryParams } from '../../helpers/url';
-import { getStatus, getGraphsURL, modifyAlert } from '../helpers';
+import { getStatus, getGraphsURL, modifyAlert, formatNumber } from '../helpers';
 import SimpleTooltip from '../../shared/SimpleTooltip';
 import ProgressBar from '../ProgressBar';
 import {
@@ -200,8 +200,6 @@ export default class AlertTableRow extends React.Component {
       ? `Classified by ${alert.classifier_email}`
       : 'Classified automatically';
 
-    const numberFormat = new Intl.NumberFormat();
-
     return (
       <tr
         className={
@@ -248,9 +246,7 @@ export default class AlertTableRow extends React.Component {
             this.getTitleText(alert, alertStatus)
           )}
         </td>
-        <td className="table-width-md">
-          {numberFormat.format(alert.prev_value)}
-        </td>
+        <td className="table-width-md">{formatNumber(alert.prev_value)}</td>
         <td className="table-width-sm">
           <span
             className={alert.is_regression ? 'text-danger' : 'text-success'}
@@ -259,9 +255,7 @@ export default class AlertTableRow extends React.Component {
             {alert.prev_value > alert.new_value && <span>&gt;</span>}
           </span>
         </td>
-        <td className="table-width-md">
-          {numberFormat.format(alert.new_value)}
-        </td>
+        <td className="table-width-md">{formatNumber(alert.new_value)}</td>
         <td className="table-width-md">
           <SimpleTooltip
             textClass="detail-hint"
@@ -286,7 +280,7 @@ export default class AlertTableRow extends React.Component {
                   icon={faUser}
                 />
               ) : (
-                numberFormat.format(alert.t_value)
+                formatNumber(alert.t_value)
               )
             }
             tooltipText={

--- a/ui/perfherder/compare/TableAverage.jsx
+++ b/ui/perfherder/compare/TableAverage.jsx
@@ -2,16 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import SimpleTooltip from '../../shared/SimpleTooltip';
-import { displayNumber } from '../helpers';
+import { displayNumber, formatNumber } from '../helpers';
 
 import TooltipGraph from './TooltipGraph';
 
 const TableAverage = ({ value, stddev, stddevpct, replicates }) => {
   let tooltipText;
   if (replicates.length > 1) {
-    tooltipText = `Runs: < ${replicates.join(' ')} > ${displayNumber(
-      stddev,
-    )} = ${displayNumber(stddevpct)}% standard deviation)`;
+    tooltipText = `Runs: < ${replicates.join(' ')} > ${formatNumber(
+      displayNumber(stddev),
+    )} = ${formatNumber(displayNumber(stddevpct))}% standard deviation)`;
   } else if (replicates.length === 1) {
     tooltipText = 'Only one run (consider more for greater confidence)';
   }
@@ -29,10 +29,10 @@ const TableAverage = ({ value, stddev, stddevpct, replicates }) => {
           textClass="detail-hint"
           text={
             replicates.length === 1
-              ? displayNumber(value)
-              : `${displayNumber(value)} ${'\u00B1'} ${displayNumber(
-                  stddevpct,
-                )}`
+              ? formatNumber(displayNumber(value))
+              : `${formatNumber(
+                  displayNumber(value),
+                )} ${'\u00B1'} ${formatNumber(displayNumber(stddevpct))}`
           }
           tooltipText={
             notZeroSum ? (

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -20,6 +20,8 @@ import last from 'lodash/last';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
+import { formatNumber } from '../helpers';
+
 import GraphTooltip from './GraphTooltip';
 
 const VictoryZoomSelectionContainer = createContainer('zoom', 'selection');
@@ -209,8 +211,8 @@ class GraphsContainer extends React.Component {
       this.leftChartPadding > newLeftPadding
         ? this.leftChartPadding
         : newLeftPadding;
-    const numberFormat = new Intl.NumberFormat();
-    return numberFormat.format(tick);
+
+    return formatNumber(tick);
   };
 
   // debounced

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -21,10 +21,14 @@ import {
   phTimeRanges,
 } from './constants';
 
+export const formatNumber = input => {
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(
+    input,
+  );
+};
+
 export const displayNumber = input =>
-  Number.isNaN(input)
-    ? 'N/A'
-    : (Math.round(Number(input) * 1e2) / 1e2).toLocaleString();
+  Number.isNaN(input) ? 'N/A' : Number(input).toFixed(2);
 
 export const calcPercentOf = function calcPercentOf(a, b) {
   return b ? (100 * a) / b : 0;

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -22,7 +22,9 @@ import {
 } from './constants';
 
 export const displayNumber = input =>
-  Number.isNaN(input) ? 'N/A' : Number(input).toFixed(2);
+  Number.isNaN(input)
+    ? 'N/A'
+    : (Math.round(Number(input) * 1e2) / 1e2).toLocaleString();
 
 export const calcPercentOf = function calcPercentOf(a, b) {
   return b ? (100 * a) / b : 0;

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -21,11 +21,8 @@ import {
   phTimeRanges,
 } from './constants';
 
-export const formatNumber = input => {
-  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(
-    input,
-  );
-};
+export const formatNumber = input =>
+  new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(input);
 
 export const displayNumber = input =>
   Number.isNaN(input) ? 'N/A' : Number(input).toFixed(2);


### PR DESCRIPTION
"Removed text-align: center in perf.css so that numbers are left alligned by default and added thousands separator for numbers in helpers.js"
Hey @camd @sarah-clements. This is actually my first pull request for open source. Please tell me what I need to fix. Part of this bug was to fix the numbers not having a thousands separators so I changed the helper function "displayNumber" and because it returns a string now with thousands separators it does not pass the test provided for this function.
Is this a problem I need to fix and any directions for it?
All criticism is welcome.