### PR TITLE
Add style for darker colors

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -56,7 +56,7 @@ For example:
 
 Known reactstrap components that accept the `color` prop and work with custom Treeherder colors: `Badge`, `Button`, `Card`, `DropdownToggle`, `FormText`, `NavBar`, `Progress`, `Spinner`.
 
-In case you need to add more custom colors, please add on `treeherder-global.css` style sheet.
+In case you need to add more custom colors, please add on [treeherder-global.css](https://github.com/mozilla/treeherder/blob/master/ui/css/treeherder-global.css#L371) style sheet.
 
 ### Inserting new colors
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -54,6 +54,10 @@ For example:
 </Button>
 ```
 
+Known reactstrap components that accept the `color` prop and work with custom Treeherder colors: `Badge`, `Button`, `Card`, `DropdownToggle`, `FormText`, `NavBar`, `Progress`, `Spinner`.
+
+In case you need to add more custom colors, please add on `treeherder-global.css` style sheet.
+
 ### Inserting new colors
 
 If you add new colors to the style sheets, please make sure the text and background color combination passes the minimum contrast ratio defined by WCAG.

--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -315,8 +315,7 @@ input[type='checkbox'] {
   background-color: #0a5e6d;
 }
 
-.btn-darker-info.disabled,
-.btn-darker-info.disabled:hover {
+.btn-darker-info.disabled {
   color: black;
   background-color: #30b9ce80;
 }
@@ -331,6 +330,12 @@ input[type='checkbox'] {
   background-color: #0d7d8f;
   border-color: #0d7d8f;
   color: #ffffff;
+}
+
+.btn-outline-darker-info.disabled {
+  color: #02363f;
+  background-color: white;
+  border-color: #0d7d8f;
 }
 
 /*
@@ -354,6 +359,14 @@ input[type='checkbox'] {
 
 .bg-lightgray {
   background-color: lightgray;
+}
+
+.bg-darker-info {
+  background-color: #0d7d8f;
+}
+
+.bg-darker-secondary {
+  background-color: #6c757d;
 }
 
 .midgray,
@@ -416,6 +429,10 @@ h4 {
 
 .text-darker-info {
   color: #0d7d8f;
+}
+
+.text-darker-secondary {
+  color: #6c757d;
 }
 
 /*

--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -286,58 +286,6 @@ input[type='checkbox'] {
   border-color: #2e6da4;
 }
 
-.btn-darker-secondary {
-  color: #ffffff;
-  background-color: #6c757d;
-  border-color: #6c757d;
-}
-
-.btn-darker-secondary:hover {
-  color: #ffffff;
-  background-color: #5a6268;
-  border-color: #545b62;
-}
-
-.btn-darker-secondary.disabled {
-  color: #242424;
-  background-color: white;
-  border-color: #6c757d;
-}
-
-.btn-darker-info {
-  background-color: #0d7d8f;
-  border-color: #0d7d8f;
-  color: #ffffff;
-}
-
-.btn-darker-info:hover {
-  color: #ffffff;
-  background-color: #0a5e6d;
-}
-
-.btn-darker-info.disabled {
-  color: black;
-  background-color: #30b9ce80;
-}
-
-.btn-outline-darker-info {
-  color: #0d7d8f;
-  border-color: #0d7d8f;
-}
-
-.btn-outline-darker-info:hover,
-.btn-outline-darker-info:not(:disabled):not(.disabled).active {
-  background-color: #0d7d8f;
-  border-color: #0d7d8f;
-  color: #ffffff;
-}
-
-.btn-outline-darker-info.disabled {
-  color: #02363f;
-  background-color: white;
-  border-color: #0d7d8f;
-}
-
 /*
  * Colors
  */
@@ -361,14 +309,6 @@ input[type='checkbox'] {
   background-color: lightgray;
 }
 
-.bg-darker-info {
-  background-color: #0d7d8f;
-}
-
-.bg-darker-secondary {
-  background-color: #6c757d;
-}
-
 .midgray,
 .midgray a {
   color: gray;
@@ -380,16 +320,6 @@ input[type='checkbox'] {
 
 .darkorange {
   color: #dd6602;
-}
-
-.badge-darker-info {
-  background: #0d7d8f;
-  color: white;
-}
-
-.badge-darker-secondary {
-  background-color: #6c757d;
-  color: white;
 }
 
 /*
@@ -437,12 +367,88 @@ h4 {
   font-size: 18px;
 }
 
+/*
+ * Bootstrap/Reactstrap Custom Colors
+ */
+
+/* Darker Info */
 .text-darker-info {
   color: #0d7d8f;
 }
 
+.badge-darker-info {
+  background: #0d7d8f;
+  color: white;
+}
+
+.bg-darker-info {
+  background-color: #0d7d8f;
+}
+
+.btn-darker-info {
+  background-color: #0d7d8f;
+  border-color: #0d7d8f;
+  color: #ffffff;
+}
+
+.btn-darker-info:hover {
+  color: #ffffff;
+  background-color: #0a5e6d;
+}
+
+.btn-darker-info.disabled {
+  color: black;
+  background-color: #30b9ce80;
+}
+
+.btn-outline-darker-info {
+  color: #0d7d8f;
+  border-color: #0d7d8f;
+}
+
+.btn-outline-darker-info:hover,
+.btn-outline-darker-info:not(:disabled):not(.disabled).active {
+  background-color: #0d7d8f;
+  border-color: #0d7d8f;
+  color: #ffffff;
+}
+
+.btn-outline-darker-info.disabled {
+  color: #02363f;
+  background-color: white;
+  border-color: #0d7d8f;
+}
+
+/* Darker Secondary */
 .text-darker-secondary {
   color: #6c757d;
+}
+
+.badge-darker-secondary {
+  background-color: #6c757d;
+  color: white;
+}
+
+.bg-darker-secondary {
+  background-color: #6c757d;
+}
+
+.btn-darker-secondary {
+  color: #ffffff;
+  background-color: #6c757d;
+  border-color: #6c757d;
+}
+
+.btn-darker-secondary:hover {
+  color: #ffffff;
+  background-color: #5a6268;
+  border-color: #545b62;
+}
+
+.btn-darker-secondary.disabled {
+  color: #242424;
+  background-color: white;
+  border-color: #6c757d;
 }
 
 /*

--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -382,6 +382,16 @@ input[type='checkbox'] {
   color: #dd6602;
 }
 
+.badge-darker-info {
+  background: #0d7d8f;
+  color: white;
+}
+
+.badge-darker-secondary {
+  background-color: #6c757d;
+  color: white;
+}
+
 /*
  * Text
  */


### PR DESCRIPTION
## Description
Related: #5920 

Add style specs in case `darker-secondary` and `darker-info` color props are used in other reactstrap components in the future.

E.g. `Button`, `Progress`, or in `className` in case of `.text-darker-*`