### PR TITLE
Bug 1610705 - Add filtering by Test path

### DIFF
--- a/tests/ui/mock/push_health.json
+++ b/tests/ui/mock/push_health.json
@@ -1,252 +1,3025 @@
 {
-  "revision": "a910c2e5d29d9b91b738330842f9d24ff74acfb9",
-  "id": 556229,
+  "revision": "cd02b96bdce57d9ae53b632ca4740c871d3ecc32",
+  "id": 630837,
   "result": "fail",
-  "metrics": [
-    {
+  "metrics": {
+    "linting": { "name": "Linting", "result": "pass", "details": [] },
+    "tests": {
       "name": "Tests",
       "result": "fail",
-      "failures": {
+      "details": {
         "needInvestigation": [
           {
-            "testName": "devtools/client/application/test/browser/browser_application_panel_sidebar.js",
-            "jobName": "test-linux64/opt-mochitest-devtools-chrome-fis-e10s-4",
-            "jobSymbol": "dt4",
-            "platform": "linux64",
+            "testName": "IndexedDB/idb-explicit-commit.any.worker.html",
+            "action": "test",
+            "jobName": "test-windows7-32-shippable/opt-web-platform-tests-e10s-12",
+            "jobSymbol": "wpt12",
+            "jobGroup": "Web platform tests",
+            "jobGroupSymbol": "W",
+            "platform": "windows7-32-shippable",
             "config": "opt",
-            "key": "devtools/client/application/test/browser/browser_application_panel_sidebar.jsoptlinux64test-linux64/opt-mochitest-devtools-chrome-fis-e10s-4",
-            "jobKey": "optlinux64test-linux64/opt-mochitest-devtools-chrome-fis-e10s-4",
+            "key": "IndexedDBidbexplicitcommitanyworkerhtmloptwindows732shippabletestwindows732shippableoptwebplatformtestse10s12Webplatformtests",
+            "jobKey": "optwindows7-32-shippabletest-windows7-32-shippable/opt-web-platform-tests-e10s-12Web platform tests",
+            "inProgressJobs": [],
             "failJobs": [
               {
-                "id": 266673531,
-                "machine_platform_id": 104,
+                "id": 285384588,
+                "machine_platform_id": 582,
                 "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
-                "job_type_id": 199653,
+                "job_type_id": 182256,
+                "job_group_id": 461,
                 "result": "testfailed",
+                "state": "completed",
                 "failure_classification_id": 1,
-                "push_id": 556229,
-                "job_type_name": "test-linux64/opt-mochitest-devtools-chrome-fis-e10s-4"
+                "push_id": 630837,
+                "job_type_name": "test-windows7-32-shippable/opt-web-platform-tests-e10s-12",
+                "job_type_symbol": "wpt12",
+                "platform": "windows7-32-shippable"
               }
             ],
             "passJobs": [],
             "passInFailedJobs": [],
-            "inProgressJobs": [],
             "logLines": [
               {
                 "action": "test_result",
-                "line_number": 242,
-                "test": "devtools/client/application/test/browser/browser_application_panel_sidebar.js",
-                "subtest": "A promise chain failed to handle a rejection: Connection closed, pending request to server0.conn17.child1/manifestActor19, type fetchCanonicalManifest failed\n\nRequest stack:\nrequest@resource://devtools/shared/protocol/Front.js:176:14\ngenerateRequestMethods/</frontProto[name]@resource://devtools/shared/protocol/Front/FrontClassWithSpec.js:49:19\nfetchManifest@resource://devtools/client/application/src/modules/services.js:21:42\nasync*fetchManifest/<@resource://devtools/client/application/src/actions/manifest.js:18:55\nthunk/</<@resource://devtools/client/shared/redux/middleware/thunk.js:15:9\nloadManifestIfNeeded@resource://devtools/client/application/src/components/manifest/ManifestLoader.js:49:18\ncomponentDidMount@resource://devtools/client/application/src/components/manifest/ManifestLoader.js:38:10\ncommitLifeCycles@resource://devtools/client/shared/vendor/react-dom.js:12949:22\ncommitAllLifeCycles@resource://devtools/client/shared/vendor/react-dom.js:14174:23\ncommitRoot@resource://devtools/client/shared/vendor/react-dom.js:14380:28\ncompleteRoot/<@resource://devtools/client/shared/vendor/react-dom.js:15731:15\nunstable_runWithPriority@resource://devtools/client/shared/vendor/react.js:617:12\ncompleteRoot@resource://devtools/client/shared/vendor/react-dom.js:15730:27\nperformWorkOnRoot@resource://devtools/client/shared/vendor/react-dom.js:15659:21\nperformWork@resource://devtools/client/shared/vendor/react-dom.js:15567:24\nperformSyncWork@resource://devtools/client/shared/vendor/react-dom.js:15541:14\nrequestWork@resource://devtools/client/shared/vendor/react-dom.js:15410:5\nscheduleWork@resource://devtools/client/shared/vendor/react-dom.js:15224:16\nscheduleRootUpdate@resource://devtools/client/shared/vendor/react-dom.js:15865:15\nupdateContainerAtExpirationTime@resource://devtools/client/shared/vendor/react-dom.js:15881:10\nupdateContainer@resource://devtools/client/shared/vendor/react-dom.js:15908:10\nReactRoot.prototype.render@resource://devtools/client/shared/vendor/react-dom.js:16133:18\nlegacyRenderSubtreeIntoContainer/<@resource://devtools/client/shared/vendor/react-dom.js:16242:14\nunbatchedUpdates@resource://devtools/client/shared/vendor/react-dom.js:15772:10\nlegacyRenderSubtreeIntoContainer@resource://devtools/client/shared/vendor/react-dom.js:16238:21\nrender@resource://devtools/client/shared/vendor/react-dom.js:16289:12\nbootstrap@resource://devtools/client/application/initializer.js:79:11\nasync*open@resource://devtools/client/application/panel.js:26:37\nonLoad@resource://devtools/client/framework/toolbox.js:2330:27\n - stack: destroy@resource://devtools/shared/protocol/Front.js:81:23\nTargetMixin/destroy/this._destroyer<@resource://devtools/shared/fronts/targets/target-mixin.js:445:23\nasync*destroy@resource://devtools/shared/fronts/targets/target-mixin.js:480:9\ndestroy@resource://devtools/shared/fronts/targets/browsing-context.js:148:27\nemit@resource://devtools/shared/event-emitter.js:190:24\nemit@resource://devtools/shared/event-emitter.js:271:18\nonPacket@resource://devtools/shared/protocol/Front.js:214:13\nonPacket@resource://devtools/shared/client/debugger-client.js:592:13\nsend/<@resource://devtools/shared/transport/local-transport.js:70:25\nexports.makeInfallible/<@resource://devtools/shared/ThreadSafeDevToolsUtils.js:111:22\nDevToolsUtils.executeSoon*exports.executeSoon@resource://devtools/shared/DevToolsUtils.js:62:21\nsend@resource://devtools/shared/transport/local-transport.js:58:21\nsend@resource://devtools/server/debugger-server-connection.js:89:20\nconnectToFrame/</destroy<@resource://devtools/server/connectors/frame-connector.js:270:20\nexports.makeInfallible/<@resource://devtools/shared/ThreadSafeDevToolsUtils.js:111:22\nonMessageManagerClose@resource://devtools/server/connectors/frame-connector.js:288:9\n_endRemoveTab@chrome://browser/content/tabbrowser.js:3567:15\nremoveTab@chrome://browser/content/tabbrowser.js:3218:14\nremoveTab@resource://testing-common/BrowserTestUtils.jsm:1601:30\n@chrome://mochitests/content/browser/devtools/client/application/test/browser/browser_application_panel_sidebar.js:79:26\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1350:34\nasync*Tester_execTest@chrome://mochikit/content/browser-test.js:1385:11\nnextTest/<@chrome://mochikit/content/browser-test.js:1213:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:805:67\nRejection date: Tue Sep 17 2019 21:31:47 GMT+0000 (Coordinated Universal Time) - false == true",
+                "line_number": 1494,
+                "test": "/IndexedDB/idb-explicit-commit.any.worker.html",
+                "subtest": "Transactions that explicitly commit and have errors should abort.",
                 "status": "FAIL",
                 "expected": "PASS",
-                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 263\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:263\nchrome://mochikit/content/browser-test.js:nextTest:912\nchrome://mochikit/content/browser-test.js:testScope/test_finish/<:1732\nchrome://mochikit/content/browser-test.js:run:1647"
+                "message": "assert_equals: Expected abort event, but got complete event instead expected \"abort\" but got \"complete\"",
+                "stack": "transactionWatcher@http://web-platform.test:8000/IndexedDB/support-promises.js:20:10\n@http://web-platform.test:8000/IndexedDB/idb-explicit-commit.any.js:245:7\nasync*Test.prototype.step@http://web-platform.test:8000/resources/testharness.js:2024:25\npromise_test/tests.promise_tests</<@http://web-platform.test:8000/resources/testharness.js:605:36\npromise_test/tests.promise_tests<@http://web-platform.test:8000/resources/testharness.js:604:20\npromise callback*promise_test@http://web-platform.test:8000/resources/testharness.js:603:51\n@http://web-platform.test:8000/IndexedDB/idb-explicit-commit.any.js:221:13\n@http://web-platform.test:8000/IndexedDB/idb-explicit-commit.any.worker.js:8:14\n"
+              },
+              {
+                "action": "test_result",
+                "line_number": 1496,
+                "test": "/IndexedDB/idb-explicit-commit.any.worker.html",
+                "status": "ERROR",
+                "expected": "OK",
+                "message": "Error in remote: uncaught exception: Error: assert_unreached: Transaction with invalid \"add\" call should not be completed. Reached unreachable code"
               }
             ],
             "suggestedClassification": "New Failure",
             "confidence": 0,
-            "tier": 1
+            "tier": 1,
+            "passFailRatio": 0.0
           },
           {
-            "testName": "devtools/client/application/test/browser/browser_application_panel_sidebar.js",
-            "jobName": "test-linux64/debug-mochitest-devtools-chrome-fis-e10s-6",
-            "jobSymbol": "dt6",
+            "testName": "Non-Test Error",
+            "action": "log",
+            "jobName": "test-linux1804-64-asan/opt-mochitest-e10s-3",
+            "jobSymbol": "3",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "linux1804-64-asan",
+            "config": "opt",
+            "key": "NonTestErroroptlinux180464asantestlinux180464asanoptmochiteste10s3Mochitests",
+            "jobKey": "optlinux1804-64-asantest-linux1804-64-asan/opt-mochitest-e10s-3Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363164,
+                "machine_platform_id": 728,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 212990,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-asan/opt-mochitest-e10s-3",
+                "job_type_symbol": "3",
+                "platform": "linux1804-64-asan"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "log",
+                "line_number": 6408,
+                "message": "Force-terminating active process(es).",
+                "level": "ERROR"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "Non-Test Error",
+            "action": "log",
+            "jobName": "test-macosx1014-64-shippable/opt-mochitest-devtools-chrome-e10s-3",
+            "jobSymbol": "dt3",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "macosx1014-64-shippable",
+            "config": "opt",
+            "key": "NonTestErroroptmacosx101464shippabletestmacosx101464shippableoptmochitestdevtoolschromee10s3Mochitests",
+            "jobKey": "optmacosx1014-64-shippabletest-macosx1014-64-shippable/opt-mochitest-devtools-chrome-e10s-3Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285379398,
+                "machine_platform_id": 655,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 198391,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64-shippable/opt-mochitest-devtools-chrome-e10s-3",
+                "job_type_symbol": "dt3",
+                "platform": "macosx1014-64-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "log",
+                "line_number": 1510,
+                "message": "TEST-UNEXPECTED-FAIL | Last test finished | application terminated with exit code 1",
+                "level": "ERROR"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "browser/components/extensions/test/browser/browser_ext_tabs_zoom.js",
+            "action": "test",
+            "jobName": "test-linux64/debug-mochitest-browser-chrome-e10s-15",
+            "jobSymbol": "bc15",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
             "platform": "linux64",
             "config": "debug",
-            "key": "devtools/client/application/test/browser/browser_application_panel_sidebar.jsdebuglinux64test-linux64/debug-mochitest-devtools-chrome-fis-e10s-6",
-            "jobKey": "debuglinux64test-linux64/debug-mochitest-devtools-chrome-fis-e10s-6",
+            "key": "browsercomponentsextensionstestbrowserbrowser_ext_tabs_zoomjsdebuglinux64testlinux64debugmochitestbrowserchromee10s15Mochitests",
+            "jobKey": "debuglinux64test-linux64/debug-mochitest-browser-chrome-e10s-15Mochitests",
+            "inProgressJobs": [],
             "failJobs": [
               {
-                "id": 266673911,
+                "id": 285363868,
                 "machine_platform_id": 104,
                 "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
-                "job_type_id": 199543,
+                "job_type_id": 50896,
+                "job_group_id": 448,
                 "result": "testfailed",
+                "state": "completed",
                 "failure_classification_id": 1,
-                "push_id": 556229,
-                "job_type_name": "test-linux64/debug-mochitest-devtools-chrome-fis-e10s-6"
+                "push_id": 630837,
+                "job_type_name": "test-linux64/debug-mochitest-browser-chrome-e10s-15",
+                "job_type_symbol": "bc15",
+                "platform": "linux64"
               }
             ],
-            "passJobs": [],
+            "passJobs": [
+              {
+                "id": 285369162,
+                "machine_platform_id": 104,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 50896,
+                "job_group_id": 448,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux64/debug-mochitest-browser-chrome-e10s-15",
+                "job_type_symbol": "bc15",
+                "platform": "linux64"
+              }
+            ],
             "passInFailedJobs": [],
-            "inProgressJobs": [],
             "logLines": [
               {
                 "action": "test_result",
-                "line_number": 867,
-                "test": "devtools/client/application/test/browser/browser_application_panel_sidebar.js",
-                "subtest": "A promise chain failed to handle a rejection: Connection closed, pending request to server0.conn12.child1/manifestActor19, type fetchCanonicalManifest failed\n\nRequest stack:\nrequest@resource://devtools/shared/protocol/Front.js:176:14\ngenerateRequestMethods/</frontProto[name]@resource://devtools/shared/protocol/Front/FrontClassWithSpec.js:49:19\nfetchManifest@resource://devtools/client/application/src/modules/services.js:21:42\nasync*fetchManifest/<@resource://devtools/client/application/src/actions/manifest.js:18:55\nthunk/</<@resource://devtools/client/shared/redux/middleware/thunk.js:15:9\nloadManifestIfNeeded@resource://devtools/client/application/src/components/manifest/ManifestLoader.js:49:18\ncomponentDidMount@resource://devtools/client/application/src/components/manifest/ManifestLoader.js:38:10\ncommitLifeCycles@resource://devtools/client/shared/vendor/react-dom.js:12949:22\ncommitAllLifeCycles@resource://devtools/client/shared/vendor/react-dom.js:14174:23\ncommitRoot@resource://devtools/client/shared/vendor/react-dom.js:14380:28\ncompleteRoot/<@resource://devtools/client/shared/vendor/react-dom.js:15731:15\nunstable_runWithPriority@resource://devtools/client/shared/vendor/react.js:617:12\ncompleteRoot@resource://devtools/client/shared/vendor/react-dom.js:15730:27\nperformWorkOnRoot@resource://devtools/client/shared/vendor/react-dom.js:15659:21\nperformWork@resource://devtools/client/shared/vendor/react-dom.js:15567:24\nperformSyncWork@resource://devtools/client/shared/vendor/react-dom.js:15541:14\nrequestWork@resource://devtools/client/shared/vendor/react-dom.js:15410:5\nscheduleWork@resource://devtools/client/shared/vendor/react-dom.js:15224:16\nscheduleRootUpdate@resource://devtools/client/shared/vendor/react-dom.js:15865:15\nupdateContainerAtExpirationTime@resource://devtools/client/shared/vendor/react-dom.js:15881:10\nupdateContainer@resource://devtools/client/shared/vendor/react-dom.js:15908:10\nReactRoot.prototype.render@resource://devtools/client/shared/vendor/react-dom.js:16133:18\nlegacyRenderSubtreeIntoContainer/<@resource://devtools/client/shared/vendor/react-dom.js:16242:14\nunbatchedUpdates@resource://devtools/client/shared/vendor/react-dom.js:15772:10\nlegacyRenderSubtreeIntoContainer@resource://devtools/client/shared/vendor/react-dom.js:16238:21\nrender@resource://devtools/client/shared/vendor/react-dom.js:16289:12\nbootstrap@resource://devtools/client/application/initializer.js:79:11\nasync*open@resource://devtools/client/application/panel.js:26:37\nonLoad@resource://devtools/client/framework/toolbox.js:2330:27\n - stack: destroy@resource://devtools/shared/protocol/Front.js:81:23\nTargetMixin/destroy/this._destroyer<@resource://devtools/shared/fronts/targets/target-mixin.js:445:23\nasync*destroy@resource://devtools/shared/fronts/targets/target-mixin.js:480:9\ndestroy@resource://devtools/shared/fronts/targets/browsing-context.js:148:27\nemit@resource://devtools/shared/event-emitter.js:190:24\nemit@resource://devtools/shared/event-emitter.js:271:18\nonPacket@resource://devtools/shared/protocol/Front.js:214:13\nonPacket@resource://devtools/shared/client/debugger-client.js:592:13\nsend/<@resource://devtools/shared/transport/local-transport.js:70:25\nexports.makeInfallible/<@resource://devtools/shared/ThreadSafeDevToolsUtils.js:111:22\nDevToolsUtils.executeSoon*exports.executeSoon@resource://devtools/shared/DevToolsUtils.js:62:21\nsend@resource://devtools/shared/transport/local-transport.js:58:21\nsend@resource://devtools/server/debugger-server-connection.js:89:20\nconnectToFrame/</destroy<@resource://devtools/server/connectors/frame-connector.js:270:20\nexports.makeInfallible/<@resource://devtools/shared/ThreadSafeDevToolsUtils.js:111:22\nonMessageManagerClose@resource://devtools/server/connectors/frame-connector.js:288:9\n_endRemoveTab@chrome://browser/content/tabbrowser.js:3567:15\nremoveTab@chrome://browser/content/tabbrowser.js:3218:14\nremoveTab@resource://testing-common/BrowserTestUtils.jsm:1601:30\n@chrome://mochitests/content/browser/devtools/client/application/test/browser/browser_application_panel_sidebar.js:79:26\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1350:34\nasync*Tester_execTest@chrome://mochikit/content/browser-test.js:1385:11\nnextTest/<@chrome://mochikit/content/browser-test.js:1213:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:805:67\nRejection date: Tue Sep 17 2019 21:32:05 GMT+0000 (Coordinated Universal Time) - false == true",
+                "line_number": 22988,
+                "test": "browser/components/extensions/test/browser/browser_ext_tabs_zoom.js",
+                "subtest": "A promise chain failed to handle a rejection: [Exception... \"Component is not available\"  nsresult: \"0x80040111 (NS_ERROR_NOT_AVAILABLE)\"  location: \"<unknown>\"  data: no] - stack: (No stack available.)\nRejection date: Tue Jan 21 2020 23:12:45 GMT+0000 (Coordinated Universal Time) - false == true",
                 "status": "FAIL",
                 "expected": "PASS",
-                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 263\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:263\nchrome://mochikit/content/browser-test.js:nextTest:912\nchrome://mochikit/content/browser-test.js:testScope/test_finish/<:1732\nchrome://mochikit/content/browser-test.js:run:1647"
+                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 265\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:265\nchrome://mochikit/content/browser-test.js:nextTest:624\nchrome://mochikit/content/browser-test.js:testScope/test_finish/<:1457\nchrome://mochikit/content/browser-test.js:run:1372"
+              },
+              {
+                "action": "test_result",
+                "line_number": 22990,
+                "test": "browser/components/extensions/test/browser/browser_ext_tabs_zoom.js",
+                "subtest": "A promise chain failed to handle a rejection: [Exception... \"Component is not available\"  nsresult: \"0x80040111 (NS_ERROR_NOT_AVAILABLE)\"  location: \"<unknown>\"  data: no] - stack: (No stack available.)\nRejection date: Tue Jan 21 2020 23:12:45 GMT+0000 (Coordinated Universal Time) - false == true",
+                "status": "FAIL",
+                "expected": "PASS",
+                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 265\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:265\nchrome://mochikit/content/browser-test.js:nextTest:624\nchrome://mochikit/content/browser-test.js:testScope/test_finish/<:1457\nchrome://mochikit/content/browser-test.js:run:1372"
               }
             ],
             "suggestedClassification": "New Failure",
             "confidence": 0,
-            "tier": 2
+            "tier": 1,
+            "passFailRatio": 0.5
           },
           {
-            "testName": "devtools/client/netmonitor/test/browser_net_ws-early-connection.js",
-            "jobName": "test-linux64/opt-mochitest-devtools-chrome-fis-e10s-4",
-            "jobSymbol": "dt4",
-            "platform": "linux64",
+            "testName": "browser/extensions/doh-rollout/test/browser/browser_policyOverride.js",
+            "action": "test",
+            "jobName": "test-windows7-32-shippable/opt-mochitest-browser-chrome-e10s-6",
+            "jobSymbol": "bc6",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "windows7-32-shippable",
             "config": "opt",
-            "key": "devtools/client/netmonitor/test/browser_net_ws-early-connection.jsoptlinux64test-linux64/opt-mochitest-devtools-chrome-fis-e10s-4",
-            "jobKey": "optlinux64test-linux64/opt-mochitest-devtools-chrome-fis-e10s-4",
+            "key": "browserextensionsdohrollouttestbrowserbrowser_policyOverridejsoptwindows732shippabletestwindows732shippableoptmochitestbrowserchromee10s6Mochitests",
+            "jobKey": "optwindows7-32-shippabletest-windows7-32-shippable/opt-mochitest-browser-chrome-e10s-6Mochitests",
+            "inProgressJobs": [],
             "failJobs": [
               {
-                "id": 266673531,
-                "machine_platform_id": 104,
+                "id": 285384567,
+                "machine_platform_id": 582,
                 "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
-                "job_type_id": 199653,
+                "job_type_id": 182290,
+                "job_group_id": 448,
                 "result": "testfailed",
+                "state": "completed",
                 "failure_classification_id": 1,
-                "push_id": 556229,
-                "job_type_name": "test-linux64/opt-mochitest-devtools-chrome-fis-e10s-4"
+                "push_id": 630837,
+                "job_type_name": "test-windows7-32-shippable/opt-mochitest-browser-chrome-e10s-6",
+                "job_type_symbol": "bc6",
+                "platform": "windows7-32-shippable"
               }
             ],
             "passJobs": [],
             "passInFailedJobs": [],
-            "inProgressJobs": [],
             "logLines": [
               {
                 "action": "test_result",
-                "line_number": 3626,
-                "test": "devtools/client/netmonitor/test/browser_net_ws-early-connection.js",
+                "line_number": 4137,
+                "test": "browser/extensions/doh-rollout/test/browser/browser_policyOverride.js",
+                "subtest": "Uncaught exception",
+                "status": "FAIL",
+                "expected": "PASS",
+                "message": "undefined - timed out after 50 tries."
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "browser/extensions/doh-rollout/test/browser/browser_userInterference.js",
+            "action": "test",
+            "jobName": "test-windows7-32-shippable/opt-mochitest-browser-chrome-e10s-6",
+            "jobSymbol": "bc6",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "windows7-32-shippable",
+            "config": "opt",
+            "key": "browserextensionsdohrollouttestbrowserbrowser_userInterferencejsoptwindows732shippabletestwindows732shippableoptmochitestbrowserchromee10s6Mochitests",
+            "jobKey": "optwindows7-32-shippabletest-windows7-32-shippable/opt-mochitest-browser-chrome-e10s-6Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285384567,
+                "machine_platform_id": 582,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 182290,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-windows7-32-shippable/opt-mochitest-browser-chrome-e10s-6",
+                "job_type_symbol": "bc6",
+                "platform": "windows7-32-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 4150,
+                "test": "browser/extensions/doh-rollout/test/browser/browser_userInterference.js",
+                "subtest": "Uncaught exception",
+                "status": "FAIL",
+                "expected": "PASS",
+                "message": "undefined - timed out after 50 tries."
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "devtools/client/framework/test/browser_about-devtools-toolbox_reload.js",
+            "action": "test",
+            "jobName": "test-macosx1014-64-shippable/opt-mochitest-devtools-chrome-e10s-3",
+            "jobSymbol": "dt3",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "macosx1014-64-shippable",
+            "config": "opt",
+            "key": "devtoolsclientframeworktestbrowser_aboutdevtoolstoolbox_reloadjsoptmacosx101464shippabletestmacosx101464shippableoptmochitestdevtoolschromee10s3Mochitests",
+            "jobKey": "optmacosx1014-64-shippabletest-macosx1014-64-shippable/opt-mochitest-devtools-chrome-e10s-3Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285379398,
+                "machine_platform_id": 655,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 198391,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64-shippable/opt-mochitest-devtools-chrome-e10s-3",
+                "job_type_symbol": "dt3",
+                "platform": "macosx1014-64-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 706,
+                "test": "devtools/client/framework/test/browser_about-devtools-toolbox_reload.js",
                 "subtest": "Test timed out",
                 "status": "FAIL",
                 "expected": "PASS"
               },
               {
                 "action": "test_result",
-                "line_number": 3633,
-                "test": "devtools/client/netmonitor/test/browser_net_ws-early-connection.js",
-                "subtest": "A promise chain failed to handle a rejection: 'getResponseCookies' pending request packet to 'server0.conn152.netEvent4' can't be sent as the connection just closed. - stack: listenerJson@resource://devtools/shared/client/debugger-client.js:341:17\nemit@resource://devtools/shared/event-emitter.js:190:24\nemit@resource://devtools/shared/event-emitter.js:271:18\nreject@resource://devtools/shared/client/debugger-client.js:815:15\npurgeRequests/<@resource://devtools/shared/client/debugger-client.js:826:54\npurgeRequests@resource://devtools/shared/client/debugger-client.js:826:29\nonClosed@resource://devtools/shared/client/debugger-client.js:762:10\nclose@resource://devtools/shared/transport/local-transport.js:171:20\nclose@resource://devtools/shared/transport/local-transport.js:167:13\nclose@resource://devtools/shared/transport/local-transport.js:167:13\ncleanup@resource://devtools/shared/client/debugger-client.js:215:27\nclose/promise<@resource://devtools/shared/client/debugger-client.js:231:7\nclose@resource://devtools/shared/client/debugger-client.js:208:21\nTargetMixin/destroy/this._destroyer<@resource://devtools/shared/fronts/targets/target-mixin.js:457:32\nasync*destroy@resource://devtools/shared/fronts/targets/target-mixin.js:480:9\ndestroy@resource://devtools/shared/fronts/targets/browsing-context.js:148:27\n_destroyToolbox/onceDestroyed</<@resource://devtools/client/framework/toolbox.js:3637:27\npromise callback*_destroyToolbox/onceDestroyed<@resource://devtools/client/framework/toolbox.js:3594:12\n_destroyToolbox@resource://devtools/client/framework/toolbox.js:3590:27\ndestroy@resource://devtools/client/framework/toolbox.js:3466:28\n_onRemotenessChange@resource://devtools/shared/fronts/targets/local-tab.js:131:19\n_handleTabEvent@resource://devtools/shared/fronts/targets/local-tab.js:109:14\nupdateBrowserRemoteness@chrome://browser/content/tabbrowser.js:2046:11\nrestoreTabContent@resource:///modules/sessionstore/SessionStore.jsm:4715:39\nrestoreTab@resource:///modules/sessionstore/SessionStore.jsm:4630:14\n_asyncNavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3721:10\nasync*navigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3614:24\nnavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:403:33\nLoadInOtherProcess@chrome://browser/content/browser.js:1596:16\n_loadURI@chrome://browser/content/browser.js:1561:25\nloadURI@resource://testing-common/BrowserTestUtils.jsm:744:13\n@chrome://mochitests/content/browser/devtools/client/netmonitor/test/browser_net_ws-early-connection.js:32:20\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1350:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1385:11\nnextTest/<@chrome://mochikit/content/browser-test.js:1213:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:805:67\nRejection date: Tue Sep 17 2019 21:42:02 GMT+0000 (Coordinated Universal Time) - false == true",
+                "line_number": 712,
+                "test": "devtools/client/framework/test/browser_about-devtools-toolbox_reload.js",
+                "subtest": "The main process DebuggerServer has no pending connection when the test ends",
                 "status": "FAIL",
                 "expected": "PASS",
-                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 263\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:263\nchrome://mochikit/content/browser-test.js:nextTest:912\nchrome://mochikit/content/browser-test.js:timeoutFn:1471\nsetTimeout handler*chrome://mochikit/content/browser-test.js:Tester_execTest:1418\nchrome://mochikit/content/browser-test.js:nextTest/<:1213\nchrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:805"
+                "message": "\nStack trace:\nchrome://mochikit/content/browser-test.js:test_ok:1292\nchrome://mochitests/content/browser/devtools/client/shared/test/shared-head.js:cleanup:170\nchrome://mochikit/content/browser-test.js:nextTest:570\nchrome://mochikit/content/browser-test.js:timeoutFn:1183\nsetTimeout handler*chrome://mochikit/content/browser-test.js:Tester_execTest:1130\nchrome://mochikit/content/browser-test.js:nextTest/<:925\nchrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:808"
               },
               {
                 "action": "test_result",
-                "line_number": 3635,
-                "test": "devtools/client/netmonitor/test/browser_net_ws-early-connection.js",
-                "subtest": "A promise chain failed to handle a rejection: 'getEventTimings' pending request packet to 'server0.conn152.netEvent4' can't be sent as the connection just closed. - stack: listenerJson@resource://devtools/shared/client/debugger-client.js:341:17\nemit@resource://devtools/shared/event-emitter.js:190:24\nemit@resource://devtools/shared/event-emitter.js:271:18\nreject@resource://devtools/shared/client/debugger-client.js:815:15\npurgeRequests/<@resource://devtools/shared/client/debugger-client.js:826:54\npurgeRequests@resource://devtools/shared/client/debugger-client.js:826:29\nonClosed@resource://devtools/shared/client/debugger-client.js:762:10\nclose@resource://devtools/shared/transport/local-transport.js:171:20\nclose@resource://devtools/shared/transport/local-transport.js:167:13\nclose@resource://devtools/shared/transport/local-transport.js:167:13\ncleanup@resource://devtools/shared/client/debugger-client.js:215:27\nclose/promise<@resource://devtools/shared/client/debugger-client.js:231:7\nclose@resource://devtools/shared/client/debugger-client.js:208:21\nTargetMixin/destroy/this._destroyer<@resource://devtools/shared/fronts/targets/target-mixin.js:457:32\nasync*destroy@resource://devtools/shared/fronts/targets/target-mixin.js:480:9\ndestroy@resource://devtools/shared/fronts/targets/browsing-context.js:148:27\n_destroyToolbox/onceDestroyed</<@resource://devtools/client/framework/toolbox.js:3637:27\npromise callback*_destroyToolbox/onceDestroyed<@resource://devtools/client/framework/toolbox.js:3594:12\n_destroyToolbox@resource://devtools/client/framework/toolbox.js:3590:27\ndestroy@resource://devtools/client/framework/toolbox.js:3466:28\n_onRemotenessChange@resource://devtools/shared/fronts/targets/local-tab.js:131:19\n_handleTabEvent@resource://devtools/shared/fronts/targets/local-tab.js:109:14\nupdateBrowserRemoteness@chrome://browser/content/tabbrowser.js:2046:11\nrestoreTabContent@resource:///modules/sessionstore/SessionStore.jsm:4715:39\nrestoreTab@resource:///modules/sessionstore/SessionStore.jsm:4630:14\n_asyncNavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3721:10\nasync*navigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3614:24\nnavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:403:33\nLoadInOtherProcess@chrome://browser/content/browser.js:1596:16\n_loadURI@chrome://browser/content/browser.js:1561:25\nloadURI@resource://testing-common/BrowserTestUtils.jsm:744:13\n@chrome://mochitests/content/browser/devtools/client/netmonitor/test/browser_net_ws-early-connection.js:32:20\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1350:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1385:11\nnextTest/<@chrome://mochikit/content/browser-test.js:1213:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:805:67\nRejection date: Tue Sep 17 2019 21:42:02 GMT+0000 (Coordinated Universal Time) - false == true",
+                "line_number": 714,
+                "test": "devtools/client/framework/test/browser_about-devtools-toolbox_reload.js",
+                "subtest": "A promise chain failed to handle a rejection: Can't find the actor ID for thread from root or target actor's form. - stack: getFront@resource://devtools/shared/protocol/types.js:586:11\ngetFront@resource://devtools/shared/fronts/targets/target-mixin.js:196:15\nattachThread@resource://devtools/shared/fronts/targets/target-mixin.js:371:37\n_attachAndResumeThread@resource://devtools/client/framework/toolbox.js:705:42\n_attachTarget@resource://devtools/client/framework/toolbox.js:687:38\nasync*_onTargetAvailable@resource://devtools/client/framework/toolbox.js:655:16\nwatchTargets@resource://devtools/shared/resources/target-list.js:392:19\nopen/<@resource://devtools/client/framework/toolbox.js:759:29\nAsync*open@resource://devtools/client/framework/toolbox.js:906:18\ncreateToolbox@resource://devtools/client/framework/devtools.js:622:19\nasync*showToolbox@resource://devtools/client/framework/devtools.js:509:35\ninitToolbox@chrome://devtools/content/framework/toolbox-init.js:151:21\nasync*@chrome://devtools/content/framework/toolbox-init.js:161:14\nRejection date: Wed Jan 22 2020 00:38:56 GMT+0000 (Greenwich Mean Time) - false == true",
                 "status": "FAIL",
                 "expected": "PASS",
-                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 263\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:263\nchrome://mochikit/content/browser-test.js:nextTest:912\nchrome://mochikit/content/browser-test.js:timeoutFn:1471\nsetTimeout handler*chrome://mochikit/content/browser-test.js:Tester_execTest:1418\nchrome://mochikit/content/browser-test.js:nextTest/<:1213\nchrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:805"
+                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 265\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:265\nchrome://mochikit/content/browser-test.js:nextTest:624\nchrome://mochikit/content/browser-test.js:timeoutFn:1183\nsetTimeout handler*chrome://mochikit/content/browser-test.js:Tester_execTest:1130\nchrome://mochikit/content/browser-test.js:nextTest/<:925\nchrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:808"
               },
               {
                 "action": "test_result",
-                "line_number": 3637,
-                "test": "devtools/client/netmonitor/test/browser_net_ws-early-connection.js",
-                "subtest": "A promise chain failed to handle a rejection: 'getRequestCookies' active request packet to 'server0.conn152.netEvent4' can't be sent as the connection just closed. - stack: listenerJson@resource://devtools/shared/client/debugger-client.js:341:17\nemit@resource://devtools/shared/event-emitter.js:190:24\nemit@resource://devtools/shared/event-emitter.js:271:18\nreject@resource://devtools/shared/client/debugger-client.js:815:15\npurgeRequests/<@resource://devtools/shared/client/debugger-client.js:836:53\npurgeRequests@resource://devtools/shared/client/debugger-client.js:836:28\nonClosed@resource://devtools/shared/client/debugger-client.js:762:10\nclose@resource://devtools/shared/transport/local-transport.js:171:20\nclose@resource://devtools/shared/transport/local-transport.js:167:13\nclose@resource://devtools/shared/transport/local-transport.js:167:13\ncleanup@resource://devtools/shared/client/debugger-client.js:215:27\nclose/promise<@resource://devtools/shared/client/debugger-client.js:231:7\nclose@resource://devtools/shared/client/debugger-client.js:208:21\nTargetMixin/destroy/this._destroyer<@resource://devtools/shared/fronts/targets/target-mixin.js:457:32\nasync*destroy@resource://devtools/shared/fronts/targets/target-mixin.js:480:9\ndestroy@resource://devtools/shared/fronts/targets/browsing-context.js:148:27\n_destroyToolbox/onceDestroyed</<@resource://devtools/client/framework/toolbox.js:3637:27\npromise callback*_destroyToolbox/onceDestroyed<@resource://devtools/client/framework/toolbox.js:3594:12\n_destroyToolbox@resource://devtools/client/framework/toolbox.js:3590:27\ndestroy@resource://devtools/client/framework/toolbox.js:3466:28\n_onRemotenessChange@resource://devtools/shared/fronts/targets/local-tab.js:131:19\n_handleTabEvent@resource://devtools/shared/fronts/targets/local-tab.js:109:14\nupdateBrowserRemoteness@chrome://browser/content/tabbrowser.js:2046:11\nrestoreTabContent@resource:///modules/sessionstore/SessionStore.jsm:4715:39\nrestoreTab@resource:///modules/sessionstore/SessionStore.jsm:4630:14\n_asyncNavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3721:10\nasync*navigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3614:24\nnavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:403:33\nLoadInOtherProcess@chrome://browser/content/browser.js:1596:16\n_loadURI@chrome://browser/content/browser.js:1561:25\nloadURI@resource://testing-common/BrowserTestUtils.jsm:744:13\n@chrome://mochitests/content/browser/devtools/client/netmonitor/test/browser_net_ws-early-connection.js:32:20\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1350:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1385:11\nnextTest/<@chrome://mochikit/content/browser-test.js:1213:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:805:67\nRejection date: Tue Sep 17 2019 21:42:02 GMT+0000 (Coordinated Universal Time) - false == true",
+                "line_number": 727,
+                "test": "devtools/client/framework/test/browser_about-devtools-toolbox_reload.js",
+                "subtest": "Uncaught exception received from previously timed out test",
                 "status": "FAIL",
                 "expected": "PASS",
-                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 263\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:263\nchrome://mochikit/content/browser-test.js:nextTest:912\nchrome://mochikit/content/browser-test.js:timeoutFn:1471\nsetTimeout handler*chrome://mochikit/content/browser-test.js:Tester_execTest:1418\nchrome://mochikit/content/browser-test.js:nextTest/<:1213\nchrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:805"
-              },
-              {
-                "action": "test_result",
-                "line_number": 3639,
-                "test": "devtools/client/netmonitor/test/browser_net_ws-early-connection.js",
-                "subtest": "A promise chain failed to handle a rejection: Error while calling method getResponseCookies: 'getResponseCookies' pending request packet to 'server0.conn152.netEvent4' can't be sent as the connection just closed. - stack: _requestData/response</<@resource://devtools/client/netmonitor/src/connector/firefox-data-provider.js:620:17\nsafeOnResponse@resource://devtools/shared/client/debugger-client.js:314:14\nlistenerJson@resource://devtools/shared/client/debugger-client.js:339:16\nemit@resource://devtools/shared/event-emitter.js:190:24\nemit@resource://devtools/shared/event-emitter.js:271:18\nreject@resource://devtools/shared/client/debugger-client.js:815:15\npurgeRequests/<@resource://devtools/shared/client/debugger-client.js:826:54\npurgeRequests@resource://devtools/shared/client/debugger-client.js:826:29\nonClosed@resource://devtools/shared/client/debugger-client.js:762:10\nclose@resource://devtools/shared/transport/local-transport.js:171:20\nclose@resource://devtools/shared/transport/local-transport.js:167:13\nclose@resource://devtools/shared/transport/local-transport.js:167:13\ncleanup@resource://devtools/shared/client/debugger-client.js:215:27\nclose/promise<@resource://devtools/shared/client/debugger-client.js:231:7\nclose@resource://devtools/shared/client/debugger-client.js:208:21\nTargetMixin/destroy/this._destroyer<@resource://devtools/shared/fronts/targets/target-mixin.js:457:32\nasync*destroy@resource://devtools/shared/fronts/targets/target-mixin.js:480:9\ndestroy@resource://devtools/shared/fronts/targets/browsing-context.js:148:27\n_destroyToolbox/onceDestroyed</<@resource://devtools/client/framework/toolbox.js:3637:27\npromise callback*_destroyToolbox/onceDestroyed<@resource://devtools/client/framework/toolbox.js:3594:12\n_destroyToolbox@resource://devtools/client/framework/toolbox.js:3590:27\ndestroy@resource://devtools/client/framework/toolbox.js:3466:28\n_onRemotenessChange@resource://devtools/shared/fronts/targets/local-tab.js:131:19\n_handleTabEvent@resource://devtools/shared/fronts/targets/local-tab.js:109:14\nupdateBrowserRemoteness@chrome://browser/content/tabbrowser.js:2046:11\nrestoreTabContent@resource:///modules/sessionstore/SessionStore.jsm:4715:39\nrestoreTab@resource:///modules/sessionstore/SessionStore.jsm:4630:14\n_asyncNavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3721:10\nasync*navigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3614:24\nnavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:403:33\nLoadInOtherProcess@chrome://browser/content/browser.js:1596:16\n_loadURI@chrome://browser/content/browser.js:1561:25\nloadURI@resource://testing-common/BrowserTestUtils.jsm:744:13\n@chrome://mochitests/content/browser/devtools/client/netmonitor/test/browser_net_ws-early-connection.js:32:20\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1350:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1385:11\nnextTest/<@chrome://mochikit/content/browser-test.js:1213:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:805:67\nRejection date: Tue Sep 17 2019 21:42:02 GMT+0000 (Coordinated Universal Time) - false == true",
-                "status": "FAIL",
-                "expected": "PASS",
-                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 263\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:263\nchrome://mochikit/content/browser-test.js:nextTest:912\nchrome://mochikit/content/browser-test.js:timeoutFn:1471\nsetTimeout handler*chrome://mochikit/content/browser-test.js:Tester_execTest:1418\nchrome://mochikit/content/browser-test.js:nextTest/<:1213\nchrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:805"
-              },
-              {
-                "action": "test_result",
-                "line_number": 3641,
-                "test": "devtools/client/netmonitor/test/browser_net_ws-early-connection.js",
-                "subtest": "A promise chain failed to handle a rejection: Error while calling method getEventTimings: 'getEventTimings' pending request packet to 'server0.conn152.netEvent4' can't be sent as the connection just closed. - stack: _requestData/response</<@resource://devtools/client/netmonitor/src/connector/firefox-data-provider.js:620:17\nsafeOnResponse@resource://devtools/shared/client/debugger-client.js:314:14\nlistenerJson@resource://devtools/shared/client/debugger-client.js:339:16\nemit@resource://devtools/shared/event-emitter.js:190:24\nemit@resource://devtools/shared/event-emitter.js:271:18\nreject@resource://devtools/shared/client/debugger-client.js:815:15\npurgeRequests/<@resource://devtools/shared/client/debugger-client.js:826:54\npurgeRequests@resource://devtools/shared/client/debugger-client.js:826:29\nonClosed@resource://devtools/shared/client/debugger-client.js:762:10\nclose@resource://devtools/shared/transport/local-transport.js:171:20\nclose@resource://devtools/shared/transport/local-transport.js:167:13\nclose@resource://devtools/shared/transport/local-transport.js:167:13\ncleanup@resource://devtools/shared/client/debugger-client.js:215:27\nclose/promise<@resource://devtools/shared/client/debugger-client.js:231:7\nclose@resource://devtools/shared/client/debugger-client.js:208:21\nTargetMixin/destroy/this._destroyer<@resource://devtools/shared/fronts/targets/target-mixin.js:457:32\nasync*destroy@resource://devtools/shared/fronts/targets/target-mixin.js:480:9\ndestroy@resource://devtools/shared/fronts/targets/browsing-context.js:148:27\n_destroyToolbox/onceDestroyed</<@resource://devtools/client/framework/toolbox.js:3637:27\npromise callback*_destroyToolbox/onceDestroyed<@resource://devtools/client/framework/toolbox.js:3594:12\n_destroyToolbox@resource://devtools/client/framework/toolbox.js:3590:27\ndestroy@resource://devtools/client/framework/toolbox.js:3466:28\n_onRemotenessChange@resource://devtools/shared/fronts/targets/local-tab.js:131:19\n_handleTabEvent@resource://devtools/shared/fronts/targets/local-tab.js:109:14\nupdateBrowserRemoteness@chrome://browser/content/tabbrowser.js:2046:11\nrestoreTabContent@resource:///modules/sessionstore/SessionStore.jsm:4715:39\nrestoreTab@resource:///modules/sessionstore/SessionStore.jsm:4630:14\n_asyncNavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3721:10\nasync*navigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3614:24\nnavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:403:33\nLoadInOtherProcess@chrome://browser/content/browser.js:1596:16\n_loadURI@chrome://browser/content/browser.js:1561:25\nloadURI@resource://testing-common/BrowserTestUtils.jsm:744:13\n@chrome://mochitests/content/browser/devtools/client/netmonitor/test/browser_net_ws-early-connection.js:32:20\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1350:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1385:11\nnextTest/<@chrome://mochikit/content/browser-test.js:1213:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:805:67\nRejection date: Tue Sep 17 2019 21:42:02 GMT+0000 (Coordinated Universal Time) - false == true",
-                "status": "FAIL",
-                "expected": "PASS",
-                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 263\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:263\nchrome://mochikit/content/browser-test.js:nextTest:912\nchrome://mochikit/content/browser-test.js:timeoutFn:1471\nsetTimeout handler*chrome://mochikit/content/browser-test.js:Tester_execTest:1418\nchrome://mochikit/content/browser-test.js:nextTest/<:1213\nchrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:805"
-              },
-              {
-                "action": "test_result",
-                "line_number": 3643,
-                "test": "devtools/client/netmonitor/test/browser_net_ws-early-connection.js",
-                "subtest": "A promise chain failed to handle a rejection: Error while calling method getEventTimings: 'getEventTimings' pending request packet to 'server0.conn152.netEvent4' can't be sent as the connection just closed. - stack: _requestData/response</<@resource://devtools/client/netmonitor/src/connector/firefox-data-provider.js:620:17\nsafeOnResponse@resource://devtools/shared/client/debugger-client.js:314:14\nlistenerJson@resource://devtools/shared/client/debugger-client.js:339:16\nemit@resource://devtools/shared/event-emitter.js:190:24\nemit@resource://devtools/shared/event-emitter.js:271:18\nreject@resource://devtools/shared/client/debugger-client.js:815:15\npurgeRequests/<@resource://devtools/shared/client/debugger-client.js:826:54\npurgeRequests@resource://devtools/shared/client/debugger-client.js:826:29\nonClosed@resource://devtools/shared/client/debugger-client.js:762:10\nclose@resource://devtools/shared/transport/local-transport.js:171:20\nclose@resource://devtools/shared/transport/local-transport.js:167:13\nclose@resource://devtools/shared/transport/local-transport.js:167:13\ncleanup@resource://devtools/shared/client/debugger-client.js:215:27\nclose/promise<@resource://devtools/shared/client/debugger-client.js:231:7\nclose@resource://devtools/shared/client/debugger-client.js:208:21\nTargetMixin/destroy/this._destroyer<@resource://devtools/shared/fronts/targets/target-mixin.js:457:32\nasync*destroy@resource://devtools/shared/fronts/targets/target-mixin.js:480:9\ndestroy@resource://devtools/shared/fronts/targets/browsing-context.js:148:27\n_destroyToolbox/onceDestroyed</<@resource://devtools/client/framework/toolbox.js:3637:27\npromise callback*_destroyToolbox/onceDestroyed<@resource://devtools/client/framework/toolbox.js:3594:12\n_destroyToolbox@resource://devtools/client/framework/toolbox.js:3590:27\ndestroy@resource://devtools/client/framework/toolbox.js:3466:28\n_onRemotenessChange@resource://devtools/shared/fronts/targets/local-tab.js:131:19\n_handleTabEvent@resource://devtools/shared/fronts/targets/local-tab.js:109:14\nupdateBrowserRemoteness@chrome://browser/content/tabbrowser.js:2046:11\nrestoreTabContent@resource:///modules/sessionstore/SessionStore.jsm:4715:39\nrestoreTab@resource:///modules/sessionstore/SessionStore.jsm:4630:14\n_asyncNavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3721:10\nasync*navigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3614:24\nnavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:403:33\nLoadInOtherProcess@chrome://browser/content/browser.js:1596:16\n_loadURI@chrome://browser/content/browser.js:1561:25\nloadURI@resource://testing-common/BrowserTestUtils.jsm:744:13\n@chrome://mochitests/content/browser/devtools/client/netmonitor/test/browser_net_ws-early-connection.js:32:20\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1350:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1385:11\nnextTest/<@chrome://mochikit/content/browser-test.js:1213:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:805:67\nRejection date: Tue Sep 17 2019 21:42:02 GMT+0000 (Coordinated Universal Time) - false == true",
-                "status": "FAIL",
-                "expected": "PASS",
-                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 263\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:263\nchrome://mochikit/content/browser-test.js:nextTest:912\nchrome://mochikit/content/browser-test.js:timeoutFn:1471\nsetTimeout handler*chrome://mochikit/content/browser-test.js:Tester_execTest:1418\nchrome://mochikit/content/browser-test.js:nextTest/<:1213\nchrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:805"
-              },
-              {
-                "action": "test_result",
-                "line_number": 3645,
-                "test": "devtools/client/netmonitor/test/browser_net_ws-early-connection.js",
-                "subtest": "A promise chain failed to handle a rejection: Error while calling method getEventTimings: 'getEventTimings' pending request packet to 'server0.conn152.netEvent4' can't be sent as the connection just closed. - stack: _requestData/response</<@resource://devtools/client/netmonitor/src/connector/firefox-data-provider.js:620:17\nsafeOnResponse@resource://devtools/shared/client/debugger-client.js:314:14\nlistenerJson@resource://devtools/shared/client/debugger-client.js:339:16\nemit@resource://devtools/shared/event-emitter.js:190:24\nemit@resource://devtools/shared/event-emitter.js:271:18\nreject@resource://devtools/shared/client/debugger-client.js:815:15\npurgeRequests/<@resource://devtools/shared/client/debugger-client.js:826:54\npurgeRequests@resource://devtools/shared/client/debugger-client.js:826:29\nonClosed@resource://devtools/shared/client/debugger-client.js:762:10\nclose@resource://devtools/shared/transport/local-transport.js:171:20\nclose@resource://devtools/shared/transport/local-transport.js:167:13\nclose@resource://devtools/shared/transport/local-transport.js:167:13\ncleanup@resource://devtools/shared/client/debugger-client.js:215:27\nclose/promise<@resource://devtools/shared/client/debugger-client.js:231:7\nclose@resource://devtools/shared/client/debugger-client.js:208:21\nTargetMixin/destroy/this._destroyer<@resource://devtools/shared/fronts/targets/target-mixin.js:457:32\nasync*destroy@resource://devtools/shared/fronts/targets/target-mixin.js:480:9\ndestroy@resource://devtools/shared/fronts/targets/browsing-context.js:148:27\n_destroyToolbox/onceDestroyed</<@resource://devtools/client/framework/toolbox.js:3637:27\npromise callback*_destroyToolbox/onceDestroyed<@resource://devtools/client/framework/toolbox.js:3594:12\n_destroyToolbox@resource://devtools/client/framework/toolbox.js:3590:27\ndestroy@resource://devtools/client/framework/toolbox.js:3466:28\n_onRemotenessChange@resource://devtools/shared/fronts/targets/local-tab.js:131:19\n_handleTabEvent@resource://devtools/shared/fronts/targets/local-tab.js:109:14\nupdateBrowserRemoteness@chrome://browser/content/tabbrowser.js:2046:11\nrestoreTabContent@resource:///modules/sessionstore/SessionStore.jsm:4715:39\nrestoreTab@resource:///modules/sessionstore/SessionStore.jsm:4630:14\n_asyncNavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3721:10\nasync*navigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3614:24\nnavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:403:33\nLoadInOtherProcess@chrome://browser/content/browser.js:1596:16\n_loadURI@chrome://browser/content/browser.js:1561:25\nloadURI@resource://testing-common/BrowserTestUtils.jsm:744:13\n@chrome://mochitests/content/browser/devtools/client/netmonitor/test/browser_net_ws-early-connection.js:32:20\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1350:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1385:11\nnextTest/<@chrome://mochikit/content/browser-test.js:1213:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:805:67\nRejection date: Tue Sep 17 2019 21:42:02 GMT+0000 (Coordinated Universal Time) - false == true",
-                "status": "FAIL",
-                "expected": "PASS",
-                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 263\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:263\nchrome://mochikit/content/browser-test.js:nextTest:912\nchrome://mochikit/content/browser-test.js:timeoutFn:1471\nsetTimeout handler*chrome://mochikit/content/browser-test.js:Tester_execTest:1418\nchrome://mochikit/content/browser-test.js:nextTest/<:1213\nchrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:805"
-              },
-              {
-                "action": "test_result",
-                "line_number": 3647,
-                "test": "devtools/client/netmonitor/test/browser_net_ws-early-connection.js",
-                "subtest": "A promise chain failed to handle a rejection: Error while calling method getEventTimings: 'getEventTimings' pending request packet to 'server0.conn152.netEvent4' can't be sent as the connection just closed. - stack: _requestData/response</<@resource://devtools/client/netmonitor/src/connector/firefox-data-provider.js:620:17\nsafeOnResponse@resource://devtools/shared/client/debugger-client.js:314:14\nlistenerJson@resource://devtools/shared/client/debugger-client.js:339:16\nemit@resource://devtools/shared/event-emitter.js:190:24\nemit@resource://devtools/shared/event-emitter.js:271:18\nreject@resource://devtools/shared/client/debugger-client.js:815:15\npurgeRequests/<@resource://devtools/shared/client/debugger-client.js:826:54\npurgeRequests@resource://devtools/shared/client/debugger-client.js:826:29\nonClosed@resource://devtools/shared/client/debugger-client.js:762:10\nclose@resource://devtools/shared/transport/local-transport.js:171:20\nclose@resource://devtools/shared/transport/local-transport.js:167:13\nclose@resource://devtools/shared/transport/local-transport.js:167:13\ncleanup@resource://devtools/shared/client/debugger-client.js:215:27\nclose/promise<@resource://devtools/shared/client/debugger-client.js:231:7\nclose@resource://devtools/shared/client/debugger-client.js:208:21\nTargetMixin/destroy/this._destroyer<@resource://devtools/shared/fronts/targets/target-mixin.js:457:32\nasync*destroy@resource://devtools/shared/fronts/targets/target-mixin.js:480:9\ndestroy@resource://devtools/shared/fronts/targets/browsing-context.js:148:27\n_destroyToolbox/onceDestroyed</<@resource://devtools/client/framework/toolbox.js:3637:27\npromise callback*_destroyToolbox/onceDestroyed<@resource://devtools/client/framework/toolbox.js:3594:12\n_destroyToolbox@resource://devtools/client/framework/toolbox.js:3590:27\ndestroy@resource://devtools/client/framework/toolbox.js:3466:28\n_onRemotenessChange@resource://devtools/shared/fronts/targets/local-tab.js:131:19\n_handleTabEvent@resource://devtools/shared/fronts/targets/local-tab.js:109:14\nupdateBrowserRemoteness@chrome://browser/content/tabbrowser.js:2046:11\nrestoreTabContent@resource:///modules/sessionstore/SessionStore.jsm:4715:39\nrestoreTab@resource:///modules/sessionstore/SessionStore.jsm:4630:14\n_asyncNavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3721:10\nasync*navigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3614:24\nnavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:403:33\nLoadInOtherProcess@chrome://browser/content/browser.js:1596:16\n_loadURI@chrome://browser/content/browser.js:1561:25\nloadURI@resource://testing-common/BrowserTestUtils.jsm:744:13\n@chrome://mochitests/content/browser/devtools/client/netmonitor/test/browser_net_ws-early-connection.js:32:20\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1350:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1385:11\nnextTest/<@chrome://mochikit/content/browser-test.js:1213:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:805:67\nRejection date: Tue Sep 17 2019 21:42:02 GMT+0000 (Coordinated Universal Time) - false == true",
-                "status": "FAIL",
-                "expected": "PASS",
-                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 263\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:263\nchrome://mochikit/content/browser-test.js:nextTest:912\nchrome://mochikit/content/browser-test.js:timeoutFn:1471\nsetTimeout handler*chrome://mochikit/content/browser-test.js:Tester_execTest:1418\nchrome://mochikit/content/browser-test.js:nextTest/<:1213\nchrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:805"
-              },
-              {
-                "action": "test_result",
-                "line_number": 3649,
-                "test": "devtools/client/netmonitor/test/browser_net_ws-early-connection.js",
-                "subtest": "A promise chain failed to handle a rejection: Error while calling method getEventTimings: 'getEventTimings' pending request packet to 'server0.conn152.netEvent4' can't be sent as the connection just closed. - stack: _requestData/response</<@resource://devtools/client/netmonitor/src/connector/firefox-data-provider.js:620:17\nsafeOnResponse@resource://devtools/shared/client/debugger-client.js:314:14\nlistenerJson@resource://devtools/shared/client/debugger-client.js:339:16\nemit@resource://devtools/shared/event-emitter.js:190:24\nemit@resource://devtools/shared/event-emitter.js:271:18\nreject@resource://devtools/shared/client/debugger-client.js:815:15\npurgeRequests/<@resource://devtools/shared/client/debugger-client.js:826:54\npurgeRequests@resource://devtools/shared/client/debugger-client.js:826:29\nonClosed@resource://devtools/shared/client/debugger-client.js:762:10\nclose@resource://devtools/shared/transport/local-transport.js:171:20\nclose@resource://devtools/shared/transport/local-transport.js:167:13\nclose@resource://devtools/shared/transport/local-transport.js:167:13\ncleanup@resource://devtools/shared/client/debugger-client.js:215:27\nclose/promise<@resource://devtools/shared/client/debugger-client.js:231:7\nclose@resource://devtools/shared/client/debugger-client.js:208:21\nTargetMixin/destroy/this._destroyer<@resource://devtools/shared/fronts/targets/target-mixin.js:457:32\nasync*destroy@resource://devtools/shared/fronts/targets/target-mixin.js:480:9\ndestroy@resource://devtools/shared/fronts/targets/browsing-context.js:148:27\n_destroyToolbox/onceDestroyed</<@resource://devtools/client/framework/toolbox.js:3637:27\npromise callback*_destroyToolbox/onceDestroyed<@resource://devtools/client/framework/toolbox.js:3594:12\n_destroyToolbox@resource://devtools/client/framework/toolbox.js:3590:27\ndestroy@resource://devtools/client/framework/toolbox.js:3466:28\n_onRemotenessChange@resource://devtools/shared/fronts/targets/local-tab.js:131:19\n_handleTabEvent@resource://devtools/shared/fronts/targets/local-tab.js:109:14\nupdateBrowserRemoteness@chrome://browser/content/tabbrowser.js:2046:11\nrestoreTabContent@resource:///modules/sessionstore/SessionStore.jsm:4715:39\nrestoreTab@resource:///modules/sessionstore/SessionStore.jsm:4630:14\n_asyncNavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3721:10\nasync*navigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3614:24\nnavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:403:33\nLoadInOtherProcess@chrome://browser/content/browser.js:1596:16\n_loadURI@chrome://browser/content/browser.js:1561:25\nloadURI@resource://testing-common/BrowserTestUtils.jsm:744:13\n@chrome://mochitests/content/browser/devtools/client/netmonitor/test/browser_net_ws-early-connection.js:32:20\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1350:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1385:11\nnextTest/<@chrome://mochikit/content/browser-test.js:1213:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:805:67\nRejection date: Tue Sep 17 2019 21:42:02 GMT+0000 (Coordinated Universal Time) - false == true",
-                "status": "FAIL",
-                "expected": "PASS",
-                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 263\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:263\nchrome://mochikit/content/browser-test.js:nextTest:912\nchrome://mochikit/content/browser-test.js:timeoutFn:1471\nsetTimeout handler*chrome://mochikit/content/browser-test.js:Tester_execTest:1418\nchrome://mochikit/content/browser-test.js:nextTest/<:1213\nchrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:805"
-              },
-              {
-                "action": "test_result",
-                "line_number": 3651,
-                "test": "devtools/client/netmonitor/test/browser_net_ws-early-connection.js",
-                "subtest": "A promise chain failed to handle a rejection: Error while calling method getEventTimings: 'getEventTimings' pending request packet to 'server0.conn152.netEvent4' can't be sent as the connection just closed. - stack: _requestData/response</<@resource://devtools/client/netmonitor/src/connector/firefox-data-provider.js:620:17\nsafeOnResponse@resource://devtools/shared/client/debugger-client.js:314:14\nlistenerJson@resource://devtools/shared/client/debugger-client.js:339:16\nemit@resource://devtools/shared/event-emitter.js:190:24\nemit@resource://devtools/shared/event-emitter.js:271:18\nreject@resource://devtools/shared/client/debugger-client.js:815:15\npurgeRequests/<@resource://devtools/shared/client/debugger-client.js:826:54\npurgeRequests@resource://devtools/shared/client/debugger-client.js:826:29\nonClosed@resource://devtools/shared/client/debugger-client.js:762:10\nclose@resource://devtools/shared/transport/local-transport.js:171:20\nclose@resource://devtools/shared/transport/local-transport.js:167:13\nclose@resource://devtools/shared/transport/local-transport.js:167:13\ncleanup@resource://devtools/shared/client/debugger-client.js:215:27\nclose/promise<@resource://devtools/shared/client/debugger-client.js:231:7\nclose@resource://devtools/shared/client/debugger-client.js:208:21\nTargetMixin/destroy/this._destroyer<@resource://devtools/shared/fronts/targets/target-mixin.js:457:32\nasync*destroy@resource://devtools/shared/fronts/targets/target-mixin.js:480:9\ndestroy@resource://devtools/shared/fronts/targets/browsing-context.js:148:27\n_destroyToolbox/onceDestroyed</<@resource://devtools/client/framework/toolbox.js:3637:27\npromise callback*_destroyToolbox/onceDestroyed<@resource://devtools/client/framework/toolbox.js:3594:12\n_destroyToolbox@resource://devtools/client/framework/toolbox.js:3590:27\ndestroy@resource://devtools/client/framework/toolbox.js:3466:28\n_onRemotenessChange@resource://devtools/shared/fronts/targets/local-tab.js:131:19\n_handleTabEvent@resource://devtools/shared/fronts/targets/local-tab.js:109:14\nupdateBrowserRemoteness@chrome://browser/content/tabbrowser.js:2046:11\nrestoreTabContent@resource:///modules/sessionstore/SessionStore.jsm:4715:39\nrestoreTab@resource:///modules/sessionstore/SessionStore.jsm:4630:14\n_asyncNavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3721:10\nasync*navigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3614:24\nnavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:403:33\nLoadInOtherProcess@chrome://browser/content/browser.js:1596:16\n_loadURI@chrome://browser/content/browser.js:1561:25\nloadURI@resource://testing-common/BrowserTestUtils.jsm:744:13\n@chrome://mochitests/content/browser/devtools/client/netmonitor/test/browser_net_ws-early-connection.js:32:20\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1350:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1385:11\nnextTest/<@chrome://mochikit/content/browser-test.js:1213:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:805:67\nRejection date: Tue Sep 17 2019 21:42:02 GMT+0000 (Coordinated Universal Time) - false == true",
-                "status": "FAIL",
-                "expected": "PASS",
-                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 263\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:263\nchrome://mochikit/content/browser-test.js:nextTest:912\nchrome://mochikit/content/browser-test.js:timeoutFn:1471\nsetTimeout handler*chrome://mochikit/content/browser-test.js:Tester_execTest:1418\nchrome://mochikit/content/browser-test.js:nextTest/<:1213\nchrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:805"
-              },
-              {
-                "action": "test_result",
-                "line_number": 3653,
-                "test": "devtools/client/netmonitor/test/browser_net_ws-early-connection.js",
-                "subtest": "A promise chain failed to handle a rejection: Error while calling method getRequestCookies: 'getRequestCookies' active request packet to 'server0.conn152.netEvent4' can't be sent as the connection just closed. - stack: _requestData/response</<@resource://devtools/client/netmonitor/src/connector/firefox-data-provider.js:620:17\nsafeOnResponse@resource://devtools/shared/client/debugger-client.js:314:14\nlistenerJson@resource://devtools/shared/client/debugger-client.js:339:16\nemit@resource://devtools/shared/event-emitter.js:190:24\nemit@resource://devtools/shared/event-emitter.js:271:18\nreject@resource://devtools/shared/client/debugger-client.js:815:15\npurgeRequests/<@resource://devtools/shared/client/debugger-client.js:836:53\npurgeRequests@resource://devtools/shared/client/debugger-client.js:836:28\nonClosed@resource://devtools/shared/client/debugger-client.js:762:10\nclose@resource://devtools/shared/transport/local-transport.js:171:20\nclose@resource://devtools/shared/transport/local-transport.js:167:13\nclose@resource://devtools/shared/transport/local-transport.js:167:13\ncleanup@resource://devtools/shared/client/debugger-client.js:215:27\nclose/promise<@resource://devtools/shared/client/debugger-client.js:231:7\nclose@resource://devtools/shared/client/debugger-client.js:208:21\nTargetMixin/destroy/this._destroyer<@resource://devtools/shared/fronts/targets/target-mixin.js:457:32\nasync*destroy@resource://devtools/shared/fronts/targets/target-mixin.js:480:9\ndestroy@resource://devtools/shared/fronts/targets/browsing-context.js:148:27\n_destroyToolbox/onceDestroyed</<@resource://devtools/client/framework/toolbox.js:3637:27\npromise callback*_destroyToolbox/onceDestroyed<@resource://devtools/client/framework/toolbox.js:3594:12\n_destroyToolbox@resource://devtools/client/framework/toolbox.js:3590:27\ndestroy@resource://devtools/client/framework/toolbox.js:3466:28\n_onRemotenessChange@resource://devtools/shared/fronts/targets/local-tab.js:131:19\n_handleTabEvent@resource://devtools/shared/fronts/targets/local-tab.js:109:14\nupdateBrowserRemoteness@chrome://browser/content/tabbrowser.js:2046:11\nrestoreTabContent@resource:///modules/sessionstore/SessionStore.jsm:4715:39\nrestoreTab@resource:///modules/sessionstore/SessionStore.jsm:4630:14\n_asyncNavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3721:10\nasync*navigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:3614:24\nnavigateAndRestore@resource:///modules/sessionstore/SessionStore.jsm:403:33\nLoadInOtherProcess@chrome://browser/content/browser.js:1596:16\n_loadURI@chrome://browser/content/browser.js:1561:25\nloadURI@resource://testing-common/BrowserTestUtils.jsm:744:13\n@chrome://mochitests/content/browser/devtools/client/netmonitor/test/browser_net_ws-early-connection.js:32:20\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1350:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1385:11\nnextTest/<@chrome://mochikit/content/browser-test.js:1213:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:805:67\nRejection date: Tue Sep 17 2019 21:42:02 GMT+0000 (Coordinated Universal Time) - false == true",
-                "status": "FAIL",
-                "expected": "PASS",
-                "message": "JS frame :: resource://testing-common/PromiseTestUtils.jsm :: assertNoUncaughtRejections :: line 263\nStack trace:\nresource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:263\nchrome://mochikit/content/browser-test.js:nextTest:912\nchrome://mochikit/content/browser-test.js:timeoutFn:1471\nsetTimeout handler*chrome://mochikit/content/browser-test.js:Tester_execTest:1418\nchrome://mochikit/content/browser-test.js:nextTest/<:1213\nchrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<:805"
+                "message": "at chrome://mochitests/content/browser/devtools/client/shared/test/shared-head.js:230 - ReferenceError: info is not defined\nStack trace:\nremoveTab@chrome://mochitests/content/browser/devtools/client/shared/test/shared-head.js:230:3\n@chrome://mochitests/content/browser/devtools/client/framework/test/browser_about-devtools-toolbox_reload.js:54:9\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1062:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1097:11\nnextTest/<@chrome://mochikit/content/browser-test.js:925:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:808:67\n"
               }
             ],
             "suggestedClassification": "New Failure",
             "confidence": 0,
-            "tier": 2
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "devtools/client/inspector/markup/test/browser_markup_links_02.js",
+            "action": "test",
+            "jobName": "test-windows7-32-shippable/opt-mochitest-devtools-chrome-e10s-3",
+            "jobSymbol": "dt3",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "windows7-32-shippable",
+            "config": "opt",
+            "key": "devtoolsclientinspectormarkuptestbrowser_markup_links_02jsoptwindows732shippabletestwindows732shippableoptmochitestdevtoolschromee10s3Mochitests",
+            "jobKey": "optwindows7-32-shippabletest-windows7-32-shippable/opt-mochitest-devtools-chrome-e10s-3Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285384504,
+                "machine_platform_id": 582,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 182249,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-windows7-32-shippable/opt-mochitest-devtools-chrome-e10s-3",
+                "job_type_symbol": "dt3",
+                "platform": "windows7-32-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 8565,
+                "test": "devtools/client/inspector/markup/test/browser_markup_links_02.js",
+                "subtest": "Uncaught exception",
+                "status": "FAIL",
+                "expected": "PASS",
+                "message": "at chrome://mochitests/content/browser/devtools/client/inspector/markup/test/head.js:181 - TypeError: can't access property \"input\", inplaceEditor(...) is undefined\nStack trace:\nsetEditableFieldValue@chrome://mochitests/content/browser/devtools/client/inspector/markup/test/head.js:181:30\n@chrome://mochitests/content/browser/devtools/client/inspector/markup/test/browser_markup_links_02.js:31:24\nAsync*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1062:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1097:11\nnextTest/<@chrome://mochikit/content/browser-test.js:925:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:808:67\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "devtools/client/netmonitor/test/browser_net_req-resp-bodies.js",
+            "action": "test",
+            "jobName": "test-windows7-32-shippable/opt-mochitest-devtools-chrome-e10s-4",
+            "jobSymbol": "dt4",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "windows7-32-shippable",
+            "config": "opt",
+            "key": "devtoolsclientnetmonitortestbrowser_net_reqrespbodiesjsoptwindows732shippabletestwindows732shippableoptmochitestdevtoolschromee10s4Mochitests",
+            "jobKey": "optwindows7-32-shippabletest-windows7-32-shippable/opt-mochitest-devtools-chrome-e10s-4Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285384576,
+                "machine_platform_id": 582,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 182251,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-windows7-32-shippable/opt-mochitest-devtools-chrome-e10s-4",
+                "job_type_symbol": "dt4",
+                "platform": "windows7-32-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 3243,
+                "test": "devtools/client/netmonitor/test/browser_net_req-resp-bodies.js",
+                "subtest": "Uncaught exception",
+                "status": "FAIL",
+                "expected": "PASS",
+                "message": "TypeError: content.wrappedJSObject.performRequests is not a function"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-01.js",
+            "action": "test",
+            "jobName": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+            "jobSymbol": "dt-wr",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "macosx1014-64-shippable",
+            "config": "opt",
+            "key": "devtoolsclientwebreplaymochitestbrowser_dbg_rr_breakpoints01jsoptmacosx101464shippabletestmacosx101464shippableoptmochitestdevtoolswebreplaye10sMochitests",
+            "jobKey": "optmacosx1014-64-shippabletest-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10sMochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285379368,
+                "machine_platform_id": 655,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 198337,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+                "job_type_symbol": "dt-wr",
+                "platform": "macosx1014-64-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 88,
+                "test": "devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-01.js",
+                "subtest": "Test timed out",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 2,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-02.js",
+            "action": "test",
+            "jobName": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+            "jobSymbol": "dt-wr",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "macosx1014-64-shippable",
+            "config": "opt",
+            "key": "devtoolsclientwebreplaymochitestbrowser_dbg_rr_breakpoints02jsoptmacosx101464shippabletestmacosx101464shippableoptmochitestdevtoolswebreplaye10sMochitests",
+            "jobKey": "optmacosx1014-64-shippabletest-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10sMochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285379368,
+                "machine_platform_id": 655,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 198337,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+                "job_type_symbol": "dt-wr",
+                "platform": "macosx1014-64-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 124,
+                "test": "devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-02.js",
+                "subtest": "Test timed out",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 2,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-03.js",
+            "action": "test",
+            "jobName": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+            "jobSymbol": "dt-wr",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "macosx1014-64-shippable",
+            "config": "opt",
+            "key": "devtoolsclientwebreplaymochitestbrowser_dbg_rr_breakpoints03jsoptmacosx101464shippabletestmacosx101464shippableoptmochitestdevtoolswebreplaye10sMochitests",
+            "jobKey": "optmacosx1014-64-shippabletest-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10sMochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285379368,
+                "machine_platform_id": 655,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 198337,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+                "job_type_symbol": "dt-wr",
+                "platform": "macosx1014-64-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 159,
+                "test": "devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-03.js",
+                "subtest": "Test timed out",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 2,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-04.js",
+            "action": "test",
+            "jobName": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+            "jobSymbol": "dt-wr",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "macosx1014-64-shippable",
+            "config": "opt",
+            "key": "devtoolsclientwebreplaymochitestbrowser_dbg_rr_breakpoints04jsoptmacosx101464shippabletestmacosx101464shippableoptmochitestdevtoolswebreplaye10sMochitests",
+            "jobKey": "optmacosx1014-64-shippabletest-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10sMochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285379368,
+                "machine_platform_id": 655,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 198337,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+                "job_type_symbol": "dt-wr",
+                "platform": "macosx1014-64-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 194,
+                "test": "devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-04.js",
+                "subtest": "Test timed out",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 2,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-05.js",
+            "action": "test",
+            "jobName": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+            "jobSymbol": "dt-wr",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "macosx1014-64-shippable",
+            "config": "opt",
+            "key": "devtoolsclientwebreplaymochitestbrowser_dbg_rr_breakpoints05jsoptmacosx101464shippabletestmacosx101464shippableoptmochitestdevtoolswebreplaye10sMochitests",
+            "jobKey": "optmacosx1014-64-shippabletest-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10sMochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285379368,
+                "machine_platform_id": 655,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 198337,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+                "job_type_symbol": "dt-wr",
+                "platform": "macosx1014-64-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 229,
+                "test": "devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-05.js",
+                "subtest": "Test timed out",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 2,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-06.js",
+            "action": "test",
+            "jobName": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+            "jobSymbol": "dt-wr",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "macosx1014-64-shippable",
+            "config": "opt",
+            "key": "devtoolsclientwebreplaymochitestbrowser_dbg_rr_breakpoints06jsoptmacosx101464shippabletestmacosx101464shippableoptmochitestdevtoolswebreplaye10sMochitests",
+            "jobKey": "optmacosx1014-64-shippabletest-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10sMochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285379368,
+                "machine_platform_id": 655,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 198337,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+                "job_type_symbol": "dt-wr",
+                "platform": "macosx1014-64-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 264,
+                "test": "devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-06.js",
+                "subtest": "Test timed out",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 2,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-07.js",
+            "action": "test",
+            "jobName": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+            "jobSymbol": "dt-wr",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "macosx1014-64-shippable",
+            "config": "opt",
+            "key": "devtoolsclientwebreplaymochitestbrowser_dbg_rr_breakpoints07jsoptmacosx101464shippabletestmacosx101464shippableoptmochitestdevtoolswebreplaye10sMochitests",
+            "jobKey": "optmacosx1014-64-shippabletest-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10sMochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285379368,
+                "machine_platform_id": 655,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 198337,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+                "job_type_symbol": "dt-wr",
+                "platform": "macosx1014-64-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 299,
+                "test": "devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-07.js",
+                "subtest": "Test timed out",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 2,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "devtools/client/webreplay/mochitest/browser_dbg_rr_console_warp-01.js",
+            "action": "test",
+            "jobName": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+            "jobSymbol": "dt-wr",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "macosx1014-64-shippable",
+            "config": "opt",
+            "key": "devtoolsclientwebreplaymochitestbrowser_dbg_rr_console_warp01jsoptmacosx101464shippabletestmacosx101464shippableoptmochitestdevtoolswebreplaye10sMochitests",
+            "jobKey": "optmacosx1014-64-shippabletest-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10sMochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285379368,
+                "machine_platform_id": 655,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 198337,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+                "job_type_symbol": "dt-wr",
+                "platform": "macosx1014-64-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 334,
+                "test": "devtools/client/webreplay/mochitest/browser_dbg_rr_console_warp-01.js",
+                "subtest": "Test timed out",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 2,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "devtools/client/webreplay/mochitest/browser_dbg_rr_console_warp-02.js",
+            "action": "test",
+            "jobName": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+            "jobSymbol": "dt-wr",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "macosx1014-64-shippable",
+            "config": "opt",
+            "key": "devtoolsclientwebreplaymochitestbrowser_dbg_rr_console_warp02jsoptmacosx101464shippabletestmacosx101464shippableoptmochitestdevtoolswebreplaye10sMochitests",
+            "jobKey": "optmacosx1014-64-shippabletest-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10sMochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285379368,
+                "machine_platform_id": 655,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 198337,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64-shippable/opt-mochitest-devtools-webreplay-e10s",
+                "job_type_symbol": "dt-wr",
+                "platform": "macosx1014-64-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 369,
+                "test": "devtools/client/webreplay/mochitest/browser_dbg_rr_console_warp-02.js",
+                "subtest": "Test timed out",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 2,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "dom/broadcastchannel/tests/test_broadcastchannel_any.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-qr/debug-mochitest-fis-e10s-3",
+            "jobSymbol": "3",
+            "jobGroup": "Mochitests with fission enabled",
+            "jobGroupSymbol": "M-fis",
+            "platform": "linux1804-64-qr",
+            "config": "debug",
+            "key": "dombroadcastchannelteststest_broadcastchannel_anyhtmldebuglinux180464qrtestlinux180464qrdebugmochitestfise10s3Mochitestswithfissionenabled",
+            "jobKey": "debuglinux1804-64-qrtest-linux1804-64-qr/debug-mochitest-fis-e10s-3Mochitests with fission enabled",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363826,
+                "machine_platform_id": 725,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 215210,
+                "job_group_id": 1014,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-qr/debug-mochitest-fis-e10s-3",
+                "job_type_symbol": "3",
+                "platform": "linux1804-64-qr"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 1088,
+                "test": "dom/broadcastchannel/tests/test_broadcastchannel_any.html",
+                "subtest": "Test timed out.",
+                "status": "FAIL",
+                "expected": "PASS",
+                "stack": "    SimpleTest.ok@SimpleTest/SimpleTest.js:277:18\n    reportError@SimpleTest/TestRunner.js:121:22\n    TestRunner._checkForHangs@SimpleTest/TestRunner.js:142:18\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    TestRunner.runTests/<@SimpleTest/TestRunner.js:388:20\n    promise callback*TestRunner.runTests@SimpleTest/TestRunner.js:375:50\n    RunSet.runtests@SimpleTest/setup.js:201:14\n    RunSet.runall@SimpleTest/setup.js:180:12\n    hookupTests@SimpleTest/setup.js:273:12\nparseTestManifest@http://mochi.test:8888/manifestLibrary.js:48:13\ngetTestManifest/req.onload@http://mochi.test:8888/manifestLibrary.js:61:28\nEventHandlerNonNull*getTestManifest@http://mochi.test:8888/manifestLibrary.js:57:3\n    hookup@SimpleTest/setup.js:253:20\nEventHandlerNonNull*@http://mochi.test:8888/tests?autorun=1&closeWhenDone=1&consoleLevel=INFO&manifestFile=tests.json&dumpOutputDirectory=%2Ftmp&cleanupCrashes=true:11:1\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "dom/events/webkit-animation-iteration-event.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-qr/debug-web-platform-tests-fis-e10s-1",
+            "jobSymbol": "wpt1",
+            "jobGroup": "Web platform tests with fission enabled",
+            "jobGroupSymbol": "W-fis",
+            "platform": "linux1804-64-qr",
+            "config": "debug",
+            "key": "domeventswebkitanimationiterationeventhtmldebuglinux180464qrtestlinux180464qrdebugwebplatformtestsfise10s1Webplatformtestswithfissionenabled",
+            "jobKey": "debuglinux1804-64-qrtest-linux1804-64-qr/debug-web-platform-tests-fis-e10s-1Web platform tests with fission enabled",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363869,
+                "machine_platform_id": 725,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 214353,
+                "job_group_id": 1013,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-qr/debug-web-platform-tests-fis-e10s-1",
+                "job_type_symbol": "wpt1",
+                "platform": "linux1804-64-qr"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 15959,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "onwebkitanimationiteration event handler should trigger for an animation",
+                "status": "TIMEOUT",
+                "expected": "PASS",
+                "message": "Test timed out"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15960,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "onwebkitanimationiteration event handler should not trigger if an unprefixed event handler also exists",
+                "status": "NOTRUN",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15961,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "onwebkitanimationiteration event handler should not trigger if an unprefixed listener also exists",
+                "status": "NOTRUN",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15962,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "event types for prefixed and unprefixed animationiteration event handlers should be named appropriately",
+                "status": "NOTRUN",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15963,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "webkitAnimationIteration event listener should trigger for an animation",
+                "status": "NOTRUN",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15964,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "webkitAnimationIteration event listener should not trigger if an unprefixed listener also exists",
+                "status": "NOTRUN",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15965,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "webkitAnimationIteration event listener should not trigger if an unprefixed event handler also exists",
+                "status": "NOTRUN",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15966,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "event types for prefixed and unprefixed animationiteration event listeners should be named appropriately",
+                "status": "NOTRUN",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15967,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "webkitAnimationIteration event listener is case sensitive",
+                "status": "NOTRUN",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15968,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "status": "TIMEOUT",
+                "expected": "OK"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 2,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "dom/indexedDB/test/test_rename_index.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-asan/opt-mochitest-e10s-3",
+            "jobSymbol": "3",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "linux1804-64-asan",
+            "config": "opt",
+            "key": "domindexedDBtesttest_rename_indexhtmloptlinux180464asantestlinux180464asanoptmochiteste10s3Mochitests",
+            "jobKey": "optlinux1804-64-asantest-linux1804-64-asan/opt-mochitest-e10s-3Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363164,
+                "machine_platform_id": 728,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 212990,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-asan/opt-mochitest-e10s-3",
+                "job_type_symbol": "3",
+                "platform": "linux1804-64-asan"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 6254,
+                "test": "dom/indexedDB/test/test_rename_index.html",
+                "subtest": "Test timed out.",
+                "status": "FAIL",
+                "expected": "PASS",
+                "stack": "    SimpleTest.ok@SimpleTest/SimpleTest.js:277:18\n    reportError@SimpleTest/TestRunner.js:121:22\n    TestRunner._checkForHangs@SimpleTest/TestRunner.js:142:18\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    TestRunner.runTests/<@SimpleTest/TestRunner.js:388:20\n    promise callback*TestRunner.runTests@SimpleTest/TestRunner.js:375:50\n    RunSet.runtests@SimpleTest/setup.js:201:14\n    RunSet.runall@SimpleTest/setup.js:180:12\n    hookupTests@SimpleTest/setup.js:273:12\nparseTestManifest@http://mochi.test:8888/manifestLibrary.js:48:13\ngetTestManifest/req.onload@http://mochi.test:8888/manifestLibrary.js:61:28\nEventHandlerNonNull*getTestManifest@http://mochi.test:8888/manifestLibrary.js:57:3\n    hookup@SimpleTest/setup.js:253:20\nEventHandlerNonNull*@http://mochi.test:8888/tests?autorun=1&closeWhenDone=1&consoleLevel=INFO&manifestFile=tests.json&dumpOutputDirectory=%2Ftmp&cleanupCrashes=true:11:1\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "dom/indexedDB/test/test_rename_index_errors.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-asan/opt-mochitest-e10s-3",
+            "jobSymbol": "3",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "linux1804-64-asan",
+            "config": "opt",
+            "key": "domindexedDBtesttest_rename_index_errorshtmloptlinux180464asantestlinux180464asanoptmochiteste10s3Mochitests",
+            "jobKey": "optlinux1804-64-asantest-linux1804-64-asan/opt-mochitest-e10s-3Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363164,
+                "machine_platform_id": 728,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 212990,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-asan/opt-mochitest-e10s-3",
+                "job_type_symbol": "3",
+                "platform": "linux1804-64-asan"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 6265,
+                "test": "dom/indexedDB/test/test_rename_index_errors.html",
+                "subtest": "Test timed out.",
+                "status": "FAIL",
+                "expected": "PASS",
+                "stack": "    SimpleTest.ok@SimpleTest/SimpleTest.js:277:18\n    reportError@SimpleTest/TestRunner.js:121:22\n    TestRunner._checkForHangs@SimpleTest/TestRunner.js:142:18\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    TestRunner.runTests/<@SimpleTest/TestRunner.js:388:20\n    promise callback*TestRunner.runTests@SimpleTest/TestRunner.js:375:50\n    RunSet.runtests@SimpleTest/setup.js:201:14\n    RunSet.runall@SimpleTest/setup.js:180:12\n    hookupTests@SimpleTest/setup.js:273:12\nparseTestManifest@http://mochi.test:8888/manifestLibrary.js:48:13\ngetTestManifest/req.onload@http://mochi.test:8888/manifestLibrary.js:61:28\nEventHandlerNonNull*getTestManifest@http://mochi.test:8888/manifestLibrary.js:57:3\n    hookup@SimpleTest/setup.js:253:20\nEventHandlerNonNull*@http://mochi.test:8888/tests?autorun=1&closeWhenDone=1&consoleLevel=INFO&manifestFile=tests.json&dumpOutputDirectory=%2Ftmp&cleanupCrashes=true:11:1\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "dom/indexedDB/test/test_rename_objectStore.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-asan/opt-mochitest-e10s-3",
+            "jobSymbol": "3",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "linux1804-64-asan",
+            "config": "opt",
+            "key": "domindexedDBtesttest_rename_objectStorehtmloptlinux180464asantestlinux180464asanoptmochiteste10s3Mochitests",
+            "jobKey": "optlinux1804-64-asantest-linux1804-64-asan/opt-mochitest-e10s-3Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363164,
+                "machine_platform_id": 728,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 212990,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-asan/opt-mochitest-e10s-3",
+                "job_type_symbol": "3",
+                "platform": "linux1804-64-asan"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 6276,
+                "test": "dom/indexedDB/test/test_rename_objectStore.html",
+                "subtest": "Test timed out.",
+                "status": "FAIL",
+                "expected": "PASS",
+                "stack": "    SimpleTest.ok@SimpleTest/SimpleTest.js:277:18\n    reportError@SimpleTest/TestRunner.js:121:22\n    TestRunner._checkForHangs@SimpleTest/TestRunner.js:142:18\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    TestRunner.runTests/<@SimpleTest/TestRunner.js:388:20\n    promise callback*TestRunner.runTests@SimpleTest/TestRunner.js:375:50\n    RunSet.runtests@SimpleTest/setup.js:201:14\n    RunSet.runall@SimpleTest/setup.js:180:12\n    hookupTests@SimpleTest/setup.js:273:12\nparseTestManifest@http://mochi.test:8888/manifestLibrary.js:48:13\ngetTestManifest/req.onload@http://mochi.test:8888/manifestLibrary.js:61:28\nEventHandlerNonNull*getTestManifest@http://mochi.test:8888/manifestLibrary.js:57:3\n    hookup@SimpleTest/setup.js:253:20\nEventHandlerNonNull*@http://mochi.test:8888/tests?autorun=1&closeWhenDone=1&consoleLevel=INFO&manifestFile=tests.json&dumpOutputDirectory=%2Ftmp&cleanupCrashes=true:11:1\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "dom/indexedDB/test/test_rename_objectStore_errors.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-asan/opt-mochitest-e10s-3",
+            "jobSymbol": "3",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "linux1804-64-asan",
+            "config": "opt",
+            "key": "domindexedDBtesttest_rename_objectStore_errorshtmloptlinux180464asantestlinux180464asanoptmochiteste10s3Mochitests",
+            "jobKey": "optlinux1804-64-asantest-linux1804-64-asan/opt-mochitest-e10s-3Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363164,
+                "machine_platform_id": 728,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 212990,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-asan/opt-mochitest-e10s-3",
+                "job_type_symbol": "3",
+                "platform": "linux1804-64-asan"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 6287,
+                "test": "dom/indexedDB/test/test_rename_objectStore_errors.html",
+                "subtest": "Test timed out.",
+                "status": "FAIL",
+                "expected": "PASS",
+                "stack": "    SimpleTest.ok@SimpleTest/SimpleTest.js:277:18\n    reportError@SimpleTest/TestRunner.js:121:22\n    TestRunner._checkForHangs@SimpleTest/TestRunner.js:142:18\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    TestRunner.runTests/<@SimpleTest/TestRunner.js:388:20\n    promise callback*TestRunner.runTests@SimpleTest/TestRunner.js:375:50\n    RunSet.runtests@SimpleTest/setup.js:201:14\n    RunSet.runall@SimpleTest/setup.js:180:12\n    hookupTests@SimpleTest/setup.js:273:12\nparseTestManifest@http://mochi.test:8888/manifestLibrary.js:48:13\ngetTestManifest/req.onload@http://mochi.test:8888/manifestLibrary.js:61:28\nEventHandlerNonNull*getTestManifest@http://mochi.test:8888/manifestLibrary.js:57:3\n    hookup@SimpleTest/setup.js:253:20\nEventHandlerNonNull*@http://mochi.test:8888/tests?autorun=1&closeWhenDone=1&consoleLevel=INFO&manifestFile=tests.json&dumpOutputDirectory=%2Ftmp&cleanupCrashes=true:11:1\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "dom/media/test/test_cloneElementVisually_ended_video.html",
+            "action": "test",
+            "jobName": "test-windows10-64-asan/opt-mochitest-media-spi-e10s",
+            "jobSymbol": "mda",
+            "jobGroup": "Mochitests with socket process",
+            "jobGroupSymbol": "M-spi",
+            "platform": "windows10-64",
+            "config": "asan",
+            "key": "dommediatesttest_cloneElementVisually_ended_videohtmlasanwindows1064testwindows1064asanoptmochitestmediaspie10sMochitestswithsocketprocess",
+            "jobKey": "asanwindows10-64test-windows10-64-asan/opt-mochitest-media-spi-e10sMochitests with socket process",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285369706,
+                "machine_platform_id": 207,
+                "option_collection_hash": "03abd064e50ec12b8c7309950268531d78c63f60",
+                "job_type_id": 179941,
+                "job_group_id": 925,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-windows10-64-asan/opt-mochitest-media-spi-e10s",
+                "job_type_symbol": "mda",
+                "platform": "windows10-64"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 861,
+                "test": "dom/media/test/test_cloneElementVisually_ended_video.html",
+                "subtest": "Test timed out.",
+                "status": "FAIL",
+                "expected": "PASS",
+                "stack": "    SimpleTest.ok@SimpleTest/SimpleTest.js:277:18\n    reportError@SimpleTest/TestRunner.js:121:22\n    TestRunner._checkForHangs@SimpleTest/TestRunner.js:142:18\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    TestRunner.runTests/<@SimpleTest/TestRunner.js:388:20\n    promise callback*TestRunner.runTests@SimpleTest/TestRunner.js:375:50\n    RunSet.runtests@SimpleTest/setup.js:201:14\n    RunSet.runall@SimpleTest/setup.js:180:12\n    hookupTests@SimpleTest/setup.js:273:12\nparseTestManifest@http://mochi.test:8888/manifestLibrary.js:48:13\ngetTestManifest/req.onload@http://mochi.test:8888/manifestLibrary.js:61:28\nEventHandlerNonNull*getTestManifest@http://mochi.test:8888/manifestLibrary.js:57:3\n    hookup@SimpleTest/setup.js:253:20\nEventHandlerNonNull*@http://mochi.test:8888/tests?autorun=1&closeWhenDone=1&consoleLevel=INFO&manifestFile=tests.json&dumpOutputDirectory=c%3A%5Cusers%5Ctask_1579646169%5Cappdata%5Clocal%5Ctemp&cleanupCrashes=true:11:1\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "dom/media/test/test_cloneElementVisually_no_suspend.html",
+            "action": "test",
+            "jobName": "test-windows10-64-asan/opt-mochitest-media-spi-e10s",
+            "jobSymbol": "mda",
+            "jobGroup": "Mochitests with socket process",
+            "jobGroupSymbol": "M-spi",
+            "platform": "windows10-64",
+            "config": "asan",
+            "key": "dommediatesttest_cloneElementVisually_no_suspendhtmlasanwindows1064testwindows1064asanoptmochitestmediaspie10sMochitestswithsocketprocess",
+            "jobKey": "asanwindows10-64test-windows10-64-asan/opt-mochitest-media-spi-e10sMochitests with socket process",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285369706,
+                "machine_platform_id": 207,
+                "option_collection_hash": "03abd064e50ec12b8c7309950268531d78c63f60",
+                "job_type_id": 179941,
+                "job_group_id": 925,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-windows10-64-asan/opt-mochitest-media-spi-e10s",
+                "job_type_symbol": "mda",
+                "platform": "windows10-64"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 875,
+                "test": "dom/media/test/test_cloneElementVisually_no_suspend.html",
+                "subtest": "Test timed out.",
+                "status": "FAIL",
+                "expected": "PASS",
+                "stack": "    SimpleTest.ok@SimpleTest/SimpleTest.js:277:18\n    reportError@SimpleTest/TestRunner.js:121:22\n    TestRunner._checkForHangs@SimpleTest/TestRunner.js:142:18\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    TestRunner.runTests/<@SimpleTest/TestRunner.js:388:20\n    promise callback*TestRunner.runTests@SimpleTest/TestRunner.js:375:50\n    RunSet.runtests@SimpleTest/setup.js:201:14\n    RunSet.runall@SimpleTest/setup.js:180:12\n    hookupTests@SimpleTest/setup.js:273:12\nparseTestManifest@http://mochi.test:8888/manifestLibrary.js:48:13\ngetTestManifest/req.onload@http://mochi.test:8888/manifestLibrary.js:61:28\nEventHandlerNonNull*getTestManifest@http://mochi.test:8888/manifestLibrary.js:57:3\n    hookup@SimpleTest/setup.js:253:20\nEventHandlerNonNull*@http://mochi.test:8888/tests?autorun=1&closeWhenDone=1&consoleLevel=INFO&manifestFile=tests.json&dumpOutputDirectory=c%3A%5Cusers%5Ctask_1579646169%5Cappdata%5Clocal%5Ctemp&cleanupCrashes=true:11:1\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "dom/media/test/test_cloneElementVisually_poster.html",
+            "action": "test",
+            "jobName": "test-windows10-64-asan/opt-mochitest-media-spi-e10s",
+            "jobSymbol": "mda",
+            "jobGroup": "Mochitests with socket process",
+            "jobGroupSymbol": "M-spi",
+            "platform": "windows10-64",
+            "config": "asan",
+            "key": "dommediatesttest_cloneElementVisually_posterhtmlasanwindows1064testwindows1064asanoptmochitestmediaspie10sMochitestswithsocketprocess",
+            "jobKey": "asanwindows10-64test-windows10-64-asan/opt-mochitest-media-spi-e10sMochitests with socket process",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285369706,
+                "machine_platform_id": 207,
+                "option_collection_hash": "03abd064e50ec12b8c7309950268531d78c63f60",
+                "job_type_id": 179941,
+                "job_group_id": 925,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-windows10-64-asan/opt-mochitest-media-spi-e10s",
+                "job_type_symbol": "mda",
+                "platform": "windows10-64"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 886,
+                "test": "dom/media/test/test_cloneElementVisually_poster.html",
+                "subtest": "Test timed out.",
+                "status": "FAIL",
+                "expected": "PASS",
+                "stack": "    SimpleTest.ok@SimpleTest/SimpleTest.js:277:18\n    reportError@SimpleTest/TestRunner.js:121:22\n    TestRunner._checkForHangs@SimpleTest/TestRunner.js:142:18\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    TestRunner.runTests/<@SimpleTest/TestRunner.js:388:20\n    promise callback*TestRunner.runTests@SimpleTest/TestRunner.js:375:50\n    RunSet.runtests@SimpleTest/setup.js:201:14\n    RunSet.runall@SimpleTest/setup.js:180:12\n    hookupTests@SimpleTest/setup.js:273:12\nparseTestManifest@http://mochi.test:8888/manifestLibrary.js:48:13\ngetTestManifest/req.onload@http://mochi.test:8888/manifestLibrary.js:61:28\nEventHandlerNonNull*getTestManifest@http://mochi.test:8888/manifestLibrary.js:57:3\n    hookup@SimpleTest/setup.js:253:20\nEventHandlerNonNull*@http://mochi.test:8888/tests?autorun=1&closeWhenDone=1&consoleLevel=INFO&manifestFile=tests.json&dumpOutputDirectory=c%3A%5Cusers%5Ctask_1579646169%5Cappdata%5Clocal%5Ctemp&cleanupCrashes=true:11:1\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "dom/media/test/test_cloneElementVisually_resource_change.html",
+            "action": "test",
+            "jobName": "test-windows10-64-asan/opt-mochitest-media-spi-e10s",
+            "jobSymbol": "mda",
+            "jobGroup": "Mochitests with socket process",
+            "jobGroupSymbol": "M-spi",
+            "platform": "windows10-64",
+            "config": "asan",
+            "key": "dommediatesttest_cloneElementVisually_resource_changehtmlasanwindows1064testwindows1064asanoptmochitestmediaspie10sMochitestswithsocketprocess",
+            "jobKey": "asanwindows10-64test-windows10-64-asan/opt-mochitest-media-spi-e10sMochitests with socket process",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285369706,
+                "machine_platform_id": 207,
+                "option_collection_hash": "03abd064e50ec12b8c7309950268531d78c63f60",
+                "job_type_id": 179941,
+                "job_group_id": 925,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-windows10-64-asan/opt-mochitest-media-spi-e10s",
+                "job_type_symbol": "mda",
+                "platform": "windows10-64"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 894,
+                "test": "dom/media/test/test_cloneElementVisually_resource_change.html",
+                "subtest": "Test timed out.",
+                "status": "FAIL",
+                "expected": "PASS",
+                "stack": "    SimpleTest.ok@SimpleTest/SimpleTest.js:277:18\n    reportError@SimpleTest/TestRunner.js:121:22\n    TestRunner._checkForHangs@SimpleTest/TestRunner.js:142:18\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n    setTimeout handler*TestRunner._checkForHangs@SimpleTest/TestRunner.js:170:15\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "dom/tests/mochitest/general/test_resizeby.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-qr/debug-mochitest-e10s-9",
+            "jobSymbol": "9",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "linux1804-64-qr",
+            "config": "debug",
+            "key": "domtestsmochitestgeneraltest_resizebyhtmldebuglinux180464qrtestlinux180464qrdebugmochiteste10s9Mochitests",
+            "jobKey": "debuglinux1804-64-qrtest-linux1804-64-qr/debug-mochitest-e10s-9Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285364012,
+                "machine_platform_id": 725,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 212952,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-qr/debug-mochitest-e10s-9",
+                "job_type_symbol": "9",
+                "platform": "linux1804-64-qr"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 15258,
+                "test": "dom/tests/mochitest/general/test_resizeby.html",
+                "subtest": "ending width is 550",
+                "status": "FAIL",
+                "expected": "PASS",
+                "message": "got 500, expected 550",
+                "stack": "    SimpleTest.is@SimpleTest/SimpleTest.js:325:16\n    resizeby@dom/tests/mochitest/general/test_resizeby.html:56:7\n    async*nextTick/<@SimpleTest/SimpleTest.js:1824:34\n    nextTick@SimpleTest/SimpleTest.js:1840:11\n    setTimeout handler*SimpleTest_setTimeoutShim@SimpleTest/SimpleTest.js:689:43\n    add_task@SimpleTest/SimpleTest.js:1784:17\n    @dom/tests/mochitest/general/test_resizeby.html:22:11\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-006.html == layout/reftests/high-contrast/backplate-bg-image-006-ref.html",
+            "action": "test",
+            "jobName": "test-windows10-64-mingwclang/debug-reftest-e10s-1",
+            "jobSymbol": "R1",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "windows10-64-mingwclang",
+            "config": "debug",
+            "key": "layoutreftestshighcontrastbackplatebgimage006htmllayoutreftestshighcontrastbackplatebgimage006refhtmldebugwindows1064mingwclangtestwindows1064mingwclangdebugrefteste10s1Reftests",
+            "jobKey": "debugwindows10-64-mingwclangtest-windows10-64-mingwclang/debug-reftest-e10s-1Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285364198,
+                "machine_platform_id": 501,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 196683,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-windows10-64-mingwclang/debug-reftest-e10s-1",
+                "job_type_symbol": "R1",
+                "platform": "windows10-64-mingwclang"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 46610,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-006.html == layout/reftests/high-contrast/backplate-bg-image-006-ref.html",
+                "subtest": "image comparison, max difference: 15, number of differing pixels: 3200",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 2,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-006.html == layout/reftests/high-contrast/backplate-bg-image-006-ref.html",
+            "action": "test",
+            "jobName": "test-windows10-64-asan/opt-reftest-e10s-3",
+            "jobSymbol": "R3",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "windows10-64",
+            "config": "asan",
+            "key": "layoutreftestshighcontrastbackplatebgimage006htmllayoutreftestshighcontrastbackplatebgimage006refhtmlasanwindows1064testwindows1064asanoptrefteste10s3Reftests",
+            "jobKey": "asanwindows10-64test-windows10-64-asan/opt-reftest-e10s-3Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285369722,
+                "machine_platform_id": 207,
+                "option_collection_hash": "03abd064e50ec12b8c7309950268531d78c63f60",
+                "job_type_id": 207022,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-windows10-64-asan/opt-reftest-e10s-3",
+                "job_type_symbol": "R3",
+                "platform": "windows10-64"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 30542,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-006.html == layout/reftests/high-contrast/backplate-bg-image-006-ref.html",
+                "subtest": "image comparison, max difference: 15, number of differing pixels: 3200",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-006.html == layout/reftests/high-contrast/backplate-bg-image-006-ref.html",
+            "action": "test",
+            "jobName": "test-windows10-64-qr/debug-reftest-e10s-1",
+            "jobSymbol": "R1",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "windows10-64-qr",
+            "config": "debug",
+            "key": "layoutreftestshighcontrastbackplatebgimage006htmllayoutreftestshighcontrastbackplatebgimage006refhtmldebugwindows1064qrtestwindows1064qrdebugrefteste10s1Reftests",
+            "jobKey": "debugwindows10-64-qrtest-windows10-64-qr/debug-reftest-e10s-1Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285369818,
+                "machine_platform_id": 420,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 116126,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-windows10-64-qr/debug-reftest-e10s-1",
+                "job_type_symbol": "R1",
+                "platform": "windows10-64-qr"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 63026,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-006.html == layout/reftests/high-contrast/backplate-bg-image-006-ref.html",
+                "subtest": "image comparison, max difference: 15, number of differing pixels: 3200",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-006.html == layout/reftests/high-contrast/backplate-bg-image-006-ref.html",
+            "action": "test",
+            "jobName": "test-windows10-64/debug-reftest-e10s-1",
+            "jobSymbol": "R1",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "windows10-64",
+            "config": "debug",
+            "key": "layoutreftestshighcontrastbackplatebgimage006htmllayoutreftestshighcontrastbackplatebgimage006refhtmldebugwindows1064testwindows1064debugrefteste10s1Reftests",
+            "jobKey": "debugwindows10-64test-windows10-64/debug-reftest-e10s-1Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285369821,
+                "machine_platform_id": 207,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 40437,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-windows10-64/debug-reftest-e10s-1",
+                "job_type_symbol": "R1",
+                "platform": "windows10-64"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 26722,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-006.html == layout/reftests/high-contrast/backplate-bg-image-006-ref.html",
+                "subtest": "image comparison, max difference: 15, number of differing pixels: 3200",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-006.html == layout/reftests/high-contrast/backplate-bg-image-006-ref.html",
+            "action": "test",
+            "jobName": "test-windows10-64-shippable-qr/opt-reftest-e10s-2",
+            "jobSymbol": "R2",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "windows10-64-shippable-qr",
+            "config": "opt",
+            "key": "layoutreftestshighcontrastbackplatebgimage006htmllayoutreftestshighcontrastbackplatebgimage006refhtmloptwindows1064shippableqrtestwindows1064shippableqroptrefteste10s2Reftests",
+            "jobKey": "optwindows10-64-shippable-qrtest-windows10-64-shippable-qr/opt-reftest-e10s-2Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285382039,
+                "machine_platform_id": 588,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 182377,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-windows10-64-shippable-qr/opt-reftest-e10s-2",
+                "job_type_symbol": "R2",
+                "platform": "windows10-64-shippable-qr"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 6838,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-006.html == layout/reftests/high-contrast/backplate-bg-image-006-ref.html",
+                "subtest": "image comparison, max difference: 15, number of differing pixels: 3200",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-006.html == layout/reftests/high-contrast/backplate-bg-image-006-ref.html",
+            "action": "test",
+            "jobName": "test-windows10-64-shippable/opt-reftest-e10s-2",
+            "jobSymbol": "R2",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "windows10-64-shippable",
+            "config": "opt",
+            "key": "layoutreftestshighcontrastbackplatebgimage006htmllayoutreftestshighcontrastbackplatebgimage006refhtmloptwindows1064shippabletestwindows1064shippableoptrefteste10s2Reftests",
+            "jobKey": "optwindows10-64-shippabletest-windows10-64-shippable/opt-reftest-e10s-2Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285382072,
+                "machine_platform_id": 580,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 181976,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-windows10-64-shippable/opt-reftest-e10s-2",
+                "job_type_symbol": "R2",
+                "platform": "windows10-64-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 9274,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-006.html == layout/reftests/high-contrast/backplate-bg-image-006-ref.html",
+                "subtest": "image comparison, max difference: 15, number of differing pixels: 3200",
+                "status": "FAIL",
+                "expected": "PASS"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-asan/opt-reftest-no-accel-e10s-4",
+            "jobSymbol": "Ru4",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "linux1804-64-asan",
+            "config": "opt",
+            "key": "layoutreftestshighcontrastbackplatebgimage009htmllayoutreftestshighcontrastbackplatebgimage009refhtmloptlinux180464asantestlinux180464asanoptreftestnoaccele10s4Reftests",
+            "jobKey": "optlinux1804-64-asantest-linux1804-64-asan/opt-reftest-no-accel-e10s-4Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363073,
+                "machine_platform_id": 728,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 213278,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-asan/opt-reftest-no-accel-e10s-4",
+                "job_type_symbol": "Ru4",
+                "platform": "linux1804-64-asan"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 7892,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+                "subtest": "image comparison, max difference: 0, number of differing pixels: 0",
+                "status": "PASS",
+                "expected": "FAIL"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-asan/opt-reftest-e10s-4",
+            "jobSymbol": "R4",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "linux1804-64-asan",
+            "config": "opt",
+            "key": "layoutreftestshighcontrastbackplatebgimage009htmllayoutreftestshighcontrastbackplatebgimage009refhtmloptlinux180464asantestlinux180464asanoptrefteste10s4Reftests",
+            "jobKey": "optlinux1804-64-asantest-linux1804-64-asan/opt-reftest-e10s-4Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363139,
+                "machine_platform_id": 728,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 213275,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-asan/opt-reftest-e10s-4",
+                "job_type_symbol": "R4",
+                "platform": "linux1804-64-asan"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 7949,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+                "subtest": "image comparison, max difference: 0, number of differing pixels: 0",
+                "status": "PASS",
+                "expected": "FAIL"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-asan-qr/opt-reftest-e10s-4",
+            "jobSymbol": "R4",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "linux1804-64-asan-qr",
+            "config": "opt",
+            "key": "layoutreftestshighcontrastbackplatebgimage009htmllayoutreftestshighcontrastbackplatebgimage009refhtmloptlinux180464asanqrtestlinux180464asanqroptrefteste10s4Reftests",
+            "jobKey": "optlinux1804-64-asan-qrtest-linux1804-64-asan-qr/opt-reftest-e10s-4Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363147,
+                "machine_platform_id": 730,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 213886,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-asan-qr/opt-reftest-e10s-4",
+                "job_type_symbol": "R4",
+                "platform": "linux1804-64-asan-qr"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 7934,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+                "subtest": "image comparison, max difference: 0, number of differing pixels: 0",
+                "status": "PASS",
+                "expected": "FAIL"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 2,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-qr/debug-reftest-fis-e10s-4",
+            "jobSymbol": "R4",
+            "jobGroup": "Reftests with fission enabled",
+            "jobGroupSymbol": "R-fis",
+            "platform": "linux1804-64-qr",
+            "config": "debug",
+            "key": "layoutreftestshighcontrastbackplatebgimage009htmllayoutreftestshighcontrastbackplatebgimage009refhtmldebuglinux180464qrtestlinux180464qrdebugreftestfise10s4Reftestswithfissionenabled",
+            "jobKey": "debuglinux1804-64-qrtest-linux1804-64-qr/debug-reftest-fis-e10s-4Reftests with fission enabled",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363814,
+                "machine_platform_id": 725,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 215060,
+                "job_group_id": 1011,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-qr/debug-reftest-fis-e10s-4",
+                "job_type_symbol": "R4",
+                "platform": "linux1804-64-qr"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 18402,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+                "subtest": "image comparison, max difference: 0, number of differing pixels: 0",
+                "status": "PASS",
+                "expected": "FAIL"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+            "action": "test",
+            "jobName": "test-linux1804-64/debug-reftest-no-accel-e10s-4",
+            "jobSymbol": "Ru4",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "linux1804-64",
+            "config": "debug",
+            "key": "layoutreftestshighcontrastbackplatebgimage009htmllayoutreftestshighcontrastbackplatebgimage009refhtmldebuglinux180464testlinux180464debugreftestnoaccele10s4Reftests",
+            "jobKey": "debuglinux1804-64test-linux1804-64/debug-reftest-no-accel-e10s-4Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363950,
+                "machine_platform_id": 722,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 213238,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64/debug-reftest-no-accel-e10s-4",
+                "job_type_symbol": "Ru4",
+                "platform": "linux1804-64"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 23391,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+                "subtest": "image comparison, max difference: 0, number of differing pixels: 0",
+                "status": "PASS",
+                "expected": "FAIL"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+            "action": "test",
+            "jobName": "test-linux1804-64/debug-reftest-e10s-4",
+            "jobSymbol": "R4",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "linux1804-64",
+            "config": "debug",
+            "key": "layoutreftestshighcontrastbackplatebgimage009htmllayoutreftestshighcontrastbackplatebgimage009refhtmldebuglinux180464testlinux180464debugrefteste10s4Reftests",
+            "jobKey": "debuglinux1804-64test-linux1804-64/debug-reftest-e10s-4Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363953,
+                "machine_platform_id": 722,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 213240,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64/debug-reftest-e10s-4",
+                "job_type_symbol": "R4",
+                "platform": "linux1804-64"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 21152,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+                "subtest": "image comparison, max difference: 0, number of differing pixels: 0",
+                "status": "PASS",
+                "expected": "FAIL"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-qr/debug-reftest-e10s-4",
+            "jobSymbol": "R4",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "linux1804-64-qr",
+            "config": "debug",
+            "key": "layoutreftestshighcontrastbackplatebgimage009htmllayoutreftestshighcontrastbackplatebgimage009refhtmldebuglinux180464qrtestlinux180464qrdebugrefteste10s4Reftests",
+            "jobKey": "debuglinux1804-64-qrtest-linux1804-64-qr/debug-reftest-e10s-4Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363982,
+                "machine_platform_id": 725,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 213259,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-qr/debug-reftest-e10s-4",
+                "job_type_symbol": "R4",
+                "platform": "linux1804-64-qr"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 18288,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+                "subtest": "image comparison, max difference: 0, number of differing pixels: 0",
+                "status": "PASS",
+                "expected": "FAIL"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-shippable-qr/opt-reftest-e10s-4",
+            "jobSymbol": "R4",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "linux1804-64-shippable-qr",
+            "config": "opt",
+            "key": "layoutreftestshighcontrastbackplatebgimage009htmllayoutreftestshighcontrastbackplatebgimage009refhtmloptlinux180464shippableqrtestlinux180464shippableqroptrefteste10s4Reftests",
+            "jobKey": "optlinux1804-64-shippable-qrtest-linux1804-64-shippable-qr/opt-reftest-e10s-4Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285383288,
+                "machine_platform_id": 726,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 213302,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-shippable-qr/opt-reftest-e10s-4",
+                "job_type_symbol": "R4",
+                "platform": "linux1804-64-shippable-qr"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 7769,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+                "subtest": "image comparison, max difference: 0, number of differing pixels: 0",
+                "status": "PASS",
+                "expected": "FAIL"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-shippable/opt-reftest-no-accel-e10s-1",
+            "jobSymbol": "Ru1",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "linux1804-64-shippable",
+            "config": "opt",
+            "key": "layoutreftestshighcontrastbackplatebgimage009htmllayoutreftestshighcontrastbackplatebgimage009refhtmloptlinux180464shippabletestlinux180464shippableoptreftestnoaccele10s1Reftests",
+            "jobKey": "optlinux1804-64-shippabletest-linux1804-64-shippable/opt-reftest-no-accel-e10s-1Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285383304,
+                "machine_platform_id": 724,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 213293,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-shippable/opt-reftest-no-accel-e10s-1",
+                "job_type_symbol": "Ru1",
+                "platform": "linux1804-64-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 21176,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+                "subtest": "image comparison, max difference: 0, number of differing pixels: 0",
+                "status": "PASS",
+                "expected": "FAIL"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-shippable/opt-reftest-e10s-2",
+            "jobSymbol": "R2",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "linux1804-64-shippable",
+            "config": "opt",
+            "key": "layoutreftestshighcontrastbackplatebgimage009htmllayoutreftestshighcontrastbackplatebgimage009refhtmloptlinux180464shippabletestlinux180464shippableoptrefteste10s2Reftests",
+            "jobKey": "optlinux1804-64-shippabletest-linux1804-64-shippable/opt-reftest-e10s-2Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285383305,
+                "machine_platform_id": 724,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 213301,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-shippable/opt-reftest-e10s-2",
+                "job_type_symbol": "R2",
+                "platform": "linux1804-64-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 12368,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+                "subtest": "image comparison, max difference: 0, number of differing pixels: 0",
+                "status": "PASS",
+                "expected": "FAIL"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "pointerlock/movementX_Y_basic.html",
+            "action": "test",
+            "jobName": "test-linux1804-64-qr/debug-web-platform-tests-fis-e10s-1",
+            "jobSymbol": "wpt1",
+            "jobGroup": "Web platform tests with fission enabled",
+            "jobGroupSymbol": "W-fis",
+            "platform": "linux1804-64-qr",
+            "config": "debug",
+            "key": "pointerlockmovementX_Y_basichtmldebuglinux180464qrtestlinux180464qrdebugwebplatformtestsfise10s1Webplatformtestswithfissionenabled",
+            "jobKey": "debuglinux1804-64-qrtest-linux1804-64-qr/debug-web-platform-tests-fis-e10s-1Web platform tests with fission enabled",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363869,
+                "machine_platform_id": 725,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 214353,
+                "job_group_id": 1013,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux1804-64-qr/debug-web-platform-tests-fis-e10s-1",
+                "job_type_symbol": "wpt1",
+                "platform": "linux1804-64-qr"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 27411,
+                "test": "/pointerlock/movementX_Y_basic.html",
+                "subtest": "Test that movementX/Y = eNow.screenX/Y-ePrevious.screenX/Y.",
+                "status": "FAIL",
+                "expected": "PASS",
+                "message": "assert_equals: movementX = screen_delta expected -50 but got 609",
+                "stack": "@http://web-platform.test:8000/pointerlock/movementX_Y_basic.html:105:38\nTest.prototype.step@http://web-platform.test:8000/resources/testharness.js:2024:25\n@http://web-platform.test:8000/pointerlock/movementX_Y_basic.html:104:52\nAsync*@tests/web-platform/tests/tools/wptrunner/wptrunner/executors/executormarionette.py:67:14\n@tests/web-platform/tests/tools/wptrunner/wptrunner/executors/executormarionette.py:68:8\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 2,
+            "passFailRatio": 0.0
+          },
+          {
+            "testName": "webrtc/RTCPeerConnection-ondatachannel.html",
+            "action": "test",
+            "jobName": "test-windows7-32-shippable/opt-web-platform-tests-e10s-10",
+            "jobSymbol": "wpt10",
+            "jobGroup": "Web platform tests",
+            "jobGroupSymbol": "W",
+            "platform": "windows7-32-shippable",
+            "config": "opt",
+            "key": "webrtcRTCPeerConnectionondatachannelhtmloptwindows732shippabletestwindows732shippableoptwebplatformtestse10s10Webplatformtests",
+            "jobKey": "optwindows7-32-shippabletest-windows7-32-shippable/opt-web-platform-tests-e10s-10Web platform tests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285384585,
+                "machine_platform_id": 582,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 182266,
+                "job_group_id": 461,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-windows7-32-shippable/opt-web-platform-tests-e10s-10",
+                "job_type_symbol": "wpt10",
+                "platform": "windows7-32-shippable"
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 43037,
+                "test": "/webrtc/RTCPeerConnection-ondatachannel.html",
+                "subtest": "Negotiated channel should not fire datachannel event on remote peer",
+                "status": "TIMEOUT",
+                "expected": "PASS",
+                "message": "Test timed out"
+              },
+              {
+                "action": "test_result",
+                "line_number": 43038,
+                "test": "/webrtc/RTCPeerConnection-ondatachannel.html",
+                "status": "TIMEOUT",
+                "expected": "OK"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.0
           }
         ],
-        "intermittent": []
+        "intermittent": [
+          {
+            "testName": "Non-Test Error",
+            "action": "log",
+            "jobName": "test-macosx1014-64/debug-mochitest-browser-chrome-e10s-6",
+            "jobSymbol": "bc6",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "macosx1014-64",
+            "config": "debug",
+            "key": "NonTestErrordebugmacosx101464testmacosx101464debugmochitestbrowserchromee10s6Mochitests",
+            "jobKey": "debugmacosx1014-64test-macosx1014-64/debug-mochitest-browser-chrome-e10s-6Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285364376,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198310,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-mochitest-browser-chrome-e10s-6",
+                "job_type_symbol": "bc6",
+                "platform": "macosx1014-64"
+              }
+            ],
+            "passJobs": [
+              {
+                "id": 285371125,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198310,
+                "job_group_id": 448,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-mochitest-browser-chrome-e10s-6",
+                "job_type_symbol": "bc6",
+                "platform": "macosx1014-64"
+              },
+              {
+                "id": 285371126,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198310,
+                "job_group_id": 448,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-mochitest-browser-chrome-e10s-6",
+                "job_type_symbol": "bc6",
+                "platform": "macosx1014-64"
+              },
+              {
+                "id": 285371143,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198310,
+                "job_group_id": 448,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-mochitest-browser-chrome-e10s-6",
+                "job_type_symbol": "bc6",
+                "platform": "macosx1014-64"
+              }
+            ],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "log",
+                "line_number": 9829,
+                "message": "TEST-UNEXPECTED-FAIL | ShutdownLeaks | process() called before end of test suite",
+                "level": "ERROR"
+              },
+              {
+                "action": "log",
+                "line_number": 9835,
+                "message": "TEST-UNEXPECTED-FAIL | browser/components/customizableui/test/browser_923857_customize_mode_event_wrapping_during_reset.js | application terminated with exit code 5",
+                "level": "ERROR"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.75
+          },
+          {
+            "testName": "browser/components/customizableui/test/browser_923857_customize_mode_event_wrapping_during_reset.js",
+            "action": "crash",
+            "jobName": "test-macosx1014-64/debug-mochitest-browser-chrome-e10s-6",
+            "jobSymbol": "bc6",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "macosx1014-64",
+            "config": "debug",
+            "key": "browsercomponentscustomizableuitestbrowser_923857_customize_mode_event_wrapping_during_resetjsdebugmacosx101464testmacosx101464debugmochitestbrowserchromee10s6Mochitests",
+            "jobKey": "debugmacosx1014-64test-macosx1014-64/debug-mochitest-browser-chrome-e10s-6Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285364376,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198310,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-mochitest-browser-chrome-e10s-6",
+                "job_type_symbol": "bc6",
+                "platform": "macosx1014-64"
+              }
+            ],
+            "passJobs": [
+              {
+                "id": 285371125,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198310,
+                "job_group_id": 448,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-mochitest-browser-chrome-e10s-6",
+                "job_type_symbol": "bc6",
+                "platform": "macosx1014-64"
+              },
+              {
+                "id": 285371126,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198310,
+                "job_group_id": 448,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-mochitest-browser-chrome-e10s-6",
+                "job_type_symbol": "bc6",
+                "platform": "macosx1014-64"
+              },
+              {
+                "id": 285371143,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198310,
+                "job_group_id": 448,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-mochitest-browser-chrome-e10s-6",
+                "job_type_symbol": "bc6",
+                "platform": "macosx1014-64"
+              }
+            ],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "crash",
+                "line_number": 9859,
+                "test": "browser/components/customizableui/test/browser_923857_customize_mode_event_wrapping_during_reset.js",
+                "signature": "@ __abort_with_payload + 0xa",
+                "stackwalk_stdout": "Operating system: Mac OS X\n                  10.14.5 18F132\nCPU: amd64\n     family 6 model 69 stepping 1\n     4 CPUs\n\nGPU: UNKNOWN\n\nCrash reason:  EXC_SOFTWARE / SIGABRT\nCrash address: 0x7fff5cdb6016\nProcess uptime: 53 seconds\n\nThread 0 (crashed)\n 0  libsystem_kernel.dylib!__abort_with_payload + 0xa\n    rax = 0x0000000002000209   rdx = 0x0000000000000000\n    rcx = 0x00007ffeea4e36f8   rbx = 0x0000000000000080\n    rsi = 0x0000000000000001   rdi = 0x0000000000000008\n    rbp = 0x00007ffeea4e3740   rsp = 0x00007ffeea4e36f8\n     r8 = 0x0000000156fbec80    r9 = 0x0000000000000080\n    r10 = 0x0000000000000000   r11 = 0x0000000000000246\n    r12 = 0x0000000000000000   r13 = 0x0000000000000000\n    r14 = 0x0000000000000001   r15 = 0x0000000000000008\n    rip = 0x00007fff5cdb6016\n    Found by: given as instruction pointer in context\n 1  libsystem_kernel.dylib!abort_with_reason + 0x16\n    rbp = 0x00007ffeea4e3750   rsp = 0x00007ffeea4e3750\n    rip = 0x00007fff5cdb1589\n    Found by: previous frame's frame pointer\n 2  libobjc.A.dylib!_objc_fatalv(unsigned long long, unsigned long long, char const*, __va_list_tag*) + 0x6c\n    rbp = 0x00007ffeea4e3790   rsp = 0x00007ffeea4e3760\n    rip = 0x00007fff5b4978dd\n    Found by: previous frame's frame pointer\n 3  libobjc.A.dylib!_objc_fatal(char const*, ...) + 0x87\n    rbp = 0x00007ffeea4e3870   rsp = 0x00007ffeea4e37a0\n    rip = 0x00007fff5b49778f\n    Found by: previous frame's frame pointer\n 4  libobjc.A.dylib!lookUpImpOrForward + 0x4f2\n    rbp = 0x00007ffeea4e38d0   rsp = 0x00007ffeea4e3880\n    rip = 0x00007fff5b488a9e\n    Found by: previous frame's frame pointer\n 5  libobjc.A.dylib!_objc_msgSend_uncached + 0x44\n    rbp = 0x00007ffeea4e39a0   rsp = 0x00007ffeea4e38e0\n    rip = 0x00007fff5b488114\n    Found by: previous frame's frame pointer\n 6  AppKit!-[NSView buildLayerTreeWithOwnLayerRequirement:someAncestorWantsLayer:] + 0xcac\n    rbp = 0x00007ffeea4e3e30   rsp = 0x00007ffeea4e39b0\n    rip = 0x00007fff2e4c66fa\n    Found by: previous frame's frame pointer\n 7  AppKit!-[NSView buildLayerTreeWithOwnLayerRequirement:someAncestorWantsLayer:] + 0x4c9\n    rbp = 0x00007ffeea4e42c0   rsp = 0x00007ffeea4e3e40\n    rip = 0x00007fff2e4c5f17\n    Found by: previous frame's frame pointer\n 8  AppKit!-[NSView buildLayerTreeWithOwnLayerRequirement:someAncestorWantsLayer:] + 0x4c9\n    rbp = 0x00007ffeea4e4750   rsp = 0x00007ffeea4e42d0\n    rip = 0x00007fff2e4c5f17\n    Found by: previous frame's frame pointer\n 9  AppKit!-[NSView buildLayerTreeWithOwnLayerRequirement:someAncestorWantsLayer:] + 0x4c9\n    rbp = 0x00007ffeea4e4be0   rsp = 0x00007ffeea4e4760\n    rip = 0x00007fff2e4c5f17\n    Found by: previous frame's frame pointer\n10  AppKit!-[NSView buildLayerTree] + 0x1d1\n    rbp = 0x00007ffeea4e4c40   rsp = 0x00007ffeea4e4bf0\n    rip = 0x00007fff2e4c5a08\n    Found by: previous frame's frame pointer\n11  AppKit!NSViewBuildLayerTreeForDisplay + 0x2e\n    rbp = 0x00007ffeea4e4c90   rsp = 0x00007ffeea4e4c50\n    rip = 0x00007fff2e4c565e\n    Found by: previous frame's frame pointer\n12  AppKit!-[NSWindow displayIfNeeded] + 0xe5\n    rbp = 0x00007ffeea4e4cc0   rsp = 0x00007ffeea4e4ca0\n    rip = 0x00007fff2e4c55cc\n    Found by: previous frame's frame pointer\n13  AppKit!__NSWindowGetDisplayCycleObserverForDisplay_block_invoke + 0x2ac\n    rbp = 0x00007ffeea4e4d20   rsp = 0x00007ffeea4e4cd0\n    rip = 0x00007fff2e4c5440\n    Found by: previous frame's frame pointer\n14  AppKit!NSDisplayCycleObserverInvoke + 0xa2\n    rbp = 0x00007ffeea4e4d70   rsp = 0x00007ffeea4e4d30\n    rip = 0x00007fff2e4c0534\n    Found by: previous frame's frame pointer\n15  AppKit!NSDisplayCycleFlush + 0x406\n    rbp = 0x00007ffeea4e4f30   rsp = 0x00007ffeea4e4d80\n    rip = 0x00007fff2e4c00b4\n    Found by: previous frame's frame pointer\n16  QuartzCore!CA::Transaction::run_commit_handlers(CATransactionPhase) + 0x31\n    rbp = 0x00007ffeea4e4f60   rsp = 0x00007ffeea4e4f40\n    rip = 0x00007fff3b7a6003\n    Found by: previous frame's frame pointer\n17  QuartzCore!CA::Transaction::commit() + 0xd5\n    rbp = 0x00007ffeea4e5000   rsp = 0x00007ffeea4e4f70\n    rip = 0x00007fff3b7a574b\n    Found by: previous frame's frame pointer\n18  AppKit!__65+[CATransaction(NSCATransaction) NS_setFlushesWithDisplayRefresh]_block_invoke + 0x112\n    rbp = 0x00007ffeea4e5130   rsp = 0x00007ffeea4e5010\n    rip = 0x00007fff2e4bfa4d\n    Found by: previous frame's frame pointer\n19  CoreFoundation + 0x98928\n    rbp = 0x00007ffeea4e5140   rsp = 0x00007ffeea4e5140\n    rip = 0x00007fff30d96928\n    Found by: previous frame's frame pointer\n20  CoreFoundation + 0x9885d\n    rbp = 0x00007ffeea4e5200   rsp = 0x00007ffeea4e5150\n    rip = 0x00007fff30d9685d\n    Found by: previous frame's frame pointer\n21  CoreFoundation + 0x3af80\n    rbp = 0x00007ffeea4e5f10   rsp = 0x00007ffeea4e5210\n    rip = 0x00007fff30d38f80\n    Found by: previous frame's frame pointer\n22  CoreFoundation + 0x3a8be\n    rbp = 0x00007ffeea4e5fa0   rsp = 0x00007ffeea4e5f20\n    rip = 0x00007fff30d388be\n    Found by: previous frame's frame pointer\n23  HIToolbox!RunCurrentEventLoopInMode + 0x124\n    rbp = 0x00007ffeea4e5ff0   rsp = 0x00007ffeea4e5fb0\n    rip = 0x00007fff3002496b\n    Found by: previous frame's frame pointer\n24  HIToolbox!ReceiveNextEventCommon + 0x163\n    rbp = 0x00007ffeea4e6070   rsp = 0x00007ffeea4e6000\n    rip = 0x00007fff300245ad\n    Found by: previous frame's frame pointer\n25  HIToolbox!_BlockUntilNextEventMatchingListInModeWithFilter + 0x40\n    rbp = 0x00007ffeea4e6090   rsp = 0x00007ffeea4e6080\n    rip = 0x00007fff30024436\n    Found by: previous frame's frame pointer\n26  AppKit!_DPSNextEvent + 0x3c5\n    rbp = 0x00007ffeea4e64a0   rsp = 0x00007ffeea4e60a0\n    rip = 0x00007fff2e3be987\n    Found by: previous frame's frame pointer\n27  AppKit!-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 0x551\n    rbp = 0x00007ffeea4e6720   rsp = 0x00007ffeea4e64b0\n    rip = 0x00007fff2e3bd71f\n    Found by: previous frame's frame pointer\n28  XUL!-[GeckoNSApplication nextEventMatchingMask:untilDate:inMode:dequeue:] [nsAppShell.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 169 + 0x2c]\n    rbp = 0x00007ffeea4e6790   rsp = 0x00007ffeea4e6730\n    rip = 0x0000000112b6bbe9\n    Found by: previous frame's frame pointer\n29  AppKit!-[NSApplication run] + 0x2bb\n    rbp = 0x00007ffeea4e6860   rsp = 0x00007ffeea4e67a0\n    rip = 0x00007fff2e3b783c\n    Found by: previous frame's frame pointer\n30  XUL!nsAppShell::Run() [nsAppShell.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 703 + 0x1a]\n    rbp = 0x00007ffeea4e68b0   rsp = 0x00007ffeea4e6870\n    rip = 0x0000000112b6d64d\n    Found by: previous frame's frame pointer\n31  XUL!nsAppStartup::Run() [nsAppStartup.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 272 + 0xf]\n    rbp = 0x00007ffeea4e68d0   rsp = 0x00007ffeea4e68c0\n    rip = 0x00000001142dc32b\n    Found by: previous frame's frame pointer\n32  XUL!XREMain::XRE_mainRun() [nsAppRunner.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 4603 + 0x16]\n    rbp = 0x00007ffeea4e6a20   rsp = 0x00007ffeea4e68e0\n    rip = 0x0000000114465ce1\n    Found by: previous frame's frame pointer\n33  XUL!XREMain::XRE_main(int, char**, mozilla::BootstrapConfig const&) [nsAppRunner.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 4740 + 0x8]\n    rbp = 0x00007ffeea4e6b10   rsp = 0x00007ffeea4e6a30\n    rip = 0x0000000114467030\n    Found by: previous frame's frame pointer\n34  XUL!XRE_main(int, char**, mozilla::BootstrapConfig const&) [nsAppRunner.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 4821 + 0x11]\n    rbp = 0x00007ffeea4e6c60   rsp = 0x00007ffeea4e6b20\n    rip = 0x0000000114467b52\n    Found by: previous frame's frame pointer\n35  firefox + 0x1684\n    rbp = 0x00007ffeea4e70e0   rsp = 0x00007ffeea4e6c70\n    rip = 0x0000000105719684\n    Found by: previous frame's frame pointer\n36  libdyld.dylib!start + 0x1\n    rbp = 0x00007ffeea4e70f0   rsp = 0x00007ffeea4e70f0\n    rip = 0x00007fff5cc633d5\n    Found by: previous frame's frame pointer\n\nThread 1\n 0  libsystem_kernel.dylib!__workq_kernreturn + 0xa\n    rax = 0x0000000002000170   rdx = 0x0000000000000000\n    rcx = 0x000070000ee76f98   rbx = 0x000070000ee77000\n    rsi = 0x0000000000000000   rdi = 0x0000000000000004\n    rbp = 0x000070000ee76fd0   rsp = 0x000070000ee76f98\n     r8 = 0x0000000105e00000    r9 = 0x0000000000000000\n    r10 = 0x0000000000000000   r11 = 0x0000000000000246\n    r12 = 0x0000000000064003   r13 = 0x00000000000004ff\n    r14 = 0x000070000ee770a4   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd99bfe\n    Found by: given as instruction pointer in context\n 1  libsystem_pthread.dylib!start_wqthread + 0xd\n    rbp = 0x000070000ee76ff8   rsp = 0x000070000ee76fe0\n    rip = 0x00007fff5ce563fd\n    Found by: previous frame's frame pointer\n 2  libdispatch.dylib!_dispatch_root_queues_init_once + 0xcd\n    rsp = 0x000070000ee77090   rip = 0x00007fff5cc24aec\n    Found by: stack scanning\n\nThread 2\n 0  libsystem_kernel.dylib!__workq_kernreturn + 0xa\n    rax = 0x0000000002000170   rdx = 0x0000000000000001\n    rcx = 0x000070000eef9b08   rbx = 0x000070000eefa000\n    rsi = 0x000070000eef9b80   rdi = 0x0000000000000100\n    rbp = 0x000070000eef9b40   rsp = 0x000070000eef9b08\n     r8 = 0x0000000000000080    r9 = 0x0000003700000003\n    r10 = 0x0000000000000000   r11 = 0x0000000000000246\n    r12 = 0x00000000004f4005   r13 = 0x00000000810010ff\n    r14 = 0x000070000eefa098   r15 = 0x000070000eefa0a0\n    rip = 0x00007fff5cd99bfe\n    Found by: given as instruction pointer in context\n 1  libsystem_pthread.dylib!start_wqthread + 0xd\n    rbp = 0x000070000eef9b68   rsp = 0x000070000eef9b50\n    rip = 0x00007fff5ce563fd\n    Found by: previous frame's frame pointer\n 2  libmozglue.dylib!AddressRadixTree<44ul>::Get(void*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1639 + 0x8]\n    rsp = 0x000070000eef9be0   rip = 0x000000010572c38e\n    Found by: stack scanning\n 3  libmozglue.dylib!AddressRadixTree<44ul>::Get(void*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1639 + 0x8]\n    rsp = 0x000070000eef9bf0   rip = 0x000000010572c38e\n    Found by: stack scanning\n 4  libmozglue.dylib!arena_t::DallocSmall(arena_chunk_t*, void*, arena_chunk_map_t*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 3259 + 0x10]\n    rsp = 0x000070000eef9c00   rip = 0x000000010572c98a\n    Found by: stack scanning\n 5  libmozglue.dylib!AddressRadixTree<44ul>::Get(void*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1639 + 0x8]\n    rsp = 0x000070000eef9c20   rip = 0x000000010572c38e\n    Found by: stack scanning\n 6  libmozglue.dylib!AddressRadixTree<44ul>::Get(void*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1639 + 0x8]\n    rsp = 0x000070000eef9c30   rip = 0x000000010572c38e\n    Found by: stack scanning\n 7  libmozglue.dylib!arena_t::DallocSmall(arena_chunk_t*, void*, arena_chunk_map_t*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 3259 + 0x10]\n    rsp = 0x000070000eef9c40   rip = 0x000000010572c98a\n    Found by: stack scanning\n 8  libobjc.A.dylib!std::__1::__hash_iterator<std::__1::__hash_node<std::__1::__hash_value_type<unsigned long, objc_references_support::ObjectAssociationMap*>, void*>*> std::__1::__hash_table<std::__1::__hash_value_type<unsigned long, objc_references_support::ObjectAssociationMap*>, std::__1::__unordered_map_hasher<unsigned long, std::__1::__hash_value_type<unsigned long, objc_references_support::ObjectAssociationMap*>, objc_references_support::DisguisedPointerHash, true>, std::__1::__unordered_map_equal<unsigned long, std::__1::__hash_value_type<unsigned long, objc_references_support::ObjectAssociationMap*>, objc_references_support::DisguisedPointerEqual, true>, objc_references_support::ObjcAllocator<std::__1::__hash_value_type<unsigned long, objc_references_support::ObjectAssociationMap*> > >::find<unsigned long>(unsigned long const&) + 0x19\n    rsp = 0x000070000eef9c50   rip = 0x00007fff5b4a098b\n    Found by: stack scanning\n 9  libmozglue.dylib!AddressRadixTree<44ul>::Get(void*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1639 + 0x8]\n    rsp = 0x000070000eef9c90   rip = 0x000000010572c38e\n    Found by: stack scanning\n10  libmozglue.dylib!AddressRadixTree<44ul>::Get(void*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1639 + 0x8]\n    rsp = 0x000070000eef9ca0   rip = 0x000000010572c38e\n    Found by: stack scanning\n11  libmozglue.dylib!arena_t::DallocSmall(arena_chunk_t*, void*, arena_chunk_map_t*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 3259 + 0x10]\n    rsp = 0x000070000eef9cb0   rip = 0x000000010572c98a\n    Found by: stack scanning\n12  libmozglue.dylib!arena_dalloc(void*, unsigned long, arena_t*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 3345 + 0xe]\n    rsp = 0x000070000eef9cf0   rip = 0x000000010572c4bf\n    Found by: stack scanning\n13  libdispatch.dylib!_dispatch_dispose + 0x9a\n    rsp = 0x000070000eef9d30   rip = 0x00007fff5cc15b6d\n    Found by: stack scanning\n14  libdispatch.dylib!_dispatch_source_invoke + 0xc3c\n    rsp = 0x000070000eef9d70   rip = 0x00007fff5cc28376\n    Found by: stack scanning\n15  libobjc.A.dylib!cache_getImp + 0x90\n    rsp = 0x000070000eef9d98   rip = 0x00007fff5b487680\n    Found by: stack scanning\n16  libmozglue.dylib!AddressRadixTree<44ul>::Get(void*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1639 + 0x8]\n    rsp = 0x000070000eef9dd0   rip = 0x000000010572c38e\n    Found by: stack scanning\n17  libmozglue.dylib!AddressRadixTree<44ul>::Get(void*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1639 + 0x8]\n    rsp = 0x000070000eef9de0   rip = 0x000000010572c38e\n    Found by: stack scanning\n18  vImage + 0x2decb\n    rsp = 0x000070000eef9e10   rip = 0x00007fff2d1b5ecb\n    Found by: stack scanning\n19  libdispatch.dylib!_dispatch_continuation_free_to_cache_limit + 0xc\n    rsp = 0x000070000eef9e70   rip = 0x00007fff5cc18c00\n    Found by: stack scanning\n20  libdispatch.dylib!_dispatch_apply_invoke + 0x150\n    rsp = 0x000070000eef9e90   rip = 0x00007fff5cc26048\n    Found by: stack scanning\n21  libdispatch.dylib!__libdispatchVersionNumber + 0x2512\n    rsp = 0x000070000eef9ea8   rip = 0x00007fff5cc44fd2\n    Found by: stack scanning\n22  libdispatch.dylib!_dispatch_last_resort_autorelease_pool_pop + 0x1b\n    rsp = 0x000070000eef9f00   rip = 0x00007fff5cc16626\n    Found by: stack scanning\n23  libdispatch.dylib!_dispatch_root_queue_drain + 0x479\n    rsp = 0x000070000eef9f20   rip = 0x00007fff5cc246f1\n    Found by: stack scanning\n24  libdispatch.dylib!_dispatch_worker_thread2 + 0x5a\n    rsp = 0x000070000eef9f90   rip = 0x00007fff5cc24b46\n    Found by: stack scanning\n25  libsystem_pthread.dylib!_pthread_wqthread + 0x27a\n    rsp = 0x000070000eef9fa0   rip = 0x00007fff5ce566e6\n    Found by: stack scanning\n26  libsystem_pthread.dylib!start_wqthread + 0xd\n    rsp = 0x000070000eef9fe0   rip = 0x00007fff5ce563fd\n    Found by: stack scanning\n27  libdispatch.dylib!_dispatch_kevent_worker_thread + 0x902\n    rsp = 0x000070000eefa090   rip = 0x00007fff5cc25497\n    Found by: stack scanning\n\nThread 3\n 0  libsystem_kernel.dylib!mach_msg_trap + 0xa\n    rax = 0x000000000100001f   rdx = 0x0000000000000000\n    rcx = 0x000070000ef7cbd8   rbx = 0x0000000000000006\n    rsi = 0x0000000000000006   rdi = 0x000070000ef7cc90\n    rbp = 0x000070000ef7cc30   rsp = 0x000070000ef7cbd8\n     r8 = 0x0000000000005403    r9 = 0x0000000000000000\n    r10 = 0x000000000000024c   r11 = 0x0000000000000206\n    r12 = 0x0000000000000006   r13 = 0x000000000000024c\n    r14 = 0x000070000ef7cc90   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd9822a\n    Found by: given as instruction pointer in context\n 1  XUL!google_breakpad::ExceptionHandler::WaitForMessage(void*) [exception_handler.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 518 + 0x1d]\n    rbp = 0x000070000ef7cf10   rsp = 0x000070000ef7cc40\n    rip = 0x00000001143de605\n    Found by: previous frame's frame pointer\n 2  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000ef7cf30   rsp = 0x000070000ef7cf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 3  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000ef7cf50   rsp = 0x000070000ef7cf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000ef7cf78   rsp = 0x000070000ef7cf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 5  XUL!google_breakpad::ExceptionHandler::WriteMinidumpWithException(int, int, int, __darwin_ucontext*, unsigned int, unsigned int, bool, bool) [exception_handler.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 405 + 0x1f]\n    rsp = 0x000070000ef7d090   rip = 0x00000001143de570\n    Found by: stack scanning\n\nThread 4\n 0  libsystem_kernel.dylib!__workq_kernreturn + 0xa\n    rax = 0x0000000002000170   rdx = 0x0000000000000000\n    rcx = 0x000070000effff98   rbx = 0x000070000f000000\n    rsi = 0x0000000000000000   rdi = 0x0000000000000004\n    rbp = 0x000070000effffd0   rsp = 0x000070000effff98\n     r8 = 0x0000000000064003    r9 = 0x0000000000000000\n    r10 = 0x0000000000000000   r11 = 0x0000000000000246\n    r12 = 0x0000000000064003   r13 = 0x00000000000004ff\n    r14 = 0x000070000f0000a4   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd99bfe\n    Found by: given as instruction pointer in context\n 1  libsystem_pthread.dylib!start_wqthread + 0xd\n    rbp = 0x000070000efffff8   rsp = 0x000070000effffe0\n    rip = 0x00007fff5ce563fd\n    Found by: previous frame's frame pointer\n 2  libdispatch.dylib!_dispatch_root_queues_init_once + 0xcd\n    rsp = 0x000070000f000090   rip = 0x00007fff5cc24aec\n    Found by: stack scanning\n\nThread 5\n 0  libsystem_kernel.dylib!kevent + 0xa\n    rax = 0x000000000200016b   rdx = 0x0000000000000000\n    rcx = 0x000070000f148b28   rbx = 0x0000000000000040\n    rsi = 0x0000000105965800   rdi = 0x000000000000000b\n    rbp = 0x000070000f148b90   rsp = 0x000070000f148b28\n     r8 = 0x0000000000000040    r9 = 0x0000000000000000\n    r10 = 0x0000000105975000   r11 = 0x0000000000000246\n    r12 = 0x0000000000000000   r13 = 0x0000000000000000\n    r14 = 0x0000000105965800   r15 = 0x00000001080c8800\n    rip = 0x00007fff5cd9e78e\n    Found by: given as instruction pointer in context\n 1  XUL!event_base_loop [event.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1947 + 0xd]\n    rbp = 0x000070000f148c20   rsp = 0x000070000f148ba0\n    rip = 0x000000010f186b03\n    Found by: previous frame's frame pointer\n 2  XUL!base::MessagePumpLibevent::Run(base::MessagePump::Delegate*) [message_pump_libevent.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 0 + 0xe]\n    rbp = 0x000070000f148ca0   rsp = 0x000070000f148c30\n    rip = 0x000000010f169b9d\n    Found by: previous frame's frame pointer\n 3  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x000070000f148cd0   rsp = 0x000070000f148cb0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 4  XUL!base::Thread::ThreadMain() [thread.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 192 + 0x8]\n    rbp = 0x000070000f148f00   rsp = 0x000070000f148ce0\n    rip = 0x000000010f1774a6\n    Found by: previous frame's frame pointer\n 5  XUL!ThreadFunc(void*) [platform_thread_posix.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 40 + 0x6]\n    rbp = 0x000070000f148f10   rsp = 0x000070000f148f10\n    rip = 0x000000010f17166a\n    Found by: previous frame's frame pointer\n 6  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000f148f30   rsp = 0x000070000f148f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 7  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000f148f50   rsp = 0x000070000f148f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 8  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000f148f78   rsp = 0x000070000f148f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 9  XUL + 0x8d6660\n    rsp = 0x000070000f149090   rip = 0x000000010f171660\n    Found by: stack scanning\n\nThread 6\n 0  libsystem_kernel.dylib!mach_msg_trap + 0xa\n    rax = 0x000000000100001f   rdx = 0x0000000000000000\n    rcx = 0x000070000f105688   rbx = 0x0000000000000002\n    rsi = 0x0000000000000002   rdi = 0x000070000f105e70\n    rbp = 0x000070000f1056e0   rsp = 0x000070000f105688\n     r8 = 0x000000000000a007    r9 = 0x0000000000000000\n    r10 = 0x000000000000005c   r11 = 0x0000000000000202\n    r12 = 0x0000000000000002   r13 = 0x000000000000005c\n    r14 = 0x000070000f105e70   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd9822a\n    Found by: given as instruction pointer in context\n 1  XUL!js::MachExceptionHandler() [MemoryProtectionExceptionHandler.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 542 + 0x1f]\n    rbp = 0x000070000f105ef0   rsp = 0x000070000f1056f0\n    rip = 0x0000000114bf3dd8\n    Found by: previous frame's frame pointer\n 2  XUL!js::detail::ThreadTrampoline<void (&)()>::Start(void*) [Thread.h:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 207 + 0x16]\n    rbp = 0x000070000f105f10   rsp = 0x000070000f105f00\n    rip = 0x0000000114c0e560\n    Found by: previous frame's frame pointer\n 3  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000f105f30   rsp = 0x000070000f105f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000f105f50   rsp = 0x000070000f105f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000f105f78   rsp = 0x000070000f105f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 6  XUL + 0x6373540\n    rsp = 0x000070000f106090   rip = 0x0000000114c0e540\n    Found by: stack scanning\n\nThread 7\n 0  libsystem_kernel.dylib!__select + 0xa\n    rax = 0x000000000200005d   rdx = 0x000070000f210e50\n    rcx = 0x000070000f210c38   rbx = 0x0000000000004000\n    rsi = 0x000070000f211050   rdi = 0x000000000000006f\n    rbp = 0x000070000f211280   rsp = 0x000070000f210c38\n     r8 = 0x0000000000000000    r9 = 0x00000001080a8ed0\n    r10 = 0x000070000f210c50   r11 = 0x0000000000000206\n    r12 = 0x0000000000000000   r13 = 0x000070000f211300\n    r14 = 0x0000000000000002   r15 = 0x00000000ffffffff\n    rip = 0x00007fff5cd9f61a\n    Found by: given as instruction pointer in context\n 1  libnss3.dylib!PR_Poll [ptio.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 4647 + 0x509]\n    rbp = 0x000070000f211530   rsp = 0x000070000f211290\n    rip = 0x0000000105b6f8e4\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::net::nsSocketTransportService::Poll(mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*, unsigned int) [nsSocketTransportService2.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 665 + 0x20]\n    rbp = 0x000070000f2115a0   rsp = 0x000070000f211540\n    rip = 0x000000010ebabd3e\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::net::nsSocketTransportService::DoPollIteration(mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [nsSocketTransportService2.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1308 + 0xe]\n    rbp = 0x000070000f211610   rsp = 0x000070000f2115b0\n    rip = 0x000000010ebaea95\n    Found by: previous frame's frame pointer\n 4  XUL!mozilla::net::nsSocketTransportService::Run() [nsSocketTransportService2.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1095 + 0xc]\n    rbp = 0x000070000f2116d0   rsp = 0x000070000f211620\n    rip = 0x000000010ebadecf\n    Found by: previous frame's frame pointer\n 5  XUL!non-virtual thunk to mozilla::net::nsSocketTransportService::Run() [nsSocketTransportService2.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 0 + 0xd]\n    rbp = 0x000070000f2116e0   rsp = 0x000070000f2116e0\n    rip = 0x000000010ebaf0dd\n    Found by: previous frame's frame pointer\n 6  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1220 + 0x6]\n    rbp = 0x000070000f211c30   rsp = 0x000070000f2116f0\n    rip = 0x000000010ea0cd03\n    Found by: previous frame's frame pointer\n 7  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x000070000f211c60   rsp = 0x000070000f211c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 8  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x000070000f211cb0   rsp = 0x000070000f211c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 9  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x000070000f211ce0   rsp = 0x000070000f211cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n10  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x000070000f211ed0   rsp = 0x000070000f211cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n11  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x000070000f211f10   rsp = 0x000070000f211ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000f211f30   rsp = 0x000070000f211f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000f211f50   rsp = 0x000070000f211f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n14  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000f211f78   rsp = 0x000070000f211f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n15  libnss3.dylib + 0x178de0\n    rsp = 0x000070000f212090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 8\n 0  libsystem_kernel.dylib!__semwait_signal + 0xa\n    rax = 0x000000000200014e   rdx = 0x0000000000000001\n    rcx = 0x000070000f617bb8   rbx = 0x0000000000000000\n    rsi = 0x0000000000000000   rdi = 0x0000000000000903\n    rbp = 0x000070000f617bf0   rsp = 0x000070000f617bb8\n     r8 = 0x0000000000000e10    r9 = 0x0000000000000000\n    r10 = 0x0000000000000001   r11 = 0x0000000000000246\n    r12 = 0x000070000f617cd8   r13 = 0x000070000f617d60\n    r14 = 0x000070000f617c60   r15 = 0x000070000f617c60\n    rip = 0x00007fff5cd9bf32\n    Found by: given as instruction pointer in context\n 1  XUL!std::thread::sleep [mod.rs:4560ea788cb760f0a34127156c78e2552949f734 : 781 + 0x40]\n    rbp = 0x000070000f617c90   rsp = 0x000070000f617c00\n    rip = 0x000000011682e590\n    Found by: previous frame's frame pointer\n 2  XUL!fog::prototype_ping_init::{{closure}} [lib.rs:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 75 + 0xc]\n    rbp = 0x000070000f617d50   rsp = 0x000070000f617ca0\n    rip = 0x000000011594a7ec\n    Found by: previous frame's frame pointer\n 3  XUL!std::sys_common::backtrace::__rust_begin_short_backtrace [backtrace.rs:4560ea788cb760f0a34127156c78e2552949f734 : 126 + 0x38]\n    rbp = 0x000070000f617d90   rsp = 0x000070000f617d60\n    rip = 0x0000000115949f20\n    Found by: previous frame's frame pointer\n 4  XUL!std::panicking::try::do_call [mod.rs:4560ea788cb760f0a34127156c78e2552949f734 : 470 + 0x38]\n    rbp = 0x000070000f617dd0   rsp = 0x000070000f617da0\n    rip = 0x000000011594ad50\n    Found by: previous frame's frame pointer\n 5  XUL!__rust_maybe_catch_panic [lib.rs:4560ea788cb760f0a34127156c78e2552949f734 : 28 + 0x5]\n    rbp = 0x000070000f617de0   rsp = 0x000070000f617de0\n    rip = 0x000000011685b9bc\n    Found by: previous frame's frame pointer\n 6  XUL!core::ops::function::FnOnce::call_once{{vtable.shim}} [function.rs:4560ea788cb760f0a34127156c78e2552949f734 : 227 + 0x9d]\n    rbp = 0x000070000f617e50   rsp = 0x000070000f617df0\n    rip = 0x000000011594c08d\n    Found by: call frame info\n 7  XUL!<alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once [boxed.rs:4560ea788cb760f0a34127156c78e2552949f734 : 922 + 0x2d]\n    rbp = 0x000070000f617ec0   rsp = 0x000070000f617e60\n    rip = 0x000000011682dd1e\n    Found by: previous frame's frame pointer\n 8  XUL!std::sys::unix::thread::Thread::new::thread_start [thread.rs:4560ea788cb760f0a34127156c78e2552949f734 : 79 + 0x80]\n    rbp = 0x000070000f617f10   rsp = 0x000070000f617ed0\n    rip = 0x000000011685aaae\n    Found by: previous frame's frame pointer\n 9  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000f617f30   rsp = 0x000070000f617f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000f617f50   rsp = 0x000070000f617f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000f617f78   rsp = 0x000070000f617f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n12  XUL + 0x7fbfa20\n    rsp = 0x000070000f618090   rip = 0x000000011685aa20\n    Found by: stack scanning\n\nThread 9\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000000\n    rcx = 0x000070000f21cd58   rbx = 0x0000000000000002\n    rsi = 0x00002d0100002e00   rdi = 0x000000010cc9f7c8\n    rbp = 0x000070000f21cde0   rsp = 0x000070000f21cd58\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a0\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000010cc9f7c8   r13 = 0x0000000000000016\n    r14 = 0x00002d0100002e00   r15 = 0x000070000f21d000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libnss3.dylib!PR_WaitCondVar [ptsynch.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 404 + 0x8f]\n    rbp = 0x000070000f21ce50   rsp = 0x000070000f21cdf0\n    rip = 0x0000000105b6d4e8\n    Found by: previous frame's frame pointer\n 2  XUL!WatchdogMain(void*) [XPCJSContext.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 485 + 0x1f]\n    rbp = 0x000070000f21ced0   rsp = 0x000070000f21ce60\n    rip = 0x000000010f81688c\n    Found by: previous frame's frame pointer\n 3  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x000070000f21cf10   rsp = 0x000070000f21cee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000f21cf30   rsp = 0x000070000f21cf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000f21cf50   rsp = 0x000070000f21cf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 6  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000f21cf78   rsp = 0x000070000f21cf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 7  libnss3.dylib + 0x178de0\n    rsp = 0x000070000f21d090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 10\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000056200\n    rcx = 0x000070000f818d88   rbx = 0x0000000000000002\n    rsi = 0x0005620000056500   rdi = 0x000000010c906780\n    rbp = 0x000070000f818e10   rsp = 0x000070000f818d88\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000010c906780   r13 = 0x0000000000000016\n    r14 = 0x0005620000056500   r15 = 0x000070000f819000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x000070000f818e60   rsp = 0x000070000f818e20\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!js::HelperThread::threadLoop() [ConditionVariable.h:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 107 + 0x16]\n    rbp = 0x000070000f818ed0   rsp = 0x000070000f818e70\n    rip = 0x00000001147e1d09\n    Found by: previous frame's frame pointer\n 3  XUL!js::HelperThread::ThreadMain(void*) [HelperThreads.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 2184 + 0x8]\n    rbp = 0x000070000f818ef0   rsp = 0x000070000f818ee0\n    rip = 0x00000001147db228\n    Found by: previous frame's frame pointer\n 4  XUL!js::detail::ThreadTrampoline<void (&)(void*), js::HelperThread*>::Start(void*) [Thread.h:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 207 + 0x1a]\n    rbp = 0x000070000f818f10   rsp = 0x000070000f818f00\n    rip = 0x00000001147fccc4\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000f818f30   rsp = 0x000070000f818f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 6  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000f818f50   rsp = 0x000070000f818f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 7  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000f818f78   rsp = 0x000070000f818f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 8  XUL + 0x5f61ca0\n    rsp = 0x000070000f819090   rip = 0x00000001147fcca0\n    Found by: stack scanning\n\nThread 11\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000056200\n    rcx = 0x000070000fa19d88   rbx = 0x0000000000000002\n    rsi = 0x0005620000056600   rdi = 0x000000010c906780\n    rbp = 0x000070000fa19e10   rsp = 0x000070000fa19d88\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000010c906780   r13 = 0x0000000000000016\n    r14 = 0x0005620000056600   r15 = 0x000070000fa1a000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x000070000fa19e60   rsp = 0x000070000fa19e20\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!js::HelperThread::threadLoop() [ConditionVariable.h:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 107 + 0x16]\n    rbp = 0x000070000fa19ed0   rsp = 0x000070000fa19e70\n    rip = 0x00000001147e1d09\n    Found by: previous frame's frame pointer\n 3  XUL!js::HelperThread::ThreadMain(void*) [HelperThreads.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 2184 + 0x8]\n    rbp = 0x000070000fa19ef0   rsp = 0x000070000fa19ee0\n    rip = 0x00000001147db228\n    Found by: previous frame's frame pointer\n 4  XUL!js::detail::ThreadTrampoline<void (&)(void*), js::HelperThread*>::Start(void*) [Thread.h:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 207 + 0x1a]\n    rbp = 0x000070000fa19f10   rsp = 0x000070000fa19f00\n    rip = 0x00000001147fccc4\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000fa19f30   rsp = 0x000070000fa19f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 6  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000fa19f50   rsp = 0x000070000fa19f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 7  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000fa19f78   rsp = 0x000070000fa19f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 8  XUL + 0x5f61ca0\n    rsp = 0x000070000fa1a090   rip = 0x00000001147fcca0\n    Found by: stack scanning\n\nThread 12\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000056200\n    rcx = 0x000070000fc1ad88   rbx = 0x0000000000000002\n    rsi = 0x0005620000056400   rdi = 0x000000010c906780\n    rbp = 0x000070000fc1ae10   rsp = 0x000070000fc1ad88\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000010c906780   r13 = 0x0000000000000016\n    r14 = 0x0005620000056400   r15 = 0x000070000fc1b000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x000070000fc1ae60   rsp = 0x000070000fc1ae20\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!js::HelperThread::threadLoop() [ConditionVariable.h:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 107 + 0x16]\n    rbp = 0x000070000fc1aed0   rsp = 0x000070000fc1ae70\n    rip = 0x00000001147e1d09\n    Found by: previous frame's frame pointer\n 3  XUL!js::HelperThread::ThreadMain(void*) [HelperThreads.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 2184 + 0x8]\n    rbp = 0x000070000fc1aef0   rsp = 0x000070000fc1aee0\n    rip = 0x00000001147db228\n    Found by: previous frame's frame pointer\n 4  XUL!js::detail::ThreadTrampoline<void (&)(void*), js::HelperThread*>::Start(void*) [Thread.h:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 207 + 0x1a]\n    rbp = 0x000070000fc1af10   rsp = 0x000070000fc1af00\n    rip = 0x00000001147fccc4\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000fc1af30   rsp = 0x000070000fc1af20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 6  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000fc1af50   rsp = 0x000070000fc1af40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 7  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000fc1af78   rsp = 0x000070000fc1af60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 8  XUL + 0x5f61ca0\n    rsp = 0x000070000fc1b090   rip = 0x00000001147fcca0\n    Found by: stack scanning\n\nThread 13\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000056200\n    rcx = 0x000070000fe1bd88   rbx = 0x0000000000000002\n    rsi = 0x0005620100056300   rdi = 0x000000010c906780\n    rbp = 0x000070000fe1be10   rsp = 0x000070000fe1bd88\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000010c906780   r13 = 0x0000000000000016\n    r14 = 0x0005620100056300   r15 = 0x000070000fe1c000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x000070000fe1be60   rsp = 0x000070000fe1be20\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!js::HelperThread::threadLoop() [ConditionVariable.h:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 107 + 0x16]\n    rbp = 0x000070000fe1bed0   rsp = 0x000070000fe1be70\n    rip = 0x00000001147e1d09\n    Found by: previous frame's frame pointer\n 3  XUL!js::HelperThread::ThreadMain(void*) [HelperThreads.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 2184 + 0x8]\n    rbp = 0x000070000fe1bef0   rsp = 0x000070000fe1bee0\n    rip = 0x00000001147db228\n    Found by: previous frame's frame pointer\n 4  XUL!js::detail::ThreadTrampoline<void (&)(void*), js::HelperThread*>::Start(void*) [Thread.h:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 207 + 0x1a]\n    rbp = 0x000070000fe1bf10   rsp = 0x000070000fe1bf00\n    rip = 0x00000001147fccc4\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000fe1bf30   rsp = 0x000070000fe1bf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 6  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000fe1bf50   rsp = 0x000070000fe1bf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 7  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000fe1bf78   rsp = 0x000070000fe1bf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 8  XUL + 0x5f61ca0\n    rsp = 0x000070000fe1c090   rip = 0x00000001147fcca0\n    Found by: stack scanning\n\nThread 14\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000128600\n    rcx = 0x000070000f2a2568   rbx = 0x0000000000128600\n    rsi = 0x0012860100128700   rdi = 0x000000010592f8b8\n    rbp = 0x000070000f2a25f0   rsp = 0x000070000f2a2568\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000246\n    r12 = 0x000000010592f8b8   r13 = 0x0000000000000016\n    r14 = 0x0012860100128700   r15 = 0x0000000000128700\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 147 + 0xb]\n    rbp = 0x000070000f2a2640   rsp = 0x000070000f2a2600\n    rip = 0x000000010577db34\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait(mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>) [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 524 + 0x5]\n    rbp = 0x000070000f2a2680   rsp = 0x000070000f2a2650\n    rip = 0x000000010e9e741d\n    Found by: previous frame's frame pointer\n 3  XUL!TimerThread::Run() [TimerThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 503 + 0xb]\n    rbp = 0x000070000f2a26e0   rsp = 0x000070000f2a2690\n    rip = 0x000000010ea03d91\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1220 + 0x6]\n    rbp = 0x000070000f2a2c30   rsp = 0x000070000f2a26f0\n    rip = 0x000000010ea0cd03\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x000070000f2a2c60   rsp = 0x000070000f2a2c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 302 + 0xa]\n    rbp = 0x000070000f2a2cb0   rsp = 0x000070000f2a2c70\n    rip = 0x000000010f1d8891\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x000070000f2a2ce0   rsp = 0x000070000f2a2cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x000070000f2a2ed0   rsp = 0x000070000f2a2cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x000070000f2a2f10   rsp = 0x000070000f2a2ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000f2a2f30   rsp = 0x000070000f2a2f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000f2a2f50   rsp = 0x000070000f2a2f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000f2a2f78   rsp = 0x000070000f2a2f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x000070000f2a3090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 15\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000003900\n    rcx = 0x000070000f2c5ce8   rbx = 0x0000000000000002\n    rsi = 0x0000390100003a00   rdi = 0x000000010809da20\n    rbp = 0x000070000f2c5d70   rsp = 0x000070000f2c5ce8\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000010809da20   r13 = 0x0000000000000016\n    r14 = 0x0000390100003a00   r15 = 0x000070000f2c6000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x000070000f2c5dc0   rsp = 0x000070000f2c5d80\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x000070000f2c5e00   rsp = 0x000070000f2c5dd0\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::net::CacheIOThread::ThreadFunc() [Monitor.h:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 36 + 0x5]\n    rbp = 0x000070000f2c5eb0   rsp = 0x000070000f2c5e10\n    rip = 0x000000010ee6a995\n    Found by: previous frame's frame pointer\n 4  XUL!mozilla::net::CacheIOThread::ThreadFunc(void*) [CacheIOThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 414 + 0x8]\n    rbp = 0x000070000f2c5ed0   rsp = 0x000070000f2c5ec0\n    rip = 0x000000010ee69b94\n    Found by: previous frame's frame pointer\n 5  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x000070000f2c5f10   rsp = 0x000070000f2c5ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n 6  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000f2c5f30   rsp = 0x000070000f2c5f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 7  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000f2c5f50   rsp = 0x000070000f2c5f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 8  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000f2c5f78   rsp = 0x000070000f2c5f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib + 0x178de0\n    rsp = 0x000070000f2c6090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 16\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000100\n    rcx = 0x000070000f308538   rbx = 0x0000000000000002\n    rsi = 0x0000010100000200   rdi = 0x000000010c8eecb8\n    rbp = 0x000070000f3085c0   rsp = 0x000070000f308538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000010c8eecb8   r13 = 0x0000000000000016\n    r14 = 0x0000010100000200   r15 = 0x000070000f309000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x000070000f308610   rsp = 0x000070000f3085d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x000070000f308650   rsp = 0x000070000f308620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x000070000f3086e0   rsp = 0x000070000f308660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x000070000f308c30   rsp = 0x000070000f3086f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x000070000f308c60   rsp = 0x000070000f308c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x000070000f308cb0   rsp = 0x000070000f308c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x000070000f308ce0   rsp = 0x000070000f308cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x000070000f308ed0   rsp = 0x000070000f308cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x000070000f308f10   rsp = 0x000070000f308ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000f308f30   rsp = 0x000070000f308f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000f308f50   rsp = 0x000070000f308f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000f308f78   rsp = 0x000070000f308f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x000070000f309090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 17\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x000000000000bb00\n    rcx = 0x000070001001c268   rbx = 0x0000000000000002\n    rsi = 0x0000bb010000bc00   rdi = 0x000000010cc73840\n    rbp = 0x000070001001c2f0   rsp = 0x000070001001c268\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000010cc73840   r13 = 0x0000000000000016\n    r14 = 0x0000bb010000bc00   r15 = 0x000070001001d000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x000070001001c340   rsp = 0x000070001001c300\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x000070001001c380   rsp = 0x000070001001c350\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::dom::WorkerPrivate::WaitForWorkerEvents() [WorkerPrivate.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 3401 + 0xc]\n    rbp = 0x000070001001c3c0   rsp = 0x000070001001c390\n    rip = 0x00000001126f1ea4\n    Found by: previous frame's frame pointer\n 4  XUL!mozilla::dom::WorkerPrivate::DoRunLoop(JSContext*) [WorkerPrivate.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 2785 + 0x8]\n    rbp = 0x000070001001c4d0   rsp = 0x000070001001c3d0\n    rip = 0x00000001126f15bd\n    Found by: previous frame's frame pointer\n 5  XUL!mozilla::dom::workerinternals::(anonymous namespace)::WorkerThreadPrimaryRunnable::Run() [RuntimeService.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 2318 + 0xc]\n    rbp = 0x000070001001c6e0   rsp = 0x000070001001c4e0\n    rip = 0x00000001126d027d\n    Found by: previous frame's frame pointer\n 6  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1220 + 0x6]\n    rbp = 0x000070001001cc30   rsp = 0x000070001001c6f0\n    rip = 0x000000010ea0cd03\n    Found by: previous frame's frame pointer\n 7  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x000070001001cc60   rsp = 0x000070001001cc40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 8  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x000070001001ccb0   rsp = 0x000070001001cc70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 9  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x000070001001cce0   rsp = 0x000070001001ccc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n10  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x000070001001ced0   rsp = 0x000070001001ccf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n11  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x000070001001cf10   rsp = 0x000070001001cee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070001001cf30   rsp = 0x000070001001cf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070001001cf50   rsp = 0x000070001001cf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n14  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070001001cf78   rsp = 0x000070001001cf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n15  libnss3.dylib + 0x178de0\n    rsp = 0x000070001001d090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 18\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x000000000022b800\n    rcx = 0x000070000f34b538   rbx = 0x0000000000000002\n    rsi = 0x0022b8010022b900   rdi = 0x000000010dadf2b8\n    rbp = 0x000070000f34b5c0   rsp = 0x000070000f34b538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000010dadf2b8   r13 = 0x0000000000000016\n    r14 = 0x0022b8010022b900   r15 = 0x000070000f34c000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x000070000f34b610   rsp = 0x000070000f34b5d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x000070000f34b650   rsp = 0x000070000f34b620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x000070000f34b6e0   rsp = 0x000070000f34b660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x000070000f34bc30   rsp = 0x000070000f34b6f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x000070000f34bc60   rsp = 0x000070000f34bc40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x000070000f34bcb0   rsp = 0x000070000f34bc70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x000070000f34bce0   rsp = 0x000070000f34bcc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x000070000f34bed0   rsp = 0x000070000f34bcf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x000070000f34bf10   rsp = 0x000070000f34bee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000f34bf30   rsp = 0x000070000f34bf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000f34bf50   rsp = 0x000070000f34bf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000f34bf78   rsp = 0x000070000f34bf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x000070000f34c090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 19\n 0  libsystem_kernel.dylib!mach_msg_trap + 0xa\n    rax = 0x000000000100001f   rdx = 0x0000000000000000\n    rcx = 0x000070000f3ceb08   rbx = 0x0000000000000002\n    rsi = 0x0000000000000002   rdi = 0x000070000f3cee50\n    rbp = 0x000070000f3ceb60   rsp = 0x000070000f3ceb08\n     r8 = 0x0000000000008f03    r9 = 0x0000000000000000\n    r10 = 0x000000000000005c   r11 = 0x0000000000000202\n    r12 = 0x0000000000000002   r13 = 0x000000000000005c\n    r14 = 0x000070000f3cee50   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd9822a\n    Found by: given as instruction pointer in context\n 1  XUL!MachExceptionHandlerThread() [WasmSignalHandlers.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 871 + 0x22]\n    rbp = 0x000070000f3ceef0   rsp = 0x000070000f3ceb70\n    rip = 0x000000011554a1f9\n    Found by: previous frame's frame pointer\n 2  XUL!js::detail::ThreadTrampoline<void (&)()>::Start(void*) [Thread.h:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 207 + 0x16]\n    rbp = 0x000070000f3cef10   rsp = 0x000070000f3cef00\n    rip = 0x0000000114c0e560\n    Found by: previous frame's frame pointer\n 3  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000f3cef30   rsp = 0x000070000f3cef20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000f3cef50   rsp = 0x000070000f3cef40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000f3cef78   rsp = 0x000070000f3cef60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 6  XUL + 0x6373540\n    rsp = 0x000070000f3cf090   rip = 0x0000000114c0e540\n    Found by: stack scanning\n\nThread 20\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000113e00\n    rcx = 0x000070001005f4e8   rbx = 0x0000000000113e00\n    rsi = 0x00113e0000114300   rdi = 0x00000001080d6258\n    rbp = 0x000070001005f570   rsp = 0x000070001005f4e8\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000246\n    r12 = 0x00000001080d6258   r13 = 0x0000000000000016\n    r14 = 0x00113e0000114300   r15 = 0x0000000000114300\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 147 + 0xb]\n    rbp = 0x000070001005f5c0   rsp = 0x000070001005f580\n    rip = 0x000000010577db34\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait(mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>) [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 524 + 0x5]\n    rbp = 0x000070001005f600   rsp = 0x000070001005f5d0\n    rip = 0x000000010e9e741d\n    Found by: previous frame's frame pointer\n 3  XUL!nsThreadPool::Run() [nsThreadPool.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 278 + 0x8]\n    rbp = 0x000070001005f6d0   rsp = 0x000070001005f610\n    rip = 0x000000010ea1591a\n    Found by: previous frame's frame pointer\n 4  XUL!non-virtual thunk to nsThreadPool::Run() [nsThreadPool.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 0 + 0xd]\n    rbp = 0x000070001005f6e0   rsp = 0x000070001005f6e0\n    rip = 0x000000010ea15e8d\n    Found by: previous frame's frame pointer\n 5  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1220 + 0x6]\n    rbp = 0x000070001005fc30   rsp = 0x000070001005f6f0\n    rip = 0x000000010ea0cd03\n    Found by: previous frame's frame pointer\n 6  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x000070001005fc60   rsp = 0x000070001005fc40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 7  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x000070001005fcb0   rsp = 0x000070001005fc70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 8  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x000070001005fce0   rsp = 0x000070001005fcc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 9  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x000070001005fed0   rsp = 0x000070001005fcf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n10  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x000070001005ff10   rsp = 0x000070001005fee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070001005ff30   rsp = 0x000070001005ff20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070001005ff50   rsp = 0x000070001005ff40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070001005ff78   rsp = 0x000070001005ff60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n14  libnss3.dylib + 0x178de0\n    rsp = 0x0000700010060090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 21\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000001f00\n    rcx = 0x00007000100a2538   rbx = 0x0000000000000002\n    rsi = 0x00001f0100002000   rdi = 0x00000001199d5ab8\n    rbp = 0x00007000100a25c0   rsp = 0x00007000100a2538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x00000001199d5ab8   r13 = 0x0000000000000016\n    r14 = 0x00001f0100002000   r15 = 0x00007000100a3000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x00007000100a2610   rsp = 0x00007000100a25d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x00007000100a2650   rsp = 0x00007000100a2620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x00007000100a26e0   rsp = 0x00007000100a2660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x00007000100a2c30   rsp = 0x00007000100a26f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x00007000100a2c60   rsp = 0x00007000100a2c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x00007000100a2cb0   rsp = 0x00007000100a2c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x00007000100a2ce0   rsp = 0x00007000100a2cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x00007000100a2ed0   rsp = 0x00007000100a2cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x00007000100a2f10   rsp = 0x00007000100a2ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x00007000100a2f30   rsp = 0x00007000100a2f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x00007000100a2f50   rsp = 0x00007000100a2f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x00007000100a2f78   rsp = 0x00007000100a2f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x00007000100a3090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 22\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000100\n    rcx = 0x00007000102e6538   rbx = 0x0000000000000002\n    rsi = 0x0000010100000200   rdi = 0x0000000119d617b8\n    rbp = 0x00007000102e65c0   rsp = 0x00007000102e6538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x0000000119d617b8   r13 = 0x0000000000000016\n    r14 = 0x0000010100000200   r15 = 0x00007000102e7000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x00007000102e6610   rsp = 0x00007000102e65d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x00007000102e6650   rsp = 0x00007000102e6620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x00007000102e66e0   rsp = 0x00007000102e6660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x00007000102e6c30   rsp = 0x00007000102e66f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x00007000102e6c60   rsp = 0x00007000102e6c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x00007000102e6cb0   rsp = 0x00007000102e6c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x00007000102e6ce0   rsp = 0x00007000102e6cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x00007000102e6ed0   rsp = 0x00007000102e6cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x00007000102e6f10   rsp = 0x00007000102e6ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x00007000102e6f30   rsp = 0x00007000102e6f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x00007000102e6f50   rsp = 0x00007000102e6f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x00007000102e6f78   rsp = 0x00007000102e6f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x00007000102e7090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 23\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000500\n    rcx = 0x0000700010329538   rbx = 0x0000000000000002\n    rsi = 0x0000050100000600   rdi = 0x000000011afb12b8\n    rbp = 0x00007000103295c0   rsp = 0x0000700010329538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000011afb12b8   r13 = 0x0000000000000016\n    r14 = 0x0000050100000600   r15 = 0x000070001032a000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x0000700010329610   rsp = 0x00007000103295d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x0000700010329650   rsp = 0x0000700010329620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x00007000103296e0   rsp = 0x0000700010329660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x0000700010329c30   rsp = 0x00007000103296f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700010329c60   rsp = 0x0000700010329c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700010329cb0   rsp = 0x0000700010329c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700010329ce0   rsp = 0x0000700010329cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700010329ed0   rsp = 0x0000700010329cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700010329f10   rsp = 0x0000700010329ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700010329f30   rsp = 0x0000700010329f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700010329f50   rsp = 0x0000700010329f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700010329f78   rsp = 0x0000700010329f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x000070001032a090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 24\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000100\n    rcx = 0x000070001036c538   rbx = 0x0000000000000002\n    rsi = 0x0000010100000200   rdi = 0x000000011afb13b8\n    rbp = 0x000070001036c5c0   rsp = 0x000070001036c538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000011afb13b8   r13 = 0x0000000000000016\n    r14 = 0x0000010100000200   r15 = 0x000070001036d000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x000070001036c610   rsp = 0x000070001036c5d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x000070001036c650   rsp = 0x000070001036c620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x000070001036c6e0   rsp = 0x000070001036c660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x000070001036cc30   rsp = 0x000070001036c6f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x000070001036cc60   rsp = 0x000070001036cc40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x000070001036ccb0   rsp = 0x000070001036cc70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x000070001036cce0   rsp = 0x000070001036ccc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x000070001036ced0   rsp = 0x000070001036ccf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x000070001036cf10   rsp = 0x000070001036cee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070001036cf30   rsp = 0x000070001036cf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070001036cf50   rsp = 0x000070001036cf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070001036cf78   rsp = 0x000070001036cf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x000070001036d090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 25\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000000\n    rcx = 0x00007000103af9f8   rbx = 0x0000000000000002\n    rsi = 0x0000000100000100   rdi = 0x00007000103afb30\n    rbp = 0x00007000103afa80   rsp = 0x00007000103af9f8\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a5\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x00007000103afb30   r13 = 0x0000000000000016\n    r14 = 0x0000000100000100   r15 = 0x00007000103b0000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  XUL!ConditionVariable::Wait() [condition_variable_posix.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 60 + 0x9]\n    rbp = 0x00007000103afac0   rsp = 0x00007000103afa90\n    rip = 0x000000010f1623cf\n    Found by: previous frame's frame pointer\n 2  XUL!base::WaitableEvent::TimedWait(base::TimeDelta const&) [waitable_event_posix.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 178 + 0x8]\n    rbp = 0x00007000103afbe0   rsp = 0x00007000103afad0\n    rip = 0x000000010f1781d0\n    Found by: previous frame's frame pointer\n 3  XUL!base::WaitableEvent::Wait() [waitable_event_posix.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 183 + 0x27]\n    rbp = 0x00007000103afc00   rsp = 0x00007000103afbf0\n    rip = 0x000000010f177147\n    Found by: previous frame's frame pointer\n 4  XUL!base::MessagePumpDefault::Run(base::MessagePump::Delegate*) [message_pump_default.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 55 + 0x5]\n    rbp = 0x00007000103afca0   rsp = 0x00007000103afc10\n    rip = 0x000000010f169203\n    Found by: previous frame's frame pointer\n 5  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x00007000103afcd0   rsp = 0x00007000103afcb0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 6  XUL!base::Thread::ThreadMain() [thread.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 192 + 0x8]\n    rbp = 0x00007000103aff00   rsp = 0x00007000103afce0\n    rip = 0x000000010f1774a6\n    Found by: previous frame's frame pointer\n 7  XUL!ThreadFunc(void*) [platform_thread_posix.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 40 + 0x6]\n    rbp = 0x00007000103aff10   rsp = 0x00007000103aff10\n    rip = 0x000000010f17166a\n    Found by: previous frame's frame pointer\n 8  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x00007000103aff30   rsp = 0x00007000103aff20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 9  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x00007000103aff50   rsp = 0x00007000103aff40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x00007000103aff78   rsp = 0x00007000103aff60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n11  XUL + 0x8d6660\n    rsp = 0x00007000103b0090   rip = 0x000000010f171660\n    Found by: stack scanning\n\nThread 26\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000c00\n    rcx = 0x00007000103f24e8   rbx = 0x0000000000000002\n    rsi = 0x00000c0100000d00   rdi = 0x000000011abc31a8\n    rbp = 0x00007000103f2570   rsp = 0x00007000103f24e8\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000011abc31a8   r13 = 0x0000000000000016\n    r14 = 0x00000c0100000d00   r15 = 0x00007000103f3000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x00007000103f25c0   rsp = 0x00007000103f2580\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x00007000103f2600   rsp = 0x00007000103f25d0\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::image::DecodePoolImpl::PopWorkLocked(bool) [DecodePool.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 199 + 0x5]\n    rbp = 0x00007000103f2670   rsp = 0x00007000103f2610\n    rip = 0x000000011007c3cc\n    Found by: previous frame's frame pointer\n 4  XUL!mozilla::image::DecodePoolWorker::Run() [DecodePool.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 288 + 0x2c]\n    rbp = 0x00007000103f26e0   rsp = 0x00007000103f2680\n    rip = 0x000000011007bc64\n    Found by: previous frame's frame pointer\n 5  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1220 + 0x6]\n    rbp = 0x00007000103f2c30   rsp = 0x00007000103f26f0\n    rip = 0x000000010ea0cd03\n    Found by: previous frame's frame pointer\n 6  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x00007000103f2c60   rsp = 0x00007000103f2c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 7  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x00007000103f2cb0   rsp = 0x00007000103f2c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 8  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x00007000103f2ce0   rsp = 0x00007000103f2cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 9  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x00007000103f2ed0   rsp = 0x00007000103f2cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n10  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x00007000103f2f10   rsp = 0x00007000103f2ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x00007000103f2f30   rsp = 0x00007000103f2f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x00007000103f2f50   rsp = 0x00007000103f2f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x00007000103f2f78   rsp = 0x00007000103f2f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n14  libnss3.dylib + 0x178de0\n    rsp = 0x00007000103f3090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 27\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000400\n    rcx = 0x0000700010435538   rbx = 0x0000000000000002\n    rsi = 0x0000040100000500   rdi = 0x000000011ab5d1b8\n    rbp = 0x00007000104355c0   rsp = 0x0000700010435538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000011ab5d1b8   r13 = 0x0000000000000016\n    r14 = 0x0000040100000500   r15 = 0x0000700010436000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x0000700010435610   rsp = 0x00007000104355d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x0000700010435650   rsp = 0x0000700010435620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x00007000104356e0   rsp = 0x0000700010435660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x0000700010435c30   rsp = 0x00007000104356f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700010435c60   rsp = 0x0000700010435c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700010435cb0   rsp = 0x0000700010435c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700010435ce0   rsp = 0x0000700010435cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700010435ed0   rsp = 0x0000700010435cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700010435f10   rsp = 0x0000700010435ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700010435f30   rsp = 0x0000700010435f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700010435f50   rsp = 0x0000700010435f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700010435f78   rsp = 0x0000700010435f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x0000700010436090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 28\n 0  libsystem_kernel.dylib!mach_msg_trap + 0xa\n    rax = 0x000000000100001f   rdx = 0x0000000000000000\n    rcx = 0x000070001053aea8   rbx = 0x0000000007000806\n    rsi = 0x0000000007000806   rdi = 0x000070001053b060\n    rbp = 0x000070001053af00   rsp = 0x000070001053aea8\n     r8 = 0x000000000000c703    r9 = 0x00000000ffffffff\n    r10 = 0x0000000000000c00   r11 = 0x0000000000000206\n    r12 = 0x0000000007000806   r13 = 0x0000000000000c00\n    r14 = 0x000070001053b060   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd9822a\n    Found by: given as instruction pointer in context\n 1  CoreFoundation + 0x3bbee\n    rbp = 0x000070001053af80   rsp = 0x000070001053af10\n    rip = 0x00007fff30d39bee\n    Found by: previous frame's frame pointer\n 2  CoreFoundation + 0x3b15c\n    rbp = 0x000070001053bc90   rsp = 0x000070001053af90\n    rip = 0x00007fff30d3915c\n    Found by: previous frame's frame pointer\n 3  CoreFoundation + 0x3a8be\n    rbp = 0x000070001053bd20   rsp = 0x000070001053bca0\n    rip = 0x00007fff30d388be\n    Found by: previous frame's frame pointer\n 4  AppKit!_NSEventThread + 0xaf\n    rbp = 0x000070001053bf10   rsp = 0x000070001053bd30\n    rip = 0x00007fff2e3c66a6\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070001053bf30   rsp = 0x000070001053bf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 6  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070001053bf50   rsp = 0x000070001053bf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 7  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070001053bf78   rsp = 0x000070001053bf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 8  AppKit!+[NSEvent(NSConcurrentEvents) _startConcurrentEventProcessing] + 0xed\n    rsp = 0x000070001053c090   rip = 0x00007fff2e3c65f7\n    Found by: stack scanning\n\nThread 29\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000001f00\n    rcx = 0x000070001057df68   rbx = 0x0000000000000002\n    rsi = 0x00001f0100002000   rdi = 0x000000011afb14b8\n    rbp = 0x000070001057dff0   rsp = 0x000070001057df68\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000011afb14b8   r13 = 0x0000000000000016\n    r14 = 0x00001f0100002000   r15 = 0x000070001057f000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x000070001057e040   rsp = 0x000070001057e000\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x000070001057e080   rsp = 0x000070001057e050\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x000070001057e110   rsp = 0x000070001057e090\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x000070001057e660   rsp = 0x000070001057e120\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x000070001057e690   rsp = 0x000070001057e670\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::dom::indexedDB::(anonymous namespace)::ConnectionPool::ThreadRunnable::Run() [ActorsParent.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 12645 + 0x4b]\n    rbp = 0x000070001057e6e0   rsp = 0x000070001057e6a0\n    rip = 0x00000001124ea9a4\n    Found by: previous frame's frame pointer\n 7  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1220 + 0x6]\n    rbp = 0x000070001057ec30   rsp = 0x000070001057e6f0\n    rip = 0x000000010ea0cd03\n    Found by: previous frame's frame pointer\n 8  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x000070001057ec60   rsp = 0x000070001057ec40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 9  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x000070001057ecb0   rsp = 0x000070001057ec70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n10  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x000070001057ece0   rsp = 0x000070001057ecc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n11  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x000070001057eed0   rsp = 0x000070001057ecf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n12  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x000070001057ef10   rsp = 0x000070001057eee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070001057ef30   rsp = 0x000070001057ef20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n14  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070001057ef50   rsp = 0x000070001057ef40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n15  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070001057ef78   rsp = 0x000070001057ef60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n16  libnss3.dylib + 0x178de0\n    rsp = 0x000070001057f090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 30\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x00000000000a5a00\n    rcx = 0x0000700010604798   rbx = 0x0000000000000002\n    rsi = 0x000a5a00000a5d00   rdi = 0x0000000124884df0\n    rbp = 0x0000700010604820   rsp = 0x0000700010604798\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a0\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x0000000124884df0   r13 = 0x0000000000000016\n    r14 = 0x000a5a00000a5d00   r15 = 0x0000700010605000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  XUL!rayon_core::sleep::Sleep::sleep [condvar.rs:4560ea788cb760f0a34127156c78e2552949f734 : 71 + 0xb]\n    rbp = 0x00007000106048d0   rsp = 0x0000700010604830\n    rip = 0x00000001167cec28\n    Found by: previous frame's frame pointer\n 2  XUL!rayon_core::sleep::Sleep::no_work_found [mod.rs:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 91 + 0xb]\n    rbp = 0x0000700010604970   rsp = 0x00007000106048e0\n    rip = 0x00000001167cb601\n    Found by: previous frame's frame pointer\n 3  XUL!rayon_core::registry::WorkerThread::wait_until_cold [registry.rs:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 721 + 0x1b]\n    rbp = 0x0000700010604a30   rsp = 0x0000700010604980\n    rip = 0x00000001167cabef\n    Found by: previous frame's frame pointer\n 4  XUL!rayon_core::registry::ThreadBuilder::run [registry.rs:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 58 + 0x9c]\n    rbp = 0x0000700010604c90   rsp = 0x0000700010604a40\n    rip = 0x00000001167c94ec\n    Found by: previous frame's frame pointer\n 5  XUL!std::sys_common::backtrace::__rust_begin_short_backtrace [backtrace.rs:4560ea788cb760f0a34127156c78e2552949f734 : 126 + 0x13]\n    rbp = 0x0000700010604d00   rsp = 0x0000700010604ca0\n    rip = 0x00000001167c6cd2\n    Found by: previous frame's frame pointer\n 6  XUL!std::panicking::try::do_call [mod.rs:4560ea788cb760f0a34127156c78e2552949f734 : 470 + 0x13]\n    rbp = 0x0000700010604d70   rsp = 0x0000700010604d10\n    rip = 0x00000001167c7842\n    Found by: previous frame's frame pointer\n 7  XUL!__rust_maybe_catch_panic [lib.rs:4560ea788cb760f0a34127156c78e2552949f734 : 28 + 0x5]\n    rbp = 0x0000700010604d80   rsp = 0x0000700010604d80\n    rip = 0x000000011685b9bc\n    Found by: previous frame's frame pointer\n 8  XUL!core::ops::function::FnOnce::call_once{{vtable.shim}} [function.rs:4560ea788cb760f0a34127156c78e2552949f734 : 227 + 0x80]\n    rbp = 0x0000700010604e20   rsp = 0x0000700010604d90\n    rip = 0x00000001167c7cb0\n    Found by: call frame info\n 9  XUL!<alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once [boxed.rs:4560ea788cb760f0a34127156c78e2552949f734 : 922 + 0x2d]\n    rbp = 0x0000700010604ec0   rsp = 0x0000700010604e30\n    rip = 0x000000011682dd1e\n    Found by: previous frame's frame pointer\n10  XUL!std::sys::unix::thread::Thread::new::thread_start [thread.rs:4560ea788cb760f0a34127156c78e2552949f734 : 79 + 0x80]\n    rbp = 0x0000700010604f10   rsp = 0x0000700010604ed0\n    rip = 0x000000011685aaae\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700010604f30   rsp = 0x0000700010604f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700010604f50   rsp = 0x0000700010604f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700010604f78   rsp = 0x0000700010604f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n14  XUL + 0x7fbfa20\n    rsp = 0x0000700010605090   rip = 0x000000011685aa20\n    Found by: stack scanning\n\nThread 31\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x00000000000a5a00\n    rcx = 0x0000700010647798   rbx = 0x0000000000000002\n    rsi = 0x000a5a00000a5c00   rdi = 0x0000000124884df0\n    rbp = 0x0000700010647820   rsp = 0x0000700010647798\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a0\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x0000000124884df0   r13 = 0x0000000000000016\n    r14 = 0x000a5a00000a5c00   r15 = 0x0000700010648000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  XUL!rayon_core::sleep::Sleep::sleep [condvar.rs:4560ea788cb760f0a34127156c78e2552949f734 : 71 + 0xb]\n    rbp = 0x00007000106478d0   rsp = 0x0000700010647830\n    rip = 0x00000001167cec28\n    Found by: previous frame's frame pointer\n 2  XUL!rayon_core::sleep::Sleep::no_work_found [mod.rs:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 91 + 0xb]\n    rbp = 0x0000700010647970   rsp = 0x00007000106478e0\n    rip = 0x00000001167cb601\n    Found by: previous frame's frame pointer\n 3  XUL!rayon_core::registry::WorkerThread::wait_until_cold [registry.rs:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 721 + 0x1b]\n    rbp = 0x0000700010647a30   rsp = 0x0000700010647980\n    rip = 0x00000001167cabef\n    Found by: previous frame's frame pointer\n 4  XUL!rayon_core::registry::ThreadBuilder::run [registry.rs:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 58 + 0x9c]\n    rbp = 0x0000700010647c90   rsp = 0x0000700010647a40\n    rip = 0x00000001167c94ec\n    Found by: previous frame's frame pointer\n 5  XUL!std::sys_common::backtrace::__rust_begin_short_backtrace [backtrace.rs:4560ea788cb760f0a34127156c78e2552949f734 : 126 + 0x13]\n    rbp = 0x0000700010647d00   rsp = 0x0000700010647ca0\n    rip = 0x00000001167c6cd2\n    Found by: previous frame's frame pointer\n 6  XUL!std::panicking::try::do_call [mod.rs:4560ea788cb760f0a34127156c78e2552949f734 : 470 + 0x13]\n    rbp = 0x0000700010647d70   rsp = 0x0000700010647d10\n    rip = 0x00000001167c7842\n    Found by: previous frame's frame pointer\n 7  XUL!__rust_maybe_catch_panic [lib.rs:4560ea788cb760f0a34127156c78e2552949f734 : 28 + 0x5]\n    rbp = 0x0000700010647d80   rsp = 0x0000700010647d80\n    rip = 0x000000011685b9bc\n    Found by: previous frame's frame pointer\n 8  XUL!core::ops::function::FnOnce::call_once{{vtable.shim}} [function.rs:4560ea788cb760f0a34127156c78e2552949f734 : 227 + 0x80]\n    rbp = 0x0000700010647e20   rsp = 0x0000700010647d90\n    rip = 0x00000001167c7cb0\n    Found by: call frame info\n 9  XUL!<alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once [boxed.rs:4560ea788cb760f0a34127156c78e2552949f734 : 922 + 0x2d]\n    rbp = 0x0000700010647ec0   rsp = 0x0000700010647e30\n    rip = 0x000000011682dd1e\n    Found by: previous frame's frame pointer\n10  XUL!std::sys::unix::thread::Thread::new::thread_start [thread.rs:4560ea788cb760f0a34127156c78e2552949f734 : 79 + 0x80]\n    rbp = 0x0000700010647f10   rsp = 0x0000700010647ed0\n    rip = 0x000000011685aaae\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700010647f30   rsp = 0x0000700010647f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700010647f50   rsp = 0x0000700010647f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700010647f78   rsp = 0x0000700010647f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n14  XUL + 0x7fbfa20\n    rsp = 0x0000700010648090   rip = 0x000000011685aa20\n    Found by: stack scanning\n\nThread 32\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x00000000000a5a00\n    rcx = 0x000070001068a798   rbx = 0x0000000000000002\n    rsi = 0x000a5a01000a5b00   rdi = 0x0000000124884df0\n    rbp = 0x000070001068a820   rsp = 0x000070001068a798\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a0\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x0000000124884df0   r13 = 0x0000000000000016\n    r14 = 0x000a5a01000a5b00   r15 = 0x000070001068b000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  XUL!rayon_core::sleep::Sleep::sleep [condvar.rs:4560ea788cb760f0a34127156c78e2552949f734 : 71 + 0xb]\n    rbp = 0x000070001068a8d0   rsp = 0x000070001068a830\n    rip = 0x00000001167cec28\n    Found by: previous frame's frame pointer\n 2  XUL!rayon_core::sleep::Sleep::no_work_found [mod.rs:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 91 + 0xb]\n    rbp = 0x000070001068a970   rsp = 0x000070001068a8e0\n    rip = 0x00000001167cb601\n    Found by: previous frame's frame pointer\n 3  XUL!rayon_core::registry::WorkerThread::wait_until_cold [registry.rs:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 721 + 0x1b]\n    rbp = 0x000070001068aa30   rsp = 0x000070001068a980\n    rip = 0x00000001167cabef\n    Found by: previous frame's frame pointer\n 4  XUL!rayon_core::registry::ThreadBuilder::run [registry.rs:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 58 + 0x9c]\n    rbp = 0x000070001068ac90   rsp = 0x000070001068aa40\n    rip = 0x00000001167c94ec\n    Found by: previous frame's frame pointer\n 5  XUL!std::sys_common::backtrace::__rust_begin_short_backtrace [backtrace.rs:4560ea788cb760f0a34127156c78e2552949f734 : 126 + 0x13]\n    rbp = 0x000070001068ad00   rsp = 0x000070001068aca0\n    rip = 0x00000001167c6cd2\n    Found by: previous frame's frame pointer\n 6  XUL!std::panicking::try::do_call [mod.rs:4560ea788cb760f0a34127156c78e2552949f734 : 470 + 0x13]\n    rbp = 0x000070001068ad70   rsp = 0x000070001068ad10\n    rip = 0x00000001167c7842\n    Found by: previous frame's frame pointer\n 7  XUL!__rust_maybe_catch_panic [lib.rs:4560ea788cb760f0a34127156c78e2552949f734 : 28 + 0x5]\n    rbp = 0x000070001068ad80   rsp = 0x000070001068ad80\n    rip = 0x000000011685b9bc\n    Found by: previous frame's frame pointer\n 8  XUL!core::ops::function::FnOnce::call_once{{vtable.shim}} [function.rs:4560ea788cb760f0a34127156c78e2552949f734 : 227 + 0x80]\n    rbp = 0x000070001068ae20   rsp = 0x000070001068ad90\n    rip = 0x00000001167c7cb0\n    Found by: call frame info\n 9  XUL!<alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once [boxed.rs:4560ea788cb760f0a34127156c78e2552949f734 : 922 + 0x2d]\n    rbp = 0x000070001068aec0   rsp = 0x000070001068ae30\n    rip = 0x000000011682dd1e\n    Found by: previous frame's frame pointer\n10  XUL!std::sys::unix::thread::Thread::new::thread_start [thread.rs:4560ea788cb760f0a34127156c78e2552949f734 : 79 + 0x80]\n    rbp = 0x000070001068af10   rsp = 0x000070001068aed0\n    rip = 0x000000011685aaae\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070001068af30   rsp = 0x000070001068af20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070001068af50   rsp = 0x000070001068af40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070001068af78   rsp = 0x000070001068af60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n14  XUL + 0x7fbfa20\n    rsp = 0x000070001068b090   rip = 0x000000011685aa20\n    Found by: stack scanning\n\nThread 33\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x00000000000a5a00\n    rcx = 0x00007000106cd798   rbx = 0x0000000000000002\n    rsi = 0x000a5a00000a5e00   rdi = 0x0000000124884df0\n    rbp = 0x00007000106cd820   rsp = 0x00007000106cd798\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a0\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x0000000124884df0   r13 = 0x0000000000000016\n    r14 = 0x000a5a00000a5e00   r15 = 0x00007000106ce000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  XUL!rayon_core::sleep::Sleep::sleep [condvar.rs:4560ea788cb760f0a34127156c78e2552949f734 : 71 + 0xb]\n    rbp = 0x00007000106cd8d0   rsp = 0x00007000106cd830\n    rip = 0x00000001167cec28\n    Found by: previous frame's frame pointer\n 2  XUL!rayon_core::sleep::Sleep::no_work_found [mod.rs:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 91 + 0xb]\n    rbp = 0x00007000106cd970   rsp = 0x00007000106cd8e0\n    rip = 0x00000001167cb601\n    Found by: previous frame's frame pointer\n 3  XUL!rayon_core::registry::WorkerThread::wait_until_cold [registry.rs:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 721 + 0x1b]\n    rbp = 0x00007000106cda30   rsp = 0x00007000106cd980\n    rip = 0x00000001167cabef\n    Found by: previous frame's frame pointer\n 4  XUL!rayon_core::registry::ThreadBuilder::run [registry.rs:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 58 + 0x9c]\n    rbp = 0x00007000106cdc90   rsp = 0x00007000106cda40\n    rip = 0x00000001167c94ec\n    Found by: previous frame's frame pointer\n 5  XUL!std::sys_common::backtrace::__rust_begin_short_backtrace [backtrace.rs:4560ea788cb760f0a34127156c78e2552949f734 : 126 + 0x13]\n    rbp = 0x00007000106cdd00   rsp = 0x00007000106cdca0\n    rip = 0x00000001167c6cd2\n    Found by: previous frame's frame pointer\n 6  XUL!std::panicking::try::do_call [mod.rs:4560ea788cb760f0a34127156c78e2552949f734 : 470 + 0x13]\n    rbp = 0x00007000106cdd70   rsp = 0x00007000106cdd10\n    rip = 0x00000001167c7842\n    Found by: previous frame's frame pointer\n 7  XUL!__rust_maybe_catch_panic [lib.rs:4560ea788cb760f0a34127156c78e2552949f734 : 28 + 0x5]\n    rbp = 0x00007000106cdd80   rsp = 0x00007000106cdd80\n    rip = 0x000000011685b9bc\n    Found by: previous frame's frame pointer\n 8  XUL!core::ops::function::FnOnce::call_once{{vtable.shim}} [function.rs:4560ea788cb760f0a34127156c78e2552949f734 : 227 + 0x80]\n    rbp = 0x00007000106cde20   rsp = 0x00007000106cdd90\n    rip = 0x00000001167c7cb0\n    Found by: call frame info\n 9  XUL!<alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once [boxed.rs:4560ea788cb760f0a34127156c78e2552949f734 : 922 + 0x2d]\n    rbp = 0x00007000106cdec0   rsp = 0x00007000106cde30\n    rip = 0x000000011682dd1e\n    Found by: previous frame's frame pointer\n10  XUL!std::sys::unix::thread::Thread::new::thread_start [thread.rs:4560ea788cb760f0a34127156c78e2552949f734 : 79 + 0x80]\n    rbp = 0x00007000106cdf10   rsp = 0x00007000106cded0\n    rip = 0x000000011685aaae\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x00007000106cdf30   rsp = 0x00007000106cdf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x00007000106cdf50   rsp = 0x00007000106cdf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x00007000106cdf78   rsp = 0x00007000106cdf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n14  XUL + 0x7fbfa20\n    rsp = 0x00007000106ce090   rip = 0x000000011685aa20\n    Found by: stack scanning\n\nThread 34\n 0  libsystem_kernel.dylib!mach_msg_trap + 0xa\n    rax = 0x000000000100001f   rdx = 0x0000000000000000\n    rcx = 0x00007000107d35b8   rbx = 0x0000000000000002\n    rsi = 0x0000000000000002   rdi = 0x00007000107d3aa0\n    rbp = 0x00007000107d3610   rsp = 0x00007000107d35b8\n     r8 = 0x0000000000011967    r9 = 0x0000000000000000\n    r10 = 0x000000000000041c   r11 = 0x0000000000000202\n    r12 = 0x0000000000000002   r13 = 0x000000000000041c\n    r14 = 0x00007000107d3aa0   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd9822a\n    Found by: given as instruction pointer in context\n 1  XUL!google_breakpad::ReceivePort::WaitForMessage(google_breakpad::MachReceiveMessage*, unsigned int) [MachIPC.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 249 + 0x18]\n    rbp = 0x00007000107d3630   rsp = 0x00007000107d3620\n    rip = 0x00000001143e5fca\n    Found by: previous frame's frame pointer\n 2  XUL!google_breakpad::CrashGenerationServer::WaitForOneMessage() [crash_generation_server.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 102 + 0x10]\n    rbp = 0x00007000107d3ef0   rsp = 0x00007000107d3640\n    rip = 0x00000001143db069\n    Found by: previous frame's frame pointer\n 3  XUL!google_breakpad::CrashGenerationServer::WaitForMessages(void*) [crash_generation_server.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 96 + 0x8]\n    rbp = 0x00007000107d3f10   rsp = 0x00007000107d3f00\n    rip = 0x00000001143db008\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x00007000107d3f30   rsp = 0x00007000107d3f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x00007000107d3f50   rsp = 0x00007000107d3f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 6  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x00007000107d3f78   rsp = 0x00007000107d3f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 7  XUL + 0x5b3fff0\n    rsp = 0x00007000107d4090   rip = 0x00000001143daff0\n    Found by: stack scanning\n\nThread 35\n 0  libsystem_kernel.dylib!mach_msg_trap + 0xa\n    rax = 0x000000000100001f   rdx = 0x0000000000000000\n    rcx = 0x0000700010856de8   rbx = 0x0000000000000002\n    rsi = 0x0000000000000002   rdi = 0x0000000124b78000\n    rbp = 0x0000700010856e40   rsp = 0x0000700010856de8\n     r8 = 0x0000000000011403    r9 = 0x0000000000000000\n    r10 = 0x000000000000041c   r11 = 0x0000000000000202\n    r12 = 0x0000000000000002   r13 = 0x000000000000041c\n    r14 = 0x0000000124b78000   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd9822a\n    Found by: given as instruction pointer in context\n 1  XUL!ReceivePort::WaitForMessage(MachReceiveMessage*, unsigned int) [mach_ipc_mac.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 237 + 0x13]\n    rbp = 0x0000700010856e60   rsp = 0x0000700010856e50\n    rip = 0x000000010f182dc7\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::ipc::PortServerThread(void*) [SharedMemoryBasic_mach.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 344 + 0xe]\n    rbp = 0x0000700010856f10   rsp = 0x0000700010856e70\n    rip = 0x000000010f1eca01\n    Found by: previous frame's frame pointer\n 3  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700010856f30   rsp = 0x0000700010856f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700010856f50   rsp = 0x0000700010856f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700010856f78   rsp = 0x0000700010856f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 6  XUL + 0x951960\n    rsp = 0x0000700010857090   rip = 0x000000010f1ec960\n    Found by: stack scanning\n\nThread 36\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000000\n    rcx = 0x00007000105c19f8   rbx = 0x0000000000000002\n    rsi = 0x0000000100000100   rdi = 0x00007000105c1b30\n    rbp = 0x00007000105c1a80   rsp = 0x00007000105c19f8\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a5\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x00007000105c1b30   r13 = 0x0000000000000016\n    r14 = 0x0000000100000100   r15 = 0x00007000105c2000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  XUL!ConditionVariable::Wait() [condition_variable_posix.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 60 + 0x9]\n    rbp = 0x00007000105c1ac0   rsp = 0x00007000105c1a90\n    rip = 0x000000010f1623cf\n    Found by: previous frame's frame pointer\n 2  XUL!base::WaitableEvent::TimedWait(base::TimeDelta const&) [waitable_event_posix.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 178 + 0x8]\n    rbp = 0x00007000105c1be0   rsp = 0x00007000105c1ad0\n    rip = 0x000000010f1781d0\n    Found by: previous frame's frame pointer\n 3  XUL!base::WaitableEvent::Wait() [waitable_event_posix.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 183 + 0x27]\n    rbp = 0x00007000105c1c00   rsp = 0x00007000105c1bf0\n    rip = 0x000000010f177147\n    Found by: previous frame's frame pointer\n 4  XUL!base::MessagePumpDefault::Run(base::MessagePump::Delegate*) [message_pump_default.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 55 + 0x5]\n    rbp = 0x00007000105c1ca0   rsp = 0x00007000105c1c10\n    rip = 0x000000010f169203\n    Found by: previous frame's frame pointer\n 5  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x00007000105c1cd0   rsp = 0x00007000105c1cb0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 6  XUL!base::Thread::ThreadMain() [thread.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 192 + 0x8]\n    rbp = 0x00007000105c1f00   rsp = 0x00007000105c1ce0\n    rip = 0x000000010f1774a6\n    Found by: previous frame's frame pointer\n 7  XUL!ThreadFunc(void*) [platform_thread_posix.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 40 + 0x6]\n    rbp = 0x00007000105c1f10   rsp = 0x00007000105c1f10\n    rip = 0x000000010f17166a\n    Found by: previous frame's frame pointer\n 8  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x00007000105c1f30   rsp = 0x00007000105c1f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 9  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x00007000105c1f50   rsp = 0x00007000105c1f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x00007000105c1f78   rsp = 0x00007000105c1f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n11  XUL + 0x8d6660\n    rsp = 0x00007000105c2090   rip = 0x000000010f171660\n    Found by: stack scanning\n\nThread 37\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000006900\n    rcx = 0x0000700010899538   rbx = 0x0000000000000002\n    rsi = 0x0000690100006a00   rdi = 0x000000010592fab8\n    rbp = 0x00007000108995c0   rsp = 0x0000700010899538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000010592fab8   r13 = 0x0000000000000016\n    r14 = 0x0000690100006a00   r15 = 0x000070001089a000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x0000700010899610   rsp = 0x00007000108995d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x0000700010899650   rsp = 0x0000700010899620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x00007000108996e0   rsp = 0x0000700010899660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x0000700010899c30   rsp = 0x00007000108996f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700010899c60   rsp = 0x0000700010899c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700010899cb0   rsp = 0x0000700010899c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700010899ce0   rsp = 0x0000700010899cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700010899ed0   rsp = 0x0000700010899cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700010899f10   rsp = 0x0000700010899ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700010899f30   rsp = 0x0000700010899f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700010899f50   rsp = 0x0000700010899f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700010899f78   rsp = 0x0000700010899f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x000070001089a090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 38\n 0  libsystem_kernel.dylib!mach_msg_trap + 0xa\n    rax = 0x000000000100001f   rdx = 0x0000000000000000\n    rcx = 0x0000700010a25de8   rbx = 0x0000000000000002\n    rsi = 0x0000000000000002   rdi = 0x000000010d4ca800\n    rbp = 0x0000700010a25e40   rsp = 0x0000700010a25de8\n     r8 = 0x000000000000e203    r9 = 0x0000000000000000\n    r10 = 0x000000000000041c   r11 = 0x0000000000000202\n    r12 = 0x0000000000000002   r13 = 0x000000000000041c\n    r14 = 0x000000010d4ca800   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd9822a\n    Found by: given as instruction pointer in context\n 1  XUL!ReceivePort::WaitForMessage(MachReceiveMessage*, unsigned int) [mach_ipc_mac.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 237 + 0x13]\n    rbp = 0x0000700010a25e60   rsp = 0x0000700010a25e50\n    rip = 0x000000010f182dc7\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::ipc::PortServerThread(void*) [SharedMemoryBasic_mach.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 344 + 0xe]\n    rbp = 0x0000700010a25f10   rsp = 0x0000700010a25e70\n    rip = 0x000000010f1eca01\n    Found by: previous frame's frame pointer\n 3  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700010a25f30   rsp = 0x0000700010a25f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700010a25f50   rsp = 0x0000700010a25f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700010a25f78   rsp = 0x0000700010a25f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 6  XUL + 0x951960\n    rsp = 0x0000700010a26090   rip = 0x000000010f1ec960\n    Found by: stack scanning\n\nThread 39\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000a00\n    rcx = 0x0000700010710538   rbx = 0x0000000000000002\n    rsi = 0x00000a0100000b00   rdi = 0x00000001265749b8\n    rbp = 0x00007000107105c0   rsp = 0x0000700010710538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x00000001265749b8   r13 = 0x0000000000000016\n    r14 = 0x00000a0100000b00   r15 = 0x0000700010711000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x0000700010710610   rsp = 0x00007000107105d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x0000700010710650   rsp = 0x0000700010710620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x00007000107106e0   rsp = 0x0000700010710660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x0000700010710c30   rsp = 0x00007000107106f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700010710c60   rsp = 0x0000700010710c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700010710cb0   rsp = 0x0000700010710c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700010710ce0   rsp = 0x0000700010710cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700010710ed0   rsp = 0x0000700010710cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700010710f10   rsp = 0x0000700010710ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700010710f30   rsp = 0x0000700010710f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700010710f50   rsp = 0x0000700010710f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700010710f78   rsp = 0x0000700010710f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x0000700010711090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 40\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000000\n    rcx = 0x00007000108dc538   rbx = 0x0000000000000002\n    rsi = 0x0000000100000100   rdi = 0x000000010dadf6b8\n    rbp = 0x00007000108dc5c0   rsp = 0x00007000108dc538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000010dadf6b8   r13 = 0x0000000000000016\n    r14 = 0x0000000100000100   r15 = 0x00007000108dd000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x00007000108dc610   rsp = 0x00007000108dc5d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x00007000108dc650   rsp = 0x00007000108dc620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x00007000108dc6e0   rsp = 0x00007000108dc660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x00007000108dcc30   rsp = 0x00007000108dc6f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x00007000108dcc60   rsp = 0x00007000108dcc40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x00007000108dccb0   rsp = 0x00007000108dcc70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x00007000108dcce0   rsp = 0x00007000108dccc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x00007000108dced0   rsp = 0x00007000108dccf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x00007000108dcf10   rsp = 0x00007000108dcee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x00007000108dcf30   rsp = 0x00007000108dcf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x00007000108dcf50   rsp = 0x00007000108dcf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x00007000108dcf78   rsp = 0x00007000108dcf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x00007000108dd090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 41\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000800\n    rcx = 0x00007000109a24e8   rbx = 0x0000000000000800\n    rsi = 0x0000080100000900   rdi = 0x0000000105933f48\n    rbp = 0x00007000109a2570   rsp = 0x00007000109a24e8\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000246\n    r12 = 0x0000000105933f48   r13 = 0x0000000000000016\n    r14 = 0x0000080100000900   r15 = 0x0000000000000900\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 147 + 0xb]\n    rbp = 0x00007000109a25c0   rsp = 0x00007000109a2580\n    rip = 0x000000010577db34\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait(mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>) [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 524 + 0x5]\n    rbp = 0x00007000109a2600   rsp = 0x00007000109a25d0\n    rip = 0x000000010e9e741d\n    Found by: previous frame's frame pointer\n 3  XUL!nsThreadPool::Run() [nsThreadPool.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 278 + 0x8]\n    rbp = 0x00007000109a26d0   rsp = 0x00007000109a2610\n    rip = 0x000000010ea1591a\n    Found by: previous frame's frame pointer\n 4  XUL!non-virtual thunk to nsThreadPool::Run() [nsThreadPool.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 0 + 0xd]\n    rbp = 0x00007000109a26e0   rsp = 0x00007000109a26e0\n    rip = 0x000000010ea15e8d\n    Found by: previous frame's frame pointer\n 5  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1220 + 0x6]\n    rbp = 0x00007000109a2c30   rsp = 0x00007000109a26f0\n    rip = 0x000000010ea0cd03\n    Found by: previous frame's frame pointer\n 6  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x00007000109a2c60   rsp = 0x00007000109a2c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 7  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x00007000109a2cb0   rsp = 0x00007000109a2c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 8  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x00007000109a2ce0   rsp = 0x00007000109a2cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 9  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x00007000109a2ed0   rsp = 0x00007000109a2cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n10  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x00007000109a2f10   rsp = 0x00007000109a2ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x00007000109a2f30   rsp = 0x00007000109a2f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x00007000109a2f50   rsp = 0x00007000109a2f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x00007000109a2f78   rsp = 0x00007000109a2f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n14  libnss3.dylib + 0x178de0\n    rsp = 0x00007000109a3090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 42\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000100\n    rcx = 0x0000700010a68538   rbx = 0x0000000000000002\n    rsi = 0x0000010100000200   rdi = 0x0000000126575fb8\n    rbp = 0x0000700010a685c0   rsp = 0x0000700010a68538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x0000000126575fb8   r13 = 0x0000000000000016\n    r14 = 0x0000010100000200   r15 = 0x0000700010a69000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x0000700010a68610   rsp = 0x0000700010a685d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x0000700010a68650   rsp = 0x0000700010a68620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x0000700010a686e0   rsp = 0x0000700010a68660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x0000700010a68c30   rsp = 0x0000700010a686f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700010a68c60   rsp = 0x0000700010a68c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700010a68cb0   rsp = 0x0000700010a68c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700010a68ce0   rsp = 0x0000700010a68cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700010a68ed0   rsp = 0x0000700010a68cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700010a68f10   rsp = 0x0000700010a68ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700010a68f30   rsp = 0x0000700010a68f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700010a68f50   rsp = 0x0000700010a68f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700010a68f78   rsp = 0x0000700010a68f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x0000700010a69090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 43\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000003e00\n    rcx = 0x0000700010c69268   rbx = 0x0000000000000002\n    rsi = 0x00003e0100003f00   rdi = 0x0000000126fdb840\n    rbp = 0x0000700010c692f0   rsp = 0x0000700010c69268\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x0000000126fdb840   r13 = 0x0000000000000016\n    r14 = 0x00003e0100003f00   r15 = 0x0000700010c6a000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x0000700010c69340   rsp = 0x0000700010c69300\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x0000700010c69380   rsp = 0x0000700010c69350\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::dom::WorkerPrivate::WaitForWorkerEvents() [WorkerPrivate.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 3401 + 0xc]\n    rbp = 0x0000700010c693c0   rsp = 0x0000700010c69390\n    rip = 0x00000001126f1ea4\n    Found by: previous frame's frame pointer\n 4  XUL!mozilla::dom::WorkerPrivate::DoRunLoop(JSContext*) [WorkerPrivate.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 2785 + 0x8]\n    rbp = 0x0000700010c694d0   rsp = 0x0000700010c693d0\n    rip = 0x00000001126f15bd\n    Found by: previous frame's frame pointer\n 5  XUL!mozilla::dom::workerinternals::(anonymous namespace)::WorkerThreadPrimaryRunnable::Run() [RuntimeService.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 2318 + 0xc]\n    rbp = 0x0000700010c696e0   rsp = 0x0000700010c694e0\n    rip = 0x00000001126d027d\n    Found by: previous frame's frame pointer\n 6  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1220 + 0x6]\n    rbp = 0x0000700010c69c30   rsp = 0x0000700010c696f0\n    rip = 0x000000010ea0cd03\n    Found by: previous frame's frame pointer\n 7  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700010c69c60   rsp = 0x0000700010c69c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 8  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700010c69cb0   rsp = 0x0000700010c69c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 9  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700010c69ce0   rsp = 0x0000700010c69cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n10  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700010c69ed0   rsp = 0x0000700010c69cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n11  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700010c69f10   rsp = 0x0000700010c69ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700010c69f30   rsp = 0x0000700010c69f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700010c69f50   rsp = 0x0000700010c69f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n14  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700010c69f78   rsp = 0x0000700010c69f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n15  libnss3.dylib + 0x178de0\n    rsp = 0x0000700010c6a090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 44\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000003700\n    rcx = 0x0000700010cac538   rbx = 0x0000000000000002\n    rsi = 0x0000370100003800   rdi = 0x0000000126d3f4b8\n    rbp = 0x0000700010cac5c0   rsp = 0x0000700010cac538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x0000000126d3f4b8   r13 = 0x0000000000000016\n    r14 = 0x0000370100003800   r15 = 0x0000700010cad000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x0000700010cac610   rsp = 0x0000700010cac5d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x0000700010cac650   rsp = 0x0000700010cac620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x0000700010cac6e0   rsp = 0x0000700010cac660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x0000700010cacc30   rsp = 0x0000700010cac6f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700010cacc60   rsp = 0x0000700010cacc40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700010caccb0   rsp = 0x0000700010cacc70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700010cacce0   rsp = 0x0000700010caccc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700010caced0   rsp = 0x0000700010caccf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700010cacf10   rsp = 0x0000700010cacee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700010cacf30   rsp = 0x0000700010cacf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700010cacf50   rsp = 0x0000700010cacf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700010cacf78   rsp = 0x0000700010cacf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x0000700010cad090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 45\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000004200\n    rcx = 0x0000700010ead268   rbx = 0x0000000000000002\n    rsi = 0x0000420100004300   rdi = 0x0000000126fdc840\n    rbp = 0x0000700010ead2f0   rsp = 0x0000700010ead268\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x0000000126fdc840   r13 = 0x0000000000000016\n    r14 = 0x0000420100004300   r15 = 0x0000700010eae000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x0000700010ead340   rsp = 0x0000700010ead300\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x0000700010ead380   rsp = 0x0000700010ead350\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::dom::WorkerPrivate::WaitForWorkerEvents() [WorkerPrivate.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 3401 + 0xc]\n    rbp = 0x0000700010ead3c0   rsp = 0x0000700010ead390\n    rip = 0x00000001126f1ea4\n    Found by: previous frame's frame pointer\n 4  XUL!mozilla::dom::WorkerPrivate::DoRunLoop(JSContext*) [WorkerPrivate.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 2785 + 0x8]\n    rbp = 0x0000700010ead4d0   rsp = 0x0000700010ead3d0\n    rip = 0x00000001126f15bd\n    Found by: previous frame's frame pointer\n 5  XUL!mozilla::dom::workerinternals::(anonymous namespace)::WorkerThreadPrimaryRunnable::Run() [RuntimeService.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 2318 + 0xc]\n    rbp = 0x0000700010ead6e0   rsp = 0x0000700010ead4e0\n    rip = 0x00000001126d027d\n    Found by: previous frame's frame pointer\n 6  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1220 + 0x6]\n    rbp = 0x0000700010eadc30   rsp = 0x0000700010ead6f0\n    rip = 0x000000010ea0cd03\n    Found by: previous frame's frame pointer\n 7  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700010eadc60   rsp = 0x0000700010eadc40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 8  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700010eadcb0   rsp = 0x0000700010eadc70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 9  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700010eadce0   rsp = 0x0000700010eadcc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n10  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700010eaded0   rsp = 0x0000700010eadcf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n11  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700010eadf10   rsp = 0x0000700010eadee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700010eadf30   rsp = 0x0000700010eadf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700010eadf50   rsp = 0x0000700010eadf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n14  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700010eadf78   rsp = 0x0000700010eadf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n15  libnss3.dylib + 0x178de0\n    rsp = 0x0000700010eae090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 46\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000700\n    rcx = 0x0000700010fb9538   rbx = 0x0000000000000002\n    rsi = 0x0000070100000800   rdi = 0x00000001234aefb8\n    rbp = 0x0000700010fb95c0   rsp = 0x0000700010fb9538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x00000001234aefb8   r13 = 0x0000000000000016\n    r14 = 0x0000070100000800   r15 = 0x0000700010fba000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x0000700010fb9610   rsp = 0x0000700010fb95d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x0000700010fb9650   rsp = 0x0000700010fb9620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x0000700010fb96e0   rsp = 0x0000700010fb9660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x0000700010fb9c30   rsp = 0x0000700010fb96f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700010fb9c60   rsp = 0x0000700010fb9c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700010fb9cb0   rsp = 0x0000700010fb9c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700010fb9ce0   rsp = 0x0000700010fb9cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700010fb9ed0   rsp = 0x0000700010fb9cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700010fb9f10   rsp = 0x0000700010fb9ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700010fb9f30   rsp = 0x0000700010fb9f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700010fb9f50   rsp = 0x0000700010fb9f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700010fb9f78   rsp = 0x0000700010fb9f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x0000700010fba090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 47\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000007800\n    rcx = 0x000070001103f538   rbx = 0x0000000000000002\n    rsi = 0x0000780100007900   rdi = 0x000000012a2a63b8\n    rbp = 0x000070001103f5c0   rsp = 0x000070001103f538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000012a2a63b8   r13 = 0x0000000000000016\n    r14 = 0x0000780100007900   r15 = 0x0000700011040000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x000070001103f610   rsp = 0x000070001103f5d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x000070001103f650   rsp = 0x000070001103f620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x000070001103f6e0   rsp = 0x000070001103f660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x000070001103fc30   rsp = 0x000070001103f6f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x000070001103fc60   rsp = 0x000070001103fc40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x000070001103fcb0   rsp = 0x000070001103fc70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x000070001103fce0   rsp = 0x000070001103fcc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x000070001103fed0   rsp = 0x000070001103fcf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x000070001103ff10   rsp = 0x000070001103fee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070001103ff30   rsp = 0x000070001103ff20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070001103ff50   rsp = 0x000070001103ff40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070001103ff78   rsp = 0x000070001103ff60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x0000700011040090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 48\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000001400\n    rcx = 0x0000700011105538   rbx = 0x0000000000000002\n    rsi = 0x0000140100001500   rdi = 0x000000012a2a8db8\n    rbp = 0x00007000111055c0   rsp = 0x0000700011105538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000012a2a8db8   r13 = 0x0000000000000016\n    r14 = 0x0000140100001500   r15 = 0x0000700011106000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x0000700011105610   rsp = 0x00007000111055d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x0000700011105650   rsp = 0x0000700011105620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x00007000111056e0   rsp = 0x0000700011105660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x0000700011105c30   rsp = 0x00007000111056f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700011105c60   rsp = 0x0000700011105c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700011105cb0   rsp = 0x0000700011105c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700011105ce0   rsp = 0x0000700011105cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700011105ed0   rsp = 0x0000700011105cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700011105f10   rsp = 0x0000700011105ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700011105f30   rsp = 0x0000700011105f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700011105f50   rsp = 0x0000700011105f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700011105f78   rsp = 0x0000700011105f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x0000700011106090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 49\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000200\n    rcx = 0x0000700010ffc538   rbx = 0x0000000000000002\n    rsi = 0x0000020100000300   rdi = 0x000000012a3aa2b8\n    rbp = 0x0000700010ffc5c0   rsp = 0x0000700010ffc538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000012a3aa2b8   r13 = 0x0000000000000016\n    r14 = 0x0000020100000300   r15 = 0x0000700010ffd000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x0000700010ffc610   rsp = 0x0000700010ffc5d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x0000700010ffc650   rsp = 0x0000700010ffc620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x0000700010ffc6e0   rsp = 0x0000700010ffc660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x0000700010ffcc30   rsp = 0x0000700010ffc6f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700010ffcc60   rsp = 0x0000700010ffcc40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700010ffccb0   rsp = 0x0000700010ffcc70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700010ffcce0   rsp = 0x0000700010ffccc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700010ffced0   rsp = 0x0000700010ffccf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700010ffcf10   rsp = 0x0000700010ffcee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700010ffcf30   rsp = 0x0000700010ffcf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700010ffcf50   rsp = 0x0000700010ffcf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700010ffcf78   rsp = 0x0000700010ffcf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x0000700010ffd090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 50\n 0  libsystem_kernel.dylib!mach_msg_trap + 0xa\n    rax = 0x000000000100001f   rdx = 0x0000000000000000\n    rcx = 0x0000700011188de8   rbx = 0x0000000000000002\n    rsi = 0x0000000000000002   rdi = 0x000000010d4bd000\n    rbp = 0x0000700011188e40   rsp = 0x0000700011188de8\n     r8 = 0x000000000001f803    r9 = 0x0000000000000000\n    r10 = 0x000000000000041c   r11 = 0x0000000000000202\n    r12 = 0x0000000000000002   r13 = 0x000000000000041c\n    r14 = 0x000000010d4bd000   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd9822a\n    Found by: given as instruction pointer in context\n 1  XUL!ReceivePort::WaitForMessage(MachReceiveMessage*, unsigned int) [mach_ipc_mac.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 237 + 0x13]\n    rbp = 0x0000700011188e60   rsp = 0x0000700011188e50\n    rip = 0x000000010f182dc7\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::ipc::PortServerThread(void*) [SharedMemoryBasic_mach.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 344 + 0xe]\n    rbp = 0x0000700011188f10   rsp = 0x0000700011188e70\n    rip = 0x000000010f1eca01\n    Found by: previous frame's frame pointer\n 3  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700011188f30   rsp = 0x0000700011188f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700011188f50   rsp = 0x0000700011188f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700011188f78   rsp = 0x0000700011188f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 6  XUL + 0x951960\n    rsp = 0x0000700011189090   rip = 0x000000010f1ec960\n    Found by: stack scanning\n\nThread 51\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000c00\n    rcx = 0x00007000111caf68   rbx = 0x0000000000000002\n    rsi = 0x00000c0100000d00   rdi = 0x000000012b29fab8\n    rbp = 0x00007000111caff0   rsp = 0x00007000111caf68\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000012b29fab8   r13 = 0x0000000000000016\n    r14 = 0x00000c0100000d00   r15 = 0x00007000111cc000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x00007000111cb040   rsp = 0x00007000111cb000\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x00007000111cb080   rsp = 0x00007000111cb050\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x00007000111cb110   rsp = 0x00007000111cb090\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x00007000111cb660   rsp = 0x00007000111cb120\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x00007000111cb690   rsp = 0x00007000111cb670\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::dom::indexedDB::(anonymous namespace)::ConnectionPool::ThreadRunnable::Run() [ActorsParent.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 12645 + 0x4b]\n    rbp = 0x00007000111cb6e0   rsp = 0x00007000111cb6a0\n    rip = 0x00000001124ea9a4\n    Found by: previous frame's frame pointer\n 7  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1220 + 0x6]\n    rbp = 0x00007000111cbc30   rsp = 0x00007000111cb6f0\n    rip = 0x000000010ea0cd03\n    Found by: previous frame's frame pointer\n 8  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x00007000111cbc60   rsp = 0x00007000111cbc40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 9  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x00007000111cbcb0   rsp = 0x00007000111cbc70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n10  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x00007000111cbce0   rsp = 0x00007000111cbcc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n11  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x00007000111cbed0   rsp = 0x00007000111cbcf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n12  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x00007000111cbf10   rsp = 0x00007000111cbee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x00007000111cbf30   rsp = 0x00007000111cbf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n14  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x00007000111cbf50   rsp = 0x00007000111cbf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n15  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x00007000111cbf78   rsp = 0x00007000111cbf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n16  libnss3.dylib + 0x178de0\n    rsp = 0x00007000111cc090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 52\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000400\n    rcx = 0x0000700011082538   rbx = 0x0000000000000002\n    rsi = 0x0000040100000500   rdi = 0x000000011afb11b8\n    rbp = 0x00007000110825c0   rsp = 0x0000700011082538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x000000011afb11b8   r13 = 0x0000000000000016\n    r14 = 0x0000040100000500   r15 = 0x0000700011083000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x0000700011082610   rsp = 0x00007000110825d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x0000700011082650   rsp = 0x0000700011082620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x00007000110826e0   rsp = 0x0000700011082660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x0000700011082c30   rsp = 0x00007000110826f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700011082c60   rsp = 0x0000700011082c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700011082cb0   rsp = 0x0000700011082c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700011082ce0   rsp = 0x0000700011082cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700011082ed0   rsp = 0x0000700011082cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700011082f10   rsp = 0x0000700011082ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700011082f30   rsp = 0x0000700011082f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700011082f50   rsp = 0x0000700011082f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700011082f78   rsp = 0x0000700011082f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x0000700011083090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 53\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000300\n    rcx = 0x0000700011291538   rbx = 0x0000000000000002\n    rsi = 0x0000030100000400   rdi = 0x0000000123d24ab8\n    rbp = 0x00007000112915c0   rsp = 0x0000700011291538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x0000000123d24ab8   r13 = 0x0000000000000016\n    r14 = 0x0000030100000400   r15 = 0x0000700011292000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x0000700011291610   rsp = 0x00007000112915d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x0000700011291650   rsp = 0x0000700011291620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x00007000112916e0   rsp = 0x0000700011291660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x0000700011291c30   rsp = 0x00007000112916f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700011291c60   rsp = 0x0000700011291c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700011291cb0   rsp = 0x0000700011291c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700011291ce0   rsp = 0x0000700011291cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700011291ed0   rsp = 0x0000700011291cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700011291f10   rsp = 0x0000700011291ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700011291f30   rsp = 0x0000700011291f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700011291f50   rsp = 0x0000700011291f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700011291f78   rsp = 0x0000700011291f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x0000700011292090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 54\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000002300\n    rcx = 0x0000700011317538   rbx = 0x0000000000000002\n    rsi = 0x0000230100002400   rdi = 0x0000000123ebc5b8\n    rbp = 0x00007000113175c0   rsp = 0x0000700011317538\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000202\n    r12 = 0x0000000123ebc5b8   r13 = 0x0000000000000016\n    r14 = 0x0000230100002400   r15 = 0x0000700011318000\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 116 + 0xb]\n    rbp = 0x0000700011317610   rsp = 0x00007000113175d0\n    rip = 0x000000010577da2d\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait() [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 508 + 0x5c]\n    rbp = 0x0000700011317650   rsp = 0x0000700011317620\n    rip = 0x000000010e9e72e7\n    Found by: previous frame's frame pointer\n 3  XUL!mozilla::ThreadEventQueue<mozilla::EventQueue>::GetEvent(bool, mozilla::EventQueuePriority*, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>*) [ThreadEventQueue.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 208 + 0x5]\n    rbp = 0x00007000113176e0   rsp = 0x0000700011317660\n    rip = 0x000000010e9fc35a\n    Found by: previous frame's frame pointer\n 4  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1141 + 0x21]\n    rbp = 0x0000700011317c30   rsp = 0x00007000113176f0\n    rip = 0x000000010ea0c50d\n    Found by: previous frame's frame pointer\n 5  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700011317c60   rsp = 0x0000700011317c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 6  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700011317cb0   rsp = 0x0000700011317c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 7  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700011317ce0   rsp = 0x0000700011317cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 8  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700011317ed0   rsp = 0x0000700011317cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n 9  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700011317f10   rsp = 0x0000700011317ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n10  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700011317f30   rsp = 0x0000700011317f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700011317f50   rsp = 0x0000700011317f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700011317f78   rsp = 0x0000700011317f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n13  libnss3.dylib + 0x178de0\n    rsp = 0x0000700011318090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 55\n 0  libsystem_kernel.dylib!mach_msg_trap + 0xa\n    rax = 0x000000000100001f   rdx = 0x0000000000000000\n    rcx = 0x00007000113ddde8   rbx = 0x0000000000000002\n    rsi = 0x0000000000000002   rdi = 0x000000010d4cd800\n    rbp = 0x00007000113dde40   rsp = 0x00007000113ddde8\n     r8 = 0x000000000001e403    r9 = 0x0000000000000000\n    r10 = 0x000000000000041c   r11 = 0x0000000000000202\n    r12 = 0x0000000000000002   r13 = 0x000000000000041c\n    r14 = 0x000000010d4cd800   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd9822a\n    Found by: given as instruction pointer in context\n 1  XUL!ReceivePort::WaitForMessage(MachReceiveMessage*, unsigned int) [mach_ipc_mac.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 237 + 0x13]\n    rbp = 0x00007000113dde60   rsp = 0x00007000113dde50\n    rip = 0x000000010f182dc7\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::ipc::PortServerThread(void*) [SharedMemoryBasic_mach.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 344 + 0xe]\n    rbp = 0x00007000113ddf10   rsp = 0x00007000113dde70\n    rip = 0x000000010f1eca01\n    Found by: previous frame's frame pointer\n 3  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x00007000113ddf30   rsp = 0x00007000113ddf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x00007000113ddf50   rsp = 0x00007000113ddf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x00007000113ddf78   rsp = 0x00007000113ddf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 6  XUL + 0x951960\n    rsp = 0x00007000113de090   rip = 0x000000010f1ec960\n    Found by: stack scanning\n\nThread 56\n 0  libsystem_kernel.dylib!mach_msg_trap + 0xa\n    rax = 0x000000000100001f   rdx = 0x0000000000000000\n    rcx = 0x0000700011460de8   rbx = 0x0000000000000002\n    rsi = 0x0000000000000002   rdi = 0x000000010cc7e000\n    rbp = 0x0000700011460e40   rsp = 0x0000700011460de8\n     r8 = 0x0000000000017403    r9 = 0x0000000000000000\n    r10 = 0x000000000000041c   r11 = 0x0000000000000202\n    r12 = 0x0000000000000002   r13 = 0x000000000000041c\n    r14 = 0x000000010cc7e000   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd9822a\n    Found by: given as instruction pointer in context\n 1  XUL!ReceivePort::WaitForMessage(MachReceiveMessage*, unsigned int) [mach_ipc_mac.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 237 + 0x13]\n    rbp = 0x0000700011460e60   rsp = 0x0000700011460e50\n    rip = 0x000000010f182dc7\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::ipc::PortServerThread(void*) [SharedMemoryBasic_mach.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 344 + 0xe]\n    rbp = 0x0000700011460f10   rsp = 0x0000700011460e70\n    rip = 0x000000010f1eca01\n    Found by: previous frame's frame pointer\n 3  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700011460f30   rsp = 0x0000700011460f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700011460f50   rsp = 0x0000700011460f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700011460f78   rsp = 0x0000700011460f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 6  XUL + 0x951960\n    rsp = 0x0000700011461090   rip = 0x000000010f1ec960\n    Found by: stack scanning\n\nThread 57\n 0  libsystem_kernel.dylib!mach_msg_trap + 0xa\n    rax = 0x000000000100001f   rdx = 0x0000000000000000\n    rcx = 0x00007000114e3de8   rbx = 0x0000000000000002\n    rsi = 0x0000000000000002   rdi = 0x000000010d627800\n    rbp = 0x00007000114e3e40   rsp = 0x00007000114e3de8\n     r8 = 0x000000000001da03    r9 = 0x0000000000000000\n    r10 = 0x000000000000041c   r11 = 0x0000000000000202\n    r12 = 0x0000000000000002   r13 = 0x000000000000041c\n    r14 = 0x000000010d627800   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd9822a\n    Found by: given as instruction pointer in context\n 1  XUL!ReceivePort::WaitForMessage(MachReceiveMessage*, unsigned int) [mach_ipc_mac.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 237 + 0x13]\n    rbp = 0x00007000114e3e60   rsp = 0x00007000114e3e50\n    rip = 0x000000010f182dc7\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::ipc::PortServerThread(void*) [SharedMemoryBasic_mach.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 344 + 0xe]\n    rbp = 0x00007000114e3f10   rsp = 0x00007000114e3e70\n    rip = 0x000000010f1eca01\n    Found by: previous frame's frame pointer\n 3  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x00007000114e3f30   rsp = 0x00007000114e3f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x00007000114e3f50   rsp = 0x00007000114e3f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x00007000114e3f78   rsp = 0x00007000114e3f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 6  XUL + 0x951960\n    rsp = 0x00007000114e4090   rip = 0x000000010f1ec960\n    Found by: stack scanning\n\nThread 58\n 0  libsystem_kernel.dylib!mach_msg_trap + 0xa\n    rax = 0x000000000100001f   rdx = 0x0000000000000000\n    rcx = 0x0000700011566de8   rbx = 0x0000000000000002\n    rsi = 0x0000000000000002   rdi = 0x0000000119bd1000\n    rbp = 0x0000700011566e40   rsp = 0x0000700011566de8\n     r8 = 0x000000000001d503    r9 = 0x0000000000000000\n    r10 = 0x000000000000041c   r11 = 0x0000000000000202\n    r12 = 0x0000000000000002   r13 = 0x000000000000041c\n    r14 = 0x0000000119bd1000   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd9822a\n    Found by: given as instruction pointer in context\n 1  XUL!ReceivePort::WaitForMessage(MachReceiveMessage*, unsigned int) [mach_ipc_mac.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 237 + 0x13]\n    rbp = 0x0000700011566e60   rsp = 0x0000700011566e50\n    rip = 0x000000010f182dc7\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::ipc::PortServerThread(void*) [SharedMemoryBasic_mach.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 344 + 0xe]\n    rbp = 0x0000700011566f10   rsp = 0x0000700011566e70\n    rip = 0x000000010f1eca01\n    Found by: previous frame's frame pointer\n 3  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700011566f30   rsp = 0x0000700011566f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700011566f50   rsp = 0x0000700011566f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700011566f78   rsp = 0x0000700011566f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 6  XUL + 0x951960\n    rsp = 0x0000700011567090   rip = 0x000000010f1ec960\n    Found by: stack scanning\n\nThread 59\n 0  libsystem_kernel.dylib!mach_msg_trap + 0xa\n    rax = 0x000000000100001f   rdx = 0x0000000000000000\n    rcx = 0x00007000115e9de8   rbx = 0x0000000000000002\n    rsi = 0x0000000000000002   rdi = 0x000000012a3c7800\n    rbp = 0x00007000115e9e40   rsp = 0x00007000115e9de8\n     r8 = 0x0000000000018203    r9 = 0x0000000000000000\n    r10 = 0x000000000000041c   r11 = 0x0000000000000202\n    r12 = 0x0000000000000002   r13 = 0x000000000000041c\n    r14 = 0x000000012a3c7800   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd9822a\n    Found by: given as instruction pointer in context\n 1  XUL!ReceivePort::WaitForMessage(MachReceiveMessage*, unsigned int) [mach_ipc_mac.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 237 + 0x13]\n    rbp = 0x00007000115e9e60   rsp = 0x00007000115e9e50\n    rip = 0x000000010f182dc7\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::ipc::PortServerThread(void*) [SharedMemoryBasic_mach.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 344 + 0xe]\n    rbp = 0x00007000115e9f10   rsp = 0x00007000115e9e70\n    rip = 0x000000010f1eca01\n    Found by: previous frame's frame pointer\n 3  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x00007000115e9f30   rsp = 0x00007000115e9f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x00007000115e9f50   rsp = 0x00007000115e9f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x00007000115e9f78   rsp = 0x00007000115e9f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 6  XUL + 0x951960\n    rsp = 0x00007000115ea090   rip = 0x000000010f1ec960\n    Found by: stack scanning\n\nThread 60\n 0  libsystem_kernel.dylib!mach_msg_trap + 0xa\n    rax = 0x000000000100001f   rdx = 0x0000000000000000\n    rcx = 0x000070001166cde8   rbx = 0x0000000000000002\n    rsi = 0x0000000000000002   rdi = 0x0000000119bde800\n    rbp = 0x000070001166ce40   rsp = 0x000070001166cde8\n     r8 = 0x000000000001ce03    r9 = 0x0000000000000000\n    r10 = 0x000000000000041c   r11 = 0x0000000000000202\n    r12 = 0x0000000000000002   r13 = 0x000000000000041c\n    r14 = 0x0000000119bde800   r15 = 0x0000000000000000\n    rip = 0x00007fff5cd9822a\n    Found by: given as instruction pointer in context\n 1  XUL!ReceivePort::WaitForMessage(MachReceiveMessage*, unsigned int) [mach_ipc_mac.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 237 + 0x13]\n    rbp = 0x000070001166ce60   rsp = 0x000070001166ce50\n    rip = 0x000000010f182dc7\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::ipc::PortServerThread(void*) [SharedMemoryBasic_mach.mm:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 344 + 0xe]\n    rbp = 0x000070001166cf10   rsp = 0x000070001166ce70\n    rip = 0x000000010f1eca01\n    Found by: previous frame's frame pointer\n 3  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070001166cf30   rsp = 0x000070001166cf20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070001166cf50   rsp = 0x000070001166cf40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070001166cf78   rsp = 0x000070001166cf60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 6  XUL + 0x951960\n    rsp = 0x000070001166d090   rip = 0x000000010f1ec960\n    Found by: stack scanning\n\nThread 61\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000113f00\n    rcx = 0x00007000117354e8   rbx = 0x0000000000113f00\n    rsi = 0x00113f0000114400   rdi = 0x00000001080d6258\n    rbp = 0x0000700011735570   rsp = 0x00007000117354e8\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000246\n    r12 = 0x00000001080d6258   r13 = 0x0000000000000016\n    r14 = 0x00113f0000114400   r15 = 0x0000000000114400\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 147 + 0xb]\n    rbp = 0x00007000117355c0   rsp = 0x0000700011735580\n    rip = 0x000000010577db34\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait(mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>) [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 524 + 0x5]\n    rbp = 0x0000700011735600   rsp = 0x00007000117355d0\n    rip = 0x000000010e9e741d\n    Found by: previous frame's frame pointer\n 3  XUL!nsThreadPool::Run() [nsThreadPool.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 278 + 0x8]\n    rbp = 0x00007000117356d0   rsp = 0x0000700011735610\n    rip = 0x000000010ea1591a\n    Found by: previous frame's frame pointer\n 4  XUL!non-virtual thunk to nsThreadPool::Run() [nsThreadPool.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 0 + 0xd]\n    rbp = 0x00007000117356e0   rsp = 0x00007000117356e0\n    rip = 0x000000010ea15e8d\n    Found by: previous frame's frame pointer\n 5  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1220 + 0x6]\n    rbp = 0x0000700011735c30   rsp = 0x00007000117356f0\n    rip = 0x000000010ea0cd03\n    Found by: previous frame's frame pointer\n 6  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700011735c60   rsp = 0x0000700011735c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 7  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700011735cb0   rsp = 0x0000700011735c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 8  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700011735ce0   rsp = 0x0000700011735cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 9  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700011735ed0   rsp = 0x0000700011735cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n10  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700011735f10   rsp = 0x0000700011735ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700011735f30   rsp = 0x0000700011735f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700011735f50   rsp = 0x0000700011735f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700011735f78   rsp = 0x0000700011735f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n14  libnss3.dylib + 0x178de0\n    rsp = 0x0000700011736090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 62\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000114100\n    rcx = 0x00007000118844e8   rbx = 0x0000000000114100\n    rsi = 0x0011410000114600   rdi = 0x00000001080d6258\n    rbp = 0x0000700011884570   rsp = 0x00007000118844e8\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000246\n    r12 = 0x00000001080d6258   r13 = 0x0000000000000016\n    r14 = 0x0011410000114600   r15 = 0x0000000000114600\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 147 + 0xb]\n    rbp = 0x00007000118845c0   rsp = 0x0000700011884580\n    rip = 0x000000010577db34\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait(mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>) [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 524 + 0x5]\n    rbp = 0x0000700011884600   rsp = 0x00007000118845d0\n    rip = 0x000000010e9e741d\n    Found by: previous frame's frame pointer\n 3  XUL!nsThreadPool::Run() [nsThreadPool.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 278 + 0x8]\n    rbp = 0x00007000118846d0   rsp = 0x0000700011884610\n    rip = 0x000000010ea1591a\n    Found by: previous frame's frame pointer\n 4  XUL!non-virtual thunk to nsThreadPool::Run() [nsThreadPool.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 0 + 0xd]\n    rbp = 0x00007000118846e0   rsp = 0x00007000118846e0\n    rip = 0x000000010ea15e8d\n    Found by: previous frame's frame pointer\n 5  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1220 + 0x6]\n    rbp = 0x0000700011884c30   rsp = 0x00007000118846f0\n    rip = 0x000000010ea0cd03\n    Found by: previous frame's frame pointer\n 6  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x0000700011884c60   rsp = 0x0000700011884c40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 7  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x0000700011884cb0   rsp = 0x0000700011884c70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 8  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x0000700011884ce0   rsp = 0x0000700011884cc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 9  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x0000700011884ed0   rsp = 0x0000700011884cf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n10  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x0000700011884f10   rsp = 0x0000700011884ee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x0000700011884f30   rsp = 0x0000700011884f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x0000700011884f50   rsp = 0x0000700011884f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x0000700011884f78   rsp = 0x0000700011884f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n14  libnss3.dylib + 0x178de0\n    rsp = 0x0000700011885090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 63\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000114000\n    rcx = 0x000070001190a4e8   rbx = 0x0000000000114000\n    rsi = 0x0011400000114500   rdi = 0x00000001080d6258\n    rbp = 0x000070001190a570   rsp = 0x000070001190a4e8\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000246\n    r12 = 0x00000001080d6258   r13 = 0x0000000000000016\n    r14 = 0x0011400000114500   r15 = 0x0000000000114500\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 147 + 0xb]\n    rbp = 0x000070001190a5c0   rsp = 0x000070001190a580\n    rip = 0x000000010577db34\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait(mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>) [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 524 + 0x5]\n    rbp = 0x000070001190a600   rsp = 0x000070001190a5d0\n    rip = 0x000000010e9e741d\n    Found by: previous frame's frame pointer\n 3  XUL!nsThreadPool::Run() [nsThreadPool.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 278 + 0x8]\n    rbp = 0x000070001190a6d0   rsp = 0x000070001190a610\n    rip = 0x000000010ea1591a\n    Found by: previous frame's frame pointer\n 4  XUL!non-virtual thunk to nsThreadPool::Run() [nsThreadPool.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 0 + 0xd]\n    rbp = 0x000070001190a6e0   rsp = 0x000070001190a6e0\n    rip = 0x000000010ea15e8d\n    Found by: previous frame's frame pointer\n 5  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1220 + 0x6]\n    rbp = 0x000070001190ac30   rsp = 0x000070001190a6f0\n    rip = 0x000000010ea0cd03\n    Found by: previous frame's frame pointer\n 6  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x000070001190ac60   rsp = 0x000070001190ac40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 7  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x000070001190acb0   rsp = 0x000070001190ac70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 8  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x000070001190ace0   rsp = 0x000070001190acc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 9  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x000070001190aed0   rsp = 0x000070001190acf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n10  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x000070001190af10   rsp = 0x000070001190aee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070001190af30   rsp = 0x000070001190af20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070001190af50   rsp = 0x000070001190af40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070001190af78   rsp = 0x000070001190af60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n14  libnss3.dylib + 0x178de0\n    rsp = 0x000070001190b090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 64\n 0  libsystem_kernel.dylib!__workq_kernreturn + 0xa\n    rax = 0x0000000002000170   rdx = 0x0000000000000001\n    rcx = 0x00007000104b8b08   rbx = 0x00007000104b9000\n    rsi = 0x00007000104b8b80   rdi = 0x0000000000000100\n    rbp = 0x00007000104b8b40   rsp = 0x00007000104b8b08\n     r8 = 0x0000000000000080    r9 = 0x0000003700000003\n    r10 = 0x0000000000000000   r11 = 0x0000000000000246\n    r12 = 0x00000000004f4005   r13 = 0x00000000810010ff\n    r14 = 0x00007000104b9098   r15 = 0x00007000104b90a0\n    rip = 0x00007fff5cd99bfe\n    Found by: given as instruction pointer in context\n 1  libsystem_pthread.dylib!start_wqthread + 0xd\n    rbp = 0x00007000104b8b68   rsp = 0x00007000104b8b50\n    rip = 0x00007fff5ce563fd\n    Found by: previous frame's frame pointer\n 2  libmozglue.dylib!BaseAllocator::malloc(unsigned long) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 3964 + 0xd]\n    rsp = 0x00007000104b8bd0   rip = 0x000000010572eb27\n    Found by: stack scanning\n 3  libmozglue.dylib!Allocator<MozJemallocBase>::malloc(unsigned long) [malloc_decls.h:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 51 + 0x2a]\n    rsp = 0x00007000104b8c00   rip = 0x000000010572d3ca\n    Found by: stack scanning\n 4  libmozglue.dylib!RedBlackTree<arena_chunk_map_t, ArenaRunTreeTrait>::Remove(RedBlackTree<arena_chunk_map_t, ArenaRunTreeTrait>::TreeNode) [rb.h:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 404 + 0x8]\n    rsp = 0x00007000104b8c10   rip = 0x00000001057327e3\n    Found by: stack scanning\n 5  libmozglue.dylib!arena_t::ArenaRunRegAlloc(arena_run_t*, arena_bin_t*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 2084 + 0x8]\n    rsp = 0x00007000104b8c40   rip = 0x000000010572bd6c\n    Found by: stack scanning\n 6  libmozglue.dylib!arena_t::MallocSmall(unsigned long, bool) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 2847 + 0x10]\n    rsp = 0x00007000104b8c90   rip = 0x000000010572ba09\n    Found by: stack scanning\n 7  libmozglue.dylib!arena_t::DallocSmall(arena_chunk_t*, void*, arena_chunk_map_t*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 3300 + 0x5]\n    rsp = 0x00007000104b8cf0   rip = 0x000000010572cc06\n    Found by: stack scanning\n 8  libmozglue.dylib!arena_dalloc(void*, unsigned long, arena_t*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 3345 + 0xe]\n    rsp = 0x00007000104b8d30   rip = 0x000000010572c4bf\n    Found by: stack scanning\n 9  CoreFoundation + 0x3a939\n    rsp = 0x00007000104b8d70   rip = 0x00007fff30d38939\n    Found by: stack scanning\n10  CoreFoundation + 0xe0ba\n    rsp = 0x00007000104b8de0   rip = 0x00007fff30d0c0ba\n    Found by: stack scanning\n11  libmozglue.dylib!arena_t::DallocSmall(arena_chunk_t*, void*, arena_chunk_map_t*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 3309 + 0x8]\n    rsp = 0x00007000104b8e30   rip = 0x000000010572ccb9\n    Found by: stack scanning\n12  libobjc.A.dylib!std::__1::__hash_iterator<std::__1::__hash_node<std::__1::__hash_value_type<unsigned long, objc_references_support::ObjectAssociationMap*>, void*>*> std::__1::__hash_table<std::__1::__hash_value_type<unsigned long, objc_references_support::ObjectAssociationMap*>, std::__1::__unordered_map_hasher<unsigned long, std::__1::__hash_value_type<unsigned long, objc_references_support::ObjectAssociationMap*>, objc_references_support::DisguisedPointerHash, true>, std::__1::__unordered_map_equal<unsigned long, std::__1::__hash_value_type<unsigned long, objc_references_support::ObjectAssociationMap*>, objc_references_support::DisguisedPointerEqual, true>, objc_references_support::ObjcAllocator<std::__1::__hash_value_type<unsigned long, objc_references_support::ObjectAssociationMap*> > >::find<unsigned long>(unsigned long const&) + 0x19\n    rsp = 0x00007000104b8e40   rip = 0x00007fff5b4a098b\n    Found by: stack scanning\n13  libmozglue.dylib!AddressRadixTree<44ul>::Get(void*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1639 + 0x8]\n    rsp = 0x00007000104b8e60   rip = 0x000000010572c38e\n    Found by: stack scanning\n14  libmozglue.dylib!AddressRadixTree<44ul>::Get(void*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1639 + 0x8]\n    rsp = 0x00007000104b8e70   rip = 0x000000010572c38e\n    Found by: stack scanning\n15  libmozglue.dylib!arena_t::DallocSmall(arena_chunk_t*, void*, arena_chunk_map_t*) [mozjemalloc.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 3259 + 0x10]\n    rsp = 0x00007000104b8e80   rip = 0x000000010572c98a\n    Found by: stack scanning\n16  libdispatch.dylib!_dispatch_last_resort_autorelease_pool_pop + 0x1b\n    rsp = 0x00007000104b8f00   rip = 0x00007fff5cc16626\n    Found by: stack scanning\n17  libdispatch.dylib!_dispatch_root_queue_drain + 0x479\n    rsp = 0x00007000104b8f20   rip = 0x00007fff5cc246f1\n    Found by: stack scanning\n18  libdispatch.dylib!_dispatch_worker_thread2 + 0x5a\n    rsp = 0x00007000104b8f90   rip = 0x00007fff5cc24b46\n    Found by: stack scanning\n19  libsystem_pthread.dylib!_pthread_wqthread + 0x27a\n    rsp = 0x00007000104b8fa0   rip = 0x00007fff5ce566e6\n    Found by: stack scanning\n20  libsystem_pthread.dylib!start_wqthread + 0xd\n    rsp = 0x00007000104b8fe0   rip = 0x00007fff5ce563fd\n    Found by: stack scanning\n21  libdispatch.dylib!_dispatch_kevent_worker_thread + 0x902\n    rsp = 0x00007000104b9090   rip = 0x00007fff5cc25497\n    Found by: stack scanning\n\nThread 65\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000114200\n    rcx = 0x000070000f25f4e8   rbx = 0x0000000000114200\n    rsi = 0x0011420000114700   rdi = 0x00000001080d6258\n    rbp = 0x000070000f25f570   rsp = 0x000070000f25f4e8\n     r8 = 0x0000000000000000    r9 = 0x00000000000000a4\n    r10 = 0x0000000000000000   r11 = 0x0000000000000246\n    r12 = 0x00000001080d6258   r13 = 0x0000000000000016\n    r14 = 0x0011420000114700   r15 = 0x0000000000114700\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  libmozglue.dylib!mozilla::detail::ConditionVariableImpl::wait_for(mozilla::detail::MutexImpl&, mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator> const&) [ConditionVariable_posix.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 147 + 0xb]\n    rbp = 0x000070000f25f5c0   rsp = 0x000070000f25f580\n    rip = 0x000000010577db34\n    Found by: previous frame's frame pointer\n 2  XUL!mozilla::OffTheBooksCondVar::Wait(mozilla::BaseTimeDuration<mozilla::TimeDurationValueCalculator>) [BlockingResourceBase.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 524 + 0x5]\n    rbp = 0x000070000f25f600   rsp = 0x000070000f25f5d0\n    rip = 0x000000010e9e741d\n    Found by: previous frame's frame pointer\n 3  XUL!nsThreadPool::Run() [nsThreadPool.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 278 + 0x8]\n    rbp = 0x000070000f25f6d0   rsp = 0x000070000f25f610\n    rip = 0x000000010ea1591a\n    Found by: previous frame's frame pointer\n 4  XUL!non-virtual thunk to nsThreadPool::Run() [nsThreadPool.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 0 + 0xd]\n    rbp = 0x000070000f25f6e0   rsp = 0x000070000f25f6e0\n    rip = 0x000000010ea15e8d\n    Found by: previous frame's frame pointer\n 5  XUL!nsThread::ProcessNextEvent(bool, bool*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 1220 + 0x6]\n    rbp = 0x000070000f25fc30   rsp = 0x000070000f25f6f0\n    rip = 0x000000010ea0cd03\n    Found by: previous frame's frame pointer\n 6  XUL!NS_ProcessNextEvent(nsIThread*, bool) [nsThreadUtils.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 486 + 0xd]\n    rbp = 0x000070000f25fc60   rsp = 0x000070000f25fc40\n    rip = 0x000000010ea12dfc\n    Found by: previous frame's frame pointer\n 7  XUL!mozilla::ipc::MessagePumpForNonMainThreads::Run(base::MessagePump::Delegate*) [MessagePump.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 332 + 0xd]\n    rbp = 0x000070000f25fcb0   rsp = 0x000070000f25fc70\n    rip = 0x000000010f1d88d8\n    Found by: previous frame's frame pointer\n 8  XUL!MessageLoop::Run() [message_loop.cc:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 290 + 0x5]\n    rbp = 0x000070000f25fce0   rsp = 0x000070000f25fcc0\n    rip = 0x000000010f16712e\n    Found by: previous frame's frame pointer\n 9  XUL!nsThread::ThreadFunc(void*) [nsThread.cpp:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 464 + 0x8]\n    rbp = 0x000070000f25fed0   rsp = 0x000070000f25fcf0\n    rip = 0x000000010ea08fa4\n    Found by: previous frame's frame pointer\n10  libnss3.dylib!_pt_root [ptthread.c:cd02b96bdce57d9ae53b632ca4740c871d3ecc32 : 201 + 0xa]\n    rbp = 0x000070000f25ff10   rsp = 0x000070000f25fee0\n    rip = 0x0000000105b78f11\n    Found by: previous frame's frame pointer\n11  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000f25ff30   rsp = 0x000070000f25ff20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n12  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000f25ff50   rsp = 0x000070000f25ff40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n13  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000f25ff78   rsp = 0x000070000f25ff60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n14  libnss3.dylib + 0x178de0\n    rsp = 0x000070000f260090   rip = 0x0000000105b78de0\n    Found by: stack scanning\n\nThread 66\n 0  libsystem_kernel.dylib!__psynch_cvwait + 0xa\n    rax = 0x0000000002000131   rdx = 0x0000000000000000\n    rcx = 0x000070000f082cb8   rbx = 0x0000000000000000\n    rsi = 0x0000630100006400   rdi = 0x000000010d60f878\n    rbp = 0x000070000f082d40   rsp = 0x000070000f082cb8\n     r8 = 0x0000000000000000    r9 = 0x00000000000100a8\n    r10 = 0x0000000000000000   r11 = 0x0000000000000246\n    r12 = 0x000000010d60f878   r13 = 0x0000000000000016\n    r14 = 0x0000630100006400   r15 = 0x0000000000006400\n    rip = 0x00007fff5cd9b86a\n    Found by: given as instruction pointer in context\n 1  CoreVideo!CVDisplayLink::waitUntil(unsigned long long) + 0xe5\n    rbp = 0x000070000f082d80   rsp = 0x000070000f082d50\n    rip = 0x00007fff32aa5d23\n    Found by: previous frame's frame pointer\n 2  CoreVideo!CVDisplayLink::runIOThread() + 0x1e2\n    rbp = 0x000070000f082f10   rsp = 0x000070000f082d90\n    rip = 0x00007fff32aa52d2\n    Found by: previous frame's frame pointer\n 3  libsystem_pthread.dylib!_pthread_body + 0x7e\n    rbp = 0x000070000f082f30   rsp = 0x000070000f082f20\n    rip = 0x00007fff5ce572eb\n    Found by: previous frame's frame pointer\n 4  libsystem_pthread.dylib!_pthread_start + 0x42\n    rbp = 0x000070000f082f50   rsp = 0x000070000f082f40\n    rip = 0x00007fff5ce5a249\n    Found by: previous frame's frame pointer\n 5  libsystem_pthread.dylib!thread_start + 0xd\n    rbp = 0x000070000f082f78   rsp = 0x000070000f082f60\n    rip = 0x00007fff5ce5640d\n    Found by: previous frame's frame pointer\n 6  CoreVideo!CVDisplayLink::start() + 0x137\n    rsp = 0x000070000f083090   rip = 0x00007fff32aa50cb\n    Found by: stack scanning\n\nLoaded modules:\n0x105718000 - 0x10571afff  firefox  ???  (main)  (WARNING: No symbols, firefox, E1A7D66107A23BDFAFCBA05034CF19CB0)\n0x105722000 - 0x1057bffff  libmozglue.dylib  ???\n0x1057e9000 - 0x1057effff  liblgpllibs.dylib  ???\n0x105a00000 - 0x105cb9fff  libnss3.dylib  ???\n0x10e89b000 - 0x1177c6fff  XUL  ???\n0x11c0d1000 - 0x11c0d4fff  libobjc-trampolines.dylib  ???\n0x127c25000 - 0x127c6bfff  libsoftokn3.dylib  ???\n0x127c71000 - 0x127ce7fff  libfreebl3.dylib  ???\n0x127cf0000 - 0x127d3cfff  libnssckbi.dylib  ???\n0x130100000 - 0x130122fff  libmozavutil.dylib  ???\n0x15a030000 - 0x15a24cfff  libmozavcodec.dylib  ???\n0x7fff25513000 - 0x7fff2586cfff  RawCamera  ???\n0x7fff28fb9000 - 0x7fff294cbfff  AppleIntelHD5000GraphicsGLDriver  ???\n0x7fff294cc000 - 0x7fff2955dfff  AppleIntelHD5000GraphicsMTLDriver  ???\n0x7fff2cdc6000 - 0x7fff2cfa2fff  AVFoundation  ???\n0x7fff2cfa3000 - 0x7fff2d068fff  AVFAudio  ???\n0x7fff2d170000 - 0x7fff2d170fff  Accelerate  ???\n0x7fff2d171000 - 0x7fff2d187fff  libCGInterfaces.dylib  ???\n0x7fff2d188000 - 0x7fff2d821fff  vImage  ???  (WARNING: No symbols, vImage, EFFD9A9C5563376291CA9F50FDB7A5470)\n0x7fff2d822000 - 0x7fff2da9bfff  libBLAS.dylib  ???\n0x7fff2da9c000 - 0x7fff2db0efff  libBNNS.dylib  ???\n0x7fff2db0f000 - 0x7fff2deb8fff  libLAPACK.dylib  ???\n0x7fff2deb9000 - 0x7fff2decefff  libLinearAlgebra.dylib  ???\n0x7fff2decf000 - 0x7fff2ded4fff  libQuadrature.dylib  ???\n0x7fff2ded5000 - 0x7fff2df51fff  libSparse.dylib  ???\n0x7fff2df52000 - 0x7fff2df65fff  libSparseBLAS.dylib  ???\n0x7fff2df66000 - 0x7fff2e14dfff  libvDSP.dylib  ???\n0x7fff2e14e000 - 0x7fff2e201fff  libvMisc.dylib  ???\n0x7fff2e202000 - 0x7fff2e202fff  vecLib  ???\n0x7fff2e203000 - 0x7fff2e25dfff  Accounts  ???\n0x7fff2e260000 - 0x7fff2e3a3fff  AddressBook  ???\n0x7fff2e3a4000 - 0x7fff2f159fff  AppKit  ???\n0x7fff2f1ab000 - 0x7fff2f1abfff  ApplicationServices  ???\n0x7fff2f1ac000 - 0x7fff2f217fff  ATS  ???\n0x7fff2f2b0000 - 0x7fff2f3c7fff  libFontParser.dylib  ???\n0x7fff2f3c8000 - 0x7fff2f40afff  libFontRegistry.dylib  ???\n0x7fff2f464000 - 0x7fff2f496fff  libTrueTypeScaler.dylib  ???\n0x7fff2f4fb000 - 0x7fff2f4fffff  ColorSyncLegacy  ???\n0x7fff2f59a000 - 0x7fff2f5ecfff  HIServices  ???\n0x7fff2f5ed000 - 0x7fff2f5fcfff  LangAnalysis  ???\n0x7fff2f5fd000 - 0x7fff2f646fff  PrintCore  ???\n0x7fff2f647000 - 0x7fff2f680fff  QD  ???\n0x7fff2f681000 - 0x7fff2f68dfff  SpeechSynthesis  ???\n0x7fff2f68e000 - 0x7fff2f905fff  AudioToolbox  ???\n0x7fff2f907000 - 0x7fff2f907fff  AudioUnit  ???\n0x7fff2fc5f000 - 0x7fff30000fff  CFNetwork  ???\n0x7fff30015000 - 0x7fff30015fff  Carbon  ???\n0x7fff30016000 - 0x7fff30019fff  CommonPanels  ???\n0x7fff3001a000 - 0x7fff30310fff  HIToolbox  ???\n0x7fff30311000 - 0x7fff30314fff  Help  ???\n0x7fff30315000 - 0x7fff3031afff  ImageCapture  ???\n0x7fff3031b000 - 0x7fff303b0fff  Ink  ???\n0x7fff303b1000 - 0x7fff303c9fff  OpenScripting  ???\n0x7fff303e9000 - 0x7fff303eafff  Print  ???\n0x7fff303eb000 - 0x7fff303edfff  SecurityHI  ???\n0x7fff303ee000 - 0x7fff303f4fff  SpeechRecognition  ???\n0x7fff30516000 - 0x7fff30516fff  Cocoa  ???\n0x7fff30524000 - 0x7fff305f0fff  ColorSync  ???\n0x7fff305f1000 - 0x7fff306d9fff  Contacts  ???\n0x7fff3077c000 - 0x7fff30802fff  CoreAudio  ???\n0x7fff30866000 - 0x7fff30890fff  CoreBluetooth  ???\n0x7fff30891000 - 0x7fff30c15fff  CoreData  ???\n0x7fff30c16000 - 0x7fff30cfdfff  CoreDisplay  ???\n0x7fff30cfe000 - 0x7fff31142fff  CoreFoundation  ???  (WARNING: No symbols, CoreFoundation, 64C38BF2186933C8B1B6DCA9C824C0E40)\n0x7fff31144000 - 0x7fff317d3fff  CoreGraphics  ???\n0x7fff317d5000 - 0x7fff31af5fff  CoreImage  ???\n0x7fff31af6000 - 0x7fff31b6efff  CoreLocation  ???\n0x7fff31bc8000 - 0x7fff31df1fff  CoreML  ???\n0x7fff31df2000 - 0x7fff31ef6fff  CoreMedia  ???\n0x7fff31ef7000 - 0x7fff31f52fff  CoreMediaIO  ???\n0x7fff31f53000 - 0x7fff31f53fff  CoreServices  ???\n0x7fff31f54000 - 0x7fff31fd0fff  AE  ???\n0x7fff31fd1000 - 0x7fff322a8fff  CarbonCore  ???\n0x7fff322a9000 - 0x7fff322f1fff  DictionaryServices  ???\n0x7fff322f2000 - 0x7fff322fafff  FSEvents  ???\n0x7fff322fb000 - 0x7fff324adfff  LaunchServices  ???\n0x7fff324ae000 - 0x7fff3254cfff  Metadata  ???\n0x7fff3254d000 - 0x7fff32597fff  OSServices  ???\n0x7fff32598000 - 0x7fff325fffff  SearchKit  ???\n0x7fff32600000 - 0x7fff32621fff  SharedFileList  ???\n0x7fff3292c000 - 0x7fff32a8efff  CoreText  ???\n0x7fff32a8f000 - 0x7fff32acefff  CoreVideo  ???\n0x7fff32acf000 - 0x7fff32b5efff  CoreWLAN  ???\n0x7fff32cd5000 - 0x7fff32ce0fff  DirectoryService  ???\n0x7fff32ce1000 - 0x7fff32d8ffff  DiscRecording  ???\n0x7fff32db5000 - 0x7fff32dbafff  DiskArbitration  ???\n0x7fff32f59000 - 0x7fff32f5bfff  ExceptionHandling  ???\n0x7fff32f80000 - 0x7fff3332dfff  Foundation  ???\n0x7fff3339c000 - 0x7fff333cbfff  GSS  ???\n0x7fff334cb000 - 0x7fff335d5fff  IOBluetooth  ???\n0x7fff33637000 - 0x7fff336c6fff  IOKit  ???\n0x7fff336c8000 - 0x7fff336d7fff  IOSurface  ???\n0x7fff336d8000 - 0x7fff3372afff  ImageCaptureCore  ???\n0x7fff3372b000 - 0x7fff338b6fff  ImageIO  ???\n0x7fff338b7000 - 0x7fff338bbfff  libGIF.dylib  ???\n0x7fff338bc000 - 0x7fff33998fff  libJP2.dylib  ???\n0x7fff33999000 - 0x7fff339befff  libJPEG.dylib  ???\n0x7fff33c81000 - 0x7fff33ca7fff  libPng.dylib  ???\n0x7fff33ca8000 - 0x7fff33caafff  libRadiance.dylib  ???\n0x7fff33cab000 - 0x7fff33cf8fff  libTIFF.dylib  ???\n0x7fff33ff3000 - 0x7fff34e57fff  JavaScriptCore  ???\n0x7fff34e6f000 - 0x7fff34e88fff  Kerberos  ???\n0x7fff34e89000 - 0x7fff34ebefff  LDAP  ???\n0x7fff34f0b000 - 0x7fff34f29fff  SharedUtils  ???\n0x7fff34f2a000 - 0x7fff34f3efff  LocalAuthentication  ???\n0x7fff35142000 - 0x7fff3514cfff  MediaAccessibility  ???\n0x7fff351fc000 - 0x7fff358a2fff  MediaToolbox  ???\n0x7fff358a4000 - 0x7fff3594cfff  Metal  ???\n0x7fff3594e000 - 0x7fff35967fff  MetalKit  ???\n0x7fff35968000 - 0x7fff35987fff  MPSCore  ???\n0x7fff35988000 - 0x7fff35a04fff  MPSImage  ???\n0x7fff35a05000 - 0x7fff35a2cfff  MPSMatrix  ???\n0x7fff35a2d000 - 0x7fff35b58fff  MPSNeuralNetwork  ???\n0x7fff35b59000 - 0x7fff35b73fff  MPSRayIntersector  ???\n0x7fff35b74000 - 0x7fff35b75fff  MetalPerformanceShaders  ???\n0x7fff3696c000 - 0x7fff36978fff  NetFS  ???\n0x7fff3940d000 - 0x7fff39415fff  libcldcpuengine.dylib  ???\n0x7fff39416000 - 0x7fff3946dfff  OpenCL  ???\n0x7fff3946e000 - 0x7fff39489fff  CFOpenDirectory  ???\n0x7fff3948a000 - 0x7fff39495fff  OpenDirectory  ???\n0x7fff39de5000 - 0x7fff39de7fff  libCVMSPluginSupport.dylib  ???\n0x7fff39de8000 - 0x7fff39dedfff  libCoreFSCache.dylib  ???\n0x7fff39dee000 - 0x7fff39df2fff  libCoreVMClient.dylib  ???\n0x7fff39df3000 - 0x7fff39dfbfff  libGFXShared.dylib  ???\n0x7fff39dfc000 - 0x7fff39e07fff  libGL.dylib  ???\n0x7fff39e08000 - 0x7fff39e42fff  libGLImage.dylib  ???\n0x7fff39e43000 - 0x7fff39fb5fff  libGLProgrammability.dylib  ???\n0x7fff39fb6000 - 0x7fff39ff4fff  libGLU.dylib  ???\n0x7fff3a991000 - 0x7fff3a9a0fff  OpenGL  ???\n0x7fff3a9a1000 - 0x7fff3ab38fff  GLEngine  ???\n0x7fff3ab39000 - 0x7fff3ab62fff  GLRendererFloat  ???\n0x7fff3ad1d000 - 0x7fff3ae66fff  QTKit  ???\n0x7fff3ae67000 - 0x7fff3b0bbfff  ImageKit  ???\n0x7fff3b0bc000 - 0x7fff3b1a8fff  PDFKit  ???\n0x7fff3b1a9000 - 0x7fff3b678fff  QuartzComposer  ???\n0x7fff3b679000 - 0x7fff3b69ffff  QuartzFilters  ???\n0x7fff3b6a0000 - 0x7fff3b7a1fff  QuickLookUI  ???\n0x7fff3b7a2000 - 0x7fff3b7a2fff  Quartz  ???\n0x7fff3b7a3000 - 0x7fff3b9f9fff  QuartzCore  ???\n0x7fff3b9fa000 - 0x7fff3ba51fff  QuickLook  ???\n0x7fff3bc18000 - 0x7fff3bc2ffff  SafariServices  ???\n0x7fff3c22e000 - 0x7fff3c52dfff  Security  ???\n0x7fff3c52e000 - 0x7fff3c5bafff  SecurityFoundation  ???\n0x7fff3c5bb000 - 0x7fff3c5ebfff  SecurityInterface  ???\n0x7fff3c5ec000 - 0x7fff3c5f0fff  ServiceManagement  ???\n0x7fff3c988000 - 0x7fff3c9f5fff  SystemConfiguration  ???\n0x7fff3cc54000 - 0x7fff3cfb3fff  VideoToolbox  ???\n0x7fff3fc74000 - 0x7fff3fd19fff  APFS  ???\n0x7fff405c5000 - 0x7fff4070ffff  AddressBookCore  ???\n0x7fff4072b000 - 0x7fff4072cfff  AggregateDictionary  ???\n0x7fff40ae7000 - 0x7fff40c2afff  AnnotationKit  ???\n0x7fff40d2a000 - 0x7fff40d56fff  Apple80211  ???\n0x7fff40e7e000 - 0x7fff40e8dfff  AppleFSCompression  ???\n0x7fff40f89000 - 0x7fff40f94fff  AppleIDAuthSupport  ???\n0x7fff40fd5000 - 0x7fff4101efff  AppleJPEG  ???\n0x7fff4101f000 - 0x7fff4102ffff  AppleLDAP  ???\n0x7fff4124f000 - 0x7fff4126cfff  ApplePushService  ???\n0x7fff4126d000 - 0x7fff41271fff  AppleSRP  ???\n0x7fff41272000 - 0x7fff41294fff  AppleSauce  ???\n0x7fff41354000 - 0x7fff41357fff  AppleSystemInfo  ???\n0x7fff41358000 - 0x7fff413a8fff  AppleVA  ???\n0x7fff413f3000 - 0x7fff41407fff  AssertionServices  ???\n0x7fff417d6000 - 0x7fff418c2fff  AuthKit  ???\n0x7fff41a84000 - 0x7fff41a8cfff  BackgroundTaskManagement  ???\n0x7fff41a8d000 - 0x7fff41b22fff  Backup  ???\n0x7fff41b23000 - 0x7fff41b90fff  BaseBoard  ???\n0x7fff41b99000 - 0x7fff41b9ffff  BezelServices  ???\n0x7fff41c16000 - 0x7fff41c52fff  Bom  ???\n0x7fff42301000 - 0x7fff4232dfff  CalendarAgentLink  ???\n0x7fff429ee000 - 0x7fff42a3dfff  ChunkingLibrary  ???\n0x7fff42b57000 - 0x7fff42bdcfff  CloudDocs  ???\n0x7fff437fa000 - 0x7fff43803fff  CommonAuth  ???\n0x7fff43817000 - 0x7fff4382cfff  CommonUtilities  ???\n0x7fff43ad4000 - 0x7fff43b36fff  ContactsFoundation  ???\n0x7fff43b37000 - 0x7fff43b5afff  ContactsPersistence  ???\n0x7fff43c9c000 - 0x7fff4407ffff  CoreAUC  ???\n0x7fff44080000 - 0x7fff440aefff  CoreAVCHD  ???\n0x7fff440ce000 - 0x7fff440ecfff  CoreAnalytics  ???\n0x7fff44144000 - 0x7fff441a1fff  CoreBrightness  ???\n0x7fff442d8000 - 0x7fff442e1fff  CoreDaemon  ???\n0x7fff444db000 - 0x7fff444ecfff  CoreEmoji  ???\n0x7fff44694000 - 0x7fff44783fff  CoreHandwriting  ???\n0x7fff44955000 - 0x7fff4496bfff  CoreMediaAuthoring  ???\n0x7fff44a95000 - 0x7fff44afbfff  CoreNLP  ???\n0x7fff44c67000 - 0x7fff44cf3fff  CorePDF  ???\n0x7fff44da8000 - 0x7fff44db0fff  CorePhoneNumbers  ???\n0x7fff44f2c000 - 0x7fff44f5dfff  CoreServicesInternal  ???\n0x7fff45324000 - 0x7fff453a8fff  CoreSymbolication  ???\n0x7fff45438000 - 0x7fff45563fff  CoreUI  ???\n0x7fff45564000 - 0x7fff45702fff  CoreUtils  ???\n0x7fff45756000 - 0x7fff457b9fff  CoreWiFi  ???\n0x7fff457ba000 - 0x7fff457cbfff  CrashReporterSupport  ???\n0x7fff4585b000 - 0x7fff4586afff  DFRFoundation  ???\n0x7fff4586b000 - 0x7fff4586ffff  DSExternalDisplay  ???\n0x7fff458f0000 - 0x7fff45965fff  DataDetectorsCore  ???\n0x7fff459b1000 - 0x7fff459eefff  DebugSymbols  ???\n0x7fff459ef000 - 0x7fff45b2afff  DesktopServicesPriv  ???\n0x7fff45d36000 - 0x7fff45dfcfff  DiskManagement  ???\n0x7fff45dfd000 - 0x7fff45e01fff  DisplayServices  ???\n0x7fff45ea8000 - 0x7fff45eabfff  EFILogin  ???\n0x7fff465e1000 - 0x7fff468c3fff  Espresso  ???\n0x7fff46a67000 - 0x7fff46e82fff  FaceCore  ???\n0x7fff46eb3000 - 0x7fff46f38fff  FileProvider  ???\n0x7fff4a736000 - 0x7fff4a737fff  libmetal_timestamp.dylib  ???\n0x7fff4bdcb000 - 0x7fff4bdd6fff  libGPUSupportMercury.dylib  ???\n0x7fff4bdd7000 - 0x7fff4bddcfff  GPUWrangler  ???\n0x7fff4c169000 - 0x7fff4c18dfff  GenerationalStorage  ???\n0x7fff4c1a6000 - 0x7fff4cba5fff  GeoServices  ???\n0x7fff4cbe7000 - 0x7fff4cbf6fff  GraphVisualizer  ???\n0x7fff4cd46000 - 0x7fff4cdbafff  Heimdal  ???\n0x7fff4cdbb000 - 0x7fff4cde9fff  HelpData  ???\n0x7fff4e0a9000 - 0x7fff4e0b0fff  IOAccelerator  ???\n0x7fff4e0b4000 - 0x7fff4e0ccfff  IOPresentment  ???\n0x7fff4e474000 - 0x7fff4e4a1fff  IconServices  ???\n0x7fff4e5cb000 - 0x7fff4e5cffff  InternationalSupport  ???\n0x7fff4e639000 - 0x7fff4e646fff  IntlPreferences  ???\n0x7fff4e735000 - 0x7fff4e747fff  KeychainCircle  ???\n0x7fff4e762000 - 0x7fff4e83dfff  LanguageModeling  ???\n0x7fff4e83e000 - 0x7fff4e87afff  Lexicon  ???\n0x7fff4e881000 - 0x7fff4e886fff  LinguisticData  ???\n0x7fff4f0a4000 - 0x7fff4f0a7fff  Mangrove  ???\n0x7fff4f12e000 - 0x7fff4f154fff  MarkupUI  ???\n0x7fff4f1bc000 - 0x7fff4f1effff  MediaKit  ???\n0x7fff4f57b000 - 0x7fff4f5a3fff  MetadataUtilities  ???\n0x7fff4f5a4000 - 0x7fff4f631fff  MetalTools  ???\n0x7fff4f647000 - 0x7fff4f660fff  MobileAsset  ???\n0x7fff4f7de000 - 0x7fff4f7f9fff  MobileKeyBag  ???\n0x7fff4f80c000 - 0x7fff4f881fff  Montreal  ???\n0x7fff4f882000 - 0x7fff4f8acfff  MultitouchSupport  ???\n0x7fff4fae8000 - 0x7fff4faf2fff  NetAuth  ???\n0x7fff50353000 - 0x7fff503a4fff  OTSVG  ???\n0x7fff51435000 - 0x7fff51528fff  PencilKit  ???\n0x7fff51529000 - 0x7fff51538fff  PerformanceAnalysis  ???\n0x7fff5175f000 - 0x7fff5175ffff  PhoneNumbers  ???\n0x7fff52f67000 - 0x7fff52f78fff  PowerLog  ???\n0x7fff53373000 - 0x7fff533c7fff  ProtectedCloudStorage  ???\n0x7fff533c8000 - 0x7fff533e6fff  ProtocolBuffer  ???\n0x7fff53564000 - 0x7fff53567fff  QuickLookNonBaseSystem  ???\n0x7fff53568000 - 0x7fff5357dfff  QuickLookThumbnailing  ???\n0x7fff5357e000 - 0x7fff535cefff  ROCKit  ???\n0x7fff536ff000 - 0x7fff5370afff  RemoteServiceDiscovery  ???\n0x7fff5371d000 - 0x7fff5373ffff  RemoteViewServices  ???\n0x7fff53740000 - 0x7fff53753fff  RemoteXPC  ???\n0x7fff54f44000 - 0x7fff55062fff  Sharing  ???\n0x7fff55063000 - 0x7fff55082fff  Shortcut  ???\n0x7fff55e73000 - 0x7fff56121fff  SkyLight  ???\n0x7fff568c3000 - 0x7fff568cffff  SpeechRecognitionCore  ???\n0x7fff56981000 - 0x7fff56be4fff  SpotlightIndex  ???\n0x7fff56f6e000 - 0x7fff56faafff  StreamingZip  ???\n0x7fff57020000 - 0x7fff570abfff  Symbolication  ???\n0x7fff570ac000 - 0x7fff570b4fff  SymptomDiagnosticReporter  ???\n0x7fff57582000 - 0x7fff5758efff  SystemPolicy  ???\n0x7fff57593000 - 0x7fff5759ffff  TCC  ???\n0x7fff57805000 - 0x7fff578cdfff  TextureIO  ???\n0x7fff5792a000 - 0x7fff57945fff  ToneKit  ???\n0x7fff57946000 - 0x7fff5796bfff  ToneLibrary  ???\n0x7fff57983000 - 0x7fff57984fff  TrustEvaluationAgent  ???\n0x7fff5798a000 - 0x7fff57b40fff  UIFoundation  ???\n0x7fff587bc000 - 0x7fff58895fff  ViewBridge  ???\n0x7fff5906c000 - 0x7fff5906ffff  XCTTargetBootstrap  ???\n0x7fff59470000 - 0x7fff59472fff  loginsupport  ???\n0x7fff59473000 - 0x7fff59488fff  login  ???\n0x7fff594bf000 - 0x7fff594f0fff  vCard  ???\n0x7fff5973c000 - 0x7fff59770fff  libCRFSuite.dylib  ???\n0x7fff59773000 - 0x7fff5977dfff  libChineseTokenizer.dylib  ???\n0x7fff5977e000 - 0x7fff59807fff  libCoreStorage.dylib  ???\n0x7fff5980b000 - 0x7fff5980cfff  libDiagnosticMessagesClient.dylib  ???\n0x7fff59843000 - 0x7fff59a9afff  libFosl_dynamic.dylib  ???\n0x7fff59aeb000 - 0x7fff59b09fff  libMobileGestalt.dylib  ???\n0x7fff59b0a000 - 0x7fff59b0afff  libOpenScriptingUtil.dylib  ???\n0x7fff59c4a000 - 0x7fff59c4bfff  libSystem.B.dylib  ???\n0x7fff59cc7000 - 0x7fff59cc8fff  libThaiTokenizer.dylib  ???\n0x7fff59cda000 - 0x7fff59cf0fff  libapple_nghttp2.dylib  ???\n0x7fff59cf1000 - 0x7fff59d1afff  libarchive.2.dylib  ???\n0x7fff59d1b000 - 0x7fff59d9afff  libate.dylib  ???\n0x7fff59d9e000 - 0x7fff59d9efff  libauto.dylib  ???\n0x7fff59e6e000 - 0x7fff59e7efff  libbsm.0.dylib  ???\n0x7fff59e7f000 - 0x7fff59e8cfff  libbz2.1.0.dylib  ???\n0x7fff59e8d000 - 0x7fff59ee0fff  libc++.1.dylib  ???\n0x7fff59ee1000 - 0x7fff59ef6fff  libc++abi.dylib  ???\n0x7fff59ef7000 - 0x7fff59ef7fff  libcharset.1.dylib  ???\n0x7fff59ef8000 - 0x7fff59f08fff  libcmph.dylib  ???\n0x7fff59f09000 - 0x7fff59f21fff  libcompression.dylib  ???\n0x7fff5a196000 - 0x7fff5a1acfff  libcoretls.dylib  ???\n0x7fff5a1ad000 - 0x7fff5a1aefff  libcoretls_cfhelpers.dylib  ???\n0x7fff5a34c000 - 0x7fff5a444fff  libcrypto.35.dylib  ???\n0x7fff5a647000 - 0x7fff5a652fff  libcsfde.dylib  ???\n0x7fff5a65a000 - 0x7fff5a6b0fff  libcups.2.dylib  ???\n0x7fff5a7e4000 - 0x7fff5a7e4fff  libenergytrace.dylib  ???\n0x7fff5a816000 - 0x7fff5a81bfff  libgermantok.dylib  ???\n0x7fff5a81c000 - 0x7fff5a821fff  libheimdal-asn1.dylib  ???\n0x7fff5a84c000 - 0x7fff5a93cfff  libiconv.2.dylib  ???\n0x7fff5a93d000 - 0x7fff5ab9efff  libicucore.A.dylib  ???\n0x7fff5abeb000 - 0x7fff5abecfff  liblangid.dylib  ???\n0x7fff5abed000 - 0x7fff5ac05fff  liblzma.5.dylib  ???\n0x7fff5ac1d000 - 0x7fff5acc1fff  libmecab.1.0.0.dylib  ???\n0x7fff5acc2000 - 0x7fff5aec6fff  libmecabra.dylib  ???\n0x7fff5b09e000 - 0x7fff5b3effff  libnetwork.dylib  ???\n0x7fff5b481000 - 0x7fff5bc06fff  libobjc.A.dylib  ???\n0x7fff5bc18000 - 0x7fff5bc1cfff  libpam.2.dylib  ???\n0x7fff5bc1f000 - 0x7fff5bc54fff  libpcap.A.dylib  ???\n0x7fff5bd6d000 - 0x7fff5bd85fff  libresolv.9.dylib  ???\n0x7fff5bdc3000 - 0x7fff5bdd5fff  libsasl2.2.dylib  ???\n0x7fff5bdd6000 - 0x7fff5bdd7fff  libspindump.dylib  ???\n0x7fff5bdd8000 - 0x7fff5bfb5fff  libsqlite3.dylib  ???\n0x7fff5c1ce000 - 0x7fff5c1d1fff  libutil.dylib  ???\n0x7fff5c1d2000 - 0x7fff5c1dffff  libxar.1.dylib  ???\n0x7fff5c1e4000 - 0x7fff5c2c6fff  libxml2.2.dylib  ???\n0x7fff5c2c7000 - 0x7fff5c2effff  libxslt.1.dylib  ???\n0x7fff5c2f0000 - 0x7fff5c302fff  libz.1.dylib  ???\n0x7fff5cae6000 - 0x7fff5caeafff  libcache.dylib  ???\n0x7fff5caeb000 - 0x7fff5caf5fff  libcommonCrypto.dylib  ???\n0x7fff5caf6000 - 0x7fff5cafdfff  libcompiler_rt.dylib  ???\n0x7fff5cafe000 - 0x7fff5cb07fff  libcopyfile.dylib  ???\n0x7fff5cb08000 - 0x7fff5cb8cfff  libcorecrypto.dylib  ???\n0x7fff5cc13000 - 0x7fff5cc4cfff  libdispatch.dylib  ???\n0x7fff5cc4d000 - 0x7fff5cc79fff  libdyld.dylib  ???\n0x7fff5cc7a000 - 0x7fff5cc7afff  libkeymgr.dylib  ???\n0x7fff5cc7b000 - 0x7fff5cc87fff  libkxld.dylib  ???\n0x7fff5cc88000 - 0x7fff5cc88fff  liblaunch.dylib  ???\n0x7fff5cc89000 - 0x7fff5cc8efff  libmacho.dylib  ???\n0x7fff5cc8f000 - 0x7fff5cc91fff  libquarantine.dylib  ???\n0x7fff5cc92000 - 0x7fff5cc93fff  libremovefile.dylib  ???\n0x7fff5cc94000 - 0x7fff5ccabfff  libsystem_asl.dylib  ???\n0x7fff5ccac000 - 0x7fff5ccacfff  libsystem_blocks.dylib  ???\n0x7fff5ccad000 - 0x7fff5cd34fff  libsystem_c.dylib  ???\n0x7fff5cd35000 - 0x7fff5cd38fff  libsystem_configuration.dylib  ???\n0x7fff5cd39000 - 0x7fff5cd3cfff  libsystem_coreservices.dylib  ???\n0x7fff5cd3d000 - 0x7fff5cd43fff  libsystem_darwin.dylib  ???\n0x7fff5cd44000 - 0x7fff5cd4afff  libsystem_dnssd.dylib  ???\n0x7fff5cd4b000 - 0x7fff5cd96fff  libsystem_info.dylib  ???\n0x7fff5cd97000 - 0x7fff5cdbffff  libsystem_kernel.dylib  ???\n0x7fff5cdc0000 - 0x7fff5ce0bfff  libsystem_m.dylib  ???\n0x7fff5ce0c000 - 0x7fff5ce36fff  libsystem_malloc.dylib  ???\n0x7fff5ce37000 - 0x7fff5ce41fff  libsystem_networkextension.dylib  ???\n0x7fff5ce42000 - 0x7fff5ce49fff  libsystem_notify.dylib  ???\n0x7fff5ce4a000 - 0x7fff5ce53fff  libsystem_platform.dylib  ???\n0x7fff5ce54000 - 0x7fff5ce5efff  libsystem_pthread.dylib  ???\n0x7fff5ce5f000 - 0x7fff5ce62fff  libsystem_sandbox.dylib  ???\n0x7fff5ce63000 - 0x7fff5ce65fff  libsystem_secinit.dylib  ???\n0x7fff5ce66000 - 0x7fff5ce6dfff  libsystem_symptoms.dylib  ???\n0x7fff5ce6e000 - 0x7fff5ce83fff  libsystem_trace.dylib  ???\n0x7fff5ce85000 - 0x7fff5ce8afff  libunwind.dylib  ???\n0x7fff5ce8b000 - 0x7fff5cebafff  libxpc.dylib  ???\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.75
+          },
+          {
+            "testName": "dom/events/webkit-animation-iteration-event.html",
+            "action": "test",
+            "jobName": "test-macosx1014-64/debug-web-platform-tests-e10s-5",
+            "jobSymbol": "wpt5",
+            "jobGroup": "Web platform tests",
+            "jobGroupSymbol": "W",
+            "platform": "macosx1014-64",
+            "config": "debug",
+            "key": "domeventswebkitanimationiterationeventhtmldebugmacosx101464testmacosx101464debugwebplatformtestse10s5Webplatformtests",
+            "jobKey": "debugmacosx1014-64test-macosx1014-64/debug-web-platform-tests-e10s-5Web platform tests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285364353,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198370,
+                "job_group_id": 461,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-web-platform-tests-e10s-5",
+                "job_type_symbol": "wpt5",
+                "platform": "macosx1014-64"
+              }
+            ],
+            "passJobs": [
+              {
+                "id": 285384046,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198370,
+                "job_group_id": 461,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-web-platform-tests-e10s-5",
+                "job_type_symbol": "wpt5",
+                "platform": "macosx1014-64"
+              },
+              {
+                "id": 285384050,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198370,
+                "job_group_id": 461,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-web-platform-tests-e10s-5",
+                "job_type_symbol": "wpt5",
+                "platform": "macosx1014-64"
+              },
+              {
+                "id": 285384110,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198370,
+                "job_group_id": 461,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-web-platform-tests-e10s-5",
+                "job_type_symbol": "wpt5",
+                "platform": "macosx1014-64"
+              },
+              {
+                "id": 285384117,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198370,
+                "job_group_id": 461,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-web-platform-tests-e10s-5",
+                "job_type_symbol": "wpt5",
+                "platform": "macosx1014-64"
+              },
+              {
+                "id": 285384119,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198370,
+                "job_group_id": 461,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-web-platform-tests-e10s-5",
+                "job_type_symbol": "wpt5",
+                "platform": "macosx1014-64"
+              }
+            ],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 15355,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "event types for prefixed and unprefixed animationiteration event handlers should be named appropriately",
+                "status": "TIMEOUT",
+                "expected": "PASS",
+                "message": "Test timed out"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15356,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "webkitAnimationIteration event listener should trigger for an animation",
+                "status": "NOTRUN",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15357,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "webkitAnimationIteration event listener should not trigger if an unprefixed listener also exists",
+                "status": "NOTRUN",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15358,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "webkitAnimationIteration event listener should not trigger if an unprefixed event handler also exists",
+                "status": "NOTRUN",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15359,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "event types for prefixed and unprefixed animationiteration event listeners should be named appropriately",
+                "status": "NOTRUN",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15360,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "subtest": "webkitAnimationIteration event listener is case sensitive",
+                "status": "NOTRUN",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 15361,
+                "test": "/dom/events/webkit-animation-iteration-event.html",
+                "status": "TIMEOUT",
+                "expected": "OK"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.8333333333333334
+          },
+          {
+            "testName": "pointerevents/pointerlock/pointerevent_pointermove_on_chorded_mouse_button_when_locked.html",
+            "action": "test",
+            "jobName": "test-macosx1014-64/debug-web-platform-tests-e10s-1",
+            "jobSymbol": "wpt1",
+            "jobGroup": "Web platform tests",
+            "jobGroupSymbol": "W",
+            "platform": "macosx1014-64",
+            "config": "debug",
+            "key": "pointereventspointerlockpointerevent_pointermove_on_chorded_mouse_button_when_lockedhtmldebugmacosx101464testmacosx101464debugwebplatformtestse10s1Webplatformtests",
+            "jobKey": "debugmacosx1014-64test-macosx1014-64/debug-web-platform-tests-e10s-1Web platform tests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285364356,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198377,
+                "job_group_id": 461,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-web-platform-tests-e10s-1",
+                "job_type_symbol": "wpt1",
+                "platform": "macosx1014-64"
+              }
+            ],
+            "passJobs": [
+              {
+                "id": 285383963,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198377,
+                "job_group_id": 461,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-web-platform-tests-e10s-1",
+                "job_type_symbol": "wpt1",
+                "platform": "macosx1014-64"
+              },
+              {
+                "id": 285383967,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198377,
+                "job_group_id": 461,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-web-platform-tests-e10s-1",
+                "job_type_symbol": "wpt1",
+                "platform": "macosx1014-64"
+              },
+              {
+                "id": 285384039,
+                "machine_platform_id": 660,
+                "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+                "job_type_id": 198377,
+                "job_group_id": 461,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-macosx1014-64/debug-web-platform-tests-e10s-1",
+                "job_type_symbol": "wpt1",
+                "platform": "macosx1014-64"
+              }
+            ],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 58998,
+                "test": "/pointerevents/pointerlock/pointerevent_pointermove_on_chorded_mouse_button_when_locked.html",
+                "subtest": "pointer locked pointermove events received for button state changes",
+                "status": "FAIL",
+                "expected": "PASS",
+                "message": "assert_true: The pointerup event must be triggered after pressing and releasing the second button. expected true got false",
+                "stack": "run/</<@http://web-platform.test:8000/pointerevents/pointerlock/pointerevent_pointermove_on_chorded_mouse_button_when_locked.html:71:70\nTest.prototype.step@http://web-platform.test:8000/resources/testharness.js:2024:25\nrun/<@http://web-platform.test:8000/pointerevents/pointerlock/pointerevent_pointermove_on_chorded_mouse_button_when_locked.html:71:42\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.75
+          },
+          {
+            "testName": "toolkit/components/pictureinpicture/tests/browser_togglePolicies.js",
+            "action": "test",
+            "jobName": "test-linux64-asan/opt-mochitest-browser-chrome-e10s-3",
+            "jobSymbol": "bc3",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "linux64",
+            "config": "asan",
+            "key": "toolkitcomponentspictureinpicturetestsbrowser_togglePoliciesjsasanlinux64testlinux64asanoptmochitestbrowserchromee10s3Mochitests",
+            "jobKey": "asanlinux64test-linux64-asan/opt-mochitest-browser-chrome-e10s-3Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363114,
+                "machine_platform_id": 104,
+                "option_collection_hash": "03abd064e50ec12b8c7309950268531d78c63f60",
+                "job_type_id": 32702,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux64-asan/opt-mochitest-browser-chrome-e10s-3",
+                "job_type_symbol": "bc3",
+                "platform": "linux64"
+              }
+            ],
+            "passJobs": [
+              {
+                "id": 285367247,
+                "machine_platform_id": 104,
+                "option_collection_hash": "03abd064e50ec12b8c7309950268531d78c63f60",
+                "job_type_id": 32702,
+                "job_group_id": 448,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux64-asan/opt-mochitest-browser-chrome-e10s-3",
+                "job_type_symbol": "bc3",
+                "platform": "linux64"
+              },
+              {
+                "id": 285367269,
+                "machine_platform_id": 104,
+                "option_collection_hash": "03abd064e50ec12b8c7309950268531d78c63f60",
+                "job_type_id": 32702,
+                "job_group_id": 448,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux64-asan/opt-mochitest-browser-chrome-e10s-3",
+                "job_type_symbol": "bc3",
+                "platform": "linux64"
+              }
+            ],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 3122,
+                "test": "toolkit/components/pictureinpicture/tests/browser_togglePolicies.js",
+                "subtest": "Test timed out",
+                "status": "FAIL",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 3126,
+                "test": "toolkit/components/pictureinpicture/tests/browser_togglePolicies.js",
+                "subtest": "Found a tab after previous test timed out: http://example.org/browser/toolkit/components/pictureinpicture/tests/test-page.html",
+                "status": "FAIL",
+                "expected": "PASS"
+              },
+              {
+                "action": "test_result",
+                "line_number": 3133,
+                "test": "toolkit/components/pictureinpicture/tests/browser_togglePolicies.js",
+                "subtest": "Uncaught exception received from previously timed out test",
+                "status": "FAIL",
+                "expected": "PASS",
+                "message": "[Exception... \"(null)\"  nsresult: \"0x80040111 (NS_ERROR_NOT_AVAILABLE)\"  location: \"<unknown>\"  data: no]"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.6666666666666666
+          },
+          {
+            "testName": "toolkit/components/pictureinpicture/tests/browser_toggleTransparentOverlay-1.js",
+            "action": "test",
+            "jobName": "test-linux64-asan/opt-mochitest-browser-chrome-e10s-3",
+            "jobSymbol": "bc3",
+            "jobGroup": "Mochitests",
+            "jobGroupSymbol": "M",
+            "platform": "linux64",
+            "config": "asan",
+            "key": "toolkitcomponentspictureinpicturetestsbrowser_toggleTransparentOverlay1jsasanlinux64testlinux64asanoptmochitestbrowserchromee10s3Mochitests",
+            "jobKey": "asanlinux64test-linux64-asan/opt-mochitest-browser-chrome-e10s-3Mochitests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285363114,
+                "machine_platform_id": 104,
+                "option_collection_hash": "03abd064e50ec12b8c7309950268531d78c63f60",
+                "job_type_id": 32702,
+                "job_group_id": 448,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux64-asan/opt-mochitest-browser-chrome-e10s-3",
+                "job_type_symbol": "bc3",
+                "platform": "linux64"
+              }
+            ],
+            "passJobs": [
+              {
+                "id": 285367247,
+                "machine_platform_id": 104,
+                "option_collection_hash": "03abd064e50ec12b8c7309950268531d78c63f60",
+                "job_type_id": 32702,
+                "job_group_id": 448,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux64-asan/opt-mochitest-browser-chrome-e10s-3",
+                "job_type_symbol": "bc3",
+                "platform": "linux64"
+              },
+              {
+                "id": 285367269,
+                "machine_platform_id": 104,
+                "option_collection_hash": "03abd064e50ec12b8c7309950268531d78c63f60",
+                "job_type_id": 32702,
+                "job_group_id": 448,
+                "result": "success",
+                "state": "completed",
+                "failure_classification_id": 1,
+                "push_id": 630837,
+                "job_type_name": "test-linux64-asan/opt-mochitest-browser-chrome-e10s-3",
+                "job_type_symbol": "bc3",
+                "platform": "linux64"
+              }
+            ],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 3138,
+                "test": "toolkit/components/pictureinpicture/tests/browser_toggleTransparentOverlay-1.js",
+                "subtest": "No toggle policy should be set. - false == true",
+                "status": "FAIL",
+                "expected": "PASS",
+                "message": "got false, expected true (operator ==)\nStack trace:\n@chrome://mochitests/content/browser/toolkit/components/pictureinpicture/tests/head.js:193:14\nasync*execute@resource://specialpowers/SpecialPowersSandbox.jsm:140:12\n_spawnTask@resource://specialpowers/SpecialPowersChild.jsm:1723:15\nreceiveMessage@resource://specialpowers/SpecialPowersChild.jsm:285:21\nJSWindowActor query*receiveMessage@resource://specialpowers/SpecialPowersParent.jsm:1055:12\nJSWindowActor query*spawn@resource://specialpowers/SpecialPowersChild.jsm:1678:17\nassertTogglePolicy@chrome://mochitests/content/browser/toolkit/components/pictureinpicture/tests/head.js:169:23\ntestToggleHelper@chrome://mochitests/content/browser/toolkit/components/pictureinpicture/tests/head.js:419:9\nasync*testToggle/<@chrome://mochitests/content/browser/toolkit/components/pictureinpicture/tests/head.js:378:15\nasync*withNewTab@resource://testing-common/BrowserTestUtils.jsm:150:24\nasync*testToggle@chrome://mochitests/content/browser/toolkit/components/pictureinpicture/tests/head.js:363:26\n@chrome://mochitests/content/browser/toolkit/components/pictureinpicture/tests/browser_toggleTransparentOverlay-1.js:12:9\nTester_execTest/<@chrome://mochikit/content/browser-test.js:1062:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1097:11\nnextTest/<@chrome://mochikit/content/browser-test.js:925:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:808:67\n"
+              },
+              {
+                "action": "test_result",
+                "line_number": 3155,
+                "test": "toolkit/components/pictureinpicture/tests/browser_toggleTransparentOverlay-1.js",
+                "subtest": "No toggle policy should be set. - false == true",
+                "status": "FAIL",
+                "expected": "PASS",
+                "message": "got false, expected true (operator ==)\nStack trace:\n@chrome://mochitests/content/browser/toolkit/components/pictureinpicture/tests/head.js:193:14\nasync*execute@resource://specialpowers/SpecialPowersSandbox.jsm:140:12\n_spawnTask@resource://specialpowers/SpecialPowersChild.jsm:1723:15\nreceiveMessage@resource://specialpowers/SpecialPowersChild.jsm:285:21\nJSWindowActor query*receiveMessage@resource://specialpowers/SpecialPowersParent.jsm:1055:12\nJSWindowActor query*spawn@resource://specialpowers/SpecialPowersChild.jsm:1678:17\nassertTogglePolicy@chrome://mochitests/content/browser/toolkit/components/pictureinpicture/tests/head.js:169:23\ntestToggleHelper@chrome://mochitests/content/browser/toolkit/components/pictureinpicture/tests/head.js:419:9\nasync*testToggle/<@chrome://mochitests/content/browser/toolkit/components/pictureinpicture/tests/head.js:378:15\nasync*withNewTab@resource://testing-common/BrowserTestUtils.jsm:150:24\nasync*testToggle@chrome://mochitests/content/browser/toolkit/components/pictureinpicture/tests/head.js:363:26\n@chrome://mochitests/content/browser/toolkit/components/pictureinpicture/tests/browser_toggleTransparentOverlay-1.js:12:9\nTester_execTest/<@chrome://mochikit/content/browser-test.js:1062:34\nTester_execTest@chrome://mochikit/content/browser-test.js:1097:11\nnextTest/<@chrome://mochikit/content/browser-test.js:925:14\nSimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:808:67\n"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "passFailRatio": 0.6666666666666666
+          }
+        ],
+        "unsupported": [
+          {
+            "id": 285364197,
+            "machine_platform_id": 501,
+            "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+            "job_type_id": 196729,
+            "job_group_id": 450,
+            "result": "testfailed",
+            "state": "completed",
+            "failure_classification_id": 1,
+            "push_id": 630837,
+            "job_type_name": "test-windows10-64-mingwclang/debug-reftest-e10s-2",
+            "job_type_symbol": "R2",
+            "platform": "windows10-64-mingwclang"
+          },
+          {
+            "id": 285364441,
+            "machine_platform_id": 644,
+            "option_collection_hash": "32faaecac742100f7753f0c1d0aa0add01b4046b",
+            "job_type_id": 196636,
+            "job_group_id": 958,
+            "result": "testfailed",
+            "state": "completed",
+            "failure_classification_id": 1,
+            "push_id": 630837,
+            "job_type_name": "test-windows7-32-mingwclang/debug-firefox-ui-functional-local-e10s",
+            "job_type_symbol": "en-US",
+            "platform": "windows7-32-mingwclang"
+          },
+          {
+            "id": 285366836,
+            "machine_platform_id": 540,
+            "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+            "job_type_id": 180280,
+            "job_group_id": 2,
+            "result": "testfailed",
+            "state": "completed",
+            "failure_classification_id": 1,
+            "push_id": 630837,
+            "job_type_name": "test-android-em-7.0-x86_64/opt-geckoview-junit-e10s",
+            "job_type_symbol": "gv-junit",
+            "platform": "android-em-7-0-x86_64"
+          },
+          {
+            "id": 285366840,
+            "machine_platform_id": 540,
+            "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+            "job_type_id": 204756,
+            "job_group_id": 452,
+            "result": "testfailed",
+            "state": "completed",
+            "failure_classification_id": 1,
+            "push_id": 630837,
+            "job_type_name": "test-android-em-7.0-x86_64/opt-geckoview-xpcshell-e10s-2",
+            "job_type_symbol": "X2",
+            "platform": "android-em-7-0-x86_64"
+          },
+          {
+            "id": 285379288,
+            "machine_platform_id": 655,
+            "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+            "job_type_id": 207624,
+            "job_group_id": 729,
+            "result": "testfailed",
+            "state": "completed",
+            "failure_classification_id": 1,
+            "push_id": 630837,
+            "job_type_name": "test-macosx1014-64-shippable/opt-raptor-tp6-10-firefox-cold-e10s",
+            "job_type_symbol": "tp6-c-10",
+            "platform": "macosx1014-64-shippable"
+          },
+          {
+            "id": 285383333,
+            "machine_platform_id": 577,
+            "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+            "job_type_id": 181866,
+            "job_group_id": 729,
+            "result": "testfailed",
+            "state": "completed",
+            "failure_classification_id": 1,
+            "push_id": 630837,
+            "job_type_name": "test-linux64-shippable/opt-raptor-unity-webgl-firefox-e10s",
+            "job_type_symbol": "ugl",
+            "platform": "linux64-shippable"
+          }
+        ]
       }
     },
-    {
-      "name": "Builds (Not yet implemented)",
-      "result": "pass",
-      "details": ["Wow, everything passed!"]
-    },
-    {
-      "name": "Linting (Not yet implemented)",
-      "result": "pass",
-      "details": ["Gosh, this code is really nicely formatted."]
-    },
-    {
-      "name": "Coverage (Not yet implemented)",
-      "result": "pass",
+    "builds": { "name": "Builds", "result": "pass", "details": [] },
+    "performance": {
+      "name": "Performance",
+      "result": "fail",
       "details": [
-        "Covered 42% of the tests that are needed for feature ``foo``.",
-        "Covered 100% of the tests that are needed for feature ``bar``.",
-        "The ratio of people to cake is too many..."
+        {
+          "id": 285379288,
+          "machine_platform_id": 655,
+          "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+          "job_type_id": 207624,
+          "job_group_id": 729,
+          "result": "testfailed",
+          "state": "completed",
+          "failure_classification_id": 1,
+          "push_id": 630837,
+          "job_type_name": "test-macosx1014-64-shippable/opt-raptor-tp6-10-firefox-cold-e10s",
+          "job_type_symbol": "tp6-c-10",
+          "platform": "macosx1014-64-shippable"
+        },
+        {
+          "id": 285383333,
+          "machine_platform_id": 577,
+          "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+          "job_type_id": 181866,
+          "job_group_id": 729,
+          "result": "testfailed",
+          "state": "completed",
+          "failure_classification_id": 1,
+          "push_id": 630837,
+          "job_type_name": "test-linux64-shippable/opt-raptor-unity-webgl-firefox-e10s",
+          "job_type_symbol": "ugl",
+          "platform": "linux64-shippable"
+        }
       ]
-    },
-    {
-      "name": "Performance (Not yet implemented)",
-      "result": "pass",
-      "details": ["Ludicrous Speed"]
     }
-  ]
+  },
+  "status": {
+    "completed": 1791,
+    "pending": 0,
+    "running": 0,
+    "success": 1741,
+    "retry": 11,
+    "testfailed": 39
+  }
 }

--- a/tests/ui/push-health/GroupedTests_test.jsx
+++ b/tests/ui/push-health/GroupedTests_test.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, waitForElement } from '@testing-library/react';
+
+import pushHealth from '../mock/push_health';
+import GroupedTests from '../../../ui/push-health/GroupedTests';
+
+const tests = pushHealth.metrics.tests.details.needInvestigation;
+const repoName = 'autoland';
+
+describe('GroupedTests', () => {
+  const testGroupedTests = (tests, path, count, searchStr) => (
+    <GroupedTests
+      group={tests}
+      repo={repoName}
+      revision={pushHealth.revision}
+      user={{ email: 'foo' }}
+      groupedBy={path}
+      orderedBy={count}
+      currentRepo={{ name: repoName }}
+      notify={() => {}}
+      searchStr={searchStr}
+    />
+  );
+
+  test('should group by test path', async () => {
+    const { getAllByTestId } = render(
+      testGroupedTests(tests, 'path', 'count', ''),
+    );
+
+    expect(
+      await waitForElement(() => getAllByTestId('test-grouping')),
+    ).toHaveLength(32);
+  });
+
+  test('should filter when grouped by test path', async () => {
+    const { getAllByTestId, getByText } = render(
+      testGroupedTests(tests, 'path', 'count', 'point'),
+    );
+
+    expect(
+      await waitForElement(() => getAllByTestId('test-grouping')),
+    ).toHaveLength(8);
+    expect(
+      await waitForElement(() =>
+        getByText(
+          'devtools/client/webreplay/mochitest/browser_dbg_rr_breakpoints-01.js',
+          {
+            exact: false,
+          },
+        ),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test('should group by platform', async () => {
+    const { getAllByTestId } = render(
+      testGroupedTests(tests, 'platform', 'count', ''),
+    );
+
+    expect(
+      await waitForElement(() => getAllByTestId('test-grouping')),
+    ).toHaveLength(15);
+  });
+
+  test('should filter when grouped by platform', async () => {
+    const { getAllByTestId, getByText } = render(
+      testGroupedTests(tests, 'platform', 'count', 'point'),
+    );
+
+    expect(
+      await waitForElement(() => getAllByTestId('test-grouping')),
+    ).toHaveLength(2);
+    expect(
+      await waitForElement(() =>
+        getByText('macosx1014-64-shippable opt', {
+          exact: false,
+        }),
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/perfherder/FilterControls.jsx
+++ b/ui/perfherder/FilterControls.jsx
@@ -11,8 +11,7 @@ import {
 
 import SimpleTooltip from '../shared/SimpleTooltip';
 import DropdownMenuItems from '../shared/DropdownMenuItems';
-
-import InputFilter from './InputFilter';
+import InputFilter from '../shared/InputFilter';
 
 export const createDropdowns = (dropdownOptions, colClass, outline = false) => (
   <React.Fragment>

--- a/ui/perfherder/graphs/TestDataModal.jsx
+++ b/ui/perfherder/graphs/TestDataModal.jsx
@@ -13,7 +13,7 @@ import {
 } from 'reactstrap';
 
 import { createDropdowns } from '../FilterControls';
-import InputFilter from '../InputFilter';
+import InputFilter from '../../shared/InputFilter';
 import { processResponse } from '../../helpers/http';
 import PerfSeriesModel from '../../models/perfSeries';
 import { thPerformanceBranches } from '../../helpers/constants';

--- a/ui/push-health/ClassificationGroup.jsx
+++ b/ui/push-health/ClassificationGroup.jsx
@@ -89,6 +89,7 @@ class ClassificationGroup extends React.PureComponent {
       hasRetriggerAll,
       notify,
       currentRepo,
+      searchStr,
     } = this.props;
     const expandIcon = detailsShowing ? faMinusSquare : faPlusSquare;
     const expandTitle = detailsShowing
@@ -222,6 +223,7 @@ class ClassificationGroup extends React.PureComponent {
               orderedBy={orderedBy}
               currentRepo={currentRepo}
               notify={notify}
+              searchStr={searchStr}
             />
           </div>
         </Collapse>

--- a/ui/push-health/GroupedTests.jsx
+++ b/ui/push-health/GroupedTests.jsx
@@ -7,12 +7,15 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons';
 
 import TestFailure from './TestFailure';
+import { filterTests } from './helpers';
 
 class GroupedTests extends Component {
   getGroupedTests = tests => {
-    const { groupedBy } = this.props;
-
-    const grouped = groupBy(tests, test => {
+    const { groupedBy, searchStr } = this.props;
+    const filteredTests = searchStr.length
+      ? filterTests(tests, searchStr)
+      : tests;
+    const grouped = groupBy(filteredTests, test => {
       switch (groupedBy) {
         case 'none':
           return 'none';
@@ -53,7 +56,7 @@ class GroupedTests extends Component {
       <div>
         {groupedTests &&
           sortedGroups.map(group => (
-            <div key={group.id}>
+            <div key={group.id} data-testid="test-grouping">
               <Button
                 id={`${group.id}-group`}
                 color="secondary"
@@ -98,6 +101,7 @@ GroupedTests.propTypes = {
   currentRepo: PropTypes.object.isRequired,
   user: PropTypes.object.isRequired,
   notify: PropTypes.func.isRequired,
+  searchStr: PropTypes.string.isRequired,
 };
 
 export default GroupedTests;

--- a/ui/push-health/Health.jsx
+++ b/ui/push-health/Health.jsx
@@ -16,6 +16,12 @@ import {
 import PushModel from '../models/push';
 import StatusProgress from '../shared/StatusProgress';
 import { getPercentComplete } from '../helpers/display';
+import {
+  createQueryParams,
+  parseQueryParams,
+  updateQueryParams,
+} from '../helpers/url';
+import InputFilter from '../shared/InputFilter';
 
 import { resultColorMap } from './helpers';
 import Metric from './Metric';
@@ -42,6 +48,7 @@ export default class Health extends React.PureComponent {
       buildsExpanded: false,
       testsExpanded: false,
       performanceExpanded: false,
+      searchStr: params.get('searchStr') || '',
     };
   }
 
@@ -114,6 +121,21 @@ export default class Health extends React.PureComponent {
     });
   };
 
+  filter = searchStr => {
+    const { location, history } = this.props;
+    const newParams = { ...parseQueryParams(location.search), searchStr };
+
+    if (!searchStr.length) {
+      delete newParams.searchStr;
+    }
+
+    const queryString = createQueryParams(newParams);
+
+    updateQueryParams(queryString, history, location);
+
+    this.setState({ searchStr });
+  };
+
   render() {
     const {
       metrics,
@@ -129,6 +151,7 @@ export default class Health extends React.PureComponent {
       buildsExpanded,
       testsExpanded,
       performanceExpanded,
+      searchStr,
     } = this.state;
     const { tests, linting, builds, performance } = metrics;
     const { currentRepo } = this.props;
@@ -149,37 +172,47 @@ export default class Health extends React.PureComponent {
           repo={repo}
           revision={revision}
         >
-          <Navbar color="light" light expand="sm" sticky="top">
+          <Navbar color="light" light expand="sm">
             {!!tests && (
-              <Nav className="metric-buttons mb-3 pt-2 pl-3">
-                {[progress, linting, builds, tests, performance].map(metric => (
-                  <Button
-                    size="sm"
-                    className="mr-2"
-                    color={resultColorMap[metric.result]}
-                    title={`Click to toggle ${
-                      metric.name
-                    }: ${metric.result.toUpperCase()}`}
-                    onClick={() => this.toggleExpanded(metric.name)}
-                    key={metric.name}
-                  >
-                    {metric.name}
-                    {['pass', 'fail', 'indeterminate'].includes(
-                      metric.result,
-                    ) ? (
-                      <FontAwesomeIcon
-                        className="ml-1"
-                        icon={
-                          metric.result === 'pass'
-                            ? faCheckCircle
-                            : faExclamationTriangle
-                        }
-                      />
-                    ) : (
-                      <span className="ml-1">{metric.value}%</span>
-                    )}
-                  </Button>
-                ))}
+              <Nav className="metric-buttons mb-2 pt-2 pl-3 justify-content-between w-100">
+                <span>
+                  {[progress, linting, builds, tests, performance].map(
+                    metric => (
+                      <Button
+                        size="sm"
+                        className="mr-2"
+                        color={resultColorMap[metric.result]}
+                        title={`Click to toggle ${
+                          metric.name
+                        }: ${metric.result.toUpperCase()}`}
+                        onClick={() => this.toggleExpanded(metric.name)}
+                        key={metric.name}
+                      >
+                        {metric.name}
+                        {['pass', 'fail', 'indeterminate'].includes(
+                          metric.result,
+                        ) ? (
+                          <FontAwesomeIcon
+                            className="ml-1"
+                            icon={
+                              metric.result === 'pass'
+                                ? faCheckCircle
+                                : faExclamationTriangle
+                            }
+                          />
+                        ) : (
+                          <span className="ml-1">{metric.value}%</span>
+                        )}
+                      </Button>
+                    ),
+                  )}
+                </span>
+                <span className="mr-2">
+                  <InputFilter
+                    updateFilterText={this.filter}
+                    placeholder="filter path or platform"
+                  />
+                </span>
               </Nav>
             )}
           </Navbar>
@@ -232,6 +265,7 @@ export default class Health extends React.PureComponent {
                   notify={this.notify}
                   expanded={testsExpanded}
                   toggleExpanded={this.toggleExpanded}
+                  searchStr={searchStr}
                 />
               </Row>
               <Row>

--- a/ui/push-health/TestMetric.jsx
+++ b/ui/push-health/TestMetric.jsx
@@ -16,6 +16,7 @@ export default class TestMetric extends React.PureComponent {
       currentRepo,
       expanded,
       toggleExpanded,
+      searchStr,
     } = this.props;
     const { name, result, details } = data;
     const { needInvestigation, intermittent, unsupported } = details;
@@ -40,6 +41,7 @@ export default class TestMetric extends React.PureComponent {
             user={user}
             hasRetriggerAll
             notify={notify}
+            searchStr={searchStr}
           />
           <ClassificationGroup
             group={intermittent}
@@ -52,6 +54,7 @@ export default class TestMetric extends React.PureComponent {
             expanded={false}
             user={user}
             notify={notify}
+            searchStr={searchStr}
           />
           <UnsupportedGroup
             group={unsupported}
@@ -76,4 +79,5 @@ TestMetric.propTypes = {
   notify: PropTypes.func.isRequired,
   toggleExpanded: PropTypes.func.isRequired,
   expanded: PropTypes.bool.isRequired,
+  searchStr: PropTypes.string.isRequired,
 };

--- a/ui/push-health/helpers.js
+++ b/ui/push-health/helpers.js
@@ -1,8 +1,17 @@
-// eslint-disable-next-line import/prefer-default-export
 export const resultColorMap = {
   pass: 'success',
   fail: 'danger',
   indeterminate: 'warning',
   done: 'info',
   'in progress': 'secondary',
+};
+
+export const filterTests = (tests, searchStr) => {
+  const filters = searchStr.split(' ').map(filter => new RegExp(filter, 'i'));
+
+  return tests.filter(test =>
+    filters.every(f =>
+      f.test(`${test.testName} ${test.platform} ${test.config}`),
+    ),
+  );
 };

--- a/ui/shared/InputFilter.jsx
+++ b/ui/shared/InputFilter.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { InputGroup, Input } from 'reactstrap';
 import debounce from 'lodash/debounce';
 
-import { filterText } from './constants';
+import { filterText } from '../perfherder/constants';
 
 export default class InputFilter extends React.Component {
   // eslint-disable-next-line react/sort-comp
@@ -34,13 +34,13 @@ export default class InputFilter extends React.Component {
   };
 
   render() {
-    const { disabled } = this.props;
+    const { disabled, placeholder } = this.props;
     const { input } = this.state;
 
     return (
       <InputGroup>
         <Input
-          placeholder={filterText.inputPlaceholder}
+          placeholder={placeholder}
           onChange={this.updateInput}
           value={input}
           disabled={disabled}
@@ -54,8 +54,10 @@ export default class InputFilter extends React.Component {
 InputFilter.propTypes = {
   updateFilterText: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
+  placeholder: PropTypes.string,
 };
 
 InputFilter.defaultProps = {
   disabled: false,
+  placeholder: filterText.inputPlaceholder,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,11 +1531,6 @@ abab@^2.0.0:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
   integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
 
-abbrev@1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
-  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -1687,18 +1682,10 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-aproba@^1.0.3, aproba@^1.1.1:
+aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
-
-are-we-there-yet@~1.1.2:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
-  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^2.0.6"
 
 argparse@^1.0.7, argparse@^1.0.9:
   version "1.0.10"
@@ -2645,11 +2632,6 @@ console-browserify@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
 
-console-control-strings@^1.0.0, console-control-strings@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
-
 "consolidated-events@^1.1.1 || ^2.0.0":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/consolidated-events/-/consolidated-events-2.0.2.tgz#da8d8f8c2b232831413d9e190dc11669c79f4a91"
@@ -3023,7 +3005,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -3058,11 +3040,6 @@ deep-equal@^1.0.1, deep-equal@^1.1.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -3146,11 +3123,6 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -3173,11 +3145,6 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -4338,13 +4305,6 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -4396,20 +4356,6 @@ fuse.js@3.4.6:
   version "3.4.6"
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.4.6.tgz#545c3411fed88bf2e27c457cab6e73e7af697a45"
   integrity sha512-H6aJY4UpLFwxj1+5nAvufom5b2BT2v45P1MkPvdGIK8fWjQx/7o6tTT1+ALV0yawQvbmvCF0ufl2et8eJ7v7Cg==
-
-gauge@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
-  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
-  dependencies:
-    aproba "^1.0.3"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.0"
-    object-assign "^4.1.0"
-    signal-exit "^3.0.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wide-align "^1.1.0"
 
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
@@ -4611,11 +4557,6 @@ has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
-
-has-unicode@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
-  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -4935,7 +4876,7 @@ https-proxy-agent@^2.2.1:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5052,7 +4993,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.4, ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -6480,21 +6421,6 @@ minimist@^1.1.1, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
-
 mississippi@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
@@ -6524,7 +6450,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -6629,15 +6555,6 @@ nearley@^2.7.10:
     randexp "0.4.6"
     semver "^5.4.1"
 
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -6735,36 +6652,12 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.44:
   version "1.1.46"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.46.tgz#6b262afef1bdc9a950a96df2e77e0d2290f484bf"
   integrity sha512-YOjdx+Uoh9FbRO7yVYbnbt1puRWPQMemR3SutLeyv2XfxKs1ihpe0OLAUwBPEP2ImNH/PZC7SEiC6j32dwRZ7g==
   dependencies:
     semver "^6.3.0"
-
-nopt@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
-  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-package-data@^2.3.2:
   version "2.5.0"
@@ -6798,42 +6691,12 @@ normalize-url@1.9.1:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
-  integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
-
-npmlog@^4.0.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
 
 nth-check@~1.0.1:
   version "1.0.2"
@@ -7027,11 +6890,6 @@ os-browserify@^0.3.0:
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
 
-os-homedir@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
-
 os-locale@^3.0.0, os-locale@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
@@ -7041,18 +6899,10 @@ os-locale@^3.0.0, os-locale@^3.1.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
+os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
-
-osenv@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
-  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
-  dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.0"
 
 p-defer@^1.0.0:
   version "1.0.0"
@@ -7726,16 +7576,6 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-dates@21.5.1:
   version "21.5.1"
   resolved "https://registry.yarnpkg.com/react-dates/-/react-dates-21.5.1.tgz#de8d7ff862f08bdf96cc9045721149b7199c21b4"
@@ -8108,7 +7948,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -8463,7 +8303,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -8591,7 +8431,7 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "0.9.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -8653,7 +8493,7 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -9028,7 +8868,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
+string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -9143,11 +8983,6 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
   integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 style-loader@^1.0.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.1.3.tgz#9e826e69c683c4d9bf9db924f85e9abb30d5e200"
@@ -9210,19 +9045,6 @@ tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 taskcluster-client-web@8.1.1:
   version "8.1.1"
@@ -10337,13 +10159,6 @@ which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
-wide-align@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
-  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
-  dependencies:
-    string-width "^1.0.2 || 2"
-
 winchan@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/winchan/-/winchan-0.2.2.tgz#6766917b88e5e1cb75f455ffc7cc13f51e5c834e"
@@ -10433,7 +10248,7 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
Addresses [Bug 1610705](https://bugzilla.mozilla.org/show_bug.cgi?id=1610705)

This enables filtering by Test Path, Platform and Config (opt, asan, debug, etc).  You can type in any number of space-separated terms and it will filter with AND for each term.  It does it on every keystroke, so it's super-responsive.  But if it ends up being clunky when there are lots of tests, then I may need to introduce a debounce to it.  For now, though, the list is short enough that it's super quick.  It's persisted in the URL, too.

The box is in the upper-right corner:
![Screenshot 2020-01-23 08 47 47](https://user-images.githubusercontent.com/419924/73005254-7f2d2600-3dbd-11ea-8424-132d7ee55670.png)

First commit
-------------
The first commit fixes the data format returned by the API.  It had actually become out of date a few commits ago, but I hadn't fixed it.  The code still worked because of how the test was written.  So I fixed that.  It introduces a pretty large ``mock`` file, but I think it will be useful for future tests.  So the line-change-count is huge.  

I also had to do some trickery to get the test to pass with the current usage of ``reactstrap/Collapse`` component.  They don't remove collapsed data, just hide it.  And it's the ``CSS`` that detects the change to hide them.  The comment in the code explains why.