### PR TITLE
Bug 1615535 Changing alert's status/assignee changes page's content

### DIFF
--- a/ui/perfherder/alerts/AlertsView.jsx
+++ b/ui/perfherder/alerts/AlertsView.jsx
@@ -333,7 +333,7 @@ class AlertsView extends React.Component {
             frameworkOptions={frameworkOptions}
             issueTrackers={issueTrackers}
             optionCollectionMap={optionCollectionMap}
-            fetchAlertSummaries={(id, update, page) =>
+            fetchAlertSummaries={(id, page, update = true) =>
               this.fetchAlertSummaries(id, update, page)
             }
             updateViewState={state => this.setState(state)}


### PR DESCRIPTION
This is a fix for [Bug 1565480](https://bugzilla.mozilla.org/show_bug.cgi?id=1565480) that didn't kept update param of fetchAlertSummaries to true used to update alert statuses.
Recordings: [before](https://mozilla.zoom.us/rec/share/wZ1KD-H7-39JXJHy6nHGRYQwH6n4aaa8g3Ac_vUKmEwTcAhHyDy5QB9behtM74g?startTime=1582186704000) | [after](https://mozilla.zoom.us/rec/share/wZ1KD-H7-39JXJHy6nHGRYQwH6n4aaa8g3Ac_vUKmEwTcAhHyDy5QB9behtM74g?startTime=1582186417000)