### PR TITLE
Bug 1595018 - Temporarily allow maxLength of 100 for extra options

### DIFF
--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -80,7 +80,7 @@
           "title": "Extra options used in running suite",
           "items": {
             "type": "string",
-            "maxLength": 45
+            "maxLength": 100
           },
           "uniqueItems": true,
           "maxItems": 8


### PR DESCRIPTION
The [same change](https://phabricator.services.mozilla.com/D52136) is landed on mozilla-central. 