### PR TITLE
Clear test warnings for Filtering_test.jsx

### DIFF
--- a/ui/job-view/App.jsx
+++ b/ui/job-view/App.jsx
@@ -373,16 +373,18 @@ class App extends React.Component {
                   </div>
                 )}
               </div>
-              {currentRepo && (
-                <DetailsPanel
-                  resizedHeight={detailsHeight}
-                  currentRepo={currentRepo}
-                  repoName={repoName}
-                  user={user}
-                  classificationTypes={classificationTypes}
-                  classificationMap={classificationMap}
-                />
-              )}
+              <>
+                {currentRepo && (
+                  <DetailsPanel
+                    resizedHeight={detailsHeight}
+                    currentRepo={currentRepo}
+                    repoName={repoName}
+                    user={user}
+                    classificationTypes={classificationTypes}
+                    classificationMap={classificationMap}
+                  />
+                )}
+              </>
             </SplitPane>
             <Notifications />
             {showShortCuts && (


### PR DESCRIPTION
Uses a React Fragment to clear the below warning for `Filtering_test.jsx`, as discussed [here](https://github.com/mozilla/treeherder/issues/5721#issuecomment-565055568) - 

```js
% yarn test tests/ui/job-view/Filtering_test.jsx
yarn run v1.19.2
$ node ./node_modules/jest/bin/jest tests/ui/job-view/Filtering_test.jsx
 PASS  tests/ui/job-view/Filtering_test.jsx (11.762s)
  ● Console

    console.error node_modules/prop-types/checkPropTypes.js:20
      Warning: Failed prop type: The prop `children` is marked as required in `Pane`, but its value is `undefined`.
          in Pane (created by SplitPane)
          in SplitPane (at App.jsx:340)
          in div (created by FocusTrap)
          in FocusTrap (created by HotKeys)
          in HotKeys (at KeyboardShortcuts.jsx:239)
          in KeyboardShortcuts (created by ConnectFunction)
          in ConnectFunction (at App.jsx:321)
          in Provider (at App.jsx:320)
          in div (at App.jsx:319)
          in App (at Filtering_test.jsx:104)
```

Related to #5721 