### PR TITLE
Changes to running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,11 @@ matrix:
     - env: python-linters
       language: minimal
       install:
-        - docker-compose build
-        - pip install codecov --user
+        - pip install -r requirements/common.txt
+        - pip install -r requirements/dev.txt
+        - pip install -r requirements/docs.txt
       script:
-        - docker-compose run backend ./runtests.sh
-      after_success:
-        - codecov -f coverage.xml
+        - ./runchecks.sh
 
     - env: python-tests-main
       language: minimal
@@ -49,12 +48,7 @@ matrix:
         - docker-compose build
         - pip install codecov --user
       script:
-        # Several security features in settings.py (eg setting HSTS headers) are conditional on
-        # 'https://' being in the site URL. In addition, we override the test environment's debug
-        # value so the tests pass. The real environment variable will be checked during deployment.
-        - docker-compose run -e SITE_URL=https://treeherder.dev -e TREEHERDER_DEBUG=False backend python -bb ./manage.py check --deploy --fail-level WARNING
-        # Using `-bb` mode to surface BytesWarnings: https://docs.python.org/3.7/using/cmdline.html#cmdoption-b
-        - docker-compose run backend bash -c "pytest --cov --cov-report=xml tests/ --runslow --ignore=tests/selenium"
+        - docker-compose run backend bash -c "pytest --cov --cov-report=xml tests/ --ignore=tests/selenium"
       after_success:
         - codecov -f coverage.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     - env: python-linters
       language: python
       python:
-        - "3.7"
+        - '3.7'
       install:
         - pip install -r requirements/common.txt
         - pip install -r requirements/dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,6 @@ matrix:
         # Run in `before_script` to prevent the Selenium tests from running if the UI build fails.
         - yarn build
       script:
-        # Using `-bb` mode to surface BytesWarnings: https://docs.python.org/3.7/using/cmdline.html#cmdoption-b
         - docker-compose run backend bash -c "pytest --cov --cov-report=xml tests/selenium/"
       after_success:
         - codecov -f coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,9 @@ matrix:
         - yarn build
 
     - env: python-linters
-      language: minimal
+      language: python
+      python:
+        - "3.7"
       install:
         - pip install -r requirements/common.txt
         - pip install -r requirements/dev.txt

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -14,9 +14,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 #### Required for running Selenium tests ####
 ENV GECKODRIVER_VERSION='0.24.0'
-RUN curl -sSfL "https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz" \
+RUN curl -sSfL --retry 5 "https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz" \
     | tar -zxC "/usr/local/bin" \
-    && curl -sSfL 'https://download.mozilla.org/?product=firefox-beta-latest&lang=en-US&os=linux64' \
+    && curl -sSfL --retry 5 'https://download.mozilla.org/?product=firefox-beta-latest&lang=en-US&os=linux64' \
     | tar -jxC "/usr/local/bin"
 # Bug in Firefox which requires GTK+ and GLib in headless mode
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1372998
@@ -30,7 +30,7 @@ ENV PATH="/usr/local/bin/firefox:${PATH}"
 
 #### Required for running shellcheck tests ####
 ENV SHELLCHECK_VERSION="0.4.6"
-RUN curl -sSfL "https://storage.googleapis.com/shellcheck/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+RUN curl -sSfL --retry 5 "https://storage.googleapis.com/shellcheck/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
     | tar -Jx --strip-components=1 -C /usr/local/bin
 
 # /app will be mounted via a volume defined in docker-compose

--- a/docs/backend_tasks.md
+++ b/docs/backend_tasks.md
@@ -33,12 +33,6 @@ Then run the individual tools within that shell, like so:
   pytest tests/selenium/test_pin_jobs.py::test_pin_all_jobs
   ```
 
-  To run all tests, including slow tests that are normally skipped, use:
-
-  ```bash
-  pytest --runslow tests/
-  ```
-
   For more options, see `pytest --help` or <https://docs.pytest.org/en/stable/usage.html>.
 
   To assist with debugging Selenium test failures, an HTML reporting containing screenshots

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -57,10 +57,10 @@ The tests will perform an initial run and then re-execute each time a project fi
 
 ## Python
 
-To run all Python unit tests, including linting, sorting, etc:
+To run all Python tests, including linting, sorting, etc:
 
 ```bash
-docker-compose run backend sh -c "./runtests.sh"
+docker-compose run backend sh -c "./runchecks.sh && pytest tests/"
 ```
 
 ### Running a specific set of Python unit tests
@@ -71,19 +71,19 @@ of specificity:
 All tests:
 
 ```bash
-docker-compose run backend python -bb -m pytest tests/
+docker-compose run backend pytest tests/
 ```
 
 Just `/etl` tests
 
 ```bash
-docker-compose run backend python -bb -m pytest tests/etl/
+docker-compose run backend pytest tests/etl/
 ```
 
 Just the `test_ingest_pending_pulse_job` within the `/etl` tests
 
 ```bash
-docker-compose run backend python -bb -m pytest tests/ -k test_ingest_pending_pulse_job
+docker-compose run backend pytest tests/ -k test_ingest_pending_pulse_job
 ```
 
 ## Selenium
@@ -91,17 +91,11 @@ docker-compose run backend python -bb -m pytest tests/ -k test_ingest_pending_pu
 The Selenium tests are written in Python, so when you execute some of the
 commands above, you will execute the Selenium tests as well.
 
-The Selenium tests require a UI build. So you will need to use two terminal
-windows. In the first, run this:
+The Selenium tests require a UI build:
 
 ```bash
 docker-compose up --build
-```
-
-Then to execute the tests:
-
-```bash
-docker-compose run backend python -bb -m pytest tests/selenium/
+docker-compose run backend pytest tests/selenium/
 ```
 
 [eslint]: https://eslint.org

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -7,7 +7,7 @@ echo "Running pip check"
 pip check
 
 echo "Checking CELERY_TASK_QUEUES matches Procfile"
-python -bb ./lints/queuelint.py
+python ./lints/queuelint.py
 
 echo "Running flake8"
 flake8 --show-source || { echo "flake8 errors found!"; exit 1; }
@@ -23,8 +23,7 @@ echo "Running test docs generation"
 mkdocs build
 
 echo "Running Django system checks"
-# See .travis.yml for explanation of the environment variable overriding.
-SITE_URL="https://treeherder.dev" TREEHERDER_DEBUG="False" python -bb ./manage.py check --deploy --fail-level WARNING
-
-echo "Running Python tests"
-pytest --cov --cov-report=xml tests/
+# Several security features in settings.py (eg setting HSTS headers) are conditional on
+# 'https://' being in the site URL. In addition, we override the test environment's debug
+# value so the tests pass. The real environment variable will be checked during deployment.
+SITE_URL="https://treeherder.dev" TREEHERDER_DEBUG="False" python ./manage.py check --deploy --fail-level WARNING

--- a/runchecks.sh
+++ b/runchecks.sh
@@ -23,7 +23,16 @@ echo "Running test docs generation"
 mkdocs build
 
 echo "Running Django system checks"
+# We can remove these env variables once the default values are properly set:
+# https://github.com/mozilla/treeherder/issues/5926
+BROKER_URL=localhost//guest:guest@rabbitmq//
+DATABASE_URL=mysql://root@localhost:3306/treeherder
+REDIS_URL=redis://localhost:6379
+SITE_URL=http://backend:8000/
+TREEHERDER_DEBUG=True
+TREEHERDER_DJANGO_SECRET_KEY=secret-key-of-at-least-50-characters-to-pass-check-deploy
+NEW_RELIC_DEVELOPER_MODE=True
 # Several security features in settings.py (eg setting HSTS headers) are conditional on
 # 'https://' being in the site URL. In addition, we override the test environment's debug
 # value so the tests pass. The real environment variable will be checked during deployment.
-SITE_URL="https://treeherder.dev" TREEHERDER_DEBUG="False" python ./manage.py check --deploy --fail-level WARNING
+python ./manage.py check --deploy --fail-level WARNING

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,24 +29,11 @@ from treeherder.perf.models import (IssueTracker,
 from treeherder.services.pulse.exchange import get_exchange
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--runslow",
-        action="store_true",
-        help="run slow tests",
-    )
-
-
 def pytest_runtest_setup(item):
     """
     Per-test setup.
-    - Add an option to run those tests marked as 'slow'
     - Clear the django cache between runs
     """
-
-    if 'slow' in item.keywords and not item.config.getoption("--runslow"):
-        pytest.skip("need --runslow option to run")
-
     from django.core.cache import cache
     cache.clear()
 


### PR DESCRIPTION
Changes:

* `runtests.sh` is renamed to `runchecks.sh` and it does **not** run Python tests
* The `python-linters` check on Travis now *only* runs checks and no Python tests
  * If you compare the output of `python-tests-main` on Travis you will see that we're duplicating test runs
* This is a step forward toward adding `pre-commit` set up
* The `manage.py check --deploy` was duplicated in Travis
* Updated the testing documentation
* Removed `-bb` since it is not needed since Python 3.5