### PR TITLE
Bug 1602969 - Show matching in-progress jobs for failures

### DIFF
--- a/tests/ui/mock/push_health.json
+++ b/tests/ui/mock/push_health.json
@@ -30,6 +30,7 @@
             ],
             "passJobs": [],
             "passInFailedJobs": [],
+            "inProgressJobs": [],
             "logLines": [
               {
                 "action": "test_result",
@@ -67,6 +68,7 @@
             ],
             "passJobs": [],
             "passInFailedJobs": [],
+            "inProgressJobs": [],
             "logLines": [
               {
                 "action": "test_result",
@@ -104,6 +106,7 @@
             ],
             "passJobs": [],
             "passInFailedJobs": [],
+            "inProgressJobs": [],
             "logLines": [
               {
                 "action": "test_result",

--- a/treeherder/push_health/tests.py
+++ b/treeherder/push_health/tests.py
@@ -128,6 +128,7 @@ def get_current_test_failures(push, option_map):
                 'config': config,
                 'key': test_key,
                 'jobKey': job.job_key,
+                'inProgressJobs': [],
                 'failJobs': [],
                 'passJobs': [],
                 'passInFailedJobs': [],  # This test passed in a job that failed for another test

--- a/ui/push-health/Job.jsx
+++ b/ui/push-health/Job.jsx
@@ -13,8 +13,10 @@ class Job extends PureComponent {
     const {
       id,
       result,
+      state,
       failure_classification_id: failureClassificationId,
     } = job;
+    const resultStatus = state === 'completed' ? result : state;
 
     return (
       <span className="mr-2" key={id}>
@@ -22,9 +24,9 @@ class Job extends PureComponent {
           className={`btn job-btn filter-shown btn-sm mt-1 ${getBtnClass(
             result,
             failureClassificationId,
-          )}`}
+          )} border`}
           href={getJobsUrl({ selectedJob: job.id, repo, revision })}
-          title={jobName}
+          title={`${jobName} - ${resultStatus}`}
         >
           {jobSymbol}
         </a>

--- a/ui/push-health/TestFailure.jsx
+++ b/ui/push-health/TestFailure.jsx
@@ -46,6 +46,7 @@ class TestFailure extends React.PureComponent {
       action,
       jobName,
       jobSymbol,
+      inProgressJobs,
       failJobs,
       passJobs,
       passInFailedJobs,
@@ -145,6 +146,16 @@ class TestFailure extends React.PureComponent {
               repo={repo}
               revision={revision}
               key={passedInAFailedJob.id}
+            />
+          ))}
+          {inProgressJobs.map(inProgressJob => (
+            <Job
+              job={inProgressJob}
+              jobName={jobName}
+              jobSymbol={jobSymbol}
+              repo={repo}
+              revision={revision}
+              key={inProgressJob.id}
             />
           ))}
         </div>


### PR DESCRIPTION
This just shows any in-progress jobs that are the same ``platform``, ``config`` and ``job_type`` as one of the failures being displayed.  This is so it shows them when they are retriggered.