### PR TITLE
Bug 1594416 - Fix perf permalinks

### DIFF
--- a/tests/ui/perfherder/compare_table_test.jsx
+++ b/tests/ui/perfherder/compare_table_test.jsx
@@ -91,13 +91,11 @@ const getMockRetrigger = data => {
 
 const regexComptableHeaderId = /table-header-\d+/;
 const regexComptableRowId = /table-row-\d+/;
+const mockHandlePermalinkClick = jest.fn();
 
 afterEach(cleanup);
 
-const compareTableControlsNode = (onPermalinkClick, userLoggedIn = false) => {
-  // eslint-disable-next-line no-unused-vars
-  const handlePermalinkClick = onPermalinkClick || (hashBasedValue => {});
-
+const compareTableControlsNode = (userLoggedIn = false) => {
   return (
     <CompareTableControls
       compareResults={results}
@@ -105,14 +103,14 @@ const compareTableControlsNode = (onPermalinkClick, userLoggedIn = false) => {
       user={{ isLoggedIn: userLoggedIn }}
       notify={() => {}}
       isBaseAggregate={false}
-      onPermalinkClick={handlePermalinkClick}
+      onPermalinkClick={mockHandlePermalinkClick}
       projects={projects}
     />
   );
 };
 
-const compareTableControls = (onPermalinkClick, userLoggedIn = false) =>
-  render(compareTableControlsNode(onPermalinkClick, userLoggedIn));
+const compareTableControls = (userLoggedIn = false) =>
+  render(compareTableControlsNode(userLoggedIn));
 
 const compareTable = (
   userLoggedIn,
@@ -233,10 +231,7 @@ test('table header & rows all have hash-based ids', async () => {
 });
 
 test('clicking compare table permalinks callbacks with unique hash-based ids', async () => {
-  const mockHandlePermalinkClick = jest.fn();
-  const { getByTitle, getAllByTitle } = compareTableControls(
-    mockHandlePermalinkClick,
-  );
+  const { getByTitle, getAllByTitle } = compareTableControls();
 
   const compareTablePermalink = await waitForElement(() =>
     getByTitle('Permalink to this test table'),
@@ -263,12 +258,12 @@ test('clicking compare table permalinks callbacks with unique hash-based ids', a
 });
 
 test('retrigger buttons should appear only when the user is logged in', async () => {
-  const { queryAllByTitle, rerender } = compareTableControls(() => {}, false);
+  const { queryAllByTitle, rerender } = compareTableControls(false);
   let retriggerButtons = queryAllByTitle(compareTableText.retriggerButtonTitle);
   expect(retriggerButtons).toHaveLength(0);
 
   // simulate login
-  rerender(compareTableControlsNode(() => {}, true));
+  rerender(compareTableControlsNode(true));
 
   retriggerButtons = queryAllByTitle(compareTableText.retriggerButtonTitle);
   expect(retriggerButtons).toHaveLength(2);

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -1,4 +1,4 @@
-body {
+html {
   overflow: auto;
   height: auto;
 }

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -1,5 +1,11 @@
 body {
   overflow: auto;
+  height: auto;
+}
+
+body {
+  overflow: visible;
+  height: auto;
 }
 
 section {

--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -455,8 +455,6 @@ fieldset[disabled] .btn-view-nav-closed.active {
 /* Used by Perfherder and IFV */
 .top-navbar {
   background-color: #222;
-  height: 34px;
-  position: absolute;
 }
 
 .navbar-link {

--- a/ui/perfherder/Validation.jsx
+++ b/ui/perfherder/Validation.jsx
@@ -41,6 +41,15 @@ const withValidation = (
       this.validateParams(parseQueryParams(this.props.location.search));
     }
 
+    shouldComponentUpdate(prevProps) {
+      const { location } = this.props;
+
+      if (location.hash !== prevProps.location.hash) {
+        return false;
+      }
+      return true;
+    }
+
     componentDidUpdate(prevProps) {
       const { location } = this.props;
 

--- a/ui/perfherder/Validation.jsx
+++ b/ui/perfherder/Validation.jsx
@@ -44,10 +44,7 @@ const withValidation = (
     shouldComponentUpdate(prevProps) {
       const { location } = this.props;
 
-      if (location.hash !== prevProps.location.hash) {
-        return false;
-      }
-      return true;
+      return location.hash === prevProps.location.hash;
     }
 
     componentDidUpdate(prevProps) {

--- a/ui/perfherder/compare/CompareSubtestsView.jsx
+++ b/ui/perfherder/compare/CompareSubtestsView.jsx
@@ -7,7 +7,6 @@ import {
   createNoiseMetric,
   getCounterMap,
   createGraphsLinks,
-  onPermalinkClick,
 } from '../helpers';
 import { noiseMetricTitle } from '../constants';
 import withValidation from '../Validation';
@@ -212,8 +211,6 @@ class CompareSubtestsView extends React.PureComponent {
         {...this.props}
         getQueryParams={this.getQueryParams}
         getDisplayResults={this.getDisplayResults}
-        onPermalinkClick={hashValue => onPermalinkClick(hashValue, this.props)}
-        hashFragment={this.props.location.hash}
         hasSubtests
       />
     );

--- a/ui/perfherder/compare/CompareTable.jsx
+++ b/ui/perfherder/compare/CompareTable.jsx
@@ -4,53 +4,17 @@ import React from 'react';
 import { Button, Table } from 'reactstrap';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  faExclamationTriangle,
-  faRedo,
-  faThumbsUp,
-  faHashtag,
-} from '@fortawesome/free-solid-svg-icons';
+import { faHashtag, faRedo } from '@fortawesome/free-solid-svg-icons';
 
-import SimpleTooltip from '../../shared/SimpleTooltip';
-import { displayNumber, formatNumber } from '../helpers';
+import { getHashBasedId } from '../helpers';
 import { compareTableText } from '../constants';
-import ProgressBar from '../ProgressBar';
 import { hashFunction } from '../../helpers/utils';
 import JobModel from '../../models/job';
 import RepositoryModel from '../../models/repository';
 
-import TableAverage from './TableAverage';
+import CompareTableRow from './CompareTableRow';
 
 export default class CompareTable extends React.PureComponent {
-  getColorClass = (data, type) => {
-    const { className, isRegression, isImprovement } = data;
-    if (type === 'bar' && !isRegression && !isImprovement) return 'secondary';
-    if (type === 'background' && className === 'warning')
-      return `bg-${className}`;
-    if (type === 'text' && className) return `text-${className}`;
-    return className;
-  };
-
-  deltaTooltipText = (delta, percentage, improvement) =>
-    `Mean difference: ${formatNumber(displayNumber(delta))} (= ${Math.abs(
-      displayNumber(percentage),
-    )}% ${improvement ? 'better' : 'worse'})`;
-
-  // human readable signature name
-  getSignatureName = (testName, platformName) =>
-    [testName, platformName].filter(item => item !== null).join(' ');
-
-  getHashBasedId = (testName, platformName = null) => {
-    const { hashFunction } = this.props;
-
-    const tableSection = platformName === null ? 'header' : 'row';
-    const hashValue = hashFunction(
-      this.getSignatureName(testName, platformName),
-    );
-
-    return `table-${tableSection}-${hashValue}`;
-  };
-
   retriggerJobs = async (results, times) => {
     // retrigger base revision jobs
     const { projects } = this.props;
@@ -97,7 +61,7 @@ export default class CompareTable extends React.PureComponent {
 
     return (
       <Table
-        id={this.getHashBasedId(testName)}
+        id={getHashBasedId(testName)}
         aria-label="Comparison table"
         sz="small"
         className="compare-table mb-0 px-0"
@@ -116,7 +80,7 @@ export default class CompareTable extends React.PureComponent {
                   color="link"
                   onClick={() =>
                     onPermalinkClick(
-                      this.getHashBasedId(testName),
+                      getHashBasedId(testName),
                       history,
                       this.header,
                     )
@@ -155,149 +119,10 @@ export default class CompareTable extends React.PureComponent {
         </thead>
         <tbody>
           {data.map(rowLevelResults => (
-            <tr
-              id={this.getHashBasedId(testName, rowLevelResults.name)}
-              aria-label="Comparison table row"
-              key={rowLevelResults.name}
-            >
-              <th className="text-left font-weight-normal pl-1">
-                {rowLevelResults.name}
-                <span className="result-links">
-                  {onPermalinkClick && (
-                    <span>
-                      <Button
-                        className="permalink p-0 ml-1"
-                        color="link"
-                        onClick={() =>
-                          onPermalinkClick(
-                            this.getHashBasedId(testName, rowLevelResults.name),
-                          )
-                        }
-                        title="Permalink to this test"
-                      >
-                        <FontAwesomeIcon icon={faHashtag} />
-                      </Button>
-                    </span>
-                  )}
-                  {rowLevelResults.links &&
-                    rowLevelResults.links.map(link => (
-                      <span key={link.title}>
-                        <a href={link.href}>{` ${link.title}`}</a>
-                      </span>
-                    ))}
-                </span>
-              </th>
-              <TableAverage
-                value={rowLevelResults.originalValue}
-                stddev={rowLevelResults.originalStddev}
-                stddevpct={rowLevelResults.originalStddevPct}
-                replicates={rowLevelResults.originalRuns}
-              />
-              <td>
-                {rowLevelResults.originalValue < rowLevelResults.newValue && (
-                  <span>&lt;</span>
-                )}
-                {rowLevelResults.originalValue > rowLevelResults.newValue && (
-                  <span>&gt;</span>
-                )}
-              </td>
-              <TableAverage
-                value={rowLevelResults.newValue}
-                stddev={rowLevelResults.newStddev}
-                stddevpct={rowLevelResults.newStddevPct}
-                replicates={rowLevelResults.newRuns}
-              />
-              <td className={this.getColorClass(rowLevelResults, 'background')}>
-                {rowLevelResults.delta &&
-                Math.abs(displayNumber(rowLevelResults.deltaPercentage)) !==
-                  0 ? (
-                  <SimpleTooltip
-                    textClass="detail-hint"
-                    text={
-                      <React.Fragment>
-                        {(rowLevelResults.isRegression ||
-                          rowLevelResults.isImprovement) && (
-                          <FontAwesomeIcon
-                            icon={
-                              rowLevelResults.isRegression
-                                ? faExclamationTriangle
-                                : faThumbsUp
-                            }
-                            title={
-                              rowLevelResults.isRegression
-                                ? 'regression'
-                                : 'improvement'
-                            }
-                            className={this.getColorClass(
-                              rowLevelResults,
-                              'text',
-                            )}
-                            size="lg"
-                          />
-                        )}
-                        {`  ${displayNumber(rowLevelResults.deltaPercentage)}%`}
-                      </React.Fragment>
-                    }
-                    tooltipText={this.deltaTooltipText(
-                      rowLevelResults.delta,
-                      rowLevelResults.deltaPercentage,
-                      rowLevelResults.newIsBetter,
-                    )}
-                  />
-                ) : null}
-                {rowLevelResults.delta
-                  ? Math.abs(displayNumber(rowLevelResults.deltaPercentage)) ===
-                      0 && (
-                      <span>
-                        {displayNumber(rowLevelResults.deltaPercentage)}%
-                      </span>
-                    )
-                  : null}
-              </td>
-              <td>
-                {rowLevelResults.delta ? (
-                  <ProgressBar
-                    magnitude={rowLevelResults.magnitude}
-                    regression={!rowLevelResults.newIsBetter}
-                    color={this.getColorClass(rowLevelResults, 'bar')}
-                  />
-                ) : null}
-              </td>
-              <td>
-                {rowLevelResults.delta &&
-                rowLevelResults.confidence &&
-                rowLevelResults.confidenceText ? (
-                  <SimpleTooltip
-                    textClass="detail-hint"
-                    text={`${displayNumber(rowLevelResults.confidence)} (${
-                      rowLevelResults.confidenceText
-                    })`}
-                    tooltipText={rowLevelResults.confidenceTextLong}
-                  />
-                ) : null}
-              </td>
-              <td className="text-right">
-                {!hasSubtests &&
-                  !rowLevelResults.isNoiseMetric &&
-                  (rowLevelResults.newRetriggerableJobId || !isBaseAggregate) &&
-                  user.isLoggedIn && (
-                    <Button
-                      className="retrigger-btn btn icon-green mr-1 py-0 px-1"
-                      title={compareTableText.retriggerButtonTitle}
-                      onClick={() => this.retriggerJobs(rowLevelResults, 5)}
-                    >
-                      <FontAwesomeIcon icon={faRedo} />
-                    </Button>
-                  )}
-                {rowLevelResults.originalRuns && (
-                  <SimpleTooltip
-                    textClass="detail-hint"
-                    text={`${rowLevelResults.originalRuns.length} / ${rowLevelResults.newRuns.length}`}
-                    tooltipText={`${rowLevelResults.originalRuns.length} base / ${rowLevelResults.newRuns.length} new`}
-                  />
-                )}
-              </td>
-            </tr>
+            <CompareTableRow
+              rowLevelResults={rowLevelResults}
+              {...this.props}
+            />
           ))}
         </tbody>
       </Table>

--- a/ui/perfherder/compare/CompareTable.jsx
+++ b/ui/perfherder/compare/CompareTable.jsx
@@ -92,7 +92,9 @@ export default class CompareTable extends React.PureComponent {
       hasSubtests,
       isBaseAggregate,
       onPermalinkClick,
+      history,
     } = this.props;
+
     return (
       <Table
         id={this.getHashBasedId(testName)}
@@ -100,6 +102,9 @@ export default class CompareTable extends React.PureComponent {
         sz="small"
         className="compare-table mb-0 px-0"
         key={testName}
+        innerRef={el => {
+          this.header = el;
+        }}
       >
         <thead>
           <tr className="subtest-header bg-lightgray">
@@ -110,7 +115,11 @@ export default class CompareTable extends React.PureComponent {
                   className="permalink p-0 ml-1"
                   color="link"
                   onClick={() =>
-                    onPermalinkClick(this.getHashBasedId(testName))
+                    onPermalinkClick(
+                      this.getHashBasedId(testName),
+                      history,
+                      this.header,
+                    )
                   }
                   title="Permalink to this test table"
                 >

--- a/ui/perfherder/compare/CompareTableControls.jsx
+++ b/ui/perfherder/compare/CompareTableControls.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Container } from 'reactstrap';
 
 import { filterText } from '../constants';
-import { convertParams, containsText } from '../helpers';
+import { convertParams, containsText, onPermalinkClick } from '../helpers';
 import FilterControls from '../FilterControls';
 
 import CompareTable from './CompareTable';
@@ -115,6 +115,7 @@ export default class CompareTableControls extends React.Component {
       hasSubtests,
       onPermalinkClick,
       projects,
+      history,
     } = this.props;
 
     const {
@@ -176,6 +177,7 @@ export default class CompareTableControls extends React.Component {
               notify={notify}
               hasSubtests={hasSubtests}
               projects={projects}
+              history={history}
             />
           ))
         ) : (
@@ -217,5 +219,5 @@ CompareTableControls.defaultProps = {
     showOnlyNoise: undefined,
   },
   showTestsWithNoise: null,
-  onPermalinkClick: undefined,
+  onPermalinkClick,
 };

--- a/ui/perfherder/compare/CompareTableRow.jsx
+++ b/ui/perfherder/compare/CompareTableRow.jsx
@@ -1,7 +1,5 @@
-/* eslint-disable jsx-a11y/control-has-associated-label */
-
 import React from 'react';
-import { Button, Table } from 'reactstrap';
+import { Button } from 'reactstrap';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -12,12 +10,15 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 import SimpleTooltip from '../../shared/SimpleTooltip';
-import { displayNumber, formatNumber } from '../helpers';
-import { CompareTableRowText } from '../constants';
+import {
+  displayNumber,
+  formatNumber,
+  getHashBasedId,
+  retriggerJobs,
+} from '../helpers';
+import { compareTableText } from '../constants';
 import ProgressBar from '../ProgressBar';
 import { hashFunction } from '../../helpers/utils';
-import JobModel from '../../models/job';
-import RepositoryModel from '../../models/repository';
 
 import TableAverage from './TableAverage';
 
@@ -36,288 +37,175 @@ export default class CompareTableRow extends React.PureComponent {
       displayNumber(percentage),
     )}% ${improvement ? 'better' : 'worse'})`;
 
-  // human readable signature name
-  getSignatureName = (testName, platformName) =>
-    [testName, platformName].filter(item => item !== null).join(' ');
-
-  getHashBasedId = (testName, platformName = null) => {
-    const { hashFunction } = this.props;
-
-    const tableSection = platformName === null ? 'header' : 'row';
-    const hashValue = hashFunction(
-      this.getSignatureName(testName, platformName),
-    );
-
-    return `table-${tableSection}-${hashValue}`;
-  };
-
-  retriggerJobs = async (results, times) => {
-    // retrigger base revision jobs
-    const { projects } = this.props;
-
-    this.retriggerByRevision(
-      results.originalRetriggerableJobId,
-      RepositoryModel.getRepo(results.originalRepoName, projects),
-      true,
-      times,
-    );
-    // retrigger new revision jobs
-    this.retriggerByRevision(
-      results.newRetriggerableJobId,
-      RepositoryModel.getRepo(results.newRepoName, projects),
-      false,
-      times,
-    );
-  };
-
-  retriggerByRevision = async (jobId, currentRepo, isBaseline, times) => {
-    const { isBaseAggregate, notify, retriggerJob, getJob } = this.props;
-
-    // do not retrigger if the base is aggregate (there is a selected time range)
-    if (isBaseline && isBaseAggregate) {
-      return;
-    }
-
-    if (jobId) {
-      const job = await getJob(currentRepo.name, jobId);
-      retriggerJob([job], currentRepo, notify, times);
-    }
-  };
-
   render() {
     const {
-      data,
       testName,
       user,
       hasSubtests,
       isBaseAggregate,
       onPermalinkClick,
       history,
+      rowLevelResults,
+      hashFunction,
     } = this.props;
 
     return (
-      <Table
-        id={this.getHashBasedId(testName)}
-        aria-label="Comparison table"
-        sz="small"
-        className="compare-table mb-0 px-0"
-        key={testName}
-        innerRef={el => {
-          this.header = el;
+      <tr
+        id={getHashBasedId(testName, hashFunction, rowLevelResults.name)}
+        aria-label="Comparison table row"
+        ref={el => {
+          this.rowTitle = el;
         }}
       >
-        <thead>
-          <tr className="subtest-header bg-lightgray">
-            <th className="text-left">
-              <span>{testName}</span>
-              {onPermalinkClick && (
+        <th className="text-left font-weight-normal pl-1">
+          {rowLevelResults.name}
+          <span className="result-links">
+            {onPermalinkClick && (
+              <span>
                 <Button
                   className="permalink p-0 ml-1"
                   color="link"
                   onClick={() =>
                     onPermalinkClick(
-                      this.getHashBasedId(testName),
+                      getHashBasedId(
+                        testName,
+                        hashFunction,
+                        rowLevelResults.name,
+                      ),
                       history,
-                      this.header,
+                      this.rowTitle,
                     )
                   }
-                  title="Permalink to this test table"
+                  title="Permalink to this test"
                 >
                   <FontAwesomeIcon icon={faHashtag} />
                 </Button>
-              )}
-            </th>
-            <th className="table-width-lg">Base</th>
-            {/* empty for less than/greater than data */}
-            <th className="table-width-sm" />
-            <th className="table-width-lg">New</th>
-            <th className="table-width-lg">Delta</th>
-            {/* empty for progress bars (magnitude of difference) */}
-            <th className="table-width-lg" />
-            <th className="table-width-lg">Confidence</th>
-            <th className="text-right table-width-md">
-              {hasSubtests &&
-                data &&
-                data.length &&
-                (data[0].newRetriggerableJobId || !isBaseAggregate) &&
-                user.isLoggedIn && (
-                  <Button
-                    className="retrigger-btn btn icon-green mr-1 py-0 px-1"
-                    title={CompareTableRowText.retriggerButtonTitle}
-                    onClick={() => this.retriggerJobs(data[0], 5)}
-                  >
-                    <FontAwesomeIcon icon={faRedo} />
-                  </Button>
-                )}
-              # Runs
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {data.map(rowLevelResults => (
-            <tr
-              id={this.getHashBasedId(testName, rowLevelResults.name)}
-              aria-label="Comparison table row"
-              key={rowLevelResults.name}
-            >
-              <th className="text-left font-weight-normal pl-1">
-                {rowLevelResults.name}
-                <span className="result-links">
-                  {onPermalinkClick && (
-                    <span>
-                      <Button
-                        className="permalink p-0 ml-1"
-                        color="link"
-                        onClick={() =>
-                          onPermalinkClick(
-                            this.getHashBasedId(testName, rowLevelResults.name),
-                          )
-                        }
-                        title="Permalink to this test"
-                      >
-                        <FontAwesomeIcon icon={faHashtag} />
-                      </Button>
-                    </span>
-                  )}
-                  {rowLevelResults.links &&
-                    rowLevelResults.links.map(link => (
-                      <span key={link.title}>
-                        <a href={link.href}>{` ${link.title}`}</a>
-                      </span>
-                    ))}
+              </span>
+            )}
+            {rowLevelResults.links &&
+              rowLevelResults.links.map(link => (
+                <span key={link.title}>
+                  <a href={link.href}>{` ${link.title}`}</a>
                 </span>
-              </th>
-              <TableAverage
-                value={rowLevelResults.originalValue}
-                stddev={rowLevelResults.originalStddev}
-                stddevpct={rowLevelResults.originalStddevPct}
-                replicates={rowLevelResults.originalRuns}
-              />
-              <td>
-                {rowLevelResults.originalValue < rowLevelResults.newValue && (
-                  <span>&lt;</span>
-                )}
-                {rowLevelResults.originalValue > rowLevelResults.newValue && (
-                  <span>&gt;</span>
-                )}
-              </td>
-              <TableAverage
-                value={rowLevelResults.newValue}
-                stddev={rowLevelResults.newStddev}
-                stddevpct={rowLevelResults.newStddevPct}
-                replicates={rowLevelResults.newRuns}
-              />
-              <td className={this.getColorClass(rowLevelResults, 'background')}>
-                {rowLevelResults.delta &&
-                Math.abs(displayNumber(rowLevelResults.deltaPercentage)) !==
-                  0 ? (
-                  <SimpleTooltip
-                    textClass="detail-hint"
-                    text={
-                      <React.Fragment>
-                        {(rowLevelResults.isRegression ||
-                          rowLevelResults.isImprovement) && (
-                          <FontAwesomeIcon
-                            icon={
-                              rowLevelResults.isRegression
-                                ? faExclamationTriangle
-                                : faThumbsUp
-                            }
-                            title={
-                              rowLevelResults.isRegression
-                                ? 'regression'
-                                : 'improvement'
-                            }
-                            className={this.getColorClass(
-                              rowLevelResults,
-                              'text',
-                            )}
-                            size="lg"
-                          />
-                        )}
-                        {`  ${displayNumber(rowLevelResults.deltaPercentage)}%`}
-                      </React.Fragment>
-                    }
-                    tooltipText={this.deltaTooltipText(
-                      rowLevelResults.delta,
-                      rowLevelResults.deltaPercentage,
-                      rowLevelResults.newIsBetter,
-                    )}
-                  />
-                ) : null}
-                {rowLevelResults.delta
-                  ? Math.abs(displayNumber(rowLevelResults.deltaPercentage)) ===
-                      0 && (
-                      <span>
-                        {displayNumber(rowLevelResults.deltaPercentage)}%
-                      </span>
-                    )
-                  : null}
-              </td>
-              <td>
-                {rowLevelResults.delta ? (
-                  <ProgressBar
-                    magnitude={rowLevelResults.magnitude}
-                    regression={!rowLevelResults.newIsBetter}
-                    color={this.getColorClass(rowLevelResults, 'bar')}
-                  />
-                ) : null}
-              </td>
-              <td>
-                {rowLevelResults.delta &&
-                rowLevelResults.confidence &&
-                rowLevelResults.confidenceText ? (
-                  <SimpleTooltip
-                    textClass="detail-hint"
-                    text={`${displayNumber(rowLevelResults.confidence)} (${
-                      rowLevelResults.confidenceText
-                    })`}
-                    tooltipText={rowLevelResults.confidenceTextLong}
-                  />
-                ) : null}
-              </td>
-              <td className="text-right">
-                {!hasSubtests &&
-                  !rowLevelResults.isNoiseMetric &&
-                  (rowLevelResults.newRetriggerableJobId || !isBaseAggregate) &&
-                  user.isLoggedIn && (
-                    <Button
-                      className="retrigger-btn btn icon-green mr-1 py-0 px-1"
-                      title={CompareTableRowText.retriggerButtonTitle}
-                      onClick={() => this.retriggerJobs(rowLevelResults, 5)}
-                    >
-                      <FontAwesomeIcon icon={faRedo} />
-                    </Button>
+              ))}
+          </span>
+        </th>
+        <TableAverage
+          value={rowLevelResults.originalValue}
+          stddev={rowLevelResults.originalStddev}
+          stddevpct={rowLevelResults.originalStddevPct}
+          replicates={rowLevelResults.originalRuns}
+        />
+        <td>
+          {rowLevelResults.originalValue < rowLevelResults.newValue && (
+            <span>&lt;</span>
+          )}
+          {rowLevelResults.originalValue > rowLevelResults.newValue && (
+            <span>&gt;</span>
+          )}
+        </td>
+        <TableAverage
+          value={rowLevelResults.newValue}
+          stddev={rowLevelResults.newStddev}
+          stddevpct={rowLevelResults.newStddevPct}
+          replicates={rowLevelResults.newRuns}
+        />
+        <td className={this.getColorClass(rowLevelResults, 'background')}>
+          {rowLevelResults.delta &&
+          Math.abs(displayNumber(rowLevelResults.deltaPercentage)) !== 0 ? (
+            <SimpleTooltip
+              textClass="detail-hint"
+              text={
+                <React.Fragment>
+                  {(rowLevelResults.isRegression ||
+                    rowLevelResults.isImprovement) && (
+                    <FontAwesomeIcon
+                      icon={
+                        rowLevelResults.isRegression
+                          ? faExclamationTriangle
+                          : faThumbsUp
+                      }
+                      title={
+                        rowLevelResults.isRegression
+                          ? 'regression'
+                          : 'improvement'
+                      }
+                      className={this.getColorClass(rowLevelResults, 'text')}
+                      size="lg"
+                    />
                   )}
-                {rowLevelResults.originalRuns && (
-                  <SimpleTooltip
-                    textClass="detail-hint"
-                    text={`${rowLevelResults.originalRuns.length} / ${rowLevelResults.newRuns.length}`}
-                    tooltipText={`${rowLevelResults.originalRuns.length} base / ${rowLevelResults.newRuns.length} new`}
-                  />
-                )}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </Table>
+                  {`  ${displayNumber(rowLevelResults.deltaPercentage)}%`}
+                </React.Fragment>
+              }
+              tooltipText={this.deltaTooltipText(
+                rowLevelResults.delta,
+                rowLevelResults.deltaPercentage,
+                rowLevelResults.newIsBetter,
+              )}
+            />
+          ) : null}
+          {rowLevelResults.delta
+            ? Math.abs(displayNumber(rowLevelResults.deltaPercentage)) ===
+                0 && (
+                <span>{displayNumber(rowLevelResults.deltaPercentage)}%</span>
+              )
+            : null}
+        </td>
+        <td>
+          {rowLevelResults.delta ? (
+            <ProgressBar
+              magnitude={rowLevelResults.magnitude}
+              regression={!rowLevelResults.newIsBetter}
+              color={this.getColorClass(rowLevelResults, 'bar')}
+            />
+          ) : null}
+        </td>
+        <td>
+          {rowLevelResults.delta &&
+          rowLevelResults.confidence &&
+          rowLevelResults.confidenceText ? (
+            <SimpleTooltip
+              textClass="detail-hint"
+              text={`${displayNumber(rowLevelResults.confidence)} (${
+                rowLevelResults.confidenceText
+              })`}
+              tooltipText={rowLevelResults.confidenceTextLong}
+            />
+          ) : null}
+        </td>
+        <td className="text-right">
+          {!hasSubtests &&
+            !rowLevelResults.isNoiseMetric &&
+            (rowLevelResults.newRetriggerableJobId || !isBaseAggregate) &&
+            user.isLoggedIn && (
+              <Button
+                className="retrigger-btn btn icon-green mr-1 py-0 px-1"
+                title={compareTableText.retriggerButtonTitle}
+                onClick={() => retriggerJobs(rowLevelResults, 5, this.props)}
+              >
+                <FontAwesomeIcon icon={faRedo} />
+              </Button>
+            )}
+          {rowLevelResults.originalRuns && (
+            <SimpleTooltip
+              textClass="detail-hint"
+              text={`${rowLevelResults.originalRuns.length} / ${rowLevelResults.newRuns.length}`}
+              tooltipText={`${rowLevelResults.originalRuns.length} base / ${rowLevelResults.newRuns.length} new`}
+            />
+          )}
+        </td>
+      </tr>
     );
   }
 }
 
 CompareTableRow.propTypes = {
-  data: PropTypes.arrayOf(PropTypes.shape({})),
   testName: PropTypes.string.isRequired,
   hashFunction: PropTypes.func,
   onPermalinkClick: PropTypes.func,
-  getJob: PropTypes.func,
-  retriggerJob: PropTypes.func,
 };
 
 CompareTableRow.defaultProps = {
-  data: null,
   hashFunction,
   onPermalinkClick: undefined,
-  getJob: JobModel.get,
-  retriggerJob: JobModel.retrigger,
 };

--- a/ui/perfherder/compare/CompareTableRow.jsx
+++ b/ui/perfherder/compare/CompareTableRow.jsx
@@ -1,0 +1,323 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
+
+import React from 'react';
+import { Button, Table } from 'reactstrap';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faExclamationTriangle,
+  faRedo,
+  faThumbsUp,
+  faHashtag,
+} from '@fortawesome/free-solid-svg-icons';
+
+import SimpleTooltip from '../../shared/SimpleTooltip';
+import { displayNumber, formatNumber } from '../helpers';
+import { CompareTableRowText } from '../constants';
+import ProgressBar from '../ProgressBar';
+import { hashFunction } from '../../helpers/utils';
+import JobModel from '../../models/job';
+import RepositoryModel from '../../models/repository';
+
+import TableAverage from './TableAverage';
+
+export default class CompareTableRow extends React.PureComponent {
+  getColorClass = (data, type) => {
+    const { className, isRegression, isImprovement } = data;
+    if (type === 'bar' && !isRegression && !isImprovement) return 'secondary';
+    if (type === 'background' && className === 'warning')
+      return `bg-${className}`;
+    if (type === 'text' && className) return `text-${className}`;
+    return className;
+  };
+
+  deltaTooltipText = (delta, percentage, improvement) =>
+    `Mean difference: ${formatNumber(displayNumber(delta))} (= ${Math.abs(
+      displayNumber(percentage),
+    )}% ${improvement ? 'better' : 'worse'})`;
+
+  // human readable signature name
+  getSignatureName = (testName, platformName) =>
+    [testName, platformName].filter(item => item !== null).join(' ');
+
+  getHashBasedId = (testName, platformName = null) => {
+    const { hashFunction } = this.props;
+
+    const tableSection = platformName === null ? 'header' : 'row';
+    const hashValue = hashFunction(
+      this.getSignatureName(testName, platformName),
+    );
+
+    return `table-${tableSection}-${hashValue}`;
+  };
+
+  retriggerJobs = async (results, times) => {
+    // retrigger base revision jobs
+    const { projects } = this.props;
+
+    this.retriggerByRevision(
+      results.originalRetriggerableJobId,
+      RepositoryModel.getRepo(results.originalRepoName, projects),
+      true,
+      times,
+    );
+    // retrigger new revision jobs
+    this.retriggerByRevision(
+      results.newRetriggerableJobId,
+      RepositoryModel.getRepo(results.newRepoName, projects),
+      false,
+      times,
+    );
+  };
+
+  retriggerByRevision = async (jobId, currentRepo, isBaseline, times) => {
+    const { isBaseAggregate, notify, retriggerJob, getJob } = this.props;
+
+    // do not retrigger if the base is aggregate (there is a selected time range)
+    if (isBaseline && isBaseAggregate) {
+      return;
+    }
+
+    if (jobId) {
+      const job = await getJob(currentRepo.name, jobId);
+      retriggerJob([job], currentRepo, notify, times);
+    }
+  };
+
+  render() {
+    const {
+      data,
+      testName,
+      user,
+      hasSubtests,
+      isBaseAggregate,
+      onPermalinkClick,
+      history,
+    } = this.props;
+
+    return (
+      <Table
+        id={this.getHashBasedId(testName)}
+        aria-label="Comparison table"
+        sz="small"
+        className="compare-table mb-0 px-0"
+        key={testName}
+        innerRef={el => {
+          this.header = el;
+        }}
+      >
+        <thead>
+          <tr className="subtest-header bg-lightgray">
+            <th className="text-left">
+              <span>{testName}</span>
+              {onPermalinkClick && (
+                <Button
+                  className="permalink p-0 ml-1"
+                  color="link"
+                  onClick={() =>
+                    onPermalinkClick(
+                      this.getHashBasedId(testName),
+                      history,
+                      this.header,
+                    )
+                  }
+                  title="Permalink to this test table"
+                >
+                  <FontAwesomeIcon icon={faHashtag} />
+                </Button>
+              )}
+            </th>
+            <th className="table-width-lg">Base</th>
+            {/* empty for less than/greater than data */}
+            <th className="table-width-sm" />
+            <th className="table-width-lg">New</th>
+            <th className="table-width-lg">Delta</th>
+            {/* empty for progress bars (magnitude of difference) */}
+            <th className="table-width-lg" />
+            <th className="table-width-lg">Confidence</th>
+            <th className="text-right table-width-md">
+              {hasSubtests &&
+                data &&
+                data.length &&
+                (data[0].newRetriggerableJobId || !isBaseAggregate) &&
+                user.isLoggedIn && (
+                  <Button
+                    className="retrigger-btn btn icon-green mr-1 py-0 px-1"
+                    title={CompareTableRowText.retriggerButtonTitle}
+                    onClick={() => this.retriggerJobs(data[0], 5)}
+                  >
+                    <FontAwesomeIcon icon={faRedo} />
+                  </Button>
+                )}
+              # Runs
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map(rowLevelResults => (
+            <tr
+              id={this.getHashBasedId(testName, rowLevelResults.name)}
+              aria-label="Comparison table row"
+              key={rowLevelResults.name}
+            >
+              <th className="text-left font-weight-normal pl-1">
+                {rowLevelResults.name}
+                <span className="result-links">
+                  {onPermalinkClick && (
+                    <span>
+                      <Button
+                        className="permalink p-0 ml-1"
+                        color="link"
+                        onClick={() =>
+                          onPermalinkClick(
+                            this.getHashBasedId(testName, rowLevelResults.name),
+                          )
+                        }
+                        title="Permalink to this test"
+                      >
+                        <FontAwesomeIcon icon={faHashtag} />
+                      </Button>
+                    </span>
+                  )}
+                  {rowLevelResults.links &&
+                    rowLevelResults.links.map(link => (
+                      <span key={link.title}>
+                        <a href={link.href}>{` ${link.title}`}</a>
+                      </span>
+                    ))}
+                </span>
+              </th>
+              <TableAverage
+                value={rowLevelResults.originalValue}
+                stddev={rowLevelResults.originalStddev}
+                stddevpct={rowLevelResults.originalStddevPct}
+                replicates={rowLevelResults.originalRuns}
+              />
+              <td>
+                {rowLevelResults.originalValue < rowLevelResults.newValue && (
+                  <span>&lt;</span>
+                )}
+                {rowLevelResults.originalValue > rowLevelResults.newValue && (
+                  <span>&gt;</span>
+                )}
+              </td>
+              <TableAverage
+                value={rowLevelResults.newValue}
+                stddev={rowLevelResults.newStddev}
+                stddevpct={rowLevelResults.newStddevPct}
+                replicates={rowLevelResults.newRuns}
+              />
+              <td className={this.getColorClass(rowLevelResults, 'background')}>
+                {rowLevelResults.delta &&
+                Math.abs(displayNumber(rowLevelResults.deltaPercentage)) !==
+                  0 ? (
+                  <SimpleTooltip
+                    textClass="detail-hint"
+                    text={
+                      <React.Fragment>
+                        {(rowLevelResults.isRegression ||
+                          rowLevelResults.isImprovement) && (
+                          <FontAwesomeIcon
+                            icon={
+                              rowLevelResults.isRegression
+                                ? faExclamationTriangle
+                                : faThumbsUp
+                            }
+                            title={
+                              rowLevelResults.isRegression
+                                ? 'regression'
+                                : 'improvement'
+                            }
+                            className={this.getColorClass(
+                              rowLevelResults,
+                              'text',
+                            )}
+                            size="lg"
+                          />
+                        )}
+                        {`  ${displayNumber(rowLevelResults.deltaPercentage)}%`}
+                      </React.Fragment>
+                    }
+                    tooltipText={this.deltaTooltipText(
+                      rowLevelResults.delta,
+                      rowLevelResults.deltaPercentage,
+                      rowLevelResults.newIsBetter,
+                    )}
+                  />
+                ) : null}
+                {rowLevelResults.delta
+                  ? Math.abs(displayNumber(rowLevelResults.deltaPercentage)) ===
+                      0 && (
+                      <span>
+                        {displayNumber(rowLevelResults.deltaPercentage)}%
+                      </span>
+                    )
+                  : null}
+              </td>
+              <td>
+                {rowLevelResults.delta ? (
+                  <ProgressBar
+                    magnitude={rowLevelResults.magnitude}
+                    regression={!rowLevelResults.newIsBetter}
+                    color={this.getColorClass(rowLevelResults, 'bar')}
+                  />
+                ) : null}
+              </td>
+              <td>
+                {rowLevelResults.delta &&
+                rowLevelResults.confidence &&
+                rowLevelResults.confidenceText ? (
+                  <SimpleTooltip
+                    textClass="detail-hint"
+                    text={`${displayNumber(rowLevelResults.confidence)} (${
+                      rowLevelResults.confidenceText
+                    })`}
+                    tooltipText={rowLevelResults.confidenceTextLong}
+                  />
+                ) : null}
+              </td>
+              <td className="text-right">
+                {!hasSubtests &&
+                  !rowLevelResults.isNoiseMetric &&
+                  (rowLevelResults.newRetriggerableJobId || !isBaseAggregate) &&
+                  user.isLoggedIn && (
+                    <Button
+                      className="retrigger-btn btn icon-green mr-1 py-0 px-1"
+                      title={CompareTableRowText.retriggerButtonTitle}
+                      onClick={() => this.retriggerJobs(rowLevelResults, 5)}
+                    >
+                      <FontAwesomeIcon icon={faRedo} />
+                    </Button>
+                  )}
+                {rowLevelResults.originalRuns && (
+                  <SimpleTooltip
+                    textClass="detail-hint"
+                    text={`${rowLevelResults.originalRuns.length} / ${rowLevelResults.newRuns.length}`}
+                    tooltipText={`${rowLevelResults.originalRuns.length} base / ${rowLevelResults.newRuns.length} new`}
+                  />
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    );
+  }
+}
+
+CompareTableRow.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.shape({})),
+  testName: PropTypes.string.isRequired,
+  hashFunction: PropTypes.func,
+  onPermalinkClick: PropTypes.func,
+  getJob: PropTypes.func,
+  retriggerJob: PropTypes.func,
+};
+
+CompareTableRow.defaultProps = {
+  data: null,
+  hashFunction,
+  onPermalinkClick: undefined,
+  getJob: JobModel.get,
+  retriggerJob: JobModel.retrigger,
+};

--- a/ui/perfherder/compare/CompareTableView.jsx
+++ b/ui/perfherder/compare/CompareTableView.jsx
@@ -355,7 +355,6 @@ CompareTableView.propTypes = {
   getQueryParams: PropTypes.func.isRequired,
   projects: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   hasSubtests: PropTypes.bool,
-  hashFragment: PropTypes.string,
   frameworks: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
 };
 
@@ -364,5 +363,4 @@ CompareTableView.defaultProps = {
   filterByFramework: null,
   validated: PropTypes.shape({}),
   hasSubtests: false,
-  hashFragment: '',
 };

--- a/ui/perfherder/compare/CompareTableView.jsx
+++ b/ui/perfherder/compare/CompareTableView.jsx
@@ -192,13 +192,7 @@ export default class CompareTableView extends React.Component {
       pageTitle,
     } = this.props.validated;
 
-    const {
-      filterByFramework,
-      hasSubtests,
-      onPermalinkClick,
-      frameworks,
-      projects,
-    } = this.props;
+    const { filterByFramework, hasSubtests, frameworks, projects } = this.props;
     const {
       compareResults,
       loading,
@@ -315,7 +309,6 @@ export default class CompareTableView extends React.Component {
                 {...this.props}
                 dropdownOptions={compareDropdowns}
                 updateState={state => this.setState(state)}
-                onPermalinkClick={onPermalinkClick}
                 compareResults={compareResults}
                 isBaseAggregate={!originalRevision}
                 notify={this.notifyFailure}
@@ -362,7 +355,6 @@ CompareTableView.propTypes = {
   getQueryParams: PropTypes.func.isRequired,
   projects: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   hasSubtests: PropTypes.bool,
-  onPermalinkClick: PropTypes.func,
   hashFragment: PropTypes.string,
   frameworks: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
 };
@@ -373,5 +365,4 @@ CompareTableView.defaultProps = {
   validated: PropTypes.shape({}),
   hasSubtests: false,
   hashFragment: '',
-  onPermalinkClick: undefined,
 };

--- a/ui/perfherder/compare/CompareTableView.jsx
+++ b/ui/perfherder/compare/CompareTableView.jsx
@@ -16,10 +16,9 @@ import {
   perfSummaryEndpoint,
   createQueryParams,
 } from '../../helpers/url';
-import { getFrameworkData } from '../helpers';
+import { getFrameworkData, scrollWithOffset } from '../helpers';
 import TruncatedText from '../../shared/TruncatedText';
 import LoadingSpinner from '../../shared/LoadingSpinner';
-import { scrollToLine } from '../../helpers/utils';
 
 import RevisionInformation from './RevisionInformation';
 import ComparePageTitle from './ComparePageTitle';
@@ -53,18 +52,18 @@ export default class CompareTableView extends React.Component {
     } else {
       this.getPerformanceData();
     }
+
+    if (location.hash) {
+      setTimeout(() => {
+        const el = document.querySelector(location.hash);
+        if (el) scrollWithOffset(el);
+      }, 1500);
+    }
   }
 
   componentDidUpdate(prevProps) {
-    const { loading } = this.state;
-    const { hashFragment } = this.props;
-
     if (this.props.location.search !== prevProps.location.search) {
       this.getPerformanceData();
-    }
-
-    if (!loading && hashFragment) {
-      scrollToLine(hashFragment, 100);
     }
   }
 

--- a/ui/perfherder/compare/CompareView.jsx
+++ b/ui/perfherder/compare/CompareView.jsx
@@ -7,7 +7,6 @@ import {
   createNoiseMetric,
   getCounterMap,
   createGraphsLinks,
-  onPermalinkClick,
 } from '../helpers';
 import { noiseMetricTitle, phTimeRanges } from '../constants';
 import withValidation from '../Validation';
@@ -235,7 +234,6 @@ class CompareView extends React.PureComponent {
         {...this.props}
         getQueryParams={this.getQueryParams}
         getDisplayResults={this.getDisplayResults}
-        onPermalinkClick={hashValue => onPermalinkClick(hashValue, this.props)}
         hashFragment={this.props.location.hash}
         filterByFramework
       />

--- a/ui/perfherder/compare/CompareView.jsx
+++ b/ui/perfherder/compare/CompareView.jsx
@@ -234,7 +234,6 @@ class CompareView extends React.PureComponent {
         {...this.props}
         getQueryParams={this.getQueryParams}
         getDisplayResults={this.getDisplayResults}
-        hashFragment={this.props.location.hash}
         filterByFramework
       />
     );

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -627,8 +627,16 @@ export const getSeriesData = async (
   return updates;
 };
 
+export const scrollWithOffset = function scrollWithOffset(el) {
+  // solution from https://github.com/rafrex/react-router-hash-link/issues/25#issuecomment-536688104
+
+  const yCoordinate = el.getBoundingClientRect().top + window.pageYOffset;
+  const yOffset = -35;
+  window.scrollTo({ top: yCoordinate + yOffset, behavior: 'smooth' });
+};
+
 export const onPermalinkClick = (hashBasedValue, props) => {
   const { history, location } = props;
-
+  // scrollWithOffset()
   history.replace(`${location.pathname}${location.search}#${hashBasedValue}`);
 };

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -635,8 +635,9 @@ export const scrollWithOffset = function scrollWithOffset(el) {
   window.scrollTo({ top: yCoordinate + yOffset, behavior: 'smooth' });
 };
 
-export const onPermalinkClick = (hashBasedValue, props) => {
-  const { history, location } = props;
-  // scrollWithOffset()
-  history.replace(`${location.pathname}${location.search}#${hashBasedValue}`);
+export const onPermalinkClick = (hashBasedValue, history, element) => {
+  scrollWithOffset(element);
+  history.replace(
+    `${history.location.pathname}${history.location.search}#${hashBasedValue}`,
+  );
 };

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -641,3 +641,18 @@ export const onPermalinkClick = (hashBasedValue, history, element) => {
     `${history.location.pathname}${history.location.search}#${hashBasedValue}`,
   );
 };
+
+// human readable signature name
+const getSignatureName = (testName, platformName) =>
+  [testName, platformName].filter(item => item !== null).join(' ');
+
+export const getHashBasedId = function getHashBasedId(
+  testName,
+  hashFunction,
+  platformName = null,
+) {
+  const tableSection = platformName === null ? 'header' : 'row';
+  const hashValue = hashFunction(getSignatureName(testName, platformName));
+
+  return `table-${tableSection}-${hashValue}`;
+};


### PR DESCRIPTION
The permalinks feature in the Perfherder compare and compare subtests view (click on the # symbol when hovering over a table header or row) that landed right before the switch to react router wasn't translated very nicely on my part. 

Two things were addressed in this pr:

1. Due to differences between how UI-router and react-router designate the parent container, `scrollIntoView` meant the element would always hide behind the top navbar. Using `scrollTo` with an offset was the solution.
2. The scroll function had a lag due to history being replaced with the new hash in `onPermalinkClick`. This is because any change to the history or location object will trigger a new render, so I added a condition at the top level `Validation` component with `shouldComponentUpdate`.

I also moved the CompareTable row into its own component in order to utilize ref's since its a better practice to get into using those to access a dom node instead of document.querySelector (except in cases where you can't actually use a ref).

FYI @ionutgoldan