### PR TITLE
Bug 1608148 - Update Treestatus URL

### DIFF
--- a/ui/job-view/headerbars/WatchedRepo.jsx
+++ b/ui/job-view/headerbars/WatchedRepo.jsx
@@ -199,7 +199,7 @@ export default class WatchedRepo extends React.Component {
           )}
           <li className="watched-repo-dropdown-item">
             <a
-              href={`https://mozilla-releng.net/treestatus/show/${treeStatusName}`}
+              href={`https://mozilla-releng.net/static/ui/treestatus/show/${treeStatusName}`}
               className="dropdown-item"
               target="_blank"
               rel="noopener noreferrer"

--- a/ui/job-view/headerbars/WatchedRepo.jsx
+++ b/ui/job-view/headerbars/WatchedRepo.jsx
@@ -199,7 +199,7 @@ export default class WatchedRepo extends React.Component {
           )}
           <li className="watched-repo-dropdown-item">
             <a
-              href={`https://mozilla-releng.net/static/ui/treestatus/show/${treeStatusName}`}
+              href={`https://treestatus.mozilla-releng.net/static/ui/treestatus/show/${treeStatusName}`}
               className="dropdown-item"
               target="_blank"
               rel="noopener noreferrer"


### PR DESCRIPTION
BugZilla Link : https://bugzilla.mozilla.org/show_bug.cgi?id=1608148
Here the treestatus URL "/treestatus/show/${treeStatusName}" needs to be updated to"/static/ui/treestatus/show/${treeStatusName}" according to the Issue explained in the link above.
Please Review it and let me know 

- [X] All Tests Passed Successfully