### PR TITLE
Bug 1611334 - Remove View Tests button from PushHeader

### DIFF
--- a/tests/ui/job-view/Filtering_test.jsx
+++ b/tests/ui/job-view/Filtering_test.jsx
@@ -116,21 +116,21 @@ describe('Filtering', () => {
     });
 
     test('should have 1 push', async () => {
-      const { getAllByText, getByTestId } = render(<App />);
+      const { getAllByText, getAllByTestId, getByTestId } = render(<App />);
       // wait till the ``reviewbot`` authored push is shown before filtering.
       await waitForElement(() => getAllByText('reviewbot'));
       setUrlParam('author', 'reviewbot');
       await waitForElementToBeRemoved(() => getByTestId('push-511138'));
 
       const filteredPushes = await waitForElement(() =>
-        getAllByText('View Tests'),
+        getAllByTestId('push-header'),
       );
       expect(filteredPushes).toHaveLength(1);
 
       setUrlParam('author', null);
       await waitForElement(() => getAllByText('jarilvalenciano@gmail.com'));
       const unFilteredPushes = await waitForElement(() =>
-        getAllByText('View Tests'),
+        getAllByTestId('push-header'),
       );
       expect(unFilteredPushes).toHaveLength(10);
     });

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -346,15 +346,6 @@ class PushHeader extends React.Component {
                 {watchStateLabel}
               </button>
             )}
-            <a
-              className="btn btn-sm btn-push test-view-btn"
-              href={`/testview.html?repo=${currentRepo.name}&revision=${revision}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              title="DEPRECATED: Please use Push Health instead"
-            >
-              View Tests
-            </a>
             {isLoggedIn && (
               <button
                 type="button"


### PR DESCRIPTION
There is a little bit of GraphQL api activity.  So I want to remove this button first, without deleting the app.  Perhaps people are hitting it occasionally out of curiosity.  Otherwise I will have to track down who is linking to it.  :)