### PR TITLE
Manual ingestion improvements

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -141,7 +141,8 @@ Ingestion tasks populate the database with version control push logs, queued/run
 docker-compose run backend ./manage.py ingest push -p autoland -r 63f8a47cfdf5
 ```
 
-`NOTE`: In the future you will also be able to append `--ingest-all-tasks` to ingest all tasks.
+You can ingest all tasks for a push. Check the help output for the script to determine the
+parameters needed.
 
 ### Ingesting a range of pushes
 

--- a/treeherder/etl/management/commands/ingest.py
+++ b/treeherder/etl/management/commands/ingest.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 
 import aiohttp
+import requests
 import taskcluster
 import taskcluster.aio
 import taskcluster_urls as liburls
-import requests
 from django.conf import settings
 from django.core.management.base import BaseCommand
 

--- a/treeherder/etl/management/commands/ingest.py
+++ b/treeherder/etl/management/commands/ingest.py
@@ -127,7 +127,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--enable-eager-celery",
             action="store_true",
-            help="This will cause all Celery queues to excute (like log parsing). This will take way longer."
+            help="This will cause all Celery queues to execute (like log parsing). This will take way longer."
         )
         parser.add_argument(
             "-a", "--ingest-all-tasks",

--- a/treeherder/etl/management/commands/ingest.py
+++ b/treeherder/etl/management/commands/ingest.py
@@ -28,6 +28,7 @@ stateToExchange = {}
 for key, value in EXCHANGE_EVENT_MAP.items():
     stateToExchange[value] = key
 
+
 async def handleTaskId(taskId, root_url):
     asyncQueue = taskcluster.aio.Queue({"rootUrl": root_url}, session=session)
     results = await asyncio.gather(asyncQueue.status(taskId), asyncQueue.task(taskId))


### PR DESCRIPTION
…ko decision task

I noticed that we can ingest all tasks for a push without having to parse all logs by not
enabling eager celery consumption. If the user would like to do so it is still possible.

You can now also specify `--gecko-decision-task` to specify the Gecko decision task
associated to a push/revision. In the future we can determine this for the user but for
now we can just require it to be inputted manually.

A sample command:

```
./manage.py ingest push --project mozilla-central --revision fc3002cb85dc4d2c44d8aec1246f0356097411e3 --ingest-all-tasks --gecko-decision-task YiQiigCNQl63Hm21DjxXlA
```