### PR TITLE
Bug 1613302 - Revert and fix for Revert of Better wording on Push Health Status

### DIFF
--- a/tests/ui/push-health/PushParent_test.jsx
+++ b/tests/ui/push-health/PushParent_test.jsx
@@ -69,7 +69,7 @@ describe('PushParent', () => {
       queryByTestId('health-status-76ee1827c820f34b3b595f887f57b4c847316fcc'),
     ).not.toBeInTheDocument();
     expect(
-      await waitForElement(() => getByText('87 tests need investigation')),
+      await waitForElement(() => getByText('87 items')),
     ).toBeInTheDocument();
   });
 
@@ -91,7 +91,7 @@ describe('PushParent', () => {
       getByText('00000827c820f34b3b595f887f57b4c847316fcc'),
     ).toBeInTheDocument();
     expect(
-      await waitForElement(() => getByText('87 tests need investigation')),
+      await waitForElement(() => getByText('87 items')),
     ).toBeInTheDocument();
   });
 

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -69,7 +69,7 @@ function PushCounts(props) {
     <div>
       {fixedByCommit >= 1 && (
         <span
-          className="badge badge-warning"
+          className="badge badge-warning ml-1"
           title="Count of Fixed By Commit tasks for this push"
         >
           {fixedByCommit}

--- a/ui/shared/PushHealthStatus.jsx
+++ b/ui/shared/PushHealthStatus.jsx
@@ -55,7 +55,7 @@ class PushHealthStatus extends Component {
   render() {
     const { repoName, revision } = this.props;
     const { needInvestigation, unsupported } = this.state;
-    const testsNeed = needInvestigation > 1 ? 'tests need' : 'test needs';
+    const items = needInvestigation > 1 ? 'items' : 'item';
     const icon =
       needInvestigation + unsupported === 0 ? faCheck : faExclamationTriangle;
     let healthStatus = 'OK';
@@ -63,12 +63,12 @@ class PushHealthStatus extends Component {
     let extraTitle = 'Looks good';
 
     if (unsupported) {
-      healthStatus = `${unsupported} unsupported tests`;
+      healthStatus = `${unsupported} unsupported ${items}`;
       badgeColor = 'warning';
       extraTitle = 'Indeterminate';
     }
     if (needInvestigation) {
-      healthStatus = `${needInvestigation} ${testsNeed} investigation`;
+      healthStatus = `${needInvestigation} ${items}`;
       badgeColor = 'danger';
       extraTitle = 'Needs investigation';
     }


### PR DESCRIPTION
This reverts commit 7e39d90a85617384f7b1fb9eaba857c5db49aaac.

Better wording on Push Health summary badge.
Fixed test to look for new wording of Push Health Badge.