### PR TITLE
Bug 1600761 - Color Adjustment for running and pending jobs

### DIFF
--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -465,8 +465,7 @@ fieldset[disabled] .btn-ltblue.active {
 .btn-ltgray-count,
 .btn-ltgray-classified,
 .btn-ltgray-classified-count {
-  color: #737373;
-  border: 1px solid #737373;
+  color: #757575;
 }
 .btn-ltgray-count:hover,
 .btn-ltgray-classified-count:hover {
@@ -537,17 +536,15 @@ fieldset[disabled] .btn-mdgray.active {
 .btn-dkgray-classified-count,
 .btn-dkgray-count:hover,
 .btn-dkgray-classified-count:hover {
-  background-color: #737373;
-  border-color: #737373;
-  color: white;
+  color: black;
 }
 .btn-dkgray:hover,
 .btn-dkgray-classified:hover,
 .btn-dkgray:focus,
 .btn-dkgray:active,
 .btn-dkgray.active {
-  background-color: #333333;
-  border-color: #1c1c1c;
+  background-color: black;
+  border-color: black;
   color: white;
 }
 .btn-dkgray.disabled:hover,

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -176,7 +176,6 @@
 /* Orange, testfailed */
 .btn-orange {
   background-color: #f7c194;
-  border-color: #a87f5c;
   color: #743603;
 }
 .btn-orange:hover,
@@ -184,7 +183,6 @@
 .btn-orange:active,
 .btn-orange.active {
   background-color: #c15700;
-  border-color: #9f4a03;
   color: white;
 }
 .btn-orange.disabled:hover,
@@ -238,7 +236,6 @@ fieldset[disabled] .btn-orange-classified.active {
 /* Red, busted */
 .btn-red {
   background-color: #b74c4c;
-  border-color: #a1020e;
   color: white;
 }
 .btn-red:hover,
@@ -246,7 +243,6 @@ fieldset[disabled] .btn-orange-classified.active {
 .btn-red:active,
 .btn-red.active {
   background-color: #a1020e;
-  border-color: #a1020e;
   color: white;
 }
 .btn-red.disabled:hover,
@@ -368,7 +364,6 @@ fieldset[disabled] .btn-green.active {
 /* Purple, infrastructure exception */
 .btn-purple {
   background-color: #9a7da6;
-  border-color: #6f0296;
   color: #3a004d;
 }
 .btn-purple:hover,
@@ -376,7 +371,6 @@ fieldset[disabled] .btn-green.active {
 .btn-purple:active,
 .btn-purple.active {
   background-color: #3a004d;
-  border-color: #3a004d;
   color: white;
 }
 .btn-purple.disabled:hover,

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -465,7 +465,8 @@ fieldset[disabled] .btn-ltblue.active {
 .btn-ltgray-count,
 .btn-ltgray-classified,
 .btn-ltgray-classified-count {
-  color: #747474;
+  color: #737373;
+  border: 1px solid #737373;
 }
 .btn-ltgray-count:hover,
 .btn-ltgray-classified-count:hover {
@@ -536,7 +537,9 @@ fieldset[disabled] .btn-mdgray.active {
 .btn-dkgray-classified-count,
 .btn-dkgray-count:hover,
 .btn-dkgray-classified-count:hover {
-  color: #333333;
+  background-color: #737373;
+  border-color: #737373;
+  color: white;
 }
 .btn-dkgray:hover,
 .btn-dkgray-classified:hover,

--- a/ui/css/treeherder-userguide.css
+++ b/ui/css/treeherder-userguide.css
@@ -34,11 +34,11 @@ body {
 }
 
 .ug-btn-orange {
-  border-color: #dd6602;
+  border-color: #743603;
 }
 
 .ug-btn-purple {
-  border-color: #6f0296;
+  border-color: #3a004d;
 }
 
 .ug-btn-red {


### PR DESCRIPTION
## Description
Running and pending jobs are not very discernable after the first 1600761 push.

## Proposed Solution
![Screenshot from 2020-02-04 16-45-17](https://user-images.githubusercontent.com/3901809/73781439-fcb64600-476e-11ea-9687-cd8cc8370350.png)


On the jobs view, the border can either be seen by default or only by hovering the mouse:

**No border**
![Screenshot from 2020-02-04 16-47-09](https://user-images.githubusercontent.com/3901809/73781524-24a5a980-476f-11ea-9040-a4f9b9048dcd.png)

**Border**
![Screenshot from 2020-02-04 16-46-21](https://user-images.githubusercontent.com/3901809/73781534-2b342100-476f-11ea-9df9-7506b72a1716.png)



