### PR TITLE
Bug 1610242 -  Logo Menu dropdown is hidden by the second navbar in push-health page

### DIFF
--- a/ui/push-health/Health.jsx
+++ b/ui/push-health/Health.jsx
@@ -149,7 +149,7 @@ export default class Health extends React.PureComponent {
           repo={repo}
           revision={revision}
         >
-          <Navbar color="light" light expand="sm" sticky="top">
+          <Navbar color="light" light expand="sm">
             {!!tests && (
               <Nav className="metric-buttons mb-3 pt-2 pl-3">
                 {[progress, linting, builds, tests, performance].map(metric => (


### PR DESCRIPTION
The Logo Menu Navbar menu on the push-health page remains on the top and the dropdown menu is not hidden behind the second nav bar