### PR TITLE
Align the dropdown dropmarkers on the navbar in the exact middle, so …

### DIFF
--- a/ui/css/treeherder-navbar.css
+++ b/ui/css/treeherder-navbar.css
@@ -89,6 +89,7 @@ label.dropdown-item.active,
 
 .nav-menu-btn:after {
   font-size: 14px;
+  vertical-align: middle;
 }
 
 .nav-help-btn {


### PR DESCRIPTION
…they stop floating.

This is simply something small that's be bothering me and I just *had* to fix it. I hope you don't mind!