### PR TITLE
Revert "Heroku Review Apps: Bump the plan for JawsDB (#5948)"

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "heroku-redis:premium-0",
     "papertrail:choklad",
     {
-      "plan": "jawsdb:whitetip",
+      "plan": "jawsdb:blacktip",
       "options": {
         "version": "5.7"
       }


### PR DESCRIPTION
This reverts commit 634d056e3d9cbeee4468a84a1683b25bfaba8c50.

This is due to the add-on taking longer to start up than the shared add-on
*and* the release step not executing as the last step, thus, the DB is not
avalaible for the release step.

I have filed a Heroku ticket to solve this.