### PR TITLE
Bug 1609975 - SETA to be enabled for Try

### DIFF
--- a/treeherder/seta/settings.py
+++ b/treeherder/seta/settings.py
@@ -1,7 +1,7 @@
 # repos that SETA supports
 SETA_PROJECTS = [
-    'mozilla-inbound',
-    'autoland'
+    'autoland',
+    'try'
 ]
 
 # for taskcluster, only jobs that start with any of these names


### PR DESCRIPTION
Currently SETA is restricted to only accept API calls for autoland and mozilla-inbound:
https://github.com/mozilla/treeherder/blob/ffaa2e4b2af200d3ae91e3e6ecdc2d4e4f093e84/treeherder/seta/settings.py#L2

To keep our options open with smart scheduling experiments and solutions, we should expand that list to have 'Try'. While we are at it remove 'mozilla-inbound'.