### PR TITLE
Bug 1602493 - Show Job Groups for test failures

### DIFF
--- a/treeherder/push_health/similar_jobs.py
+++ b/treeherder/push_health/similar_jobs.py
@@ -9,6 +9,7 @@ job_fields = [
     'machine_platform_id',
     'option_collection_hash',
     'job_type_id',
+    'job_group_id',
     'result',
     'state',
     'failure_classification_id',

--- a/treeherder/push_health/tests.py
+++ b/treeherder/push_health/tests.py
@@ -98,7 +98,7 @@ def get_current_test_failures(push, option_map):
         job_log__job__result='testfailed',
         job_log__job__tier__lte=2
     ).select_related(
-        'job_log__job__job_type', 'job_log__job__machine_platform'
+        'job_log__job__job_type', 'job_log__job__job_group', 'job_log__job__machine_platform'
     )
 
     # using a dict here to avoid duplicates due to multiple failure_lines for
@@ -114,9 +114,11 @@ def get_current_test_failures(push, option_map):
         platform = clean_platform(job.machine_platform.platform)
         job_name = job.job_type.name
         job_symbol = job.job_type.symbol
-        job.job_key = '{}{}{}'.format(config, platform, job_name)
+        job_group = job.job_group.name
+        job_group_symbol = job.job_group.symbol
+        job.job_key = '{}{}{}{}'.format(config, platform, job_name, job_group)
         all_failed_jobs[job.id] = job
-        test_key = re.sub(r'\W+', '', '{}{}{}{}'.format(test_name, config, platform, job_name))
+        test_key = re.sub(r'\W+', '', '{}{}{}{}{}'.format(test_name, config, platform, job_name, job_group))
 
         if test_key not in tests:
             line = {
@@ -124,6 +126,8 @@ def get_current_test_failures(push, option_map):
                 'action': failure_line.action.split('_')[0],
                 'jobName': job_name,
                 'jobSymbol': job_symbol,
+                'jobGroup': job_group,
+                'jobGroupSymbol': job_group_symbol,
                 'platform': platform,
                 'config': config,
                 'key': test_key,

--- a/ui/push-health/TestFailure.jsx
+++ b/ui/push-health/TestFailure.jsx
@@ -53,6 +53,8 @@ class TestFailure extends React.PureComponent {
       action,
       jobName,
       jobSymbol,
+      jobGroup,
+      jobGroupSymbol,
       inProgressJobs,
       failJobs,
       passJobs,
@@ -86,6 +88,12 @@ class TestFailure extends React.PureComponent {
               {platform} {config}:
             </span>
           )}
+          <span
+            className="mx-1 px-1 border border-secondary rounded"
+            title={jobGroup}
+          >
+            {jobGroupSymbol}
+          </span>
           {tier > 1 && (
             <span className="ml-1 small text-muted">[tier-{tier}]</span>
           )}


### PR DESCRIPTION
This just shows the Job Group that jobs belong to.  But it also now uses it to ensure we don't lump jobs from different groups together.  Here is what it will look like visually Note the ``M-1proc``:

![Screenshot 2020-01-15 12 39 58](https://user-images.githubusercontent.com/419924/72469545-7b354e80-3794-11ea-8bd4-9ee26d8975c4.png)
