### PR TITLE
Bug 1612000 - Fix classified jobs disappearing at right time

### DIFF
--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -209,10 +209,10 @@ class Push extends React.PureComponent {
       // remove old versions of jobs we just fetched.
       const existingJobs = jobList.filter(job => !newIds.includes(job.id));
       // Join both lists and add test_paths property
-      const newJobList = [...existingJobs, ...jobs].map(job => ({
-        ...job,
-        test_paths: jobTypeNameToManifests[job.job_type_name] || [],
-      }));
+      const newJobList = [...existingJobs, ...jobs].map(job => {
+        job.test_paths = jobTypeNameToManifests[job.job_type_name] || [];
+        return job;
+      });
       const platforms = this.sortGroupedJobs(
         this.groupJobByPlatform(newJobList),
       );


### PR DESCRIPTION
This is my fault.  I ASKED you to change it to the code that's there.  :)  I forgot that this particular area is a little brittle and the instances of the jobs matter, not just the contents.  I need to fix this.