### PR TITLE
Bug 1611334 - Enable Push Health badge on Try by default

### DIFF
--- a/ui/job-view/App.jsx
+++ b/ui/job-view/App.jsx
@@ -75,7 +75,7 @@ class App extends React.Component {
       duplicateJobsVisible: urlParams.get('duplicate_jobs') === 'visible',
       showShortCuts: false,
       pushHealthVisibility:
-        localStorage.getItem(PUSH_HEALTH_VISIBILITY) || 'None',
+        localStorage.getItem(PUSH_HEALTH_VISIBILITY) || 'Try',
     };
   }
 

--- a/ui/shared/PushHealthStatus.jsx
+++ b/ui/shared/PushHealthStatus.jsx
@@ -57,9 +57,7 @@ class PushHealthStatus extends Component {
     const { repoName, revision } = this.props;
     const { healthStatus, needInvestigation } = this.state;
     const color = needInvestigation ? 'danger' : 'success';
-    const extraTitle = needInvestigation
-      ? 'Count of tests that need investigation'
-      : 'Push looks good';
+    const extraTitle = needInvestigation ? 'Needs investigation' : 'Looks good';
 
     return (
       <a
@@ -69,7 +67,7 @@ class PushHealthStatus extends Component {
       >
         <Badge
           color={color}
-          title={`Push Health status for Tests only - click for details: ${extraTitle}`}
+          title={`Push Health status - click for details: ${extraTitle}`}
         >
           {healthStatus}
         </Badge>


### PR DESCRIPTION
This enables the Push Health badge on the Push Header on Try by default.  If the user has already made a choice, it keeps that.

I also cleaned up some wording.