### PR TITLE
Anchor-Dropdown fix for AlertHeader

### DIFF
--- a/ui/perfherder/alerts/AlertHeader.jsx
+++ b/ui/perfherder/alerts/AlertHeader.jsx
@@ -68,7 +68,8 @@ const AlertHeader = ({
               {alertSummary.revision.slice(0, 12)}
             </DropdownToggle>
             <DropdownMenu>
-              <a
+              <DropdownItem
+                tag="a"
                 className="text-dark"
                 href={getJobsUrl({
                   repo: alertSummary.repository,
@@ -78,9 +79,10 @@ const AlertHeader = ({
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <DropdownItem tag="a">Jobs</DropdownItem>
-              </a>
-              <a
+                Jobs
+              </DropdownItem>
+              <DropdownItem
+                tag="a"
                 className="text-dark"
                 href={repoModel.getPushLogRangeHref({
                   fromchange: alertSummary.prev_push_revision,
@@ -89,8 +91,8 @@ const AlertHeader = ({
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <DropdownItem tag="a">Pushlog</DropdownItem>
-              </a>
+                Pushlog
+              </DropdownItem>
             </DropdownMenu>
           </UncontrolledDropdown>
           <span>·</span>


### PR DESCRIPTION
## Description of issue
This PR fixes the following error:

![Screenshot of red alert React error - <a> cannot appear as a descendant of <a>](https://user-images.githubusercontent.com/3901809/72075764-25affc00-32d3-11ea-9522-9710f0ec6b2e.png)

## Proposed solution

Remove the additional `<a>` and keep only `<DropdownItem>`.

## Testing

Compared the visual appearance and functionality of the element to the production version.
