### PR TITLE
Bug 1616311 - Fix link for the Parent Push

### DIFF
--- a/tests/push_health/test_compare.py
+++ b/tests/push_health/test_compare.py
@@ -12,7 +12,7 @@ def test_get_response_object(test_push, test_repository):
     assert resp['parentSha'] == '1234'
     assert resp['id'] == 1
     assert resp['exactMatch'] is False
-    assert resp['revision'] == '4c45a777949168d16c03a4cba167678b7ab65f76'
+    assert resp['parentPushRevision'] == '4c45a777949168d16c03a4cba167678b7ab65f76'
 
 
 @responses.activate
@@ -53,7 +53,7 @@ def test_get_commit_history_automationrelevance(test_push, test_repository):
 
     history = get_commit_history(test_repository, test_revision, test_push)
     assert history['parentSha'] == parent_revision
-    assert history['revision'] == parent_revision
+    assert history['parentPushRevision'] == parent_revision
 
 
 @responses.activate
@@ -99,7 +99,7 @@ def test_get_commit_history_json_pushes(test_push, test_repository):
 
     history = get_commit_history(test_repository, test_revision, test_push)
     assert history['parentSha'] == parent_revision
-    assert history['revision'] == parent_revision
+    assert history['parentPushRevision'] == parent_revision
 
 
 @responses.activate
@@ -122,4 +122,4 @@ def test_get_commit_history_not_found(test_push, test_repository):
 
     parent = get_commit_history(test_repository, test_revision, test_push)
     assert parent['parentSha'] == parent_revision
-    assert parent['revision'] is None
+    assert parent['parentPushRevision'] is None

--- a/tests/ui/mock/push_health.json
+++ b/tests/ui/mock/push_health.json
@@ -9,7 +9,7 @@
       "details": {
         "parentSha": "eeb6fd68c0223a72d8714734a34d3e6da69995e1",
         "exactMatch": true,
-        "revision": "eeb6fd68c0223a72d8714734a34d3e6da69995e1",
+        "parentPushRevision": "eeb6fd68c0223a72d8714734a34d3e6da69995e1",
         "repository": {
           "id": 77,
           "repository_group": {

--- a/tests/ui/push-health/CommitHistory_test.jsx
+++ b/tests/ui/push-health/CommitHistory_test.jsx
@@ -18,7 +18,7 @@ afterEach(() => {
 });
 
 describe('CommitHistory', () => {
-  const revision = 'eeb6fd68c0223a72d8714734a34d3e6da69995e1';
+  const revision = 'b6affc2813062a8e5a227a3ecf679e13c0c7a853';
   const testCommitHistory = history => (
     <CommitHistory history={history} revision={revision} />
   );

--- a/treeherder/push_health/compare.py
+++ b/treeherder/push_health/compare.py
@@ -9,10 +9,23 @@ logger = logging.getLogger(__name__)
 
 
 def get_response_object(parent_sha, revisions, revision_count, push, repository):
+    """Build a response object that shows the parent and commit history.
+
+    parent_sha -- The SHA of the parent of the latest commit
+    revisions -- The revisions/commits of the current Push
+    revision_count -- The count of those revisions (may be different from len(revisions)
+        because we only keep so many actual revisions in Treeherder, even if the Push has
+        more.
+    push -- The Push for the parent.  This might be the actual parent Push, or the closest
+        thing we could find.  Could also be the Push for the commit of the `parent_sha`.
+    repository -- The repository of the parent.  If we can't find a parent Push, then this
+        will be the repository of the current Push.
+    """
+
     resp = {
         'parentSha': parent_sha,
         'exactMatch': False,
-        'revision': None,
+        'parentPushRevision': None,
         'repository': RepositorySerializer(repository).data,
         'id': None,
         'jobCounts': None,
@@ -21,7 +34,9 @@ def get_response_object(parent_sha, revisions, revision_count, push, repository)
     }
     if push:
         resp.update({
-            'revision': push.revision,
+            # This will be the revision of the Parent, as long as we could find a Push in
+            # Treeherder for it.
+            'parentPushRevision': push.revision,
             'id': push.id,
             'jobCounts': push.get_status(),
             'exactMatch': parent_sha == push.revision,

--- a/ui/push-health/CommitHistory.jsx
+++ b/ui/push-health/CommitHistory.jsx
@@ -29,6 +29,7 @@ class CommitHistory extends React.PureComponent {
         exactMatch,
         parentSha,
         id,
+        parentPushRevision,
         revisions,
         revisionCount,
       },
@@ -69,16 +70,19 @@ class CommitHistory extends React.PureComponent {
         {id && (
           <div className="ml-5">
             <a
-              href={`${getJobsUrl({ revision, repo: repository.name })}`}
+              href={`${getJobsUrl({
+                revision: parentPushRevision,
+                repo: repository.name,
+              })}`}
               className="mx-3"
               target="_blank"
               rel="noopener noreferrer"
               title="Open this push in Treeherder"
             >
-              {revision}
+              {parentPushRevision}
             </a>
             <PushHealthStatus
-              revision={revision}
+              revision={parentPushRevision}
               repoName={repository.name}
               jobCounts={jobCounts}
             />
@@ -100,6 +104,7 @@ CommitHistory.propTypes = {
   history: PropTypes.shape({
     repository: PropTypes.object.isRequired,
     revisionCount: PropTypes.number.isRequired,
+    parentPushRevision: PropTypes.string.isRequired,
     job_counts: PropTypes.shape({
       completed: PropTypes.number.isRequired,
       pending: PropTypes.number.isRequired,


### PR DESCRIPTION
I used the wrong link for the Parent Push in my last PR.  So it would link back to the same Push as the one it's showing the health for, rather than its parent.  The word `revision` is too ambiguous.  So I added some docs and used a better name.