### PR TITLE
Bug 1597136 - Optimize cycle_data to fragment table less

### DIFF
--- a/tests/model/test_cycle_data.py
+++ b/tests/model/test_cycle_data.py
@@ -30,10 +30,10 @@ def test_cycle_all_data(test_repository, failure_classifications, sample_data,
     job_data = sample_data.job_data[:20]
     test_utils.do_job_ingestion(test_repository, job_data, sample_push, False)
 
-    # set the submit time to be a week before today
+    # set the last_modified time to be a week before today
     cycle_date_ts = datetime.datetime.now() - datetime.timedelta(weeks=1)
     for job in Job.objects.all():
-        job.submit_time = cycle_date_ts
+        job.last_modified = cycle_date_ts
         job.save()
 
     call_command('cycle_data', 'from:treeherder', sleep_time=0, days=1)
@@ -55,9 +55,9 @@ def test_cycle_all_but_one_job(test_repository, failure_classifications, sample_
     job_data = sample_data.job_data[:20]
     test_utils.do_job_ingestion(test_repository, job_data, sample_push, False)
 
-    # one job should not be deleted, set its submit time to now
+    # one job should not be deleted, set its last_modified time to now
     job_not_deleted = Job.objects.get(id=2)
-    job_not_deleted.submit_time = datetime.datetime.now()
+    job_not_deleted.last_modified = datetime.datetime.now()
     job_not_deleted.save()
 
     extra_objects = {
@@ -72,10 +72,10 @@ def test_cycle_all_but_one_job(test_repository, failure_classifications, sample_
             value='testvalue')])
     }
 
-    # set other job's submit time to be a week ago from now
+    # set other job's last_modified time to be a week ago from now
     cycle_date_ts = datetime.datetime.now() - datetime.timedelta(weeks=1)
     for job in Job.objects.all().exclude(id=job_not_deleted.id):
-        job.submit_time = cycle_date_ts
+        job.last_modified = cycle_date_ts
         job.save()
     num_job_logs_to_be_deleted = JobLog.objects.all().exclude(
         id=job_not_deleted.id).count()
@@ -103,7 +103,7 @@ def test_cycle_all_data_in_chunks(test_repository, failure_classifications, samp
     # build a date that will cause the data to be cycled
     cycle_date_ts = datetime.datetime.now() - datetime.timedelta(weeks=1)
     for job in Job.objects.all():
-        job.submit_time = cycle_date_ts
+        job.last_modified = cycle_date_ts
         job.save()
 
     create_failure_lines(Job.objects.get(id=1),
@@ -151,7 +151,7 @@ def test_cycle_job_with_performance_data(test_repository, failure_classification
                                          test_job, mock_log_parser,
                                          test_perf_signature):
     # build a date that will cause the data to be cycled
-    test_job.submit_time = datetime.datetime.now() - datetime.timedelta(weeks=1)
+    test_job.last_modified = datetime.datetime.now() - datetime.timedelta(weeks=1)
     test_job.save()
 
     p = PerformanceDatum.objects.create(

--- a/tests/model/test_cycle_data.py
+++ b/tests/model/test_cycle_data.py
@@ -30,10 +30,10 @@ def test_cycle_all_data(test_repository, failure_classifications, sample_data,
     job_data = sample_data.job_data[:20]
     test_utils.do_job_ingestion(test_repository, job_data, sample_push, False)
 
-    # set the last_modified time to be a week before today
+    # set the submit time to be a week before today
     cycle_date_ts = datetime.datetime.now() - datetime.timedelta(weeks=1)
     for job in Job.objects.all():
-        job.last_modified = cycle_date_ts
+        job.submit_time = cycle_date_ts
         job.save()
 
     call_command('cycle_data', 'from:treeherder', sleep_time=0, days=1)
@@ -55,9 +55,9 @@ def test_cycle_all_but_one_job(test_repository, failure_classifications, sample_
     job_data = sample_data.job_data[:20]
     test_utils.do_job_ingestion(test_repository, job_data, sample_push, False)
 
-    # one job should not be deleted, set its last_modified time to now
+    # one job should not be deleted, set its submit time to now
     job_not_deleted = Job.objects.get(id=2)
-    job_not_deleted.last_modified = datetime.datetime.now()
+    job_not_deleted.submit_time = datetime.datetime.now()
     job_not_deleted.save()
 
     extra_objects = {
@@ -72,10 +72,10 @@ def test_cycle_all_but_one_job(test_repository, failure_classifications, sample_
             value='testvalue')])
     }
 
-    # set other job's last_modified time to be a week ago from now
+    # set other job's submit time to be a week ago from now
     cycle_date_ts = datetime.datetime.now() - datetime.timedelta(weeks=1)
     for job in Job.objects.all().exclude(id=job_not_deleted.id):
-        job.last_modified = cycle_date_ts
+        job.submit_time = cycle_date_ts
         job.save()
     num_job_logs_to_be_deleted = JobLog.objects.all().exclude(
         id=job_not_deleted.id).count()
@@ -103,7 +103,7 @@ def test_cycle_all_data_in_chunks(test_repository, failure_classifications, samp
     # build a date that will cause the data to be cycled
     cycle_date_ts = datetime.datetime.now() - datetime.timedelta(weeks=1)
     for job in Job.objects.all():
-        job.last_modified = cycle_date_ts
+        job.submit_time = cycle_date_ts
         job.save()
 
     create_failure_lines(Job.objects.get(id=1),
@@ -151,7 +151,7 @@ def test_cycle_job_with_performance_data(test_repository, failure_classification
                                          test_job, mock_log_parser,
                                          test_perf_signature):
     # build a date that will cause the data to be cycled
-    test_job.last_modified = datetime.datetime.now() - datetime.timedelta(weeks=1)
+    test_job.submit_time = datetime.datetime.now() - datetime.timedelta(weeks=1)
     test_job.save()
 
     p = PerformanceDatum.objects.create(

--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -6,8 +6,7 @@ from django.core.management.base import BaseCommand
 from treeherder.model.models import (Job,
                                      JobGroup,
                                      JobType,
-                                     Machine,
-                                     Repository)
+                                     Machine)
 from treeherder.perf.models import PerformanceDatum
 
 logging.basicConfig(format='%(levelname)s:%(message)s')
@@ -40,17 +39,11 @@ class TreeherderCycler(DataCycler):
     source = TREEHERDER.title()
 
     def cycle(self):
-        repositories = Repository.objects.all()
-        repo_count = len(repositories)
-
-        for idx, repository in enumerate(repositories):
-            self.logger.warning("Cycling repository: {0}. {1} of {2} repositories".format(repository.name, idx, repo_count))
-            rs_deleted = Job.objects.cycle_data(repository,
-                                                self.cycle_interval,
-                                                self.chunk_size,
-                                                self.sleep_time)
-            self.logger.warning("Deleted {} jobs from {}"
-                                .format(rs_deleted, repository.name))
+        self.logger.warning("Cycling jobs across all repositories")
+        rs_deleted = Job.objects.cycle_data(self.cycle_interval,
+                                            self.chunk_size,
+                                            self.sleep_time)
+        self.logger.warning("Deleted {} jobs".format(rs_deleted))
 
         self.remove_leftovers()
 

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -461,6 +461,9 @@ class JobManager(models.Manager):
                 # Allow some time for other queries to get through
                 time.sleep(sleep_time)
 
+            if len(jobs_chunk) < chunk_size:
+                return jobs_cycled
+
 
 class Job(models.Model):
     """

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -417,7 +417,7 @@ class JobManager(models.Manager):
 
         jobs_cycled = 0
         while True:
-            jobs_chunk = list(self.filter(submit_time__lt=jobs_max_timestamp)
+            jobs_chunk = list(self.filter(last_modified__lt=jobs_max_timestamp)
                                   .order_by('id')
                                   .values_list('guid', flat=True)[:chunk_size])
 

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -417,7 +417,7 @@ class JobManager(models.Manager):
 
         jobs_cycled = 0
         while True:
-            jobs_chunk = list(self.filter(last_modified__lt=jobs_max_timestamp)
+            jobs_chunk = list(self.filter(submit_time__lt=jobs_max_timestamp)
                                   .order_by('id')
                                   .values_list('guid', flat=True)[:chunk_size])
 

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -406,7 +406,7 @@ class JobManager(models.Manager):
     Convenience functions for operations on groups of jobs
     """
 
-    def cycle_data(self, repository, cycle_interval, chunk_size, sleep_time):
+    def cycle_data(self, cycle_interval, chunk_size, sleep_time):
         """
         Delete data older than cycle_interval, splitting the target data into
         chunks of chunk_size size. Returns the number of result sets deleted
@@ -417,12 +417,11 @@ class JobManager(models.Manager):
 
         jobs_cycled = 0
         while True:
-            jobs_chunk = list(self.filter(repository=repository, submit_time__lt=jobs_max_timestamp)
+            jobs_chunk = list(self.filter(submit_time__lt=jobs_max_timestamp)
                                   .order_by('id')
                                   .values_list('guid', flat=True)[:chunk_size])
 
-            logger.warning('Pruning {}: chunk of {} older than {}'.format(
-                repository.name,
+            logger.warning('Pruning jobs: chunk of {} older than {}'.format(
                 len(jobs_chunk),
                 jobs_max_timestamp.strftime('%b %d %Y')
             ))


### PR DESCRIPTION
This removes the cycling on a per-repo basis.  Now that our DB isn't segragated by repo, it is unnecessary.  Cycling by repo is going to be slower and leave holes (fragments) in the table on each delete.