### PR TITLE
Bug 1618619 - Fix font differences caused by ESLint

### DIFF
--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -58,13 +58,13 @@ h1 {
   border-left: 10px solid;
 }
 
-.graph-legend-card > p {
+.graph-legend-card > button {
   word-wrap: break-word;
-  cursor: pointer;
   font-size: 13px;
+  max-width: 200px;
 }
 
-.graph-legend-card > p:hover {
+.graph-legend-card > button:hover {
   text-decoration: underline;
 }
 

--- a/ui/css/treeherder-custom-styles.css
+++ b/ui/css/treeherder-custom-styles.css
@@ -336,6 +336,12 @@
   border-color: #6c757d;
 }
 
+.btn-outline-darker-secondary {
+  color: #6c757d;
+  background-color: #fff;
+  border-color: #6c757d;
+}
+
 /*
  * Tables and panels
  */

--- a/ui/css/treeherder-details-panel.css
+++ b/ui/css/treeherder-details-panel.css
@@ -322,6 +322,7 @@ ul.failure-summary-list li .btn-xs {
 
 /* We override global anchor color to replicate TBPL here */
 .show-hide-more {
+  font-size: 11px;
   padding: 0 0 0 37px;
   color: #0000ee;
   cursor: pointer;

--- a/ui/css/treeherder-navbar-panels.css
+++ b/ui/css/treeherder-navbar-panels.css
@@ -24,6 +24,10 @@
   display: inline-block;
 }
 
+.filtersbar-filter button {
+  font-size: 12px;
+}
+
 .new-filter-input {
   margin-top: 5px;
 }

--- a/ui/css/treeherder-pinboard.css
+++ b/ui/css/treeherder-pinboard.css
@@ -91,17 +91,20 @@
 }
 
 .pinned-job {
+  font-size: 12px;
   margin-bottom: 2px;
   padding: 1px 2px;
   width: 3.5em;
 }
 
 .pinned-job-close-btn {
+  font-size: 12px;
   padding: 1px 2px 1px 2px;
   border-color: #fafafa #fafafa #fafafa transparent;
 }
 
 .pinboard-preload-txt {
+  font-size: 12px;
   color: #bfbfbf;
 }
 


### PR DESCRIPTION
## Description
This PR fixes some styles caused by enabling a11y ESLint, as pointed out [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1618619).

### Affected areas
#### Main View
**Active filters**
![active-filters](https://user-images.githubusercontent.com/3901809/75579663-146aac80-5a45-11ea-9505-8ab62de15c40.png)

**Get Next buttons**
![get-next](https://user-images.githubusercontent.com/3901809/75579667-159bd980-5a45-11ea-9e5c-9a992cf96d57.png)

-----------------

#### Main View's Details
**Show / Hide more button in Failure Summary**
![failure-summary-showmore](https://user-images.githubusercontent.com/3901809/75579666-15034300-5a45-11ea-8785-c9436a4b1b25.png)

**Pinboard Bug icon**

![pinboard-bug](https://user-images.githubusercontent.com/3901809/75579671-16347000-5a45-11ea-87ac-0579f84ce40a.png)

**Pinboard Add related bugs**

![pinboard-related](https://user-images.githubusercontent.com/3901809/75579673-16cd0680-5a45-11ea-8548-18a26b1eb3bc.png)

---------------

#### Perfherder's Graph

**Legend Cards**
![legend-card](https://user-images.githubusercontent.com/3901809/75579668-16347000-5a45-11ea-9376-9250800e117e.png)




