### PR TITLE
BigQuery extraction to use smaller chunks for performance data

### DIFF
--- a/treeherder/extract/extract_perf.json
+++ b/treeherder/extract/extract_perf.json
@@ -5,7 +5,7 @@
     },
     "key": "treeherder.extract.perf.state",
     "sql": "treeherder.extract.perf.sql",
-    "chunk_size": 4000
+    "chunk_size": 2000
   },
   "source": {
     "fact_table": "performance_datum",


### PR DESCRIPTION
The chunk size of 4000 results in BigQuery uploads that are too big.