### PR TITLE
Fix bug 1584135 to show the current date when there is no data

### DIFF
--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -306,7 +306,11 @@ class GraphsContainer extends React.Component {
               />
               <VictoryAxis
                 tickCount={10}
-                tickFormat={x => moment.utc(x).format('MMM DD')}
+                tickFormat={x =>
+                  moment(x) < moment('1975-01-01')
+                    ? moment.utc(new Date()).format('MMM DD')
+                    : moment.utc(x).format('MMM DD')
+                }
                 style={axisStyle}
               />
               {testData.map(item => (
@@ -415,7 +419,11 @@ class GraphsContainer extends React.Component {
               />
               <VictoryAxis
                 tickCount={6}
-                tickFormat={x => moment.utc(x).format('MMM DD hh:mm')}
+                tickFormat={x =>
+                  moment(x) < moment('1975-01-01')
+                    ? moment.utc(new Date()).format('MMM DD hh:mm')
+                    : moment.utc(x).format('MMM DD hh:mm')
+                }
                 style={axisStyle}
                 fixLabelOverlap
               />


### PR DESCRIPTION
I found the GraphsContainer.jsx file where the data was showing up, my solution was to update the date when there was no data, the moment library showed the default date which is 01 Jan 1970 - So I checked if the current date is earlier than the 1975 and I added the current date to the view. 