### PR TITLE
Bug 1577532 - Reflect new job classified status after using BugFiler

### DIFF
--- a/ui/job-view/details/BugFiler.jsx
+++ b/ui/job-view/details/BugFiler.jsx
@@ -476,8 +476,8 @@ export class BugFilerClass extends React.Component {
         );
 
         if (!failureStatus) {
-          successCallback(data);
           toggle();
+          successCallback(data);
         } else {
           this.submitFailure('Treeherder Bug Filer API', failureStatus, data);
         }

--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -114,9 +114,13 @@ class PinBoard extends React.Component {
     });
   };
 
-  saveClassification = async job => {
-    const { recalculateUnclassifiedCounts, notify } = this.props;
+  saveClassification = async pinnedJob => {
+    const { recalculateUnclassifiedCounts, notify, jobMap } = this.props;
     const classification = this.createNewClassification();
+    // Ensure the version of the job we have is the one that is displayed in
+    // the main job field.  Not the "full" selected job instance only shown in
+    // the job details panel.
+    const job = jobMap[pinnedJob.id];
 
     // classification can be left unset making this a no-op
     if (classification.failure_classification_id > 0) {
@@ -131,6 +135,8 @@ class PinBoard extends React.Component {
         // update the job to show that it's now classified
         const jobInstance = findJobInstance(job.id);
 
+        // Filter in case we are hiding unclassified.  Also causes a repaint on the job
+        // to show it if has been newly classified or not.
         if (jobInstance) {
           jobInstance.refilter();
         }
@@ -637,6 +643,7 @@ class PinBoard extends React.Component {
 PinBoard.propTypes = {
   recalculateUnclassifiedCounts: PropTypes.func.isRequired,
   decisionTaskMap: PropTypes.object.isRequired,
+  jobMap: PropTypes.object.isRequired,
   classificationTypes: PropTypes.array.isRequired,
   isLoggedIn: PropTypes.bool.isRequired,
   isPinBoardVisible: PropTypes.bool.isRequired,
@@ -665,7 +672,7 @@ PinBoard.defaultProps = {
 };
 
 const mapStateToProps = ({
-  pushes: { revisionTips, decisionTaskMap },
+  pushes: { revisionTips, decisionTaskMap, jobMap },
   pinnedJobs: {
     isPinBoardVisible,
     pinnedJobs,
@@ -676,6 +683,7 @@ const mapStateToProps = ({
 }) => ({
   revisionTips,
   decisionTaskMap,
+  jobMap,
   isPinBoardVisible,
   pinnedJobs,
   pinnedJobBugs,


### PR DESCRIPTION
This was, in some cases, using a copy of the job used for the ``DetailsPanel``.  Since this is a separate instance than the one displayed in the main job field, it didn't update after using the ``BugFiler``.  The ``jobMap`` has a mapping of all jobs displayed in the job field, by id.

This was also attributed to a timing of display with the modal dialog being ``toggle``d off and the ``successCallback`` being called.  So just swapped them.