### PR TITLE
Bug 1605214 - Improve Push.health_summary API

### DIFF
--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -203,16 +203,17 @@ class PushViewSet(viewsets.ViewSet):
                             status=HTTP_404_NOT_FOUND)
         return Response(push.get_status())
 
-    @action(detail=True)
-    def health_summary(self, request, project, pk=None):
+    @action(detail=False)
+    def health_summary(self, request, project):
         """
         Return a calculated summary of the health of this push.
         """
+        revision = request.query_params.get('revision')
 
         try:
-            push = Push.objects.get(id=pk)
+            push = Push.objects.get(revision=revision, repository__name=project)
         except Push.DoesNotExist:
-            return Response("No push with id: {0}".format(pk),
+            return Response("No push with revision: {0}".format(revision),
                             status=HTTP_404_NOT_FOUND)
         push_health_test_failures = get_test_failures(push, REPO_GROUPS['trunk'])
         push_health_lint_failures = get_lint_failures(push)

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -318,7 +318,6 @@ class PushHeader extends React.Component {
           {showPushHealthStatus && (
             <PushHealthStatus
               repoName={currentRepo.name}
-              pushId={pushId}
               revision={revision}
               jobCounts={jobCounts}
             />

--- a/ui/models/push.js
+++ b/ui/models/push.js
@@ -173,9 +173,12 @@ export default class PushModel {
     );
   }
 
-  static getHealthSummary(repoName, pushId) {
+  static getHealthSummary(repoName, revision) {
     return getData(
-      getProjectUrl(`${pushEndpoint}${pushId}/health_summary/`, repoName),
+      getProjectUrl(
+        `${pushEndpoint}health_summary/?revision=${revision}`,
+        repoName,
+      ),
     );
   }
 

--- a/ui/shared/PushHealthStatus.jsx
+++ b/ui/shared/PushHealthStatus.jsx
@@ -34,9 +34,9 @@ class PushHealthStatus extends Component {
   }
 
   async loadLatestStatus() {
-    const { repoName, pushId } = this.props;
+    const { repoName, revision } = this.props;
 
-    PushModel.getHealthSummary(repoName, pushId).then(resp => {
+    PushModel.getHealthSummary(repoName, revision).then(resp => {
       const { data, error } = resp;
       if (!error) {
         const { needInvestigation } = data;
@@ -76,7 +76,6 @@ class PushHealthStatus extends Component {
 }
 
 PushHealthStatus.propTypes = {
-  pushId: PropTypes.number.isRequired,
   revision: PropTypes.string.isRequired,
   repoName: PropTypes.string.isRequired,
   jobCounts: PropTypes.shape({

--- a/ui/shared/PushHealthStatus.jsx
+++ b/ui/shared/PushHealthStatus.jsx
@@ -4,50 +4,53 @@ import { Badge } from 'reactstrap';
 
 import PushModel from '../models/push';
 import { getPushHealthUrl } from '../helpers/url';
+import { didObjectsChange } from '../helpers/object';
 
 class PushHealthStatus extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      healthStatus: 'Loading...',
+      healthStatus: '',
       needInvestigation: 0,
     };
   }
 
   async componentDidMount() {
-    await this.loadLatestStatus();
+    const {
+      jobCounts: { completed },
+    } = this.props;
+
+    if (completed > 0) {
+      await this.loadLatestStatus();
+    }
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
+  async componentDidUpdate(prevProps) {
     const { jobCounts } = this.props;
-    const { healthStatus } = this.state;
+    const fields = ['completed', 'fixedByCommit', 'pending', 'running'];
 
-    return (
-      jobCounts !== nextProps.jobCounts ||
-      healthStatus !== nextState.healthStatus
-    );
-  }
-
-  async componentDidUpdate() {
-    await this.loadLatestStatus();
+    if (didObjectsChange(jobCounts, prevProps.jobCounts, fields)) {
+      await this.loadLatestStatus();
+    }
   }
 
   async loadLatestStatus() {
     const { repoName, revision } = this.props;
+    const { data, failureStatus } = await PushModel.getHealthSummary(
+      repoName,
+      revision,
+    );
 
-    PushModel.getHealthSummary(repoName, revision).then(resp => {
-      const { data, error } = resp;
-      if (!error) {
-        const { needInvestigation } = data;
-        const testsNeed = needInvestigation > 1 ? 'tests need' : 'test needs';
-        const healthStatus = needInvestigation
-          ? `${needInvestigation} ${testsNeed} investigation`
-          : 'OK';
+    if (!failureStatus) {
+      const { needInvestigation } = data;
+      const testsNeed = needInvestigation > 1 ? 'tests need' : 'test needs';
+      const healthStatus = needInvestigation
+        ? `${needInvestigation} ${testsNeed} investigation`
+        : 'OK';
 
-        this.setState({ healthStatus, needInvestigation });
-      }
-    });
+      this.setState({ healthStatus, needInvestigation });
+    }
   }
 
   render() {


### PR DESCRIPTION
This modifies the ``health_summary`` api to require a ``revision`` rather than a ``push_id``.  This will make it easier for outside tools to use it.

I also noticed that I was calling the endpoint too many times during page load.  So the second commit fixes that.