### PR TITLE
Bug 1648878 - Change fuzzy finder to accept Fuse.js 6's new enhanced search operators

### DIFF
--- a/tests/ui/job-view/fuzzy_test.jsx
+++ b/tests/ui/job-view/fuzzy_test.jsx
@@ -7,6 +7,7 @@ import { render, fireEvent, waitFor } from '@testing-library/react';
 import fuzzyJobList from '../mock/job_list/fuzzy_jobs/fuzzyJobList.json';
 import initialJobList from '../mock/job_list/fuzzy_jobs/initial_job_list.json';
 import searchLinuxResults from '../mock/job_list/fuzzy_jobs/search_linux_results.json';
+import searchDebugResults from '../mock/job_list/fuzzy_jobs/search_debug_results.json';
 import FuzzyJobFinder from '../../../ui/job-view/pushes/FuzzyJobFinder';
 
 const mockStore = configureMockStore([thunk]);
@@ -78,6 +79,35 @@ describe('FuzzyJobFinder', () => {
       );
       expect(fuzzySearchArray).toStrictEqual(
         expect.arrayContaining(searchLinuxResults),
+      );
+    });
+  });
+
+  test('Fuzzy search gives expected results for extended operators', async () => {
+    const { getByTitle, queryAllByTestId } = await render(testFuzzyJobFinder);
+    const inputElement = getByTitle('Filter the list of runnable jobs');
+
+    await waitFor(() => {
+      expect(queryAllByTestId('fuzzyList')).toHaveLength(60);
+      const fuzzySearchArray = queryAllByTestId('fuzzyList').map(
+        (job) => job.innerHTML,
+      );
+      expect(fuzzySearchArray).toStrictEqual(
+        expect.arrayContaining(initialJobList),
+      );
+    });
+
+    await fireEvent.change(inputElement, { target: { value: 'debug$' } });
+    expect(inputElement.value).toBe('debug$');
+    await fireEvent.keyDown(inputElement, { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => {
+      expect(queryAllByTestId('fuzzyList')).toHaveLength(16);
+      const fuzzySearchArray = queryAllByTestId('fuzzyList').map(
+        (job) => job.innerHTML,
+      );
+      expect(fuzzySearchArray).toStrictEqual(
+        expect.arrayContaining(searchDebugResults),
       );
     });
   });

--- a/tests/ui/mock/job_list/fuzzy_jobs/search_debug_results.json
+++ b/tests/ui/mock/job_list/fuzzy_jobs/search_debug_results.json
@@ -1,0 +1,18 @@
+[
+  "build-android-aarch64-gcp/debug",
+  "build-android-aarch64/debug",
+  "build-android-api-16-gcp/debug",
+  "build-android-api-16/debug",
+  "build-android-x86-fuzzing/debug",
+  "build-android-x86_64-gcp/debug",
+  "build-android-x86_64/debug",
+  "build-linux-gcp/debug",
+  "build-linux-rusttests/debug",
+  "build-linux/debug",
+  "build-linux64-asan/debug",
+  "build-linux64-fuzzing/debug",
+  "build-linux64-gcp/debug",
+  "build-linux64-noopt/debug",
+  "build-linux64-plain/debug",
+  "build-linux64-rusttests/debug"
+]

--- a/ui/job-view/pushes/FuzzyJobFinder.jsx
+++ b/ui/job-view/pushes/FuzzyJobFinder.jsx
@@ -53,8 +53,9 @@ class FuzzyJobFinder extends React.Component {
         this.setState({ fuzzySearch: ev.target.value }, () => {
           const options = {
             // http://fusejs.io/ describes the options available
+            useExtendedSearch: true,
             keys: ['name', 'symbol'],
-            threshold: 0.6, // This seems like a good threshold to remove most false matches, lower is stricter
+            threshold: 0.4, // This seems like a good threshold to remove most false matches, lower is stricter
             matchAllTokens: true,
             tokenize: true,
           };


### PR DESCRIPTION
Fuse.js 4.0 is adding support for search tokens, allowing us to do more precise searches. This commit upgrades to an unreleased version of Fuse.js with that support included, and switches to use it for Treeherder's Fuzzy Job Finder.