### PR TITLE
Bug 1603269 - Alt. View for Intermittent Failures View for Screen Reader

### DIFF
--- a/ui/css/intermittent-failures.css
+++ b/ui/css/intermittent-failures.css
@@ -42,47 +42,8 @@ h1,
   margin: 0 auto;
 }
 
-.alternate-table .rt-th {
-  font-weight: bold;
-  font-size: 1.2rem;
-}
-
-/* Failures Count per Push Table */
-.failure-per-count .rt-th:last-child {
-  background-color: rgb(221, 102, 2, 0.8);
-}
-
-.failure-per-count .rt-tr .rt-td:last-child {
-  background-color: rgba(221, 102, 2, 0.3);
-}
-
-.failure-per-count .rt-tr.-odd .rt-td:last-child {
-  background-color: rgba(221, 102, 2, 0.5);
-}
-
-/* Failure Count vs Push Count Table */
-.failure-and-count .rt-th:nth-child(2) {
-  background-color: rgba(109, 172, 238, 0.8);
-}
-
-.failure-and-count .rt-th:last-child {
-  background-color: rgba(48, 179, 38, 0.8);
-}
-
-.failure-and-count .rt-tr .rt-td:nth-child(2) {
-  background-color: rgba(109, 172, 238, 0.3);
-}
-
-.failure-and-count .rt-tr.-odd .rt-td:nth-child(2) {
-  background-color: rgba(109, 172, 238, 0.5);
-}
-
-.failure-and-count .rt-tr .rt-td:last-child {
-  background-color: rgba(48, 179, 37, 0.3);
-}
-
-.failure-and-count .rt-tr.-odd .rt-td:last-child {
-  background-color: rgba(48, 179, 38, 0.5);
+.alternate-table .ReactTable.-striped .rt-tr.-odd {
+  background-color: rgba(221, 102, 2, 0.2);
 }
 
 /* overriding bootstrap default input style */

--- a/ui/css/intermittent-failures.css
+++ b/ui/css/intermittent-failures.css
@@ -72,6 +72,17 @@ ul {
   text-align: left;
 }
 
+.alternate-table {
+  max-width: 660px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+/* ReactTable style */
+.ReactTable .-pagination .-btn:focus {
+  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5);
+}
+
 /* overriding react-dates default input and button style */
 input.DateInput_input {
   font-size: 1rem;

--- a/ui/css/intermittent-failures.css
+++ b/ui/css/intermittent-failures.css
@@ -35,6 +35,56 @@ h1,
   display: initial;
 }
 
+/* Graph Alternate View - Table */
+.alternate-table {
+  max-width: 660px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.alternate-table .rt-th {
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+
+/* Failures Count per Push Table */
+.failure-per-count .rt-th:last-child {
+  background-color: rgb(221, 102, 2, 0.8);
+}
+
+.failure-per-count .rt-tr .rt-td:last-child {
+  background-color: rgba(221, 102, 2, 0.3);
+}
+
+.failure-per-count .rt-tr.-odd .rt-td:last-child {
+  background-color: rgba(221, 102, 2, 0.5);
+}
+
+/* Failure Count vs Push Count Table */
+.failure-and-count .rt-th:nth-child(2) {
+  background-color: rgba(109, 172, 238, 0.8);
+}
+
+.failure-and-count .rt-th:last-child {
+  background-color: rgba(48, 179, 38, 0.8);
+}
+
+.failure-and-count .rt-tr .rt-td:nth-child(2) {
+  background-color: rgba(109, 172, 238, 0.3);
+}
+
+.failure-and-count .rt-tr.-odd .rt-td:nth-child(2) {
+  background-color: rgba(109, 172, 238, 0.5);
+}
+
+.failure-and-count .rt-tr .rt-td:last-child {
+  background-color: rgba(48, 179, 37, 0.3);
+}
+
+.failure-and-count .rt-tr.-odd .rt-td:last-child {
+  background-color: rgba(48, 179, 38, 0.5);
+}
+
 /* overriding bootstrap default input style */
 input {
   padding: 0.4em 1em;
@@ -70,12 +120,6 @@ ul {
   max-width: 1000px;
   list-style-type: none;
   text-align: left;
-}
-
-.alternate-table {
-  max-width: 660px;
-  width: 100%;
-  margin: 0 auto;
 }
 
 /* ReactTable style */

--- a/ui/intermittent-failures/GraphAlternateView.jsx
+++ b/ui/intermittent-failures/GraphAlternateView.jsx
@@ -3,7 +3,7 @@ import ReactTable from 'react-table';
 import PropTypes from 'prop-types';
 
 const GraphAlternateView = ({ className, graphData, colNum, title }) => {
-  const columnsOne = [
+  const columnsTwo = [
     {
       Header: 'Date',
       accessor: 'date',
@@ -14,7 +14,7 @@ const GraphAlternateView = ({ className, graphData, colNum, title }) => {
     },
   ];
 
-  const columnsTwo = [
+  const columnsThree = [
     {
       Header: 'Date',
       accessor: 'date',
@@ -34,12 +34,12 @@ const GraphAlternateView = ({ className, graphData, colNum, title }) => {
     data: [],
   };
 
-  graphData.forEach(item => {
+  graphData.forEach(graphItem => {
     if (colNum === 1) {
-      alternateGraph.column = columnsOne;
+      alternateGraph.column = columnsTwo;
 
-      item.data.forEach(itemOne => {
-        const { date, failurePerPush } = itemOne;
+      graphItem.data.forEach(item => {
+        const { date, failurePerPush } = item;
 
         alternateGraph.data.push({
           date,
@@ -47,14 +47,13 @@ const GraphAlternateView = ({ className, graphData, colNum, title }) => {
         });
       });
     } else {
-      alternateGraph.column = columnsTwo;
+      alternateGraph.column = columnsThree;
 
-      item.data.forEach((itemTwo, indexTwo) => {
-        const { date, failureCount, pushCount } = itemTwo;
-
-        alternateGraph.data[indexTwo] = {
+      graphItem.data.forEach((item, index) => {
+        const { date, failureCount, pushCount } = item;
+        alternateGraph.data[index] = {
           date,
-          ...alternateGraph.data[indexTwo],
+          ...alternateGraph.data[index],
           ...(failureCount && { failureCount }),
           ...(pushCount && { pushCount }),
         };
@@ -85,5 +84,5 @@ GraphAlternateView.propTypes = {
 };
 
 GraphAlternateView.defaultProps = {
-  colNum: 1,
+  colNum: 2,
 };

--- a/ui/intermittent-failures/GraphAlternateView.jsx
+++ b/ui/intermittent-failures/GraphAlternateView.jsx
@@ -64,7 +64,7 @@ const GraphAlternateView = ({ className, graphData, colNum, title }) => {
 
   return (
     <div className="alternate-table mb-3">
-      <h3>{title}</h3>
+      <p className="subheader mb-3">{title}</p>
       <ReactTable
         data={alternateGraph.data}
         showPageSizeOptions

--- a/ui/intermittent-failures/GraphAlternateView.jsx
+++ b/ui/intermittent-failures/GraphAlternateView.jsx
@@ -1,0 +1,87 @@
+/* eslint-disable array-callback-return */
+
+import React from 'react';
+import ReactTable from 'react-table';
+
+const GraphAlternateView = ({ graphData, colNum }) => {
+  const columnsOne = [
+    {
+      Header: 'Date',
+      accessor: 'x',
+    },
+    {
+      Header: 'Failure Count per Push',
+      accessor: 'y',
+    },
+  ];
+
+  const columnsTwo = [
+    {
+      Header: 'Date',
+      accessor: 'x',
+    },
+    {
+      Header: 'Failure Count',
+      accessor: 'y',
+    },
+    {
+      Header: 'Push Count',
+      accessor: 'z',
+    },
+  ];
+
+  const alternateGraph = {
+    column: [],
+    data: [],
+  };
+
+  const convertDateToString = date =>
+    date.toLocaleDateString('en-US', {
+      day: 'numeric',
+      month: 'short',
+    });
+
+  graphData.map((item, index) => {
+    if (colNum === 1) {
+      item.data.map(itemOne => {
+        alternateGraph.column = columnsOne;
+
+        const dataPoint = {};
+
+        dataPoint.x = convertDateToString(itemOne.x);
+        dataPoint.y = itemOne.y.toFixed(2);
+
+        alternateGraph.data.push(dataPoint);
+      });
+    } else {
+      alternateGraph.column = columnsTwo;
+
+      item.data.map((itemTwo, indexTwo) => {
+        const dataPoint = {};
+
+        if (index > 0) {
+          alternateGraph.data[indexTwo].z = itemTwo.y;
+        } else {
+          dataPoint.x = convertDateToString(itemTwo.x);
+          dataPoint.y = itemTwo.y;
+
+          alternateGraph.data.push(dataPoint);
+        }
+      });
+    }
+  });
+
+  return (
+    <ReactTable
+      data={alternateGraph.data}
+      showPageSizeOptions
+      columns={alternateGraph.column}
+      className="-striped mb-5 alternate-table"
+      getTableProps={() => ({ role: 'table' })}
+      showPaginationTop
+      defaultPageSize={10}
+    />
+  );
+};
+
+export default GraphAlternateView;

--- a/ui/intermittent-failures/GraphAlternateView.jsx
+++ b/ui/intermittent-failures/GraphAlternateView.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactTable from 'react-table';
 import PropTypes from 'prop-types';
+import { zipWith } from 'lodash';
 
 const GraphAlternateView = ({ className, graphData, colNum, title }) => {
   const columnsTwo = [
@@ -39,20 +40,20 @@ const GraphAlternateView = ({ className, graphData, colNum, title }) => {
     alternateGraph.data = graphData[0].data;
   } else {
     alternateGraph.column = columnsThree;
-    // iterate between different types of data
-    graphData.forEach(graphItem => {
-      // iterate each data point
-      graphItem.data.forEach((item, index) => {
-        const { date, failureCount, pushCount } = item;
-        // populate array with data points, with combined properties
-        alternateGraph.data[index] = {
+    // create new array with objects with combined properties
+    alternateGraph.data = zipWith(
+      graphData[0].data,
+      graphData[1].data,
+      (a, b) => {
+        const { date, failureCount } = a;
+        const { pushCount } = b;
+        return {
           date,
-          ...alternateGraph.data[index],
-          ...(failureCount && { failureCount }),
-          ...(pushCount && { pushCount }),
+          failureCount,
+          pushCount,
         };
-      });
-    });
+      },
+    );
   }
 
   return (

--- a/ui/intermittent-failures/GraphAlternateView.jsx
+++ b/ui/intermittent-failures/GraphAlternateView.jsx
@@ -1,32 +1,31 @@
-/* eslint-disable array-callback-return */
-
 import React from 'react';
 import ReactTable from 'react-table';
+import PropTypes from 'prop-types';
 
 const GraphAlternateView = ({ graphData, colNum }) => {
   const columnsOne = [
     {
       Header: 'Date',
-      accessor: 'x',
+      accessor: 'date',
     },
     {
       Header: 'Failure Count per Push',
-      accessor: 'y',
+      accessor: 'failurePerPush',
     },
   ];
 
   const columnsTwo = [
     {
       Header: 'Date',
-      accessor: 'x',
+      accessor: 'date',
     },
     {
       Header: 'Failure Count',
-      accessor: 'y',
+      accessor: 'failureCount',
     },
     {
       Header: 'Push Count',
-      accessor: 'z',
+      accessor: 'pushCount',
     },
   ];
 
@@ -35,38 +34,30 @@ const GraphAlternateView = ({ graphData, colNum }) => {
     data: [],
   };
 
-  const convertDateToString = date =>
-    date.toLocaleDateString('en-US', {
-      day: 'numeric',
-      month: 'short',
-    });
-
-  graphData.map((item, index) => {
+  graphData.forEach(item => {
     if (colNum === 1) {
-      item.data.map(itemOne => {
-        alternateGraph.column = columnsOne;
+      alternateGraph.column = columnsOne;
 
-        const dataPoint = {};
+      item.data.forEach(itemOne => {
+        const { date, failurePerPush } = itemOne;
 
-        dataPoint.x = convertDateToString(itemOne.x);
-        dataPoint.y = itemOne.y.toFixed(2);
-
-        alternateGraph.data.push(dataPoint);
+        alternateGraph.data.push({
+          date,
+          failurePerPush,
+        });
       });
     } else {
       alternateGraph.column = columnsTwo;
 
-      item.data.map((itemTwo, indexTwo) => {
-        const dataPoint = {};
+      item.data.forEach((itemTwo, indexTwo) => {
+        const { date, failureCount, pushCount } = itemTwo;
 
-        if (index > 0) {
-          alternateGraph.data[indexTwo].z = itemTwo.y;
-        } else {
-          dataPoint.x = convertDateToString(itemTwo.x);
-          dataPoint.y = itemTwo.y;
-
-          alternateGraph.data.push(dataPoint);
-        }
+        alternateGraph.data[indexTwo] = {
+          date,
+          ...alternateGraph.data[indexTwo],
+          ...(failureCount && { failureCount }),
+          ...(pushCount && { pushCount }),
+        };
       });
     }
   });
@@ -85,3 +76,11 @@ const GraphAlternateView = ({ graphData, colNum }) => {
 };
 
 export default GraphAlternateView;
+
+GraphAlternateView.propTypes = {
+  colNum: PropTypes.number,
+};
+
+GraphAlternateView.defaultProps = {
+  colNum: 1,
+};

--- a/ui/intermittent-failures/GraphAlternateView.jsx
+++ b/ui/intermittent-failures/GraphAlternateView.jsx
@@ -34,23 +34,17 @@ const GraphAlternateView = ({ className, graphData, colNum, title }) => {
     data: [],
   };
 
-  graphData.forEach(graphItem => {
-    if (colNum === 1) {
-      alternateGraph.column = columnsTwo;
-
-      graphItem.data.forEach(item => {
-        const { date, failurePerPush } = item;
-
-        alternateGraph.data.push({
-          date,
-          failurePerPush,
-        });
-      });
-    } else {
-      alternateGraph.column = columnsThree;
-
+  if (colNum === 1) {
+    alternateGraph.column = columnsTwo;
+    alternateGraph.data = graphData[0].data;
+  } else {
+    alternateGraph.column = columnsThree;
+    // iterate between different types of data
+    graphData.forEach(graphItem => {
+      // iterate each data point
       graphItem.data.forEach((item, index) => {
         const { date, failureCount, pushCount } = item;
+        // populate array with data points, with combined properties
         alternateGraph.data[index] = {
           date,
           ...alternateGraph.data[index],
@@ -58,8 +52,8 @@ const GraphAlternateView = ({ className, graphData, colNum, title }) => {
           ...(pushCount && { pushCount }),
         };
       });
-    }
-  });
+    });
+  }
 
   return (
     <div className="alternate-table mb-3">

--- a/ui/intermittent-failures/GraphAlternateView.jsx
+++ b/ui/intermittent-failures/GraphAlternateView.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactTable from 'react-table';
 import PropTypes from 'prop-types';
 
-const GraphAlternateView = ({ graphData, colNum }) => {
+const GraphAlternateView = ({ className, graphData, colNum, title }) => {
   const columnsOne = [
     {
       Header: 'Date',
@@ -63,15 +63,18 @@ const GraphAlternateView = ({ graphData, colNum }) => {
   });
 
   return (
-    <ReactTable
-      data={alternateGraph.data}
-      showPageSizeOptions
-      columns={alternateGraph.column}
-      className="-striped mb-5 alternate-table"
-      getTableProps={() => ({ role: 'table' })}
-      showPaginationTop
-      defaultPageSize={10}
-    />
+    <div className="alternate-table mb-3">
+      <h3>{title}</h3>
+      <ReactTable
+        data={alternateGraph.data}
+        showPageSizeOptions
+        columns={alternateGraph.column}
+        className={`${className} -striped mb-5`}
+        getTableProps={() => ({ role: 'table' })}
+        showPaginationTop
+        defaultPageSize={10}
+      />
+    </div>
   );
 };
 

--- a/ui/intermittent-failures/GraphsContainer.jsx
+++ b/ui/intermittent-failures/GraphsContainer.jsx
@@ -3,12 +3,14 @@ import { Row, Button, Col } from 'reactstrap';
 import PropTypes from 'prop-types';
 
 import Graph from './Graph';
+import GraphAlternateView from './GraphAlternateView';
 
 export default class GraphsContainer extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       showGraphTwo: false,
+      showAlternateView: false,
     };
   }
 
@@ -16,28 +18,43 @@ export default class GraphsContainer extends React.Component {
     this.setState(prevState => ({ showGraphTwo: !prevState.showGraphTwo }));
   };
 
+  toggleAltViewGraph = () => {
+    this.setState(prevState => ({
+      showAlternateView: !prevState.showAlternateView,
+    }));
+  };
+
   render() {
     const { graphOneData, graphTwoData, children } = this.props;
-    const { showGraphTwo } = this.state;
+    const { showGraphTwo, showAlternateView } = this.state;
 
     return (
       <React.Fragment>
         <Row className="pt-5">
-          <Graph graphData={graphOneData} title="Failure Count per Push" />
+          {showAlternateView ? (
+            <GraphAlternateView graphData={graphOneData} colNum={1} />
+          ) : (
+            <Graph graphData={graphOneData} title="Failure Count per Push" />
+          )}
         </Row>
         <Row>
           <Col xs="12" className="mx-auto pb-5">
+            <Button onClick={this.toggleAltViewGraph} className="mr-3">
+              {showAlternateView ? 'Show graph view' : 'Show table view'}
+            </Button>
             <Button
               color="secondary"
               onClick={this.toggleGraph}
               className="d-inline-block mr-3"
             >
-              {`${showGraphTwo ? 'less' : 'more'} graphs`}
+              {`${showGraphTwo ? 'less' : 'more'} ${
+                showAlternateView ? 'tables' : 'graphs'
+              }`}
             </Button>
             {children}
           </Col>
         </Row>
-        {showGraphTwo && (
+        {showGraphTwo && !showAlternateView && (
           <Row className="pt-5">
             <Graph
               graphData={graphTwoData}
@@ -54,6 +71,9 @@ export default class GraphsContainer extends React.Component {
               ]}
             />
           </Row>
+        )}
+        {showGraphTwo && showAlternateView && (
+          <GraphAlternateView graphData={graphTwoData} colNum={2} />
         )}
       </React.Fragment>
     );

--- a/ui/intermittent-failures/GraphsContainer.jsx
+++ b/ui/intermittent-failures/GraphsContainer.jsx
@@ -32,7 +32,11 @@ export default class GraphsContainer extends React.Component {
       <React.Fragment>
         <Row className="pt-5">
           {showAlternateView ? (
-            <GraphAlternateView graphData={graphOneData} />
+            <GraphAlternateView
+              graphData={graphOneData}
+              className="failure-per-count"
+              title="Failure Count Per Push"
+            />
           ) : (
             <Graph graphData={graphOneData} title="Failure Count per Push" />
           )}
@@ -73,7 +77,12 @@ export default class GraphsContainer extends React.Component {
           </Row>
         )}
         {showGraphTwo && showAlternateView && (
-          <GraphAlternateView graphData={graphTwoData} colNum={2} />
+          <GraphAlternateView
+            graphData={graphTwoData}
+            className="failure-and-count"
+            colNum={2}
+            title="Failure Count vs Push Count"
+          />
         )}
       </React.Fragment>
     );

--- a/ui/intermittent-failures/GraphsContainer.jsx
+++ b/ui/intermittent-failures/GraphsContainer.jsx
@@ -32,7 +32,7 @@ export default class GraphsContainer extends React.Component {
       <React.Fragment>
         <Row className="pt-5">
           {showAlternateView ? (
-            <GraphAlternateView graphData={graphOneData} colNum={1} />
+            <GraphAlternateView graphData={graphOneData} />
           ) : (
             <Graph graphData={graphOneData} title="Failure Count per Push" />
           )}

--- a/ui/intermittent-failures/GraphsContainer.jsx
+++ b/ui/intermittent-failures/GraphsContainer.jsx
@@ -35,6 +35,7 @@ export default class GraphsContainer extends React.Component {
             <GraphAlternateView
               graphData={graphOneData}
               className="failure-per-count"
+              colNum={1}
               title="Failure Count Per Push"
             />
           ) : (
@@ -80,7 +81,6 @@ export default class GraphsContainer extends React.Component {
           <GraphAlternateView
             graphData={graphTwoData}
             className="failure-and-count"
-            colNum={2}
             title="Failure Count vs Push Count"
           />
         )}

--- a/ui/intermittent-failures/helpers.js
+++ b/ui/intermittent-failures/helpers.js
@@ -46,13 +46,29 @@ export const calculateMetrics = function calculateMetricsForGraphs(data) {
     const failures = data[i].failure_count;
     const testRuns = data[i].test_runs;
     const freq = testRuns < 1 || failures < 1 ? 0 : failures / testRuns;
-    const date = moment(data[i].date).toDate();
+    const date = moment(data[i].date).format('MMM DD');
+    const dateObj = moment(data[i].date).toDate();
 
     totalFailures += failures;
     totalRuns += testRuns;
-    dateCounts.data.push({ x: date, y: failures });
-    dateTestRunCounts.data.push({ x: date, y: testRuns });
-    dateFreqs.data.push({ x: date, y: freq });
+    dateCounts.data.push({
+      date,
+      failureCount: failures,
+      x: dateObj,
+      y: failures,
+    });
+    dateTestRunCounts.data.push({
+      date,
+      pushCount: testRuns,
+      x: dateObj,
+      y: testRuns,
+    });
+    dateFreqs.data.push({
+      date,
+      failurePerPush: freq.toFixed(2),
+      x: dateObj,
+      y: freq,
+    });
   }
 
   return {


### PR DESCRIPTION
## Description of issue
It is noted that the Graph in Intermittent Failures View is not accessible via Screen Reader. There are two tables:
- Failures Count per Push
- Failures Count vs Push Count

## Proposed Solution
As discussed, we decided to try on an alternate view as a table. The user can change the view from Graph to Table, via a toggle button. 

![Screenshot of Intermittent Failures view, showing its main screen, with two tables, one above the other.](https://user-images.githubusercontent.com/3901809/72580011-81711b00-38b9-11ea-822a-add1f94a8e85.png)

## Testing
NVDA navigation to test if the table was SR accessible. Also compared with the graph and console log of data, to check if data in the table was being mirrored.
