### PR TITLE
Bug 1620667 - Refactor currentRepo property and CommitHistory layout

### DIFF
--- a/tests/ui/mock/push_health.json
+++ b/tests/ui/mock/push_health.json
@@ -10,7 +10,7 @@
         "parentSha": "eeb6fd68c0223a72d8714734a34d3e6da69995e1",
         "exactMatch": true,
         "parentPushRevision": "eeb6fd68c0223a72d8714734a34d3e6da69995e1",
-        "repository": {
+        "parentRepository": {
           "id": 77,
           "repository_group": {
             "name": "development",

--- a/tests/ui/push-health/CommitHistory_test.jsx
+++ b/tests/ui/push-health/CommitHistory_test.jsx
@@ -4,6 +4,8 @@ import { render, cleanup, waitForElement } from '@testing-library/react';
 
 import CommitHistory from '../../../ui/push-health/CommitHistory';
 import pushHealth from '../mock/push_health';
+import repositories from '../mock/repositories';
+import RepositoryModel from '../../../ui/models/repository';
 
 beforeEach(() => {
   fetchMock.get(
@@ -19,21 +21,29 @@ afterEach(() => {
 
 describe('CommitHistory', () => {
   const revision = 'b6affc2813062a8e5a227a3ecf679e13c0c7a853';
+  const currentRepo = new RepositoryModel(repositories[1]);
   const testCommitHistory = history => (
-    <CommitHistory history={history} revision={revision} />
+    <CommitHistory
+      history={history}
+      revision={revision}
+      currentRepo={currentRepo}
+    />
   );
 
   test('should show a parent commit and health icon for that parent', async () => {
     const { details: commitHistory } = pushHealth.metrics.commitHistory;
-    const { getByText, queryByTestId } = render(
+    const { getByText, getByTestId, queryByTestId } = render(
       testCommitHistory(commitHistory),
     );
+    const parentLink = getByTestId('parent-commit-sha');
+
+    expect(parentLink).toBeInTheDocument();
+    expect(parentLink.text).toBe('eeb6fd68c0223a72d8714734a34d3e6da69995e1');
     expect(
-      getByText('eeb6fd68c0223a72d8714734a34d3e6da69995e1'),
+      await waitForElement(() =>
+        queryByTestId('health-status-eeb6fd68c0223a72d8714734a34d3e6da69995e1'),
+      ),
     ).toBeInTheDocument();
-    expect(
-      queryByTestId('health-status-eeb6fd68c0223a72d8714734a34d3e6da69995e1'),
-    ).not.toBeInTheDocument();
     expect(
       await waitForElement(() => getByText('87 items')),
     ).toBeInTheDocument();
@@ -44,24 +54,29 @@ describe('CommitHistory', () => {
 
     commitHistory.id = 123;
     commitHistory.parentSha = '00000827c820f34b3b595f887f57b4c847316fcc';
+    commitHistory.parentPushRevision = null;
     commitHistory.exactMatch = false;
 
-    const { getByText } = render(testCommitHistory(commitHistory));
+    const { getByText, getByTestId, queryByTestId } = render(
+      testCommitHistory(commitHistory),
+    );
     expect(
       getByText(
         'Warning: Could not find an exact match parent Push in Treeherder.',
       ),
     ).toBeInTheDocument();
     expect(getByText('Closest match:')).toBeInTheDocument();
+    const parentLink = getByTestId('parent-commit-sha');
+
+    expect(parentLink).toBeInTheDocument();
+    expect(parentLink.text).toBe('00000827c820f34b3b595f887f57b4c847316fcc');
     expect(
-      getByText('eeb6fd68c0223a72d8714734a34d3e6da69995e1'),
-    ).toBeInTheDocument();
+      queryByTestId('health-status-eeb6fd68c0223a72d8714734a34d3e6da69995e1'),
+    ).not.toBeInTheDocument();
+    // Should not have a parent PushHealthStatus when it's not an exact match.
     expect(
-      getByText('00000827c820f34b3b595f887f57b4c847316fcc'),
-    ).toBeInTheDocument();
-    expect(
-      await waitForElement(() => getByText('87 items')),
-    ).toBeInTheDocument();
+      queryByTestId('health-status-00000827c820f34b3b595f887f57b4c847316fcc'),
+    ).not.toBeInTheDocument();
   });
 
   test('should not have parent PushHealthStatus if no push id', async () => {
@@ -69,6 +84,7 @@ describe('CommitHistory', () => {
 
     commitHistory.id = null;
     commitHistory.parentSha = '00000827c820f34b3b595f887f57b4c847316fcc';
+    commitHistory.parentPushRevision = null;
     commitHistory.exactMatch = false;
 
     const { getByText, queryByTestId } = render(

--- a/treeherder/push_health/compare.py
+++ b/treeherder/push_health/compare.py
@@ -26,7 +26,7 @@ def get_response_object(parent_sha, revisions, revision_count, push, repository)
         'parentSha': parent_sha,
         'exactMatch': False,
         'parentPushRevision': None,
-        'repository': RepositorySerializer(repository).data,
+        'parentRepository': RepositorySerializer(repository).data,
         'id': None,
         'jobCounts': None,
         'revisions': revisions,

--- a/ui/push-health/App.jsx
+++ b/ui/push-health/App.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { hot } from 'react-hot-loader/root';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
-
-import RepositoryModel from '../models/repository';
-import { getRepo } from '../helpers/location';
 
 import NotFound from './NotFound';
 import Health from './Health';
@@ -15,60 +11,29 @@ function hasProps(search) {
   return params.get('repo') && params.get('revision');
 }
 
-class App extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      currentRepo: null,
-    };
-  }
-
-  componentDidMount() {
-    const repoName = getRepo();
-
-    if (repoName) {
-      RepositoryModel.getList().then(repos => {
-        const newRepo = repos.find(repo => repo.name === repoName);
-
-        this.setState({ currentRepo: newRepo });
-      });
-    }
-  }
-
-  render() {
-    const { currentRepo } = this.state;
-
-    return (
-      <BrowserRouter>
+const App = () => {
+  return (
+    <BrowserRouter>
+      <div>
         <div>
-          <div>
-            <Switch>
-              <Route
-                exact
-                path="/pushhealth.html"
-                render={props =>
-                  hasProps(props.location.search) ? (
-                    <Health currentRepo={currentRepo} {...props} />
-                  ) : (
-                    <NotFound {...props} />
-                  )
-                }
-              />
-              <Route name="notfound" component={NotFound} />
-            </Switch>
-          </div>
+          <Switch>
+            <Route
+              exact
+              path="/pushhealth.html"
+              render={props =>
+                hasProps(props.location.search) ? (
+                  <Health {...props} />
+                ) : (
+                  <NotFound {...props} />
+                )
+              }
+            />
+            <Route name="notfound" component={NotFound} />
+          </Switch>
         </div>
-      </BrowserRouter>
-    );
-  }
-}
-
-App.propTypes = {
-  location: PropTypes.object,
-};
-
-App.defaultProps = {
-  location: null,
+      </div>
+    </BrowserRouter>
+  );
 };
 
 export default hot(App);

--- a/ui/shared/PushHealthStatus.jsx
+++ b/ui/shared/PushHealthStatus.jsx
@@ -92,13 +92,12 @@ class PushHealthStatus extends Component {
     }
 
     return (
-      <React.Fragment>
+      <span data-testid={`health-status-${revision}`}>
         {needInvestigation !== null ? (
           <a
             href={getPushHealthUrl({ repo: repoName, revision })}
             target="_blank"
             rel="noopener noreferrer"
-            data-testid={`health-status-${revision}`}
           >
             <Badge
               color={badgeColor}
@@ -111,7 +110,7 @@ class PushHealthStatus extends Component {
         ) : (
           <Spinner size="sm" />
         )}
-      </React.Fragment>
+      </span>
     );
   }
 }


### PR DESCRIPTION
This is a refactor to make these a few of these more test-able and improve the testing of them, therein.

The terms `revision` and `repository` were getting mixed up in my head with regard to which one was for the `parent` and which one for the `push` in question.  So for the parent ones, I made the name clearer.

In doing this, I realized that the `currentRepo` object getting created in `App` was bogus and never worked right.  Ends up `App` can be greatly simplified, and creating `currentRepo` in `Health.jsx` makes more sense.

I moved a few things around to give them `data-testid` so that they're more test-able.