### PR TITLE
Bug 1584140 - Lower labels from Graphs view are being cut off

### DIFF
--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -221,7 +221,7 @@ class GraphsContainer extends React.Component {
       this.rightChartPadding > newRightPadding
         ? this.rightChartPadding
         : newRightPadding;
-    return moment.utc(tick).format('MMM DD hh:mm')
+    return moment.utc(tick).format('MMM DD hh:mm');
   };
 
   // debounced
@@ -264,9 +264,12 @@ class GraphsContainer extends React.Component {
       tickLabels: { fontSize: 13 },
     };
 
-    const chartPadding = { top: 10, bottom: 50 };
-    chartPadding.left = this.leftChartPadding;
-    chartPadding.right = this.rightChartPadding;
+    const chartPadding = {
+      top: 10,
+      left: this.leftChartPadding,
+      right: this.rightChartPadding,
+      bottom: 50,
+    };
 
     return (
       <React.Fragment>

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -31,6 +31,7 @@ class GraphsContainer extends React.Component {
     this.hideTooltip = debounce(this.hideTooltip.bind(this), 250);
     this.tooltip = React.createRef();
     this.leftChartPadding = 25;
+    this.rightChartPadding = 10;
     this.state = {
       highlights: [],
       scatterPlotData: this.props.testData.flatMap(item =>
@@ -213,6 +214,16 @@ class GraphsContainer extends React.Component {
     return numberFormat.format(tick);
   };
 
+  setRightPadding = (tick, index, ticks) => {
+    const highestTickLength = ticks[ticks.length - 1].toString();
+    const newRightPadding = highestTickLength.length / 2;
+    this.rightChartPadding =
+      this.rightChartPadding > newRightPadding
+        ? this.rightChartPadding
+        : newRightPadding;
+    return moment.utc(tick).format('MMM DD hh:mm')
+  };
+
   // debounced
   hideTooltip() {
     const { showTooltip, lockTooltip } = this.state;
@@ -253,8 +264,9 @@ class GraphsContainer extends React.Component {
       tickLabels: { fontSize: 13 },
     };
 
-    const chartPadding = { top: 10, right: 10, bottom: 50 };
+    const chartPadding = { top: 10, bottom: 50 };
     chartPadding.left = this.leftChartPadding;
+    chartPadding.right = this.rightChartPadding;
 
     return (
       <React.Fragment>
@@ -415,7 +427,7 @@ class GraphsContainer extends React.Component {
               />
               <VictoryAxis
                 tickCount={6}
-                tickFormat={x => moment.utc(x).format('MMM DD hh:mm')}
+                tickFormat={this.setRightPadding}
                 style={axisStyle}
                 fixLabelOverlap
               />


### PR DESCRIPTION
Hi @sarah-clements,

### Description of issue
In Perfherder, lower horizontal labels from the Graph are being cut off the right side.

### Proposed Solution
This inserts `setRightPadding()`, which calculates the `padding-right` of the chart, according to the last horizontal axis tick.

This probably need some refactoring and I can do that after the first review.

### Testing
Since finding the occurrence of the issue may be difficult, I have used the page reported by the user to [test](http://localhost:5000/perf.html#/graphs?timerange=2592000&series=mozilla-central,1834678,1,10&series=mozilla-central,1955233,1,10&series=mozilla-central,2110541,1,10&series=mozilla-central,2117747,1,10&series=mozilla-central,1834673,1,10&series=mozilla-central,1955223,1,10&series=mozilla-central,2110530,1,10&series=mozilla-central,2117883,1,10&series=mozilla-central,1834668,1,10&series=mozilla-central,2008512,1,10&series=mozilla-central,2110577,1,10&series=mozilla-central,2117729,1,10&highlightAlerts=1&zoom=1568128753960,1569398786379,9.73925316100027,20.03165154831082).

![image](https://user-images.githubusercontent.com/3901809/66073346-45de5b00-e52d-11e9-848d-165f276dcd54.png)

I have also tested on other pages, but couldn't find the issue.