### PR TITLE
Bug 1611485 - Fix inconsistencies with Push Health badge

### DIFF
--- a/ui/shared/PushHealthStatus.jsx
+++ b/ui/shared/PushHealthStatus.jsx
@@ -1,6 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Badge } from 'reactstrap';
+import { Badge, Spinner } from 'reactstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faCheck,
+  faExclamationTriangle,
+} from '@fortawesome/free-solid-svg-icons';
 
 import PushModel from '../models/push';
 import { getPushHealthUrl } from '../helpers/url';
@@ -11,8 +16,8 @@ class PushHealthStatus extends Component {
     super(props);
 
     this.state = {
-      healthStatus: '',
-      needInvestigation: 0,
+      unsupported: null,
+      needInvestigation: null,
     };
   }
 
@@ -43,35 +48,51 @@ class PushHealthStatus extends Component {
     );
 
     if (!failureStatus) {
-      const { needInvestigation } = data;
-      const testsNeed = needInvestigation > 1 ? 'tests need' : 'test needs';
-      const healthStatus = needInvestigation
-        ? `${needInvestigation} ${testsNeed} investigation`
-        : 'OK';
-
-      this.setState({ healthStatus, needInvestigation });
+      this.setState({ ...data });
     }
   }
 
   render() {
     const { repoName, revision } = this.props;
-    const { healthStatus, needInvestigation } = this.state;
-    const color = needInvestigation ? 'danger' : 'success';
-    const extraTitle = needInvestigation ? 'Needs investigation' : 'Looks good';
+    const { needInvestigation, unsupported } = this.state;
+    const testsNeed = needInvestigation > 1 ? 'tests need' : 'test needs';
+    const icon =
+      needInvestigation + unsupported === 0 ? faCheck : faExclamationTriangle;
+    let healthStatus = 'OK';
+    let badgeColor = 'success';
+    let extraTitle = 'Looks good';
+
+    if (unsupported) {
+      healthStatus = `${unsupported} unsupported tests`;
+      badgeColor = 'warning';
+      extraTitle = 'Indeterminate';
+    }
+    if (needInvestigation) {
+      healthStatus = `${needInvestigation} ${testsNeed} investigation`;
+      badgeColor = 'danger';
+      extraTitle = 'Needs investigation';
+    }
 
     return (
-      <a
-        href={getPushHealthUrl({ repo: repoName, revision })}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <Badge
-          color={color}
-          title={`Push Health status - click for details: ${extraTitle}`}
-        >
-          {healthStatus}
-        </Badge>
-      </a>
+      <React.Fragment>
+        {needInvestigation !== null ? (
+          <a
+            href={getPushHealthUrl({ repo: repoName, revision })}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Badge
+              color={badgeColor}
+              title={`Push Health status - click for details: ${extraTitle}`}
+            >
+              <FontAwesomeIcon className="mr-1" icon={icon} />
+              {healthStatus}
+            </Badge>
+          </a>
+        ) : (
+          <Spinner size="sm" />
+        )}
+      </React.Fragment>
     );
   }
 }


### PR DESCRIPTION
This fixes several issue:

1. The `/health_summary` endpoint was not showing `unsupported` count, which made a push with unsupported jobs show as ``OK`` when it should call them out.

2. The overall `/health` endpoint was only showing `pass` or `fail`.  Now it also shows ``indeterminate`` if there are no failures, but include unsupported tasks.

3. The UI was also not taking `unsupported` jobs into consideration.  

This also adds an icon to the `PushHeader` badge and a loading spinner.

![Screenshot 2020-01-27 14 24 57](https://user-images.githubusercontent.com/419924/73219389-d827f180-4110-11ea-9791-980bf16105af.png)
