### PR TITLE
Heroku Review Apps: Bump the plan for JawsDB

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "heroku-redis:premium-0",
     "papertrail:choklad",
     {
-      "plan": "jawsdb:blacktip",
+      "plan": "jawsdb:whitetip",
       "options": {
         "version": "5.7"
       }


### PR DESCRIPTION
* From $24/mo to $39/mo
* Dedicated RAM instead of shared
* Single Tenant
* 66 connections instead of 30
* 5GB instead of 2.5GB of storage