### PR TITLE
Bug 1593815 - Perfherder doesn't reload if you change the URL

### DIFF
--- a/ui/perfherder/compare/CompareTableView.jsx
+++ b/ui/perfherder/compare/CompareTableView.jsx
@@ -62,7 +62,7 @@ export default class CompareTableView extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.location.search !== prevProps.location.search) {
+    if (this.props.location.search !== prevProps.location.search || this.props.validated.newRevision !== prevProps.validated.newRevision) {
       this.getPerformanceData();
     }
   }

--- a/ui/perfherder/compare/CompareTableView.jsx
+++ b/ui/perfherder/compare/CompareTableView.jsx
@@ -62,10 +62,7 @@ export default class CompareTableView extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (
-      this.props.location.search !== prevProps.location.search ||
-      this.props.validated.newRevision !== prevProps.validated.newRevision
-    ) {
+    if (this.props.validated !== prevProps.validated) {
       this.getPerformanceData();
     }
   }

--- a/ui/perfherder/compare/CompareTableView.jsx
+++ b/ui/perfherder/compare/CompareTableView.jsx
@@ -62,7 +62,10 @@ export default class CompareTableView extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.location.search !== prevProps.location.search || this.props.validated.newRevision !== prevProps.validated.newRevision) {
+    if (
+      this.props.location.search !== prevProps.location.search ||
+      this.props.validated.newRevision !== prevProps.validated.newRevision
+    ) {
       this.getPerformanceData();
     }
   }


### PR DESCRIPTION
The following PR fixes [1593815](https://bugzilla.mozilla.org/show_bug.cgi?id=1593815).
change in `newRevision` updates the comparison without force refresh.

Can the same be done for other query parameters as well? 
