### PR TITLE
Disable isort pre-commit lint check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,6 @@ repos:
     rev: 3.7.9
     hooks:
       - id: flake8
-  - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
-    hooks:
-      - id: isort
   - repo: https://github.com/ryanrhee/shellcheck-py
     rev: v0.7.0.1-1
     hooks:


### PR DESCRIPTION
It currently gets confused when executed within a virtualenv
and behaves differently to executing within the Docker container.

I will fix it next week.