### PR TITLE
Bug 1600932 - Avoid CCing all Perf sheriffs

### DIFF
--- a/treeherder/perf/fixtures/performance_bug_templates.yaml
+++ b/treeherder/perf/fixtures/performance_bug_templates.yaml
@@ -5,7 +5,6 @@
     keywords: perf, perf-alert, regression, talos-regression
     default_component: Performance
     default_product: Testing
-    cc_list: rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, aionescu@mozilla.com, marian.raiciof@softvision.ro
     text: |
       Talos has detected a Firefox performance regression from push:
 
@@ -33,7 +32,7 @@
     keywords: perf-alert, regression
     default_component: Performance
     default_product: Testing
-    cc_list: rwood@mozilla.com, nfroyd@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, aionescu@mozilla.com, marian.raiciof@softvision.ro
+    cc_list: nfroyd@mozilla.com
     text: |
       We have detected a build metrics regression from push:
 
@@ -57,7 +56,7 @@
     keywords: perf, perf-alert, regression
     default_component: Performance
     default_product: Testing
-    cc_list: rwood@mozilla.com, bob@bclary.com, igoldan@mozilla.com, erahm@mozilla.com, fstrugariu@mozilla.com, aionescu@mozilla.com, marian.raiciof@softvision.ro
+    cc_list: bob@bclary.com, erahm@mozilla.com
     text: |
       We have detected an awsy regression from push:
 
@@ -79,7 +78,6 @@
     keywords: perf, perf-alert, regression
     default_component: Performance
     default_product: Testing
-    cc_list: rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, aionescu@mozilla.com, marian.raiciof@softvision.ro
     text: |
       We have detected an awfy regression from push:
 
@@ -101,7 +99,6 @@
     keywords: perf, perf-alert, regression
     default_component: Performance
     default_product: Testing
-    cc_list: rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, aionescu@mozilla.com, marian.raiciof@softvision.ro
     text: |
       We have detected a platform microbenchmarks regression from push:
 
@@ -123,7 +120,6 @@
     keywords: perf, perf-alert, regression
     default_component: Performance
     default_product: Testing
-    cc_list: rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, aionescu@mozilla.com, marian.raiciof@softvision.ro
     text: |
       Raptor has detected a Firefox performance regression from push:
 

--- a/treeherder/perf/fixtures/performance_bug_templates.yaml
+++ b/treeherder/perf/fixtures/performance_bug_templates.yaml
@@ -5,7 +5,7 @@
     keywords: perf, perf-alert, regression, talos-regression
     default_component: Performance
     default_product: Testing
-    cc_list: rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, alexandru.ionescu@softvision.ro, marian.raiciof@softvision.ro
+    cc_list: rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, aionescu@mozilla.com, marian.raiciof@softvision.ro
     text: |
       Talos has detected a Firefox performance regression from push:
 
@@ -33,7 +33,7 @@
     keywords: perf-alert, regression
     default_component: Performance
     default_product: Testing
-    cc_list: rwood@mozilla.com, nfroyd@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, alexandru.ionescu@softvision.ro, marian.raiciof@softvision.ro
+    cc_list: rwood@mozilla.com, nfroyd@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, aionescu@mozilla.com, marian.raiciof@softvision.ro
     text: |
       We have detected a build metrics regression from push:
 
@@ -57,7 +57,7 @@
     keywords: perf, perf-alert, regression
     default_component: Performance
     default_product: Testing
-    cc_list: rwood@mozilla.com, bob@bclary.com, igoldan@mozilla.com, erahm@mozilla.com, fstrugariu@mozilla.com, alexandru.ionescu@softvision.ro, marian.raiciof@softvision.ro
+    cc_list: rwood@mozilla.com, bob@bclary.com, igoldan@mozilla.com, erahm@mozilla.com, fstrugariu@mozilla.com, aionescu@mozilla.com, marian.raiciof@softvision.ro
     text: |
       We have detected an awsy regression from push:
 
@@ -79,7 +79,7 @@
     keywords: perf, perf-alert, regression
     default_component: Performance
     default_product: Testing
-    cc_list: rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, alexandru.ionescu@softvision.ro, marian.raiciof@softvision.ro
+    cc_list: rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, aionescu@mozilla.com, marian.raiciof@softvision.ro
     text: |
       We have detected an awfy regression from push:
 
@@ -101,7 +101,7 @@
     keywords: perf, perf-alert, regression
     default_component: Performance
     default_product: Testing
-    cc_list: rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, alexandru.ionescu@softvision.ro, marian.raiciof@softvision.ro
+    cc_list: rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, aionescu@mozilla.com, marian.raiciof@softvision.ro
     text: |
       We have detected a platform microbenchmarks regression from push:
 
@@ -123,7 +123,7 @@
     keywords: perf, perf-alert, regression
     default_component: Performance
     default_product: Testing
-    cc_list: rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, alexandru.ionescu@softvision.ro, marian.raiciof@softvision.ro
+    cc_list: rwood@mozilla.com, igoldan@mozilla.com, fstrugariu@mozilla.com, aionescu@mozilla.com, marian.raiciof@softvision.ro
     text: |
       Raptor has detected a Firefox performance regression from push:
 


### PR DESCRIPTION
Due to the recent expansion of the sheriffing team, I updated the regression template to avoid spamming all team members when a regression bug is open from an alert.