### PR TITLE
Bug 1603241 - Accessibility improvements in Intermittent Failures View

### DIFF
--- a/ui/css/intermittent-failures.css
+++ b/ui/css/intermittent-failures.css
@@ -30,7 +30,8 @@ h1,
   display: none;
 }
 
-.bug-column:hover .bug-details {
+.bug-column:hover .bug-details,
+.bug-column:focus-within .bug-details {
   display: initial;
 }
 
@@ -69,4 +70,9 @@ ul {
   max-width: 1000px;
   list-style-type: none;
   text-align: left;
+}
+
+/* ReactTable style */
+.ReactTable .-pagination .-btn:focus {
+  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5);
 }

--- a/ui/intermittent-failures/MainView.jsx
+++ b/ui/intermittent-failures/MainView.jsx
@@ -11,8 +11,6 @@ import {
   calculateMetrics,
   prettyDate,
   ISODate,
-  tableProps,
-  theadFilterThProps,
   tableRowStyling,
 } from './helpers';
 import withView from './View';
@@ -107,6 +105,16 @@ const MainView = props => {
     } = calculateMetrics(graphData));
   }
 
+  const theadFilterThProps = (state, bug, data) => {
+    const ariaLabelValue =
+      data.Header === 'Count'
+        ? 'Filter not available for count'
+        : `Type to filter ${data.Header}`;
+    return {
+      'aria-label': ariaLabelValue,
+    };
+  };
+
   return (
     <Layout
       {...props}
@@ -161,7 +169,7 @@ const MainView = props => {
             showPageSizeOptions
             columns={columns}
             className="-striped"
-            getTableProps={tableProps}
+            getTableProps={() => ({ role: 'table' })}
             getTheadFilterThProps={theadFilterThProps}
             getTrProps={tableRowStyling}
             showPaginationTop

--- a/ui/intermittent-failures/MainView.jsx
+++ b/ui/intermittent-failures/MainView.jsx
@@ -11,6 +11,8 @@ import {
   calculateMetrics,
   prettyDate,
   ISODate,
+  tableProps,
+  theadFilterThProps,
   tableRowStyling,
 } from './helpers';
 import withView from './View';
@@ -159,6 +161,8 @@ const MainView = props => {
             showPageSizeOptions
             columns={columns}
             className="-striped"
+            getTableProps={tableProps}
+            getTheadFilterThProps={theadFilterThProps}
             getTrProps={tableRowStyling}
             showPaginationTop
             defaultPageSize={50}

--- a/ui/intermittent-failures/MainView.jsx
+++ b/ui/intermittent-failures/MainView.jsx
@@ -105,7 +105,7 @@ const MainView = props => {
     } = calculateMetrics(graphData));
   }
 
-  const theadFilterThProps = (state, bug, data) => {
+  const getHeaderAriaLabel = (state, bug, data) => {
     const ariaLabelValue =
       data.Header === 'Count'
         ? 'Filter not available for count'
@@ -170,7 +170,7 @@ const MainView = props => {
             columns={columns}
             className="-striped"
             getTableProps={() => ({ role: 'table' })}
-            getTheadFilterThProps={theadFilterThProps}
+            getTheadFilterThProps={getHeaderAriaLabel}
             getTrProps={tableRowStyling}
             showPaginationTop
             defaultPageSize={50}

--- a/ui/intermittent-failures/helpers.js
+++ b/ui/intermittent-failures/helpers.js
@@ -120,24 +120,4 @@ export const tableRowStyling = function tableRowStyling(state, bug) {
   return {};
 };
 
-export const tableProps = function tableProps() {
-  return {
-    role: 'table',
-  };
-};
-
-export const theadFilterThProps = function theadFilterThProps(
-  state,
-  bug,
-  data,
-) {
-  const ariaLabelValue =
-    data.Header === 'Count'
-      ? 'Filter not available for count'
-      : `Type to filter ${data.Header}`;
-  return {
-    'aria-label': ariaLabelValue,
-  };
-};
-
 export const removePath = (line = '') => line.replace(/\/?([\w\d-.]+\/)+/, '');

--- a/ui/intermittent-failures/helpers.js
+++ b/ui/intermittent-failures/helpers.js
@@ -120,4 +120,24 @@ export const tableRowStyling = function tableRowStyling(state, bug) {
   return {};
 };
 
+export const tableProps = function tableProps() {
+  return {
+    role: 'table',
+  };
+};
+
+export const theadFilterThProps = function theadFilterThProps(
+  state,
+  bug,
+  data,
+) {
+  const ariaLabelValue =
+    data.Header === 'Count'
+      ? 'Filter not available for count'
+      : `Type to filter ${data.Header}`;
+  return {
+    'aria-label': ariaLabelValue,
+  };
+};
+
 export const removePath = (line = '') => line.replace(/\/?([\w\d-.]+\/)+/, '');


### PR DESCRIPTION
## Description of issue

- [X] **Table**: role should be set to `table`;
- [X] **Search inputs**: need `aria-label`;
- [X] **Row - details link**: show link when row/cell is focused;
- [X] **Previous/Next button**: set focus style

## Proposed Solution

For the attribute insertion, they needed to be passed down by ReactTable props, such as `getTableProps`. The passed function is declared in `ui/intermittent-failures/helpers.js`.

The other tasks were solved via CSS.

## Testing
Simple NVDA navigation and visual test on the CSS related tasks. Other views were also tested - only one view has the same React Table component, Perfherder Health, but apparently they are not linked.
