### PR TITLE
Bug 1604324 - Push Health show failed performance tasks

### DIFF
--- a/treeherder/push_health/performance.py
+++ b/treeherder/push_health/performance.py
@@ -1,0 +1,15 @@
+from treeherder.model.models import (Job,
+                                     JobGroup)
+from treeherder.push_health.similar_jobs import job_to_dict
+
+
+def get_perf_failures(push):
+    perf_groups = JobGroup.objects.filter(name__contains='performance')
+    perf_failures = Job.objects.filter(
+        push=push,
+        tier__lte=2,
+        result='testfailed',
+        job_group__in=perf_groups
+    )
+
+    return [job_to_dict(job) for job in perf_failures]

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -15,6 +15,7 @@ from treeherder.model.models import (Job,
                                      Repository)
 from treeherder.push_health.builds import get_build_failures
 from treeherder.push_health.linting import get_lint_failures
+from treeherder.push_health.performance import get_perf_failures
 from treeherder.push_health.tests import get_test_failures
 from treeherder.webapp.api.serializers import PushSerializer
 from treeherder.webapp.api.utils import (REPO_GROUPS,
@@ -249,6 +250,9 @@ class PushViewSet(viewsets.ViewSet):
         lint_failures = get_lint_failures(push)
         lint_result = 'fail' if len(lint_failures) else 'pass'
 
+        perf_failures = get_perf_failures(push)
+        perf_result = 'fail' if len(perf_failures) else 'pass'
+
         return Response({
             'revision': revision,
             'id': push.id,
@@ -269,19 +273,10 @@ class PushViewSet(viewsets.ViewSet):
                     'result': build_result,
                     'details': build_failures,
                 },
-                'coverage': {
-                    'name': 'Coverage (Not yet implemented)',
-                    'result': 'none',
-                    'details': [
-                        'Covered 42% of the tests that are needed for feature ``foo``.',
-                        'Covered 100% of the tests that are needed for feature ``bar``.',
-                        'The ratio of people to cake is too many...',
-                    ],
-                },
                 'performance': {
-                    'name': 'Performance (Not yet implemented)',
-                    'result': 'none',
-                    'details': ['Ludicrous Speed'],
+                    'name': 'Performance',
+                    'result': perf_result,
+                    'details': perf_failures,
                 },
             },
             'status': push.get_status(),

--- a/ui/push-health/Health.jsx
+++ b/ui/push-health/Health.jsx
@@ -95,7 +95,7 @@ export default class Health extends React.PureComponent {
       notifications,
       status,
     } = this.state;
-    const { tests, linting, builds, coverage, performance } = metrics;
+    const { tests, linting, builds, performance } = metrics;
     const { currentRepo } = this.props;
     const percentComplete = status ? getPercentComplete(status) : 0;
 
@@ -150,17 +150,13 @@ export default class Health extends React.PureComponent {
                       notify={this.notify}
                     />
                   </tr>
-                  {[coverage, performance].map(metric => (
-                    <tr key={metric.name}>
-                      <Metric result={metric.result} name={metric.name}>
-                        <div>
-                          {metric.details.map(detail => (
-                            <div key={detail}>{detail}</div>
-                          ))}
-                        </div>
-                      </Metric>
-                    </tr>
-                  ))}
+                  <tr>
+                    <JobListMetric
+                      data={performance}
+                      repo={repo}
+                      revision={revision}
+                    />
+                  </tr>
                 </tbody>
               </Table>
             </div>


### PR DESCRIPTION
This is a very simplistic start to this metric.  It just checks if there are any failed tasks that are in a performance group and lists those.  We will make this better in the months to come, but it's a start.