### PR TITLE
Tc migration prep part2

### DIFF
--- a/docs/pulseload.md
+++ b/docs/pulseload.md
@@ -123,9 +123,10 @@ Here is a set of example parameters that could be used to run it:
 ./manage.py publish_to_pulse mozilla-inbound.staging amqp://treeherder-test:mypassword@pulse.mozilla.org:5672/ ./scratch/test_job.json
 ```
 
-You can use the handy [Pulse Inspector] to view messages in your exchange to
-test that they are arriving at Pulse the way you expect.
+You can use the handy Pulse Inspector to view messages in your exchange to
+test that they are arriving at Pulse the way you expect. Each exchange has its
+own inspector that can be accessed like so: <rootUrl>/pulse-messages/
+ex: https://community-tc.services.mozilla.com/pulse-messages/
 
 [pulse guardian]: https://pulseguardian.mozilla.org/whats_pulse
-[pulse inspector]: https://tools.taskcluster.net/pulse-inspector/
 [yml schema]: https://github.com/mozilla/treeherder/blob/master/schemas/pulse-job.yml

--- a/docs/submitting_data.md
+++ b/docs/submitting_data.md
@@ -153,7 +153,6 @@ The following steps are required:
 
 [pulse guardian]: https://pulseguardian.mozilla.org/whats_pulse
 [pulse]: https://wiki.mozilla.org/Auto-tools/Projects/Pulse
-[pulse inspector]: https://tools.taskcluster.net/pulse-inspector/
 [pulse job schema]: https://github.com/mozilla/treeherder/blob/master/schemas/pulse-job.yml
 [treeherder bug]: https://bugzilla.mozilla.org/enter_bug.cgi?component=Treeherder:%20Data%20Ingestion&form_name=enter_bug&product=Tree%20Management
 [mozillapulse]: https://pypi.python.org/pypi/MozillaPulse

--- a/treeherder/etl/common.py
+++ b/treeherder/etl/common.py
@@ -10,15 +10,11 @@ def make_request(url, method='GET', headers=None, timeout=30, **kwargs):
     """A wrapper around requests to set defaults & call raise_for_status()."""
     headers = headers or {}
     headers['User-Agent'] = 'treeherder/{}'.format(settings.SITE_HOSTNAME)
-    # Work around bug 1305768.
-    if 'queue.taskcluster.net' in url:
-        headers['x-taskcluster-skip-cache'] = 'true'
     response = requests.request(method,
                                 url,
                                 headers=headers,
                                 timeout=timeout,
                                 **kwargs)
-
     if response.history:
         params = {
             'url': url,

--- a/treeherder/etl/management/commands/ingest_push_and_tasks.py
+++ b/treeherder/etl/management/commands/ingest_push_and_tasks.py
@@ -117,7 +117,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--root-url",
             dest="root_url",
-            default="https://taskcluster.net",
+            default="https://firefox-ci-tc.services.mozilla.com",
             help="Taskcluster root URL for non-Firefox tasks (e.g. https://community-tc.services.mozilla.com"
         )
         parser.add_argument(

--- a/treeherder/etl/runnable_jobs.py
+++ b/treeherder/etl/runnable_jobs.py
@@ -8,8 +8,8 @@ from treeherder.etl.common import fetch_json
 
 logger = logging.getLogger(__name__)
 
-RUNNABLE_JOBS_URL = 'https://queue.taskcluster.net/v1/task/{task_id}/runs/{run_number}/artifacts/public/runnable-jobs.json'
-TASKCLUSTER_INDEX_URL = 'https://index.taskcluster.net/v1/task/gecko.v2.%s.latest.taskgraph.decision'
+RUNNABLE_JOBS_URL = 'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/{task_id}/runs/{run_number}/artifacts/public/runnable-jobs.json'
+TASKCLUSTER_INDEX_URL = 'https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.%s.latest.taskgraph.decision'
 
 
 def _taskcluster_runnable_jobs(project):

--- a/treeherder/middleware.py
+++ b/treeherder/middleware.py
@@ -19,7 +19,7 @@ CSP_DIRECTIVES = [
     "font-src 'self' https://fonts.gstatic.com",
     # The `data:` is required for images that were inlined by webpack's url-loader (as an optimisation).
     "img-src 'self' data:",
-    "connect-src 'self' https://*.taskcluster.net https://taskcluster-artifacts.net https://treestatus.mozilla-releng.net https://bugzilla.mozilla.org https://auth.mozilla.auth0.com",
+    "connect-src 'self' https://community-tc.services.mozilla.com https://firefox-ci-tc.services.mozilla.com https://*.taskcluster.net https://taskcluster-artifacts.net https://treestatus.mozilla-releng.net https://bugzilla.mozilla.org https://auth.mozilla.auth0.com",
     # Required since auth0-js performs session renewals in an iframe.
     "frame-src 'self' https://auth.mozilla.auth0.com",
     "report-uri {}".format(reverse('csp-report')),

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -11,7 +11,7 @@
       "repository_group": 1,
       "description": "",
       "expire_performance_data": false,
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -27,7 +27,7 @@
       "description": "",
       "performance_alerts_enabled": true,
       "expire_performance_data": false,
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -41,7 +41,7 @@
       "codebase": "gecko",
       "repository_group": 1,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -56,7 +56,7 @@
       "repository_group": 1,
       "description": "",
       "is_try_repo": true,
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -72,7 +72,7 @@
       "description": "",
       "performance_alerts_enabled": true,
       "expire_performance_data": false,
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -88,7 +88,7 @@
       "description": "",
       "performance_alerts_enabled": true,
       "expire_performance_data": false,
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -104,7 +104,7 @@
       "description": "",
       "performance_alerts_enabled": true,
       "expire_performance_data": false,
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -118,7 +118,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -132,7 +132,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -146,7 +146,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -160,7 +160,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -174,7 +174,7 @@
       "codebase": "jetpack",
       "repository_group": 1,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -188,7 +188,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -204,7 +204,7 @@
       "description": "",
       "performance_alerts_enabled": false,
       "expire_performance_data": false,
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -218,7 +218,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -232,7 +232,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -246,7 +246,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -260,7 +260,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -274,7 +274,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -288,7 +288,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -302,7 +302,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -316,7 +316,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -330,7 +330,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -344,7 +344,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -358,7 +358,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -372,7 +372,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -386,7 +386,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -400,7 +400,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -414,7 +414,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -428,7 +428,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -442,7 +442,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -456,7 +456,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -470,7 +470,7 @@
       "codebase": "comm",
       "repository_group": 8,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -485,7 +485,7 @@
       "repository_group": 8,
       "description": "",
       "is_try_repo": true,
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -499,7 +499,7 @@
       "codebase": "comm",
       "repository_group": 8,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -513,7 +513,7 @@
       "codebase": "comm",
       "repository_group": 8,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -527,7 +527,7 @@
       "codebase": "comm",
       "repository_group": 8,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -541,7 +541,7 @@
       "codebase": "gecko",
       "repository_group": 6,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -555,7 +555,7 @@
       "codebase": "",
       "repository_group": 1,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -569,7 +569,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -584,7 +584,7 @@
       "codebase": "gaia",
       "repository_group": 1,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -598,7 +598,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -612,7 +612,7 @@
       "codebase": "taskcluster",
       "repository_group": 4,
       "description": "taskcluster integration test dumping ground.",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -627,7 +627,7 @@
       "codebase": "gaia",
       "repository_group": 4,
       "description": "Gaia master branch",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -641,7 +641,7 @@
       "codebase": "gaia",
       "repository_group": 4,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -655,7 +655,7 @@
       "codebase": "gecko",
       "repository_group": 4,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -669,7 +669,7 @@
       "codebase": "gaia",
       "repository_group": 1,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -683,7 +683,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -697,7 +697,7 @@
       "codebase": "gecko",
       "repository_group": 5,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -711,7 +711,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -725,7 +725,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -739,7 +739,7 @@
       "codebase": "gecko",
       "repository_group": 1,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -753,7 +753,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -767,7 +767,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -781,7 +781,7 @@
       "codebase": "comm",
       "repository_group": 8,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -795,7 +795,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -809,7 +809,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -824,7 +824,7 @@
       "codebase": "bugzilla",
       "repository_group": 4,
       "description": "A suite of tests to check the quality of the Bugzilla codebase.",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -839,7 +839,7 @@
       "codebase": "bugzilla",
       "repository_group": 4,
       "description": "A suite of tests to check the quality of the BMO codebase.",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -853,7 +853,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -867,7 +867,7 @@
       "codebase": "comm",
       "repository_group": 8,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -882,7 +882,7 @@
       "codebase": "bugzilla",
       "repository_group": 4,
       "description": "A suite of tests to check the quality of the Bugzilla 5.0 codebase.",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -897,7 +897,7 @@
       "codebase": "bugzilla",
       "repository_group": 4,
       "description": "A suite of tests to check the quality of the Bugzilla 4.4 codebase.",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -912,7 +912,7 @@
       "codebase": "bugzilla",
       "repository_group": 4,
       "description": "A suite of tests to check the quality of the Bugzilla 4.2 codebase.",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -927,7 +927,7 @@
       "codebase": "bugzilla",
       "repository_group": 4,
       "description": "A suite of tests to check the quality of the BMO codebase.",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -941,7 +941,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -955,7 +955,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -970,7 +970,7 @@
       "codebase": "bugzilla",
       "repository_group": 4,
       "description": "A suite of tests to check the quality of the BMO codebase.",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -984,7 +984,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -998,7 +998,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1012,7 +1012,7 @@
       "codebase": "comm",
       "repository_group": 8,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1042,7 +1042,7 @@
       "codebase": "version-control-tools",
       "repository_group": 7,
       "description": "Version control infrastructure and tooling.",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1058,7 +1058,7 @@
       "description": "The destination for automatically landed Firefox commits.",
       "performance_alerts_enabled": true,
       "expire_performance_data": false,
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1073,7 +1073,7 @@
       "codebase": "autopush",
       "repository_group": 7,
       "description": "Mozilla Push server and Push Endpoint.",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1087,7 +1087,7 @@
       "codebase": "nss",
       "repository_group": 7,
       "description": "Network Security Services.",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1102,7 +1102,7 @@
       "repository_group": 7,
       "description": "Network Security Services.",
       "is_try_repo": true,
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1117,7 +1117,7 @@
       "codebase": "example-addon-repo",
       "repository_group": 7,
       "description": "Example add-on repository for templates and best practices.",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1131,7 +1131,7 @@
       "codebase": "gecko",
       "repository_group": 1,
       "description": "Testing Servo integration with Gecko",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1146,7 +1146,7 @@
       "repository_group": 1,
       "description": "Try repo for Servo integration",
       "is_try_repo": true,
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1160,7 +1160,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1174,7 +1174,7 @@
       "codebase": "comm",
       "repository_group": 8,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1189,7 +1189,7 @@
       "codebase": "servo",
       "repository_group": 7,
       "description": "GPU renderer for Servo",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1204,7 +1204,7 @@
       "codebase": "addon-tests",
       "repository_group": 5,
       "description": "Tests for Add-ons",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1219,7 +1219,7 @@
       "codebase": "fxapom",
       "repository_group": 5,
       "description": "Firefox Account Page Object Model",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1234,7 +1234,7 @@
       "codebase": "go-bouncer",
       "repository_group": 5,
       "description": "Go version of the redirector portion of bouncer",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1249,7 +1249,7 @@
       "codebase": "mozillians-tests",
       "repository_group": 5,
       "description": "Tests for Mozillians",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1264,7 +1264,7 @@
       "codebase": "snippets-service",
       "repository_group": 5,
       "description": "Snippets Service",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1279,7 +1279,7 @@
       "codebase": "socorro",
       "repository_group": 5,
       "description": "Server for collecting, processing, and displaying crash reports from clients using the Breakpad libraries",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1294,7 +1294,7 @@
       "codebase": "stubattribution-tests",
       "repository_group": 5,
       "description": "Tests for the stub attribution service",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1309,7 +1309,7 @@
       "codebase": "treeherder",
       "repository_group": 5,
       "description": "A system for managing CI data for Mozilla projects",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1323,7 +1323,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1337,7 +1337,7 @@
       "codebase": "comm",
       "repository_group": 8,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1351,7 +1351,7 @@
       "codebase": "ci-admin",
       "repository_group": 9,
       "description": "Administrative scripts for Firefox CI",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1365,7 +1365,7 @@
       "codebase": "ci-admin",
       "repository_group": 9,
       "description": "Administrative configuration for Firefox CI",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1443,7 +1443,7 @@
       "codebase": "taskgraph",
       "repository_group": 9,
       "description": "Tools for defining graphs fo taskclutser tasks",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1458,7 +1458,7 @@
       "repository_group": 9,
       "description": "Tools for defining graphs fo taskclutser tasks",
       "is_try_repo": true,
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1472,7 +1472,7 @@
       "codebase": "ci-admin",
       "repository_group": 9,
       "description": "Administrative scripts for Firefox CI",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1486,7 +1486,7 @@
       "codebase": "ci-admin",
       "repository_group": 9,
       "description": "Administrative configuration for Firefox CI",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1501,7 +1501,7 @@
       "codebase": "reference-browser",
       "repository_group": 11,
       "description": "A full-featured browser reference implementation using Mozilla Android Components",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1516,7 +1516,7 @@
       "codebase": "fenix",
       "repository_group": 11,
       "description": "Fenix is not your parent's Android browser",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1530,7 +1530,7 @@
       "codebase": "gecko",
       "repository_group": 2,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1544,7 +1544,7 @@
       "codebase": "comm",
       "repository_group": 8,
       "description": "",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },
   {
@@ -1559,7 +1559,7 @@
       "codebase": "android-components",
       "repository_group": 11,
       "description": "A collection of Android libraries to build browsers or browser-like applications.",
-      "tc_root_url": "https://taskcluster.net"
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   }
 ]

--- a/treeherder/seta/update_job_priority.py
+++ b/treeherder/seta/update_job_priority.py
@@ -102,7 +102,7 @@ def query_sanitized_data(repo_name='autoland'):
 
      We need to find the latest gecko decision task ID (by querying the index [1][2]).
 
-     [1] https://index.taskcluster.net/v1/task/gecko.v2.%s.latest.taskgraph.decision/
+     [1] firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.%s.latest.taskgraph.decision/
      [2] Index's data structure:
       {
         "namespace": "gecko.v2.autoland.latest.taskgraph.decision",

--- a/ui/job-view/headerbars/InfraMenu.jsx
+++ b/ui/job-view/headerbars/InfraMenu.jsx
@@ -31,21 +31,11 @@ export default function InfraMenu() {
         <li>
           <a
             className="dropdown-item"
-            href="https://tools.taskcluster.net/provisioners/releng-hardware/worker-types?layout=table&orderBy=pendingTasks&lastActive=false"
+            href="https://firefox-ci-tc.services.mozilla.com/provisioners"
             target="_blank"
             rel="noopener noreferrer"
           >
-            Taskcluster Workers: releng-hardware
-          </a>
-        </li>
-        <li>
-          <a
-            className="dropdown-item"
-            href="https://tools.taskcluster.net/provisioners/aws-provisioner-v1/worker-types?layout=table&orderBy=pendingCapacity&lastActive=false"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Taskcluster Workers: aws-provisioner-v1
+            Taskcluster Workers
           </a>
         </li>
         <li>


### PR DESCRIPTION
This is the second part of pr #5604 that landed yesterday and Armen reverted today because he wanted only the UI changes to land on production without the changes to the repository fixture (for firefox-ci).
I'm going to merge it today so I can test out the third party login, but I won't promote it to production until tomorrow.