### PR TITLE
Add a quick link to compare a given revision in perfherder.

### DIFF
--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -8,7 +8,7 @@ import { getUrlParam } from '../../helpers/location';
 import { formatTaskclusterError } from '../../helpers/errorMessage';
 import CustomJobActions from '../CustomJobActions';
 import PushModel from '../../models/push';
-import { getPushHealthUrl } from '../../helpers/url';
+import { getPushHealthUrl, getCompareChooserUrl } from '../../helpers/url';
 import { notify } from '../redux/stores/notifications';
 import { thEvents } from '../../helpers/constants';
 
@@ -271,6 +271,20 @@ class PushActionMenu extends React.PureComponent {
               title="Enable Health Badges in the Health menu"
             >
               Push Health
+            </a>
+          </li>
+          <li>
+            <a
+              className="dropdown-item"
+              href={getCompareChooserUrl({
+                newProject: currentRepo.name,
+                newRevision: revision,
+              })}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Compare performance against another revision"
+            >
+              Compare Performance
             </a>
           </li>
         </ul>


### PR DESCRIPTION
I've wanted to look at the performance comparison of push to try a few times recently, and I got annoyed buy having to copy the tip revision of the push and then navigate to perfherder, so I added a link in the push menu (where I went looking for an option to do that).

It turns out that the performance tab of a job also has that info (which I discovered looking at the code).