### PR TITLE
[WIP] Fetch the CI changelog and display it in the perfherder timeline

### DIFF
--- a/ui/perfherder/constants.js
+++ b/ui/perfherder/constants.js
@@ -5,6 +5,7 @@ export const tValueConfidence = 5; // Anything above this is "high" in confidenc
 export const endpoints = {
   alert: '/performance/alert/',
   alertSummary: '/performance/alertsummary/',
+  changelog: '/changelog/',
   frameworks: '/performance/framework/',
   issueTrackers: '/performance/issue-tracker/',
   summary: '/performance/summary/',

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Row, Col } from 'reactstrap';
 import PropTypes from 'prop-types';
 import {
+  VictoryBar,
   VictoryChart,
   VictoryLine,
   VictoryAxis,
@@ -267,7 +268,13 @@ class GraphsContainer extends React.Component {
   };
 
   render() {
-    const { testData, showTable, zoom, highlightedRevisions } = this.props;
+    const {
+      testData,
+      changelogData,
+      showTable,
+      zoom,
+      highlightedRevisions,
+    } = this.props;
     const {
       highlights,
       scatterPlotData,
@@ -406,16 +413,25 @@ class GraphsContainer extends React.Component {
                     },
                   ]}
                 >
-                  {highlights.length > 0 &&
-                    highlights.map(item => (
-                      <VictoryLine
-                        key={item}
-                        style={{
-                          data: { stroke: 'gray', strokeWidth: 1 },
-                        }}
-                        x={() => item.x}
-                      />
-                    ))}
+                  {highlights.length > 0 && (
+                    <VictoryAxis
+                      tickValues={highlights.map(i => i.x)}
+                      style={{
+                        tickLabels: { display: 'none' },
+                        grid: { stroke: 'gray', strokeWidth: 1 },
+                      }}
+                    />
+                  )}
+
+                  {changelogData.length > 0 && (
+                    <VictoryAxis
+                      tickValues={changelogData.map(i => i.date)}
+                      style={{
+                        tickLabels: { display: 'none' },
+                        grid: { stroke: '#ff0000', strokeWidth: 1 },
+                      }}
+                    />
+                  )}
 
                   <VictoryScatter
                     name="scatter-plot"
@@ -500,6 +516,7 @@ class GraphsContainer extends React.Component {
 
 GraphsContainer.propTypes = {
   testData: PropTypes.arrayOf(PropTypes.shape({})),
+  changelogData: PropTypes.arrayOf(PropTypes.shape({})),
   measurementUnits: PropTypes.instanceOf(Set).isRequired,
   updateStateParams: PropTypes.func.isRequired,
   zoom: PropTypes.shape({}),
@@ -514,6 +531,7 @@ GraphsContainer.propTypes = {
 
 GraphsContainer.defaultProps = {
   testData: [],
+  changelogData: [],
   zoom: {},
   selectedDataPoint: undefined,
   highlightAlerts: true,

--- a/ui/perfherder/graphs/GraphsView.jsx
+++ b/ui/perfherder/graphs/GraphsView.jsx
@@ -39,6 +39,7 @@ class GraphsView extends React.Component {
       highlightAlerts: true,
       highlightedRevisions: ['', ''],
       testData: [],
+      changelogData: [],
       errorMessages: [],
       options: {},
       loading: false,
@@ -74,6 +75,8 @@ class GraphsView extends React.Component {
     } = queryString.parse(this.props.location.search);
 
     const updates = {};
+
+    this.getChangelogData();
 
     if (series) {
       const _series = typeof series === 'string' ? [series] : series;
@@ -164,6 +167,15 @@ class GraphsView extends React.Component {
         },
       );
     }
+  };
+
+  getChangelogData = async () => {
+    const rawData = await getData(createApiUrl(endpoints.changelog));
+    const changelogData = rawData.data.map(({ date, ...extra }) => ({
+      date: new Date(date),
+      ...extra,
+    }));
+    this.setState({ changelogData });
   };
 
   createGraphObject = async seriesData => {
@@ -312,6 +324,7 @@ class GraphsView extends React.Component {
     const {
       timeRange,
       testData,
+      changelogData,
       highlightAlerts,
       highlightedRevisions,
       selectedDataPoint,
@@ -394,6 +407,7 @@ class GraphsView extends React.Component {
                 options={options}
                 getTestData={this.getTestData}
                 testData={testData}
+                changelogData={changelogData}
                 showModal={showModal}
                 showTable={showTable}
                 highlightAlerts={highlightAlerts}

--- a/ui/perfherder/graphs/GraphsViewControls.jsx
+++ b/ui/perfherder/graphs/GraphsViewControls.jsx
@@ -170,6 +170,7 @@ GraphsViewControls.propTypes = {
     relatedSeries: PropTypes.shape({}),
   }),
   testData: PropTypes.arrayOf(PropTypes.shape({})),
+  changelogData: PropTypes.arrayOf(PropTypes.shape({})),
   showModal: PropTypes.bool,
   toggle: PropTypes.func.isRequired,
 };
@@ -177,5 +178,6 @@ GraphsViewControls.propTypes = {
 GraphsViewControls.defaultProps = {
   options: undefined,
   testData: [],
+  changelogData: [],
   showModal: false,
 };


### PR DESCRIPTION
This is a just a WIP demo at the moment, but I'm filing a PR for more visibility/discussion. This patch adds some red lines to the Perfherder graph to show when changes to our CI machines have occurred so that sheriffs have an easier time telling whether a change in perf numbers is due to a code change or a CI config change. Hovering over/clicking on the red lines will show a popup describing the change with links to the commit.

Note: this currently shows _every_ change from the CI changelog for testing, so there are a lot more red lines than we'd normally see. In a real version of this, we'd probably restrict it to only show actual deployments.