### PR TITLE
Reenable camelCase eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,8 +24,6 @@ module.exports = {
     browser: true,
   },
   rules: {
-    // TODO: Fix & remove the majority of these deviations from AirBnB style (bug 1183749).
-    camelcase: 'off',
     'class-methods-use-this': 'off',
     'consistent-return': 'off',
     'default-case': 'off',

--- a/tests/ui/models/jobs_test.js
+++ b/tests/ui/models/jobs_test.js
@@ -82,10 +82,10 @@ describe('JobModel', () => {
 
     test('jobs should have required fields', async () => {
       const { data: jobs } = await JobModel.getList({ push_id: 526443 });
-      const { signature, job_type_name } = jobs[0];
+      const { signature, job_type_name: jobTypeName } = jobs[0];
 
       expect(signature).toBe('2aa083621bb989d6acf1151667288d5fe9616178');
-      expect(job_type_name).toBe('Gecko Decision Task');
+      expect(jobTypeName).toBe('Gecko Decision Task');
     });
 
     test('retrigger uses passed-in decisionTaskMap', async () => {

--- a/tests/ui/perfherder/selector_card_test.jsx
+++ b/tests/ui/perfherder/selector_card_test.jsx
@@ -9,10 +9,10 @@ import {
 import SelectorCard from '../../../ui/perfherder/compare/SelectorCard';
 import { selectorCardText } from '../../../ui/perfherder/constants';
 
-const valid_hash = 'validhash21fb1fd66aea14a2f5ecfc06e68f75c';
+const validHash = 'validhash21fb1fd66aea14a2f5ecfc06e68f75c';
 
 const mockGetRevisions = async () => ({
-  data: { results: [{ id: 524930, revision: valid_hash }] },
+  data: { results: [{ id: 524930, revision: validHash }] },
   failureStatus: null,
 });
 
@@ -43,7 +43,7 @@ const selectorCard = (getRevisions, updateState, parentState, ref) =>
   render(renderReactNode(getRevisions, updateState, parentState, ref));
 
 test('correct hash for input value is valid', async () => {
-  const parentState = { selectedRevision: valid_hash };
+  const parentState = { selectedRevision: validHash };
 
   const renderResult = selectorCard(
     mockGetRevisions,
@@ -57,13 +57,13 @@ test('correct hash for input value is valid', async () => {
     getByPlaceholderText(selectorCardText.revisionPlaceHolder),
   );
   expect(inputRevision).toBeInTheDocument();
-  expect(inputRevision.value).toBe(valid_hash);
+  expect(inputRevision.value).toBe(validHash);
   expect(queryByText(selectorCardText.invalidRevisionLength)).toBeNull();
 });
 
 test('hash with whitespaces for input value is valid', async () => {
-  const hash_with_whitespaces = `  ${valid_hash}  `;
-  const parentState = { selectedRevision: hash_with_whitespaces };
+  const hashWithWhitespaces = `  ${validHash}  `;
+  const parentState = { selectedRevision: hashWithWhitespaces };
 
   const renderResult = selectorCard(
     mockGetRevisions,
@@ -78,7 +78,7 @@ test('hash with whitespaces for input value is valid', async () => {
   );
 
   expect(inputRevision).toBeInTheDocument();
-  expect(inputRevision.value).toBe(hash_with_whitespaces);
+  expect(inputRevision.value).toBe(hashWithWhitespaces);
   expect(queryByText(selectorCardText.invalidRevisionLength)).toBeNull();
 });
 
@@ -98,14 +98,14 @@ test('incorrect hash for input value is invalid', async () => {
   expect(inputRevision).toBeInTheDocument();
   expect(inputRevision.value).toBe('');
 
-  const incorrect_hash = 'incorrect_hash';
-  fireEvent.change(inputRevision, { target: { value: incorrect_hash } });
+  const incorrectHash = 'incorrect_hash';
+  fireEvent.change(inputRevision, { target: { value: incorrectHash } });
 
   renderResult.rerender(
     renderReactNode(mockGetRevisions, parentSetState, parentState),
   );
 
-  expect(inputRevision.value).toBe(incorrect_hash);
+  expect(inputRevision.value).toBe(incorrectHash);
   const validationMessage = queryByText(selectorCardText.invalidRevisionLength);
   expect(validationMessage).toBeInTheDocument();
 });

--- a/tests/ui/push-health/TestFailure_test.jsx
+++ b/tests/ui/push-health/TestFailure_test.jsx
@@ -9,10 +9,10 @@ import {
 
 import { replaceLocation, setUrlParam } from '../../../ui/helpers/location';
 import TestFailure from '../../../ui/push-health/TestFailure';
-import push_health from '../mock/push_health';
+import pushHealth from '../mock/push_health';
 
 const repoName = 'autoland';
-const failures = push_health.metrics[0].failures.needInvestigation;
+const failures = pushHealth.metrics[0].failures.needInvestigation;
 
 beforeEach(() => {
   fetchMock.get('https://treestatus.mozilla-releng.net/trees/autoland', {

--- a/ui/helpers/filter.js
+++ b/ui/helpers/filter.js
@@ -111,4 +111,4 @@ export const hasUrlFilterChanges = function hasUrlFilterChanges(
 };
 
 // DEPRECATED: Used to convert from old filter format to new.
-export const deprecated_thFilterPrefix = 'filter-';
+export const deprecatedThFilterPrefix = 'filter-';

--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -130,13 +130,19 @@ export const scrollToElement = function scrollToElement(el) {
 };
 
 export const findGroupElement = function findGroupElement(job) {
-  const { push_id, job_group_symbol, tier, platform, platform_option } = job;
-  const groupMapKey = getGroupMapKey(
-    push_id,
-    job_group_symbol,
+  const {
+    push_id: pushId,
+    job_group_symbol: jobGroupSymbol,
     tier,
     platform,
-    platform_option,
+    platform_option: platformOption,
+  } = job;
+  const groupMapKey = getGroupMapKey(
+    pushId,
+    jobGroupSymbol,
+    tier,
+    platform,
+    platformOption,
   );
   return document.querySelector(
     `#push-list span[data-group-key='${groupMapKey}']`,
@@ -167,32 +173,32 @@ export const findJobInstance = function findJobInstance(jobId, scrollTo) {
 
 export const addAggregateFields = function addAggregateFields(job) {
   const {
-    job_group_name,
-    job_group_symbol,
-    job_type_name,
-    job_type_symbol,
+    job_group_name: jobGroupName,
+    job_group_symbol: jobGroupSymbol,
+    job_type_name: jobTypeName,
+    job_type_symbol: jobTypeSymbol,
     state,
     result,
     platform,
-    platform_option,
+    platform_option: platformOption,
     signature,
-    submit_timestamp,
-    start_timestamp,
-    end_timestamp,
+    submit_timestamp: submitTimestamp,
+    start_timestamp: startTimestamp,
+    end_timestamp: endTimestamp,
   } = job;
 
   job.resultStatus = state === 'completed' ? result : state;
   // we want to join the group and type information together
   // so we can search for it as one token (useful when
   // we want to do a search on something like `fxup-esr(`)
-  const symbolInfo = job_group_symbol === '?' ? '' : job_group_symbol;
+  const symbolInfo = jobGroupSymbol === '?' ? '' : jobGroupSymbol;
 
   job.title = [
     thPlatformMap[platform] || platform,
-    platform_option,
-    job_group_name === 'unknown' ? undefined : job_group_name,
-    job_type_name,
-    `${symbolInfo}(${job_type_symbol})`,
+    platformOption,
+    jobGroupName === 'unknown' ? undefined : jobGroupName,
+    jobTypeName,
+    `${symbolInfo}(${jobTypeSymbol})`,
   ]
     .filter(item => typeof item !== 'undefined')
     .join(' ');
@@ -202,16 +208,16 @@ export const addAggregateFields = function addAggregateFields(job) {
     // If start time is 0, then duration should be from requesttime to now
     // If we have starttime and no endtime, then duration should be starttime to now
     // If we have both starttime and endtime, then duration will be between those two
-    const endtime = end_timestamp || Date.now() / 1000;
-    const starttime = start_timestamp || submit_timestamp;
+    const endtime = endTimestamp || Date.now() / 1000;
+    const starttime = startTimestamp || submitTimestamp;
     const diff = Math.max(endtime - starttime, 60);
 
     job.duration = Math.round(diff / 60, 0);
   }
 
-  job.hoverText = `${job_type_name} - ${job.resultStatus} - ${
-    job.duration
-  } min${job.duration > 1 ? 's' : ''}`;
+  job.hoverText = `${jobTypeName} - ${job.resultStatus} - ${job.duration} min${
+    job.duration > 1 ? 's' : ''
+  }`;
   return job;
 };
 

--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -66,8 +66,8 @@ export const getApiUrl = function getApiUrl(uri) {
   return getServiceUrl(`/api${uri}`);
 };
 
-export const getBugUrl = function getBugUrl(bug_id) {
-  return `${bzBaseUrl}show_bug.cgi?id=${bug_id}`;
+export const getBugUrl = function getBugUrl(bugId) {
+  return `${bzBaseUrl}show_bug.cgi?id=${bugId}`;
 };
 
 export const getInspectTaskUrl = function getInspectTaskUrl(taskId, rootUrl) {
@@ -83,12 +83,12 @@ export const getReftestUrl = function getReftestUrl(logUrl) {
 // need that since the ids are unique across projects.
 // Bug 1441938 - The project_bound_router is not needed and cumbersome in some cases
 export const getLogViewerUrl = function getLogViewerUrl(
-  job_id,
+  jobId,
   repoName,
-  line_number,
+  lineNumber,
 ) {
-  const rv = `logviewer.html#?job_id=${job_id}&repo=${repoName}`;
-  return line_number ? `${rv}&lineNumber=${line_number}` : rv;
+  const rv = `logviewer.html#?job_id=${jobId}&repo=${repoName}`;
+  return lineNumber ? `${rv}&lineNumber=${lineNumber}` : rv;
 };
 
 export const getPerfAnalysisUrl = function getPerfAnalysisUrl(url) {

--- a/ui/job-view/details/tabs/AnnotationsTab.jsx
+++ b/ui/job-view/details/tabs/AnnotationsTab.jsx
@@ -18,23 +18,23 @@ import { recalculateUnclassifiedCounts } from '../../redux/stores/pushes';
 
 function RelatedBugSaved(props) {
   const { deleteBug, bug } = props;
-  const { bug_id } = bug;
+  const { bug_id: bugId } = bug;
 
   return (
     <span className="btn-group pinboard-related-bugs-btn">
       <a
         className="btn btn-xs annotations-bug related-bugs-link"
-        href={getBugUrl(bug_id)}
+        href={getBugUrl(bugId)}
         target="_blank"
         rel="noopener noreferrer"
-        title={`View bug ${bug_id}`}
+        title={`View bug ${bugId}`}
       >
-        <em>{bug_id}</em>
+        <em>{bugId}</em>
       </a>
       <span
         className="btn classification-delete-icon hover-warning btn-xs pinned-job-close-btn annotations-bug"
         onClick={() => deleteBug(bug)}
-        title={`Delete relation to bug ${bug_id}`}
+        title={`Delete relation to bug ${bugId}`}
       >
         <FontAwesomeIcon icon={faTimesCircle} title="Delete" />
       </span>

--- a/ui/job-view/headerbars/ActiveFilters.jsx
+++ b/ui/job-view/headerbars/ActiveFilters.jsx
@@ -187,9 +187,9 @@ export default class ActiveFilters extends React.Component {
                     <option value="" disabled>
                       select value
                     </option>
-                    {Object.entries(newFilterChoices).map(([fci, fci_obj]) => (
-                      <option value={fci_obj.id} key={fci}>
-                        {fci_obj.name}
+                    {Object.entries(newFilterChoices).map(([fci, fciObj]) => (
+                      <option value={fciObj.id} key={fci}>
+                        {fciObj.name}
                       </option>
                     ))}
                   </select>

--- a/ui/job-view/pushes/JobButton.jsx
+++ b/ui/job-view/pushes/JobButton.jsx
@@ -84,21 +84,21 @@ export default class JobButtonComponent extends React.Component {
     const { isSelected, isRunnableSelected } = this.state;
     const {
       state,
-      failure_classification_id,
+      failure_classification_id: failureClassificationId,
       visible,
       id,
-      job_type_symbol,
+      job_type_symbol: jobTypeSymbol,
       resultStatus,
     } = job;
 
     if (!visible) return null;
     const runnable = state === 'runnable';
-    const btnClass = getBtnClass(resultStatus, failure_classification_id);
+    const btnClass = getBtnClass(resultStatus, failureClassificationId);
     let classifiedIcon = null;
 
-    if (failure_classification_id > 1) {
+    if (failureClassificationId > 1) {
       classifiedIcon =
-        failure_classification_id === 7 ? faStarRegular : faStarSolid;
+        failureClassificationId === 7 ? faStarRegular : faStarSolid;
     }
 
     const classes = ['btn', btnClass, 'filter-shown'];
@@ -125,7 +125,7 @@ export default class JobButtonComponent extends React.Component {
     attributes.className = classes.join(' ');
     return (
       <button type="button" {...attributes}>
-        {job_type_symbol}
+        {jobTypeSymbol}
         {classifiedIcon && (
           <FontAwesomeIcon
             icon={classifiedIcon}

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -92,19 +92,19 @@ class Push extends React.PureComponent {
   getJobGroupInfo(job) {
     const {
       job_group_name: name,
-      job_group_symbol,
+      job_group_symbol: jobGroupSymbol,
       platform,
-      platform_option,
+      platform_option: platformOption,
       tier,
-      push_id,
+      push_id: pushId,
     } = job;
-    const symbol = job_group_symbol === '?' ? '' : job_group_symbol;
+    const symbol = jobGroupSymbol === '?' ? '' : jobGroupSymbol;
     const mapKey = getGroupMapKey(
-      push_id,
+      pushId,
       symbol,
       tier,
       platform,
-      platform_option,
+      platformOption,
     );
 
     return { name, tier, symbol, mapKey };
@@ -460,7 +460,7 @@ class Push extends React.PureComponent {
       selectedRunnableJobs,
       collapsed,
     } = this.state;
-    const { id, push_timestamp, revision, author } = push;
+    const { id, push_timestamp: pushTimestamp, revision, author } = push;
     const tipRevision = push.revisions[0];
     const decisionTask = decisionTaskMap[push.id];
     const decisionTaskId = decisionTask ? decisionTask.id : null;
@@ -490,7 +490,7 @@ class Push extends React.PureComponent {
         <PushHeader
           push={push}
           pushId={id}
-          pushTimestamp={push_timestamp}
+          pushTimestamp={pushTimestamp}
           author={author}
           revision={revision}
           jobCounts={jobCounts}

--- a/ui/job-view/redux/stores/pushes.js
+++ b/ui/job-view/redux/stores/pushes.js
@@ -352,10 +352,10 @@ export const updateRange = range => {
 
     window.dispatchEvent(new CustomEvent(thEvents.clearPinboard));
     if (revisionPushList.length) {
-      const { id: push_id } = revisionPushList[0];
+      const { id: pushId } = revisionPushList[0];
       const revisionJobMap = Object.entries(jobMap).reduce(
         (acc, [id, job]) =>
-          job.push_id === push_id ? { ...acc, [id]: job } : acc,
+          job.push_id === pushId ? { ...acc, [id]: job } : acc,
         {},
       );
       dispatch(clearSelectedJob(0));

--- a/ui/models/filter.js
+++ b/ui/models/filter.js
@@ -12,7 +12,7 @@ import {
   thFieldChoices,
   thMatchType,
   thFilterDefaults,
-  deprecated_thFilterPrefix,
+  deprecatedThFilterPrefix,
   allFilterParams,
 } from '../helpers/filter';
 import { getAllUrlParams } from '../helpers/location';
@@ -20,7 +20,7 @@ import { getAllUrlParams } from '../helpers/location';
 export const getNonFilterUrlParams = () =>
   [...getAllUrlParams().entries()].reduce(
     (acc, [urlField, urlValue]) =>
-      allFilterParams.includes(urlField.replace(deprecated_thFilterPrefix, ''))
+      allFilterParams.includes(urlField.replace(deprecatedThFilterPrefix, ''))
         ? acc
         : { ...acc, [urlField]: urlValue },
     {},
@@ -33,7 +33,7 @@ export const getFilterUrlParamsWithDefaults = () => {
   // Also remove usage of the 'filter-' prefix.
   const groupedValues = [...getAllUrlParams().entries()].reduce(
     (acc, [urlField, urlValue]) => {
-      const field = urlField.replace(deprecated_thFilterPrefix, '');
+      const field = urlField.replace(deprecatedThFilterPrefix, '');
       if (!allFilterParams.includes(field)) {
         return acc;
       }

--- a/ui/models/job.js
+++ b/ui/models/job.js
@@ -26,7 +26,11 @@ export default class JobModel {
     );
 
     if (!failureStatus) {
-      const { results, job_property_names, next: nextUrl } = data;
+      const {
+        results,
+        job_property_names: jobPropertyNames,
+        next: nextUrl,
+      } = data;
       let itemList;
       let nextPagesJobs = [];
 
@@ -42,19 +46,19 @@ export default class JobModel {
           nextPagesJobs = nextData;
         }
       }
-      if (job_property_names) {
+      if (jobPropertyNames) {
         // the results came as list of fields
         // we need to convert them to objects
         itemList = results.map(elem =>
           addAggregateFields(
-            job_property_names.reduce(
+            jobPropertyNames.reduce(
               (prev, prop, i) => ({ ...prev, [prop]: elem[i] }),
               {},
             ),
           ),
         );
       } else {
-        itemList = results.map(job_obj => addAggregateFields(job_obj));
+        itemList = results.map(jobObj => addAggregateFields(jobObj));
       }
       return { data: [...itemList, ...nextPagesJobs], failureStatus: null };
     }

--- a/ui/models/runnableJob.js
+++ b/ui/models/runnableJob.js
@@ -8,7 +8,7 @@ export default class RunnableJobModel {
   }
 
   static async getList(repo, params) {
-    const { push_id, decisionTask } = params;
+    const { push_id: pushId, decisionTask } = params;
     const uri = getRunnableJobsURL(decisionTask, repo.tc_root_url);
     const rawJobs = await fetch(uri).then(response => response.json());
 
@@ -25,8 +25,8 @@ export default class RunnableJobModel {
         signature: key,
         state: 'runnable',
         result: 'runnable',
-        push_id,
-        id: escapeId(push_id + key),
+        push_id: pushId,
+        id: escapeId(pushId + key),
       }),
     );
   }

--- a/ui/perfherder/compare/CompareSubtestsView.jsx
+++ b/ui/perfherder/compare/CompareSubtestsView.jsx
@@ -15,8 +15,8 @@ import withValidation from '../Validation';
 import CompareTableView from './CompareTableView';
 
 class CompareSubtestsView extends React.PureComponent {
-  createQueryParams = (parent_signature, repository, framework) => ({
-    parent_signature,
+  createQueryParams = (parentSignature, repository, framework) => ({
+    parent_signature: parentSignature,
     framework,
     repository,
   });
@@ -90,7 +90,7 @@ class CompareSubtestsView extends React.PureComponent {
         )}`,
       });
     }
-    const signature_hash = !oldResults
+    const signatureHash = !oldResults
       ? newResults.signature_hash
       : oldResults.signature_hash;
 
@@ -99,7 +99,7 @@ class CompareSubtestsView extends React.PureComponent {
       links,
       framework,
       timeRange,
-      signature_hash,
+      signatureHash,
     );
     return links;
   };

--- a/ui/perfherder/compare/CompareView.jsx
+++ b/ui/perfherder/compare/CompareView.jsx
@@ -113,7 +113,7 @@ class CompareView extends React.PureComponent {
         href: detailsLink,
       });
     }
-    const signature_hash = !oldResults
+    const signatureHash = !oldResults
       ? newResults.signature_hash
       : oldResults.signature_hash;
     links = createGraphsLinks(
@@ -121,7 +121,7 @@ class CompareView extends React.PureComponent {
       links,
       framework,
       timeRange,
-      signature_hash,
+      signatureHash,
     );
     return links;
   };

--- a/ui/perfherder/compare/ReplicatesGraph.jsx
+++ b/ui/perfherder/compare/ReplicatesGraph.jsx
@@ -84,8 +84,8 @@ export default class ReplicatesGraph extends React.Component {
       return { replicateData };
     }
     const numRuns = perfDatum.values.length;
-    const replicatePromises = perfDatum.job_ids.map(job_id =>
-      getReplicateData({ job_id }),
+    const replicatePromises = perfDatum.job_ids.map(jobId =>
+      getReplicateData({ job_id: jobId }),
     );
 
     return Promise.all(replicatePromises).then(

--- a/ui/perfherder/graphs/GraphTooltip.jsx
+++ b/ui/perfherder/graphs/GraphTooltip.jsx
@@ -62,8 +62,8 @@ const GraphTooltip = ({
         : getStatus(alert.status, alertStatusMap);
   }
 
-  const repository_name = projects.find(
-    repository_name => repository_name.name === testDetails.repository_name,
+  const repositoryName = projects.find(
+    repositoryName => repositoryName.name === testDetails.repository_name,
   );
 
   let prevRevision;
@@ -72,7 +72,7 @@ const GraphTooltip = ({
   if (prevFlotDataPointIndex !== -1) {
     prevRevision = testDetails.data[prevFlotDataPointIndex].revision;
     prevPushId = testDetails.data[prevFlotDataPointIndex].pushId;
-    const repoModel = new RepositoryModel(repository_name);
+    const repoModel = new RepositoryModel(repositoryName);
     pushUrl = repoModel.getPushLogRangeHref({
       fromchange: prevRevision,
       tochange: dataPointDetails.revision,

--- a/ui/perfherder/graphs/GraphsView.jsx
+++ b/ui/perfherder/graphs/GraphsView.jsx
@@ -111,13 +111,17 @@ class GraphsView extends React.Component {
   };
 
   createSeriesParams = series => {
-    const { repository_name, signature_id, framework_id } = series;
+    const {
+      repository_name: repositoryName,
+      signature_id: signatureId,
+      framework_id: frameworkId,
+    } = series;
     const { timeRange } = this.state;
 
     return {
-      repository: repository_name,
-      signature: signature_id,
-      framework: framework_id,
+      repository: repositoryName,
+      signature: signatureId,
+      framework: frameworkId,
       interval: timeRange.value,
       all_data: true,
     };
@@ -212,12 +216,12 @@ class GraphsView extends React.Component {
     return graphData;
   };
 
-  getAlertSummaries = async (signature_id, repository) => {
+  getAlertSummaries = async (signatureId, repository) => {
     const { errorMessages } = this.state;
 
     const url = getApiUrl(
       `${endpoints.alertSummary}${createQueryParams({
-        alerts__series_signature: signature_id,
+        alerts__series_signature: signatureId,
         repository,
       })}`,
     );
@@ -233,19 +237,19 @@ class GraphsView extends React.Component {
   };
 
   updateData = async (
-    signature_id,
-    repository_name,
+    signatureId,
+    repositoryName,
     alertSummaryId,
     dataPointIndex,
   ) => {
     const { testData } = this.state;
 
     const updatedData = testData.find(
-      test => test.signature_id === signature_id,
+      test => test.signature_id === signatureId,
     );
     const alertSummaries = await this.getAlertSummaries(
-      signature_id,
-      repository_name,
+      signatureId,
+      repositoryName,
     );
     const alertSummary = alertSummaries.find(
       result => result.id === alertSummaryId,
@@ -321,8 +325,8 @@ class GraphsView extends React.Component {
     if (!selectedDataPoint) {
       delete params.selected;
     } else {
-      const { signature_id, pushId, x, y } = selectedDataPoint;
-      params.selected = [signature_id, pushId, x, y].join(',');
+      const { signature_id: signatureId, pushId, x, y } = selectedDataPoint;
+      params.selected = [signatureId, pushId, x, y].join(',');
     }
 
     if (Object.keys(zoom).length === 0) {

--- a/ui/perfherder/graphs/TestDataModal.jsx
+++ b/ui/perfherder/graphs/TestDataModal.jsx
@@ -44,11 +44,15 @@ export default class TestDataModal extends React.Component {
   }
 
   async componentDidMount() {
-    const { errorMessages, repository_name, framework } = this.state;
+    const {
+      errorMessages,
+      repository_name: repositoryName,
+      framework,
+    } = this.state;
     const { timeRange, getInitialData } = this.props;
     const updates = await getInitialData(
       errorMessages,
-      repository_name,
+      repositoryName,
       framework,
       timeRange,
     );
@@ -76,12 +80,16 @@ export default class TestDataModal extends React.Component {
   }
 
   async getPlatforms() {
-    const { repository_name, framework, errorMessages } = this.state;
+    const {
+      repository_name: repositoryName,
+      framework,
+      errorMessages,
+    } = this.state;
     const { timeRange } = this.props;
 
     const params = { interval: timeRange.value, framework: framework.id };
     const response = await PerfSeriesModel.getPlatformList(
-      repository_name.name,
+      repositoryName.name,
       params,
     );
 
@@ -92,10 +100,10 @@ export default class TestDataModal extends React.Component {
 
   addRelatedConfigs = async params => {
     const { relatedSeries } = this.props.options;
-    const { errorMessages, repository_name } = this.state;
+    const { errorMessages, repository_name: repositoryName } = this.state;
 
     const response = await PerfSeriesModel.getSeriesList(
-      repository_name.name,
+      repositoryName.name,
       params,
     );
     const updates = processResponse(response, 'relatedTests', errorMessages);
@@ -121,7 +129,7 @@ export default class TestDataModal extends React.Component {
     const { errorMessages } = this.state;
 
     const relatedProjects = thPerformanceBranches.filter(
-      repository_name => repository_name !== relatedSeries.repository_name,
+      repositoryName => repositoryName !== relatedSeries.repository_name,
     );
 
     const requests = relatedProjects.map(projectName =>
@@ -159,7 +167,7 @@ export default class TestDataModal extends React.Component {
       framework,
       includeSubtests,
       errorMessages,
-      repository_name,
+      repository_name: repositoryName,
     } = this.state;
     const { timeRange, getSeriesData, testData } = this.props;
 
@@ -175,7 +183,7 @@ export default class TestDataModal extends React.Component {
       const updates = await getSeriesData(
         params,
         errorMessages,
-        repository_name,
+        repositoryName,
         testData,
       );
 
@@ -254,7 +262,7 @@ export default class TestDataModal extends React.Component {
       platforms,
       seriesData,
       framework,
-      repository_name,
+      repository_name: repositoryName,
       platform,
       includeSubtests,
       selectedTests,
@@ -281,7 +289,7 @@ export default class TestDataModal extends React.Component {
       },
       {
         options: projects.length ? projects.map(item => item.name) : [],
-        selectedItem: repository_name.name || '',
+        selectedItem: repositoryName.name || '',
         updateData: value =>
           this.setState(
             { repository_name: this.findObject(projects, 'name', value) },

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -59,7 +59,7 @@ export const getStdDev = function getStandardDeviation(values, avg) {
 export const getTTest = function getTTest(
   valuesC,
   valuesT,
-  stddev_default_factor,
+  stddevDefaultFactor,
 ) {
   const lenC = valuesC.length;
   const lenT = valuesT.length;
@@ -71,9 +71,9 @@ export const getTTest = function getTTest(
   const avgC = calcAverage(valuesC);
   const avgT = calcAverage(valuesT);
   let stddevC =
-    lenC > 1 ? getStdDev(valuesC, avgC) : stddev_default_factor * avgC;
+    lenC > 1 ? getStdDev(valuesC, avgC) : stddevDefaultFactor * avgC;
   let stddevT =
-    lenT > 1 ? getStdDev(valuesT, avgT) : stddev_default_factor * avgT;
+    lenT > 1 ? getStdDev(valuesT, avgT) : stddevDefaultFactor * avgT;
 
   if (lenC === 1) {
     stddevC = (valuesC[0] * stddevT) / avgT;
@@ -571,13 +571,13 @@ export const processSelectedParam = tooltipArray => ({
 
 export const getInitialData = async (
   errorMessages,
-  repository_name,
+  repositoryName,
   framework,
   timeRange,
 ) => {
   const params = { interval: timeRange.value, framework: framework.id };
   const platforms = await PerfSeriesModel.getPlatformList(
-    repository_name.name,
+    repositoryName.name,
     params,
   );
 
@@ -595,7 +595,7 @@ export const updateSeriesData = (origSeriesData, testData) =>
 export const getSeriesData = async (
   params,
   errorMessages,
-  repository_name,
+  repositoryName,
   testData,
 ) => {
   let updates = {
@@ -605,7 +605,7 @@ export const getSeriesData = async (
     loading: false,
   };
   const response = await PerfSeriesModel.getSeriesList(
-    repository_name.name,
+    repositoryName.name,
     params,
   );
   updates = {

--- a/ui/push-health/Job.jsx
+++ b/ui/push-health/Job.jsx
@@ -10,21 +10,25 @@ import logviewerIcon from '../img/logviewerIcon.png';
 class Job extends PureComponent {
   render() {
     const { job, jobName, jobSymbol, repo, revision } = this.props;
-    const { id, result, failure_classification_id } = job;
+    const {
+      id,
+      result,
+      failure_classification_id: failureClassificationId,
+    } = job;
 
     return (
       <span className="mr-2" key={id}>
         <a
           className={`btn job-btn filter-shown btn-sm mt-1 ${getBtnClass(
             result,
-            failure_classification_id,
+            failureClassificationId,
           )}`}
           href={getJobsUrl({ selectedJob: job.id, repo, revision })}
           title={jobName}
         >
           {jobSymbol}
         </a>
-        {failure_classification_id !== 1 && (
+        {failureClassificationId !== 1 && (
           <FontAwesomeIcon icon={faStar} title="Classified" />
         )}
         {job.result === 'testfailed' && (

--- a/ui/shared/JobInfo.jsx
+++ b/ui/shared/JobInfo.jsx
@@ -7,21 +7,26 @@ import { toDateStr } from '../helpers/display';
 
 const getTimeFields = function getTimeFields(job) {
   // time fields to show in detail panel, but that should be grouped together
-  const { end_timestamp, start_timestamp, submit_timestamp, duration } = job;
+  const {
+    end_timestamp: endTimestamp,
+    start_timestamp: startTimestamp,
+    submit_timestamp: submitTimestamp,
+    duration,
+  } = job;
   const durationStr = `${duration} minute${duration > 1 ? 's' : ''}`;
   const timeFields = [
-    { title: 'Requested', value: toDateStr(submit_timestamp) },
+    { title: 'Requested', value: toDateStr(submitTimestamp) },
   ];
 
-  if (start_timestamp) {
-    timeFields.push({ title: 'Started', value: toDateStr(start_timestamp) });
+  if (startTimestamp) {
+    timeFields.push({ title: 'Started', value: toDateStr(startTimestamp) });
   }
-  if (end_timestamp) {
-    timeFields.push({ title: 'Ended', value: toDateStr(end_timestamp) });
+  if (endTimestamp) {
+    timeFields.push({ title: 'Ended', value: toDateStr(endTimestamp) });
   }
   timeFields.push({
     title: 'Duration',
-    value: start_timestamp
+    value: startTimestamp
       ? durationStr
       : `Not started (queued for ${durationStr})`,
   });
@@ -35,11 +40,11 @@ export default class JobInfo extends React.PureComponent {
     const {
       signature,
       title,
-      task_id,
-      build_platform,
-      job_type_name,
-      build_architecture,
-      build_os,
+      task_id: taskId,
+      build_platform: buildPlatform,
+      job_type_name: jobTypeName,
+      build_architecture: buildArchitecture,
+      build_os: buildOs,
     } = job;
     const timeFields = getTimeFields(job);
 
@@ -67,27 +72,27 @@ export default class JobInfo extends React.PureComponent {
             <span>{title}</span>
           )}
         </li>
-        {task_id && currentRepo && (
+        {taskId && currentRepo && (
           <li className="small">
             <strong>Task: </strong>
             <a
               id="taskInfo"
-              href={getInspectTaskUrl(task_id, currentRepo.tc_root_url)}
+              href={getInspectTaskUrl(taskId, currentRepo.tc_root_url)}
               target="_blank"
               rel="noopener noreferrer"
             >
-              {task_id}
+              {taskId}
             </a>
           </li>
         )}
         <li className="small">
           <strong>Build: </strong>
-          <span>{`${build_architecture} ${build_platform} ${build_os ||
+          <span>{`${buildArchitecture} ${buildPlatform} ${buildOs ||
             ''}`}</span>
         </li>
         <li className="small">
           <strong>Job name: </strong>
-          <span>{job_type_name}</span>
+          <span>{jobTypeName}</span>
         </li>
         {[...timeFields, ...extraFields].map(field => (
           <li className="small" key={`${field.title}${field.value}`}>


### PR DESCRIPTION
Reenabled camelCase rule and fixed all violations in the code base.

There's a failing test `tests/ui/job-view/Filtering_test.jsx`, but it also fail on the master branch, so probably not due to changes in this PR. Running a diff on the output from `yarn test` both on master and the new branch confirms that no new tests fail because of this PR.

Update: The failing test was due to an old `node` version I had on my machine, after upgrading to `v12.13.0` all tests pass.

Close #5457 