### PR TITLE
Make coverage reporting fluctuate less

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         # `yarn lint` only checks the formatting of JS/JSX, this will also check CSS/HTML/JSON/Markdown/YAML.
         - yarn format:check
         - yarn test:coverage
-      after_success: yarn codecov
+        - yarn codecov
 
     - env: test-prod-build
       language: node_js
@@ -40,7 +40,6 @@ matrix:
         - pip install codecov --user
       script:
         - docker-compose run backend ./runtests.sh
-      after_success:
         - codecov -f coverage.xml
 
     - env: python-tests-main
@@ -55,7 +54,6 @@ matrix:
         - docker-compose run -e SITE_URL=https://treeherder.dev -e TREEHERDER_DEBUG=False backend python -bb ./manage.py check --deploy --fail-level WARNING
         # Using `-bb` mode to surface BytesWarnings: https://docs.python.org/3.7/using/cmdline.html#cmdoption-b
         - docker-compose run backend bash -c "pytest --cov --cov-report=xml tests/ --runslow --ignore=tests/selenium"
-      after_success:
         - codecov -f coverage.xml
 
     - env: python-tests-selenium
@@ -76,7 +74,6 @@ matrix:
       script:
         # Using `-bb` mode to surface BytesWarnings: https://docs.python.org/3.7/using/cmdline.html#cmdoption-b
         - docker-compose run backend bash -c "pytest --cov --cov-report=xml tests/selenium/"
-      after_success:
         - codecov -f coverage.xml
 
 notifications:


### PR DESCRIPTION
If any step on the Travis run fails (like formatting checks or a test) then
we don't report the code coverage for it.

Unfortunately, this can be distracting when we see status checks
reporting a failure or a big change.

This change makes code coverage to report even if there are minor
failures.