### PR TITLE
Fix Node version for Selenium tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
     - env: python-tests-selenium
       language: node_js
       # The Node version here must be kept in sync with that in `package.json`.
-      node_js: '12'
+      node_js: '12.12.0'
       cache:
         directories:
           - node_modules


### PR DESCRIPTION
I've seen a Travis build fail because it was trying to build 12.13.0 from scratch and it timed out.
The other two Python tests on Travis are already pinning the Node version and they have not had this issue anymore.