### PR TITLE
Bug 1513583 - Enable ESLint a11y rules

### DIFF
--- a/ui/css/treeherder-global.css
+++ b/ui/css/treeherder-global.css
@@ -506,22 +506,14 @@ h4 {
 /*
  * Onscreen help
  */
-
-#onscreen-overlay {
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  z-index: 9000;
-  background: rgba(0, 0, 0, 0.4);
-}
-
 #onscreen-shortcuts {
   position: fixed;
   top: 50%;
-  left: 16.5%;
-  transform: translateY(-50%);
+  left: 50%;
+  transform: translate(-50%, -50%);
   z-index: 10000;
   width: 100%;
+  max-width: 960px;
 }
 
 #onscreen-shortcuts div div.card {

--- a/ui/intermittent-failures/BugColumn.jsx
+++ b/ui/intermittent-failures/BugColumn.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
@@ -33,6 +31,8 @@ function BugColumn({
       </a>
       &nbsp;
       <span
+        role="link"
+        tabIndex={0}
         className="ml-1 small-text bug-details"
         onClick={() => updateAppState({ graphData, tableData })}
       >

--- a/ui/intermittent-failures/BugColumn.jsx
+++ b/ui/intermittent-failures/BugColumn.jsx
@@ -30,22 +30,17 @@ function BugColumn({
         {id}
       </a>
       &nbsp;
-      <span
-        role="link"
-        tabIndex={0}
+      <Link
         className="ml-1 small-text bug-details"
         onClick={() => updateAppState({ graphData, tableData })}
+        to={{
+          pathname: '/bugdetails',
+          search: `?startday=${startday}&endday=${endday}&tree=${tree}&bug=${id}`,
+          state: { startday, endday, tree, id, summary, location },
+        }}
       >
-        <Link
-          to={{
-            pathname: '/bugdetails',
-            search: `?startday=${startday}&endday=${endday}&tree=${tree}&bug=${id}`,
-            state: { startday, endday, tree, id, summary, location },
-          }}
-        >
-          details
-        </Link>
-      </span>
+        details
+      </Link>
     </div>
   );
 }

--- a/ui/job-view/App.jsx
+++ b/ui/job-view/App.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Modal } from 'reactstrap';
 import { hot } from 'react-hot-loader/root';
 import SplitPane from 'react-split-pane';
 import pick from 'lodash/pick';
@@ -384,20 +385,13 @@ class App extends React.Component {
               </>
             </SplitPane>
             <Notifications />
-            {showShortCuts && (
-              <div
-                role="button"
-                tabIndex={0}
-                id="onscreen-overlay"
-                onClick={() => this.showOnScreenShortcuts(false)}
-              >
-                <div id="onscreen-shortcuts">
-                  <div className="col-8">
-                    <ShortcutTable />
-                  </div>
-                </div>
-              </div>
-            )}
+            <Modal
+              isOpen={showShortCuts}
+              toggle={() => this.showOnScreenShortcuts(false)}
+              id="onscreen-shortcuts"
+            >
+              <ShortcutTable />
+            </Modal>
           </KeyboardShortcuts>
         </Provider>
       </div>

--- a/ui/job-view/App.jsx
+++ b/ui/job-view/App.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import { hot } from 'react-hot-loader/root';
 import SplitPane from 'react-split-pane';
@@ -388,6 +386,8 @@ class App extends React.Component {
             <Notifications />
             {showShortCuts && (
               <div
+                role="button"
+                tabIndex={0}
                 id="onscreen-overlay"
                 onClick={() => this.showOnScreenShortcuts(false)}
               >

--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -396,27 +396,23 @@ class PinBoard extends React.Component {
               )}
               {Object.values(pinnedJobs).map(job => (
                 <span className="btn-group" key={job.id}>
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    className={`btn pinned-job ${getBtnClass(
+                  <Button
+                    className={`pinned-job mb-1 ${getBtnClass(
                       job.resultStatus,
                       job.failure_classification_id,
-                    )} ${
-                      selectedJobId === job.id
-                        ? 'btn-lg selected-job'
-                        : 'btn-xs'
-                    }`}
+                    )} ${selectedJobId === job.id ? 'selected-job' : ''}`}
                     title={job.hoverText}
                     onClick={() => setSelectedJob(job)}
                     data-job-id={job.job_id}
+                    size={selectedJobId === job.id ? 'large' : 'small'}
+                    outline
                   >
                     {job.job_type_symbol}
-                  </span>
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    className={`btn btn-ltgray pinned-job-close-btn ${
+                  </Button>
+                  <Button
+                    color="secondary"
+                    outline
+                    className={`pinned-job-close-btn ${
                       selectedJobId === job.id
                         ? 'btn-lg selected-job'
                         : 'btn-xs'
@@ -425,7 +421,7 @@ class PinBoard extends React.Component {
                     title="un-pin this job"
                   >
                     <FontAwesomeIcon icon={faTimes} title="Unpin job" />
-                  </span>
+                  </Button>
                 </span>
               ))}
             </div>
@@ -434,12 +430,11 @@ class PinBoard extends React.Component {
           {/* Related bugs */}
           <div id="pinboard-related-bugs">
             <div className="content">
-              <span
-                role="button"
-                tabIndex={0}
+              <Button
+                color="link"
                 id="add-related-bug-button"
                 onClick={() => this.toggleEnterBugNumber(!enteringBugNumber)}
-                className="pointable"
+                className="pointable p-0"
                 title="Add a related bug"
               >
                 <FontAwesomeIcon
@@ -447,18 +442,17 @@ class PinBoard extends React.Component {
                   className="add-related-bugs-icon"
                   title="Add related bugs"
                 />
-              </span>
+              </Button>
               {!this.hasPinnedJobBugs() && (
-                <span
-                  role="button"
-                  tabIndex={0}
-                  className="pinboard-preload-txt pinboard-related-bug-preload-txt"
+                <Button
+                  color="link"
+                  className="pinboard-preload-txt pinboard-related-bug-preload-txt p-0 text-decoration-none"
                   onClick={() => {
                     this.toggleEnterBugNumber(!enteringBugNumber);
                   }}
                 >
                   click to add a related bug
-                </span>
+                </Button>
               )}
               {enteringBugNumber && (
                 <span className="add-related-bugs-form">
@@ -490,15 +484,15 @@ class PinBoard extends React.Component {
                     >
                       <em>{bug.id}</em>
                     </a>
-                    <span
-                      role="button"
-                      tabIndex={0}
-                      className="btn btn-ltgray btn-xs pinned-job-close-btn"
+                    <Button
+                      color="secondary"
+                      outline
+                      className="btn-xs pinned-job-close-btn"
                       onClick={() => removeBug(bug.id)}
                       title="remove this bug"
                     >
                       <FontAwesomeIcon icon={faTimes} title="Remove bug" />
-                    </span>
+                    </Button>
                   </span>
                 </span>
               ))}

--- a/ui/job-view/details/PinBoard.jsx
+++ b/ui/job-view/details/PinBoard.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -399,6 +397,8 @@ class PinBoard extends React.Component {
               {Object.values(pinnedJobs).map(job => (
                 <span className="btn-group" key={job.id}>
                   <span
+                    role="button"
+                    tabIndex={0}
                     className={`btn pinned-job ${getBtnClass(
                       job.resultStatus,
                       job.failure_classification_id,
@@ -414,6 +414,8 @@ class PinBoard extends React.Component {
                     {job.job_type_symbol}
                   </span>
                   <span
+                    role="button"
+                    tabIndex={0}
                     className={`btn btn-ltgray pinned-job-close-btn ${
                       selectedJobId === job.id
                         ? 'btn-lg selected-job'
@@ -433,6 +435,8 @@ class PinBoard extends React.Component {
           <div id="pinboard-related-bugs">
             <div className="content">
               <span
+                role="button"
+                tabIndex={0}
                 id="add-related-bug-button"
                 onClick={() => this.toggleEnterBugNumber(!enteringBugNumber)}
                 className="pointable"
@@ -446,6 +450,8 @@ class PinBoard extends React.Component {
               </span>
               {!this.hasPinnedJobBugs() && (
                 <span
+                  role="button"
+                  tabIndex={0}
                   className="pinboard-preload-txt pinboard-related-bug-preload-txt"
                   onClick={() => {
                     this.toggleEnterBugNumber(!enteringBugNumber);
@@ -485,6 +491,8 @@ class PinBoard extends React.Component {
                       <em>{bug.id}</em>
                     </a>
                     <span
+                      role="button"
+                      tabIndex={0}
                       className="btn btn-ltgray btn-xs pinned-job-close-btn"
                       onClick={() => removeBug(bug.id)}
                       title="remove this bug"

--- a/ui/job-view/details/tabs/AnnotationsTab.jsx
+++ b/ui/job-view/details/tabs/AnnotationsTab.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -32,6 +30,8 @@ function RelatedBugSaved(props) {
         <em>{bugId}</em>
       </a>
       <span
+        role="button"
+        tabIndex={0}
         className="btn classification-delete-icon hover-warning btn-xs pinned-job-close-btn annotations-bug"
         onClick={() => deleteBug(bug)}
         title={`Delete relation to bug ${bugId}`}
@@ -97,6 +97,8 @@ function TableRow(props) {
       <td>{text}</td>
       <td>
         <span
+          role="button"
+          tabIndex={0}
           onClick={deleteEvent}
           className="classification-delete-icon hover-warning pointable"
           title="Delete this classification"

--- a/ui/job-view/details/tabs/AnnotationsTab.jsx
+++ b/ui/job-view/details/tabs/AnnotationsTab.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Button } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faStar as faStarRegular } from '@fortawesome/free-regular-svg-icons';
 import {
@@ -29,15 +30,15 @@ function RelatedBugSaved(props) {
       >
         <em>{bugId}</em>
       </a>
-      <span
-        role="button"
-        tabIndex={0}
-        className="btn classification-delete-icon hover-warning btn-xs pinned-job-close-btn annotations-bug"
+      <Button
+        color="link"
+        size="xs"
+        className="classification-delete-icon hover-warning pinned-job-close-btn annotations-bug"
         onClick={() => deleteBug(bug)}
         title={`Delete relation to bug ${bugId}`}
       >
         <FontAwesomeIcon icon={faTimesCircle} title="Delete" />
-      </span>
+      </Button>
     </span>
   );
 }
@@ -96,15 +97,14 @@ function TableRow(props) {
       </td>
       <td>{text}</td>
       <td>
-        <span
-          role="button"
-          tabIndex={0}
+        <Button
+          color="link"
           onClick={deleteEvent}
           className="classification-delete-icon hover-warning pointable"
           title="Delete this classification"
         >
           <FontAwesomeIcon icon={faTimesCircle} title="Delete classification" />
-        </span>
+        </Button>
       </td>
     </tr>
   );

--- a/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Button } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBug } from '@fortawesome/free-solid-svg-icons';
 
@@ -28,15 +29,15 @@ export default class SuggestionsListItem extends React.Component {
     return (
       <li>
         <div>
-          <span
-            role="button"
-            tabIndex={0}
-            className="btn btn-xs btn-light-bordered link-style"
+          <Button
+            color="link"
+            size="xs"
+            className="btn btn-light-bordered link-style"
             onClick={() => toggleBugFiler(suggestion)}
             title="file a bug for this failure"
           >
             <FontAwesomeIcon icon={faBug} title="File bug" />
-          </span>
+          </Button>
           <span>{suggestion.search}</span>
         </div>
 
@@ -56,15 +57,14 @@ export default class SuggestionsListItem extends React.Component {
 
         {/* <!--All other bugs--> */}
         {suggestion.valid_all_others && suggestion.valid_open_recent && (
-          <span
-            role="button"
-            tabIndex={0}
+          <Button
+            color="link"
             rel="noopener"
             onClick={this.clickShowMore}
             className="show-hide-more"
           >
             Show / Hide more
-          </span>
+          </Button>
         )}
 
         {suggestion.valid_all_others &&

--- a/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/job-view/details/tabs/failureSummary/SuggestionsListItem.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -31,6 +29,8 @@ export default class SuggestionsListItem extends React.Component {
       <li>
         <div>
           <span
+            role="button"
+            tabIndex={0}
             className="btn btn-xs btn-light-bordered link-style"
             onClick={() => toggleBugFiler(suggestion)}
             title="file a bug for this failure"
@@ -57,6 +57,8 @@ export default class SuggestionsListItem extends React.Component {
         {/* <!--All other bugs--> */}
         {suggestion.valid_all_others && suggestion.valid_open_recent && (
           <span
+            role="button"
+            tabIndex={0}
             rel="noopener"
             onClick={this.clickShowMore}
             className="show-hide-more"

--- a/ui/job-view/headerbars/ActiveFilters.jsx
+++ b/ui/job-view/headerbars/ActiveFilters.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -86,6 +84,8 @@ export default class ActiveFilters extends React.Component {
         {!!filterBarFilters.length && (
           <div>
             <span
+              role="button"
+              tabIndex={0}
               className="pointable"
               title="Clear all of these filters"
               onClick={filterModel.clearNonStatusFilters}
@@ -105,6 +105,8 @@ export default class ActiveFilters extends React.Component {
                   key={`${filter.field}${filterValue}`}
                 >
                   <span
+                    role="button"
+                    tabIndex={0}
                     className="pointable"
                     title={`Clear filter: ${filter.field}`}
                     onClick={() =>

--- a/ui/job-view/headerbars/ActiveFilters.jsx
+++ b/ui/job-view/headerbars/ActiveFilters.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Button } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 
@@ -83,10 +84,10 @@ export default class ActiveFilters extends React.Component {
       <div className="alert-info active-filters-bar">
         {!!filterBarFilters.length && (
           <div>
-            <span
-              role="button"
-              tabIndex={0}
-              className="pointable"
+            <Button
+              color="darker-info"
+              outline
+              className="pointable bg-transparent border-0 pt-0 pr-1 pb-1"
               title="Clear all of these filters"
               onClick={filterModel.clearNonStatusFilters}
             >
@@ -94,7 +95,7 @@ export default class ActiveFilters extends React.Component {
                 icon={faTimesCircle}
                 title="Clear all these filters"
               />{' '}
-            </span>
+            </Button>
             <span className="active-filters-title">
               <b>Active Filters</b>
             </span>
@@ -104,10 +105,10 @@ export default class ActiveFilters extends React.Component {
                   className="filtersbar-filter"
                   key={`${filter.field}${filterValue}`}
                 >
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    className="pointable"
+                  <Button
+                    color="darker-info"
+                    outline
+                    className="pointable bg-transparent border-0 py-0 pr-1"
                     title={`Clear filter: ${filter.field}`}
                     onClick={() =>
                       filterModel.removeFilter(filter.field, filterValue)
@@ -118,7 +119,7 @@ export default class ActiveFilters extends React.Component {
                       title={`Clear filter: ${filter.field}`}
                     />
                     &nbsp;
-                  </span>
+                  </Button>
                   <span title={`Filter by ${filter.field}: ${filterValue}`}>
                     <b>{filter.field}:</b>
                     {filter.field === 'failure_classification_id' && (

--- a/ui/job-view/headerbars/SecondaryNavBar.jsx
+++ b/ui/job-view/headerbars/SecondaryNavBar.jsx
@@ -234,17 +234,16 @@ class SecondaryNavBar extends React.PureComponent {
           </span>
           <form role="search" className="form-inline flex-row">
             {serverChanged && (
-              <span
-                role="link"
-                tabIndex={0}
-                className="btn btn-sm btn-view-nav nav-menu-btn"
+              <Button
+                size="sm"
+                className="btn-view-nav nav-menu-btn"
                 onClick={updateButtonClick}
                 id="revisionChangedLabel"
                 title="New version of Treeherder has been deployed. Reload to pick up changes."
               >
                 <FontAwesomeIcon icon={faExclamationCircle} />
                 &nbsp;Treeherder update available
-              </span>
+              </Button>
             )}
 
             {/* Unclassified Failures Button */}
@@ -341,10 +340,9 @@ class SecondaryNavBar extends React.PureComponent {
             </span>
 
             <span>
-              <span
-                role="button"
-                tabIndex={0}
-                className="btn btn-view-nav btn-sm"
+              <Button
+                size="sm"
+                className="btn-view-nav"
                 onClick={toggleFieldFilterVisible}
                 title="Filter by a job field"
               >
@@ -353,7 +351,7 @@ class SecondaryNavBar extends React.PureComponent {
                   size="sm"
                   title="Filter by a job field"
                 />
-              </span>
+              </Button>
             </span>
             <span>
               <TierIndicator filterModel={filterModel} />

--- a/ui/job-view/headerbars/SecondaryNavBar.jsx
+++ b/ui/job-view/headerbars/SecondaryNavBar.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import { Button } from 'reactstrap';
 import PropTypes from 'prop-types';
@@ -237,6 +235,8 @@ class SecondaryNavBar extends React.PureComponent {
           <form role="search" className="form-inline flex-row">
             {serverChanged && (
               <span
+                role="link"
+                tabIndex={0}
                 className="btn btn-sm btn-view-nav nav-menu-btn"
                 onClick={updateButtonClick}
                 id="revisionChangedLabel"
@@ -342,6 +342,8 @@ class SecondaryNavBar extends React.PureComponent {
 
             <span>
               <span
+                role="button"
+                tabIndex={0}
                 className="btn btn-view-nav btn-sm"
                 onClick={toggleFieldFilterVisible}
                 title="Filter by a job field"

--- a/ui/job-view/pushes/PushJobs.jsx
+++ b/ui/job-view/pushes/PushJobs.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -108,32 +106,34 @@ class PushJobs extends React.Component {
 
     return (
       <table id={this.aggregateId} className="table-hover">
-        <tbody onMouseDown={this.onMouseDown}>
-          {platforms ? (
-            platforms.map(platform => (
-              <Platform
-                platform={platform}
-                repoName={repoName}
-                filterModel={filterModel}
-                pushGroupState={pushGroupState}
-                key={`${platform.name}${platform.option}`}
-                duplicateJobsVisible={duplicateJobsVisible}
-                groupCountsExpanded={groupCountsExpanded}
-                runnableVisible={runnableVisible}
-              />
-            ))
-          ) : (
-            <tr>
-              <td>
-                <FontAwesomeIcon
-                  icon={faSpinner}
-                  pulse
-                  className="th-spinner"
-                  title="Loading..."
+        <tbody>
+          <div role="button" tabIndex={0} onMouseDown={this.onMouseDown}>
+            {platforms ? (
+              platforms.map(platform => (
+                <Platform
+                  platform={platform}
+                  repoName={repoName}
+                  filterModel={filterModel}
+                  pushGroupState={pushGroupState}
+                  key={`${platform.name}${platform.option}`}
+                  duplicateJobsVisible={duplicateJobsVisible}
+                  groupCountsExpanded={groupCountsExpanded}
+                  runnableVisible={runnableVisible}
                 />
-              </td>
-            </tr>
-          )}
+              ))
+            ) : (
+              <tr>
+                <td>
+                  <FontAwesomeIcon
+                    icon={faSpinner}
+                    pulse
+                    className="th-spinner"
+                    title="Loading..."
+                  />
+                </td>
+              </tr>
+            )}
+          </div>
         </tbody>
       </table>
     );

--- a/ui/job-view/pushes/PushJobs.jsx
+++ b/ui/job-view/pushes/PushJobs.jsx
@@ -105,9 +105,9 @@ class PushJobs extends React.Component {
     } = this.props;
 
     return (
-      <table id={this.aggregateId} className="table-hover">
-        <tbody>
-          <div role="button" tabIndex={0} onMouseDown={this.onMouseDown}>
+      <div role="button" tabIndex={0} onMouseDown={this.onMouseDown}>
+        <table id={this.aggregateId} className="table-hover">
+          <tbody>
             {platforms ? (
               platforms.map(platform => (
                 <Platform
@@ -133,9 +133,9 @@ class PushJobs extends React.Component {
                 </td>
               </tr>
             )}
-          </div>
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </div>
     );
   }
 }

--- a/ui/job-view/pushes/PushList.jsx
+++ b/ui/job-view/pushes/PushList.jsx
@@ -1,6 +1,3 @@
-/* eslint-disable jsx-a11y/control-has-associated-label */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -141,6 +138,8 @@ class PushList extends React.Component {
     }
     return (
       <div
+        role="button"
+        tabIndex={0}
         id="push-list"
         onClick={evt => this.clearIfEligibleTarget(evt.target)}
       >
@@ -170,6 +169,7 @@ class PushList extends React.Component {
           <div
             className="progress active progress-bar progress-bar-striped"
             role="progressbar"
+            aria-label="Loading tests"
           />
         )}
         {pushList.length === 0 && !loadingPushes && (
@@ -185,6 +185,8 @@ class PushList extends React.Component {
           <div className="btn-group">
             {[10, 20, 50].map(count => (
               <div
+                role="button"
+                tabIndex={0}
                 className="btn btn-light-bordered"
                 onClick={() => fetchNextPushes(count)}
                 key={count}

--- a/ui/job-view/pushes/PushList.jsx
+++ b/ui/job-view/pushes/PushList.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Button } from 'reactstrap';
 import { connect } from 'react-redux';
 import intersection from 'lodash/intersection';
 import isEqual from 'lodash/isEqual';
@@ -184,16 +185,16 @@ class PushList extends React.Component {
           <span>get next:</span>
           <div className="btn-group">
             {[10, 20, 50].map(count => (
-              <div
-                role="button"
-                tabIndex={0}
-                className="btn btn-light-bordered"
+              <Button
+                color="darker-secondary"
+                outline
+                className="btn-light-bordered"
                 onClick={() => fetchNextPushes(count)}
                 key={count}
                 data-testid={`get-next-${count}`}
               >
                 {count}
-              </div>
+              </Button>
             ))}
           </div>
         </div>

--- a/ui/perfherder/compare/CompareTable.jsx
+++ b/ui/perfherder/compare/CompareTable.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/control-has-associated-label */
-
 import React from 'react';
 import { Button, Table } from 'reactstrap';
 import PropTypes from 'prop-types';
@@ -60,7 +58,7 @@ export default class CompareTable extends React.PureComponent {
             </th>
             <th className="table-width-lg">Base</th>
             {/* empty for less than/greater than data */}
-            <th className="table-width-sm" />
+            <th className="table-width-sm" aria-label="Comparison" />
             <th className="table-width-lg">New</th>
             <th className="table-width-lg">Delta</th>
             <th className="table-width-lg">Magnitude of Difference</th>

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Badge, FormGroup, Input } from 'reactstrap';
+import { Badge, Button, FormGroup, Input } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
@@ -133,10 +133,8 @@ const LegendCard = ({
 
   return (
     <FormGroup check className="pl-0 border">
-      <span
-        role="button"
-        tabIndex={0}
-        className="close mr-3 my-2 ml-2"
+      <Button
+        className="close mr-3 my-2 ml-2 bg-transparent"
         onClick={removeTest}
       >
         <FontAwesomeIcon
@@ -145,11 +143,11 @@ const LegendCard = ({
           size="xs"
           title=""
         />
-      </span>
+      </Button>
       <div className={`${series.color[0]} graph-legend-card p-3`}>
-        <div
-          role="button"
-          tabIndex={0}
+        <Button
+          color="link"
+          outline
           className={`p-0 mb-0 pointer border-0 ${
             series.visible ? series.color[0] : 'text-muted'
           } text-left`}
@@ -163,35 +161,35 @@ const LegendCard = ({
           />
 
           {series.name}
-        </div>
-        <div
-          role="button"
-          tabIndex={0}
-          className={subtitleStyle}
+        </Button>
+        <Button
+          color="link"
+          outline
+          className={`w-100  ${subtitleStyle}`}
           onClick={() => addTestData('addRelatedBranches')}
           title="Add related branches"
         >
           {series.repository_name}
-        </div>
-        <div
-          role="button"
-          tabIndex={0}
-          className={subtitleStyle}
+        </Button>
+        <Button
+          color="link"
+          outline
+          className={`w-100  ${subtitleStyle}`}
           onClick={() => addTestData('addRelatedPlatform')}
           title="Add related platforms and branches"
         >
           {series.platform}
-        </div>
+        </Button>
         {series.application && (
-          <div
-            role="button"
-            tabIndex={0}
-            className={subtitleStyle}
+          <Button
+            color="link"
+            outline
+            className={`w-100  ${subtitleStyle}`}
             title="Add related applications"
             onClick={() => addTestData('addRelatedApplications')}
           >
             {series.application}
-          </div>
+          </Button>
         )}
         <Badge> {getFrameworkName(frameworks, series.framework_id)} </Badge>
         <div className="small">{`${series.signatureHash.slice(0, 16)}...`}</div>

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -1,6 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Badge, FormGroup, Input } from 'reactstrap';
@@ -136,7 +133,12 @@ const LegendCard = ({
 
   return (
     <FormGroup check className="pl-0 border">
-      <span className="close mr-3 my-2 ml-2" onClick={removeTest}>
+      <span
+        role="button"
+        tabIndex={0}
+        className="close mr-3 my-2 ml-2"
+        onClick={removeTest}
+      >
         <FontAwesomeIcon
           className="pointer"
           icon={faTimes}
@@ -145,13 +147,14 @@ const LegendCard = ({
         />
       </span>
       <div className={`${series.color[0]} graph-legend-card p-3`}>
-        <p
+        <div
+          role="button"
+          tabIndex={0}
           className={`p-0 mb-0 pointer border-0 ${
             series.visible ? series.color[0] : 'text-muted'
           } text-left`}
           onClick={() => addTestData('addRelatedConfigs')}
           title="Add related configurations"
-          type="button"
         >
           <GraphIcon
             iconType={symbolType[0]}
@@ -160,32 +163,35 @@ const LegendCard = ({
           />
 
           {series.name}
-        </p>
-        <p
+        </div>
+        <div
+          role="button"
+          tabIndex={0}
           className={subtitleStyle}
           onClick={() => addTestData('addRelatedBranches')}
           title="Add related branches"
-          type="button"
         >
           {series.repository_name}
-        </p>
-        <p
+        </div>
+        <div
+          role="button"
+          tabIndex={0}
           className={subtitleStyle}
           onClick={() => addTestData('addRelatedPlatform')}
           title="Add related platforms and branches"
-          type="button"
         >
           {series.platform}
-        </p>
+        </div>
         {series.application && (
-          <p
+          <div
+            role="button"
+            tabIndex={0}
             className={subtitleStyle}
             title="Add related applications"
             onClick={() => addTestData('addRelatedApplications')}
-            type="button"
           >
             {series.application}
-          </p>
+          </div>
         )}
         <Badge> {getFrameworkName(frameworks, series.framework_id)} </Badge>
         <div className="small">{`${series.signatureHash.slice(0, 16)}...`}</div>

--- a/ui/test-view/ui/Test.jsx
+++ b/ui/test-view/ui/Test.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { Badge } from 'reactstrap';
+import { Badge, Button } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faBug,
@@ -246,14 +246,9 @@ class TestComponent extends React.Component {
   render() {
     return (
       <td className="test-table">
-        <span
-          role="button"
-          tabIndex={0}
-          className="test"
-          onClick={this.onClick}
-        >
+        <Button className="test" onClick={this.onClick}>
           {this.props.name}
-        </span>
+        </Button>
         <span className="platform-list">
           {this.props.test.jobs.map(job => (
             <Platform

--- a/ui/test-view/ui/Test.jsx
+++ b/ui/test-view/ui/Test.jsx
@@ -1,6 +1,4 @@
 /* eslint-disable max-classes-per-file */
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -48,25 +46,27 @@ class BugCountComponent extends React.Component {
 
   render() {
     return (
-      <td className="bug-count" onClick={this.onClick}>
-        {// TODO: Clean this up
-        // eslint-disable-next-line no-nested-ternary
-        this.props.test.bugs === undefined ? (
-          <FontAwesomeIcon
-            icon={faMinus}
-            title="Click to expand and fetch bugs"
-          />
-        ) : Object.keys(this.props.test.bugs).length > 0 ? (
-          Object.keys(this.props.test.bugs).length
-        ) : (
-          <Badge
-            size="sm"
-            color="danger"
-            style={{ fontWeight: 400, fontSize: '.8rem', margin: '0 .5rem' }}
-          >
-            0
-          </Badge>
-        )}
+      <td className="bug-count">
+        <div role="button" tabIndex={0} onClick={this.onClick}>
+          {// TODO: Clean this up
+          // eslint-disable-next-line no-nested-ternary
+          this.props.test.bugs === undefined ? (
+            <FontAwesomeIcon
+              icon={faMinus}
+              title="Click to expand and fetch bugs"
+            />
+          ) : Object.keys(this.props.test.bugs).length > 0 ? (
+            Object.keys(this.props.test.bugs).length
+          ) : (
+            <Badge
+              size="sm"
+              color="danger"
+              style={{ fontWeight: 400, fontSize: '.8rem', margin: '0 .5rem' }}
+            >
+              0
+            </Badge>
+          )}
+        </div>
       </td>
     );
   }
@@ -246,7 +246,12 @@ class TestComponent extends React.Component {
   render() {
     return (
       <td className="test-table">
-        <span className="test" onClick={this.onClick}>
+        <span
+          role="button"
+          tabIndex={0}
+          className="test"
+          onClick={this.onClick}
+        >
           {this.props.name}
         </span>
         <span className="platform-list">


### PR DESCRIPTION
## Description of issue
There are rules disabled in some components. This removes the exceptions for a11y ESlint rules and fix them.

Note: `ActionBar`, `FiltersMenu` and `PushActionMenu` were not changed, as they were fixed in another PR.