### PR TITLE
Bug 1217058 - Preserve grouping state when clicking links

### DIFF
--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -500,6 +500,7 @@ class Push extends React.PureComponent {
           selectedRunnableJobs={selectedRunnableJobs}
           notificationSupported={notificationSupported}
           pushHealthVisibility={pushHealthVisibility}
+          groupCountsExpanded={groupCountsExpanded}
         />
         <div className="push-body-divider" />
         {!collapsed ? (

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -101,6 +101,7 @@ class PushHeader extends React.Component {
       collapsed: prevCollapsed,
       pushHealthVisibility: prevPushHealthVisibility,
       filterModel: prevFilterModel,
+      groupCountsExpanded: prevgroupCountsExpanded,
     } = prevProps;
     const {
       jobCounts,
@@ -111,6 +112,7 @@ class PushHeader extends React.Component {
       collapsed,
       pushHealthVisibility,
       filterModel,
+      groupCountsExpanded,
     } = this.props;
 
     return (
@@ -121,7 +123,8 @@ class PushHeader extends React.Component {
       prevRunnableVisible !== runnableVisible ||
       prevCollapsed !== collapsed ||
       prevPushHealthVisibility !== pushHealthVisibility ||
-      prevFilterModel !== filterModel
+      prevFilterModel !== filterModel ||
+      prevgroupCountsExpanded !== groupCountsExpanded
     );
   }
 


### PR DESCRIPTION
Hi @camd ,

## Description of issue

In Treeherder's Jobs View, when `(+)` to expand groups, the URL is updated with `&group_state=expanded`. The push's links, however, are not immediately updated with these URL params.

## Proposed Solution

Currently, the `groupCountsExpanded` props is not being passed from Push to PushHeader component.
The solution pass this props and checks it against the previous props, in the already created `shouldComponentUpdate()` method.

(Thanks @camd for the help!)

## Testing

Two brief tests were done:
1. In the default Job View (all jobs), the `(+)` button was clicked and the push link was checked.
2. After clicking on the push link (single job), the `(+)` button was toggled to check if the groups were expanded.
![image](https://user-images.githubusercontent.com/3901809/67239459-9e669100-f425-11e9-86b3-0ad6a792c752.png)
