### PR TITLE
Display revision comments in RevisionInformation.

### DIFF
--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -207,8 +207,21 @@ h1 {
 
 .push-information {
   font-size: 18px;
-  color: #777;
+  color: #555;
   margin-left: -4px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 2rem;
+}
+
+.push-information-revisions {
+  list-style: none;
+  font-size: 0.7em;
+  font-style: italic;
+  color: #757575;
+  padding: 0;
+  padding-top: 5px;
+  text-align: left;
 }
 
 .vertical-box {

--- a/ui/perfherder/compare/RevisionInformation.jsx
+++ b/ui/perfherder/compare/RevisionInformation.jsx
@@ -4,6 +4,21 @@ import { ListGroup, ListGroupItem } from 'reactstrap';
 
 import { getJobsUrl } from '../../helpers/url';
 
+function getRevisionComments(resultSet) {
+  const [firstRevisionComment, ...restRevisionsComments] =
+    resultSet && Array.isArray(resultSet.revisions)
+      ? resultSet.revisions.map(r => r.comments)
+      : [];
+  const revisionCommentsTitle = restRevisionsComments.join('\n');
+
+  return firstRevisionComment ? (
+    <ul className="push-information-revisions">
+      <li>{firstRevisionComment}</li>
+      {revisionCommentsTitle && <li title={revisionCommentsTitle}>…</li>}
+    </ul>
+  ) : null;
+}
+
 function getRevisionSpecificDetails(
   revision,
   project,
@@ -27,8 +42,7 @@ function getRevisionSpecificDetails(
       &nbsp;({project}) -&nbsp;
       {resultSet && resultSet.author}
       {!resultSet && selectedTimeRange && selectedTimeRange.text}
-      {isBaseline && ' - '}
-      {resultSet ? <span>{resultSet.comments}</span> : ''}
+      {getRevisionComments(resultSet)}
     </React.Fragment>
   );
 }
@@ -45,7 +59,7 @@ export default function RevisionInformation(props) {
   } = props;
 
   return (
-    <ListGroup className="d-inline push-information m-0">
+    <ListGroup className="push-information m-0 list-group">
       {originalRevision && (
         <ListGroupItem className="d-inline border-0 p-0">
           {getRevisionSpecificDetails(
@@ -67,6 +81,7 @@ export default function RevisionInformation(props) {
           )}
         </ListGroupItem>
       )}
+      —
       {newRevision && (
         <ListGroupItem className="d-inline border-0 p-0">
           {getRevisionSpecificDetails(


### PR DESCRIPTION
Fixes Bug 1487761.

The revision comments were supposed to be displayed,
but we were looking at the wrong place to do so.
This patch fixes this, so revision comments are displayed
under the revision number + author.
The layout is changed to flex to do this properly.
Colors are tweaked a bit in order to pass WCAG standard.

This is how it looks:

<img width="1346" alt="image" src="https://user-images.githubusercontent.com/578107/70637859-3e77b400-1c38-11ea-82a6-65274926b530.png">

