### PR TITLE
Bug 1608260 - Reduce noise in Push Health UI and add concise status

### DIFF
--- a/ui/push-health/ClassificationGroup.jsx
+++ b/ui/push-health/ClassificationGroup.jsx
@@ -96,7 +96,7 @@ class ClassificationGroup extends React.PureComponent {
           </Badge>
         </h4>
         <Collapse isOpen={detailsShowing} className="w-100">
-          {hasRetriggerAll && (
+          {hasRetriggerAll && Object.keys(group).length > 0 && (
             <ButtonGroup>
               <Button
                 title="Retrigger all 'Need Investigation' jobs once"

--- a/ui/push-health/JobListMetric.jsx
+++ b/ui/push-health/JobListMetric.jsx
@@ -6,11 +6,16 @@ import Job from './Job';
 
 export default class JobListMetric extends React.PureComponent {
   render() {
-    const { data, repo, revision } = this.props;
+    const { data, repo, revision, expanded, toggleExpanded } = this.props;
     const { name, result, details } = data;
 
     return (
-      <Metric name={name} result={result}>
+      <Metric
+        name={name}
+        result={result}
+        expanded={expanded}
+        toggleExpanded={toggleExpanded}
+      >
         <div>
           {details.length ? (
             details.map(job => (
@@ -36,4 +41,6 @@ JobListMetric.propTypes = {
   data: PropTypes.object.isRequired,
   repo: PropTypes.string.isRequired,
   revision: PropTypes.string.isRequired,
+  toggleExpanded: PropTypes.func.isRequired,
+  expanded: PropTypes.bool.isRequired,
 };

--- a/ui/push-health/Metric.jsx
+++ b/ui/push-health/Metric.jsx
@@ -1,75 +1,53 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  faPlusSquare,
-  faMinusSquare,
-} from '@fortawesome/free-regular-svg-icons';
+import { faMinusSquare } from '@fortawesome/free-regular-svg-icons';
 import { Button, Badge, Row, Col, Collapse, Card, CardBody } from 'reactstrap';
 
 import { resultColorMap } from './helpers';
 
 export default class Metric extends React.PureComponent {
-  constructor(props) {
-    super(props);
-
-    const { result } = this.props;
-
-    this.state = {
-      detailsShowing: !['pass', 'none'].includes(result),
-    };
-  }
-
-  toggleDetails = () => {
-    this.setState(prevState => ({ detailsShowing: !prevState.detailsShowing }));
-  };
-
   render() {
-    const { detailsShowing } = this.state;
-    const { result, name, children } = this.props;
+    const { result, name, expanded, children, toggleExpanded } = this.props;
     const resultColor = resultColorMap[result];
-    const expandIcon = detailsShowing ? faMinusSquare : faPlusSquare;
-    const expandTitle = detailsShowing
-      ? 'Click to collapse'
-      : 'Click to expand';
 
     return (
-      <td>
+      <Collapse isOpen={expanded} className="w-100 mt-2">
         <Row className="flex-nowrap">
-          <div className={`bg-${resultColor} pr-2 mr-2`} />
+          <Col className={`bg-${resultColor} pr-2 mr-2 flex-grow-0`} />
           <Col>
             <Row className="justify-content-between">
               <Button
-                onClick={this.toggleDetails}
+                onClick={() => toggleExpanded(name)}
                 outline
                 className="border-0"
-                aria-expanded={detailsShowing}
+                aria-expanded={expanded}
               >
                 <span className="metric-name align-top font-weight-bold">
                   {name}
                 </span>
+                <span>
+                  <Badge
+                    color={resultColor}
+                    className="ml-1 mt-1 align-middle text-uppercase"
+                  >
+                    {result}
+                  </Badge>
+                </span>
                 <span className="btn">
                   <FontAwesomeIcon
-                    icon={expandIcon}
-                    title={expandTitle}
-                    aria-label={expandTitle}
+                    icon={faMinusSquare}
+                    title="Click to collapse"
                   />
                 </span>
               </Button>
-              <span>
-                <Badge color={resultColor} className="ml-1 text-uppercase">
-                  {result}
-                </Badge>
-              </span>
             </Row>
-            <Collapse isOpen={detailsShowing}>
-              <Card>
-                <CardBody>{children}</CardBody>
-              </Card>
-            </Collapse>
+            <Card>
+              <CardBody>{children}</CardBody>
+            </Card>
           </Col>
         </Row>
-      </td>
+      </Collapse>
     );
   }
 }
@@ -78,4 +56,10 @@ Metric.propTypes = {
   result: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   children: PropTypes.object.isRequired,
+  toggleExpanded: PropTypes.func.isRequired,
+  expanded: PropTypes.bool,
+};
+
+Metric.defaultProps = {
+  expanded: true,
 };

--- a/ui/push-health/Navigation.jsx
+++ b/ui/push-health/Navigation.jsx
@@ -10,29 +10,40 @@ import { resultColorMap } from './helpers';
 
 export default class Navigation extends React.PureComponent {
   render() {
-    const { user, setUser, result, notify, repo, revision } = this.props;
+    const {
+      user,
+      setUser,
+      result,
+      notify,
+      repo,
+      revision,
+      children,
+    } = this.props;
     const overallResult = result ? resultColorMap[result] : 'none';
 
     return (
-      <Navbar dark color="dark">
-        <LogoMenu menuText="Push Health" />
-        <h4>
-          <Badge color={overallResult}>
-            <a
-              href={getJobsUrl({ repo, revision })}
-              className="text-white"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span title="repository">{repo}</span> -
-              <span title="revision" className="ml-1">
-                {revision}
-              </span>
-            </a>
-          </Badge>
-        </h4>
-        <Login user={user} setUser={setUser} notify={notify} />
-      </Navbar>
+      <React.Fragment>
+        <Navbar dark color="dark" sticky="top">
+          <LogoMenu menuText="Push Health" />
+          <h4>
+            <Badge color={overallResult}>
+              <a
+                href={getJobsUrl({ repo, revision })}
+                className="text-white"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span title="repository">{repo}</span> -
+                <span title="revision" className="ml-1">
+                  {revision}
+                </span>
+              </a>
+            </Badge>
+          </h4>
+          <Login user={user} setUser={setUser} notify={notify} />
+        </Navbar>
+        {children}
+      </React.Fragment>
     );
   }
 }
@@ -44,8 +55,10 @@ Navigation.propTypes = {
   revision: PropTypes.string.isRequired,
   notify: PropTypes.func.isRequired,
   result: PropTypes.string,
+  children: PropTypes.object,
 };
 
 Navigation.defaultProps = {
   result: '',
+  children: null,
 };

--- a/ui/push-health/TestMetric.jsx
+++ b/ui/push-health/TestMetric.jsx
@@ -7,13 +7,27 @@ import Metric from './Metric';
 
 export default class TestMetric extends React.PureComponent {
   render() {
-    const { data, repo, revision, user, notify, currentRepo } = this.props;
+    const {
+      data,
+      repo,
+      revision,
+      user,
+      notify,
+      currentRepo,
+      expanded,
+      toggleExpanded,
+    } = this.props;
     const { name, result, details } = data;
     const { needInvestigation, intermittent, unsupported } = details;
     const needInvestigationLength = Object.keys(needInvestigation).length;
 
     return (
-      <Metric name={name} result={result}>
+      <Metric
+        name={name}
+        result={result}
+        expanded={expanded}
+        toggleExpanded={toggleExpanded}
+      >
         <div className="border-bottom border-secondary">
           <ClassificationGroup
             group={needInvestigation}
@@ -60,4 +74,6 @@ TestMetric.propTypes = {
   currentRepo: PropTypes.object.isRequired,
   revision: PropTypes.string.isRequired,
   notify: PropTypes.func.isRequired,
+  toggleExpanded: PropTypes.func.isRequired,
+  expanded: PropTypes.bool.isRequired,
 };

--- a/ui/push-health/helpers.js
+++ b/ui/push-health/helpers.js
@@ -3,5 +3,6 @@ export const resultColorMap = {
   pass: 'success',
   fail: 'danger',
   indeterminate: 'warning',
-  none: 'default',
+  done: 'info',
+  'in progress': 'secondary',
 };


### PR DESCRIPTION
This adds a navigation bar to the top of the screen to get a quick status of each metric.  They're click-able to show/hide each as well.

Also, when a metric is hidden, it hides it all the way.  Before, it would leave the header present.  The top row negates the usefulness of this header on each metric when hidden.

Before:
![Screenshot 2020-01-09 13 08 55](https://user-images.githubusercontent.com/419924/72104881-38313200-32e1-11ea-9a35-0b677348d94c.png)



After:
![Screenshot 2020-01-09 13 05 00](https://user-images.githubusercontent.com/419924/72104738-eee0e280-32e0-11ea-9cfe-458e732456c0.png)
