### PR TITLE
Bug 1611502 - Do not run initialize_data when using DATABASE_URL

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,7 +14,10 @@ while ! nc -z "${DATABASE_HOST}" "${DATABASE_PORT}" &> /dev/null; do
     sleep 1;
 done
 
-# Initialize migrations and SETA
-./initialize_data.sh
+# Only execute if we're using the mysql container
+if [ "${DATABASE_URL}" == "mysql://root@mysql/treeherder" ]; then
+    # Initialize migrations and SETA
+    ./initialize_data.sh
+fi
 
 exec "$@"


### PR DESCRIPTION
Since we do not want to execute it against live production databases.

This fixes a change introduced in #5851 

One reviewer is sufficient, however, I want both of you to be aware of it.