### PR TITLE
Bug 1566190 - Implement Taskcluster login change

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -48,6 +48,10 @@ module.exports = {
         favicon: 'ui/img/tree_open.png',
         title: 'Intermittent Failures View',
       },
+      'taskcluster-auth': {
+        entry: 'taskcluster-auth-callback/index.jsx',
+        title: 'Taskcluster Authentication',
+      },
     },
     output: '.build/',
     tests: 'tests/ui/',

--- a/tests/ui/models/jobs_test.js
+++ b/tests/ui/models/jobs_test.js
@@ -44,12 +44,14 @@ describe('JobModel', () => {
   });
 
   describe('Taskcluster actions', () => {
+    // TODO change to firefox-ci
+    const rootUrl = 'taskcluster.net';
     const decisionTaskMap = {
       '526443': { id: 'LVTawdmFR2-uJiWWS2NxSw', run: '0' },
     };
-    const tcActionsUrl =
-      'https://queue.taskcluster.net/v1/task/LVTawdmFR2-uJiWWS2NxSw/artifacts/public%2Factions.json';
-    const tcTaskUrl = 'https://queue.taskcluster.net/v1/task/TASKID';
+
+    const tcActionsUrl = `https://queue.${rootUrl}/v1/task/LVTawdmFR2-uJiWWS2NxSw/artifacts/public%2Factions.json`;
+    const tcTaskUrl = `https://queue.${rootUrl}/v1/task/TASKID`;
     const decisionTaskMapUrl = getProjectUrl(
       '/push/decisiontask/?push_ids=526443',
       'autoland',
@@ -95,6 +97,7 @@ describe('JobModel', () => {
         notify,
         1,
         decisionTaskMap,
+        true,
       );
 
       expect(fetchMock.called(decisionTaskMapUrl)).toBe(false);
@@ -103,7 +106,7 @@ describe('JobModel', () => {
     });
 
     test('retrigger calls for decision task when not passed-in', async () => {
-      await JobModel.retrigger(testJobs, currentRepo, notify, 1);
+      await JobModel.retrigger(testJobs, currentRepo, notify, 1, null, true);
 
       expect(fetchMock.called(decisionTaskMapUrl)).toBe(true);
       expect(fetchMock.called(tcTaskUrl)).toBe(false);
@@ -111,7 +114,13 @@ describe('JobModel', () => {
     });
 
     test('cancel uses passed-in decisionTask', async () => {
-      await JobModel.cancel(testJobs, currentRepo, () => {}, decisionTaskMap);
+      await JobModel.cancel(
+        testJobs,
+        currentRepo,
+        () => {},
+        decisionTaskMap,
+        true,
+      );
 
       expect(fetchMock.called(decisionTaskMapUrl)).toBe(false);
       expect(fetchMock.called(tcTaskUrl)).toBe(true);
@@ -119,7 +128,7 @@ describe('JobModel', () => {
     });
 
     test('cancel calls for decision task when not passed-in', async () => {
-      await JobModel.cancel(testJobs, currentRepo, () => {});
+      await JobModel.cancel(testJobs, currentRepo, () => {}, null, true);
 
       expect(fetchMock.called(decisionTaskMapUrl)).toBe(true);
       expect(fetchMock.called(tcTaskUrl)).toBe(true);
@@ -129,7 +138,13 @@ describe('JobModel', () => {
     test('cancelAll uses passed-in decisionTask', async () => {
       const decisionTask = { id: 'LVTawdmFR2-uJiWWS2NxSw', run: '0' };
 
-      await JobModel.cancelAll(526443, currentRepo, () => {}, decisionTask);
+      await JobModel.cancelAll(
+        526443,
+        currentRepo,
+        () => {},
+        decisionTask,
+        true,
+      );
 
       expect(fetchMock.called(decisionTaskMapUrl)).toBe(false);
       expect(fetchMock.called(tcTaskUrl)).toBe(false);
@@ -137,7 +152,7 @@ describe('JobModel', () => {
     });
 
     test('cancelAll calls for decision task when not passed-in', async () => {
-      await JobModel.cancelAll(526443, currentRepo, () => {});
+      await JobModel.cancelAll(526443, currentRepo, () => {}, null, true);
 
       expect(fetchMock.called(decisionTaskMapUrl)).toBe(true);
       expect(fetchMock.called(tcTaskUrl)).toBe(false);

--- a/treeherder/middleware.py
+++ b/treeherder/middleware.py
@@ -19,7 +19,7 @@ CSP_DIRECTIVES = [
     "font-src 'self' https://fonts.gstatic.com",
     # The `data:` is required for images that were inlined by webpack's url-loader (as an optimisation).
     "img-src 'self' data:",
-    "connect-src 'self' https://community-tc.services.mozilla.com https://firefox-ci-tc.services.mozilla.com https://*.taskcluster.net https://taskcluster-artifacts.net https://treestatus.mozilla-releng.net https://bugzilla.mozilla.org https://auth.mozilla.auth0.com",
+    "connect-src 'self' https://community-tc.services.mozilla.com https://firefox-ci-tc.services.mozilla.com https://*.taskcluster-artifacts.net https://treestatus.mozilla-releng.net https://bugzilla.mozilla.org https://auth.mozilla.auth0.com",
     # Required since auth0-js performs session renewals in an iframe.
     "frame-src 'self' https://auth.mozilla.auth0.com",
     "report-uri {}".format(reverse('csp-report')),

--- a/ui/helpers/auth.js
+++ b/ui/helpers/auth.js
@@ -7,9 +7,8 @@ export const webAuth = new WebAuth({
   clientID: 'q8fZZFfGEmSB2c5uSI8hOkKdDGXnlo5z',
   domain: 'auth.mozilla.auth0.com',
   responseType: 'id_token token',
-  audience: 'login.taskcluster.net',
   redirectUri: `${window.location.protocol}//${window.location.host}${loginCallbackUrl}`,
-  scope: 'taskcluster-credentials openid profile email',
+  scope: 'openid profile email',
 });
 
 export const userSessionFromAuthResult = authResult => {
@@ -44,7 +43,7 @@ export const userSessionFromAuthResult = authResult => {
   //   "state": "<HASH>",
   //   "expiresIn": 86400,
   //   "tokenType": "Bearer",
-  //   "scope": "openid profile email taskcluster-credentials"
+  //   "scope": "openid profile email"
   // }
   //
   // For more details, see:

--- a/ui/helpers/taskcluster.js
+++ b/ui/helpers/taskcluster.js
@@ -1,36 +1,71 @@
 import { OIDCCredentialAgent, Queue } from 'taskcluster-client-web';
+import debounce from 'lodash/debounce';
 
-import { loginRootUrl, getUserSessionUrl, tcAuthCallbackUrl } from './url';
+import { clientId, redirectURI } from '../taskcluster-auth-callback/constants';
 
-// 1) check for credentials that haven't expired in localStorage - userCredentials
-// 2) if they have expired, window.open the taskcluster-auth route
-// 3) in that component navigate to the <rootUrl>oauth/authorize to get code
-// 4) check for the code in that component, which is the redirect_uri
-// 5) if we have the code, fetch the token
-// 6) when we validate the token, store the credentials
+import { loginRootUrl, getUserSessionUrl, createQueryParams } from './url';
 
 const taskcluster = (() => {
   let credentialAgent = null;
-  let fetchingCredentials = false;
+  let _rootUrl = null;
+
+  // from the MDN crypto.getRandomValues doc
+  const secureRandom = () =>
+    window.crypto.getRandomValues(new Uint32Array(1))[0] / 4294967295;
+
+  const generateNonce = () => {
+    let value = '';
+    const characters =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+    for (let i = 0; i <= 20; i++) {
+      value += characters.charAt(
+        Math.floor(secureRandom() * characters.length),
+      );
+    }
+
+    localStorage.setItem('requestState', value);
+    return value;
+  };
+
+  const getAuthCode = debounce(
+    () => {
+      const nonce = generateNonce();
+      localStorage.setItem('requestState', nonce);
+      localStorage.setItem('tcRootUrl', _rootUrl);
+
+      const params = {
+        client_id: clientId,
+        response_type: 'code',
+        redirect_uri: redirectURI,
+        scope: 'treeherder',
+        state: nonce,
+      };
+
+      window.open(
+        `${_rootUrl}login/oauth/authorize${createQueryParams(params)}`,
+        '_blank',
+      );
+    },
+    300,
+    {
+      leading: true,
+      trailing: false,
+    },
+  );
 
   const verifyCredentials = (
     rootUrl = 'https://hassan.taskcluster-dev.net/',
   ) => {
-    const userCredentials = localStorage.getItem('userCredentials');
+    const userCredentials = JSON.parse(localStorage.getItem('userCredentials'));
+    _rootUrl = rootUrl;
 
-    if (fetchingCredentials) {
-      // in case a tc action is triggered multiple times in parallel, we
-      // only want to open one window for the authorization redirect
-      return;
+    // TODO also verify credentials haven't expired - current staging instance sets
+    // expiring to time of query: moment(userCredentials[rootUrl].expires).isAfter(moment()))
+    if (!userCredentials[rootUrl]) {
+      getAuthCode();
     }
-    if (!userCredentials) {
-      fetchingCredentials = true;
-      console.log(fetchingCredentials);
-      window.open(`${tcAuthCallbackUrl}?rootUrl=${rootUrl}`, '_blank');
-      // } else {
-      //   fetchingCredentials = false;
-    }
-    fetchingCredentials = false;
+
     // TODO create custom messages if they are null - "must verify credentials, try action again"
     return userCredentials[rootUrl];
   };

--- a/ui/helpers/taskcluster.js
+++ b/ui/helpers/taskcluster.js
@@ -49,16 +49,12 @@ const taskcluster = (() => {
       scope: 'treeherder',
       state: nonce,
     };
+    const url = `${_rootUrl}login/oauth/authorize${createQueryParams(params)}`;
 
     if (useExistingWindow) {
-      window.location.href = `${_rootUrl}login/oauth/authorize${createQueryParams(
-        params,
-      )}`;
+      window.location.href = url;
     } else {
-      window.open(
-        `${_rootUrl}login/oauth/authorize${createQueryParams(params)}`,
-        '_blank',
-      );
+      window.open(url, '_blank');
     }
   };
 

--- a/ui/helpers/taskcluster.js
+++ b/ui/helpers/taskcluster.js
@@ -45,7 +45,7 @@ const taskcluster = (() => {
       client_id: clientId,
       response_type: 'code',
       redirect_uri: redirectURI,
-      scope: 'treeherder',
+      scope: 'hooks:trigger-hook:*',
       state: nonce,
       expires: '5 minutes',
     };

--- a/ui/helpers/taskcluster.js
+++ b/ui/helpers/taskcluster.js
@@ -48,6 +48,7 @@ const taskcluster = (() => {
       redirect_uri: redirectURI,
       scope: 'treeherder',
       state: nonce,
+      expires: '5 minutes'
     };
     const url = `${_rootUrl}login/oauth/authorize${createQueryParams(params)}`;
 

--- a/ui/helpers/taskcluster.js
+++ b/ui/helpers/taskcluster.js
@@ -50,7 +50,7 @@ const taskcluster = (() => {
       expires: '5 minutes',
     };
     const url = `${_rootUrl}/login/oauth/authorize${createQueryParams(params)}`;
-    console.log(url);
+
     if (useExistingWindow) {
       window.location.href = url;
     } else {

--- a/ui/helpers/taskcluster.js
+++ b/ui/helpers/taskcluster.js
@@ -48,7 +48,7 @@ const taskcluster = (() => {
       redirect_uri: redirectURI,
       scope: 'treeherder',
       state: nonce,
-      expires: '5 minutes'
+      expires: '5 minutes',
     };
     const url = `${_rootUrl}login/oauth/authorize${createQueryParams(params)}`;
 

--- a/ui/helpers/taskcluster.js
+++ b/ui/helpers/taskcluster.js
@@ -5,14 +5,13 @@ import moment from 'moment';
 
 import { clientId, redirectURI } from '../taskcluster-auth-callback/constants';
 
-import { loginRootUrl, createQueryParams } from './url';
+import { createQueryParams } from './url';
 
 export const tcCredentialsMessage =
   'Need to retrieve or renew Taskcluster credentials before action can be performed.';
 
 const taskcluster = (() => {
-  // TODO set default to firefox-ci rootUrl
-  let _rootUrl = 'https://hassan.taskcluster-dev.net/';
+  let _rootUrl = 'https://firefox-ci-tc.services.mozilla.com';
 
   // from the MDN crypto.getRandomValues doc
   const secureRandom = () =>
@@ -50,8 +49,8 @@ const taskcluster = (() => {
       state: nonce,
       expires: '5 minutes',
     };
-    const url = `${_rootUrl}login/oauth/authorize${createQueryParams(params)}`;
-
+    const url = `${_rootUrl}/login/oauth/authorize${createQueryParams(params)}`;
+    console.log(url);
     if (useExistingWindow) {
       window.location.href = url;
     } else {
@@ -66,11 +65,7 @@ const taskcluster = (() => {
 
   const getCredentials = rootUrl => {
     const userCredentials = JSON.parse(localStorage.getItem('userCredentials'));
-    // TODO remove staging instance
-    _rootUrl =
-      rootUrl === loginRootUrl
-        ? 'https://hassan.taskcluster-dev.net/'
-        : rootUrl;
+    _rootUrl = rootUrl;
 
     if (
       userCredentials &&

--- a/ui/helpers/taskcluster.js
+++ b/ui/helpers/taskcluster.js
@@ -47,7 +47,6 @@ const taskcluster = (() => {
       redirect_uri: redirectURI,
       scope: 'hooks:trigger-hook:*',
       state: nonce,
-      expires: '5 minutes',
     };
     const url = `${_rootUrl}/login/oauth/authorize${createQueryParams(params)}`;
 

--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -37,7 +37,7 @@ export const getRunnableJobsURL = function getRunnableJobsURL(
 ) {
   const { id, run } = decisionTask;
   const tcUrl = tcLibUrls.withRootUrl(rootUrl);
-  console.log(rootUrl)
+
   const url = tcUrl.api(
     'queue',
     'v1',

--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -13,9 +13,6 @@ export const hgBaseUrl = 'https://hg.mozilla.org/';
 
 export const dxrBaseUrl = 'https://dxr.mozilla.org/';
 
-// the rootUrl of the TC deployment for which user login gets credentials
-export const loginRootUrl = 'https://taskcluster.net';
-
 export const bugsEndpoint = 'failures/';
 
 export const bugDetailsEndpoint = 'failuresbybug/';
@@ -40,14 +37,15 @@ export const getRunnableJobsURL = function getRunnableJobsURL(
 ) {
   const { id, run } = decisionTask;
   const tcUrl = tcLibUrls.withRootUrl(rootUrl);
-
-  return tcUrl.api(
+  console.log(rootUrl)
+  const url = tcUrl.api(
     'queue',
     'v1',
     `/task/${id}/runs/${run}/artifacts/public/runnable-jobs.json`,
   );
+  return url;
 };
-
+// TODO remove
 export const getUserSessionUrl = function getUserSessionUrl(oidcProvider) {
   return `https://login.taskcluster.net/v1/oidc-credentials/${oidcProvider}`;
 };

--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -32,10 +32,9 @@ export const repoEndpoint = '/repository/';
 
 export const perfSummaryEndpoint = 'performance/summary/';
 
-export const getRunnableJobsURL = function getRunnableJobsURL(
-  decisionTask,
-  rootUrl,
-) {
+export const tcAuthCallbackUrl = '/taskcluster-auth.html';
+
+export const getRunnableJobsURL = function getRunnableJobsURL(decisionTask, rootUrl) {
   const { id, run } = decisionTask;
   const tcUrl = tcLibUrls.withRootUrl(rootUrl);
 

--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -45,10 +45,6 @@ export const getRunnableJobsURL = function getRunnableJobsURL(
   );
   return url;
 };
-// TODO remove
-export const getUserSessionUrl = function getUserSessionUrl(oidcProvider) {
-  return `https://login.taskcluster.net/v1/oidc-credentials/${oidcProvider}`;
-};
 
 export const createQueryParams = function createQueryParams(params) {
   const query =

--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -34,7 +34,10 @@ export const perfSummaryEndpoint = 'performance/summary/';
 
 export const tcAuthCallbackUrl = '/taskcluster-auth.html';
 
-export const getRunnableJobsURL = function getRunnableJobsURL(decisionTask, rootUrl) {
+export const getRunnableJobsURL = function getRunnableJobsURL(
+  decisionTask,
+  rootUrl,
+) {
   const { id, run } = decisionTask;
   const tcUrl = tcLibUrls.withRootUrl(rootUrl);
 

--- a/ui/login-callback/LoginCallback.jsx
+++ b/ui/login-callback/LoginCallback.jsx
@@ -18,7 +18,6 @@ class LoginCallback extends React.PureComponent {
   }
 
   async componentDidMount() {
-    console.log(this.props)
     // make the user login if there is no access token
     if (!window.location.hash) {
       return webAuth.authorize();

--- a/ui/login-callback/LoginCallback.jsx
+++ b/ui/login-callback/LoginCallback.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { hot } from 'react-hot-loader/root';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 import AuthService from '../shared/auth/AuthService';
 import { webAuth, parseHash } from '../helpers/auth';
+import CallbackMessage from '../shared/CallbackMessage';
 
 class LoginCallback extends React.PureComponent {
   constructor(props) {
@@ -56,24 +55,12 @@ class LoginCallback extends React.PureComponent {
   }
 
   render() {
-    if (this.state.loginError) {
-      return <p>{this.state.loginError}</p>;
-    }
-
-    if (window.location.hash) {
-      return (
-        <div>
-          <span>Logging in..&nbsp;</span>
-          <FontAwesomeIcon icon={faSpinner} spin />
-        </div>
-      );
-    }
-
+    const { loginError } = this.state;
     return (
-      <div>
-        <span>Redirecting..&nbsp;</span>
-        <FontAwesomeIcon icon={faSpinner} spin />
-      </div>
+      <CallbackMessage
+        errorMessage={loginError}
+        text={window.location.hash ? 'Logging in...' : 'Redirecting...'}
+      />
     );
   }
 }

--- a/ui/login-callback/LoginCallback.jsx
+++ b/ui/login-callback/LoginCallback.jsx
@@ -18,6 +18,7 @@ class LoginCallback extends React.PureComponent {
   }
 
   async componentDidMount() {
+    console.log(this.props)
     // make the user login if there is no access token
     if (!window.location.hash) {
       return webAuth.authorize();

--- a/ui/login-callback/LoginCallback.jsx
+++ b/ui/login-callback/LoginCallback.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { hot } from 'react-hot-loader/root';
+import moment from 'moment';
 
 import AuthService from '../shared/auth/AuthService';
 import { webAuth, parseHash } from '../helpers/auth';
 import CallbackMessage from '../shared/CallbackMessage';
+import taskcluster from '../helpers/taskcluster';
 
 class LoginCallback extends React.PureComponent {
   constructor(props) {
@@ -26,7 +28,6 @@ class LoginCallback extends React.PureComponent {
     // a postMessage back, and that's it.
     if (window !== window.top) {
       window.parent.postMessage(window.location.hash, window.origin);
-
       return;
     }
 
@@ -35,13 +36,7 @@ class LoginCallback extends React.PureComponent {
 
       if (authResult.accessToken) {
         await this.authService.saveCredentialsFromAuthResult(authResult);
-
-        if (window.opener) {
-          window.close();
-        } else {
-          // handle case where the user navigates directly to the login route
-          window.location.href = window.origin;
-        }
+        this.checkTaskclusterCredentials();
       }
     } catch (err) {
       this.setError(err);
@@ -53,6 +48,25 @@ class LoginCallback extends React.PureComponent {
       loginError: err.message ? err.message : err.errorDescription,
     });
   }
+
+  checkTaskclusterCredentials = () => {
+    const userCredentials = JSON.parse(localStorage.getItem('userCredentials'));
+    // TODO update with firefox-ci rootUrl
+    const defaultRootUrl = 'https://hassan.taskcluster-dev.net/';
+
+    if (
+      !userCredentials ||
+      !userCredentials[defaultRootUrl] ||
+      !moment(userCredentials[defaultRootUrl].expires).isAfter(moment())
+    ) {
+      taskcluster.getAuthCode(true);
+    } else if (window.opener) {
+      window.close();
+    } else {
+      // handle case where the user navigates directly to the login route
+      window.location.href = window.origin;
+    }
+  };
 
   render() {
     const { loginError } = this.state;

--- a/ui/login-callback/LoginCallback.jsx
+++ b/ui/login-callback/LoginCallback.jsx
@@ -51,8 +51,7 @@ class LoginCallback extends React.PureComponent {
 
   checkTaskclusterCredentials = () => {
     const userCredentials = JSON.parse(localStorage.getItem('userCredentials'));
-    // TODO update with firefox-ci rootUrl
-    const defaultRootUrl = 'https://hassan.taskcluster-dev.net/';
+    const defaultRootUrl = 'https://firefox-ci-tc.services.mozilla.com';
 
     if (
       !userCredentials ||

--- a/ui/login-callback/index.jsx
+++ b/ui/login-callback/index.jsx
@@ -2,6 +2,6 @@ import React from 'react';
 import { render } from 'react-dom';
 
 import LoginCallback from './LoginCallback';
-import '../css/login.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
 
 render(<LoginCallback />, document.getElementById('root'));

--- a/ui/models/job.js
+++ b/ui/models/job.js
@@ -89,6 +89,7 @@ export default class JobModel {
     notify,
     times = 1,
     decisionTaskIdMap = null,
+    testMode = false,
   ) {
     const jobTerm = jobs.length > 1 ? 'jobs' : 'job';
     try {
@@ -103,8 +104,8 @@ export default class JobModel {
       for (const [key, value] of Object.entries(uniquePerPushJobs)) {
         const decisionTaskId = taskIdMap[key].id;
 
-        TaskclusterModel.load(decisionTaskId, null, currentRepo).then(
-          async results => {
+        TaskclusterModel.load(decisionTaskId, null, currentRepo, testMode)
+          .then(async results => {
             const actionTaskId = slugid();
             const taskLabels = value.map(job => job.job_type_name);
 
@@ -134,6 +135,7 @@ export default class JobModel {
               input: actionInput,
               staticActionVariables: results.staticActionVariables,
               currentRepo,
+              testMode,
             })
               .then(() =>
                 notify(
@@ -147,8 +149,8 @@ export default class JobModel {
                   { sticky: true },
                 );
               });
-          },
-        );
+          })
+          .catch(error => notify(error.message, 'danger', { sticky: true }));
       }
     } catch (e) {
       notify(
@@ -159,15 +161,26 @@ export default class JobModel {
     }
   }
 
-  static async cancelAll(pushId, currentRepo, notify, decisionTask) {
+  static async cancelAll(
+    pushId,
+    currentRepo,
+    notify,
+    decisionTask,
+    testMode = false,
+  ) {
     const { id: decisionTaskId } =
       decisionTask || (await PushModel.getDecisionTaskId(pushId, notify));
-
-    const results = await TaskclusterModel.load(
-      decisionTaskId,
-      null,
-      currentRepo,
-    );
+    let results;
+    try {
+      results = await TaskclusterModel.load(
+        decisionTaskId,
+        null,
+        currentRepo,
+        testMode,
+      );
+    } catch (e) {
+      notify(e.message, 'danger', { sticky: true });
+    }
 
     try {
       const cancelAllTask = getAction(results.actions, 'cancel-all');
@@ -178,6 +191,7 @@ export default class JobModel {
         input: {},
         staticActionVariables: results.staticActionVariables,
         currentRepo,
+        testMode,
       });
     } catch (e) {
       // The full message is too large to fit in a Treeherder
@@ -188,7 +202,13 @@ export default class JobModel {
     notify('Request sent to cancel all jobs via action.json', 'success');
   }
 
-  static async cancel(jobs, currentRepo, notify, decisionTaskIdMap) {
+  static async cancel(
+    jobs,
+    currentRepo,
+    notify,
+    decisionTaskIdMap = null,
+    testMode = false,
+  ) {
     const jobTerm = jobs.length > 1 ? 'jobs' : 'job';
     const taskIdMap =
       decisionTaskIdMap ||
@@ -206,11 +226,17 @@ export default class JobModel {
       /* eslint-disable no-await-in-loop */
       for (const job of jobs) {
         const decisionTaskId = taskIdMap[job.push_id].id;
-        const results = await TaskclusterModel.load(
-          decisionTaskId,
-          job,
-          currentRepo,
-        );
+        let results;
+        try {
+          results = await TaskclusterModel.load(
+            decisionTaskId,
+            job,
+            currentRepo,
+            testMode,
+          );
+        } catch (e) {
+          notify(e.message, 'danger', { sticky: true });
+        }
 
         try {
           const cancelTask = getAction(results.actions, 'cancel');
@@ -222,6 +248,7 @@ export default class JobModel {
             input: {},
             staticActionVariables: results.staticActionVariables,
             currentRepo,
+            testMode,
           });
         } catch (e) {
           // The full message is too large to fit in a Treeherder

--- a/ui/models/job.js
+++ b/ui/models/job.js
@@ -124,7 +124,7 @@ export default class JobModel {
                 tasks: taskLabels,
               };
             }
-            console.log('retrigger in TaskclusterJobModel');
+
             await TaskclusterModel.submit({
               action: retriggerAction,
               actionTaskId,

--- a/ui/models/job.js
+++ b/ui/models/job.js
@@ -124,7 +124,7 @@ export default class JobModel {
                 tasks: taskLabels,
               };
             }
-
+            console.log('retrigger in TaskclusterJobModel');
             await TaskclusterModel.submit({
               action: retriggerAction,
               actionTaskId,

--- a/ui/models/taskcluster.js
+++ b/ui/models/taskcluster.js
@@ -60,25 +60,26 @@ export default class TaskclusterModel {
       const hookPayload = jsone(action.hookPayload, context);
       const { hookId, hookGroupId } = action;
       const auth = new Auth({ rootUrl: currentRepo.tc_root_url });
-      const hooks = new Hooks({
-        credentialAgent: taskcluster.getAgent(),
-        rootUrl: currentRepo.tc_root_url,
-      });
-      const decisionTask = await queue.task(decisionTaskId);
-      const expansion = await auth.expandScopes({
-        scopes: decisionTask.scopes,
-      });
-      const expression = `in-tree:hook-action:${hookGroupId}/${hookId}`;
+      taskcluster.getAgent();
+      // const hooks = new Hooks({
+      //   credentialAgent: taskcluster.getAgent(),
+      //   rootUrl: currentRepo.tc_root_url,
+      // });
+      // const decisionTask = await queue.task(decisionTaskId);
+      // const expansion = await auth.expandScopes({
+      //   scopes: decisionTask.scopes,
+      // });
+      // const expression = `in-tree:hook-action:${hookGroupId}/${hookId}`;
 
-      if (!satisfiesExpression(expansion.scopes, expression)) {
-        throw new Error(
-          `Action is misconfigured: decision task's scopes do not satisfy ${expression}`,
-        );
-      }
+      // if (!satisfiesExpression(expansion.scopes, expression)) {
+      //   throw new Error(
+      //     `Action is misconfigured: decision task's scopes do not satisfy ${expression}`,
+      //   );
+      // }
 
-      const result = await hooks.triggerHook(hookGroupId, hookId, hookPayload);
+      // const result = await hooks.triggerHook(hookGroupId, hookId, hookPayload);
 
-      return result.status.taskId;
+      // return result.status.taskId;
     }
   }
 

--- a/ui/shared/CallbackMessage.jsx
+++ b/ui/shared/CallbackMessage.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Row } from 'reactstrap';
+
+import ErrorMessages from './ErrorMessages';
+
+const CallBackMessage = ({ errorMessage, text }) => (
+  <div className="pt-5">
+    {errorMessage ? (
+      <ErrorMessages failureMessage={errorMessage} />
+    ) : (
+      <Row className="justify-content-center">
+        <p className="lead text-center">{text}</p>
+      </Row>
+    )}
+  </div>
+);
+
+CallBackMessage.propTypes = {
+  errorMessage: PropTypes.string,
+  text: PropTypes.string.isRequired,
+};
+
+CallBackMessage.defaultProps = {
+  errorMessage: '',
+};
+
+export default CallBackMessage;

--- a/ui/shared/CallbackMessage.jsx
+++ b/ui/shared/CallbackMessage.jsx
@@ -4,7 +4,7 @@ import { Row } from 'reactstrap';
 
 import ErrorMessages from './ErrorMessages';
 
-const CallBackMessage = ({ errorMessage, text }) => (
+const CallbackMessage = ({ errorMessage, text }) => (
   <div className="pt-5">
     {errorMessage ? (
       <ErrorMessages failureMessage={errorMessage} />
@@ -16,13 +16,13 @@ const CallBackMessage = ({ errorMessage, text }) => (
   </div>
 );
 
-CallBackMessage.propTypes = {
+CallbackMessage.propTypes = {
   errorMessage: PropTypes.string,
   text: PropTypes.string.isRequired,
 };
 
-CallBackMessage.defaultProps = {
+CallbackMessage.defaultProps = {
   errorMessage: '',
 };
 
-export default CallBackMessage;
+export default CallbackMessage;

--- a/ui/shared/ErrorMessages.jsx
+++ b/ui/shared/ErrorMessages.jsx
@@ -48,10 +48,7 @@ class ErrorMessages extends React.PureComponent {
 }
 
 ErrorMessages.propTypes = {
-  failureMessage: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.arrayOf(PropTypes.string),
-  ]),
+  failureMessage: PropTypes.string,
   errorMessages: PropTypes.arrayOf(PropTypes.string),
 };
 

--- a/ui/shared/auth/AuthService.js
+++ b/ui/shared/auth/AuthService.js
@@ -3,7 +3,6 @@ import {
   renew,
   loggedOutUser,
 } from '../../helpers/auth';
-import taskcluster from '../../helpers/taskcluster';
 import { getApiUrl } from '../../helpers/url';
 import UserModel from '../../models/user';
 
@@ -100,7 +99,5 @@ export default class AuthService {
 
     localStorage.setItem('userSession', JSON.stringify(userSession));
     localStorage.setItem('user', JSON.stringify(user));
-
-    taskcluster.updateAgent();
   }
 }

--- a/ui/shared/auth/Login.jsx
+++ b/ui/shared/auth/Login.jsx
@@ -6,17 +6,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUser } from '@fortawesome/free-solid-svg-icons';
 
 import { loggedOutUser } from '../../helpers/auth';
-import taskcluster from '../../helpers/taskcluster';
 import { getApiUrl, loginCallbackUrl } from '../../helpers/url';
 import UserModel from '../../models/user';
 
 import AuthService from './AuthService';
 
-/**
- * This component handles logging in to Taskcluster Authentication
- *
- * See: https://docs.taskcluster.net/manual/3rdparty
- */
+// This component handles user Authentication with Auth0
+
 class Login extends React.Component {
   constructor(props) {
     super(props);
@@ -58,8 +54,6 @@ class Login extends React.Component {
     const { setUser } = this.props;
 
     this.authService.logout();
-    // logging out will not trigger a storage event since localStorage is being set by the same window
-    taskcluster.updateAgent();
     setUser(loggedOutUser);
   };
 
@@ -75,9 +69,6 @@ class Login extends React.Component {
         // Show the user as logged out in all other opened tabs
         this.setLoggedOut();
       }
-    } else if (e.key === 'userSession') {
-      // used when a different tab updates userSession,
-      taskcluster.updateAgent();
     }
   };
 

--- a/ui/taskcluster-auth-callback/TaskclusterCallback.jsx
+++ b/ui/taskcluster-auth-callback/TaskclusterCallback.jsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { Row } from 'reactstrap';
+
+import {
+  createQueryParams,
+  tcAuthCallbackUrl,
+  parseQueryParams,
+} from '../helpers/url';
+import { getData } from '../helpers/http';
+import ErrorMessages from '../shared/ErrorMessages';
+
+const tcClientIdMap = {
+  'https://treeherder.mozilla.org': 'production',
+  'https://treeherder.allizom.org': 'stage',
+  'https://treeherder-prototype.herokuapp.com': 'dev',
+  'http://localhost:5000': 'localhost',
+};
+
+const clientId = `treeherder-${tcClientIdMap[window.location.origin]}`;
+const redirectURI = `${window.location.origin}${tcAuthCallbackUrl}`;
+const errorMessage = `There was a problem verifying your Taskcluster credentials. Please try again later.`;
+
+export default class TaskclusterCallback extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      errorMessage: '',
+      success: false,
+    };
+  }
+
+  componentDidMount() {
+    // We're not using react router's location prop for simplicity;
+    // we can't provide taskcluster with a redirect URI with a hash/fragment
+    // per oath2 protocol which would be used by the hash router for parsing query params
+    const { code, rootUrl, state } = parseQueryParams(
+      window.location.search || window.location.hash,
+    );
+    const requestState = localStorage.getItem('requestState');
+
+    if (!code && rootUrl) {
+      localStorage.setItem('tcRootUrl', rootUrl);
+      const nonce = this.generateNonce();
+      this.getAuthCode(rootUrl, nonce);
+    } else if (code && requestState && requestState === state) {
+      this.getCredentials(code);
+    } else {
+      this.setState({
+        errorMessage,
+      });
+    }
+  }
+
+  componentWillUnmount() {
+    localStorage.removeItem('userCredentials');
+  }
+
+  generateNonce = () => {
+    let value = '';
+    const characters =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+    for (let i = 0; i <= 20; i++) {
+      value += characters.charAt(
+        Math.floor(this.secureRandom() * characters.length),
+      );
+    }
+
+    localStorage.setItem('requestState', value);
+    return value;
+  };
+
+  // from the MDN crypto.getRandomValues doc
+  secureRandom = () =>
+    window.crypto.getRandomValues(new Uint32Array(1))[0] / 4294967295;
+
+  getAuthCode = (rootUrl, state) => {
+    const params = {
+      client_id: clientId,
+      response_type: 'code',
+      redirect_uri: redirectURI,
+      scope: 'treeherder',
+      state,
+    };
+
+    window.location.href = `${rootUrl}login/oauth/authorize${createQueryParams(
+      params,
+    )}`;
+  };
+
+  getCredentials = async code => {
+    const rootUrl = localStorage.getItem('tcRootUrl');
+    if (!rootUrl) {
+      this.setState({ errorMessage });
+      return;
+    }
+    let response = await this.fetchToken(code, rootUrl);
+
+    if (response.failureStatus) {
+      this.setState({ errorMessage });
+      return;
+    }
+    response = await this.fetchCredentials(response.data.access_token, rootUrl);
+
+    if (response.failureStatus) {
+      this.setState({ errorMessage });
+    } else {
+      localStorage.setItem('userCredentials', { rootUrl: response.data });
+      this.setState({ success: true }, () => {
+        if (window.opener) {
+          window.close();
+        } else {
+          // handle case where the user navigates directly to the login route
+          window.location.href = window.origin;
+          console.log(window.location)
+        }
+      });
+    }
+  };
+
+  fetchToken = async (code, rootUrl) => {
+    const options = {
+      method: 'POST',
+      body: `grant_type=authorization_code&code=${code}&redirect_uri=${redirectURI}&client_id=${clientId}`,
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    };
+    const response = await getData(`${rootUrl}login/oauth/token`, options);
+    return response;
+  };
+
+  fetchCredentials = async (token, rootUrl) => {
+    const options = {
+      mode: 'cors',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    };
+    const response = await getData(
+      `${rootUrl}login/oauth/credentials`,
+      options,
+    );
+    return response;
+  };
+
+  render() {
+    const { errorMessage, success } = this.state;
+
+    return (
+      <div className="pt-5">
+        {errorMessage ? (
+          <ErrorMessages failureMessage={errorMessage} />
+        ) : (
+          <Row className="justify-content-center">
+            <p className="lead text-center">
+              {!success
+                ? 'Getting Taskcluster credentials...'
+                : 'Successfully retrieved credentials. Redirecting...'}
+            </p>
+            {/* <div>
+              <FontAwesomeIcon icon={faSpinner} spin />
+            </div> */}
+          </Row>
+        )}
+      </div>
+    );
+  }
+}

--- a/ui/taskcluster-auth-callback/TaskclusterCallback.jsx
+++ b/ui/taskcluster-auth-callback/TaskclusterCallback.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Row } from 'reactstrap';
 
 import { parseQueryParams } from '../helpers/url';
 import { getData } from '../helpers/http';
-import ErrorMessages from '../shared/ErrorMessages';
+import CallbackMessage from '../shared/CallbackMessage';
 
 import { clientId, redirectURI, errorMessage } from './constants';
 
@@ -17,9 +16,9 @@ export default class TaskclusterCallback extends React.PureComponent {
   }
 
   componentDidMount() {
-    // We're not using react router's location prop for simplicity;
-    // we can't provide taskcluster with a redirect URI with a hash/fragment
-    // per oath2 protocol which would be used by the hash router for parsing query params
+    // We're not using react router's location prop because we can't provide
+    // taskcluster with a redirect URI that contains a fragment (hash) per
+    // oath2 protocol (which is used by the hash router for parsing query params)
     const { code, state } = parseQueryParams(window.location.search);
     const requestState = localStorage.getItem('requestState');
 
@@ -85,17 +84,10 @@ export default class TaskclusterCallback extends React.PureComponent {
   render() {
     const { errorMessage } = this.state;
     return (
-      <div className="pt-5">
-        {errorMessage ? (
-          <ErrorMessages failureMessage={errorMessage} />
-        ) : (
-          <Row className="justify-content-center">
-            <p className="lead text-center">
-              Getting Taskcluster credentials...
-            </p>
-          </Row>
-        )}
-      </div>
+      <CallbackMessage
+        errorMessage={errorMessage}
+        text="Getting Taskcluster credentials..."
+      />
     );
   }
 }

--- a/ui/taskcluster-auth-callback/TaskclusterCallback.jsx
+++ b/ui/taskcluster-auth-callback/TaskclusterCallback.jsx
@@ -47,12 +47,16 @@ export default class TaskclusterCallback extends React.PureComponent {
 
     if (response.failureStatus) {
       this.setState({ errorMessage });
-    } else {
-      localStorage.setItem(
-        'userCredentials',
-        JSON.stringify({ [rootUrl]: response.data }),
-      );
+      return;
+    }
+    localStorage.setItem(
+      'userCredentials',
+      JSON.stringify({ [rootUrl]: response.data }),
+    );
+    if (window.opener) {
       window.close();
+    } else {
+      window.location.href = window.origin;
     }
   };
 
@@ -62,8 +66,7 @@ export default class TaskclusterCallback extends React.PureComponent {
       body: `grant_type=authorization_code&code=${code}&redirect_uri=${redirectURI}&client_id=${clientId}`,
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     };
-    const response = await getData(`${rootUrl}login/oauth/token`, options);
-    return response;
+    return getData(`${rootUrl}login/oauth/token`, options);
   };
 
   fetchCredentials = async (token, rootUrl) => {
@@ -74,11 +77,7 @@ export default class TaskclusterCallback extends React.PureComponent {
         'Content-Type': 'application/json',
       },
     };
-    const response = await getData(
-      `${rootUrl}login/oauth/credentials`,
-      options,
-    );
-    return response;
+    return getData(`${rootUrl}login/oauth/credentials`, options);
   };
 
   render() {

--- a/ui/taskcluster-auth-callback/TaskclusterCallback.jsx
+++ b/ui/taskcluster-auth-callback/TaskclusterCallback.jsx
@@ -66,7 +66,7 @@ export default class TaskclusterCallback extends React.PureComponent {
       body: `grant_type=authorization_code&code=${code}&redirect_uri=${redirectURI}&client_id=${clientId}`,
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     };
-    return getData(`${rootUrl}login/oauth/token`, options);
+    return getData(`${rootUrl}/login/oauth/token`, options);
   };
 
   fetchCredentials = async (token, rootUrl) => {
@@ -77,7 +77,7 @@ export default class TaskclusterCallback extends React.PureComponent {
         'Content-Type': 'application/json',
       },
     };
-    return getData(`${rootUrl}login/oauth/credentials`, options);
+    return getData(`${rootUrl}/login/oauth/credentials`, options);
   };
 
   render() {

--- a/ui/taskcluster-auth-callback/constants.js
+++ b/ui/taskcluster-auth-callback/constants.js
@@ -1,0 +1,14 @@
+import { tcAuthCallbackUrl } from '../helpers/url';
+
+export const tcClientIdMap = {
+  'https://treeherder.mozilla.org': 'production',
+  'https://treeherder.allizom.org': 'stage',
+  'https://treeherder-prototype.herokuapp.com': 'dev',
+  'http://localhost:5000': 'localhost',
+};
+
+export const clientId = `treeherder-${tcClientIdMap[window.location.origin]}`;
+
+export const redirectURI = `${window.location.origin}${tcAuthCallbackUrl}`;
+
+export const errorMessage = `There was a problem verifying your Taskcluster credentials. Please try again later.`;

--- a/ui/taskcluster-auth-callback/index.jsx
+++ b/ui/taskcluster-auth-callback/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from 'react-dom';
+import 'bootstrap/dist/css/bootstrap.min.css';
+
+import TaskClusterCallback from './TaskclusterCallback';
+
+render(<TaskClusterCallback />, document.getElementById('root'));


### PR DESCRIPTION
This pr decouples taskcluster credentials from Auth0, which is kept strictly for user login and session management. _For reasons mentioned below, please only review the new login and taskcluster credential flows._
How to test these changes:
1) Login in to Treeherder - you'll need to grant permission to treeherder.mozilla.org and login continues as usual.

2) Perform a taskcluster action that requires credentials, like triggering a job. A new window will open redirecting the user to the taskcluster staging instance, and requires a login with auth0 or github. This won't show every time and I think @helfi92 had mentioned that someone is working on streamlining this for firefox-ci. After credentials are saved the window will close. 

3) You'll also notice the TC action probably won't work because the staging instance doesn't have the same tasks as taskcluster.net so performing an action with the new credentials won't work. (Note: Hassan did set up an example task that I successfully queried with the new credentials)

4) If you try to perform an action again, it shouldn't open the window to retrieve credentials unless they've expired.

I'm not planning on merging this until the taskcluster.net switch off on Nov 9th. I'll coordinate with the Taskcluster team so I can update this pr with the new rootUrls and have sheriffs test all Taskcluster actions before doing a quick merge/prod push. We'll probably also want to give Sheriff's a heads up about the likely down time between when taskcluster.net is shut off and the new instances are active (and due to pulse ingestion with the new rootUrls).

I've modeled the `TaskClusterCallback` component after the `LoginCallback` component and updated the messaging to keep it consistent for both. I've launched this to prototype for testing. 

@helfi92 or @djmitche if one of you would like to give this a look that'd be appreciated.

FYI @karlht 

Edit: If people are happy with this flow, I'll see about adding a few tests.