### PR TITLE
JSX a11y ESLint: GraphsContainer.jsx and FiltersMenu.jsx

### DIFF
--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -430,12 +430,6 @@ fieldset[disabled] .btn-view-nav-closed.active {
   list-style: none;
 }
 
-.dropdown-menu li > button {
-  border: 0;
-  padding: 0;
-  background: transparent;
-}
-
 .dropdown-header {
   font-size: 12px;
 }

--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -430,6 +430,12 @@ fieldset[disabled] .btn-view-nav-closed.active {
   list-style: none;
 }
 
+.dropdown-menu li > button {
+  border: 0;
+  padding: 0;
+  background: transparent;
+}
+
 .dropdown-header {
   font-size: 12px;
 }

--- a/ui/job-view/headerbars/FiltersMenu.jsx
+++ b/ui/job-view/headerbars/FiltersMenu.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Label } from 'reactstrap';
+import { Button, Label } from 'reactstrap';
 
 import { thAllResultStatuses } from '../../helpers/constants';
 import { getJobsUrl } from '../../helpers/url';
@@ -99,34 +99,31 @@ function FiltersMenu(props) {
             title="Pin all jobs that pass the global filters"
             className="dropdown-item"
           >
-            <button
-              type="button"
+            <Button
               className="border-0 bg-transparent p-0"
               onClick={pinAllShownJobs}
             >
               Pin all showing
-            </button>
+            </Button>
           </li>
           <li title="Show only superseded jobs" className="dropdown-item">
-            <button
-              type="button"
+            <Button
               className="border-0 bg-transparent p-0"
               onClick={filterModel.setOnlySuperseded}
             >
               Superseded only
-            </button>
+            </Button>
           </li>
           <li title={`Show only pushes for ${email}`} className="dropdown-item">
             <a href={getJobsUrl({ author: email })}>My pushes only</a>
           </li>
           <li title="Reset to default status filters" className="dropdown-item">
-            <button
-              type="button"
+            <Button
               className="border-0 bg-transparent p-0"
               onClick={filterModel.resetNonFieldFilters}
             >
               Reset
-            </button>
+            </Button>
           </li>
         </ul>
       </span>

--- a/ui/job-view/headerbars/FiltersMenu.jsx
+++ b/ui/job-view/headerbars/FiltersMenu.jsx
@@ -99,12 +99,20 @@ function FiltersMenu(props) {
             title="Pin all jobs that pass the global filters"
             className="dropdown-item"
           >
-            <button type="button" onClick={pinAllShownJobs}>
+            <button
+              type="button"
+              className="border-0 bg-transparent p-0"
+              onClick={pinAllShownJobs}
+            >
               Pin all showing
             </button>
           </li>
           <li title="Show only superseded jobs" className="dropdown-item">
-            <button type="button" onClick={filterModel.setOnlySuperseded}>
+            <button
+              type="button"
+              className="border-0 bg-transparent p-0"
+              onClick={filterModel.setOnlySuperseded}
+            >
               Superseded only
             </button>
           </li>
@@ -112,7 +120,11 @@ function FiltersMenu(props) {
             <a href={getJobsUrl({ author: email })}>My pushes only</a>
           </li>
           <li title="Reset to default status filters" className="dropdown-item">
-            <button type="button" onClick={filterModel.resetNonFieldFilters}>
+            <button
+              type="button"
+              className="border-0 bg-transparent p-0"
+              onClick={filterModel.resetNonFieldFilters}
+            >
               Reset
             </button>
           </li>

--- a/ui/job-view/headerbars/FiltersMenu.jsx
+++ b/ui/job-view/headerbars/FiltersMenu.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -100,26 +98,23 @@ function FiltersMenu(props) {
           <li
             title="Pin all jobs that pass the global filters"
             className="dropdown-item"
-            onClick={pinAllShownJobs}
           >
-            Pin all showing
+            <button type="button" onClick={pinAllShownJobs}>
+              Pin all showing
+            </button>
           </li>
-          <li
-            title="Show only superseded jobs"
-            className="dropdown-item"
-            onClick={filterModel.setOnlySuperseded}
-          >
-            Superseded only
+          <li title="Show only superseded jobs" className="dropdown-item">
+            <button type="button" onClick={filterModel.setOnlySuperseded}>
+              Superseded only
+            </button>
           </li>
           <li title={`Show only pushes for ${email}`} className="dropdown-item">
             <a href={getJobsUrl({ author: email })}>My pushes only</a>
           </li>
-          <li
-            title="Reset to default status filters"
-            className="dropdown-item"
-            onClick={filterModel.resetNonFieldFilters}
-          >
-            Reset
+          <li title="Reset to default status filters" className="dropdown-item">
+            <button type="button" onClick={filterModel.resetNonFieldFilters}>
+              Reset
+            </button>
           </li>
         </ul>
       </span>

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -1,7 +1,7 @@
 // disabling due to a new bug with this rule: https://github.com/eslint/eslint/issues/12117
 /* eslint-disable no-unused-vars */
 import React from 'react';
-import { Row, Col } from 'reactstrap';
+import { Row, Col, Button } from 'reactstrap';
 import PropTypes from 'prop-types';
 import {
   VictoryChart,
@@ -69,11 +69,11 @@ class GraphsContainer extends React.Component {
     }
 
     if (prevProps.timeRange !== timeRange && this.state.dataPoint) {
-      this.onUpdate();
+      this.resetDataPoint();
     }
   }
 
-  onUpdate = () => {
+  resetDataPoint = () => {
     this.setState({
       dataPoint: null,
       showTooltip: false,
@@ -283,19 +283,14 @@ class GraphsContainer extends React.Component {
           }`}
           ref={this.tooltip}
         >
-          <span
-            className="close mr-3 my-2 ml-2"
-            role="button"
-            onClick={this.closeTooltip}
-            tabIndex={0}
-          >
+          <Button className="close mr-3 my-2 ml-2" onClick={this.closeTooltip}>
             <FontAwesomeIcon
               className="pointer text-white"
               icon={faTimes}
               size="xs"
               title="close tooltip"
             />
-          </span>
+          </Button>
           {dataPoint && showTooltip && (
             <GraphTooltip dataPoint={dataPoint} {...this.props} />
           )}

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -1,6 +1,3 @@
-/* eslint-disable react/no-did-update-set-state */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 // disabling due to a new bug with this rule: https://github.com/eslint/eslint/issues/12117
 /* eslint-disable no-unused-vars */
 import React from 'react';
@@ -72,13 +69,17 @@ class GraphsContainer extends React.Component {
     }
 
     if (prevProps.timeRange !== timeRange && this.state.dataPoint) {
-      this.setState({
-        dataPoint: null,
-        showTooltip: false,
-        lockTooltip: false,
-      });
+      this.onUpdate();
     }
   }
+
+  onUpdate = () => {
+    this.setState({
+      dataPoint: null,
+      showTooltip: false,
+      lockTooltip: false,
+    });
+  };
 
   verifySelectedDataPoint = () => {
     const { selectedDataPoint, testData, updateStateParams } = this.props;
@@ -282,7 +283,12 @@ class GraphsContainer extends React.Component {
           }`}
           ref={this.tooltip}
         >
-          <span className="close mr-3 my-2 ml-2" onClick={this.closeTooltip}>
+          <span
+            className="close mr-3 my-2 ml-2"
+            role="button"
+            onClick={this.closeTooltip}
+            tabIndex={0}
+          >
             <FontAwesomeIcon
               className="pointer text-white"
               icon={faTimes}

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -283,7 +283,7 @@ class GraphsContainer extends React.Component {
           }`}
           ref={this.tooltip}
         >
-          <Button className="close mr-3 my-2 ml-2" onClick={this.closeTooltip}>
+          <Button className="mr-3 my-2 ml-2" close onClick={this.closeTooltip}>
             <FontAwesomeIcon
               className="pointer text-white"
               icon={faTimes}


### PR DESCRIPTION
Hi @sarah-clements and @camd,

### Description of issue
Some Treeherder files have ESlint a11y rules disabled. This PR enables and solves the ESlint rules of two files:
- **GraphsContainer.jsx**
- **FiltersMenu.jsx**

### Proposed Solution
**GraphsContainer.jsx**:
- Create a new method `onUpdate()`, which calls `this.setState()`, so there is no `this.setState()` inside of `componentDidUpdate()`.
- Insert `role="button"` to Close button in Graph Tooltip.

------------

**FiltersMenu.jsx**:
- Insert `<button>` tag inside clickable `<li>` elements, in the Filters Menu, and move the onClick event there.
- In the `treeherder-navbar.css` file, a new selector was inserted to make the layout look the same as before.

### Testing
I have tested and compared the usability and layout on both `master` (original) and `jsx-a11y-eslint-filtersmenu-graphscontainer` (modified) branches.

- One example for [GraphsContainer.jsx](http://localhost:5000/perf.html#/graphs?highlightAlerts=1&series=autoland,1928276,1,1&series=mozilla-inbound,1946584,1,1&timerange=1209600&zoom=1569395996793,1569496591175,3.3198354420949063,3.9625231358400868) - selected multiple areas for updating the Graph and selected on one point to open the Tooltip.
- One example for [FiltersMenu.jsx](http://localhost:5000/#/jobs?repo=autoland) - clicked on the Pin all showing, Superseded only and Reset buttons on the Filters Menu and checked their functionalities.