### PR TITLE
Bug 1597634 - Mirror CI schema support for public suite & test names

### DIFF
--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -40,6 +40,12 @@
           "title": "Subtest name",
           "type": "string"
         },
+        "publicName": {
+          "title": "Public subtest name",
+          "description": "Allows renaming test's name, without breaking existing performance data series",
+          "maxLength": 30,
+          "type": "string"
+        },
         "value": {
           "description": "Summary value for subtest",
           "title": "Subtest value",
@@ -104,6 +110,12 @@
       "properties": {
         "name": {
           "title": "Suite name",
+          "type": "string"
+        },
+        "publicName": {
+          "title": "Public suite name",
+          "description": "Allows renaming suite's name, without breaking existing performance data series",
+          "maxLength": 30,
           "type": "string"
         },
         "extraOptions": {


### PR DESCRIPTION
[Back to Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1597634)