### PR TITLE
Bug 1603251 - Improve expand/collapse component for screen reader users

### DIFF
--- a/ui/push-health/ClassificationGroup.jsx
+++ b/ui/push-health/ClassificationGroup.jsx
@@ -72,7 +72,9 @@ class ClassificationGroup extends React.PureComponent {
       currentRepo,
     } = this.props;
     const expandIcon = detailsShowing ? faMinusSquare : faPlusSquare;
-    const expandTitle = detailsShowing ? 'Minus sign' : 'Plus sign';
+    const expandTitle = detailsShowing
+      ? 'Click to collapse'
+      : 'Click to expand';
 
     return (
       <Row className={`justify-content-between ${className}`}>
@@ -89,6 +91,7 @@ class ClassificationGroup extends React.PureComponent {
               icon={expandIcon}
               className="ml-1"
               title={expandTitle}
+              aria-label={expandTitle}
             />
           </Badge>
         </h4>

--- a/ui/push-health/Metric.jsx
+++ b/ui/push-health/Metric.jsx
@@ -29,7 +29,9 @@ export default class Metric extends React.PureComponent {
     const { result, name, children } = this.props;
     const resultColor = resultColorMap[result];
     const expandIcon = detailsShowing ? faMinusSquare : faPlusSquare;
-    const expandTitle = detailsShowing ? 'Minus sign' : 'Plus sign';
+    const expandTitle = detailsShowing
+      ? 'Click to collapse'
+      : 'Click to expand';
 
     return (
       <td>
@@ -47,7 +49,11 @@ export default class Metric extends React.PureComponent {
                   {name}
                 </span>
                 <span className="btn">
-                  <FontAwesomeIcon icon={expandIcon} title={expandTitle} />
+                  <FontAwesomeIcon
+                    icon={expandIcon}
+                    title={expandTitle}
+                    aria-label={expandTitle}
+                  />
                 </span>
               </Button>
               <span>


### PR DESCRIPTION
## Description of issue
The Push Health view has some +/- graphic elements that informs the user if the row is expanded or not. Although it is already using a good practice of setting a `<title>` of explaining the icon for SR users, the best practice would be to also insert the `aria-expanded` attribute.

## Proposed Solution
- The `aria-expanded attribute` was introduced in the **clickable elements**.
- The `<title>` descriptions were changed to inform the SR user the look of the icon. [Reference link, 2. Inline SVG](https://css-tricks.com/accessible-svgs/#article-header-id-1).


## Testing

The changes were tested via NVDA navigation. Since the SR reads 'collapsed' or 'expanded' depending on the button state, the text choice for the `<title>` was to describe the visual of the icon.