### PR TITLE
Bug 513583 - Enable eslint a11y rules

### DIFF
--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -52,13 +52,13 @@ h1 {
   border-left: 10px solid;
 }
 
-.graph-legend-card span p {
+.graph-legend-card {
   word-wrap: break-word;
   cursor: pointer;
   font-size: 13px;
 }
 
-.graph-legend-card > p:hover {
+.graph-legend-card:hover {
   text-decoration: underline;
 }
 

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -52,7 +52,7 @@ h1 {
   border-left: 10px solid;
 }
 
-.graph-legend-card > p {
+.graph-legend-card span p {
   word-wrap: break-word;
   cursor: pointer;
   font-size: 13px;

--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -440,6 +440,12 @@ fieldset[disabled] .btn-view-nav-closed.active {
   padding-top: 0.5rem;
 }
 
+.dropdown-menu li button {
+  background: transparent;
+  border: 0;
+  padding: 0;
+}
+
 #infra-dropdown {
   min-width: 21rem;
 }

--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -440,12 +440,6 @@ fieldset[disabled] .btn-view-nav-closed.active {
   padding-top: 0.5rem;
 }
 
-.dropdown-menu li button {
-  background: transparent;
-  border: 0;
-  padding: 0;
-}
-
 #infra-dropdown {
   min-width: 21rem;
 }

--- a/ui/css/treeherder-test-view.css
+++ b/ui/css/treeherder-test-view.css
@@ -131,6 +131,11 @@ main .progress {
 
 .test {
   cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.test:hover {
+  text-decoration: none;
 }
 
 td.bug-count {

--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -15,6 +15,7 @@
 }
 
 .dropdown-item.disabled {
+  padding: 0.25rem 1.5rem;
   cursor: not-allowed;
   font-style: italic;
 }

--- a/ui/intermittent-failures/BugColumn.jsx
+++ b/ui/intermittent-failures/BugColumn.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
@@ -33,6 +31,8 @@ function BugColumn({
       </a>
       &nbsp;
       <span
+        role="button"
+        tabIndex="-1"
         className="ml-1 small-text bug-details"
         onClick={() => updateAppState({ graphData, tableData })}
       >

--- a/ui/intermittent-failures/BugColumn.jsx
+++ b/ui/intermittent-failures/BugColumn.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { Button } from 'reactstrap';
 import PropTypes from 'prop-types';
 
 import { getBugUrl } from '../helpers/url';
@@ -30,10 +31,9 @@ function BugColumn({
         {id}
       </a>
       &nbsp;
-      <span
-        role="button"
-        tabIndex="-1"
-        className="ml-1 small-text bug-details"
+      <Button
+        className="ml-1 p-0 bg-transparent border-0 small-text bug-details"
+        size="sm"
         onClick={() => updateAppState({ graphData, tableData })}
       >
         <Link
@@ -45,7 +45,7 @@ function BugColumn({
         >
           details
         </Link>
-      </span>
+      </Button>
     </div>
   );
 }

--- a/ui/job-view/App.jsx
+++ b/ui/job-view/App.jsx
@@ -4,6 +4,7 @@ import SplitPane from 'react-split-pane';
 import pick from 'lodash/pick';
 import isEqual from 'lodash/isEqual';
 import { Provider } from 'react-redux';
+import { Button } from 'reactstrap';
 
 import { thFavicons, thEvents } from '../helpers/constants';
 import ShortcutTable from '../shared/ShortcutTable';
@@ -384,9 +385,7 @@ class App extends React.Component {
             </SplitPane>
             <Notifications />
             {showShortCuts && (
-              <div
-                role="button"
-                tabIndex="-1"
+              <Button
                 id="onscreen-overlay"
                 onClick={() => this.showOnScreenShortcuts(false)}
               >
@@ -395,7 +394,7 @@ class App extends React.Component {
                     <ShortcutTable />
                   </div>
                 </div>
-              </div>
+              </Button>
             )}
           </KeyboardShortcuts>
         </Provider>

--- a/ui/job-view/App.jsx
+++ b/ui/job-view/App.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import { hot } from 'react-hot-loader/root';
 import SplitPane from 'react-split-pane';
@@ -387,6 +385,8 @@ class App extends React.Component {
             <Notifications />
             {showShortCuts && (
               <div
+                role="button"
+                tabIndex="-1"
                 id="onscreen-overlay"
                 onClick={() => this.showOnScreenShortcuts(false)}
               >

--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -399,6 +397,8 @@ class PinBoard extends React.Component {
               {Object.values(pinnedJobs).map(job => (
                 <span className="btn-group" key={job.id}>
                   <span
+                    role="button"
+                    tabIndex="-1"
                     className={`btn pinned-job ${getBtnClass(
                       job.resultStatus,
                       job.failure_classification_id,
@@ -414,6 +414,8 @@ class PinBoard extends React.Component {
                     {job.job_type_symbol}
                   </span>
                   <span
+                    role="button"
+                    tabIndex="-1"
                     className={`btn btn-ltgray pinned-job-close-btn ${
                       selectedJobId === job.id
                         ? 'btn-lg selected-job'
@@ -433,6 +435,8 @@ class PinBoard extends React.Component {
           <div id="pinboard-related-bugs">
             <div className="content">
               <span
+                role="button"
+                tabIndex="-1"
                 id="add-related-bug-button"
                 onClick={() => this.toggleEnterBugNumber(!enteringBugNumber)}
                 className="pointable"
@@ -446,6 +450,8 @@ class PinBoard extends React.Component {
               </span>
               {!this.hasPinnedJobBugs() && (
                 <span
+                  role="button"
+                  tabIndex="-1"
                   className="pinboard-preload-txt pinboard-related-bug-preload-txt"
                   onClick={() => {
                     this.toggleEnterBugNumber(!enteringBugNumber);
@@ -485,6 +491,8 @@ class PinBoard extends React.Component {
                       <em>{bug.id}</em>
                     </a>
                     <span
+                      role="button"
+                      tabIndex="-1"
                       className="btn btn-ltgray btn-xs pinned-job-close-btn"
                       onClick={() => removeBug(bug.id)}
                       title="remove this bug"

--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Button, FormGroup, Input, FormFeedback } from 'reactstrap';
+import {
+  Button,
+  FormGroup,
+  Input,
+  FormFeedback,
+  ButtonGroup,
+} from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlusSquare, faTimes } from '@fortawesome/free-solid-svg-icons';
 
@@ -395,11 +401,9 @@ class PinBoard extends React.Component {
                 </span>
               )}
               {Object.values(pinnedJobs).map(job => (
-                <span className="btn-group" key={job.id}>
-                  <span
-                    role="button"
-                    tabIndex="-1"
-                    className={`btn pinned-job ${getBtnClass(
+                <ButtonGroup key={job.id}>
+                  <Button
+                    className={`bg-transparent text-body pinned-job ${getBtnClass(
                       job.resultStatus,
                       job.failure_classification_id,
                     )} ${
@@ -412,11 +416,9 @@ class PinBoard extends React.Component {
                     data-job-id={job.job_id}
                   >
                     {job.job_type_symbol}
-                  </span>
-                  <span
-                    role="button"
-                    tabIndex="-1"
-                    className={`btn btn-ltgray pinned-job-close-btn ${
+                  </Button>
+                  <Button
+                    className={`bg-transparent btn-ltgray pinned-job-close-btn ${
                       selectedJobId === job.id
                         ? 'btn-lg selected-job'
                         : 'btn-xs'
@@ -425,8 +427,8 @@ class PinBoard extends React.Component {
                     title="un-pin this job"
                   >
                     <FontAwesomeIcon icon={faTimes} title="Unpin job" />
-                  </span>
-                </span>
+                  </Button>
+                </ButtonGroup>
               ))}
             </div>
           </div>
@@ -434,12 +436,10 @@ class PinBoard extends React.Component {
           {/* Related bugs */}
           <div id="pinboard-related-bugs">
             <div className="content">
-              <span
-                role="button"
-                tabIndex="-1"
+              <Button
                 id="add-related-bug-button"
                 onClick={() => this.toggleEnterBugNumber(!enteringBugNumber)}
-                className="pointable"
+                className="pointable p-0 bg-transparent border-0"
                 title="Add a related bug"
               >
                 <FontAwesomeIcon
@@ -447,18 +447,17 @@ class PinBoard extends React.Component {
                   className="add-related-bugs-icon"
                   title="Add related bugs"
                 />
-              </span>
+              </Button>
               {!this.hasPinnedJobBugs() && (
-                <span
-                  role="button"
-                  tabIndex="-1"
-                  className="pinboard-preload-txt pinboard-related-bug-preload-txt"
+                <Button
+                  size="sm"
+                  className="p-0 bg-transparent border-0 pinboard-preload-txt pinboard-related-bug-preload-txt"
                   onClick={() => {
                     this.toggleEnterBugNumber(!enteringBugNumber);
                   }}
                 >
                   click to add a related bug
-                </span>
+                </Button>
               )}
               {enteringBugNumber && (
                 <span className="add-related-bugs-form">
@@ -490,15 +489,13 @@ class PinBoard extends React.Component {
                     >
                       <em>{bug.id}</em>
                     </a>
-                    <span
-                      role="button"
-                      tabIndex="-1"
-                      className="btn btn-ltgray btn-xs pinned-job-close-btn"
+                    <Button
+                      className="btn-light-bordered bg-transparent btn-ltgray btn-xs pinned-job-close-btn"
                       onClick={() => removeBug(bug.id)}
                       title="remove this bug"
                     >
                       <FontAwesomeIcon icon={faTimes} title="Remove bug" />
-                    </span>
+                    </Button>
                   </span>
                 </span>
               ))}

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -533,6 +531,8 @@ class ActionBar extends React.PureComponent {
               >
                 <li>
                   <span
+                    role="button"
+                    tabIndex="-1"
                     id="backfill-btn"
                     className={`btn dropdown-item ${
                       !user.isLoggedIn || !this.canBackfill() ? 'disabled' : ''

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -509,6 +509,7 @@ class ActionBar extends React.PureComponent {
               </DropdownToggle>
               <DropdownMenu className="dropdown-menu actionbar-menu dropdown-menu-right">
                 <DropdownItem
+                  tag="a"
                   id="backfill-btn"
                   className={`${
                     !user.isLoggedIn || !this.canBackfill() ? 'disabled' : ''
@@ -521,6 +522,7 @@ class ActionBar extends React.PureComponent {
                 {selectedJobFull.task_id && (
                   <React.Fragment>
                     <DropdownItem
+                      tag="a"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="pl-4"
@@ -532,6 +534,7 @@ class ActionBar extends React.PureComponent {
                       Inspect Task
                     </DropdownItem>
                     <DropdownItem
+                      tag="a"
                       className="py-2"
                       onClick={this.createInteractiveTask}
                     >
@@ -539,6 +542,7 @@ class ActionBar extends React.PureComponent {
                     </DropdownItem>
                     {isPerfTest(selectedJobFull) && (
                       <DropdownItem
+                        tag="a"
                         className="py-2"
                         onClick={this.createGeckoProfile}
                       >
@@ -546,11 +550,15 @@ class ActionBar extends React.PureComponent {
                       </DropdownItem>
                     )}
                     {isTestIsolatable(selectedJobFull) && (
-                      <DropdownItem className="py-2" onClick={this.isolateJob}>
+                      <DropdownItem
+                        tag="a"
+                        className="py-2"
+                        onClick={this.isolateJob}
+                      >
                         Run Isolation Tests
                       </DropdownItem>
                     )}
-                    <DropdownItem onClick={this.toggleCustomJobActions}>
+                    <DropdownItem tag="a" onClick={this.toggleCustomJobActions}>
                       Custom Action...
                     </DropdownItem>
                   </React.Fragment>

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Button } from 'reactstrap';
+import {
+  Button,
+  Dropdown,
+  DropdownToggle,
+  DropdownMenu,
+  DropdownItem,
+} from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChartBar } from '@fortawesome/free-regular-svg-icons';
 import {
@@ -36,6 +42,7 @@ class ActionBar extends React.PureComponent {
 
     this.state = {
       customJobActionsShowing: false,
+      dropdownIsOpen: false,
     };
   }
 
@@ -417,6 +424,11 @@ class ActionBar extends React.PureComponent {
     this.setState({ customJobActionsShowing: !customJobActionsShowing });
   };
 
+  dropdownToggle = () => {
+    const { dropdownIsOpen } = this.state;
+    this.setState({ dropdownIsOpen: !dropdownIsOpen });
+  };
+
   render() {
     const {
       selectedJobFull,
@@ -514,35 +526,29 @@ class ActionBar extends React.PureComponent {
                 </Button>
               </li>
             )}
-            <li className="dropdown ml-auto">
-              <Button
+            <Dropdown
+              isOpen={this.state.dropdownIsOpen}
+              toggle={this.dropdownToggle}
+              className="ml-auto"
+            >
+              <DropdownToggle
                 id="actionbar-menu-btn"
                 title="Other job actions"
-                aria-haspopup="true"
-                aria-expanded="false"
                 className="btn actionbar-nav-btn btn-sm dropdown-toggle bg-transparent text-light border-0 pr-2 py-2 m-0"
-                data-toggle="dropdown"
               >
                 <FontAwesomeIcon icon={faEllipsisH} title="Other job actions" />
-              </Button>
-              <ul
-                className="dropdown-menu actionbar-menu dropdown-menu-right"
-                role="menu"
-              >
-                <li>
-                  <span
-                    role="button"
-                    tabIndex="-1"
-                    id="backfill-btn"
-                    className={`btn dropdown-item ${
-                      !user.isLoggedIn || !this.canBackfill() ? 'disabled' : ''
-                    }`}
-                    title={this.backfillButtonTitle()}
-                    onClick={() => !this.canBackfill() || this.backfillJob()}
-                  >
-                    Backfill
-                  </span>
-                </li>
+              </DropdownToggle>
+              <DropdownMenu className="dropdown-menu actionbar-menu dropdown-menu-right">
+                <DropdownItem
+                  id="backfill-btn"
+                  className={`${
+                    !user.isLoggedIn || !this.canBackfill() ? 'disabled' : ''
+                  }`}
+                  title={this.backfillButtonTitle()}
+                  onClick={() => !this.canBackfill() || this.backfillJob()}
+                >
+                  Backfill
+                </DropdownItem>
                 {selectedJobFull.task_id && (
                   <React.Fragment>
                     <li>
@@ -568,37 +574,25 @@ class ActionBar extends React.PureComponent {
                       </Button>
                     </li>
                     {isPerfTest(selectedJobFull) && (
-                      <li>
-                        <Button
-                          className="dropdown-item py-2"
-                          onClick={this.createGeckoProfile}
-                        >
-                          Create Gecko Profile
-                        </Button>
-                      </li>
+                      <DropdownItem
+                        className="py-2"
+                        onClick={this.createGeckoProfile}
+                      >
+                        Create Gecko Profile
+                      </DropdownItem>
                     )}
                     {isTestIsolatable(selectedJobFull) && (
-                      <li>
-                        <Button
-                          className="dropdown-item py-2"
-                          onClick={this.isolateJob}
-                        >
-                          Run Isolation Tests
-                        </Button>
-                      </li>
+                      <DropdownItem className="py-2" onClick={this.isolateJob}>
+                        Run Isolation Tests
+                      </DropdownItem>
                     )}
-                    <li>
-                      <Button
-                        onClick={this.toggleCustomJobActions}
-                        className="dropdown-item"
-                      >
-                        Custom Action...
-                      </Button>
-                    </li>
+                    <DropdownItem onClick={this.toggleCustomJobActions}>
+                      Custom Action...
+                    </DropdownItem>
                   </React.Fragment>
                 )}
-              </ul>
-            </li>
+              </DropdownMenu>
+            </Dropdown>
           </ul>
         </nav>
         {customJobActionsShowing && (

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
   Button,
-  Dropdown,
+  UncontrolledDropdown,
   DropdownToggle,
   DropdownMenu,
   DropdownItem,
@@ -42,7 +42,6 @@ class ActionBar extends React.PureComponent {
 
     this.state = {
       customJobActionsShowing: false,
-      dropdownIsOpen: false,
     };
   }
 
@@ -424,11 +423,6 @@ class ActionBar extends React.PureComponent {
     this.setState({ customJobActionsShowing: !customJobActionsShowing });
   };
 
-  dropdownToggle = () => {
-    const { dropdownIsOpen } = this.state;
-    this.setState({ dropdownIsOpen: !dropdownIsOpen });
-  };
-
   render() {
     const {
       selectedJobFull,
@@ -526,11 +520,7 @@ class ActionBar extends React.PureComponent {
                 </Button>
               </li>
             )}
-            <Dropdown
-              isOpen={this.state.dropdownIsOpen}
-              toggle={this.dropdownToggle}
-              className="ml-auto"
-            >
+            <UncontrolledDropdown className="ml-auto">
               <DropdownToggle
                 id="actionbar-menu-btn"
                 title="Other job actions"
@@ -592,7 +582,7 @@ class ActionBar extends React.PureComponent {
                   </React.Fragment>
                 )}
               </DropdownMenu>
-            </Dropdown>
+            </UncontrolledDropdown>
           </ul>
         </nav>
         {customJobActionsShowing && (

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -15,17 +15,11 @@ import {
   faRedo,
   faThumbtack,
   faTimesCircle,
-  faCrosshairs,
 } from '@fortawesome/free-solid-svg-icons';
 
 import { thEvents } from '../../../helpers/constants';
 import { formatTaskclusterError } from '../../../helpers/errorMessage';
-import {
-  isReftest,
-  isPerfTest,
-  isTestIsolatable,
-  findJobInstance,
-} from '../../../helpers/job';
+import { isReftest, isPerfTest, isTestIsolatable } from '../../../helpers/job';
 import { getInspectTaskUrl, getReftestUrl } from '../../../helpers/url';
 import JobModel from '../../../models/job';
 import TaskclusterModel from '../../../models/taskcluster';
@@ -488,21 +482,6 @@ class ActionBar extends React.PureComponent {
                   </a>
                 </li>
               ))}
-            <li>
-              <Button
-                id="find-job-btn"
-                title="Scroll to selection"
-                className="actionbar-nav-btn btn icon-blue bg-transparent border-0"
-                onClick={() =>
-                  findJobInstance(jobLogUrls[0] && jobLogUrls[0].job_id, true)
-                }
-              >
-                <FontAwesomeIcon
-                  icon={faCrosshairs}
-                  title="Find job instance"
-                />
-              </Button>
-            </li>
             {this.canCancel() && (
               <li>
                 <Button
@@ -541,28 +520,23 @@ class ActionBar extends React.PureComponent {
                 </DropdownItem>
                 {selectedJobFull.task_id && (
                   <React.Fragment>
-                    <li>
-                      <a
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="dropdown-item pl-4"
-                        href={getInspectTaskUrl(
-                          selectedJobFull.task_id,
-                          currentRepo.tc_root_url,
-                          selectedJobFull.submit_timestamp,
-                        )}
-                      >
-                        Inspect Task
-                      </a>
-                    </li>
-                    <li>
-                      <Button
-                        className="dropdown-item py-2"
-                        onClick={this.createInteractiveTask}
-                      >
-                        Create Interactive Task
-                      </Button>
-                    </li>
+                    <DropdownItem
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="pl-4"
+                      href={getInspectTaskUrl(
+                        selectedJobFull.task_id,
+                        currentRepo.tc_root_url,
+                      )}
+                    >
+                      Inspect Task
+                    </DropdownItem>
+                    <DropdownItem
+                      className="py-2"
+                      onClick={this.createInteractiveTask}
+                    >
+                      Create Interactive Task
+                    </DropdownItem>
                     {isPerfTest(selectedJobFull) && (
                       <DropdownItem
                         className="py-2"

--- a/ui/job-view/details/tabs/AnnotationsTab.jsx
+++ b/ui/job-view/details/tabs/AnnotationsTab.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -32,6 +30,8 @@ function RelatedBugSaved(props) {
         <em>{bugId}</em>
       </a>
       <span
+        role="button"
+        tabIndex="-1"
         className="btn classification-delete-icon hover-warning btn-xs pinned-job-close-btn annotations-bug"
         onClick={() => deleteBug(bug)}
         title={`Delete relation to bug ${bugId}`}
@@ -97,6 +97,8 @@ function TableRow(props) {
       <td>{text}</td>
       <td>
         <span
+          role="button"
+          tabIndex="-1"
           onClick={deleteEvent}
           className="classification-delete-icon hover-warning pointable"
           title="Delete this classification"

--- a/ui/job-view/details/tabs/AnnotationsTab.jsx
+++ b/ui/job-view/details/tabs/AnnotationsTab.jsx
@@ -7,6 +7,7 @@ import {
   faStar as faStarSolid,
   faTimesCircle,
 } from '@fortawesome/free-solid-svg-icons';
+import { Button } from 'reactstrap';
 
 import { thEvents } from '../../../helpers/constants';
 import { getBugUrl } from '../../../helpers/url';
@@ -29,15 +30,13 @@ function RelatedBugSaved(props) {
       >
         <em>{bugId}</em>
       </a>
-      <span
-        role="button"
-        tabIndex="-1"
-        className="btn classification-delete-icon hover-warning btn-xs pinned-job-close-btn annotations-bug"
+      <Button
+        className="btn classification-delete-icon hover-warning btn-xs pinned-job-close-btn annotations-bug py-0 px-1 bg-transparent"
         onClick={() => deleteBug(bug)}
         title={`Delete relation to bug ${bugId}`}
       >
         <FontAwesomeIcon icon={faTimesCircle} title="Delete" />
-      </span>
+      </Button>
     </span>
   );
 }
@@ -96,15 +95,13 @@ function TableRow(props) {
       </td>
       <td>{text}</td>
       <td>
-        <span
-          role="button"
-          tabIndex="-1"
+        <Button
           onClick={deleteEvent}
-          className="classification-delete-icon hover-warning pointable"
+          className="classification-delete-icon hover-warning pointable p-0 bg-transparent border-0"
           title="Delete this classification"
         >
           <FontAwesomeIcon icon={faTimesCircle} title="Delete classification" />
-        </span>
+        </Button>
       </td>
     </tr>
   );

--- a/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBug } from '@fortawesome/free-solid-svg-icons';
+import { Button } from 'reactstrap';
 
 import { thBugSuggestionLimit } from '../../../../helpers/constants';
 
@@ -28,15 +29,13 @@ export default class SuggestionsListItem extends React.Component {
     return (
       <li>
         <div>
-          <span
-            role="button"
-            tabIndex="-1"
+          <Button
             className="btn btn-xs btn-light-bordered link-style"
             onClick={() => toggleBugFiler(suggestion)}
             title="file a bug for this failure"
           >
             <FontAwesomeIcon icon={faBug} title="File bug" />
-          </span>
+          </Button>
           <span>{suggestion.search}</span>
         </div>
 
@@ -56,15 +55,15 @@ export default class SuggestionsListItem extends React.Component {
 
         {/* <!--All other bugs--> */}
         {suggestion.valid_all_others && suggestion.valid_open_recent && (
-          <span
-            role="button"
-            tabIndex="-1"
+          <Button
             rel="noopener"
             onClick={this.clickShowMore}
-            className="show-hide-more"
+            className="show-hide-more bg-transparent border-0 py-0 pr-0"
+            color="link"
+            size="sm"
           >
             Show / Hide more
-          </span>
+          </Button>
         )}
 
         {suggestion.valid_all_others &&

--- a/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -31,6 +29,8 @@ export default class SuggestionsListItem extends React.Component {
       <li>
         <div>
           <span
+            role="button"
+            tabIndex="-1"
             className="btn btn-xs btn-light-bordered link-style"
             onClick={() => toggleBugFiler(suggestion)}
             title="file a bug for this failure"
@@ -57,6 +57,8 @@ export default class SuggestionsListItem extends React.Component {
         {/* <!--All other bugs--> */}
         {suggestion.valid_all_others && suggestion.valid_open_recent && (
           <span
+            role="button"
+            tabIndex="-1"
             rel="noopener"
             onClick={this.clickShowMore}
             className="show-hide-more"

--- a/ui/job-view/headerbars/ActiveFilters.jsx
+++ b/ui/job-view/headerbars/ActiveFilters.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimesCircle } from '@fortawesome/free-solid-svg-icons';
+import { Button } from 'reactstrap';
 
 import { getFieldChoices } from '../../helpers/filter';
 
@@ -79,22 +80,22 @@ export default class ActiveFilters extends React.Component {
       fieldChoices,
     } = this.state;
 
+    const buttonStyle = 'pointable bg-transparent border-0 text-body mr-1 p-0';
     return (
       <div className="alert-info active-filters-bar">
         {!!filterBarFilters.length && (
           <div>
-            <span
-              role="button"
-              tabIndex="-1"
-              className="pointable"
+            <Button
+              className={buttonStyle}
+              size="sm"
               title="Clear all of these filters"
               onClick={filterModel.clearNonStatusFilters}
             >
               <FontAwesomeIcon
                 icon={faTimesCircle}
                 title="Clear all these filters"
-              />{' '}
-            </span>
+              />
+            </Button>
             <span className="active-filters-title">
               <b>Active Filters</b>
             </span>
@@ -104,10 +105,9 @@ export default class ActiveFilters extends React.Component {
                   className="filtersbar-filter"
                   key={`${filter.field}${filterValue}`}
                 >
-                  <span
-                    role="button"
-                    tabIndex="-1"
-                    className="pointable"
+                  <Button
+                    className={buttonStyle}
+                    size="sm"
                     title={`Clear filter: ${filter.field}`}
                     onClick={() =>
                       filterModel.removeFilter(filter.field, filterValue)
@@ -118,7 +118,7 @@ export default class ActiveFilters extends React.Component {
                       title={`Clear filter: ${filter.field}`}
                     />
                     &nbsp;
-                  </span>
+                  </Button>
                   <span title={`Filter by ${filter.field}: ${filterValue}`}>
                     <b>{filter.field}:</b>
                     {filter.field === 'failure_classification_id' && (

--- a/ui/job-view/headerbars/ActiveFilters.jsx
+++ b/ui/job-view/headerbars/ActiveFilters.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -86,6 +84,8 @@ export default class ActiveFilters extends React.Component {
         {!!filterBarFilters.length && (
           <div>
             <span
+              role="button"
+              tabIndex="-1"
               className="pointable"
               title="Clear all of these filters"
               onClick={filterModel.clearNonStatusFilters}
@@ -105,6 +105,8 @@ export default class ActiveFilters extends React.Component {
                   key={`${filter.field}${filterValue}`}
                 >
                   <span
+                    role="button"
+                    tabIndex="-1"
                     className="pointable"
                     title={`Clear filter: ${filter.field}`}
                     onClick={() =>

--- a/ui/job-view/headerbars/FiltersMenu.jsx
+++ b/ui/job-view/headerbars/FiltersMenu.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Label } from 'reactstrap';
+import { Label, Button } from 'reactstrap';
 
 import { thAllResultStatuses } from '../../helpers/constants';
 import { getJobsUrl } from '../../helpers/url';
@@ -34,6 +34,8 @@ function FiltersMenu(props) {
     }
   };
   const { email } = user;
+
+  const buttonStyle = 'bg-transparent text-body border-0 p-0';
 
   return (
     <span>
@@ -99,22 +101,28 @@ function FiltersMenu(props) {
             title="Pin all jobs that pass the global filters"
             className="dropdown-item"
           >
-            <button type="button" onClick={pinAllShownJobs}>
+            <Button onClick={pinAllShownJobs} className={buttonStyle}>
               Pin all showing
-            </button>
+            </Button>
           </li>
           <li title="Show only superseded jobs" className="dropdown-item">
-            <button type="button" onClick={filterModel.setOnlySuperseded}>
+            <Button
+              onClick={filterModel.setOnlySuperseded}
+              className={buttonStyle}
+            >
               Superseded only
-            </button>
+            </Button>
           </li>
           <li title={`Show only pushes for ${email}`} className="dropdown-item">
             <a href={getJobsUrl({ author: email })}>My pushes only</a>
           </li>
           <li title="Reset to default status filters" className="dropdown-item">
-            <button type="button" onClick={filterModel.resetNonFieldFilters}>
+            <Button
+              onClick={filterModel.resetNonFieldFilters}
+              className={buttonStyle}
+            >
               Reset
-            </button>
+            </Button>
           </li>
         </ul>
       </span>

--- a/ui/job-view/headerbars/FiltersMenu.jsx
+++ b/ui/job-view/headerbars/FiltersMenu.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -100,26 +98,23 @@ function FiltersMenu(props) {
           <li
             title="Pin all jobs that pass the global filters"
             className="dropdown-item"
-            onClick={pinAllShownJobs}
           >
-            Pin all showing
+            <button type="button" onClick={pinAllShownJobs}>
+              Pin all showing
+            </button>
           </li>
-          <li
-            title="Show only superseded jobs"
-            className="dropdown-item"
-            onClick={filterModel.setOnlySuperseded}
-          >
-            Superseded only
+          <li title="Show only superseded jobs" className="dropdown-item">
+            <button type="button" onClick={filterModel.setOnlySuperseded}>
+              Superseded only
+            </button>
           </li>
           <li title={`Show only pushes for ${email}`} className="dropdown-item">
             <a href={getJobsUrl({ author: email })}>My pushes only</a>
           </li>
-          <li
-            title="Reset to default status filters"
-            className="dropdown-item"
-            onClick={filterModel.resetNonFieldFilters}
-          >
-            Reset
+          <li title="Reset to default status filters" className="dropdown-item">
+            <button type="button" onClick={filterModel.resetNonFieldFilters}>
+              Reset
+            </button>
           </li>
         </ul>
       </span>

--- a/ui/job-view/headerbars/SecondaryNavBar.jsx
+++ b/ui/job-view/headerbars/SecondaryNavBar.jsx
@@ -1,6 +1,3 @@
-/* eslint-disable jsx-a11y/control-has-associated-label */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -209,6 +206,9 @@ class SecondaryNavBar extends React.PureComponent {
           .map(name => RepositoryModel.getRepo(name, repos))
           .filter(name => name)) ||
       [];
+    const DuplicateJobsTitle = duplicateJobsVisible
+      ? 'Hide duplicate jobs'
+      : 'Show duplicate jobs';
 
     return (
       <div
@@ -236,6 +236,8 @@ class SecondaryNavBar extends React.PureComponent {
           <form role="search" className="form-inline flex-row">
             {serverChanged && (
               <span
+                role="button"
+                tabIndex="-1"
                 className="btn btn-sm btn-view-nav nav-menu-btn"
                 onClick={updateButtonClick}
                 id="revisionChangedLabel"
@@ -284,11 +286,8 @@ class SecondaryNavBar extends React.PureComponent {
               } ${!duplicateJobsVisible ? 'strikethrough' : ''}`}
               tabIndex="0"
               role="button"
-              title={
-                duplicateJobsVisible
-                  ? 'Hide duplicate jobs'
-                  : 'Show duplicate jobs'
-              }
+              title={DuplicateJobsTitle}
+              aria-label={DuplicateJobsTitle}
               onClick={() =>
                 !groupCountsExpanded && this.toggleShowDuplicateJobs()
               }
@@ -343,6 +342,8 @@ class SecondaryNavBar extends React.PureComponent {
 
             <span>
               <span
+                role="button"
+                tabIndex="-1"
                 className="btn btn-view-nav btn-sm"
                 onClick={toggleFieldFilterVisible}
                 title="Filter by a job field"

--- a/ui/job-view/headerbars/SecondaryNavBar.jsx
+++ b/ui/job-view/headerbars/SecondaryNavBar.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Button } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircle, faDotCircle } from '@fortawesome/free-regular-svg-icons';
 import {
@@ -206,7 +207,7 @@ class SecondaryNavBar extends React.PureComponent {
           .map(name => RepositoryModel.getRepo(name, repos))
           .filter(name => name)) ||
       [];
-    const DuplicateJobsTitle = duplicateJobsVisible
+    const duplicateJobsTitle = duplicateJobsVisible
       ? 'Hide duplicate jobs'
       : 'Show duplicate jobs';
 
@@ -235,9 +236,7 @@ class SecondaryNavBar extends React.PureComponent {
           </span>
           <form role="search" className="form-inline flex-row">
             {serverChanged && (
-              <span
-                role="button"
-                tabIndex="-1"
+              <Button
                 className="btn btn-sm btn-view-nav nav-menu-btn"
                 onClick={updateButtonClick}
                 id="revisionChangedLabel"
@@ -245,26 +244,24 @@ class SecondaryNavBar extends React.PureComponent {
               >
                 <FontAwesomeIcon icon={faExclamationCircle} />
                 &nbsp;Treeherder update available
-              </span>
+              </Button>
             )}
 
             {/* Unclassified Failures Button */}
-            <span
+            <Button
               className={`btn btn-sm ${
                 allUnclassifiedFailureCount
                   ? 'btn-unclassified-failures'
                   : 'btn-view-nav'
               }${filterModel.isUnclassifiedFailures() ? ' active' : ''}`}
               title="Loaded failures / toggle filtering for unclassified failures"
-              tabIndex="-1"
-              role="button"
               onClick={this.toggleUnclassifiedFailures}
             >
               <span id="unclassified-failure-count">
                 {allUnclassifiedFailureCount}
               </span>{' '}
               unclassified
-            </span>
+            </Button>
 
             {/* Filtered Unclassified Failures Button */}
             {filteredUnclassifiedFailureCount !==
@@ -280,24 +277,20 @@ class SecondaryNavBar extends React.PureComponent {
             )}
 
             {/* Toggle Duplicate Jobs */}
-            <span
+            <Button
               className={`btn btn-view-nav btn-sm btn-toggle-duplicate-jobs ${
                 groupCountsExpanded ? 'disabled' : ''
               } ${!duplicateJobsVisible ? 'strikethrough' : ''}`}
-              tabIndex="0"
-              role="button"
-              title={DuplicateJobsTitle}
-              aria-label={DuplicateJobsTitle}
+              title={duplicateJobsTitle}
+              aria-label={duplicateJobsTitle}
               onClick={() =>
                 !groupCountsExpanded && this.toggleShowDuplicateJobs()
               }
             />
             <span className="btn-group">
               {/* Toggle Group State Button */}
-              <span
+              <Button
                 className="btn btn-view-nav btn-sm btn-toggle-group-state"
-                tabIndex="-1"
-                role="button"
                 title={
                   groupCountsExpanded
                     ? 'Collapse job groups'
@@ -310,7 +303,7 @@ class SecondaryNavBar extends React.PureComponent {
                   {groupCountsExpanded ? '-' : '+'}
                 </span>{' '}
                 )
-              </span>
+              </Button>
             </span>
 
             {/* Result Status Filter Chicklets */}
@@ -341,9 +334,7 @@ class SecondaryNavBar extends React.PureComponent {
             </span>
 
             <span>
-              <span
-                role="button"
-                tabIndex="-1"
+              <Button
                 className="btn btn-view-nav btn-sm"
                 onClick={toggleFieldFilterVisible}
                 title="Filter by a job field"
@@ -353,7 +344,7 @@ class SecondaryNavBar extends React.PureComponent {
                   size="sm"
                   title="Filter by a job field"
                 />
-              </span>
+              </Button>
             </span>
 
             {/* Quick Filter Field */}

--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Button } from 'reactstrap';
 
 import { getUrlParam } from '../../helpers/location';
 import { formatTaskclusterError } from '../../helpers/errorMessage';
@@ -165,9 +166,7 @@ class PushActionMenu extends React.PureComponent {
         <ul className="dropdown-menu pull-right">
           {runnableVisible ? (
             <li title="Hide Runnable Jobs" className="dropdown-item">
-              <button type="button" onClick={hideRunnableJobs}>
-                Hide Runnable Jobs
-              </button>
+              <Button onClick={hideRunnableJobs}>Hide Runnable Jobs</Button>
             </li>
           ) : (
             <li
@@ -175,15 +174,14 @@ class PushActionMenu extends React.PureComponent {
                 isLoggedIn ? 'Add new jobs to this push' : 'Must be logged in'
               }
             >
-              <button
+              <Button
                 className={
                   isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'
                 }
-                type="button"
                 onClick={showRunnableJobs}
               >
                 Add new jobs
-              </button>
+              </Button>
             </li>
           )}
           {true && (
@@ -194,15 +192,14 @@ class PushActionMenu extends React.PureComponent {
                   : 'Must be logged in'
               }
             >
-              <button
+              <Button
                 className={
                   isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'
                 }
-                type="button"
                 onClick={showFuzzyJobs}
               >
                 Add new jobs (Search)
-              </button>
+              </Button>
             </li>
           )}
           {triggerMissingRepos.includes(currentRepo.name) && (
@@ -213,15 +210,14 @@ class PushActionMenu extends React.PureComponent {
                   : 'Must be logged in'
               }
             >
-              <button
-                type="button"
+              <Button
                 onClick={this.triggerMissingJobs}
                 className={
                   isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'
                 }
               >
                 Trigger missing jobs
-              </button>
+              </Button>
             </li>
           )}
           <li
@@ -231,15 +227,14 @@ class PushActionMenu extends React.PureComponent {
                 : 'Must be logged in'
             }
           >
-            <button
+            <Button
               onClick={() => this.triggerAllTalosJobs(revision)}
               className={
                 isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'
               }
-              type="button"
             >
               Trigger all Talos jobs
-            </button>
+            </Button>
           </li>
           <li>
             <a
@@ -252,17 +247,13 @@ class PushActionMenu extends React.PureComponent {
               Mark with Bugherder
             </a>
           </li>
-          <li
-            className="dropdown-item"
-            title="View/Edit/Submit Action tasks for this push"
-          >
-            <button
-              className="dropdown-item"
-              type="button"
+          <li title="View/Edit/Submit Action tasks for this push">
+            <Button
               onClick={this.toggleCustomJobActions}
+              className="dropdown-item"
             >
               Custom Push Action...
-            </button>
+            </Button>
           </li>
           <li>
             <a

--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -166,24 +164,26 @@ class PushActionMenu extends React.PureComponent {
 
         <ul className="dropdown-menu pull-right">
           {runnableVisible ? (
-            <li
-              title="Hide Runnable Jobs"
-              className="dropdown-item"
-              onClick={hideRunnableJobs}
-            >
-              Hide Runnable Jobs
+            <li title="Hide Runnable Jobs" className="dropdown-item">
+              <button type="button" onClick={hideRunnableJobs}>
+                Hide Runnable Jobs
+              </button>
             </li>
           ) : (
             <li
               title={
                 isLoggedIn ? 'Add new jobs to this push' : 'Must be logged in'
               }
-              className={
-                isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'
-              }
-              onClick={showRunnableJobs}
             >
-              Add new jobs
+              <button
+                className={
+                  isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'
+                }
+                type="button"
+                onClick={showRunnableJobs}
+              >
+                Add new jobs
+              </button>
             </li>
           )}
           {true && (
@@ -193,12 +193,16 @@ class PushActionMenu extends React.PureComponent {
                   ? 'Add new jobs to this push via a fuzzy search'
                   : 'Must be logged in'
               }
-              className={
-                isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'
-              }
-              onClick={showFuzzyJobs}
             >
-              Add new jobs (Search)
+              <button
+                className={
+                  isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'
+                }
+                type="button"
+                onClick={showFuzzyJobs}
+              >
+                Add new jobs (Search)
+              </button>
             </li>
           )}
           {triggerMissingRepos.includes(currentRepo.name) && (
@@ -208,12 +212,16 @@ class PushActionMenu extends React.PureComponent {
                   ? 'Trigger all jobs that were optimized away'
                   : 'Must be logged in'
               }
-              className={
-                isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'
-              }
-              onClick={this.triggerMissingJobs}
             >
-              Trigger missing jobs
+              <button
+                type="button"
+                onClick={this.triggerMissingJobs}
+                className={
+                  isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'
+                }
+              >
+                Trigger missing jobs
+              </button>
             </li>
           )}
           <li
@@ -222,10 +230,16 @@ class PushActionMenu extends React.PureComponent {
                 ? 'Trigger all talos performance tests'
                 : 'Must be logged in'
             }
-            className={isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'}
-            onClick={() => this.triggerAllTalosJobs(revision)}
           >
-            Trigger all Talos jobs
+            <button
+              onClick={() => this.triggerAllTalosJobs(revision)}
+              className={
+                isLoggedIn ? 'dropdown-item' : 'dropdown-item disabled'
+              }
+              type="button"
+            >
+              Trigger all Talos jobs
+            </button>
           </li>
           <li>
             <a
@@ -240,10 +254,15 @@ class PushActionMenu extends React.PureComponent {
           </li>
           <li
             className="dropdown-item"
-            onClick={this.toggleCustomJobActions}
             title="View/Edit/Submit Action tasks for this push"
           >
-            Custom Push Action...
+            <button
+              className="dropdown-item"
+              type="button"
+              onClick={this.toggleCustomJobActions}
+            >
+              Custom Push Action...
+            </button>
           </li>
           <li>
             <a

--- a/ui/job-view/pushes/PushJobs.jsx
+++ b/ui/job-view/pushes/PushJobs.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -108,32 +106,34 @@ class PushJobs extends React.Component {
 
     return (
       <table id={this.aggregateId} className="table-hover">
-        <tbody onMouseDown={this.onMouseDown}>
-          {platforms ? (
-            platforms.map(platform => (
-              <Platform
-                platform={platform}
-                repoName={repoName}
-                filterModel={filterModel}
-                pushGroupState={pushGroupState}
-                key={`${platform.name}${platform.option}`}
-                duplicateJobsVisible={duplicateJobsVisible}
-                groupCountsExpanded={groupCountsExpanded}
-                runnableVisible={runnableVisible}
-              />
-            ))
-          ) : (
-            <tr>
-              <td>
-                <FontAwesomeIcon
-                  icon={faSpinner}
-                  pulse
-                  className="th-spinner"
-                  title="Loading..."
+        <tbody>
+          <div role="button" tabIndex="0" onMouseDown={this.onMouseDown}>
+            {platforms ? (
+              platforms.map(platform => (
+                <Platform
+                  platform={platform}
+                  repoName={repoName}
+                  filterModel={filterModel}
+                  pushGroupState={pushGroupState}
+                  key={`${platform.name}${platform.option}`}
+                  duplicateJobsVisible={duplicateJobsVisible}
+                  groupCountsExpanded={groupCountsExpanded}
+                  runnableVisible={runnableVisible}
                 />
-              </td>
-            </tr>
-          )}
+              ))
+            ) : (
+              <tr>
+                <td>
+                  <FontAwesomeIcon
+                    icon={faSpinner}
+                    pulse
+                    className="th-spinner"
+                    title="Loading..."
+                  />
+                </td>
+              </tr>
+            )}
+          </div>
         </tbody>
       </table>
     );

--- a/ui/job-view/pushes/PushList.jsx
+++ b/ui/job-view/pushes/PushList.jsx
@@ -1,6 +1,3 @@
-/* eslint-disable jsx-a11y/control-has-associated-label */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -141,6 +138,8 @@ class PushList extends React.Component {
     }
     return (
       <div
+        role="button"
+        tabIndex="-1"
         id="push-list"
         onClick={evt => this.clearIfEligibleTarget(evt.target)}
       >
@@ -168,6 +167,7 @@ class PushList extends React.Component {
           ))}
         {loadingPushes && (
           <div
+            aria-label="Progress Bar"
             className="progress active progress-bar progress-bar-striped"
             role="progressbar"
           />
@@ -185,6 +185,8 @@ class PushList extends React.Component {
           <div className="btn-group">
             {[10, 20, 50].map(count => (
               <div
+                role="button"
+                tabIndex="-1"
                 className="btn btn-light-bordered"
                 onClick={() => fetchNextPushes(count)}
                 key={count}

--- a/ui/job-view/pushes/PushList.jsx
+++ b/ui/job-view/pushes/PushList.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import intersection from 'lodash/intersection';
 import isEqual from 'lodash/isEqual';
+import { Button, ButtonGroup } from 'reactstrap';
 
 import ErrorBoundary from '../../shared/ErrorBoundary';
 import { notify } from '../redux/stores/notifications';
@@ -138,7 +139,7 @@ class PushList extends React.Component {
     }
     return (
       <div
-        role="button"
+        role="grid"
         tabIndex="-1"
         id="push-list"
         onClick={evt => this.clearIfEligibleTarget(evt.target)}
@@ -182,20 +183,19 @@ class PushList extends React.Component {
         )}
         <div className="card card-body get-next">
           <span>get next:</span>
-          <div className="btn-group">
+          <ButtonGroup>
             {[10, 20, 50].map(count => (
-              <div
-                role="button"
-                tabIndex="-1"
-                className="btn btn-light-bordered"
+              <Button
+                className="btn-light-bordered text-body"
                 onClick={() => fetchNextPushes(count)}
                 key={count}
+                toggle="true"
                 data-testid={`get-next-${count}`}
               >
                 {count}
-              </div>
+              </Button>
             ))}
-          </div>
+          </ButtonGroup>
         </div>
       </div>
     );

--- a/ui/job-view/pushes/Revision.jsx
+++ b/ui/job-view/pushes/Revision.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -66,7 +64,8 @@ export class Revision extends React.PureComponent {
         <span className="revision" data-tags={this.tags}>
           <span className="pl-4 pr-1 revision-holder">
             <span
-              type="button"
+              role="button"
+              tabIndex="-1"
               className="pointer"
               onClick={() => Revision.copyToClipboard(commitRevision)}
             >

--- a/ui/job-view/pushes/Revision.jsx
+++ b/ui/job-view/pushes/Revision.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Button } from 'reactstrap';
 import { faUser, faClipboard } from '@fortawesome/free-regular-svg-icons';
 
 import { parseAuthor } from '../../helpers/revision';
@@ -63,14 +64,14 @@ export class Revision extends React.PureComponent {
       <li>
         <span className="revision" data-tags={this.tags}>
           <span className="pl-4 pr-1 revision-holder">
-            <span
-              role="button"
-              tabIndex="-1"
-              className="pointer"
+            <Button
+              className="pointer bg-transparent px-2 py-0"
+              color="light"
+              size="sm"
               onClick={() => Revision.copyToClipboard(commitRevision)}
             >
               <FontAwesomeIcon icon={faClipboard} title="Copy full hash" />
-            </span>
+            </Button>
             <a
               title={`Open revision ${commitRevision} on ${repo.url}`}
               href={repo.getRevisionHref(commitRevision)}

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/no-did-update-set-state */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -226,6 +225,8 @@ export default class AlertTableRow extends React.Component {
         </td>
         <td className="px-0">
           <span
+            role="button"
+            tabIndex="-1"
             className={starred ? 'visible' : ''}
             data-testid={`alert ${alert.id.toString()} star`}
             onClick={this.toggleStar}

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormGroup, Input } from 'reactstrap';
+import { FormGroup, Input, Button } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faStar as faStarSolid,
@@ -224,18 +224,17 @@ export default class AlertTableRow extends React.Component {
           </FormGroup>
         </td>
         <td className="px-0">
-          <span
-            role="button"
-            tabIndex="-1"
-            className={starred ? 'visible' : ''}
+          <Button
+            className={`${starred ? 'visible' : ''} bg-transparent p-0`}
             data-testid={`alert ${alert.id.toString()} star`}
+            color="light"
             onClick={this.toggleStar}
           >
             <FontAwesomeIcon
               title={starred ? 'starred' : 'not starred'}
               icon={starred ? faStarSolid : faStarRegular}
             />
-          </span>
+          </Button>
         </td>
         <td className="text-left">
           {alertStatus !== 'untriaged' ? (

--- a/ui/perfherder/compare/CompareTable.jsx
+++ b/ui/perfherder/compare/CompareTable.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/control-has-associated-label */
-
 import React from 'react';
 import { Button, Table } from 'reactstrap';
 import PropTypes from 'prop-types';
@@ -120,11 +118,17 @@ export default class CompareTable extends React.PureComponent {
             </th>
             <th className="table-width-lg">Base</th>
             {/* empty for less than/greater than data */}
-            <th className="table-width-sm" />
+            <th
+              className="table-width-sm"
+              aria-label="less than or greater than data"
+            />
             <th className="table-width-lg">New</th>
             <th className="table-width-lg">Delta</th>
             {/* empty for progress bars (magnitude of difference) */}
-            <th className="table-width-lg" />
+            <th
+              className="table-width-lg"
+              aria-label="magnitude of difference"
+            />
             <th className="table-width-lg">Confidence</th>
             <th className="text-right table-width-md">
               {hasSubtests &&

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/no-did-update-set-state */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 
 // disabling due to a new bug with this rule: https://github.com/eslint/eslint/issues/12117
 /* eslint-disable no-unused-vars */
@@ -294,14 +293,18 @@ class GraphsContainer extends React.Component {
           }`}
           ref={this.tooltip}
         >
-          <span className="close mr-3 my-2 ml-2" onClick={this.closeTooltip}>
+          <button
+            type="button"
+            className="close mr-3 my-2 ml-2"
+            onClick={this.closeTooltip}
+          >
             <FontAwesomeIcon
               className="pointer text-white"
               icon={faTimes}
               size="xs"
               title="close tooltip"
             />
-          </span>
+          </button>
           {dataPoint && showTooltip && (
             <GraphTooltip dataPoint={dataPoint} {...this.props} />
           )}

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -3,7 +3,7 @@
 // disabling due to a new bug with this rule: https://github.com/eslint/eslint/issues/12117
 /* eslint-disable no-unused-vars */
 import React from 'react';
-import { Row, Col } from 'reactstrap';
+import { Row, Col, Button } from 'reactstrap';
 import PropTypes from 'prop-types';
 import {
   VictoryChart,
@@ -293,18 +293,14 @@ class GraphsContainer extends React.Component {
           }`}
           ref={this.tooltip}
         >
-          <button
-            type="button"
-            className="close mr-3 my-2 ml-2"
-            onClick={this.closeTooltip}
-          >
+          <Button className="close mr-3 my-2 ml-2" onClick={this.closeTooltip}>
             <FontAwesomeIcon
               className="pointer text-white"
               icon={faTimes}
               size="xs"
               title="close tooltip"
             />
-          </button>
+          </Button>
           {dataPoint && showTooltip && (
             <GraphTooltip dataPoint={dataPoint} {...this.props} />
           )}

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Badge, FormGroup, Input } from 'reactstrap';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { Badge, FormGroup, Input, Button } from 'reactstrap';
 
 import { legendCardText } from '../constants';
 
@@ -90,36 +88,37 @@ const LegendCard = ({
     const framework = frameworks.find(item => item.id === frameworkId);
     return framework ? framework.name : legendCardText.unknownFrameworkMessage;
   };
-  const subtitleStyle = 'p-0 mb-0 border-0 text-secondary text-left';
+  const subtitleStyle =
+    'bg-transparent p-0 my-0 border-0 text-secondary text-left btn-block';
 
   return (
     <FormGroup check className="pl-0 border">
-      <Button className="mr-3 my-2 ml-0" close onClick={removeTest} />
+      <Button className="mr-3 my-2 ml-2" close onClick={removeTest} />
       <div className={`${series.color[0]} graph-legend-card p-3`}>
         <Button
-          onClick={() => addTestData('addRelatedConfigs')}
-          className={`p-0 bg-transparent mb-0 pointer border-0 ${
+          className={`p-0 mb-0 pointer border-0 ${
             series.visible ? series.color[0] : 'text-muted'
-          } text-left`}
-          color="light"
+          } text-left bg-transparent`}
+          onClick={() => addTestData('addRelatedConfigs')}
           title="Add related configurations"
+          color="light"
         >
           {series.name}
         </Button>
         <Button
-          onClick={() => addTestData('addRelatedBranches')}
           className={subtitleStyle}
+          onClick={() => addTestData('addRelatedBranches')}
           title="Add related branches"
         >
           {series.repository_name}
         </Button>
         <Button
-          onClick={() => addTestData('addRelatedPlatform')}
           className={subtitleStyle}
+          onClick={() => addTestData('addRelatedPlatform')}
           title="Add related platforms and branches"
         >
           {series.platform}
-        </p>
+        </Button>
         <Badge> {getFrameworkName(series.framework_id)} </Badge>
         <div className="small">{`${series.signatureHash.slice(0, 16)}...`}</div>
       </div>

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -1,6 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Badge, FormGroup, Input } from 'reactstrap';
@@ -97,7 +94,12 @@ const LegendCard = ({
 
   return (
     <FormGroup check className="pl-0 border">
-      <span className="close mr-3 my-2 ml-2" onClick={removeTest}>
+      <span
+        role="button"
+        tabIndex="-1"
+        className="close mr-3 my-2 ml-2"
+        onClick={removeTest}
+      >
         <FontAwesomeIcon
           className="pointer"
           icon={faTimes}
@@ -106,29 +108,33 @@ const LegendCard = ({
         />
       </span>
       <div className={`${series.color[0]} graph-legend-card p-3`}>
-        <p
-          className={`p-0 mb-0 pointer border-0 ${
-            series.visible ? series.color[0] : 'text-muted'
-          } text-left`}
+        <span
+          role="button"
+          tabIndex="-1"
           onClick={() => addTestData('addRelatedConfigs')}
-          title="Add related configurations"
-          type="button"
         >
-          {series.name}
-        </p>
-        <p
-          className={subtitleStyle}
+          <p
+            className={`p-0 mb-0 pointer border-0 ${
+              series.visible ? series.color[0] : 'text-muted'
+            } text-left`}
+            title="Add related configurations"
+          >
+            {series.name}
+          </p>
+        </span>
+        <span
+          role="button"
+          tabIndex="-1"
           onClick={() => addTestData('addRelatedBranches')}
-          title="Add related branches"
-          type="button"
         >
-          {series.repository_name}
-        </p>
-        <p
-          className={subtitleStyle}
+          <p className={subtitleStyle} title="Add related branches">
+            {series.repository_name}
+          </p>
+        </span>
+        <span
+          role="button"
+          tabIndex="-1"
           onClick={() => addTestData('addRelatedPlatform')}
-          title="Add related platforms and branches"
-          type="button"
         >
           {series.platform}
         </p>

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -94,47 +94,29 @@ const LegendCard = ({
 
   return (
     <FormGroup check className="pl-0 border">
-      <span
-        role="button"
-        tabIndex="-1"
-        className="close mr-3 my-2 ml-2"
-        onClick={removeTest}
-      >
-        <FontAwesomeIcon
-          className="pointer"
-          icon={faTimes}
-          size="xs"
-          title=""
-        />
-      </span>
+      <Button className="mr-3 my-2 ml-0" close onClick={removeTest} />
       <div className={`${series.color[0]} graph-legend-card p-3`}>
-        <span
-          role="button"
-          tabIndex="-1"
+        <Button
           onClick={() => addTestData('addRelatedConfigs')}
+          className={`p-0 bg-transparent mb-0 pointer border-0 ${
+            series.visible ? series.color[0] : 'text-muted'
+          } text-left`}
+          color="light"
+          title="Add related configurations"
         >
-          <p
-            className={`p-0 mb-0 pointer border-0 ${
-              series.visible ? series.color[0] : 'text-muted'
-            } text-left`}
-            title="Add related configurations"
-          >
-            {series.name}
-          </p>
-        </span>
-        <span
-          role="button"
-          tabIndex="-1"
+          {series.name}
+        </Button>
+        <Button
           onClick={() => addTestData('addRelatedBranches')}
+          className={subtitleStyle}
+          title="Add related branches"
         >
-          <p className={subtitleStyle} title="Add related branches">
-            {series.repository_name}
-          </p>
-        </span>
-        <span
-          role="button"
-          tabIndex="-1"
+          {series.repository_name}
+        </Button>
+        <Button
           onClick={() => addTestData('addRelatedPlatform')}
+          className={subtitleStyle}
+          title="Add related platforms and branches"
         >
           {series.platform}
         </p>

--- a/ui/push-health/ClassificationGroup.jsx
+++ b/ui/push-health/ClassificationGroup.jsx
@@ -9,7 +9,6 @@ import {
 import {
   Row,
   Collapse,
-  Badge,
   ButtonGroup,
   ButtonDropdown,
   Button,
@@ -76,10 +75,9 @@ class ClassificationGroup extends React.PureComponent {
     return (
       <Row className={`justify-content-between ${className}`}>
         <h4 className="w-100">
-          <Badge
-            className="pointable w-100"
+          <Button
+            className={`pointable badge badge-${headerColor} w-100`}
             onClick={this.toggleDetails}
-            color={headerColor}
           >
             {name} : {Object.keys(group).length}
             <FontAwesomeIcon
@@ -87,7 +85,7 @@ class ClassificationGroup extends React.PureComponent {
               className="ml-1"
               title="expand"
             />
-          </Badge>
+          </Button>
         </h4>
         <Collapse isOpen={detailsShowing} className="w-100">
           {hasRetriggerAll && (

--- a/ui/push-health/Metric.jsx
+++ b/ui/push-health/Metric.jsx
@@ -5,9 +5,10 @@ import {
   faPlusSquare,
   faMinusSquare,
 } from '@fortawesome/free-regular-svg-icons';
-import { Button, Badge, Row, Col, Collapse, Card, CardBody } from 'reactstrap';
+import { Badge, Row, Col, Collapse, Card, CardBody, Button } from 'reactstrap';
 
 import { resultColorMap } from './helpers';
+import TestFailure from './TestFailure';
 
 export default class Metric extends React.PureComponent {
   constructor(props) {
@@ -16,7 +17,7 @@ export default class Metric extends React.PureComponent {
     const { result } = this.props;
 
     this.state = {
-      detailsShowing: !['pass', 'none'].includes(result),
+      detailsShowing: result !== 'pass',
     };
   }
 
@@ -26,7 +27,17 @@ export default class Metric extends React.PureComponent {
 
   render() {
     const { detailsShowing } = this.state;
-    const { result, name, children } = this.props;
+    const {
+      result,
+      name,
+      details,
+      failures,
+      repo,
+      revision,
+      user,
+      notify,
+      currentRepo,
+    } = this.props;
     const resultColor = resultColorMap[result];
     const expandIcon = detailsShowing ? faMinusSquare : faPlusSquare;
 
@@ -36,7 +47,10 @@ export default class Metric extends React.PureComponent {
           <div className={`bg-${resultColor} pr-2 mr-2`} />
           <Col>
             <Row className="justify-content-between">
-              <Button onClick={this.toggleDetails} outline className="border-0">
+              <Button
+                onClick={this.toggleDetails}
+                className="bg-transparent text-body border-0"
+              >
                 <span className="metric-name align-top font-weight-bold">
                   {name}
                 </span>
@@ -52,7 +66,24 @@ export default class Metric extends React.PureComponent {
             </Row>
             <Collapse isOpen={detailsShowing}>
               <Card>
-                <CardBody>{children}</CardBody>
+                <CardBody>
+                  {name === 'Tests' && (
+                    <TestFailure
+                      failures={failures}
+                      repo={repo}
+                      currentRepo={currentRepo}
+                      revision={revision}
+                      user={user}
+                      notify={notify}
+                    />
+                  )}
+                  {details &&
+                    details.map(detail => (
+                      <div key={detail} className="ml-3">
+                        {detail}
+                      </div>
+                    ))}
+                </CardBody>
               </Card>
             </Collapse>
           </Col>
@@ -63,7 +94,18 @@ export default class Metric extends React.PureComponent {
 }
 
 Metric.propTypes = {
+  repo: PropTypes.string.isRequired,
+  currentRepo: PropTypes.object.isRequired,
+  revision: PropTypes.string.isRequired,
   result: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  children: PropTypes.object.isRequired,
+  user: PropTypes.object.isRequired,
+  notify: PropTypes.func.isRequired,
+  details: PropTypes.array,
+  failures: PropTypes.object,
+};
+
+Metric.defaultProps = {
+  details: null,
+  failures: null,
 };

--- a/ui/shared/TruncatedText.jsx
+++ b/ui/shared/TruncatedText.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -22,12 +20,15 @@ export default class TruncatedText extends React.Component {
           {text}
         </p>
         {text.length > maxLength && (
-          <p
-            className={`${showMoreClass} mb-0 text-right  pointer`}
+          <span
+            role="button"
+            tabIndex="0"
             onClick={() => this.setState({ showMoreResults: !showMoreResults })}
           >
-            {`show ${showMoreResults ? 'less' : 'more'}`}
-          </p>
+            <p className={`${showMoreClass} mb-0 text-right  pointer`}>
+              {`show ${showMoreResults ? 'less' : 'more'}`}
+            </p>
+          </span>
         )}
       </React.Fragment>
     );

--- a/ui/shared/TruncatedText.jsx
+++ b/ui/shared/TruncatedText.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Button } from 'reactstrap';
 
 export default class TruncatedText extends React.Component {
   constructor(props) {
@@ -20,15 +21,15 @@ export default class TruncatedText extends React.Component {
           {text}
         </p>
         {text.length > maxLength && (
-          <span
-            role="button"
-            tabIndex="0"
+          <Button
+            className="bg-transparent border-0 p-0"
+            size="sm"
             onClick={() => this.setState({ showMoreResults: !showMoreResults })}
           >
             <p className={`${showMoreClass} mb-0 text-right  pointer`}>
               {`show ${showMoreResults ? 'less' : 'more'}`}
             </p>
-          </span>
+          </Button>
         )}
       </React.Fragment>
     );

--- a/ui/test-view/ui/Test.jsx
+++ b/ui/test-view/ui/Test.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { Badge } from 'reactstrap';
+import { Badge, Button } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faBug,
@@ -46,10 +46,9 @@ class BugCountComponent extends React.Component {
 
   render() {
     return (
-      <span
-        role="button"
-        tabIndex="-1"
-        className="bug-count"
+      <Button
+        className="text-body px-5 bug-count"
+        color="link"
         onClick={this.onClick}
       >
         {// TODO: Clean this up
@@ -65,12 +64,12 @@ class BugCountComponent extends React.Component {
           <Badge
             size="sm"
             color="danger"
-            style={{ fontWeight: 400, fontSize: '.8rem', margin: '0 .5rem' }}
+            style={{ fontWeight: 400, fontSize: '.8rem' }}
           >
             0
           </Badge>
         )}
-      </span>
+      </Button>
     );
   }
 }
@@ -249,14 +248,14 @@ class TestComponent extends React.Component {
   render() {
     return (
       <td className="test-table">
-        <span
-          role="button"
-          tabIndex="-1"
-          className="test"
+        <Button
+          className="text-body p-0 test"
+          size="sm"
+          color="link"
           onClick={this.onClick}
         >
           {this.props.name}
-        </span>
+        </Button>
         <span className="platform-list">
           {this.props.test.jobs.map(job => (
             <Platform

--- a/ui/test-view/ui/Test.jsx
+++ b/ui/test-view/ui/Test.jsx
@@ -1,6 +1,4 @@
 /* eslint-disable max-classes-per-file */
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -48,7 +46,12 @@ class BugCountComponent extends React.Component {
 
   render() {
     return (
-      <td className="bug-count" onClick={this.onClick}>
+      <span
+        role="button"
+        tabIndex="-1"
+        className="bug-count"
+        onClick={this.onClick}
+      >
         {// TODO: Clean this up
         // eslint-disable-next-line no-nested-ternary
         this.props.test.bugs === undefined ? (
@@ -67,7 +70,7 @@ class BugCountComponent extends React.Component {
             0
           </Badge>
         )}
-      </td>
+      </span>
     );
   }
 }
@@ -246,7 +249,12 @@ class TestComponent extends React.Component {
   render() {
     return (
       <td className="test-table">
-        <span className="test" onClick={this.onClick}>
+        <span
+          role="button"
+          tabIndex="-1"
+          className="test"
+          onClick={this.onClick}
+        >
           {this.props.name}
         </span>
         <span className="platform-list">


### PR DESCRIPTION
Fixed jsx-a11y accessibility:

**1. jsx-a11y/control-has-associated-label for files:**

- SecondaryNavBar;
- PushList;
- CompareTable;

**2. jsx-a11y/no-noninteractive-element-interactions for files:**

- FiltersMenu;
- PushActionMenu;
- LegendCard;
- ClassificationGroup;
- TruncatedText;
- Test;

**3. jsx-a11y/no-static-element-interactions for files:**

- BugColumn;
- App;
- PinBoard;
- ActionBar;
- AnnotationsTab;
- SuggestionsListItem;
- ActiveFilters;
- SecondaryNavBar;
- PushList;
- Revision;
- AlertTableRow;
- GraphsContainer;
- LegendCard;
- Metric;
- Test;
===================================

@sarah-clements @camd 
These are the changes I made so the accessibility rules pass. I made a few changes in the css for these files so that there aren't any differences from before these changes.

I noticed that in the codebase a lot of "react-strap" is being used. My opinion is that for a lot of these elements it would be better if I used semantic elements from the 'react-strap' library. I did not want to use it without your approval.

Also as per @sarah-clements request, I rebased my commits so the working history is clean now.

Looking forward to any critiques.
Thank you for your patience!
