### PR TITLE
Bug 1600625 - Add explanation for rules of an intermittent

### DIFF
--- a/tests/ui/push-health/TestFailure_test.jsx
+++ b/tests/ui/push-health/TestFailure_test.jsx
@@ -12,7 +12,7 @@ import TestFailure from '../../../ui/push-health/TestFailure';
 import pushHealth from '../mock/push_health';
 
 const repoName = 'autoland';
-const failures = pushHealth.metrics[0].failures.needInvestigation;
+const failure = pushHealth.metrics[0].failures.needInvestigation[0];
 
 beforeEach(() => {
   fetchMock.get('https://treestatus.mozilla-releng.net/trees/autoland', {
@@ -24,6 +24,7 @@ beforeEach(() => {
     },
   });
   setUrlParam('repo', repoName);
+  failure.key = 'wazzon';
 });
 
 afterEach(() => {
@@ -39,12 +40,13 @@ describe('TestFailure', () => {
       repo="autoland"
       user={{ email: 'foo' }}
       revision="abc"
+      currentRepo={{ name: repoName }}
       notify={() => {}}
     />
   );
 
   test('should show the test name', async () => {
-    const { getByText } = render(testTestFailure(failures[0]));
+    const { getByText } = render(testTestFailure(failure));
 
     expect(
       await waitForElement(() =>
@@ -56,7 +58,7 @@ describe('TestFailure', () => {
   });
 
   test('should show small details by default', async () => {
-    const { getByText } = render(testTestFailure(failures[0]));
+    const { getByText } = render(testTestFailure(failure));
 
     expect(
       await waitForElement(() =>
@@ -72,7 +74,7 @@ describe('TestFailure', () => {
   });
 
   test('should show details when click more...', async () => {
-    const { getByText } = render(testTestFailure(failures[0]));
+    const { getByText } = render(testTestFailure(failure));
     const moreLink = getByText('more...');
     fireEvent.click(moreLink);
 

--- a/treeherder/push_health/classification.py
+++ b/treeherder/push_health/classification.py
@@ -68,11 +68,10 @@ def get_grouped(failures):
     }
 
     for failure in failures:
-        total_jobs = len(failure['failJobs']) + len(failure['passJobs']) + len(failure['passInFailedJobs'])
-        pass_fail_ratio = (len(failure['passJobs']) + len(failure['passInFailedJobs'])) / total_jobs
         is_intermittent = failure['suggestedClassification'] == 'intermittent'
 
-        if (is_intermittent and failure['confidence'] == 100) or pass_fail_ratio > .5:
+        if ((is_intermittent and failure['confidence'] == 100) or
+                failure['passFailRatio'] > .5):
             classified['intermittent'].append(failure)
         else:
             classified['needInvestigation'].append(failure)

--- a/treeherder/push_health/classification.py
+++ b/treeherder/push_health/classification.py
@@ -75,5 +75,7 @@ def get_grouped(failures):
             classified['intermittent'].append(failure)
         else:
             classified['needInvestigation'].append(failure)
+            # If it needs investigation, we, by definition, don't have 100% confidence.
+            failure['confidence'] = min(failure['confidence'], 90)
 
     return classified

--- a/treeherder/push_health/similar_jobs.py
+++ b/treeherder/push_health/similar_jobs.py
@@ -67,6 +67,11 @@ def set_matching_passed_jobs(failures, push):
                 # This sets the ``passJobs`` key in the ``failures`` object that was passed in,
                 # which is then returned from the API.
                 failure['passJobs'] = passing_job_map[job_key]
+        # This helps the user when determining if this is an intermittent.  If it
+        # gets above 50%, then it's intermittent.
+        passed_count = len(failure['passJobs']) + len(failure['passInFailedJobs'])
+        # Persist this so it is communicated on the front-end
+        failure['passFailRatio'] = passed_count / (len(failure['failJobs']) + passed_count)
 
 
 def get_job_key(job):

--- a/treeherder/push_health/tests.py
+++ b/treeherder/push_health/tests.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import re
 from collections import defaultdict
 
 from django.core.cache import cache
@@ -115,7 +116,7 @@ def get_current_test_failures(push, option_map):
         job_symbol = job.job_type.symbol
         job.job_key = '{}{}{}'.format(config, platform, job_name)
         all_failed_jobs[job.id] = job
-        test_key = '{}{}{}{}'.format(test_name, config, platform, job_name)
+        test_key = re.sub(r'\W+', '', '{}{}{}{}'.format(test_name, config, platform, job_name))
 
         if test_key not in tests:
             line = {

--- a/ui/push-health/TestFailure.jsx
+++ b/ui/push-health/TestFailure.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Badge, Button, Row, Col } from 'reactstrap';
+import { Badge, Button, Row, Col, UncontrolledTooltip } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faRedo } from '@fortawesome/free-solid-svg-icons';
 
@@ -56,13 +56,14 @@ class TestFailure extends React.PureComponent {
       suggestedClassification,
       key,
       tier,
+      passFailRatio,
     } = failure;
     const { detailsShowing } = this.state;
 
     return (
       <Col className="mt-2 mb-3 ml-2" key={key}>
-        <Row className="border-bottom border-secondary justify-content-between">
-          <span>
+        <Row className="border-top border-secondary justify-content-between">
+          <Row className="ml-1 w-100">
             <span
               color="secondary"
               className="font-weight-bold text-uppercase mr-1"
@@ -73,7 +74,15 @@ class TestFailure extends React.PureComponent {
             {tier > 1 && (
               <span className="ml-1 small text-muted">[tier-{tier}]</span>
             )}
-          </span>
+            <span id={key} className="ml-auto mr-3">
+              <strong>Pass/Fail Ratio:</strong>{' '}
+              {Math.round(passFailRatio * 100)}%
+            </span>
+            <UncontrolledTooltip target={key} placement="left">
+              Greater than 50% (and/or classification history) will make this an
+              intermittent
+            </UncontrolledTooltip>
+          </Row>
           {!!confidence && (
             <span title="Best guess at a classification" className="ml-auto">
               {classificationMap[suggestedClassification]}


### PR DESCRIPTION
This fixes two bugs that were sort-of related, so I put them into this same PR.

The first introduces the concept of a Pass/Fail ratio to the user.  We were using it in the back-end calculation before, but now we're surfacing it to help the user understand the criteria for retriggered jobs and intermittents.

The second is just making sure a "Needs Investigation" test never has a confidence higher than 90% for being Intermittent or Fixed By Commit.  If we DID have 100% confidence, they wouldn't need investigation.  :)