### PR TITLE
enable a11y eslint rules

### DIFF
--- a/ui/css/intermittent-failures.css
+++ b/ui/css/intermittent-failures.css
@@ -32,6 +32,9 @@ h1,
 
 .bug-column:hover .bug-details {
   display: initial;
+  padding: 0;
+  border: none;
+  background: none;
 }
 
 /* overriding bootstrap default input style */

--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -30,6 +30,7 @@
   min-width: inherit;
 }
 
+.dropdown-item-link,
 .dropdown-menu > li > a {
   font-weight: normal;
   line-height: 1.42857143;
@@ -37,6 +38,7 @@
   white-space: nowrap;
 }
 
+.dropdown-item-link:visited,
 .dropdown-menu > li > a:hover,
 .dropdown-menu > li > a:focus {
   color: #262626;

--- a/ui/intermittent-failures/BugColumn.jsx
+++ b/ui/intermittent-failures/BugColumn.jsx
@@ -1,8 +1,7 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { Button } from 'reactstrap';
 
 import { getBugUrl } from '../helpers/url';
 
@@ -32,7 +31,7 @@ function BugColumn({
         {id}
       </a>
       &nbsp;
-      <span
+      <Button
         className="ml-1 small-text bug-details"
         onClick={() => updateAppState({ graphData, tableData })}
       >
@@ -45,7 +44,7 @@ function BugColumn({
         >
           details
         </Link>
-      </span>
+      </Button>
     </div>
   );
 }

--- a/ui/job-view/headerbars/FiltersMenu.jsx
+++ b/ui/job-view/headerbars/FiltersMenu.jsx
@@ -1,9 +1,12 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Label } from 'reactstrap';
+import {
+  UncontrolledDropdown,
+  DropdownMenu,
+  DropdownItem,
+  DropdownToggle,
+} from 'reactstrap';
 
 import { thAllResultStatuses } from '../../helpers/constants';
 import { getJobsUrl } from '../../helpers/url';
@@ -38,92 +41,75 @@ function FiltersMenu(props) {
   const { email } = user;
 
   return (
-    <span>
-      <span className="dropdown">
-        <button
-          id="filterLabel"
-          type="button"
-          title="Set filters"
-          data-toggle="dropdown"
-          className="btn btn-view-nav nav-menu-btn dropdown-toggle"
-        >
-          Filters
-        </button>
-        <ul
-          id="filter-dropdown"
-          className="dropdown-menu nav-dropdown-menu-right checkbox-dropdown-menu"
-          role="menu"
-          aria-labelledby="filterLabel"
-        >
-          <li>
-            {resultStatusMenuItems.map(filterName => (
-              <span key={filterName}>
-                <span>
-                  <Label className="dropdown-item">
-                    <input
-                      type="checkbox"
-                      className="mousetrap"
-                      id={filterName}
-                      checked={resultStatus.includes(filterName)}
-                      onChange={() =>
-                        filterModel.toggleResultStatuses([filterName])
-                      }
-                    />
-                    {filterName}
-                  </Label>
-                </span>
-              </span>
-            ))}
-          </li>
-          <li className="dropdown-divider separator" />
-          <Label className="dropdown-item">
+    <UncontrolledDropdown>
+      <DropdownToggle
+        caret
+        id="filterLabel"
+        className="btn btn-view-nav nav-menu-btn"
+        title="Set filters"
+      >
+        Filters
+      </DropdownToggle>
+      <DropdownMenu id="filter-dropdown">
+        {resultStatusMenuItems.map(filterName => (
+          <DropdownItem toggle={false} key={filterName}>
             <input
               type="checkbox"
-              id="classified"
-              checked={classifiedState.includes('classified')}
-              onChange={() => filterModel.toggleClassifiedFilter('classified')}
+              className="mousetrap"
+              id={filterName}
+              checked={resultStatus.includes(filterName)}
+              onChange={() => filterModel.toggleResultStatuses([filterName])}
             />
-            classified
-          </Label>
-          <Label className="dropdown-item">
-            <input
-              type="checkbox"
-              id="unclassified"
-              checked={classifiedState.includes('unclassified')}
-              onChange={() =>
-                filterModel.toggleClassifiedFilter('unclassified')
-              }
-            />
-            unclassified
-          </Label>
-          <li className="dropdown-divider separator" />
-          <li
-            title="Pin all jobs that pass the global filters"
-            className="dropdown-item"
-            onClick={pinAllShownJobs}
-          >
-            Pin all showing
-          </li>
-          <li
-            title="Show only superseded jobs"
-            className="dropdown-item"
-            onClick={filterModel.setOnlySuperseded}
-          >
-            Superseded only
-          </li>
-          <li title={`Show only pushes for ${email}`} className="dropdown-item">
-            <a href={getJobsUrl({ author: email })}>My pushes only</a>
-          </li>
-          <li
-            title="Reset to default status filters"
-            className="dropdown-item"
-            onClick={filterModel.resetNonFieldFilters}
-          >
-            Reset
-          </li>
-        </ul>
-      </span>
-    </span>
+            {filterName}
+          </DropdownItem>
+        ))}
+        <DropdownItem divider />
+        <DropdownItem toggle={false}>
+          <input
+            type="checkbox"
+            id="classified"
+            checked={classifiedState.includes('classified')}
+            onChange={() => filterModel.toggleClassifiedFilter('classified')}
+          />
+          classified
+        </DropdownItem>
+        <DropdownItem toggle={false}>
+          <input
+            type="checkbox"
+            id="unclassified"
+            checked={classifiedState.includes('unclassified')}
+            onChange={() => filterModel.toggleClassifiedFilter('unclassified')}
+          />
+          unclassified
+        </DropdownItem>
+        <DropdownItem divider />
+        <DropdownItem
+          onClick={pinAllShownJobs}
+          title="Pin all jobs that pass the global filters"
+        >
+          Pin all showing
+        </DropdownItem>
+        <DropdownItem
+          onClick={filterModel.setOnlySuperseded}
+          title="Show only superseded jobs"
+        >
+          Superseded only
+        </DropdownItem>
+        <DropdownItem
+          className="dropdown-item-link"
+          title={`Show only pushes for ${email}`}
+          href={getJobsUrl({ author: email })}
+        >
+          My pushes only
+        </DropdownItem>
+        <DropdownItem
+          onClick={filterModel.resetNonFieldFilters}
+          title="Reset to default status filters"
+        >
+          Reset
+        </DropdownItem>
+      </DropdownMenu>
+    </UncontrolledDropdown>
   );
 }
 

--- a/ui/perfherder/compare/CompareTable.jsx
+++ b/ui/perfherder/compare/CompareTable.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/control-has-associated-label */
-
 import React from 'react';
 import { Button, Table } from 'reactstrap';
 import PropTypes from 'prop-types';
@@ -120,11 +118,17 @@ export default class CompareTable extends React.PureComponent {
             </th>
             <th className="table-width-lg">Base</th>
             {/* empty for less than/greater than data */}
-            <th className="table-width-sm" />
+            <th
+              className="table-width-sm"
+              aria-label="less than or greater than data"
+            />
             <th className="table-width-lg">New</th>
             <th className="table-width-lg">Delta</th>
             {/* empty for progress bars (magnitude of difference) */}
-            <th className="table-width-lg" />
+            <th
+              className="table-width-lg"
+              aria-label="magnitude of difference"
+            />
             <th className="table-width-lg">Confidence</th>
             <th className="text-right table-width-md">
               {hasSubtests &&


### PR DESCRIPTION
1. FiltersMenu.jsx
 ================
 eslint rule: "jsx-a11y/no-noninteractive-element-interactions"
 Description: A non-interactive element does not support event handlers.
 In this case, li is a non-interactive element. So, I wrapped it's content in a div, moved the "onclick" event to the div and gave the div a presentation role.

 2. CompareTable.jsx
 ================
 eslint rule: "jsx-a11y/control-has-associated-label"
 Description: An interactive element needs to have a text label.
 In this case, the two table header(th) elements didn't contain any text label. The fix was to give it an aria-label.

 3. BugColumn.jsx
 ==============
 eslint rule: "jsx-a11y/no-static-element-interactions" 
 Description: Static elements must be given a role in order to add events handlers.
 In this case, the span had an onclick event. I added a presentation role to the span. 