### PR TITLE
Bug 1597476 - Optimize perf datum queries

### DIFF
--- a/treeherder/perf/alerts.py
+++ b/treeherder/perf/alerts.py
@@ -50,8 +50,7 @@ def generate_new_alerts_in_series(signature):
     # (use whichever is newer)
     max_alert_age = (datetime.now() -
                      settings.PERFHERDER_ALERTS_MAX_AGE)
-    series = PerformanceDatum.objects.filter(signature=signature).filter(
-        push_timestamp__gte=max_alert_age).order_by('push_timestamp')
+    series = PerformanceDatum.objects.filter(signature=signature, push_timestamp__gte=max_alert_age)
     latest_alert_timestamp = PerformanceAlert.objects.filter(
         series_signature=signature).select_related(
         'summary__push__time').order_by(

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -199,12 +199,13 @@ class PerformanceDatumViewSet(viewsets.ViewSet):
 
         datums = PerformanceDatum.objects.filter(
             repository=repository).select_related(
-                'signature__signature_hash').order_by('push_timestamp')
+                'signature', 'push')
 
         if signature_hashes:
             signature_ids = PerformanceSignature.objects.filter(
                 repository=repository,
                 signature_hash__in=signature_hashes).values_list('id', flat=True)
+
             datums = datums.filter(signature__id__in=list(signature_ids))
         elif signature_ids:
             datums = datums.filter(signature__id__in=list(signature_ids))


### PR DESCRIPTION
Removed order_by in generate_new_alerts_in_series and performance/datum list API. These both seemed to have a significant effect on execution time, however the performance datum API is still not as fast as it could be. More details in the bug.

FYI @klahnakoski and @ionutgoldan 
