### PR TITLE
Bug 1619873 - Change push-list role

### DIFF
--- a/ui/job-view/pushes/PushList.jsx
+++ b/ui/job-view/pushes/PushList.jsx
@@ -138,9 +138,10 @@ class PushList extends React.Component {
       this.setWindowTitle();
     }
     return (
-      // Bug 1619873 - interactive roles are not a good fit in this case
-      /* eslint-disable jsx-a11y/no-static-element-interactions */
+      // Bug 1619873 - role="list" works better here than an interactive role
+      /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
       <div
+        role="list"
         id="push-list"
         onClick={evt => this.clearIfEligibleTarget(evt.target)}
       >
@@ -153,6 +154,7 @@ class PushList extends React.Component {
               key={push.id}
             >
               <Push
+                role="listitem"
                 push={push}
                 isLoggedIn={isLoggedIn || false}
                 currentRepo={currentRepo}

--- a/ui/job-view/pushes/PushList.jsx
+++ b/ui/job-view/pushes/PushList.jsx
@@ -138,9 +138,9 @@ class PushList extends React.Component {
       this.setWindowTitle();
     }
     return (
+      // Bug 1619873 - interactive roles are not a good fit in this case
+      /* eslint-disable jsx-a11y/no-static-element-interactions */
       <div
-        role="grid"
-        tabIndex={0}
         id="push-list"
         onClick={evt => this.clearIfEligibleTarget(evt.target)}
       >
@@ -153,7 +153,6 @@ class PushList extends React.Component {
               key={push.id}
             >
               <Push
-                role="gridcell"
                 push={push}
                 isLoggedIn={isLoggedIn || false}
                 currentRepo={currentRepo}

--- a/ui/job-view/pushes/PushList.jsx
+++ b/ui/job-view/pushes/PushList.jsx
@@ -139,7 +139,7 @@ class PushList extends React.Component {
     }
     return (
       <div
-        role="button"
+        role="grid"
         tabIndex={0}
         id="push-list"
         onClick={evt => this.clearIfEligibleTarget(evt.target)}
@@ -153,6 +153,7 @@ class PushList extends React.Component {
               key={push.id}
             >
               <Push
+                role="gridcell"
                 push={push}
                 isLoggedIn={isLoggedIn || false}
                 currentRepo={currentRepo}


### PR DESCRIPTION
## Description of issue
PushList component should not have `role=button`. It should be `list` and its child elements, `listitem` instead.

## Proposed solution
Because PushList is interactive (that is, it has a `onClick` handler), ESLint doesn't accept `list` role. For that reason, I used `grid` and `gridcells`, as it was suggested in [ESLint repository](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-interactions.md).