### PR TITLE
Heroku Review Apps to default to the Firefox CI

### DIFF
--- a/app.json
+++ b/app.json
@@ -40,7 +40,7 @@
       "generator": "secret"
     },
     "PROJECTS_TO_INGEST": {
-      "value": "autoland,android-components"
+      "value": "autoland"
     },
     "TREEHERDER_DJANGO_SECRET_KEY": {
       "generator": "secret"

--- a/app.json
+++ b/app.json
@@ -32,6 +32,7 @@
     "HEROKU_APP_NAME": {
       "required": true
     },
+    "LOGGING_LEVEL": "INFO",
     "PULSE_URL": "amqp://treeherder-shared-pulse-user:mozilla123@pulse.mozilla.org:5671/?ssl=true",
     "PULSE_RESULSETS_QUEUE_NAME": {
       "generator": "secret"

--- a/app.json
+++ b/app.json
@@ -2,10 +2,10 @@
   "addons": [
     "scheduler",
     "cloudamqp:tiger",
-    "heroku-redis",
+    "heroku-redis:premium-0",
     "papertrail:choklad",
     {
-      "plan": "jawsdb:leopard",
+      "plan": "jawsdb:blacktip",
       "options": {
         "version": "5.7"
       }

--- a/treeherder/etl/management/commands/pulse_listener_pushes.py
+++ b/treeherder/etl/management/commands/pulse_listener_pushes.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
         # [{pulse_url: .., hgmo: true, root_url: ..}, ..]
         push_sources = env.json(
             "PULSE_PUSH_SOURCES",
-            default=[{"root_url": "https://taskcluster.net", "github": True, "hgmo": True, "pulse_url": env("PULSE_URL")}])
+            default=[{"root_url": "https://firefox-ci-tc.services.mozilla.com", "github": True, "hgmo": True, "pulse_url": env("PULSE_URL")}])
 
         consumers = prepare_consumers(
             PushConsumer,

--- a/treeherder/etl/management/commands/pulse_listener_tasks.py
+++ b/treeherder/etl/management/commands/pulse_listener_tasks.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         # root_url: ..}, ..]
         task_sources = env.json(
             "PULSE_TASK_SOURCES",
-            default=[{"root_url": "https://taskcluster.net", "pulse_url": env("PULSE_URL")}])
+            default=[{"root_url": "https://firefox-ci-tc.services.mozilla.com", "pulse_url": env("PULSE_URL")}])
 
         consumers = prepare_consumers(
             TaskConsumer,

--- a/treeherder/etl/tasks/pulse_tasks.py
+++ b/treeherder/etl/tasks/pulse_tasks.py
@@ -15,7 +15,7 @@ from treeherder.workers.task import retryable_task
 
 
 @retryable_task(name='store-pulse-tasks', max_retries=10)
-def store_pulse_tasks(pulse_job, exchange, routing_key, root_url='https://taskcluster.net'):
+def store_pulse_tasks(pulse_job, exchange, routing_key, root_url='https://firefox-ci-tc.services.mozilla.com'):
     """
     Fetches tasks from Taskcluster
     """
@@ -34,7 +34,7 @@ def store_pulse_tasks(pulse_job, exchange, routing_key, root_url='https://taskcl
 
 
 @retryable_task(name='store-pulse-pushes', max_retries=10)
-def store_pulse_pushes(body, exchange, routing_key, root_url='https://taskcluster.net'):
+def store_pulse_pushes(body, exchange, routing_key, root_url='https://firefox-ci-tc.services.mozilla.com'):
     """
     Fetches the pushes pending from pulse exchanges and loads them.
     """


### PR DESCRIPTION
…cluster instance

The Pulse sources are configured differently on Heroku Review Apps because `PULSE_PUSH_SOURCES`
and `PULSE_TASK_SOURCES` are defined as arrays rather than a string.

This is because `app.json` is a Json file and we cannot specify an array by mixing single & double
quotes.