### PR TITLE
Bug 1601725 - Add product/component column to intermittent-failures view.

### DIFF
--- a/ui/intermittent-failures/MainView.jsx
+++ b/ui/intermittent-failures/MainView.jsx
@@ -45,6 +45,7 @@ const MainView = props => {
       headerClassName: 'bug-column-header',
       className: 'bug-column',
       maxWidth: 150,
+      width: 115,
       Cell: _props => (
         <BugColumn
           data={_props.original}
@@ -63,6 +64,18 @@ const MainView = props => {
       accessor: 'count',
       maxWidth: 100,
       filterable: false,
+    },
+    {
+      Header: 'Product',
+      accessor: 'product',
+      maxWidth: 100,
+      filterMethod: (filter, row) => textFilter(filter, row),
+    },
+    {
+      Header: 'Component',
+      accessor: 'component',
+      maxWidth: 100,
+      filterMethod: (filter, row) => textFilter(filter, row),
     },
     {
       Header: 'Summary',

--- a/ui/intermittent-failures/View.jsx
+++ b/ui/intermittent-failures/View.jsx
@@ -114,7 +114,7 @@ const withView = defaultState => WrappedComponent => {
 
     batchBugRequests = async bugIds => {
       const urlParams = {
-        include_fields: 'id,status,summary,whiteboard',
+        include_fields: 'id,product,component,status,summary,whiteboard',
       };
       // TODO: bump up the max to ~1200 when this bug is fixed:
       // https://bugzilla.mozilla.org/show_bug.cgi?id=1497721


### PR DESCRIPTION
Makes it easier to find the worst offenders in a component.