### PR TITLE
Bug 1581739 - Fix when NaN duration is displayed

### DIFF
--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -672,7 +672,8 @@ class Job(models.Model):
     def get_duration(submit_time, start_time, end_time):
         endtime = end_time if to_timestamp(end_time) else datetime.datetime.now()
         starttime = start_time if to_timestamp(start_time) else submit_time
-        return round((endtime - starttime).total_seconds() / 60)
+        seconds = max((endtime - starttime).total_seconds(), 60)
+        return max(round(seconds / 60), 1)
 
 
 class TaskclusterMetadata(models.Model):

--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -176,7 +176,6 @@ export const addAggregateFields = function addAggregateFields(job) {
     platform,
     platform_option,
     signature,
-    duration,
     submit_timestamp,
     start_timestamp,
     end_timestamp,
@@ -199,16 +198,20 @@ export const addAggregateFields = function addAggregateFields(job) {
     .join(' ');
   job.searchStr = `${job.title} ${signature}`;
 
-  if (!duration) {
+  if (!('duration' in job)) {
     // If start time is 0, then duration should be from requesttime to now
     // If we have starttime and no endtime, then duration should be starttime to now
     // If we have both starttime and endtime, then duration will be between those two
     const endtime = end_timestamp || Date.now() / 1000;
     const starttime = start_timestamp || submit_timestamp;
-    job.duration = Math.round((endtime - starttime) / 60, 0);
+    const diff = Math.max(endtime - starttime, 60);
+
+    job.duration = Math.round(diff / 60, 0);
   }
 
-  job.hoverText = `${job_type_name} - ${job.resultStatus} - ${job.duration} mins`;
+  job.hoverText = `${job_type_name} - ${job.resultStatus} - ${
+    job.duration
+  } min${job.duration > 1 ? 's' : ''}`;
   return job;
 };
 


### PR DESCRIPTION
We were sometimes returning ``0`` length duration.  Our UI code was interpreting that as no duration.  So it tried to calculate it.  In some circumstances (like the larger list of jobs) we return only duration, but not the start time, end time, etc.  So we get an error when trying to calculate it.

This fixes the back-end to always return a minimum duration of 1.  It also improves the calculation of duration on the front-end if we don't have one.

Lastly, it makes the grammar of the ``title`` on a job smarter, in case it's duration of 1.