### PR TITLE
Bug 1574628 - Improve graph colors and add symbols

### DIFF
--- a/tests/ui/perfherder/graphs_view_test.jsx
+++ b/tests/ui/perfherder/graphs_view_test.jsx
@@ -12,6 +12,7 @@ import {
   endpoints,
   filterText,
   graphColors,
+  graphSymbols,
 } from '../../../ui/perfherder/constants';
 import GraphsViewControls from '../../../ui/perfherder/graphs/GraphsViewControls';
 import repos from '../mock/repositories';
@@ -26,7 +27,12 @@ import {
   getApiUrl,
 } from '../../../ui/helpers/url';
 
-const graphData = createGraphData(testData, [], [...graphColors]);
+const graphData = createGraphData(
+  testData,
+  [],
+  [...graphColors],
+  [...graphSymbols],
+);
 
 const frameworks = [
   { id: 1, name: 'talos' },

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -451,27 +451,27 @@ li.pagination-active.active > button {
 
 /* graph colors */
 .orange {
-  border-left-color: #ffba4a;
+  border-left-color: #ffb851;
 }
 
 .firered {
-  border-left-color: #c92b2a;
+  border-left-color: #c92d2f;
 }
 
 .cerulean {
-  border-left-color: #20bde0;
+  border-left-color: #16bcde;
 }
 
 .bluebell {
-  border-left-color: #9c9ccc;
+  border-left-color: #464876;
 }
 
 .gras {
-  border-left-color: #940a83;
+  border-left-color: #921181;
 }
 
 .darkpuce {
-  border-left-color: #4b2d45;
+  border-left-color: #4c3146;
 }
 
 @media only screen and (min-width: 1700px) {

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -450,32 +450,28 @@ li.pagination-active.active > button {
 }
 
 /* graph colors */
-.pink {
-  border-left-color: #ffe2f5;
+.orange {
+  border-left-color: #ffba4a;
 }
 
-.purple {
-  border-left-color: #601a4a;
+.firered {
+  border-left-color: #c92b2a;
 }
 
-.darkorchid {
-  border-left-color: #9932cc;
+.cerulean {
+  border-left-color: #20bde0;
 }
 
-.scarlet {
-  border-left-color: #b81752;
+.grape {
+  border-left-color: #464678;
 }
 
-.turquoise {
-  border-left-color: #17a2b8;
+.gras {
+  border-left-color: #940a83;
 }
 
-.magenta {
-  border-left-color: #e252cf;
-}
-
-.yellow {
-  border-left-color: #f9ed00;
+.darkpuce {
+  border-left-color: #4b2d45;
 }
 
 @media only screen and (min-width: 1700px) {

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -454,7 +454,7 @@ li.pagination-active.active > button {
   border-left-color: #ffb851;
 }
 
-.firered {
+.fire-red {
   border-left-color: #c92d2f;
 }
 
@@ -462,7 +462,7 @@ li.pagination-active.active > button {
   border-left-color: #16bcde;
 }
 
-.bluebell {
+.blue-bell {
   border-left-color: #464876;
 }
 
@@ -470,7 +470,7 @@ li.pagination-active.active > button {
   border-left-color: #921181;
 }
 
-.darkpuce {
+.dark-puce {
   border-left-color: #4c3146;
 }
 

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -450,12 +450,12 @@ li.pagination-active.active > button {
 }
 
 /* graph colors */
-.blue {
-  border-left-color: #1752b8;
+.pink {
+  border-left-color: #ffe2f5;
 }
 
-.green {
-  border-left-color: #19a572;
+.purple {
+  border-left-color: #601a4a;
 }
 
 .darkorchid {
@@ -474,8 +474,8 @@ li.pagination-active.active > button {
   border-left-color: #e252cf;
 }
 
-.brown {
-  border-left-color: #b87e17;
+.yellow {
+  border-left-color: #f9ed00;
 }
 
 @media only screen and (min-width: 1700px) {

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -462,8 +462,8 @@ li.pagination-active.active > button {
   border-left-color: #20bde0;
 }
 
-.grape {
-  border-left-color: #464678;
+.bluebell {
+  border-left-color: #9c9ccc;
 }
 
 .gras {

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -466,7 +466,7 @@ li.pagination-active.active > button {
   border-left-color: #464876;
 }
 
-.gras {
+.purple {
   border-left-color: #921181;
 }
 

--- a/ui/perfherder/constants.js
+++ b/ui/perfherder/constants.js
@@ -65,10 +65,19 @@ export const alertStatusMap = {
 export const graphColors = [
   ['scarlet', '#b81752'],
   ['turquoise', '#17a2b8'],
-  ['green', '#19a572'],
-  ['brown', '#b87e17'],
+  ['purple', '#601A4A'],
+  ['pink', '#ffe2f5'],
+  ['yellow', '#f9ed00'],
   ['darkorchid', '#9932cc'],
-  ['blue', '#1752b8'],
+];
+
+export const graphSymbols = [
+  'circle',
+  'diamond',
+  'plus',
+  'square',
+  'star',
+  'triangleUp',
 ];
 
 export const phFrameworksWithRelatedBranches = [

--- a/ui/perfherder/constants.js
+++ b/ui/perfherder/constants.js
@@ -63,21 +63,21 @@ export const alertStatusMap = {
 };
 
 export const graphColors = [
-  ['scarlet', '#b81752'],
-  ['turquoise', '#17a2b8'],
-  ['purple', '#601A4A'],
-  ['pink', '#ffe2f5'],
-  ['yellow', '#f9ed00'],
-  ['darkorchid', '#9932cc'],
+  ['orange', '#ffba4a'],
+  ['firered', '#c92b2a'],
+  ['cerulean', '#20bde0'],
+  ['grape', '#464678'],
+  ['gras', '#940a83'],
+  ['darkpuce', '#4b2d45'],
 ];
 
 export const graphSymbols = [
-  'circle',
-  'diamond',
-  'plus',
-  'square',
-  'star',
-  'triangleUp',
+  ['circle', 'outline'],
+  ['square', 'outline'],
+  ['triangleUp', 'outline'],
+  ['circle', 'fill'],
+  ['square', 'fill'],
+  ['triangleUp', 'fill'],
 ];
 
 export const phFrameworksWithRelatedBranches = [

--- a/ui/perfherder/constants.js
+++ b/ui/perfherder/constants.js
@@ -67,7 +67,7 @@ export const graphColors = [
   ['fire-red', '#C92D2F'],
   ['cerulean', '#16BCDE'],
   ['blue-bell', '#464876'],
-  ['gras', '#921181'],
+  ['purple', '#921181'],
   ['dark-puce', '#4C3146'],
 ];
 

--- a/ui/perfherder/constants.js
+++ b/ui/perfherder/constants.js
@@ -66,7 +66,7 @@ export const graphColors = [
   ['orange', '#ffba4a'],
   ['firered', '#c92b2a'],
   ['cerulean', '#20bde0'],
-  ['grape', '#464678'],
+  ['bluebell', '#9c9ccc'],
   ['gras', '#940a83'],
   ['darkpuce', '#4b2d45'],
 ];

--- a/ui/perfherder/constants.js
+++ b/ui/perfherder/constants.js
@@ -64,11 +64,11 @@ export const alertStatusMap = {
 
 export const graphColors = [
   ['orange', '#FFB851'],
-  ['firered', '#C92D2F'],
+  ['fire-red', '#C92D2F'],
   ['cerulean', '#16BCDE'],
-  ['bluebell', '#464876'],
+  ['blue-bell', '#464876'],
   ['gras', '#921181'],
-  ['darkpuce', '#4C3146'],
+  ['dark-puce', '#4C3146'],
 ];
 
 export const graphSymbols = [

--- a/ui/perfherder/constants.js
+++ b/ui/perfherder/constants.js
@@ -63,12 +63,12 @@ export const alertStatusMap = {
 };
 
 export const graphColors = [
-  ['orange', '#ffba4a'],
-  ['firered', '#c92b2a'],
-  ['cerulean', '#20bde0'],
-  ['bluebell', '#9c9ccc'],
-  ['gras', '#940a83'],
-  ['darkpuce', '#4b2d45'],
+  ['orange', '#FFB851'],
+  ['firered', '#C92D2F'],
+  ['cerulean', '#16BCDE'],
+  ['bluebell', '#464876'],
+  ['gras', '#921181'],
+  ['darkpuce', '#4C3146'],
 ];
 
 export const graphSymbols = [

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -416,6 +416,7 @@ class GraphsContainer extends React.Component {
 
               <VictoryScatter
                 name="scatter-plot"
+                symbol={({ datum }) => datum._z}
                 style={{
                   data: {
                     fill: ({ datum }) =>

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -416,21 +416,26 @@ class GraphsContainer extends React.Component {
 
               <VictoryScatter
                 name="scatter-plot"
-                symbol={({ datum }) => datum._z}
+                symbol={({ datum }) => (datum._z ? datum._z[0] : 'circle')}
                 style={{
                   data: {
-                    fill: ({ datum }) =>
-                      ((datum.alertSummary || hasHighlightedRevision(datum)) &&
+                    fill: ({ datum }) => {
+                      const symbolType = datum._z || '';
+                      return ((datum.alertSummary ||
+                        hasHighlightedRevision(datum)) &&
                         highlightPoints) ||
-                      datum._z[1] === 'fill'
+                        symbolType[1] === 'fill'
                         ? datum.z
-                        : '#fff',
+                        : '#fff';
+                    },
                     strokeOpacity: ({ datum }) =>
                       (datum.alertSummary || hasHighlightedRevision(datum)) &&
                       highlightPoints
                         ? 0.3
                         : 100,
-                    stroke: ({ datum }) => datum.z,
+                    stroke: ({ datum }) => {
+                      return datum.z;
+                    },
                     strokeWidth: ({ datum }) =>
                       (datum.alertSummary || hasHighlightedRevision(datum)) &&
                       highlightPoints

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -420,8 +420,9 @@ class GraphsContainer extends React.Component {
                 style={{
                   data: {
                     fill: ({ datum }) =>
-                      (datum.alertSummary || hasHighlightedRevision(datum)) &&
-                      highlightPoints
+                      ((datum.alertSummary || hasHighlightedRevision(datum)) &&
+                        highlightPoints) ||
+                      datum._z[1] === 'fill'
                         ? datum.z
                         : '#fff',
                     strokeOpacity: ({ datum }) =>

--- a/ui/perfherder/graphs/GraphsView.jsx
+++ b/ui/perfherder/graphs/GraphsView.jsx
@@ -18,6 +18,7 @@ import { processSelectedParam, createGraphData } from '../helpers';
 import {
   endpoints,
   graphColors,
+  graphSymbols,
   phTimeRanges,
   phDefaultTimeRangeValue,
 } from '../constants';
@@ -42,6 +43,7 @@ class GraphsView extends React.Component {
       options: {},
       loading: false,
       colors: [...graphColors],
+      symbols: [...graphSymbols],
       showModal: false,
       visibilityChanged: false,
     };
@@ -165,19 +167,23 @@ class GraphsView extends React.Component {
   };
 
   createGraphObject = async seriesData => {
-    const { colors } = this.state;
+    const { colors, symbols } = this.state;
     const alertSummaries = await Promise.all(
       seriesData.map(series =>
         this.getAlertSummaries(series.signature_id, series.repository_id),
       ),
     );
     const newColors = [...colors];
+    const newSymbols = [...symbols];
+
     const graphData = createGraphData(
       seriesData,
       alertSummaries.flat(),
       newColors,
+      newSymbols,
     );
-    this.setState({ colors: newColors });
+
+    this.setState({ colors: newColors, symbols: newSymbols });
     return graphData;
   };
 

--- a/ui/perfherder/graphs/GraphsView.jsx
+++ b/ui/perfherder/graphs/GraphsView.jsx
@@ -320,6 +320,7 @@ class GraphsView extends React.Component {
       zoom,
       options,
       colors,
+      symbols,
       showModal,
       visibilityChanged,
     } = this.state;
@@ -358,6 +359,7 @@ class GraphsView extends React.Component {
                           this.setState(state, this.changeParams)
                         }
                         colors={colors}
+                        symbols={symbols}
                         selectedDataPoint={selectedDataPoint}
                       />
                     </div>
@@ -395,6 +397,7 @@ class GraphsView extends React.Component {
                       zoom: {},
                       selectedDataPoint: null,
                       colors: [...graphColors],
+                      symbols: [...graphSymbols],
                     },
                     this.getTestData,
                   )

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -145,7 +145,7 @@ const LegendCard = ({
           title="Add related configurations"
           type="button"
         >
-          {series.name}
+          {series.symbol} {series.name}
         </p>
         <p
           className={subtitleStyle}

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -29,13 +29,14 @@ const LegendCard = ({
       if (item.signature_id === series.signature_id) {
         const isVisible = !item.visible;
 
-        if (isVisible && newColors.length) {
+        if (isVisible && newColors.length && newSymbols.length) {
           item.color = newColors.pop();
           item.symbol = newSymbols.pop();
           item.visible = isVisible;
           item.data = item.data.map(test => ({
             ...test,
             z: item.color[1],
+            _z: item.symbol,
           }));
         } else if (!isVisible) {
           newColors.push(item.color);
@@ -46,6 +47,7 @@ const LegendCard = ({
           item.data = item.data.map(test => ({
             ...test,
             z: item.color[1],
+            _z: item.symbol,
           }));
         } else {
           errorMessages.push(
@@ -75,9 +77,10 @@ const LegendCard = ({
     updateState({ options, showModal: true });
   };
 
-  const resetParams = (testData, newColors = null) => {
+  const resetParams = (testData, newColors = null, newSymbols = null) => {
     const updates = { testData };
     if (newColors) updates.colors = newColors;
+    if (newSymbols) updates.symbols = newSymbols;
 
     if (
       selectedDataPoint &&

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -8,6 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
 import { graphColors, legendCardText } from '../constants';
+import GraphIcon from '../../shared/GraphIcon';
 
 const LegendCard = ({
   series,
@@ -145,7 +146,13 @@ const LegendCard = ({
           title="Add related configurations"
           type="button"
         >
-          {series.symbol} {series.name}
+          <GraphIcon
+            iconType={series.symbol[0]}
+            fill={series.symbol[1] === 'fill' ? series.color[1] : '#ffffff'}
+            stroke={series.color[1]}
+          />
+
+          {series.name}
         </p>
         <p
           className={subtitleStyle}

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -18,9 +18,11 @@ const LegendCard = ({
   selectedDataPoint,
   frameworks,
   colors,
+  symbols,
 }) => {
   const updateSelectedTest = () => {
     const newColors = [...colors];
+    const newSymbols = [...symbols];
     const errorMessages = [];
     let updates;
     const newTestData = [...testData].map(item => {
@@ -29,6 +31,7 @@ const LegendCard = ({
 
         if (isVisible && newColors.length) {
           item.color = newColors.pop();
+          item.symbol = newSymbols.pop();
           item.visible = isVisible;
           item.data = item.data.map(test => ({
             ...test,
@@ -36,7 +39,9 @@ const LegendCard = ({
           }));
         } else if (!isVisible) {
           newColors.push(item.color);
+          newSymbols.push(item.symbol);
           item.color = ['border-secondary', ''];
+          item.symbol = ['circle', 'outline'];
           item.visible = isVisible;
           item.data = item.data.map(test => ({
             ...test,
@@ -57,6 +62,7 @@ const LegendCard = ({
       updates = {
         testData: newTestData,
         colors: newColors,
+        symbols: newSymbols,
         errorMessages,
         visibilityChanged: true,
       };
@@ -126,6 +132,7 @@ const LegendCard = ({
     return framework ? framework.name : legendCardText.unknownFrameworkMessage;
   };
   const subtitleStyle = 'p-0 mb-0 border-0 text-secondary text-left';
+  const symbolType = series.symbol || ['circle', 'outline'];
 
   return (
     <FormGroup check className="pl-0 border">
@@ -147,8 +154,8 @@ const LegendCard = ({
           type="button"
         >
           <GraphIcon
-            iconType={series.symbol[0]}
-            fill={series.symbol[1] === 'fill' ? series.color[1] : '#ffffff'}
+            iconType={symbolType[0]}
+            fill={symbolType[1] === 'fill' ? series.color[1] : '#ffffff'}
             stroke={series.color[1]}
           />
 

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -696,15 +696,17 @@ export const retriggerMultipleJobs = async (
   );
 };
 
-export const createGraphData = (seriesData, alertSummaries, colors) =>
+export const createGraphData = (seriesData, alertSummaries, colors, symbols) =>
   seriesData.map(series => {
     const color = colors.pop();
+    const symbol = symbols.pop();
     // signature_id, framework_id and repository_name are
     // not renamed in camel case in order to match the fields
     // returned by the performance/summary API (since we only fetch
     // new data if a user adds additional tests to the graph)
     return {
       color: color || ['border-secondary', ''],
+      symbol: symbol || ['circle', 'outline'],
       visible: Boolean(color),
       name: series.name,
       signature_id: series.signature_id,
@@ -718,6 +720,7 @@ export const createGraphData = (seriesData, alertSummaries, colors) =>
         x: new Date(dataPoint.push_timestamp),
         y: dataPoint.value,
         z: color ? color[1] : '',
+        _z: symbol || ['circle', 'outline'],
         revision: dataPoint.revision,
         alertSummary: alertSummaries.find(
           item => item.push_id === dataPoint.push_id,

--- a/ui/shared/GraphIcon.jsx
+++ b/ui/shared/GraphIcon.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const GraphIcon = ({ iconType, fill, stroke }) => {
+  let iconPath;
+
+  switch (iconType) {
+    case 'circle':
+      iconPath = <circle cx="9" cy="9" r="7" />;
+      break;
+    case 'square':
+      iconPath = <rect x="1" y="1" width="15" height="15" />;
+      break;
+    case 'triangleUp':
+      iconPath = <polygon points="1,13.5 7.1,2.3 13.5,13.5" />;
+      break;
+    default:
+      iconPath = <circle cx="10" cy="10" r="5" />;
+  }
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="20px"
+      height="20px"
+      fill={fill || '#6c757d'}
+      stroke={stroke || '#6c757d'}
+      strokeWidth="2"
+    >
+      {iconPath}
+    </svg>
+  );
+};
+
+GraphIcon.propTypes = {
+  iconType: PropTypes.string,
+  fill: PropTypes.string,
+  stroke: PropTypes.string,
+};
+
+GraphIcon.defaultProps = {
+  iconType: 'circle',
+  fill: '#ffffff',
+  stroke: '#ccc',
+};
+
+export default GraphIcon;


### PR DESCRIPTION
## Description of issue
The Graph view in Perfherder is not very usable for color blind users, mainly when there are multiple types of data plotted.
To improve it, it was suggested to choose a friendlier **color palette** and also use auxiliary **symbols** to help distinguish between data.

- [x] Change symbols in graph to different ones
  - [X] When graph is first created
  - [x] When more graphs are added
- [x] Insert symbol in `LegendCard`
- [X] Propose better color palette

## Proposed Solution
- In order to change the graph symbols, the `VictoryScatter` prop [`symbol`](https://formidable.com/open-source/victory/docs/victory-scatter/#symbol) in VictoryChart's library was used. The symbol name is passed from `GraphView` to `GraphContainer`, based on the stored value from `constants.js`

- In `LegendCard`, the name of the symbols have been retrieved, but in order to insert the icon, some decisions must be made - the icons are `<svg>` and live in another file? Are they React Components? Maybe we could use the same svg Victory Chart uses.

- As for the color palette, some [research](https://venngage.com/blog/color-blind-friendly-palette/) and [experiments](https://coolors.co/ffe2f5-de9b14-f9ed00-e1dabd-abc798) were made. 3 of the 6 colors were changed.

## Testing
A visual test was made, with help of [NoCoffee Add-On](https://addons.mozilla.org/en-US/firefox/addon/nocoffee/). It was tested with all available Color deficiency options.

![Screenshot of proposed color scheme for Perfherder's graph. There are legend cards on the left with 6 different border colors. On the right, there is the graph, with different symbols scattered](https://user-images.githubusercontent.com/3901809/70819683-9687f500-1db5-11ea-9e85-a72cc9005038.png)