### PR TITLE
Bug 1585483 - Find jobs with unsupported tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-hotkeys": "1.1.4",
     "react-lazylog": "4.4.1",
     "react-linkify": "0.2.2",
+    "react-markdown": "4.2.2",
     "react-redux": "7.1.3",
     "react-router-dom": "5.1.2",
     "react-split-pane": "0.1.89",

--- a/tests/ui/push-health/UnsupportedJob_test.jsx
+++ b/tests/ui/push-health/UnsupportedJob_test.jsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { fetchMock } from 'fetch-mock';
+import { render, cleanup, waitForElement } from '@testing-library/react';
+
+import { replaceLocation, setUrlParam } from '../../../ui/helpers/location';
+import UnsupportedJob from '../../../ui/push-health/UnsupportedJob';
+
+const repoName = 'autoland';
+const revision = '123abc123abc';
+const unclassifiedJob = {
+  id: 275146846,
+  machine_platform_id: 104,
+  option_collection_hash: '03abd064e50ec12b8c7309950268531d78c63f60',
+  job_type_id: 32758,
+  result: 'testfailed',
+  failure_classification_id: 1,
+  push_id: 587502,
+  job_type_name: 'test-linux64-asan/opt-reftest-e10s-7',
+  job_type_symbol: 'R7',
+  platform: 'linux64',
+};
+const classifiedJob = {
+  id: 275148683,
+  machine_platform_id: 529,
+  option_collection_hash: '102210fe594ee9b33d82058545b1ed14f4c8206e',
+  job_type_id: 180381,
+  result: 'testfailed',
+  failure_classification_id: 4,
+  push_id: 587502,
+  job_type_name: 'test-android-em-7.0-x86_64/opt-geckoview-junit-e10s',
+  job_type_symbol: 'gv-junit',
+  platform: 'android-em-7-0-x86_64',
+};
+const details275146846 = {
+  results: [
+    {
+      job_id: 275146846,
+      job_guid: '64649175-88f0-42b9-9f4c-ba482bb9fae8/0',
+      title: 'artifact uploaded',
+      value: 'reftest_errorsummary.log',
+      url:
+        'https://queue.taskcluster.net/v1/task/ZGSRdYjwQrmfTLpIK7n66A/runs/0/artifacts/public/test_info//reftest_errorsummary.log',
+    },
+  ],
+};
+
+const details275148683 = {
+  results: [
+    {
+      job_id: 275148683,
+      job_guid: '21ba8565-bc61-4246-b76b-5b186be5cfa6/0',
+      title: 'artifact uploaded',
+      value: 'resource-usage.json',
+      url:
+        'https://queue.taskcluster.net/v1/task/IbqFZbxhQka3a1sYa-XPpg/runs/0/artifacts/public/test_info//resource-usage.json',
+    },
+  ],
+};
+
+beforeEach(() => {
+  fetchMock.get('https://treestatus.mozilla-releng.net/trees/autoland', {
+    result: {
+      message_of_the_day: '',
+      reason: '',
+      status: 'open',
+      tree: 'autoland',
+    },
+  });
+  fetchMock.get('/api/jobdetail/?job_id=275146846', details275146846);
+  fetchMock.get('/api/jobdetail/?job_id=275148683', details275148683);
+  setUrlParam('repo', repoName);
+});
+
+afterEach(() => {
+  cleanup();
+  fetchMock.reset();
+  replaceLocation({});
+});
+
+describe('UnsupportedJob', () => {
+  const testTestFailure = job => (
+    <UnsupportedJob
+      job={job}
+      jobName={job.job_type_name}
+      jobSymbol={job.job_type_symbol}
+      repo={repoName}
+      revision={revision}
+    />
+  );
+
+  test('should show the job symbol', async () => {
+    const { getByText } = render(testTestFailure(unclassifiedJob));
+
+    expect(await waitForElement(() => getByText('R7'))).toBeInTheDocument();
+  });
+
+  test('A classified job should have a star', async () => {
+    const { getByTitle } = render(testTestFailure(classifiedJob));
+
+    expect(
+      await waitForElement(() => getByTitle('Classified')),
+    ).toBeInTheDocument();
+  });
+
+  test('Jobs should have a log link and a bug create link', async () => {
+    const { getByTitle } = render(testTestFailure(unclassifiedJob));
+
+    expect(
+      await waitForElement(() =>
+        getByTitle('Open the Log Viewer for this job'),
+      ),
+    ).toBeInTheDocument();
+    expect(
+      await waitForElement(() => getByTitle('File bug')),
+    ).toBeInTheDocument();
+  });
+});

--- a/treeherder/push_health/similar_jobs.py
+++ b/treeherder/push_health/similar_jobs.py
@@ -77,5 +77,7 @@ def job_to_dict(job):
     job_dict = {field: getattr(job, field) for field in job_fields}
     # required for retriggers
     job_dict['job_type_name'] = job.job_type.name
+    job_dict['job_type_symbol'] = job.job_type.symbol
+    job_dict['platform'] = job.machine_platform.platform
 
     return job_dict

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -228,7 +228,11 @@ class PushViewSet(viewsets.ViewSet):
             return Response("No push with revision: {0}".format(revision),
                             status=HTTP_404_NOT_FOUND)
         push_health_test_failures = get_push_health_test_failures(push, REPO_GROUPS['trunk'])
-        test_result = 'fail' if len(push_health_test_failures['needInvestigation']) else 'pass'
+        test_result = 'pass'
+        if len(push_health_test_failures['unsupported']):
+            test_result = 'indeterminate'
+        if len(push_health_test_failures['needInvestigation']):
+            test_result = 'fail'
 
         return Response({
             'revision': revision,

--- a/ui/push-health/TestFailures.jsx
+++ b/ui/push-health/TestFailures.jsx
@@ -2,11 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import ClassificationGroup from './ClassificationGroup';
+import UnsupportedGroup from './UnsupportedGroup';
 
 export default class TestFailures extends React.PureComponent {
   render() {
     const { failures, repo, revision, user, notify, currentRepo } = this.props;
-    const { needInvestigation, intermittent } = failures;
+    const { needInvestigation, intermittent, unsupported } = failures;
     const needInvestigationLength = Object.keys(needInvestigation).length;
 
     return (
@@ -34,6 +35,14 @@ export default class TestFailures extends React.PureComponent {
           expanded={false}
           user={user}
           notify={notify}
+        />
+        <UnsupportedGroup
+          group={unsupported}
+          name="Unsupported"
+          repo={repo}
+          revision={revision}
+          className="mb-5"
+          headerColor="warning"
         />
       </div>
     );

--- a/ui/push-health/UnsupportedGroup.jsx
+++ b/ui/push-health/UnsupportedGroup.jsx
@@ -1,0 +1,94 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faPlusSquare,
+  faMinusSquare,
+} from '@fortawesome/free-regular-svg-icons';
+import { Row, Collapse } from 'reactstrap';
+import Markdown from 'react-markdown';
+
+import UnsupportedJob from './UnsupportedJob';
+
+const description = `
+The following tasks have failed, but do not report their failures in a way that is compatible
+with Push Health.
+
+Requirements:
+
+1. Logging must be Structured Logging using MozLog or a harness that uses MozLog.
+2. Each failure must be summarized in a log file ending with \`_errorsummary.log\`.
+3. The \`_errorsummary.log\` must have at least one line that has an \`action\` of \`test_result\`.
+`;
+
+class UnsupportedGroup extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      detailsShowing: false,
+    };
+  }
+
+  toggleDetails = () => {
+    this.setState(prevState => ({ detailsShowing: !prevState.detailsShowing }));
+  };
+
+  render() {
+    const { detailsShowing } = this.state;
+    const { group, name, repo, revision, className, headerColor } = this.props;
+    const expandIcon = detailsShowing ? faMinusSquare : faPlusSquare;
+
+    return (
+      <Row className={`justify-content-between ${className}`}>
+        <h4 className="w-100" onClick={this.toggleDetails}>
+          <span className={`pointable badge badge-${headerColor} w-100`}>
+            {name} : {Object.keys(group).length}
+            <FontAwesomeIcon
+              icon={expandIcon}
+              className="ml-1"
+              title="expand"
+            />
+          </span>
+        </h4>
+        <Collapse isOpen={detailsShowing} className="w-100">
+          <Markdown source={description} />
+          <div>
+            {group &&
+              group.map(job => (
+                <div className="card" key={job.id}>
+                  <div className="card-body">
+                    <UnsupportedJob
+                      job={job}
+                      jobName={job.job_type_name}
+                      jobSymbol={job.job_type_symbol}
+                      repo={repo}
+                      revision={revision}
+                    />
+                  </div>
+                </div>
+              ))}
+          </div>
+        </Collapse>
+      </Row>
+    );
+  }
+}
+
+UnsupportedGroup.propTypes = {
+  group: PropTypes.array.isRequired,
+  name: PropTypes.string.isRequired,
+  repo: PropTypes.string.isRequired,
+  revision: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  headerColor: PropTypes.string,
+};
+
+UnsupportedGroup.defaultProps = {
+  className: '',
+  headerColor: '',
+};
+
+export default UnsupportedGroup;

--- a/ui/push-health/UnsupportedGroup.jsx
+++ b/ui/push-health/UnsupportedGroup.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -7,7 +5,7 @@ import {
   faPlusSquare,
   faMinusSquare,
 } from '@fortawesome/free-regular-svg-icons';
-import { Row, Collapse } from 'reactstrap';
+import { Badge, Card, CardBody, Row, Collapse } from 'reactstrap';
 import Markdown from 'react-markdown';
 
 import UnsupportedJob from './UnsupportedJob';
@@ -20,7 +18,7 @@ Requirements:
 
 1. Logging must be Structured Logging using MozLog or a harness that uses MozLog.
 2. Each failure must be summarized in a log file ending with \`_errorsummary.log\`.
-3. The \`_errorsummary.log\` must have at least one line that has an \`action\` of \`test_result\`.
+3. The \`*_errorsummary.log\` must have at least one line that has an \`action\` of \`test_result\`.
 `;
 
 class UnsupportedGroup extends React.PureComponent {
@@ -43,23 +41,27 @@ class UnsupportedGroup extends React.PureComponent {
 
     return (
       <Row className={`justify-content-between ${className}`}>
-        <h4 className="w-100" onClick={this.toggleDetails}>
-          <span className={`pointable badge badge-${headerColor} w-100`}>
+        <h4 className="w-100">
+          <Badge
+            className="pointable w-100"
+            color={headerColor}
+            onClick={this.toggleDetails}
+          >
             {name} : {Object.keys(group).length}
             <FontAwesomeIcon
               icon={expandIcon}
               className="ml-1"
               title="expand"
             />
-          </span>
+          </Badge>
         </h4>
         <Collapse isOpen={detailsShowing} className="w-100">
           <Markdown source={description} />
           <div>
             {group &&
               group.map(job => (
-                <div className="card" key={job.id}>
-                  <div className="card-body">
+                <Card key={job.id}>
+                  <CardBody>
                     <UnsupportedJob
                       job={job}
                       jobName={job.job_type_name}
@@ -67,8 +69,8 @@ class UnsupportedGroup extends React.PureComponent {
                       repo={repo}
                       revision={revision}
                     />
-                  </div>
-                </div>
+                  </CardBody>
+                </Card>
               ))}
           </div>
         </Collapse>

--- a/ui/push-health/UnsupportedJob.jsx
+++ b/ui/push-health/UnsupportedJob.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBug, faStar } from '@fortawesome/free-solid-svg-icons';
+import Markdown from 'react-markdown';
 
 import { getBtnClass } from '../helpers/job';
 import { bzBaseUrl, getJobsUrl, getLogViewerUrl } from '../helpers/url';
@@ -81,10 +82,12 @@ class UnsupportedJob extends PureComponent {
             className="text-dark"
           />
         </a>
-        {errorSummary && (
+        {errorSummary ? (
           <a href={errorSummary.url} target="_blank" rel="noopener noreferrer">
             {errorSummary.value}
           </a>
+        ) : (
+          <Markdown>No ``*_errorsummary.log`` exists for this task.</Markdown>
         )}
       </span>
     );

--- a/ui/push-health/UnsupportedJob.jsx
+++ b/ui/push-health/UnsupportedJob.jsx
@@ -1,0 +1,106 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBug, faStar } from '@fortawesome/free-solid-svg-icons';
+
+import { getBtnClass } from '../helpers/job';
+import { bzBaseUrl, getJobsUrl, getLogViewerUrl } from '../helpers/url';
+import logviewerIcon from '../img/logviewerIcon.png';
+import JobDetailModel from '../models/jobDetail';
+
+class UnsupportedJob extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      errorSummary: null,
+    };
+  }
+
+  componentDidMount() {
+    const { job } = this.props;
+
+    JobDetailModel.getJobDetails({ job_id: job.id }).then(result => {
+      const errorSummary = result.find(detail =>
+        detail.value.endsWith('_errorsummary.log'),
+      );
+
+      this.setState({ errorSummary });
+    });
+  }
+
+  render() {
+    const { job, jobName, jobSymbol, repo, revision } = this.props;
+    const { errorSummary } = this.state;
+    const {
+      id,
+      result,
+      failure_classification_id: failureClassificationId,
+    } = job;
+
+    return (
+      <span className="mr-2" key={id}>
+        <a
+          className={`btn job-btn filter-shown btn-sm mt-1 ${getBtnClass(
+            result,
+            failureClassificationId,
+          )}`}
+          href={getJobsUrl({ selectedJob: job.id, repo, revision })}
+          title={jobName}
+        >
+          {jobSymbol}
+        </a>
+        {failureClassificationId !== 1 && (
+          <FontAwesomeIcon icon={faStar} title="Classified" />
+        )}
+        {job.result === 'testfailed' && (
+          <a
+            className="logviewer-btn m-2"
+            href={getLogViewerUrl(job.id, repo)}
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Open the Log Viewer for this job"
+          >
+            <img
+              style={{ height: '18px' }}
+              alt="Logviewer"
+              src={logviewerIcon}
+              className="logviewer-icon text-dark mb-1"
+            />
+          </a>
+        )}
+        <a
+          className="mr-2"
+          href={`${bzBaseUrl}/enter_bug.cgi`}
+          target="_blank"
+          rel="noopener noreferrer"
+          title="file a bug for this failure"
+        >
+          <FontAwesomeIcon
+            icon={faBug}
+            title="File bug"
+            className="text-dark"
+          />
+        </a>
+        {errorSummary && (
+          <a href={errorSummary.url} target="_blank" rel="noopener noreferrer">
+            {errorSummary.value}
+          </a>
+        )}
+      </span>
+    );
+  }
+}
+
+UnsupportedJob.propTypes = {
+  job: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    result: PropTypes.string.isRequired,
+    failure_classification_id: PropTypes.number.isRequired,
+  }).isRequired,
+  jobName: PropTypes.string.isRequired,
+  jobSymbol: PropTypes.string.isRequired,
+  repo: PropTypes.string.isRequired,
+  revision: PropTypes.string.isRequired,
+};
+
+export default UnsupportedJob;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1935,6 +1935,11 @@ babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
+bail@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.4.tgz#7181b66d508aa3055d3f6c13f0a0c720641dde9b"
+  integrity sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -2278,6 +2283,21 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+character-entities-legacy@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz#3c729991d9293da0ede6dddcaf1f2ce1009ee8b4"
+  integrity sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==
+
+character-entities@^1.0.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.3.tgz#bbed4a52fe7ef98cc713c6d80d9faa26916d54e6"
+  integrity sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w==
+
+character-reference-invalid@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz#1647f4f726638d3ea4a750cf5d1975c1c7919a85"
+  integrity sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -2424,6 +2444,11 @@ codecov@3.6.1:
     js-yaml "^3.13.1"
     teeny-request "^3.11.3"
     urlgrey "^0.4.4"
+
+collapse-white-space@^1.0.2:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.5.tgz#c2495b699ab1ed380d29a1091e01063e75dbbe3a"
+  integrity sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ==
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -3325,7 +3350,7 @@ dom-helpers@^5.0.0:
     "@babel/runtime" "^7.6.3"
     csstype "^2.6.7"
 
-dom-serializer@0:
+dom-serializer@0, dom-serializer@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
   integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
@@ -3375,6 +3400,13 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+domhandler@^3.0, domhandler@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.0.0.tgz#51cd13efca31da95bbb0c5bee3a48300e333b3e9"
+  integrity sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==
+  dependencies:
+    domelementtype "^2.0.1"
+
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
@@ -3390,6 +3422,15 @@ domutils@^1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.0.0.tgz#15b8278e37bfa8468d157478c58c367718133c08"
+  integrity sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==
+  dependencies:
+    dom-serializer "^0.2.1"
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
 
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
@@ -4771,6 +4812,16 @@ html-minifier@^3.5.8:
     relateurl "0.2.x"
     uglify-js "3.4.x"
 
+html-to-react@^1.3.4:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/html-to-react/-/html-to-react-1.4.2.tgz#7b628ab56cd63a52f2d0b79d0fa838a51f088a57"
+  integrity sha512-TdTfxd95sRCo6QL8admCkE7mvNNrXtGoVr1dyS+7uvc8XCqAymnf/6ckclvnVbQNUo2Nh21VPwtfEHd0khiV7g==
+  dependencies:
+    domhandler "^3.0"
+    htmlparser2 "^4.0"
+    lodash.camelcase "^4.3.0"
+    ramda "^0.26"
+
 html-webpack-plugin@4.0.0-beta.11:
   version "4.0.0-beta.11"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.11.tgz#3059a69144b5aecef97708196ca32f9e68677715"
@@ -4794,6 +4845,16 @@ htmlparser2@^3.3.0, htmlparser2@^3.9.1:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
+
+htmlparser2@^4.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.0.0.tgz#6034658db65b7713a572a9ebf79f650832dceec8"
+  integrity sha512-cChwXn5Vam57fyXajDtPXL1wTYc8JtLbr2TN76FYu05itVVVealxLowe2B3IEznJG4p9HAYn/0tJaRlGuEglFQ==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    domutils "^2.0.0"
+    entities "^2.0.0"
 
 http-deceiver@^1.2.7:
   version "1.2.7"
@@ -5083,6 +5144,19 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.3.tgz#eb04cc47219a8895d8450ace4715abff2258a1f8"
+  integrity sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz#57ae21c374277b3defe0274c640a5704b8f6657c"
+  integrity sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arguments@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
@@ -5105,7 +5179,7 @@ is-boolean-object@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
   integrity sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -5140,6 +5214,11 @@ is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
   integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
+
+is-decimal@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.3.tgz#381068759b9dc807d8c0dc0bfbae2b68e1da48b7"
+  integrity sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -5212,6 +5291,11 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-hexadecimal@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz#e8a426a69b6d31470d3a33a47bb825cda02506ee"
+  integrity sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==
+
 is-number-object@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
@@ -5243,7 +5327,7 @@ is-path-inside@^2.1.0:
   dependencies:
     path-is-inside "^1.0.2"
 
-is-plain-obj@^1.0.0:
+is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
@@ -5294,10 +5378,20 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
+is-whitespace-character@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz#b3ad9546d916d7d3ffa78204bca0c26b56257fac"
+  integrity sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==
+
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+is-word-character@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.3.tgz#264d15541cbad0ba833d3992c34e6b40873b08aa"
+  integrity sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -6027,6 +6121,11 @@ lodash._basefor@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._basefor/-/lodash._basefor-3.0.3.tgz#7550b4e9218ef09fad24343b612021c79b4c20c2"
   integrity sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -6192,6 +6291,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-escapes@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.3.tgz#6155e10416efaafab665d466ce598216375195f5"
+  integrity sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -6200,6 +6304,13 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+mdast-add-list-metadata@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz#95e73640ce2fc1fa2dcb7ec443d09e2bfe7db4cf"
+  integrity sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==
+  dependencies:
+    unist-util-visit-parents "1.1.2"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -7067,6 +7178,18 @@ parse-asn1@^5.0.0:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
+parse-entities@^1.1.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
+  integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
@@ -7558,6 +7681,11 @@ railroad-diagrams@^1.0.0:
   resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
   integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
 
+ramda@^0.26:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
+
 randexp@0.4.6:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
@@ -7705,6 +7833,20 @@ react-linkify@0.2.2:
     linkify-it "^2.0.3"
     prop-types "^15.5.8"
     tlds "^1.57.0"
+
+react-markdown@4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.2.2.tgz#b378774fcffb354653db8749153fc8740f9ed2f1"
+  integrity sha512-/STJiRFmJuAIUdeBPp/VyO5bcenTIqP3LXuC3gYvregmYGKjnszGiFc2Ph0LsWC17Un3y/CT8TfxnwJT7v9EJw==
+  dependencies:
+    html-to-react "^1.3.4"
+    mdast-add-list-metadata "1.0.1"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
+    remark-parse "^5.0.0"
+    unified "^6.1.5"
+    unist-util-visit "^1.3.0"
+    xtend "^4.0.1"
 
 react-popper@^0.10.4:
   version "0.10.4"
@@ -8063,6 +8205,27 @@ relateurl@0.2.x, relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  integrity sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -8084,10 +8247,15 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.6.1:
+repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+
+replace-ext@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
+  integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
 request-promise-core@1.1.3:
   version "1.1.3"
@@ -8711,6 +8879,11 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
 
+state-toggle@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.2.tgz#75e93a61944116b4959d665c8db2d243631d6ddc"
+  integrity sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -9186,6 +9359,21 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+trim-trailing-lines@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz#d2f1e153161152e9f02fabc670fb40bec2ea2e3a"
+  integrity sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+
+trough@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.4.tgz#3b52b1f13924f460c3fbfd0df69b587dbcbc762e"
+  integrity sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==
+
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -9266,6 +9454,14 @@ unfetch@^4.1.0:
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"
   integrity sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==
 
+unherit@^1.0.4:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.2.tgz#14f1f397253ee4ec95cec167762e77df83678449"
+  integrity sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==
+  dependencies:
+    inherits "^2.0.1"
+    xtend "^4.0.1"
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
@@ -9288,6 +9484,18 @@ unicode-property-aliases-ecmascript@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz#a9cc6cc7ce63a0a3023fc99e341b94431d405a57"
   integrity sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
+
+unified@^6.1.5:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
+  integrity sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -9317,6 +9525,42 @@ unique-slug@^2.0.0:
   integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
   dependencies:
     imurmurhash "^0.1.4"
+
+unist-util-is@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
+  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz#ec037348b6102c897703eee6d0294ca4755a2020"
+  integrity sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+  integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
+
+unist-util-visit-parents@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz#f6e3afee8bdbf961c0e6f028ea3c0480028c3d06"
+  integrity sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q==
+
+unist-util-visit-parents@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
+  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
+  dependencies:
+    unist-util-is "^3.0.0"
+
+unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
+  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -9481,6 +9725,28 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vfile-location@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.6.tgz#8a274f39411b8719ea5728802e10d9e0dff1519e"
+  integrity sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==
+
+vfile-message@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.1.1.tgz#5833ae078a1dfa2d96e9647886cd32993ab313e1"
+  integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  integrity sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 victory-area@^33.1.2:
   version "33.1.2"
@@ -10069,12 +10335,17 @@ ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+  integrity sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xtend@^4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
This will show all jobs that are ``testfailed`` in the push, but are not able to be analyzed by Push Health.  It will provide links to write a bug against the test, see the job in streeherder, and look at the ``_errorsummary.log``, if present, to help analyze why it's not creating ``FailureLine`` records.

It will look like:

![Screenshot 2019-11-07 16 03 58](https://user-images.githubusercontent.com/419924/68438286-8195c180-0178-11ea-9fe8-64b3befac19d.png)
