### PR TITLE
Perfherder nav menu - import bootstrap jquery package

### DIFF
--- a/ui/perfherder/index.jsx
+++ b/ui/perfherder/index.jsx
@@ -3,6 +3,9 @@ import { render } from 'react-dom';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'react-table/react-table.css';
 
+// TODO remove Vendor JS
+import 'bootstrap';
+
 import '../css/treeherder-global.css';
 import '../css/treeherder-navbar.css';
 import '../css/perf.css';


### PR DESCRIPTION
I just realized the Perfherder HelpMenu and LoginMenu components aren't working properly (dropdowns aren't opening); I hadn't realized those were still using Bootstrap's jquery. Oops. I added that import. 

@camd Is removing jquery use for those two components on your to-do list or should I file a bug?