### PR TITLE
Reconfigure Renovate

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:js-app",
+    "schedule:earlyMondays",
     ":maintainLockFilesWeekly",
     ":prNotPending",
     ":unpublishSafe"
@@ -15,5 +16,16 @@
   "labels": ["dependencies", "javascript"],
   "reviewers": ["armenzg"],
   "semanticCommits": false,
+  "minor": {
+    "enabled": false
+  },
+  "separateMinorPatch": true,
+  "patch": {
+    "automerge": true,
+    "automergeType": "branch"
+  },
+  "lockFileMaintenance": {
+    "automerge": true
+  },
   "travis": { "enabled": true }
 }


### PR DESCRIPTION
I'm using this configuration for AWFY and the Health dashboard.

* Move config to a dot file
* Schedule package updates early on Mondays
* Avoid taking minor packages
* Update patch releases independently from minor releases
* Auto merge patch releases silently if tests pass, otherwise, open PR
* Auto merge lock file maintenance if tests pass. Always open PR