### PR TITLE
Bug 1581497 - Change Perfherder graph tooltips

### DIFF
--- a/tests/ui/perfherder/graphs_view_test.jsx
+++ b/tests/ui/perfherder/graphs_view_test.jsx
@@ -6,14 +6,13 @@ import {
   waitForElement,
 } from '@testing-library/react';
 
-import { filterText } from '../../../ui/perfherder/constants';
+import { filterText, graphColors } from '../../../ui/perfherder/constants';
 import GraphsViewControls from '../../../ui/perfherder/graphs/GraphsViewControls';
 import repos from '../mock/repositories';
 import testData from '../mock/performance_summary.json';
 import seriesData from '../mock/performance_signature_formatted.json';
 import seriesData2 from '../mock/performance_signature_formatted2.json';
 import { createGraphData } from '../../../ui/perfherder/helpers';
-import { graphColors } from '../../../ui/perfherder/constants';
 
 const graphData = createGraphData(testData, [], [...graphColors]);
 
@@ -49,7 +48,7 @@ const mockShowModal = jest
   .mockReturnValueOnce(true)
   .mockReturnValueOnce(false);
 
-const graphsViewControls = (hasNoData = true) =>
+const graphsViewControls = (data = testData, hasNoData = true) =>
   render(
     <GraphsViewControls
       updateStateParams={() => {}}
@@ -62,7 +61,7 @@ const graphsViewControls = (hasNoData = true) =>
       timeRange={{ value: 172800, text: 'Last two days' }}
       options={{}}
       getTestData={() => {}}
-      testData={graphData}
+      testData={data}
       getInitialData={() => ({
         platforms,
       })}
@@ -196,7 +195,7 @@ test("Selecting a test with similar unit in the Test Data Modal doesn't give war
 });
 
 test('Using select query param displays tooltip for correct datapoint', async () => {
-  const { getByTestId, getByText } = graphsViewControls(false);
+  const { getByTestId, getByText } = graphsViewControls(graphData, false);
 
   const graphContainer = await waitForElement(() =>
     getByTestId('graphContainer'),

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -83,7 +83,6 @@ h1 {
 .graph-tooltip {
   pointer-events: none;
   width: 280px;
-  z-index: 999;
   text-align: left;
 }
 .graph-tooltip.locked {

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -81,7 +81,6 @@ h1 {
 }
 
 .graph-tooltip {
-  position: absolute;
   pointer-events: none;
   width: 280px;
   z-index: 999;

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -280,12 +280,7 @@ class DetailsPanel extends React.Component {
                       d.signature_id,
                       1,
                       d.series.frameworkId,
-                    ]}&selected=${[
-                      currentRepo.name,
-                      d.signature_id,
-                      selectedJob.push_id,
-                      d.id,
-                    ]}`,
+                    ]}&selected=${[d.signature_id, d.id]}`,
                     value: d.value,
                     title: d.series.name,
                   }));

--- a/ui/perfherder/graphs/GraphTooltip.jsx
+++ b/ui/perfherder/graphs/GraphTooltip.jsx
@@ -143,6 +143,7 @@ const GraphTooltip = ({
       <div
         className={`graph-tooltip ${lockTooltip ? 'locked' : null}`}
         xmlns="http://www.w3.org/1999/xhtml"
+        data-testid="graphTooltip"
       >
         <Button
           outline

--- a/ui/perfherder/graphs/GraphTooltip.jsx
+++ b/ui/perfherder/graphs/GraphTooltip.jsx
@@ -26,6 +26,7 @@ const GraphTooltip = ({
   datum,
   x,
   y,
+  windowWidth,
 }) => {
   const testDetails = testData.find(
     item => item.signature_id === datum.signature_id,
@@ -133,8 +134,9 @@ const GraphTooltip = ({
   };
 
   const verticalOffset = 15;
+  const horizontalOffset = x >= 1275 && windowWidth <= 1825 ? 100 : 0;
   const centered = {
-    x: x - 280 / 2,
+    x: x - 280 / 2 - horizontalOffset,
     y: y - (186 + verticalOffset),
   };
 
@@ -263,7 +265,10 @@ const GraphTooltip = ({
             )}
           </div>
         </div>
-        <div className="tip" />
+        <div
+          className="tip"
+          style={{ transform: `translateX(${horizontalOffset}px)` }}
+        />
       </div>
     </foreignObject>
   );

--- a/ui/perfherder/graphs/GraphTooltip.jsx
+++ b/ui/perfherder/graphs/GraphTooltip.jsx
@@ -4,7 +4,10 @@ import countBy from 'lodash/countBy';
 import moment from 'moment';
 import { Button } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
+import {
+  faExclamationCircle,
+  faTimes,
+} from '@fortawesome/free-solid-svg-icons';
 
 import { alertStatusMap, endpoints } from '../constants';
 import { getJobsUrl, createQueryParams, getApiUrl } from '../../helpers/url';
@@ -13,17 +16,17 @@ import RepositoryModel from '../../models/repository';
 import { displayNumber, getStatus } from '../helpers';
 
 const GraphTooltip = ({
-  dataPoint,
   testData,
   user,
   updateData,
   projects,
   updateStateParams,
+  lockTooltip,
+  closeTooltip,
+  datum,
+  x,
+  y,
 }) => {
-  // we either have partial information provided by the selected
-  // query parameter or the full dataPoint object provided from the
-  // graph library
-  const datum = dataPoint.datum ? dataPoint.datum : dataPoint;
   const testDetails = testData.find(
     item => item.signature_id === datum.signature_id,
   );
@@ -36,7 +39,7 @@ const GraphTooltip = ({
   const dataPointDetails = testDetails.data[flotIndex];
 
   const retriggers = countBy(testDetails.resultSetData, resultSetId =>
-    resultSetId === dataPoint.pushId ? 'retrigger' : 'original',
+    resultSetId === datum.pushId ? 'retrigger' : 'original',
   );
   const retriggerNum = retriggers.retrigger - 1;
   const prevFlotDataPointIndex = flotIndex - 1;
@@ -129,116 +132,144 @@ const GraphTooltip = ({
     );
   };
 
-  return (
-    <div className="body">
-      <div>
-        <p>({testDetails.repository_name})</p>
-        <p className="small">{testDetails.platform}</p>
-      </div>
-      <div>
-        <p>
-          {displayNumber(value)}
-          {testDetails.measurementUnit && (
-            <span> {testDetails.measurementUnit}</span>
-          )}
-          <span className="text-muted">
-            {testDetails.lowerIsBetter
-              ? ' (lower is better)'
-              : ' (higher is better)'}
-          </span>
-        </p>
-        <p className="small">
-          &Delta; {displayNumber(deltaValue.toFixed(1))} (
-          {(100 * deltaPercent).toFixed(1)}%)
-        </p>
-      </div>
+  const verticalOffset = 15;
+  const centered = {
+    x: x - 280 / 2,
+    y: y - (186 + verticalOffset),
+  };
 
-      <div>
-        {prevRevision && (
-          <span>
-            <a href={pushUrl} target="_blank" rel="noopener noreferrer">
-              {dataPointDetails.revision.slice(0, 13)}
-            </a>{' '}
-            (
-            {dataPointDetails.jobId && (
-              <a href={jobsUrl} target="_blank" rel="noopener noreferrer">
-                job
-              </a>
-            )}
-            ,{' '}
-            <a
-              href={`#/comparesubtest${createQueryParams({
-                originalProject: testDetails.repository_name,
-                newProject: testDetails.repository_name,
-                originalRevision: prevRevision,
-                newRevision: dataPointDetails.revision,
-                originalSignature:
-                  testDetails.parentSignature || testDetails.signature_id,
-                newSignature:
-                  testDetails.parentSignature || testDetails.signature_id,
-                framework: testDetails.framework_id,
-              })}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              compare
-            </a>
-            )
-          </span>
-        )}
-        {dataPointDetails.alertSummary && (
-          <p>
-            <a
-              href={`perf.html#/alerts?id=${dataPointDetails.alertSummary.id}`}
-            >
-              <FontAwesomeIcon
-                className="text-warning"
-                icon={faExclamationCircle}
-                size="sm"
-              />
-              {` Alert # ${dataPointDetails.alertSummary.id}`}
-            </a>
-            <span className="text-muted">
-              {` - ${alertStatus} `}
-              {alert && alert.related_summary_id && (
-                <span>
-                  {alert.related_summary_id !== dataPointDetails.alertSummary.id
-                    ? 'to'
-                    : 'from'}
-                  <a
-                    href={`#/alerts?id=${alert.related_summary_id}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >{` alert # ${alert.related_summary_id}`}</a>
-                </span>
+  return (
+    <foreignObject width="100%" height="100%" x={centered.x} y={centered.y}>
+      <div
+        className={`graph-tooltip ${lockTooltip ? 'locked' : null}`}
+        xmlns="http://www.w3.org/1999/xhtml"
+      >
+        <Button
+          outline
+          color="secondary"
+          className="close mr-3 my-2 ml-2"
+          onClick={closeTooltip}
+        >
+          <FontAwesomeIcon
+            className="pointer text-white"
+            icon={faTimes}
+            size="xs"
+            title="close tooltip"
+          />
+        </Button>
+        <div className="body">
+          <div>
+            <p>({testDetails.repository_name})</p>
+            <p className="small">{testDetails.platform}</p>
+          </div>
+          <div>
+            <p>
+              {displayNumber(value)}
+              {testDetails.measurementUnit && (
+                <span> {testDetails.measurementUnit}</span>
               )}
-            </span>
-          </p>
-        )}
-        {!dataPointDetails.alertSummary && prevPushId && (
-          <p className="pt-2">
-            {user.isStaff ? (
-              <Button color="info" outline size="sm" onClick={createAlert}>
-                create alert
-              </Button>
-            ) : (
-              <span>(log in as a a sheriff to create)</span>
+              <span className="text-muted">
+                {testDetails.lowerIsBetter
+                  ? ' (lower is better)'
+                  : ' (higher is better)'}
+              </span>
+            </p>
+            <p className="small">
+              &Delta; {displayNumber(deltaValue.toFixed(1))} (
+              {(100 * deltaPercent).toFixed(1)}%)
+            </p>
+          </div>
+
+          <div>
+            {prevRevision && (
+              <span>
+                <a href={pushUrl} target="_blank" rel="noopener noreferrer">
+                  {dataPointDetails.revision.slice(0, 13)}
+                </a>{' '}
+                (
+                {dataPointDetails.jobId && (
+                  <a href={jobsUrl} target="_blank" rel="noopener noreferrer">
+                    job
+                  </a>
+                )}
+                ,{' '}
+                <a
+                  href={`#/comparesubtest${createQueryParams({
+                    originalProject: testDetails.repository_name,
+                    newProject: testDetails.repository_name,
+                    originalRevision: prevRevision,
+                    newRevision: dataPointDetails.revision,
+                    originalSignature:
+                      testDetails.parentSignature || testDetails.signature_id,
+                    newSignature:
+                      testDetails.parentSignature || testDetails.signature_id,
+                    framework: testDetails.framework_id,
+                  })}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  compare
+                </a>
+                )
+              </span>
             )}
-          </p>
-        )}
-        <p className="small text-white pt-2">{`${moment
-          .utc(dataPointDetails.x)
-          .format('MMM DD hh:mm:ss')} UTC`}</p>
-        {Boolean(retriggerNum) && (
-          <p className="small">{`Retriggers: ${retriggerNum}`}</p>
-        )}
+            {dataPointDetails.alertSummary && (
+              <p>
+                <a
+                  href={`perf.html#/alerts?id=${dataPointDetails.alertSummary.id}`}
+                >
+                  <FontAwesomeIcon
+                    className="text-warning"
+                    icon={faExclamationCircle}
+                    size="sm"
+                  />
+                  {` Alert # ${dataPointDetails.alertSummary.id}`}
+                </a>
+                <span className="text-muted">
+                  {` - ${alertStatus} `}
+                  {alert && alert.related_summary_id && (
+                    <span>
+                      {alert.related_summary_id !==
+                      dataPointDetails.alertSummary.id
+                        ? 'to'
+                        : 'from'}
+                      <a
+                        href={`#/alerts?id=${alert.related_summary_id}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >{` alert # ${alert.related_summary_id}`}</a>
+                    </span>
+                  )}
+                </span>
+              </p>
+            )}
+            {!dataPointDetails.alertSummary && prevPushId && (
+              <p className="pt-2">
+                {user.isStaff ? (
+                  <Button color="info" outline size="sm" onClick={createAlert}>
+                    create alert
+                  </Button>
+                ) : (
+                  <span>(log in as a a sheriff to create)</span>
+                )}
+              </p>
+            )}
+            <p className="small text-white pt-2">{`${moment
+              .utc(dataPointDetails.x)
+              .format('MMM DD hh:mm:ss')} UTC`}</p>
+            {Boolean(retriggerNum) && (
+              <p className="small">{`Retriggers: ${retriggerNum}`}</p>
+            )}
+          </div>
+        </div>
+        <div className="tip" />
       </div>
-    </div>
+    </foreignObject>
   );
 };
 
 GraphTooltip.propTypes = {
-  dataPoint: PropTypes.shape({}).isRequired,
+  dataPoint: PropTypes.shape({}),
   testData: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   user: PropTypes.shape({}).isRequired,
   updateData: PropTypes.func.isRequired,
@@ -247,6 +278,7 @@ GraphTooltip.propTypes = {
 
 GraphTooltip.defaultProps = {
   projects: [],
+  dataPoint: undefined,
 };
 
 export default GraphTooltip;

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -42,7 +42,7 @@ class GraphsContainer extends React.Component {
 
   componentDidMount() {
     const { zoom, selectedDataPoint } = this.props;
-
+    console.log(zoom)
     this.addHighlights();
     if (selectedDataPoint) this.verifySelectedDataPoint();
   }
@@ -88,11 +88,7 @@ class GraphsContainer extends React.Component {
     } else {
       updateStateParams({
         errorMessages: [
-          `Tooltip for datapoint with signature ${
-            selectedDataPoint.signature_id
-          } and date ${moment
-            .utc(selectedDataPoint.x)
-            .format('MMM DD hh:mm')} UTC can't be found.`,
+          'This datapoint can\'t be found for the specified date range.'
         ],
       });
     }
@@ -255,7 +251,7 @@ class GraphsContainer extends React.Component {
     });
   };
 
-  updateZoom(zoom) {
+  updateZoom = (zoom) => {
     const { lockTooltip } = this.state;
     const { updateStateParams } = this.props;
 
@@ -294,7 +290,7 @@ class GraphsContainer extends React.Component {
       right: this.rightChartPadding,
       bottom: 50,
     };
-
+    console.log(zoom)
     return (
       <React.Fragment>
         <Row>
@@ -343,7 +339,6 @@ class GraphsContainer extends React.Component {
         <Row>
           <Col className="p-0 col-md-auto">
             <VictoryChart
-              name="chart1"
               padding={chartPadding}
               width={1350}
               height={400}

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -76,10 +76,8 @@ class GraphsContainer extends React.Component {
 
     const dataPointFound = testData.find(item => {
       if (item.signature_id === selectedDataPoint.signature_id) {
-        return item.data.find(datum =>
-          selectedDataPoint.dataPointId
-            ? datum.dataPointId === selectedDataPoint.dataPointId
-            : datum.pushId === selectedDataPoint.pushId,
+        return item.data.find(
+          datum => datum.dataPointId === selectedDataPoint.dataPointId,
         );
       }
       return false;
@@ -159,9 +157,6 @@ class GraphsContainer extends React.Component {
       updateStateParams({
         selectedDataPoint: {
           signature_id: dataPoint.datum.signature_id,
-          pushId: dataPoint.datum.pushId,
-          x: dataPoint.x,
-          y: dataPoint.y,
           dataPointId: dataPoint.datum.dataPointId,
         },
       });
@@ -218,8 +213,6 @@ class GraphsContainer extends React.Component {
   hideTooltip = props =>
     this.state.lockTooltip ? { active: true } : { active: undefined };
 
-  // TODO can deprecate storage of x and y coordinates in selectedDataPoint
-  // and remove dataPoint state here.
   showTooltip = selectedDataPoint => {
     this.setState({
       externalMutation: [

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -42,7 +42,7 @@ class GraphsContainer extends React.Component {
 
   componentDidMount() {
     const { zoom, selectedDataPoint } = this.props;
-    console.log(zoom)
+
     this.addHighlights();
     if (selectedDataPoint) this.verifySelectedDataPoint();
   }
@@ -88,7 +88,7 @@ class GraphsContainer extends React.Component {
     } else {
       updateStateParams({
         errorMessages: [
-          'This datapoint can\'t be found for the specified date range.'
+          "This datapoint can't be found for the specified date range.",
         ],
       });
     }
@@ -251,7 +251,7 @@ class GraphsContainer extends React.Component {
     });
   };
 
-  updateZoom = (zoom) => {
+  updateZoom = zoom => {
     const { lockTooltip } = this.state;
     const { updateStateParams } = this.props;
 
@@ -259,7 +259,7 @@ class GraphsContainer extends React.Component {
       this.closeTooltip();
     }
     updateStateParams({ zoom });
-  }
+  };
 
   render() {
     const { testData, zoom, highlightedRevisions } = this.props;
@@ -290,9 +290,9 @@ class GraphsContainer extends React.Component {
       right: this.rightChartPadding,
       bottom: 50,
     };
-    console.log(zoom)
+
     return (
-      <React.Fragment>
+      <span data-testid="graphContainer">
         <Row>
           <Col className="p-0 col-md-auto">
             <VictoryChart
@@ -436,6 +436,7 @@ class GraphsContainer extends React.Component {
                 labels={() => ''}
                 labelComponent={
                   <VictoryTooltip
+                    renderInPortal={false}
                     flyoutComponent={
                       <VictoryPortal>
                         <GraphTooltip
@@ -466,7 +467,7 @@ class GraphsContainer extends React.Component {
             </VictoryChart>
           </Col>
         </Row>
-      </React.Fragment>
+      </span>
     );
   }
 }

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -210,7 +210,7 @@ class GraphsContainer extends React.Component {
     return null;
   };
 
-  hideTooltip = props =>
+  hideTooltip = () =>
     this.state.lockTooltip ? { active: true } : { active: undefined };
 
   showTooltip = selectedDataPoint => {
@@ -393,7 +393,7 @@ class GraphsContainer extends React.Component {
                       return [
                         {
                           target: 'labels',
-                          mutation: props => this.hideTooltip(props),
+                          mutation: this.hideTooltip,
                         },
                       ];
                     },

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -37,6 +37,7 @@ class GraphsContainer extends React.Component {
       ),
       lockTooltip: false,
       externalMutation: undefined,
+      width: window.innerWidth,
     };
   }
 
@@ -45,6 +46,9 @@ class GraphsContainer extends React.Component {
 
     this.addHighlights();
     if (selectedDataPoint) this.verifySelectedDataPoint();
+    window.addEventListener('resize', () =>
+      this.setState({ width: window.innerWidth }),
+    );
   }
 
   componentDidUpdate(prevProps) {
@@ -268,6 +272,7 @@ class GraphsContainer extends React.Component {
       scatterPlotData,
       lockTooltip,
       externalMutation,
+      width,
     } = this.state;
 
     const yAxisLabel = this.computeYAxisLabel();
@@ -344,7 +349,7 @@ class GraphsContainer extends React.Component {
               height={400}
               style={{ parent: { maxHeight: '400px', maxWidth: '1350px' } }}
               scale={{ x: 'time', y: 'linear' }}
-              domainPadding={{ y: 40 }}
+              domainPadding={{ y: 40, x: [10, 10] }}
               externalEventMutations={externalMutation}
               containerComponent={
                 <VictoryZoomSelectionContainer
@@ -442,6 +447,7 @@ class GraphsContainer extends React.Component {
                         <GraphTooltip
                           lockTooltip={lockTooltip}
                           closeTooltip={this.closeTooltip}
+                          windowWidth={width}
                           {...this.props}
                         />
                       </VictoryPortal>

--- a/ui/perfherder/graphs/GraphsView.jsx
+++ b/ui/perfherder/graphs/GraphsView.jsx
@@ -327,15 +327,9 @@ class GraphsView extends React.Component {
     if (!selectedDataPoint) {
       delete params.selected;
     } else {
-      const {
-        signature_id: signatureId,
-        pushId,
-        dataPointId,
-        x,
-        y,
-      } = selectedDataPoint;
+      const { signature_id: signatureId, dataPointId } = selectedDataPoint;
 
-      params.selected = [signatureId, pushId, x, y, dataPointId].join(',');
+      params.selected = [signatureId, dataPointId].join(',');
     }
 
     if (Object.keys(zoom).length === 0) {

--- a/ui/perfherder/graphs/GraphsView.jsx
+++ b/ui/perfherder/graphs/GraphsView.jsx
@@ -17,7 +17,7 @@ import {
   genericErrorMessage,
   errorMessageClass,
 } from '../../helpers/constants';
-import { processSelectedParam } from '../helpers';
+import { processSelectedParam, createGraphData } from '../helpers';
 import {
   endpoints,
   graphColors,
@@ -169,51 +169,17 @@ class GraphsView extends React.Component {
 
   createGraphObject = async seriesData => {
     const { colors } = this.state;
-    let alertSummaries = await Promise.all(
+    const alertSummaries = await Promise.all(
       seriesData.map(series =>
         this.getAlertSummaries(series.signature_id, series.repository_id),
       ),
     );
-    alertSummaries = alertSummaries.flat();
-    let color;
     const newColors = [...colors];
-
-    const graphData = seriesData.map(series => {
-      color = newColors.pop();
-      // signature_id, framework_id and repository_name are
-      // not renamed in camel case in order to match the fields
-      // returned by the performance/summary API (since we only fetch
-      // new data if a user adds additional tests to the graph)
-      return {
-        color: color || ['border-secondary', ''],
-        visible: Boolean(color),
-        name: series.name,
-        signature_id: series.signature_id,
-        signatureHash: series.signature_hash,
-        framework_id: series.framework_id,
-        platform: series.platform,
-        repository_name: series.repository_name,
-        projectId: series.repository_id,
-        id: `${series.repository_name} ${series.name}`,
-        data: series.data.map(dataPoint => ({
-          x: new Date(dataPoint.push_timestamp),
-          y: dataPoint.value,
-          z: color ? color[1] : '',
-          revision: dataPoint.revision,
-          alertSummary: alertSummaries.find(
-            item => item.push_id === dataPoint.push_id,
-          ),
-          signature_id: series.signature_id,
-          pushId: dataPoint.push_id,
-          jobId: dataPoint.job_id,
-          dataPointId: dataPoint.id,
-        })),
-        measurementUnit: series.measurement_unit || '',
-        lowerIsBetter: series.lower_is_better,
-        resultSetData: series.data.map(dataPoint => dataPoint.push_id),
-        parentSignature: series.parent_signature,
-      };
-    });
+    const graphData = createGraphData(
+      seriesData,
+      alertSummaries.flat(),
+      newColors,
+    );
     this.setState({ colors: newColors });
     return graphData;
   };

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -563,19 +563,10 @@ export const containsText = (string, text) => {
   return regex.test(string);
 };
 
-export const processSelectedParam = tooltipArray => {
-  const values = {
-    signature_id: parseInt(tooltipArray[0], 10),
-    pushId: parseInt(tooltipArray[1], 10),
-    x: parseFloat(tooltipArray[2]),
-    y: parseFloat(tooltipArray[3]),
-  };
-
-  if (tooltipArray[4]) {
-    values.dataPointId = parseInt(tooltipArray[4], 10);
-  }
-  return values;
-};
+export const processSelectedParam = tooltipArray => ({
+  signature_id: parseInt(tooltipArray[0], 10),
+  dataPointId: parseInt(tooltipArray[1], 10),
+});
 
 export const getInitialData = async (
   errorMessages,

--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -689,3 +689,41 @@ export const retriggerJobs = async (results, times, props) => {
     props,
   );
 };
+
+export const createGraphData = (seriesData, alertSummaries, colors) =>
+  seriesData.map(series => {
+    const color = colors.pop();
+    // signature_id, framework_id and repository_name are
+    // not renamed in camel case in order to match the fields
+    // returned by the performance/summary API (since we only fetch
+    // new data if a user adds additional tests to the graph)
+    return {
+      color: color || ['border-secondary', ''],
+      visible: Boolean(color),
+      name: series.name,
+      signature_id: series.signature_id,
+      signatureHash: series.signature_hash,
+      framework_id: series.framework_id,
+      platform: series.platform,
+      repository_name: series.repository_name,
+      projectId: series.repository_id,
+      id: `${series.repository_name} ${series.name}`,
+      data: series.data.map(dataPoint => ({
+        x: new Date(dataPoint.push_timestamp),
+        y: dataPoint.value,
+        z: color ? color[1] : '',
+        revision: dataPoint.revision,
+        alertSummary: alertSummaries.find(
+          item => item.push_id === dataPoint.push_id,
+        ),
+        signature_id: series.signature_id,
+        pushId: dataPoint.push_id,
+        jobId: dataPoint.job_id,
+        dataPointId: dataPoint.id,
+      })),
+      measurementUnit: series.measurement_unit || '',
+      lowerIsBetter: series.lower_is_better,
+      resultSetData: series.data.map(dataPoint => dataPoint.push_id),
+      parentSignature: series.parent_signature,
+    };
+  });


### PR DESCRIPTION
This pr fixes the issue with the graphs tooltip becoming unaligned with its datapoint any time the viewport falls below the graph containers specified width. This only happens when the graphs are in responsive mode, which they are currently set to:
![Screen Shot 2019-12-16 at 6 27 09 PM](https://user-images.githubusercontent.com/19615783/70959690-bd525f80-2031-11ea-9053-4cb7692b173d.png)


Rather than trying to attach event listeners to change the absolute positioning on window resize (or trying my media query suggestions in the bug, which didn't actually work), I took another stab at incorporating the custom tooltip into the Victory library. This means the tooltip is rendered as an svg within the graph, and will scale in tandem. Doing this is not clearly documented so it took a bit of digging and experimenting. The tool tip now scales appropriately.

![Screen Shot 2019-12-16 at 6 27 20 PM](https://user-images.githubusercontent.com/19615783/70959703-c4796d80-2031-11ea-98d0-b81a314fb561.png)

The upside of making these changes is that the tooltip is now testable! This isn't possible with the absolute positioned tooltip because there's no way to select the data point svg path/node in the Victory graphing library. Because of a method for tapping into the library (what is called an external mutation), we're able to find a data point based on certain query parameter values.

Recap of changes:
* No longer an absolute positioned tooltip (and no longer need to store certain value in local state)
* There's no need to store the x and y coordinates and push Id in the `select` query param when a data point is selected (to make it shareable), because on page load it is queried by `dataPointId` (the unique id). So old links to tool tips will not work. It won't break the page, it'll just show a message that the data point can't be found. @ionutgoldan @octavian-negru let me know if this will be a problem.