### PR TITLE
Bug 1619017 - Remove exception code for Thunderbird treenames in TreeStatus

### DIFF
--- a/ui/job-view/headerbars/WatchedRepo.jsx
+++ b/ui/job-view/headerbars/WatchedRepo.jsx
@@ -130,7 +130,6 @@ export default class WatchedRepo extends React.Component {
     const activeClass = watchedRepo === repoName ? 'active' : '';
     const { btnClass, icon, color } = statusInfo;
     const pulseIcon = statusInfo.pulseIcon || null;
-    const treeStatusName = TreeStatusModel.getTreeStatusName(watchedRepo);
     const changeRepoUrl = getRepoUrl(watchedRepo);
 
     return (
@@ -201,7 +200,7 @@ export default class WatchedRepo extends React.Component {
             )}
             <DropdownItem
               tag="a"
-              href={`https://treestatus.mozilla-releng.net/static/ui/treestatus/show/${treeStatusName}`}
+              href={`https://treestatus.mozilla-releng.net/static/ui/treestatus/show/${watchedRepo}`}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/ui/models/treeStatus.js
+++ b/ui/models/treeStatus.js
@@ -1,17 +1,8 @@
 const uri = 'https://treestatus.mozilla-releng.net/trees/';
 
 export default class TreeStatusModel {
-  static getTreeStatusName(name) {
-    // The thunderbird names in TreeStatus don't match what
-    // we use, so translate them.  pretty hacky, yes...
-    // TODO: Move these to the repository fixture in the service.
-    return name.includes('comm-') && name !== 'try-comm-central'
-      ? `${name}-thunderbird`
-      : name;
-  }
-
   static get(repoName) {
-    return fetch(`${uri}${TreeStatusModel.getTreeStatusName(repoName)}`)
+    return fetch(`${uri}${repoName}`)
       .then(async resp => {
         if (resp.ok) {
           return resp.json();


### PR DESCRIPTION
New trees are set up that are named the same as the repositories.
The getTreeStatusName is no longer needed.

The trees themselves are created, but the hooks on hg.mozilla.org are not updated yet. So please don't deploy this just yet.

I did test changes locally against stage and I got some funny errors with TierIndicator keys. I don't think I caused those? 