### PR TITLE
Seta: Include job priorities that are set to expire in the future

### DIFF
--- a/treeherder/seta/job_priorities.py
+++ b/treeherder/seta/job_priorities.py
@@ -6,7 +6,8 @@ from treeherder.etl.seta import (get_reference_data_names,
                                  valid_platform)
 from treeherder.seta.models import JobPriority
 from treeherder.seta.settings import (SETA_LOW_VALUE_PRIORITY,
-                                      SETA_PROJECTS)
+                                      SETA_PROJECTS,
+                                      THE_FUTURE)
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +68,7 @@ class SETAJobPriorities:
             job_priorities = []
             for jp in self._query_job_priorities(priority=priority,
                                                  excluded_build_system_type='buildbot'):
-                if jp.has_expired():
+                if jp.has_expired() or jp.expiration_date == THE_FUTURE:
                     job_priorities.append(jp)
             ref_data_names = self._process(project,
                                            build_system='taskcluster',

--- a/treeherder/seta/preseed.py
+++ b/treeherder/seta/preseed.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import logging
 import os
@@ -6,9 +5,8 @@ import os
 from treeherder.etl.seta import (get_reference_data_names,
                                  transform)
 from treeherder.seta.models import JobPriority
-from treeherder.seta.settings import SETA_LOW_VALUE_PRIORITY
-
-THE_FUTURE = datetime.datetime(2100, 12, 31)
+from treeherder.seta.settings import (SETA_LOW_VALUE_PRIORITY,
+                                      THE_FUTURE)
 
 logger = logging.getLogger(__name__)
 

--- a/treeherder/seta/preseed.py
+++ b/treeherder/seta/preseed.py
@@ -56,9 +56,6 @@ def load_preseed(validate=False):
     the * field. For example: (linux64, pgo, *) matches all Linux 64 pgo tests
     """
     logger.info("About to load preseed.json")
-    if not JobPriority.objects.exists():
-        logger.warning("There's no JobPriority objects in the table. Call first ./manage.py initialize_seta")
-        return
 
     preseed = preseed_data()
     if validate:

--- a/treeherder/seta/settings.py
+++ b/treeherder/seta/settings.py
@@ -1,3 +1,7 @@
+import datetime
+
+THE_FUTURE = datetime.datetime(2100, 12, 31)
+
 # repos that SETA supports
 SETA_PROJECTS = [
     'autoland',


### PR DESCRIPTION
Expiration dates are set for new jobs for a period of two weeks where
a job's priority is not allowed to change.

For preseed jobs it is expected to never change yet we should include
them.