### PR TITLE
Bug 1555281 - Fix intermittent-failures.html truncated failure message

### DIFF
--- a/ui/css/intermittent-failures.css
+++ b/ui/css/intermittent-failures.css
@@ -66,8 +66,7 @@ ul {
 }
 
 .failure_li {
-  max-width: 800px;
-  max-width: 76vw;
+  max-width: 1000px;
   list-style-type: none;
   text-align: left;
 }

--- a/ui/css/intermittent-failures.css
+++ b/ui/css/intermittent-failures.css
@@ -67,6 +67,7 @@ ul {
 
 .failure_li {
   max-width: 800px;
+  max-width: 76vw;
   list-style-type: none;
   text-align: left;
 }

--- a/ui/intermittent-failures/BugDetailsView.jsx
+++ b/ui/intermittent-failures/BugDetailsView.jsx
@@ -11,7 +11,12 @@ import {
 } from '../helpers/url';
 import SimpleTooltip from '../shared/SimpleTooltip';
 
-import { calculateMetrics, prettyDate, tableRowStyling } from './helpers';
+import {
+  calculateMetrics,
+  prettyDate,
+  tableRowStyling,
+  removePath,
+} from './helpers';
 import Layout from './Layout';
 import withView from './View';
 import DateOptions from './DateOptions';
@@ -108,7 +113,7 @@ const BugDetailsView = props => {
                       key={index} // eslint-disable-line react/no-array-index-key
                       className="failure_li text-truncate"
                     >
-                      {line}
+                      {removePath(line)}
                     </li>
                   ))}
                 </ul>

--- a/ui/intermittent-failures/helpers.js
+++ b/ui/intermittent-failures/helpers.js
@@ -119,3 +119,15 @@ export const tableRowStyling = function tableRowStyling(state, bug) {
   }
   return {};
 };
+
+export const removePath = function removePath(line = '') {
+  const [a, testNameWithPath, ...rest] = line.split(' | ');
+  const pathArray = testNameWithPath && testNameWithPath.split('/');
+
+  if (pathArray && pathArray.length > 1) {
+    const testName = pathArray[pathArray.length - 1];
+    return [a, testName, rest].join(' | ');
+  }
+
+  return line;
+};

--- a/ui/intermittent-failures/helpers.js
+++ b/ui/intermittent-failures/helpers.js
@@ -120,14 +120,4 @@ export const tableRowStyling = function tableRowStyling(state, bug) {
   return {};
 };
 
-export const removePath = function removePath(line = '') {
-  const [a, testNameWithPath, ...rest] = line.split(' | ');
-  const pathArray = testNameWithPath && testNameWithPath.split('/');
-
-  if (pathArray && pathArray.length > 1) {
-    const testName = pathArray[pathArray.length - 1];
-    return [a, testName, rest].join(' | ');
-  }
-
-  return line;
-};
+export const removePath = (line = '') => line.replace(/\/?([\w\d-.]+\/)+/, '');


### PR DESCRIPTION
* increase the size of the tooltip for longer failure messages when window is wide

* remove the path to the test in test name and show only the test name before the actual message