### PR TITLE
Bug 1600752 - Accessibility improvements Compare and Alert Views

### DIFF
--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -271,9 +271,9 @@ th {
 }
 
 .compare-table .subtest-header > th:first-child,
-.compare-table:hover .subtest-header > th,
-.compare-table:hover .subtest-header a,
-.compare-table:hover .subtest-header button,
+.compare-table .subtest-header > th,
+.compare-table .subtest-header a,
+.compare-table .subtest-header button,
 .compare-table {
   color: #333;
 }
@@ -297,12 +297,12 @@ th {
   transition: visibility 150ms ease-in-out;
 }
 
-.compare-table tr:hover .result-links span {
+.compare-table tr .result-links span {
   color: #333;
 }
 
-.compare-table tr:hover .result-links a,
-.compare-table tr:hover .result-links button {
+.compare-table tr .result-links a,
+.compare-table tr .result-links button {
   color: #23527c;
 }
 

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -301,21 +301,11 @@ th {
   transition: visibility 150ms ease-in-out;
 }
 
-.compare-table tr .result-links span {
-  color: #333;
-}
-
-.compare-table tr .result-links a,
-.compare-table tr .result-links button {
+.compare-table tr:hover .result-links a,
+.compare-table tr:hover .result-links button,
+.compare-table tr:focus-within .result-links a,
+.compare-table tr:focus-within .result-links button {
   color: #23527c;
-  opacity: 0.5;
-}
-
-.compare-table tr .result-links a:hover,
-.compare-table tr .result-links button:hover,
-.compare-table tr .result-links a:focus,
-.compare-table tr .result-links button:focus {
-  opacity: 1;
 }
 
 .compare-table tr:hover .retrigger-btn {

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -308,6 +308,14 @@ th {
 .compare-table tr .result-links a,
 .compare-table tr .result-links button {
   color: #23527c;
+  opacity: 0.5;
+}
+
+.compare-table tr .result-links a:hover,
+.compare-table tr .result-links button:hover,
+.compare-table tr .result-links a:focus,
+.compare-table tr .result-links button:focus {
+  opacity: 1;
 }
 
 .compare-table tr:hover .retrigger-btn {

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -263,6 +263,10 @@ th {
   cursor: default;
 }
 
+.compare-table th h3 {
+  font-size: inherit;
+}
+
 .compare-table .subtest-header > th,
 .compare-table .subtest-header a,
 .compare-table .subtest-header button {

--- a/ui/perfherder/ProgressBar.jsx
+++ b/ui/perfherder/ProgressBar.jsx
@@ -7,21 +7,26 @@ import SimpleTooltip from '../shared/SimpleTooltip';
 const ProgressBar = ({ magnitude, regression, color }) => (
   <SimpleTooltip
     text={
-      <Progress multi aria-label="Magnitude of Difference">
+      <Progress
+        multi
+        aria-label={`Magnitude of difference based on lower is better. Metric: ${
+          regression ? 100 - magnitude : magnitude
+        } % regressed`}
+      >
         {/* the % of the bars that are colored and transparent is based on the newIsBetter metric,
         which determines whether the colored bar for magnitude is displayed on the left or right */}
-        <span className="sr-only sr-only-focusable">Magnitude 1</span>
-        <Progress
-          bar
-          value={regression ? 100 - magnitude : magnitude}
-          color={regression ? 'transparent' : color}
-        />
-        <span className="sr-only sr-only-focusable">Magnitude 2</span>
-        <Progress
-          bar
-          value={regression ? magnitude : 100 - magnitude}
-          color={regression ? color : 'transparent'}
-        />
+        <div aria-hidden="true" className="progress w-100">
+          <Progress
+            bar
+            value={regression ? 100 - magnitude : magnitude}
+            color={regression ? 'transparent' : color}
+          />
+          <Progress
+            bar
+            value={regression ? magnitude : 100 - magnitude}
+            color={regression ? color : 'transparent'}
+          />
+        </div>
       </Progress>
     }
     tooltipText="Relative magnitude of change (scale from 0 - 20%+)"

--- a/ui/perfherder/ProgressBar.jsx
+++ b/ui/perfherder/ProgressBar.jsx
@@ -7,14 +7,16 @@ import SimpleTooltip from '../shared/SimpleTooltip';
 const ProgressBar = ({ magnitude, regression, color }) => (
   <SimpleTooltip
     text={
-      <Progress multi>
+      <Progress multi aria-label="Magnitude of Difference">
         {/* the % of the bars that are colored and transparent is based on the newIsBetter metric,
         which determines whether the colored bar for magnitude is displayed on the left or right */}
+        <span className="sr-only sr-only-focusable">Magnitude 1</span>
         <Progress
           bar
           value={regression ? 100 - magnitude : magnitude}
           color={regression ? 'transparent' : color}
         />
+        <span className="sr-only sr-only-focusable">Magnitude 2</span>
         <Progress
           bar
           value={regression ? magnitude : 100 - magnitude}

--- a/ui/perfherder/alerts/AlertHeader.jsx
+++ b/ui/perfherder/alerts/AlertHeader.jsx
@@ -39,17 +39,19 @@ const AlertHeader = ({
     <Container>
       <Row>
         <a
-          className="text-dark font-weight-bold align-middle"
+          className="text-dark"
           href={`#/alerts?id=${alertSummary.id}`}
           id={`alert summary ${alertSummary.id.toString()} title`}
           data-testid={`alert summary ${alertSummary.id.toString()} title`}
         >
-          Alert #{alertSummary.id} - {alertSummary.repository} -{' '}
-          {getTitle(alertSummary)}{' '}
-          <FontAwesomeIcon
-            icon={faExternalLinkAlt}
-            className="icon-superscript"
-          />
+          <h3 className="font-weight-bold align-middle">
+            Alert #{alertSummary.id} - {alertSummary.repository} -{' '}
+            {getTitle(alertSummary)}{' '}
+            <FontAwesomeIcon
+              icon={faExternalLinkAlt}
+              className="icon-superscript"
+            />
+          </h3>
         </a>
       </Row>
       <Row className="font-weight-normal">

--- a/ui/perfherder/alerts/AlertTable.jsx
+++ b/ui/perfherder/alerts/AlertTable.jsx
@@ -248,6 +248,17 @@ export default class AlertTable extends React.Component {
                   </tr>
                 </thead>
                 <tbody>
+                  <tr>
+                    <th>&nbsp;</th>
+                    <th>&nbsp;</th>
+                    <th>Alert Name</th>
+                    <th>&nbsp;</th>
+                    <th>&nbsp;</th>
+                    <th>&nbsp;</th>
+                    <th>Detail Hint</th>
+                    <th>Magnitude</th>
+                    <th>Confidence</th>
+                  </tr>
                   {filteredAlerts.map(alert => (
                     <AlertTableRow
                       key={alert.id}

--- a/ui/perfherder/alerts/AlertTable.jsx
+++ b/ui/perfherder/alerts/AlertTable.jsx
@@ -307,10 +307,10 @@ export default class AlertTable extends React.Component {
                   {alertSummary.notes && (
                     <div className="bg-white px-3 py-4">
                       <TruncatedText
+                        color="info"
                         title="Notes: "
                         maxLength={167}
                         text={alertSummary.notes}
-                        showMoreClass="text-info"
                       />
                     </div>
                   )}

--- a/ui/perfherder/alerts/AlertTable.jsx
+++ b/ui/perfherder/alerts/AlertTable.jsx
@@ -248,15 +248,15 @@ export default class AlertTable extends React.Component {
                   </tr>
                 </thead>
                 <tbody>
-                  <tr>
-                    <th>&nbsp;</th>
-                    <th>&nbsp;</th>
-                    <th>Alert Name</th>
-                    <th>&nbsp;</th>
-                    <th>&nbsp;</th>
-                    <th>&nbsp;</th>
-                    <th>Detail Hint</th>
-                    <th>Magnitude</th>
+                  <tr className="border">
+                    <th> </th>
+                    <th> </th>
+                    <th>Test and platform</th>
+                    <th>Previous Value</th>
+                    <th> </th>
+                    <th>New Value</th>
+                    <th>Absolute Difference</th>
+                    <th>Magnitude of Change</th>
                     <th>Confidence</th>
                   </tr>
                   {filteredAlerts.map(alert => (

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormGroup, Input, Label } from 'reactstrap';
+import { Button, FormGroup, Input, Label } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faStar as faStarSolid,
@@ -198,6 +198,7 @@ export default class AlertTableRow extends React.Component {
     const tooltipText = alert.classifier_email
       ? `Classified by ${alert.classifier_email}`
       : 'Classified automatically';
+    const bookmarkClass = starred ? 'visible' : '';
 
     return (
       <tr
@@ -208,13 +209,9 @@ export default class AlertTableRow extends React.Component {
       >
         <td className="table-width-xs px-1">
           <FormGroup check className="ml-2 pl-4">
-            <Label for={alert.id} hidden>
-              alert {alert.id} title
-            </Label>
+            <Label hidden>alert {alert.id} title</Label>
             <Input
-              id={alert.id}
               aria-label={`alert ${alert.id} title`}
-              aria-labelledby={`alert ${alert.id} title`}
               data-testid={`alert ${alert.id} checkbox`}
               type="checkbox"
               disabled={!user.isStaff}
@@ -229,13 +226,14 @@ export default class AlertTableRow extends React.Component {
           </FormGroup>
         </td>
         <td className="px-0">
-          <button
-            type="button"
-            className={
+          <Button
+            color="black"
+            aria-label={
               starred
-                ? 'visible border border-0 bg-transparent'
-                : 'border border-0 bg-transparent'
+                ? 'Remove bookmark from this Alert'
+                : 'Bookmark this Alert'
             }
+            className={`${bookmarkClass} border p-0 border-0 bg-transparent`}
             data-testid={`alert ${alert.id.toString()} star`}
             onClick={this.toggleStar}
           >
@@ -243,7 +241,7 @@ export default class AlertTableRow extends React.Component {
               title={starred ? 'starred' : 'not starred'}
               icon={starred ? faStarSolid : faStarRegular}
             />
-          </button>
+          </Button>
         </td>
         <td className="text-left">
           {alertStatus !== 'untriaged' ? (

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/no-did-update-set-state */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormGroup, Input } from 'reactstrap';
+import { FormGroup, Input, Label } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faStar as faStarSolid,
@@ -209,7 +209,12 @@ export default class AlertTableRow extends React.Component {
       >
         <td className="table-width-xs px-1">
           <FormGroup check className="ml-2 pl-4">
+            <Label for={alert.id} hidden>
+              alert {alert.id} title
+            </Label>
             <Input
+              id={alert.id}
+              aria-label={`alert ${alert.id} title`}
               aria-labelledby={`alert ${alert.id} title`}
               data-testid={`alert ${alert.id} checkbox`}
               type="checkbox"
@@ -225,8 +230,13 @@ export default class AlertTableRow extends React.Component {
           </FormGroup>
         </td>
         <td className="px-0">
-          <span
-            className={starred ? 'visible' : ''}
+          <button
+            type="button"
+            className={
+              starred
+                ? 'visible border border-0 bg-transparent'
+                : 'border border-0 bg-transparent'
+            }
             data-testid={`alert ${alert.id.toString()} star`}
             onClick={this.toggleStar}
           >
@@ -234,7 +244,7 @@ export default class AlertTableRow extends React.Component {
               title={starred ? 'starred' : 'not starred'}
               icon={starred ? faStarSolid : faStarRegular}
             />
-          </span>
+          </button>
         </td>
         <td className="text-left">
           {alertStatus !== 'untriaged' ? (

--- a/ui/perfherder/compare/CompareTable.jsx
+++ b/ui/perfherder/compare/CompareTable.jsx
@@ -51,7 +51,7 @@ export default class CompareTable extends React.PureComponent {
                       this.header,
                     )
                   }
-                  title="Permalink to this test table"
+                  title={`Permalink to this test table: ${testName}`}
                 >
                   <FontAwesomeIcon icon={faHashtag} />
                 </Button>
@@ -63,7 +63,7 @@ export default class CompareTable extends React.PureComponent {
             <th className="table-width-lg">New</th>
             <th className="table-width-lg">Delta</th>
             {/* empty for progress bars (magnitude of difference) */}
-            <th className="table-width-lg" />
+            <th className="table-width-lg">Magnitude of Difference</th>
             <th className="table-width-lg">Confidence</th>
             <th className="text-right table-width-md">
               {hasSubtests &&
@@ -87,10 +87,152 @@ export default class CompareTable extends React.PureComponent {
           {data.map(rowLevelResults => (
             <CompareTableRow
               key={rowLevelResults.name}
+<<<<<<< 39891e0e01f1ef9eeed451d1efada0462f91150f
               rowLevelResults={rowLevelResults}
               hashFunction={hashFunction}
               {...this.props}
             />
+=======
+            >
+              <th className="text-left font-weight-normal pl-1">
+                {rowLevelResults.name}
+                <span className="result-links">
+                  {onPermalinkClick && (
+                    <span>
+                      <Button
+                        className="permalink p-0 ml-1"
+                        color="link"
+                        onClick={() =>
+                          onPermalinkClick(
+                            this.getHashBasedId(testName, rowLevelResults.name),
+                          )
+                        }
+                        title={`Permalink to this test: ${rowLevelResults.name}`}
+                      >
+                        <FontAwesomeIcon icon={faHashtag} />
+                      </Button>
+                    </span>
+                  )}
+                  {rowLevelResults.links &&
+                    rowLevelResults.links.map(link => (
+                      <span key={link.title}>
+                        <a href={link.href}>{` ${link.title}`}</a>
+                      </span>
+                    ))}
+                </span>
+              </th>
+              <TableAverage
+                value={rowLevelResults.originalValue}
+                stddev={rowLevelResults.originalStddev}
+                stddevpct={rowLevelResults.originalStddevPct}
+                replicates={rowLevelResults.originalRuns}
+              />
+              <td>
+                {rowLevelResults.originalValue < rowLevelResults.newValue && (
+                  <span>&lt;</span>
+                )}
+                {rowLevelResults.originalValue > rowLevelResults.newValue && (
+                  <span>&gt;</span>
+                )}
+              </td>
+              <TableAverage
+                value={rowLevelResults.newValue}
+                stddev={rowLevelResults.newStddev}
+                stddevpct={rowLevelResults.newStddevPct}
+                replicates={rowLevelResults.newRuns}
+              />
+              <td className={this.getColorClass(rowLevelResults, 'background')}>
+                {rowLevelResults.delta &&
+                Math.abs(displayNumber(rowLevelResults.deltaPercentage)) !==
+                  0 ? (
+                  <SimpleTooltip
+                    textClass="detail-hint"
+                    text={
+                      <React.Fragment>
+                        {(rowLevelResults.isRegression ||
+                          rowLevelResults.isImprovement) && (
+                          <FontAwesomeIcon
+                            icon={
+                              rowLevelResults.isRegression
+                                ? faExclamationTriangle
+                                : faThumbsUp
+                            }
+                            title={
+                              rowLevelResults.isRegression
+                                ? 'regression'
+                                : 'improvement'
+                            }
+                            className={this.getColorClass(
+                              rowLevelResults,
+                              'text',
+                            )}
+                            size="lg"
+                          />
+                        )}
+                        {`  ${displayNumber(rowLevelResults.deltaPercentage)}%`}
+                      </React.Fragment>
+                    }
+                    tooltipText={this.deltaTooltipText(
+                      rowLevelResults.delta,
+                      rowLevelResults.deltaPercentage,
+                      rowLevelResults.newIsBetter,
+                    )}
+                  />
+                ) : null}
+                {rowLevelResults.delta
+                  ? Math.abs(displayNumber(rowLevelResults.deltaPercentage)) ===
+                      0 && (
+                      <span>
+                        {displayNumber(rowLevelResults.deltaPercentage)}%
+                      </span>
+                    )
+                  : null}
+              </td>
+              <td>
+                {rowLevelResults.delta ? (
+                  <ProgressBar
+                    magnitude={rowLevelResults.magnitude}
+                    regression={!rowLevelResults.newIsBetter}
+                    color={this.getColorClass(rowLevelResults, 'bar')}
+                  />
+                ) : null}
+              </td>
+              <td>
+                {rowLevelResults.delta &&
+                rowLevelResults.confidence &&
+                rowLevelResults.confidenceText ? (
+                  <SimpleTooltip
+                    textClass="detail-hint"
+                    text={`${displayNumber(rowLevelResults.confidence)} (${
+                      rowLevelResults.confidenceText
+                    })`}
+                    tooltipText={rowLevelResults.confidenceTextLong}
+                  />
+                ) : null}
+              </td>
+              <td className="text-right">
+                {!hasSubtests &&
+                  !rowLevelResults.isNoiseMetric &&
+                  (rowLevelResults.newRetriggerableJobId || !isBaseAggregate) &&
+                  user.isLoggedIn && (
+                    <Button
+                      className="retrigger-btn btn icon-green mr-1 py-0 px-1"
+                      title={compareTableText.retriggerButtonTitle}
+                      onClick={() => this.retriggerJobs(rowLevelResults, 5)}
+                    >
+                      <FontAwesomeIcon icon={faRedo} />
+                    </Button>
+                  )}
+                {rowLevelResults.originalRuns && (
+                  <SimpleTooltip
+                    textClass="detail-hint"
+                    text={`${rowLevelResults.originalRuns.length} / ${rowLevelResults.newRuns.length}`}
+                    tooltipText={`${rowLevelResults.originalRuns.length} base / ${rowLevelResults.newRuns.length} new`}
+                  />
+                )}
+              </td>
+            </tr>
+>>>>>>> Bug 1600752 - Compare View Changes
           ))}
         </tbody>
       </Table>

--- a/ui/perfherder/compare/CompareTable.jsx
+++ b/ui/perfherder/compare/CompareTable.jsx
@@ -51,7 +51,8 @@ export default class CompareTable extends React.PureComponent {
                       this.header,
                     )
                   }
-                  title={`Permalink to this test table: ${testName}`}
+                  title="Permalink to this test table"
+                  aria-label={`Permalink to test ${testName} table`}
                 >
                   <FontAwesomeIcon icon={faHashtag} />
                 </Button>
@@ -62,7 +63,6 @@ export default class CompareTable extends React.PureComponent {
             <th className="table-width-sm" />
             <th className="table-width-lg">New</th>
             <th className="table-width-lg">Delta</th>
-            {/* empty for progress bars (magnitude of difference) */}
             <th className="table-width-lg">Magnitude of Difference</th>
             <th className="table-width-lg">Confidence</th>
             <th className="text-right table-width-md">
@@ -87,152 +87,10 @@ export default class CompareTable extends React.PureComponent {
           {data.map(rowLevelResults => (
             <CompareTableRow
               key={rowLevelResults.name}
-<<<<<<< 39891e0e01f1ef9eeed451d1efada0462f91150f
               rowLevelResults={rowLevelResults}
               hashFunction={hashFunction}
               {...this.props}
             />
-=======
-            >
-              <th className="text-left font-weight-normal pl-1">
-                {rowLevelResults.name}
-                <span className="result-links">
-                  {onPermalinkClick && (
-                    <span>
-                      <Button
-                        className="permalink p-0 ml-1"
-                        color="link"
-                        onClick={() =>
-                          onPermalinkClick(
-                            this.getHashBasedId(testName, rowLevelResults.name),
-                          )
-                        }
-                        title={`Permalink to this test: ${rowLevelResults.name}`}
-                      >
-                        <FontAwesomeIcon icon={faHashtag} />
-                      </Button>
-                    </span>
-                  )}
-                  {rowLevelResults.links &&
-                    rowLevelResults.links.map(link => (
-                      <span key={link.title}>
-                        <a href={link.href}>{` ${link.title}`}</a>
-                      </span>
-                    ))}
-                </span>
-              </th>
-              <TableAverage
-                value={rowLevelResults.originalValue}
-                stddev={rowLevelResults.originalStddev}
-                stddevpct={rowLevelResults.originalStddevPct}
-                replicates={rowLevelResults.originalRuns}
-              />
-              <td>
-                {rowLevelResults.originalValue < rowLevelResults.newValue && (
-                  <span>&lt;</span>
-                )}
-                {rowLevelResults.originalValue > rowLevelResults.newValue && (
-                  <span>&gt;</span>
-                )}
-              </td>
-              <TableAverage
-                value={rowLevelResults.newValue}
-                stddev={rowLevelResults.newStddev}
-                stddevpct={rowLevelResults.newStddevPct}
-                replicates={rowLevelResults.newRuns}
-              />
-              <td className={this.getColorClass(rowLevelResults, 'background')}>
-                {rowLevelResults.delta &&
-                Math.abs(displayNumber(rowLevelResults.deltaPercentage)) !==
-                  0 ? (
-                  <SimpleTooltip
-                    textClass="detail-hint"
-                    text={
-                      <React.Fragment>
-                        {(rowLevelResults.isRegression ||
-                          rowLevelResults.isImprovement) && (
-                          <FontAwesomeIcon
-                            icon={
-                              rowLevelResults.isRegression
-                                ? faExclamationTriangle
-                                : faThumbsUp
-                            }
-                            title={
-                              rowLevelResults.isRegression
-                                ? 'regression'
-                                : 'improvement'
-                            }
-                            className={this.getColorClass(
-                              rowLevelResults,
-                              'text',
-                            )}
-                            size="lg"
-                          />
-                        )}
-                        {`  ${displayNumber(rowLevelResults.deltaPercentage)}%`}
-                      </React.Fragment>
-                    }
-                    tooltipText={this.deltaTooltipText(
-                      rowLevelResults.delta,
-                      rowLevelResults.deltaPercentage,
-                      rowLevelResults.newIsBetter,
-                    )}
-                  />
-                ) : null}
-                {rowLevelResults.delta
-                  ? Math.abs(displayNumber(rowLevelResults.deltaPercentage)) ===
-                      0 && (
-                      <span>
-                        {displayNumber(rowLevelResults.deltaPercentage)}%
-                      </span>
-                    )
-                  : null}
-              </td>
-              <td>
-                {rowLevelResults.delta ? (
-                  <ProgressBar
-                    magnitude={rowLevelResults.magnitude}
-                    regression={!rowLevelResults.newIsBetter}
-                    color={this.getColorClass(rowLevelResults, 'bar')}
-                  />
-                ) : null}
-              </td>
-              <td>
-                {rowLevelResults.delta &&
-                rowLevelResults.confidence &&
-                rowLevelResults.confidenceText ? (
-                  <SimpleTooltip
-                    textClass="detail-hint"
-                    text={`${displayNumber(rowLevelResults.confidence)} (${
-                      rowLevelResults.confidenceText
-                    })`}
-                    tooltipText={rowLevelResults.confidenceTextLong}
-                  />
-                ) : null}
-              </td>
-              <td className="text-right">
-                {!hasSubtests &&
-                  !rowLevelResults.isNoiseMetric &&
-                  (rowLevelResults.newRetriggerableJobId || !isBaseAggregate) &&
-                  user.isLoggedIn && (
-                    <Button
-                      className="retrigger-btn btn icon-green mr-1 py-0 px-1"
-                      title={compareTableText.retriggerButtonTitle}
-                      onClick={() => this.retriggerJobs(rowLevelResults, 5)}
-                    >
-                      <FontAwesomeIcon icon={faRedo} />
-                    </Button>
-                  )}
-                {rowLevelResults.originalRuns && (
-                  <SimpleTooltip
-                    textClass="detail-hint"
-                    text={`${rowLevelResults.originalRuns.length} / ${rowLevelResults.newRuns.length}`}
-                    tooltipText={`${rowLevelResults.originalRuns.length} base / ${rowLevelResults.newRuns.length} new`}
-                  />
-                )}
-              </td>
-            </tr>
->>>>>>> Bug 1600752 - Compare View Changes
           ))}
         </tbody>
       </Table>

--- a/ui/perfherder/compare/CompareTableRow.jsx
+++ b/ui/perfherder/compare/CompareTableRow.jsx
@@ -77,6 +77,7 @@ export default class CompareTableRow extends React.PureComponent {
                     )
                   }
                   title="Permalink to this test"
+                  aria-label={`Permalink to test ${rowLevelResults.name}`}
                 >
                   <FontAwesomeIcon icon={faHashtag} />
                 </Button>

--- a/ui/shared/TruncatedText.jsx
+++ b/ui/shared/TruncatedText.jsx
@@ -22,7 +22,8 @@ export default class TruncatedText extends React.Component {
         </p>
         {text.length > maxLength && (
           <Button
-            className={`${showMoreClass} bg-transparent border border-0 mb-0 text-right  pointer`}
+            color="link"
+            className={`${showMoreClass} d-block p-0 ml-auto`}
             onClick={() => this.setState({ showMoreResults: !showMoreResults })}
           >
             {`show ${showMoreResults ? 'less' : 'more'}`}

--- a/ui/shared/TruncatedText.jsx
+++ b/ui/shared/TruncatedText.jsx
@@ -22,7 +22,7 @@ export default class TruncatedText extends React.Component {
         </p>
         {text.length > maxLength && (
           <Button
-            className={`${showMoreClass} mb-0 text-right  pointer`}
+            className={`${showMoreClass} bg-transparent border border-0 mb-0 text-right  pointer`}
             onClick={() => this.setState({ showMoreResults: !showMoreResults })}
           >
             {`show ${showMoreResults ? 'less' : 'more'}`}

--- a/ui/shared/TruncatedText.jsx
+++ b/ui/shared/TruncatedText.jsx
@@ -11,7 +11,7 @@ export default class TruncatedText extends React.Component {
   }
 
   render() {
-    const { text, maxLength, title, showMoreClass } = this.props;
+    const { text, maxLength, title, color } = this.props;
     const { showMoreResults } = this.state;
 
     return (
@@ -22,8 +22,10 @@ export default class TruncatedText extends React.Component {
         </p>
         {text.length > maxLength && (
           <Button
-            color="link"
-            className={`${showMoreClass} d-block p-0 ml-auto`}
+            color={color || 'link'}
+            outline={color}
+            className={`${color ||
+              'font-weight-bold text-reset'} d-block ml-auto`}
             onClick={() => this.setState({ showMoreResults: !showMoreResults })}
           >
             {`show ${showMoreResults ? 'less' : 'more'}`}
@@ -38,10 +40,8 @@ TruncatedText.propTypes = {
   text: PropTypes.string.isRequired,
   title: PropTypes.string,
   maxLength: PropTypes.number.isRequired,
-  showMoreClass: PropTypes.string,
 };
 
 TruncatedText.defaultProps = {
-  showMoreClass: 'font-weight-bold',
   title: '',
 };

--- a/ui/shared/TruncatedText.jsx
+++ b/ui/shared/TruncatedText.jsx
@@ -22,9 +22,9 @@ export default class TruncatedText extends React.Component {
         </p>
         {text.length > maxLength && (
           <Button
-            color={color || 'link'}
-            outline={color}
-            className={`${color ||
+            color={color}
+            outline={color !== 'link'}
+            className={`${color !== 'link' ||
               'font-weight-bold text-reset'} d-block ml-auto`}
             onClick={() => this.setState({ showMoreResults: !showMoreResults })}
           >
@@ -40,8 +40,10 @@ TruncatedText.propTypes = {
   text: PropTypes.string.isRequired,
   title: PropTypes.string,
   maxLength: PropTypes.number.isRequired,
+  color: PropTypes.string,
 };
 
 TruncatedText.defaultProps = {
   title: '',
+  color: 'link',
 };

--- a/ui/shared/TruncatedText.jsx
+++ b/ui/shared/TruncatedText.jsx
@@ -1,6 +1,5 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-
 import React from 'react';
+import { Button } from 'reactstrap';
 import PropTypes from 'prop-types';
 
 export default class TruncatedText extends React.Component {
@@ -22,12 +21,12 @@ export default class TruncatedText extends React.Component {
           {text}
         </p>
         {text.length > maxLength && (
-          <p
+          <Button
             className={`${showMoreClass} mb-0 text-right  pointer`}
             onClick={() => this.setState({ showMoreResults: !showMoreResults })}
           >
             {`show ${showMoreResults ? 'less' : 'more'}`}
-          </p>
+          </Button>
         )}
       </React.Fragment>
     );


### PR DESCRIPTION
## Description of issue

There are a few suggested changes to improve accessibility in Perfherder's Compare and Alert Views:
#### Compare View:
- [X] **1a**. Add aria-label or aria-value attributes to progress bar
- [X] **1b**. Permalink title/aria text should include the test name
- [X] **1c**. Column titles and links should be shown all the time

#### Alert View:
- [x] **2a**. Checkbox needs label
- [X] **2b**. Alert Summary should be caption element
- [X] **2c**. Add Column titles
- [X] **2d**. Start needs to be button
- [x] **2e**. "Show more/less" needs to be buton

## Proposed Solution

As most of the tasks were straightforward, I'm going to point their location and some comments below:
- **1a**. `ProgressBar.jsx`: According to [Reactstrap Github](https://github.com/reactstrap/reactstrap/issues/1681), there are still some issues in ProgressBar element. In this element, the props are not spread, making it not possible to insert more `aria-` attributes. The proposed solution is to insert an `aria-label` on the wrapper ProgressBar, insert a `.sr-only` `<span>` element with the description and insert a Table Header in `CompareTable.jsx:127`.
- **1b**. `CompareTable.jsx`
- **1c**: `perf.css:272:303`: I tried to show the links only when the table was focused, but the `:focus` attribute didn't work very well. The table may have become visually busy.
 
--------
- **2a**. `AlertTableRow.jsx:211:216`: an id was needed to link the Label's for attribute.
- **2b**. `AlertHeader.jsx`: and additional css was needed to keep style in `perf.css:260:263`
- **2c**. `AlertTable.jsx`: I may need some guidance on what the header titles should read.
- **2d**. `AlertTableRow.jsx:232:238`: Utilities classes were needed to keep same style.
- **2e**. I could not find this button.

------

_P.S.:_ An additional commit was created because `yarn lint` returned `Unused eslint-disable directive`. This can be squashed into another commit if needed.

## Testing
For both Views, visual test was made to make sure their layout was the same as before, except from what was requested.
With the screen reader (SR), navigation on the changed elements was made. It was also tested the headings navigation for **2b**.

**Compare View**:
[Link used to testing](http://localhost:5000/perf.html#/compare?originalProject=mozilla-central&newProject=mozilla-central&newRevision=4d585c7edc7683e4b35eca6b18c9a646a1b8a78d&framework=10&selectedTimeRange=172800) or any with results available can be used.
![image](https://user-images.githubusercontent.com/3901809/70455985-ffa4fb00-1a8b-11ea-8dd0-489cbbba6d27.png)


**Alerts View**:
![image](https://user-images.githubusercontent.com/3901809/70455839-bc4a8c80-1a8b-11ea-9e62-a0a10c95621c.png)
- [SR] It reads both tables' headers, because they are one table inside another. This was not pointed in the bug, but I wonder if there is any way it could be better.
- Could not test checkbox and start functionality, as it is restricted to Sheriffs.