### PR TITLE
Add Python test coverage to codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ celerybeat-schedule
 
 # Ignore coverage results
 coverage
+coverage.xml
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,20 +37,26 @@ matrix:
       language: minimal
       install:
         - docker-compose build
+        - pip install codecov --user
       script:
         - docker-compose run backend ./runtests.sh
+      after_success:
+        - codecov -f coverage.xml
 
     - env: python-tests-main
       language: minimal
       install:
         - docker-compose build
+        - pip install codecov --user
       script:
         # Several security features in settings.py (eg setting HSTS headers) are conditional on
         # 'https://' being in the site URL. In addition, we override the test environment's debug
         # value so the tests pass. The real environment variable will be checked during deployment.
         - docker-compose run -e SITE_URL=https://treeherder.dev -e TREEHERDER_DEBUG=False backend python -bb ./manage.py check --deploy --fail-level WARNING
         # Using `-bb` mode to surface BytesWarnings: https://docs.python.org/3.7/using/cmdline.html#cmdoption-b
-        - docker-compose run backend python -bb -m pytest tests/ --runslow --ignore=tests/selenium/
+        - docker-compose run backend bash -c "pytest --cov-report=xml tests/ --runslow --ignore=tests/selenium"
+      after_success:
+        - codecov -f coverage.xml
 
     - env: python-tests-selenium
       language: node_js
@@ -63,12 +69,15 @@ matrix:
         - docker-compose build
       install:
         - yarn install
+        - pip install codecov --user
       before_script:
         # Run in `before_script` to prevent the Selenium tests from running if the UI build fails.
         - yarn build
       script:
         # Using `-bb` mode to surface BytesWarnings: https://docs.python.org/3.7/using/cmdline.html#cmdoption-b
-        - docker-compose run backend python -bb -m pytest tests/selenium/
+        - docker-compose run backend bash -c "pytest --cov-report=xml tests/selenium/"
+      after_success:
+        - codecov -f coverage.xml
 
 notifications:
   email:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,11 @@
 # Dependencies needed only for development/testing.
 
+coverage==5.0.3 \
+    --hash=sha256:d649dc0bcace6fcdb446ae02b98798a856593b19b637c1b9af8edadf2b150bea
+
+pytest-cov==2.8.1 \
+    --hash=sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626
+
 pytest==5.3.5 \
     --hash=sha256:ff615c761e25eb25df19edddc0b970302d2a9091fbce0e7213298d85fb61fef6 \
     --hash=sha256:0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d

--- a/runtests.sh
+++ b/runtests.sh
@@ -27,4 +27,4 @@ echo "Running Django system checks"
 SITE_URL="https://treeherder.dev" TREEHERDER_DEBUG="False" python -bb ./manage.py check --deploy --fail-level WARNING
 
 echo "Running Python tests"
-python -bb -m pytest tests/
+pytest --cov-report=xml tests/


### PR DESCRIPTION
This is based on #5860 

I need to test the branch using our codecov account rather than [shubhank-saxena](https://codecov.io/gh/shubhank-saxena/treeherder)'s set up.