### PR TITLE
Bug 1598037 - Perfherder subtests view fix

### DIFF
--- a/ui/perfherder/compare/CompareSubtestsView.jsx
+++ b/ui/perfherder/compare/CompareSubtestsView.jsx
@@ -188,6 +188,10 @@ class CompareSubtestsView extends React.PureComponent {
     compareResults = new Map([...compareResults.entries()].sort());
     const updates = { compareResults, testsWithNoise, loading: false };
 
+    if (compareResults.size === 0) {
+      return updates;
+    }
+
     const resultsArr = compareResults
       .get(parentTestName)
       .map(value => value.name);


### PR DESCRIPTION
This patch only adds a condition to fix loading spinner if test results are returned without data. I need to investigate why the Perfherder alerts has generated a link to a tests for a specific revision that we don't have data for.