### PR TITLE
Bug 1444895 - Fix frequent logout issue with Treeherder

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -48,6 +48,11 @@ WSGI_APPLICATION = 'treeherder.config.wsgi.application'
 # Send full URL within origin but only origin for cross-origin requests
 SECURE_REFERRER_POLICY = "origin-when-cross-origin"
 
+# We can't set X_FRAME_OPTIONS to DENY since renewal of an Auth0 token
+# requires opening the auth handler page in an invisible iframe with the
+# same origin.
+X_FRAME_OPTIONS = 'SAMEORIGIN'
+
 # Application definition
 INSTALLED_APPS = [
     'django.contrib.auth',
@@ -255,10 +260,6 @@ SILENCED_SYSTEM_CHECKS = [
     # We can't set CSRF_COOKIE_HTTPONLY to True since the requests to the API
     # made using Angular's `httpProvider` require access to the cookie.
     'security.W017',
-    # We can't set X_FRAME_OPTIONS to DENY since renewal of an Auth0 token
-    # requires opening the auth handler page in an invisible iframe with the
-    # same origin.  This is the default setting ('SAMEORIGIN') for Django's
-    # X_FRAME_OPTIONS setting so it isn't set in this file.
     'security.W019'
 ]
 

--- a/ui/shared/auth/AuthService.js
+++ b/ui/shared/auth/AuthService.js
@@ -7,8 +7,9 @@ import { getApiUrl } from '../../helpers/url';
 import UserModel from '../../models/user';
 
 export default class AuthService {
-  constructor() {
+  constructor(setUser) {
     this.renewalTimer = null;
+    this.setUser = setUser;
   }
 
   _fetchUser(userSession) {
@@ -57,12 +58,9 @@ export default class AuthService {
         return this.resetRenewalTimer();
       }
     } catch (err) {
-      // instance where a new scope was added and is now required in order to be logged in
-      if (err.error === 'consent_required') {
-        this.logout();
-      }
       /* eslint-disable no-console */
       console.error('Could not renew login:', err);
+      this.logout();
     }
   }
 
@@ -91,6 +89,8 @@ export default class AuthService {
   logout() {
     localStorage.removeItem('userSession');
     localStorage.setItem('user', JSON.stringify(loggedOutUser));
+
+    if (this.setUser) this.setUser(loggedOutUser);
   }
 
   async saveCredentialsFromAuthResult(authResult) {

--- a/ui/shared/auth/Login.jsx
+++ b/ui/shared/auth/Login.jsx
@@ -23,7 +23,7 @@ class Login extends React.Component {
   constructor(props) {
     super(props);
 
-    this.authService = new AuthService();
+    this.authService = new AuthService(this.props.setUser);
   }
 
   componentDidMount() {


### PR DESCRIPTION
I figured out the crux of the issue: The x-frame-options default was changed from "sameorigin" to "deny" in [django 3 ](https://docs.djangoproject.com/en/3.0/ref/clickjacking/#setting-x-frame-options-for-all-responses) and this was preventing the auth0 silent renewal (happens every 15 minutes) from completing and causing a timeout.

I changed the try/catch block in the renewal function to log out a user if there is any error whatsoever, and to ensure that is reflected in the UI (change the display back to Login/Register, which it wasn't doing before).

I tested this out on prototype and I do see a script-src being blocked every 15 minutes, but not the error showing the renewal failed (also opening another tab showed the user is still logged in).

 
