### PR TITLE
Fix cycle_data logger typo

### DIFF
--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -48,7 +48,7 @@ class TreeherderCycler(DataCycler):
                                                 self.sleep_time)
             self.logger.warning("Deleted {} jobs".format(rs_deleted))
         except OperationalError as e:
-            self.logger.errror("Error running cycle_data: {}".format(e))
+            self.logger.error("Error running cycle_data: {}".format(e))
 
         self.remove_leftovers()
 


### PR DESCRIPTION
Fix typo from pr #5669 that's causing papertrail alerts. Interesting that our python linting didn't catch it before it was merged.