### PR TITLE
1600761 - Visual/Color improvements to Treeherder apps

### DIFF
--- a/ui/css/intermittent-failures.css
+++ b/ui/css/intermittent-failures.css
@@ -72,11 +72,6 @@ ul {
   text-align: left;
 }
 
-/* ReactTable style */
-.ReactTable .-pagination .-btn:focus {
-  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5);
-}
-
 /* overriding react-dates default input and button style */
 input.DateInput_input {
   font-size: 1rem;
@@ -96,4 +91,33 @@ button.DateRangePickerInput_clearDates {
   top: 45%;
   padding: 5px 8px;
   margin: 1px 10px 0 5px;
+}
+
+/* Graphic overriding style */
+.mx-auto .mg-x-axis text,
+.mx-auto .mg-y-axis text,
+.mx-auto .mg-histogram .axis text {
+  opacity: 1;
+}
+
+.mg-x-axis .mg-year-marker text {
+  opacity: 0.9;
+}
+
+/* ReactTable style */
+.ReactTable .-pagination .-btn:focus {
+  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5);
+}
+
+.ReactTable .-pagination .-btn[disabled] {
+  background-color: rgba(0, 0, 0, 0.03);
+  opacity: 1;
+}
+
+.ReactTable .item-badge {
+  color: #0d7b86;
+}
+
+.rt-tbody a {
+  color: #187c86;
 }

--- a/ui/css/intermittent-failures.css
+++ b/ui/css/intermittent-failures.css
@@ -104,7 +104,7 @@ button.DateRangePickerInput_clearDates {
   opacity: 0.9;
 }
 
-/* ReactTable style */
+/* ReactTable overriding row, button and link color style for contrast pass */
 .ReactTable .-pagination .-btn:focus {
   box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5);
 }

--- a/ui/css/intermittent-failures.css
+++ b/ui/css/intermittent-failures.css
@@ -92,32 +92,3 @@ button.DateRangePickerInput_clearDates {
   padding: 5px 8px;
   margin: 1px 10px 0 5px;
 }
-
-/* Graphic overriding style */
-.mx-auto .mg-x-axis text,
-.mx-auto .mg-y-axis text,
-.mx-auto .mg-histogram .axis text {
-  opacity: 1;
-}
-
-.mg-x-axis .mg-year-marker text {
-  opacity: 0.9;
-}
-
-/* ReactTable overriding row, button and link color style for contrast pass */
-.ReactTable .-pagination .-btn:focus {
-  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5);
-}
-
-.ReactTable .-pagination .-btn[disabled] {
-  background-color: rgba(0, 0, 0, 0.03);
-  opacity: 1;
-}
-
-.ReactTable .item-badge {
-  color: #0d7b86;
-}
-
-.rt-tbody a {
-  color: #187c86;
-}

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -37,6 +37,32 @@ h1 {
   }
 }
 
+.btn-info {
+  background-color: #0d7d8f !important;
+  border-color: #0d7d8f !important;
+}
+
+.btn-info:hover {
+  background-color: #0a5e6d !important;
+}
+
+.btn-outline-info {
+  color: #0d7d8f;
+  border-color: #0d7d8f;
+}
+
+.btn-outline-info:hover,
+.btn-outline-info:not(:disabled):not(.disabled).active {
+  background-color: #0d7d8f;
+  border-color: #0d7d8f;
+}
+
+.btn-info.disabled,
+.btn-info.disabled:hover {
+  color: black;
+  background-color: #30b9ce80;
+}
+
 #perf-logo {
   padding: 15px;
   border: none;
@@ -211,7 +237,7 @@ h1 {
 
 .push-information {
   font-size: 18px;
-  color: #555;
+  color: #727272;
   margin-left: -4px;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
@@ -282,6 +308,19 @@ th {
 
 .compare-table th h3 {
   font-size: inherit;
+}
+
+.compare-table .text-success {
+  color: #1e8836 !important;
+}
+
+.compare-table .text-info {
+  color: #127989 !important;
+}
+
+.compare-table .btn-secondary.disabled {
+  background-color: #d1d1d1;
+  color: black;
 }
 
 .compare-table .subtest-header > th,
@@ -493,4 +532,14 @@ li.pagination-active.active > button {
 
 .page-title-text:hover .edit-icon {
   visibility: visible;
+}
+
+/* ReactTable stlye */
+.ReactTable .-pagination .-btn[disabled] {
+  background-color: rgba(0,0,0,0.03);
+  opacity: 1;
+}
+
+.ReactTable .item-badge {
+  color: #0d7b86;
 }

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -536,7 +536,7 @@ li.pagination-active.active > button {
 
 /* ReactTable stlye */
 .ReactTable .-pagination .-btn[disabled] {
-  background-color: rgba(0,0,0,0.03);
+  background-color: rgba(0, 0, 0, 0.03);
   opacity: 1;
 }
 

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -37,30 +37,55 @@ h1 {
   }
 }
 
-.btn-info {
-  background-color: #0d7d8f !important;
-  border-color: #0d7d8f !important;
+.btn-darker-secondary {
+  color: #ffffff;
+  background-color: #6c757d;
+  border-color: #6c757d;
 }
 
-.btn-info:hover {
-  background-color: #0a5e6d !important;
+.btn-darker-secondary:hover {
+  color: #ffffff;
+  background-color: #5a6268;
+  border-color: #545b62;
 }
 
-.btn-outline-info {
+.btn-darker-secondary.disabled {
+  color: #242424;
+  background-color: white;
+  border-color: #6c757d;
+}
+
+.btn-darker-info {
+  background-color: #0d7d8f;
+  border-color: #0d7d8f;
+  color: #ffffff;
+}
+
+.btn-darker-info:hover {
+  color: #ffffff;
+  background-color: #0a5e6d;
+}
+
+.btn-outline-darker-info {
   color: #0d7d8f;
   border-color: #0d7d8f;
 }
 
-.btn-outline-info:hover,
-.btn-outline-info:not(:disabled):not(.disabled).active {
+.btn-outline-darker-info:hover,
+.btn-outline-darker-info:not(:disabled):not(.disabled).active {
   background-color: #0d7d8f;
   border-color: #0d7d8f;
+  color: #ffffff;
 }
 
-.btn-info.disabled,
-.btn-info.disabled:hover {
+.btn-darker-info.disabled,
+.btn-darker-info.disabled:hover {
   color: black;
   background-color: #30b9ce80;
+}
+
+.text-darker-info {
+  color: #0d7d8f;
 }
 
 #perf-logo {
@@ -310,19 +335,6 @@ th {
   font-size: inherit;
 }
 
-.compare-table .text-success {
-  color: #1e8836 !important;
-}
-
-.compare-table .text-info {
-  color: #127989 !important;
-}
-
-.compare-table .btn-secondary.disabled {
-  background-color: #d1d1d1;
-  color: black;
-}
-
 .compare-table .subtest-header > th,
 .compare-table .subtest-header a,
 .compare-table .subtest-header button {
@@ -485,6 +497,7 @@ button:disabled {
 li.pagination-active.active > button {
   background-color: lightgray !important;
   border-color: lightgray !important;
+  color: black !important;
 }
 
 /* graph colors */
@@ -534,7 +547,7 @@ li.pagination-active.active > button {
   visibility: visible;
 }
 
-/* ReactTable stlye */
+/* ReactTable button and badge overriding style for contrast */
 .ReactTable .-pagination .-btn[disabled] {
   background-color: rgba(0, 0, 0, 0.03);
   opacity: 1;

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -37,57 +37,6 @@ h1 {
   }
 }
 
-.btn-darker-secondary {
-  color: #ffffff;
-  background-color: #6c757d;
-  border-color: #6c757d;
-}
-
-.btn-darker-secondary:hover {
-  color: #ffffff;
-  background-color: #5a6268;
-  border-color: #545b62;
-}
-
-.btn-darker-secondary.disabled {
-  color: #242424;
-  background-color: white;
-  border-color: #6c757d;
-}
-
-.btn-darker-info {
-  background-color: #0d7d8f;
-  border-color: #0d7d8f;
-  color: #ffffff;
-}
-
-.btn-darker-info:hover {
-  color: #ffffff;
-  background-color: #0a5e6d;
-}
-
-.btn-outline-darker-info {
-  color: #0d7d8f;
-  border-color: #0d7d8f;
-}
-
-.btn-outline-darker-info:hover,
-.btn-outline-darker-info:not(:disabled):not(.disabled).active {
-  background-color: #0d7d8f;
-  border-color: #0d7d8f;
-  color: #ffffff;
-}
-
-.btn-darker-info.disabled,
-.btn-darker-info.disabled:hover {
-  color: black;
-  background-color: #30b9ce80;
-}
-
-.text-darker-info {
-  color: #0d7d8f;
-}
-
 #perf-logo {
   padding: 15px;
   border: none;
@@ -545,14 +494,4 @@ li.pagination-active.active > button {
 
 .page-title-text:hover .edit-icon {
   visibility: visible;
-}
-
-/* ReactTable button and badge overriding style for contrast */
-.ReactTable .-pagination .-btn[disabled] {
-  background-color: rgba(0, 0, 0, 0.03);
-  opacity: 1;
-}
-
-.ReactTable .item-badge {
-  color: #0d7b86;
 }

--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -286,6 +286,53 @@ input[type='checkbox'] {
   border-color: #2e6da4;
 }
 
+.btn-darker-secondary {
+  color: #ffffff;
+  background-color: #6c757d;
+  border-color: #6c757d;
+}
+
+.btn-darker-secondary:hover {
+  color: #ffffff;
+  background-color: #5a6268;
+  border-color: #545b62;
+}
+
+.btn-darker-secondary.disabled {
+  color: #242424;
+  background-color: white;
+  border-color: #6c757d;
+}
+
+.btn-darker-info {
+  background-color: #0d7d8f;
+  border-color: #0d7d8f;
+  color: #ffffff;
+}
+
+.btn-darker-info:hover {
+  color: #ffffff;
+  background-color: #0a5e6d;
+}
+
+.btn-darker-info.disabled,
+.btn-darker-info.disabled:hover {
+  color: black;
+  background-color: #30b9ce80;
+}
+
+.btn-outline-darker-info {
+  color: #0d7d8f;
+  border-color: #0d7d8f;
+}
+
+.btn-outline-darker-info:hover,
+.btn-outline-darker-info:not(:disabled):not(.disabled).active {
+  background-color: #0d7d8f;
+  border-color: #0d7d8f;
+  color: #ffffff;
+}
+
 /*
  * Colors
  */
@@ -367,6 +414,10 @@ h4 {
   font-size: 18px;
 }
 
+.text-darker-info {
+  color: #0d7d8f;
+}
+
 /*
  * Tables and panels
  */
@@ -399,6 +450,24 @@ h4 {
 
 .modal-lg {
   max-width: 890px;
+}
+
+/* ReactTable overriding row, button and link color style for contrast pass */
+.ReactTable .-pagination .-btn:focus {
+  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5);
+}
+
+.ReactTable .-pagination .-btn[disabled] {
+  background-color: rgba(0, 0, 0, 0.03);
+  opacity: 1;
+}
+
+.ReactTable .item-badge {
+  color: #057699;
+}
+
+.rt-tbody a {
+  color: #187c86;
 }
 
 /*

--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -306,7 +306,7 @@ input[type='checkbox'] {
 }
 
 .bg-lightgray {
-  background-color: whitesmoke;
+  background-color: lightgray;
 }
 
 .midgray,

--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -306,7 +306,7 @@ input[type='checkbox'] {
 }
 
 .bg-lightgray {
-  background-color: lightgray;
+  background-color: whitesmoke;
 }
 
 .midgray,

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -29,7 +29,7 @@
 }
 
 .group-btn.btn.job-group-count:hover {
-  background-color: rgba(208, 228, 250, 0.51);
+  background-color: rgba(219, 235, 252, 0.51);
 }
 
 .group-symbol {
@@ -43,7 +43,6 @@
 }
 
 .group-symbol:hover {
-  background-color: rgba(208, 228, 250, 0.51);
   cursor: pointer;
 }
 
@@ -163,7 +162,7 @@
 
 /* Orange, testfailed */
 .btn-orange {
-  background-color: #eba870;
+  background-color: #b95402;
   border-color: #dd6602;
   color: white;
 }
@@ -171,7 +170,7 @@
 .btn-orange:focus,
 .btn-orange:active,
 .btn-orange.active {
-  background-color: #c45a02;
+  background-color: #996709;
   border-color: #aa4f02;
   color: white;
 }
@@ -194,13 +193,13 @@ fieldset[disabled] .btn-orange.active {
 /* Orange, testfailed classified */
 .btn-orange-classified,
 .btn-orange-classified-count {
-  color: #dd6602;
+  color: #b45303;
 }
 .btn-orange-classified:hover,
 .btn-orange-classified:focus,
 .btn-orange-classified:active,
 .btn-orange-classified.active {
-  background-color: #c45a02;
+  background-color: #b45303;
   border-color: #aa4f02;
   color: white;
 }
@@ -225,7 +224,7 @@ fieldset[disabled] .btn-orange-classified.active {
 
 /* Red, busted */
 .btn-red {
-  background-color: #b86262;
+  background-color: #cf0b18;
   border-color: #a1020e;
   color: white;
 }
@@ -327,7 +326,7 @@ fieldset[disabled] .btn-dkblue.active {
 .btn-green-classified-count,
 .btn-green-count:hover,
 .btn-green-classified-count:hover {
-  color: rgba(2, 130, 51, 0.75);
+  color: rgba(3, 81, 33, 0.75);
   font-weight: bold;
 }
 .btn-green:hover,
@@ -336,7 +335,7 @@ fieldset[disabled] .btn-dkblue.active {
 .btn-green:active,
 .btn-green.active {
   border-color: #019029;
-  background-color: #019029;
+  background-color: #017722;
   color: white;
 }
 .btn-green.disabled:hover,
@@ -356,7 +355,7 @@ fieldset[disabled] .btn-green.active {
 
 /* Purple, infrastructure exception */
 .btn-purple {
-  background-color: #9a7da6;
+  background-color: #876d92;
   border-color: #6f0296;
   color: white;
 }
@@ -423,7 +422,7 @@ fieldset[disabled] .btn-purple-classified.active {
 .btn-ltblue-classified-count,
 .btn-ltblue-count:hover,
 .btn-ltblue-classified-count:hover {
-  color: #81b8ed;
+  color: #3f77c6;
   font-weight: bold;
 }
 .btn-ltblue:hover,
@@ -431,8 +430,8 @@ fieldset[disabled] .btn-purple-classified.active {
 .btn-ltblue:focus,
 .btn-ltblue:active,
 .btn-ltblue.active {
-  border-color: #488ae9;
-  background-color: #488ae9;
+  border-color: #3f77c6;
+  background-color: #3f77c6;
   color: white;
 }
 .btn-ltblue.disabled:hover,
@@ -455,7 +454,7 @@ fieldset[disabled] .btn-ltblue.active {
 .btn-ltgray-count,
 .btn-ltgray-classified,
 .btn-ltgray-classified-count {
-  color: #e0e0e0;
+  color: #697279;
 }
 .btn-ltgray-count:hover,
 .btn-ltgray-classified-count:hover {
@@ -526,14 +525,14 @@ fieldset[disabled] .btn-mdgray.active {
 .btn-dkgray-classified-count,
 .btn-dkgray-count:hover,
 .btn-dkgray-classified-count:hover {
-  color: #7c7a7d;
+  color: #696969;
 }
 .btn-dkgray:hover,
 .btn-dkgray-classified:hover,
 .btn-dkgray:focus,
 .btn-dkgray:active,
 .btn-dkgray.active {
-  background-color: #6f6d70;
+  background-color: #69616d;
   border-color: #626163;
   color: white;
 }
@@ -596,11 +595,11 @@ fieldset[disabled] .btn-yellow.active {
 /* Pink, cancelled */
 .btn-pink,
 .btn-pink-count,
-.btn-pink-classified,
+.btn-pink-classified, 
 .btn-pink-classified-count,
 .btn-pink-count:hover,
 .btn-pink-classified-count:hover {
-  color: #ff40d9;
+  color: #cf2b9f;
   font-weight: bold;
 }
 .btn-pink:hover,
@@ -608,8 +607,8 @@ fieldset[disabled] .btn-yellow.active {
 .btn-pink:focus,
 .btn-pink:active,
 .btn-pink.active {
-  background-color: #ff40d9;
-  border-color: #ff40d9;
+  background-color: #cf2b9f;
+  border-color: #cf2b9f;
   color: white;
 }
 .btn-pink.disabled:hover,

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -595,7 +595,7 @@ fieldset[disabled] .btn-yellow.active {
 /* Pink, cancelled */
 .btn-pink,
 .btn-pink-count,
-.btn-pink-classified, 
+.btn-pink-classified,
 .btn-pink-classified-count,
 .btn-pink-count:hover,
 .btn-pink-classified-count:hover {

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -162,16 +162,16 @@
 
 /* Orange, testfailed */
 .btn-orange {
-  background-color: #b95402;
+  background-color: #eba870;
   border-color: #dd6602;
-  color: white;
+  color: #743603;
 }
 .btn-orange:hover,
 .btn-orange:focus,
 .btn-orange:active,
 .btn-orange.active {
-  background-color: #996709;
-  border-color: #aa4f02;
+  background-color: #743603;
+  border-color: #743603;
   color: white;
 }
 .btn-orange.disabled:hover,
@@ -224,16 +224,16 @@ fieldset[disabled] .btn-orange-classified.active {
 
 /* Red, busted */
 .btn-red {
-  background-color: #cf0b18;
+  background-color: #b86262;
   border-color: #a1020e;
-  color: white;
+  color: #280003;
 }
 .btn-red:hover,
 .btn-red:focus,
 .btn-red:active,
 .btn-red.active {
-  background-color: #a9020c;
-  border-color: #90010a;
+  background-color: #a1020e;
+  border-color: #a1020e;
   color: white;
 }
 .btn-red.disabled:hover,
@@ -326,7 +326,7 @@ fieldset[disabled] .btn-dkblue.active {
 .btn-green-classified-count,
 .btn-green-count:hover,
 .btn-green-classified-count:hover {
-  color: rgba(3, 81, 33, 0.75);
+  color: rgba(2, 130, 51, 0.95);
   font-weight: bold;
 }
 .btn-green:hover,
@@ -355,16 +355,16 @@ fieldset[disabled] .btn-green.active {
 
 /* Purple, infrastructure exception */
 .btn-purple {
-  background-color: #876d92;
+  background-color: #9a7da6;
   border-color: #6f0296;
-  color: white;
+  color: #3a004d;
 }
 .btn-purple:hover,
 .btn-purple:focus,
 .btn-purple:active,
 .btn-purple.active {
-  background-color: #7d02a9;
-  border-color: #6b0190;
+  background-color: #3a004d;
+  border-color: #3a004d;
   color: white;
 }
 .btn-purple.disabled:hover,
@@ -454,7 +454,8 @@ fieldset[disabled] .btn-ltblue.active {
 .btn-ltgray-count,
 .btn-ltgray-classified,
 .btn-ltgray-classified-count {
-  color: #697279;
+  color: #747474;
+  font-style: italic;
 }
 .btn-ltgray-count:hover,
 .btn-ltgray-classified-count:hover {
@@ -525,7 +526,7 @@ fieldset[disabled] .btn-mdgray.active {
 .btn-dkgray-classified-count,
 .btn-dkgray-count:hover,
 .btn-dkgray-classified-count:hover {
-  color: #696969;
+  color: #5e5e5e;
 }
 .btn-dkgray:hover,
 .btn-dkgray-classified:hover,

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -160,6 +160,19 @@
   vertical-align: super;
 }
 
+/* Bold buttons */
+
+.btn-green,
+.btn-orange,
+.btn-purple,
+.btn-red,
+.btn-dkblue,
+.btn-pink,
+.btn-yellow,
+.btn-ltblue {
+  font-weight: bold;
+}
+
 /* Orange, testfailed */
 .btn-orange {
   background-color: #f7c194;
@@ -291,7 +304,6 @@ fieldset[disabled] .btn-red-classified.active {
 .btn-dkblue-count:hover,
 .btn-dkblue-classified-count:hover {
   color: #283aa2;
-  font-weight: bold;
 }
 .btn-dkblue:hover,
 .btn-dkblue-classified:hover,
@@ -423,7 +435,6 @@ fieldset[disabled] .btn-purple-classified.active {
 .btn-ltblue-count:hover,
 .btn-ltblue-classified-count:hover {
   color: #3f77c6;
-  font-weight: bold;
 }
 .btn-ltblue:hover,
 .btn-ltblue-classified:hover,
@@ -455,7 +466,6 @@ fieldset[disabled] .btn-ltblue.active {
 .btn-ltgray-classified,
 .btn-ltgray-classified-count {
   color: #747474;
-  font-style: italic;
 }
 .btn-ltgray-count:hover,
 .btn-ltgray-classified-count:hover {
@@ -562,7 +572,6 @@ fieldset[disabled] .btn-dkgray.active {
   background-color: #fcf8e3;
   border-color: #fbd890;
   color: #8a6d3b;
-  font-weight: bold;
 }
 .btn-yellow-count:hover,
 .btn-yellow-classified-count:hover {
@@ -601,7 +610,6 @@ fieldset[disabled] .btn-yellow.active {
 .btn-pink-count:hover,
 .btn-pink-classified-count:hover {
   color: #cf2b9f;
-  font-weight: bold;
 }
 .btn-pink:hover,
 .btn-pink-classified:hover,

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -162,16 +162,16 @@
 
 /* Orange, testfailed */
 .btn-orange {
-  background-color: #eba870;
-  border-color: #dd6602;
+  background-color: #f7c194;
+  border-color: #a87f5c;
   color: #743603;
 }
 .btn-orange:hover,
 .btn-orange:focus,
 .btn-orange:active,
 .btn-orange.active {
-  background-color: #743603;
-  border-color: #743603;
+  background-color: #c15700;
+  border-color: #9f4a03;
   color: white;
 }
 .btn-orange.disabled:hover,
@@ -224,9 +224,9 @@ fieldset[disabled] .btn-orange-classified.active {
 
 /* Red, busted */
 .btn-red {
-  background-color: #b86262;
+  background-color: #b74c4c;
   border-color: #a1020e;
-  color: #280003;
+  color: white;
 }
 .btn-red:hover,
 .btn-red:focus,
@@ -526,15 +526,15 @@ fieldset[disabled] .btn-mdgray.active {
 .btn-dkgray-classified-count,
 .btn-dkgray-count:hover,
 .btn-dkgray-classified-count:hover {
-  color: #5e5e5e;
+  color: #333333;
 }
 .btn-dkgray:hover,
 .btn-dkgray-classified:hover,
 .btn-dkgray:focus,
 .btn-dkgray:active,
 .btn-dkgray.active {
-  background-color: #69616d;
-  border-color: #626163;
+  background-color: #333333;
+  border-color: #1c1c1c;
   color: white;
 }
 .btn-dkgray.disabled:hover,

--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -48,6 +48,11 @@ label.dropdown-item {
   margin-bottom: 0;
 }
 
+label.dropdown-item.active,
+.dropdown-item:active {
+  color: #0b0c0e;
+}
+
 .dropdown-item input[type='checkbox'] {
   margin-right: 5px;
 }
@@ -426,6 +431,7 @@ fieldset[disabled] .btn-view-nav-closed.active {
 
 .dropdown-header {
   font-size: 12px;
+  color: #656f77;
 }
 
 .dropdown-link,

--- a/ui/css/treeherder-resultsets.css
+++ b/ui/css/treeherder-resultsets.css
@@ -49,6 +49,10 @@
   padding-right: 10px;
 }
 
+.push-health .badge.badge-success {
+  background-color: #1b7e32;
+}
+
 .push-progress {
   color: #6f6d70;
   font-style: italic;
@@ -139,7 +143,7 @@ th-action-button .btn-push {
 }
 
 .revision[data-tags~='backout'] .revision-comment {
-  color: red;
+  color: #e20303;
 }
 
 .commit-sha {
@@ -157,11 +161,11 @@ th-action-button .btn-push {
   font-style: italic;
   font-weight: bold;
   padding-left: 3px;
-  color: gray;
+  color: #767676;
 }
 
 .revision-comment {
-  color: #777;
+  color: #767676;
 }
 
 /*
@@ -196,7 +200,11 @@ th-action-button .btn-push {
 }
 
 .job-list table tr:nth-child(even) {
-  background: #f8f8f8;
+  background: #f8f8f896;
+}
+
+.table-hover tbody tr:hover {
+  background-color: rgba(0, 0, 0, 0.03);
 }
 
 .get-next {

--- a/ui/css/treeherder-test-view.css
+++ b/ui/css/treeherder-test-view.css
@@ -63,7 +63,7 @@ main .progress {
 .badge-success,
 .bg-success,
 .btn-success {
-  background-color: #1d9862 !important;
+  background-color: #087646 !important;
 }
 
 .badge-warning,
@@ -75,7 +75,7 @@ main .progress {
 .badge-info,
 .bg-info,
 .btn-info {
-  background-color: #1d7dbb !important;
+  background-color: #1b73ac !important;
 }
 
 .badge-secondary,
@@ -116,12 +116,12 @@ main .progress {
 }
 
 .badge-infra {
-  background-color: #d78236;
+  background-color: #b15e13;
   color: white;
 }
 
 .badge-intermittent {
-  background-color: #d78236;
+  background-color: #b15e13;
   color: white;
 }
 

--- a/ui/css/treeherder-userguide.css
+++ b/ui/css/treeherder-userguide.css
@@ -15,6 +15,10 @@ body {
   padding: 5px;
 }
 
+#userguide a {
+  color: #0056b3;
+}
+
 /*
  * Job notation table
  */
@@ -54,7 +58,7 @@ body {
  */
 
 #ug-job-name {
-  color: #428bca;
+  color: #3675ac;
 }
 
 #ug-raw-log-icon {

--- a/ui/intermittent-failures/helpers.js
+++ b/ui/intermittent-failures/helpers.js
@@ -105,7 +105,10 @@ export const validateQueryParams = function validateQueryParams(
 
 export const tableRowStyling = function tableRowStyling(state, bug) {
   if (bug) {
-    const style = { color: '#aaa' };
+    const style = {
+      color: 'rgb(117, 117, 117)',
+      'background-color': 'rgba(0, 0, 0, 0.009)',
+    };
 
     if (bug.row.status === 'RESOLVED' || bug.row.status === 'VERIFIED') {
       style.textDecoration = 'line-through';

--- a/ui/job-view/headerbars/SecondaryNavBar.jsx
+++ b/ui/job-view/headerbars/SecondaryNavBar.jsx
@@ -1,7 +1,7 @@
-/* eslint-disable jsx-a11y/control-has-associated-label */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 
 import React from 'react';
+import { Button } from 'reactstrap';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -247,22 +247,20 @@ class SecondaryNavBar extends React.PureComponent {
             )}
 
             {/* Unclassified Failures Button */}
-            <span
+            <Button
               className={`btn btn-sm ${
                 allUnclassifiedFailureCount
                   ? 'btn-unclassified-failures'
                   : 'btn-view-nav'
               }${filterModel.isUnclassifiedFailures() ? ' active' : ''}`}
               title="Loaded failures / toggle filtering for unclassified failures"
-              tabIndex="-1"
-              role="button"
               onClick={this.toggleUnclassifiedFailures}
             >
               <span id="unclassified-failure-count">
                 {allUnclassifiedFailureCount}
               </span>{' '}
               unclassified
-            </span>
+            </Button>
 
             {/* Filtered Unclassified Failures Button */}
             {filteredUnclassifiedFailureCount !==
@@ -278,8 +276,8 @@ class SecondaryNavBar extends React.PureComponent {
             )}
 
             {/* Toggle Duplicate Jobs */}
-            <span
-              className={`btn btn-view-nav btn-sm btn-toggle-duplicate-jobs ${
+            <Button
+              className={`btn btn-view-nav btn-sm btn-toggle-duplicate-jobs bg-transparent border border-0 ${
                 groupCountsExpanded ? 'disabled' : ''
               } ${!duplicateJobsVisible ? 'strikethrough' : ''}`}
               tabIndex="0"
@@ -293,7 +291,7 @@ class SecondaryNavBar extends React.PureComponent {
                 !groupCountsExpanded && this.toggleShowDuplicateJobs()
               }
             />
-            <span className="btn-group">
+            <Button className="btn-group p-0 bg-transparent border border-0">
               {/* Toggle Group State Button */}
               <span
                 className="btn btn-view-nav btn-sm btn-toggle-group-state"
@@ -312,7 +310,7 @@ class SecondaryNavBar extends React.PureComponent {
                 </span>{' '}
                 )
               </span>
-            </span>
+            </Button>
 
             {/* Result Status Filter Chicklets */}
             <span className="resultStatusChicklets">

--- a/ui/job-view/pushes/JobGroup.jsx
+++ b/ui/job-view/pushes/JobGroup.jsx
@@ -15,7 +15,7 @@ const GroupSymbol = function GroupSymbol(props) {
   return (
     <button type="button" className="btn group-symbol" onClick={toggleExpanded}>
       {symbol}
-      {tier !== 1 && <span className="small text-muted">[tier {tier}]</span>}
+      {tier !== 1 && <span className="small">[tier {tier}]</span>}
     </button>
   );
 };

--- a/ui/perfherder/FilterControls.jsx
+++ b/ui/perfherder/FilterControls.jsx
@@ -45,7 +45,7 @@ const FilterControls = ({
 }) => {
   const createButton = filter => (
     <Button
-      color="info"
+      color="darker-info"
       outline
       onClick={() => updateFilter(filter.stateName)}
       active={filter.state}

--- a/ui/perfherder/alerts/AlertHeader.jsx
+++ b/ui/perfherder/alerts/AlertHeader.jsx
@@ -96,7 +96,7 @@ const AlertHeader = ({
           <Col className="p-0" xs="auto">
             {alertSummary.issue_tracker && issueTrackers.length > 0 ? (
               <a
-                className="text-info align-middle"
+                className="btn btn-secondary btn-xs ml-1 text-white"
                 href={getIssueTrackerUrl(alertSummary)}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -106,7 +106,6 @@ const AlertHeader = ({
             ) : (
               { bugNumber }
             )}
-            <span>·</span>
           </Col>
         )}
         <Col className="p-0" xs="auto">

--- a/ui/perfherder/alerts/AlertHeader.jsx
+++ b/ui/perfherder/alerts/AlertHeader.jsx
@@ -57,14 +57,10 @@ const AlertHeader = ({
       <Row className="font-weight-normal">
         <Col className="p-0" xs="auto">{`${moment(
           alertSummary.push_timestamp * 1000,
-        ).format('ddd MMM D, HH:mm:ss')} ·`}</Col>
+        ).format('ddd MMM D, HH:mm:ss')}`}</Col>
         <Col className="p-0" xs="auto">
           <UncontrolledDropdown tag="span">
-            <DropdownToggle
-              className="btn-link text-info p-0"
-              color="transparent"
-              caret
-            >
+            <DropdownToggle className="btn-xs ml-2" color="secondary" caret>
               {alertSummary.revision.slice(0, 12)}
             </DropdownToggle>
             <DropdownMenu>
@@ -95,7 +91,6 @@ const AlertHeader = ({
               </DropdownItem>
             </DropdownMenu>
           </UncontrolledDropdown>
-          <span>·</span>
         </Col>
         {bugNumber && (
           <Col className="p-0" xs="auto">

--- a/ui/perfherder/alerts/AlertTable.jsx
+++ b/ui/perfherder/alerts/AlertTable.jsx
@@ -307,7 +307,7 @@ export default class AlertTable extends React.Component {
                   {alertSummary.notes && (
                     <div className="bg-white px-3 py-4">
                       <TruncatedText
-                        color="info"
+                        color="darker-info"
                         title="Notes: "
                         maxLength={167}
                         text={alertSummary.notes}

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -7,6 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faStar as faStarSolid,
   faUser,
+  faCheck,
 } from '@fortawesome/free-solid-svg-icons';
 import { faStar as faStarRegular } from '@fortawesome/free-regular-svg-icons';
 
@@ -126,10 +127,14 @@ export default class AlertTableRow extends React.Component {
   renderAlertStatus = (alert, alertStatus, statusColor) => {
     return (
       <React.Fragment>
-        (<span className={statusColor}>{alertStatus}</span>
+        (
+        {statusColor === 'text-success' && (
+          <FontAwesomeIcon icon={faCheck} color="#28a745" />
+        )}{' '}
+        <span className={statusColor}>{alertStatus}</span>
         {alert.related_summary_id && this.getReassignment(alert)}
         {alert.backfill_record ? (
-          <span className="text-info">, important</span>
+          <span className="text-darker-info">, important</span>
         ) : null}
         )
       </React.Fragment>

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -100,7 +100,7 @@ export default class AlertTableRow extends React.Component {
         <a
           href={`#/alerts?id=${alertId}`}
           rel="noopener noreferrer"
-          className="text-info"
+          className="text-darker-info"
         >{`alert #${alertId}`}</a>
       </span>
     );

--- a/ui/perfherder/alerts/AlertsView.jsx
+++ b/ui/perfherder/alerts/AlertsView.jsx
@@ -273,7 +273,7 @@ class AlertsView extends React.Component {
                 {page > 1 && (
                   <PaginationItem>
                     <PaginationLink
-                      className="text-info"
+                      className="text-darker-info"
                       previous
                       onClick={() => this.navigatePage(page - 1)}
                     />
@@ -283,10 +283,10 @@ class AlertsView extends React.Component {
                   <PaginationItem
                     key={num}
                     active={num === page}
-                    className="text-info pagination-active"
+                    className="text-darker-info pagination-active"
                   >
                     <PaginationLink
-                      className="text-info"
+                      className="text-darker-info"
                       onClick={() => this.navigatePage(num)}
                     >
                       {num}
@@ -296,7 +296,7 @@ class AlertsView extends React.Component {
                 {page < count && (
                   <PaginationItem>
                     <PaginationLink
-                      className="text-info"
+                      className="text-darker-info"
                       next
                       onClick={() => this.navigatePage(page + 1)}
                     />

--- a/ui/perfherder/alerts/Assignee.jsx
+++ b/ui/perfherder/alerts/Assignee.jsx
@@ -100,7 +100,7 @@ export default class Assignee extends React.Component {
       <React.Fragment>
         <Button
           className="ml-1"
-          color="outline-info"
+          color="darker-secondary"
           size="xs"
           onClick={this.goToEditMode}
           title="Click to change assignee"
@@ -110,6 +110,7 @@ export default class Assignee extends React.Component {
         {!assigneeUsername && (
           <Button
             className="ml-1"
+            color="darker-secondary"
             size="xs"
             disabled={!user.isStaff}
             onClick={this.prefillWithLoggedInUsername}

--- a/ui/perfherder/alerts/StatusDropdown.jsx
+++ b/ui/perfherder/alerts/StatusDropdown.jsx
@@ -192,11 +192,7 @@ export default class StatusDropdown extends React.Component {
           updateAndClose={this.updateAndClose}
         />
         <UncontrolledDropdown tag="span">
-          <DropdownToggle
-            className="btn-link text-info p-0"
-            color="transparent"
-            caret
-          >
+          <DropdownToggle className="btn-xs" color="darker-secondary" caret>
             {getStatus(alertSummary.status)}
           </DropdownToggle>
           <DropdownMenu>

--- a/ui/perfherder/compare/CompareSelectorView.jsx
+++ b/ui/perfherder/compare/CompareSelectorView.jsx
@@ -165,7 +165,7 @@ export default class CompareSelectorView extends React.Component {
                     />
                   </ButtonDropdown>
                   <Button
-                    color="info"
+                    color="darker-info"
                     onClick={
                       newRevision !== '' && disableButton
                         ? null

--- a/ui/perfherder/graphs/GraphTooltip.jsx
+++ b/ui/perfherder/graphs/GraphTooltip.jsx
@@ -255,7 +255,12 @@ const GraphTooltip = ({
             {!dataPointDetails.alertSummary && prevPushId && (
               <p className="pt-2">
                 {user.isStaff ? (
-                  <Button color="info" outline size="sm" onClick={createAlert}>
+                  <Button
+                    color="darker-info"
+                    outline
+                    size="sm"
+                    onClick={createAlert}
+                  >
                     create alert
                   </Button>
                 ) : (

--- a/ui/perfherder/graphs/GraphsViewControls.jsx
+++ b/ui/perfherder/graphs/GraphsViewControls.jsx
@@ -76,7 +76,7 @@ export default class GraphsViewControls extends React.Component {
             </UncontrolledDropdown>
           </Col>
           <Col sm="auto" className="p-2">
-            <Button color="info" onClick={toggle}>
+            <Button color="darker-info" onClick={toggle}>
               Add test data
             </Button>
           </Col>
@@ -118,7 +118,7 @@ export default class GraphsViewControls extends React.Component {
                 ))}
               <Col sm="auto" className="pl-0">
                 <Button
-                  color="info"
+                  color="darker-info"
                   outline
                   onClick={() =>
                     updateStateParams({ highlightAlerts: !highlightAlerts })

--- a/ui/perfherder/graphs/TestDataModal.jsx
+++ b/ui/perfherder/graphs/TestDataModal.jsx
@@ -427,7 +427,7 @@ export default class TestDataModal extends React.Component {
               {createDropdowns(modalOptions, 'p-2', true)}
               <Col sm="auto" className="p-2">
                 <Button
-                  color="info"
+                  color="darker-info"
                   outline
                   onClick={() =>
                     this.setState(
@@ -516,7 +516,7 @@ export default class TestDataModal extends React.Component {
             <Row className="p-2">
               <Col className="py-2 px-0 text-right">
                 <Button
-                  color="info"
+                  color="darker-info"
                   disabled={!selectedTests.length}
                   onClick={this.submitData}
                   onKeyPress={event => event.preventDefault()}


### PR DESCRIPTION
## Description of issue
Some color combinations does not pass the [WCAG contrast](https://developer.mozilla.org/pt-BR/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast?utm_source=devtools&utm_medium=a11y-panel-checks-color-contrast) recommendation.

Also, for color blindness distinction, texts with red and green should be accompanied by an icon.

## Strategy
Using _Firefox Accessibility Inspector_'s beta "Check for issues", I've checked for "**_Contrast_**" issues. That was done for each view and a different commit was made. Then, it was a manual color tweaking of each issue. 

Some colors became harder to distinguish because of the contrast rate.  That was seem mostly in blue and green colors. Maybe propose a **different color hue**?

## Testing
Those were mostly visual and using Accessibility and Inspector devtools tabs.