### PR TITLE
Bug 1574628 - Change Perfherder's icon

### DIFF
--- a/ui/perfherder/constants.js
+++ b/ui/perfherder/constants.js
@@ -61,21 +61,21 @@ export const alertStatusMap = {
 };
 
 export const graphColors = [
+  ['dark-puce', '#4C3146'],
   ['orange', '#FFB851'],
+  ['purple', '#921181'],
   ['fire-red', '#C92D2F'],
   ['cerulean', '#16BCDE'],
   ['blue-bell', '#464876'],
-  ['purple', '#921181'],
-  ['dark-puce', '#4C3146'],
 ];
 
 export const graphSymbols = [
-  ['circle', 'outline'],
-  ['square', 'outline'],
   ['diamond', 'outline'],
-  ['circle', 'fill'],
-  ['square', 'fill'],
   ['diamond', 'fill'],
+  ['square', 'outline'],
+  ['square', 'fill'],
+  ['circle', 'outline'],
+  ['circle', 'fill'],
 ];
 
 export const phFrameworksWithRelatedBranches = [

--- a/ui/perfherder/constants.js
+++ b/ui/perfherder/constants.js
@@ -72,10 +72,10 @@ export const graphColors = [
 export const graphSymbols = [
   ['circle', 'outline'],
   ['square', 'outline'],
-  ['triangleUp', 'outline'],
+  ['diamond', 'outline'],
   ['circle', 'fill'],
   ['square', 'fill'],
-  ['triangleUp', 'fill'],
+  ['diamond', 'fill'],
 ];
 
 export const phFrameworksWithRelatedBranches = [

--- a/ui/shared/GraphIcon.jsx
+++ b/ui/shared/GraphIcon.jsx
@@ -11,8 +11,10 @@ const GraphIcon = ({ iconType, fill, stroke }) => {
     case 'square':
       iconPath = <rect x="1" y="1" width="15" height="15" />;
       break;
-    case 'triangleUp':
-      iconPath = <polygon points="1,13.5 7.1,2.3 13.5,13.5" />;
+    case 'diamond':
+      iconPath = (
+        <rect x="-7" y="9" width="10" height="10" transform="rotate(-45)" />
+      );
       break;
     default:
       iconPath = <circle cx="10" cy="10" r="5" />;


### PR DESCRIPTION
## Description
The newly implemented triangle icon in Perfherder's graph can be misleading (it could be read as a trend).

## Proposed Solution
Change the triangle icon to **diamond**.

![image](https://user-images.githubusercontent.com/3901809/73786690-8e768100-4778-11ea-814a-96b0c625e6a7.png)

Now, there are 3 icons: square, triangle, and diamond that could be either color filled or just with stroke.