### PR TITLE
Solve race condition for test path filtering

### DIFF
--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -163,15 +163,21 @@ class Push extends React.PureComponent {
 
   fetchTestManifests = async () => {
     const { currentRepo, push } = this.props;
-    const { jobList } = this.state;
 
     const jobTypeNameToManifests = await fetchTestManifests(
       currentRepo.name,
       push.revision,
     );
-    this.setState({ jobTypeNameToManifests });
-    // This adds to the jobs the test_path property
-    this.mapPushJobs(jobList);
+    // Call setState with callback to guarantee the state of jobTypeNameToManifest
+    // to be set since it is read within mapPushJobs and we might have a race
+    // condition. We are also reading jobList now rather than before fetching
+    // the artifact because it gives us an empty list
+    this.setState(
+      {
+        jobTypeNameToManifests,
+      },
+      () => this.mapPushJobs(this.state.jobList),
+    );
   };
 
   fetchJobs = async () => {


### PR DESCRIPTION
During [review time](https://github.com/mozilla/treeherder/pull/5794#discussion_r369780355) we introduced a small bug in the test filtering feature.

Reading `jobList` at the begining of the function instead of just before calling `mapPushJobs` almost guaranteed to start with an empty list which makes the call useless since it needs a non-empty list to work.

I also changed the code to call `this.setState` with a callback to `mapPushJobs` to guarantee that `jobTypeNameToManifests` is set in the state and not get an empty object.

```diff
diff --git a/ui/job-view/pushes/Push.jsx b/ui/job-view/pushes/Push.jsx
index 8e0e96547..0a79c394a 100644
--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -163,15 +163,18 @@ class Push extends React.PureComponent {

   fetchTestManifests = async () => {
     const { currentRepo, push } = this.props;
-    const { jobList } = this.state;

     const jobTypeNameToManifests = await fetchTestManifests(
       currentRepo.name,
       push.revision,
     );
-    this.setState({ jobTypeNameToManifests });
-    // This adds to the jobs the test_path property
-    this.mapPushJobs(jobList);
+    // Call setState with callback to guarantee the state of jobTypeNameToManifest
+    // to be set since it is read within mapPushJobs and we might have a race
+    // condition. We are also reading jobList now rather than before fetching
+    // the artifact because it gives us an empty list
+    this.setState({
+      jobTypeNameToManifests,
+    }, () => this.mapPushJobs(this.state.jobList));
   };
```
