### PR TITLE
Fix pre-commit's isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     rev: 4.3.21
     hooks:
       - id: isort
+        args: ['--virtual-env=.venv']
   - repo: https://github.com/ryanrhee/shellcheck-py
     rev: v0.7.0.1-1
     hooks:


### PR DESCRIPTION
`isort` as part of the pre-commit set up ends up under `$HOME/.cache/pre-commit`.

Due to that, it was unable to determine the path to the `setup.cfg` and was
unable to differentiate third party libraries from first party libraries.

Specifiying where the path to the default virtualenv is fixes it.