### PR TITLE
Bug 1600757 - Dropdown menu screen reader keyboard support

### DIFF
--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -71,6 +71,7 @@ label.dropdown-item {
 }
 
 .nav-menu-btn {
+  width: 98%;
   margin-right: -4px;
   padding-left: 14px;
   padding-right: 14px;

--- a/ui/job-view/headerbars/TiersMenu.jsx
+++ b/ui/job-view/headerbars/TiersMenu.jsx
@@ -10,15 +10,15 @@ export default function TiersMenu(props) {
 
   return (
     <span className="dropdown">
-      <span
+      <button
         id="tierLabel"
-        role="button"
+        type="button"
         title="Show/hide job tiers"
         data-toggle="dropdown"
         className="btn btn-view-nav btn-sm nav-menu-btn dropdown-toggle"
       >
         Tiers
-      </span>
+      </button>
       <ul className="dropdown-menu checkbox-dropdown-menu" role="menu">
         {TIERS.map(tier => {
           const isOnlyTier = shownTiers.length === 1 && tier === shownTiers[0];

--- a/ui/job-view/headerbars/TiersMenu.jsx
+++ b/ui/job-view/headerbars/TiersMenu.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Label } from 'reactstrap';
+import {
+  Label,
+  UncontrolledDropdown,
+  DropdownToggle,
+  DropdownMenu,
+} from 'reactstrap';
 
 const TIERS = ['1', '2', '3'];
 
@@ -9,17 +14,15 @@ export default function TiersMenu(props) {
   const shownTiers = filterModel.urlParams.tier || [];
 
   return (
-    <span className="dropdown">
-      <button
+    <UncontrolledDropdown>
+      <DropdownToggle
         id="tierLabel"
-        type="button"
         title="Show/hide job tiers"
-        data-toggle="dropdown"
         className="btn btn-view-nav btn-sm nav-menu-btn dropdown-toggle"
       >
         Tiers
-      </button>
-      <ul className="dropdown-menu checkbox-dropdown-menu" role="menu">
+      </DropdownToggle>
+      <DropdownMenu className="checkbox-dropdown-menu">
         {TIERS.map(tier => {
           const isOnlyTier = shownTiers.length === 1 && tier === shownTiers[0];
           return (
@@ -34,6 +37,7 @@ export default function TiersMenu(props) {
                   className={`dropdown-item ${isOnlyTier ? 'disabled' : ''}`}
                 >
                   <input
+                    style={{ pointerEvents: 'none' }}
                     id="tier-checkbox"
                     type="checkbox"
                     className="mousetrap"
@@ -47,8 +51,8 @@ export default function TiersMenu(props) {
             </li>
           );
         })}
-      </ul>
-    </span>
+      </DropdownMenu>
+    </UncontrolledDropdown>
   );
 }
 

--- a/ui/job-view/headerbars/TiersMenu.jsx
+++ b/ui/job-view/headerbars/TiersMenu.jsx
@@ -22,7 +22,7 @@ export default function TiersMenu(props) {
       >
         Tiers
       </DropdownToggle>
-      <DropdownMenu className="checkbox-dropdown-menu">
+      <DropdownMenu>
         {TIERS.map(tier => {
           const isOnlyTier = shownTiers.length === 1 && tier === shownTiers[0];
           return (

--- a/ui/perfherder/alerts/AlertHeader.jsx
+++ b/ui/perfherder/alerts/AlertHeader.jsx
@@ -76,7 +76,7 @@ const AlertHeader = ({
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <DropdownItem>Jobs</DropdownItem>
+                <DropdownItem tag="a">Jobs</DropdownItem>
               </a>
               <a
                 className="text-dark"
@@ -87,7 +87,7 @@ const AlertHeader = ({
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <DropdownItem>Pushlog</DropdownItem>
+                <DropdownItem tag="a">Pushlog</DropdownItem>
               </a>
             </DropdownMenu>
           </UncontrolledDropdown>

--- a/ui/perfherder/alerts/StatusDropdown.jsx
+++ b/ui/perfherder/alerts/StatusDropdown.jsx
@@ -200,9 +200,13 @@ export default class StatusDropdown extends React.Component {
             {getStatus(alertSummary.status)}
           </DropdownToggle>
           <DropdownMenu>
-            <DropdownItem onClick={this.copySummary}>Copy Summary</DropdownItem>
+            <DropdownItem tag="a" onClick={this.copySummary}>
+              Copy Summary
+            </DropdownItem>
             {!alertSummary.bug_number && (
-              <DropdownItem onClick={this.fileBug}>File bug</DropdownItem>
+              <DropdownItem tag="a" onClick={this.fileBug}>
+                File bug
+              </DropdownItem>
             )}
             {user.isStaff && (
               <React.Fragment>

--- a/ui/perfherder/compare/SelectorCard.jsx
+++ b/ui/perfherder/compare/SelectorCard.jsx
@@ -217,6 +217,7 @@ export default class SelectorCard extends React.Component {
                 <DropdownMenu className="overflow-auto dropdown-menu-height">
                   {projects.map(item => (
                     <DropdownItem
+                      tag="a"
                       key={item.name}
                       onClick={event =>
                         this.updateRevisions(event.target.innerText)
@@ -284,6 +285,7 @@ export default class SelectorCard extends React.Component {
                       <DropdownMenu>
                         {data.results.map(item => (
                           <DropdownItem
+                            tag="a"
                             key={item.id}
                             onClick={event =>
                               this.selectRevision(

--- a/ui/push-health/ClassificationGroup.jsx
+++ b/ui/push-health/ClassificationGroup.jsx
@@ -72,6 +72,7 @@ class ClassificationGroup extends React.PureComponent {
       currentRepo,
     } = this.props;
     const expandIcon = detailsShowing ? faMinusSquare : faPlusSquare;
+    const expandTitle = detailsShowing ? 'Minus sign' : 'Plus sign';
 
     return (
       <Row className={`justify-content-between ${className}`}>
@@ -80,12 +81,14 @@ class ClassificationGroup extends React.PureComponent {
             className="pointable w-100"
             onClick={this.toggleDetails}
             color={headerColor}
+            role="button"
+            aria-expanded={detailsShowing}
           >
             {name} : {Object.keys(group).length}
             <FontAwesomeIcon
               icon={expandIcon}
               className="ml-1"
-              title="expand"
+              title={expandTitle}
             />
           </Badge>
         </h4>

--- a/ui/push-health/Metric.jsx
+++ b/ui/push-health/Metric.jsx
@@ -29,6 +29,7 @@ export default class Metric extends React.PureComponent {
     const { result, name, children } = this.props;
     const resultColor = resultColorMap[result];
     const expandIcon = detailsShowing ? faMinusSquare : faPlusSquare;
+    const expandTitle = detailsShowing ? 'Minus sign' : 'Plus sign';
 
     return (
       <td>
@@ -36,12 +37,17 @@ export default class Metric extends React.PureComponent {
           <div className={`bg-${resultColor} pr-2 mr-2`} />
           <Col>
             <Row className="justify-content-between">
-              <Button onClick={this.toggleDetails} outline className="border-0">
+              <Button
+                onClick={this.toggleDetails}
+                outline
+                className="border-0"
+                aria-expanded={detailsShowing}
+              >
                 <span className="metric-name align-top font-weight-bold">
                   {name}
                 </span>
                 <span className="btn">
-                  <FontAwesomeIcon icon={expandIcon} title="expand" />
+                  <FontAwesomeIcon icon={expandIcon} title={expandTitle} />
                 </span>
               </Button>
               <span>

--- a/ui/shared/DropdownMenuItems.jsx
+++ b/ui/shared/DropdownMenuItems.jsx
@@ -8,6 +8,7 @@ const DropdownMenuItems = ({ selectedItem, updateData, options }) => (
   <DropdownMenu className="overflow-auto dropdown-menu-height">
     {options.map(item => (
       <DropdownItem
+        tag="a"
         key={item}
         onClick={event => updateData(event.target.innerText)}
       >


### PR DESCRIPTION
Hi @sarah-clements and @camd,

## Description of issue

The **dropdown** components of Treeherder are not accessible to screen reader/keyboard users. 

According to [W3C's WAI](https://www.w3.org/TR/wai-aria-practices-1.1/#menubutton) (Web Accessibility Initiative), dropdowns are composed by a **menu button** that toggles a **menu**/**menu bar**. As a general rule:
- _space_ and _enter_ keys should open the menu and the _first item_ should be focused;
- the menu should be navigable by using the _arrow, home and end keys_.
- the menu should be closed by pressing the _esc key._

So far, these issues were detected:

- [X] A. Some **dropdown components were working only with the enter key**. The space key triggered the first action/item of the list, therefore, users could not open and choose whichever item they wanted.

- [X] B. The **Tiers dropdown** in Treeherder page was being **skipped** when using tab navigation.

- [x] C. (probably should open a new bug) Most of the menu in Treeherder page, although working with keyboard keys, **does not behave as suggested** by WAI. For example, the first item is not being focused when opening the menu; arrow keys navigation are not available (Repos, Tiers, Filters).

## Proposed Solution

**A**. It was noted that `LogoMenu` component worked properly, with both _space_ and _enter_ keys. It was also noted that in the [Reactstrap's Dropdown documentation](https://reactstrap.github.io/components/dropdowns/), there were some examples that were accessible and others were not.

The difference between the working and not working components is that the menu items were `<a>` tags instead of `<buttons>`. Changing the tags solved the problems and their functionality were kept.

**B**. For some reason, the `<span>` tag was being skipped. The solution was to change it to `<button>`.

## Testing
A. First test was navigating in Perfherder's dropdown filters, with both space and enter keys.
![Perfherder - Edited](https://user-images.githubusercontent.com/3901809/70276029-18609880-178e-11ea-9d34-a794f4e3971e.gif)
Later, other dropdowns were tested as well, in other tabs and pages.

B. A simple navigation between menus with tab key was performed in Treeherder top bar.