### PR TITLE
Bug 1614581 - Remove related mozilla-inbound series when clicking through from Alerts view

### DIFF
--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -8,7 +8,6 @@ import PerfSeriesModel, {
   getSeriesName,
   getTestName,
 } from '../models/perfSeries';
-import { thPerformanceBranches } from '../helpers/constants';
 import RepositoryModel from '../models/repository';
 import JobModel from '../models/job';
 
@@ -392,10 +391,7 @@ export const getGraphsURL = (
   // the otherwise rather useless signature hash to avoid having to fetch this
   // information from the server)
   if (phFrameworksWithRelatedBranches.includes(performanceFrameworkId)) {
-    const branches =
-      alertRepository === 'mozilla-beta'
-        ? ['autoland']
-        : thPerformanceBranches.filter(branch => branch !== alertRepository);
+    const branches = alertRepository === 'mozilla-beta' ? ['autoland'] : [];
     url += branches
       .map(
         branch =>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1614581

prior to my changes, the only possible values for `branches` were `['autoland']` or `['mozilla-inbound']`

after confirming with @ionutgoldan that this is unlikely to change, I have removed the mapping and filtering, and left only URLs for autoland