### PR TITLE
Bug 1615227 - AlertsView: Add first last to pagination

### DIFF
--- a/ui/perfherder/alerts/AlertsViewControls.jsx
+++ b/ui/perfherder/alerts/AlertsViewControls.jsx
@@ -112,9 +112,9 @@ export default class AlertsViewControls extends React.Component {
           ? hasMorePages() && (
               <Row className="justify-content-center">
                 <PaginationGroup
-                  pageNums={pageNums}
+                  viewablePageNums={pageNums}
                   updateParams={validated.updateParams}
-                  page={page}
+                  currentPage={page}
                   count={count}
                   fetchData={fetchAlertSummaries}
                 />
@@ -141,9 +141,9 @@ export default class AlertsViewControls extends React.Component {
           ? hasMorePages() && (
               <Row className="justify-content-center">
                 <PaginationGroup
-                  pageNums={pageNums}
+                  viewablePageNums={pageNums}
                   updateParams={validated.updateParams}
-                  page={page}
+                  currentPage={page}
                   count={count}
                   fetchData={fetchAlertSummaries}
                 />

--- a/ui/perfherder/alerts/Pagination.jsx
+++ b/ui/perfherder/alerts/Pagination.jsx
@@ -10,25 +10,39 @@ class PaginationGroup extends React.Component {
   };
 
   render() {
-    const { pageNums, page, count } = this.props;
+    const { viewablePageNums, currentPage, count } = this.props;
+    // First and last viewable pages from the pagination. The controls
+    // shows maximum 5 pages.
+    const firstViewablePage = viewablePageNums[0];
+    const lastViewablePage = viewablePageNums[viewablePageNums.length - 1];
+
     return (
       /* The first and last pagination navigation links
          aren't working correctly (icons aren't visible)
          so they haven't been added */
-      <Pagination aria-label={`Page ${page}`}>
-        {page > 1 && (
+      <Pagination aria-label={`Page ${currentPage}`}>
+        {firstViewablePage > 1 && (
+          <PaginationItem className="text-info">
+            <PaginationLink
+              className="text-info"
+              first
+              onClick={() => this.navigatePage(1)}
+            />
+          </PaginationItem>
+        )}
+        {currentPage > 1 && (
           <PaginationItem>
             <PaginationLink
               className="text-info"
               previous
-              onClick={() => this.navigatePage(page - 1)}
+              onClick={() => this.navigatePage(currentPage - 1)}
             />
           </PaginationItem>
         )}
-        {pageNums.map((num) => (
+        {viewablePageNums.map((num) => (
           <PaginationItem
             key={num}
-            active={num === page}
+            active={num === currentPage}
             className="text-info pagination-active"
           >
             <PaginationLink
@@ -39,12 +53,21 @@ class PaginationGroup extends React.Component {
             </PaginationLink>
           </PaginationItem>
         ))}
-        {page < count && (
+        {currentPage < count && (
           <PaginationItem>
             <PaginationLink
               className="text-info"
               next
-              onClick={() => this.navigatePage(page + 1)}
+              onClick={() => this.navigatePage(currentPage + 1)}
+            />
+          </PaginationItem>
+        )}
+        {lastViewablePage < count && (
+          <PaginationItem className="text-info">
+            <PaginationLink
+              className="text-info"
+              last
+              onClick={() => this.navigatePage(count)}
             />
           </PaginationItem>
         )}
@@ -54,15 +77,15 @@ class PaginationGroup extends React.Component {
 }
 
 PaginationGroup.propTypes = {
-  pageNums: PropTypes.arrayOf(PropTypes.number).isRequired,
-  page: PropTypes.number,
+  viewablePageNums: PropTypes.arrayOf(PropTypes.number).isRequired,
+  currentPage: PropTypes.number,
   count: PropTypes.number,
   fetchData: PropTypes.func.isRequired,
   updateParams: PropTypes.func.isRequired,
 };
 
 PaginationGroup.defaultProps = {
-  page: 1,
+  currentPage: 1,
   count: 1,
 };
 


### PR DESCRIPTION
I have the solution but I would wait until [Alerts view gets stuck on last page](https://bugzilla.mozilla.org/show_bug.cgi?id=1595111) is merged because this could cause many accidental clicks on last page (I just did quite a few while testing it) and provoke frustration to sheriffs.
![Screenshot from 2020-02-14 11-16-13](https://user-images.githubusercontent.com/47977085/74528015-d727fa00-4f2f-11ea-8d4d-6daea088c803.png)
