### PR TITLE
Bug 1613302 - Better wording on Push Health Status wrt Need Investigation

### DIFF
--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -69,7 +69,7 @@ function PushCounts(props) {
     <div>
       {fixedByCommit >= 1 && (
         <span
-          className="badge badge-warning"
+          className="badge badge-warning ml-1"
           title="Count of Fixed By Commit tasks for this push"
         >
           {fixedByCommit}

--- a/ui/shared/PushHealthStatus.jsx
+++ b/ui/shared/PushHealthStatus.jsx
@@ -55,7 +55,7 @@ class PushHealthStatus extends Component {
   render() {
     const { repoName, revision } = this.props;
     const { needInvestigation, unsupported } = this.state;
-    const testsNeed = needInvestigation > 1 ? 'tests need' : 'test needs';
+    const items = needInvestigation > 1 ? 'items' : 'item';
     const icon =
       needInvestigation + unsupported === 0 ? faCheck : faExclamationTriangle;
     let healthStatus = 'OK';
@@ -63,12 +63,12 @@ class PushHealthStatus extends Component {
     let extraTitle = 'Looks good';
 
     if (unsupported) {
-      healthStatus = `${unsupported} unsupported tests`;
+      healthStatus = `${unsupported} unsupported ${items}`;
       badgeColor = 'warning';
       extraTitle = 'Indeterminate';
     }
     if (needInvestigation) {
-      healthStatus = `${needInvestigation} ${testsNeed} investigation`;
+      healthStatus = `${needInvestigation} ${items}`;
       badgeColor = 'danger';
       extraTitle = 'Needs investigation';
     }


### PR DESCRIPTION
The use of the word `tests` is not always accurate.  They could be linting or build tasks.  So changing this to the more generic `items` is better.  Also made it a bit shorter.  And added a space between this badge and the count of `fixed by commit` tasks.