### PR TITLE
Properly configure LOGGING_LEVEL

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -22,7 +22,7 @@ env = environ.Env()
 DEBUG = env.bool("TREEHERDER_DEBUG", default=False)
 
 # Papertrail logs WARNING messages. This env variable allows modifying the behaviour
-LOGGING_LEVEL = env.bool("LOGGING_LEVEL", default='DEBUG' if DEBUG else 'WARNING')
+LOGGING_LEVEL = env.str("LOGGING_LEVEL", default='DEBUG' if DEBUG else 'WARNING')
 
 GRAPHQL = env.bool("GRAPHQL", default=True)
 


### PR DESCRIPTION
Unfortunately it was being cast down to False rather than "INFO" or "DEBUG".
There were no fallouts from it but it was preventing setting the right logging
level for the Docker container or the Heroku Review Apps.