### PR TITLE
Bug 1591076 - Fix tooltip popup to support retriggers

### DIFF
--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -458,7 +458,7 @@ class PerformanceSummary(generics.ListAPIView):
 
         signature_ids = [item['id'] for item in list(self.queryset)]
 
-        data = (PerformanceDatum.objects.select_related('push', 'repository')
+        data = (PerformanceDatum.objects.select_related('push', 'repository', 'id')
                                 .filter(signature_id__in=signature_ids, repository__name=repository_name))
 
         if revision:

--- a/ui/perfherder/graphs/GraphTooltip.jsx
+++ b/ui/perfherder/graphs/GraphTooltip.jsx
@@ -28,8 +28,10 @@ const GraphTooltip = ({
     item => item.signature_id === datum.signature_id,
   );
 
-  const flotIndex = testDetails.data.findIndex(
-    item => item.pushId === datum.pushId,
+  const flotIndex = testDetails.data.findIndex(item =>
+    datum.dataPointId
+      ? item.dataPointId === datum.dataPointId
+      : item.pushId === datum.pushId,
   );
   const dataPointDetails = testDetails.data[flotIndex];
 

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -85,8 +85,10 @@ class GraphsContainer extends React.Component {
 
     const dataPointFound = testData.find(item => {
       if (item.signature_id === selectedDataPoint.signature_id) {
-        return item.data.find(
-          datum => datum.pushId === selectedDataPoint.pushId,
+        return item.data.find(datum =>
+          selectedDataPoint.dataPointId
+            ? datum.dataPointId === selectedDataPoint.dataPointId
+            : datum.pushId === selectedDataPoint.pushId,
         );
       }
       return false;
@@ -188,6 +190,7 @@ class GraphsContainer extends React.Component {
           pushId: dataPoint.datum.pushId,
           x: dataPoint.x,
           y: dataPoint.y,
+          dataPointId: dataPoint.datum.dataPointId,
         },
       });
     }

--- a/ui/perfherder/graphs/GraphsView.jsx
+++ b/ui/perfherder/graphs/GraphsView.jsx
@@ -206,6 +206,7 @@ class GraphsView extends React.Component {
           signature_id: series.signature_id,
           pushId: dataPoint.push_id,
           jobId: dataPoint.job_id,
+          dataPointId: dataPoint.id,
         })),
         lowerIsBetter: series.lower_is_better,
         resultSetData: series.data.map(dataPoint => dataPoint.push_id),
@@ -325,8 +326,15 @@ class GraphsView extends React.Component {
     if (!selectedDataPoint) {
       delete params.selected;
     } else {
-      const { signature_id: signatureId, pushId, x, y } = selectedDataPoint;
-      params.selected = [signatureId, pushId, x, y].join(',');
+      const {
+        signature_id: signatureId,
+        pushId,
+        dataPointId,
+        x,
+        y,
+      } = selectedDataPoint;
+
+      params.selected = [signatureId, pushId, x, y, dataPointId].join(',');
     }
 
     if (Object.keys(zoom).length === 0) {

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -562,12 +562,19 @@ export const containsText = (string, text) => {
   return regex.test(string);
 };
 
-export const processSelectedParam = tooltipArray => ({
-  signature_id: parseInt(tooltipArray[0], 10),
-  pushId: parseInt(tooltipArray[1], 10),
-  x: parseFloat(tooltipArray[2]),
-  y: parseFloat(tooltipArray[3]),
-});
+export const processSelectedParam = tooltipArray => {
+  const values = {
+    signature_id: parseInt(tooltipArray[0], 10),
+    pushId: parseInt(tooltipArray[1], 10),
+    x: parseFloat(tooltipArray[2]),
+    y: parseFloat(tooltipArray[3]),
+  };
+
+  if (tooltipArray[4]) {
+    values.dataPointId = parseInt(tooltipArray[4], 10);
+  }
+  return values;
+};
 
 export const getInitialData = async (
   errorMessages,


### PR DESCRIPTION
The id for PerformanceDatum was mistakenly not carried over during the conversion, so there wasn't an accurate way to show tooltip data for retriggers. This pr adds the id to the `PerformanceSummary` api and modifies the `selected` param to include this id (backwards-compatible so won't break old links).