### PR TITLE
Support filtering pushes by commit author

### DIFF
--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -145,6 +145,13 @@ class PushViewSet(viewsets.ViewSet):
         if author:
             pushes = pushes.filter(author=author)
 
+        # Filter by commit author
+        # A distinct is needed to avoid duplicate push results
+        # when a author has several commits in one push
+        commit_author = filter_params.get("commit_author")
+        if commit_author:
+            pushes = pushes.filter(commits__author__contains=commit_author).distinct()
+
         try:
             count = int(filter_params.get("count", 10))
         except ValueError:

--- a/ui/job-view/redux/stores/pushes.js
+++ b/ui/job-view/redux/stores/pushes.js
@@ -30,7 +30,7 @@ export const UPDATE_JOB_MAP = 'UPDATE_JOB_MAP';
 const DEFAULT_PUSH_COUNT = 10;
 // Keys that, if present on the url, must be passed into the push
 // polling endpoint
-const PUSH_POLLING_KEYS = ['tochange', 'enddate', 'revision', 'author'];
+const PUSH_POLLING_KEYS = ['tochange', 'enddate', 'revision', 'author', 'commit_author'];
 const PUSH_FETCH_KEYS = [...PUSH_POLLING_KEYS, 'fromchange', 'startdate'];
 
 const getRevisionTips = pushList => {

--- a/ui/job-view/redux/stores/pushes.js
+++ b/ui/job-view/redux/stores/pushes.js
@@ -30,7 +30,13 @@ export const UPDATE_JOB_MAP = 'UPDATE_JOB_MAP';
 const DEFAULT_PUSH_COUNT = 10;
 // Keys that, if present on the url, must be passed into the push
 // polling endpoint
-const PUSH_POLLING_KEYS = ['tochange', 'enddate', 'revision', 'author', 'commit_author'];
+const PUSH_POLLING_KEYS = [
+  'tochange',
+  'enddate',
+  'revision',
+  'author',
+  'commit_author',
+];
 const PUSH_FETCH_KEYS = [...PUSH_POLLING_KEYS, 'fromchange', 'startdate'];
 
 const getRevisionTips = pushList => {


### PR DESCRIPTION
Refs mozilla/code-review#133

I work on Mozilla's [code-review bot](https://github.com/mozilla/code-review).
The review bot got a new feature in production: it preserves the [commit author name & email when pushing to try](https://treeherder.mozilla.org/#/jobs?repo=try&author=reviewbot) instead of using `libmozevent` or `pulselistener` code names. 
As the push author is static and used for ssh auth, I cannot change it to replace it by the top patch author and allow filtering on Treeherder. Some users would like to list their automatic try jobs directly from Treeherder.

So I made that patch to support filtering pushes by commit author. I'm not familiar with React/Redux, so I just made the modification necessary to pass the parameters to the API.
I guess it should be possible to make the author icon clickable to use that filter.

cc @sylvestre 

