### PR TITLE
Bug 1608427 - Reland SETA: Better differentiate different kinds of ta…

### DIFF
--- a/treeherder/etl/seta.py
+++ b/treeherder/etl/seta.py
@@ -3,7 +3,8 @@ import logging
 from django.core.cache import cache
 
 from treeherder.etl.runnable_jobs import list_runnable_jobs
-from treeherder.seta.common import unique_key
+from treeherder.seta.common import (convert_job_type_name_to_testtype,
+                                    unique_key)
 from treeherder.seta.models import JobPriority
 from treeherder.seta.settings import (SETA_REF_DATA_NAMES_CACHE_TIMEOUT,
                                       SETA_SUPPORTED_TC_JOBTYPES,
@@ -30,49 +31,17 @@ def parse_testtype(build_system_type, job_type_name, platform_option, ref_data_n
     '''
     # XXX: Figure out how to ignore build, lint, etc. jobs
     # https://bugzilla.mozilla.org/show_bug.cgi?id=1318659
+    testtype = None
     if build_system_type == 'buildbot':
         # The testtype of builbot job can been found in 'ref_data_name'
         # like web-platform-tests-4 in "Ubuntu VM 12.04 x64 mozilla-inbound
         # opt test web-platform-tests-4"
-        return ref_data_name.split(' ')[-1]
+        testtype = ref_data_name.split(' ')[-1]
     else:
-        # NOTE: Buildbot bridge tasks always have a Buildbot job associated to it. We will
-        #       ignore any BBB task since we will be analyzing instead the Buildbot job associated
-        #       to it. If BBB tasks were a production system and there was a technical advantage
-        #       we could look into analyzing that instead of the BB job.
         if job_type_name.startswith(tuple(SETA_SUPPORTED_TC_JOBTYPES)):
             # we should get "jittest-3" as testtype for a job_type_name like
             # test-linux64/debug-jittest-3
-            return transform(job_type_name.split('-{buildtype}'.
-                             format(buildtype=platform_option))[-1])
-
-
-def transform(testtype):
-    '''
-    A lot of these transformations are from tasks before task labels and some of them are if we
-    grab data directly from Treeherder jobs endpoint instead of runnable jobs API.
-    '''
-    # XXX: Evaluate which of these transformations are still valid
-    if testtype.startswith('[funsize'):
-        return None
-
-    testtype = testtype.split('/opt-')[-1]
-    testtype = testtype.split('/debug-')[-1]
-
-    # this is plain-reftests for android
-    testtype = testtype.replace('plain-', '')
-
-    testtype = testtype.strip()
-
-    # https://bugzilla.mozilla.org/show_bug.cgi?id=1313844
-    testtype = testtype.replace('browser-chrome-e10s', 'e10s-browser-chrome')
-    testtype = testtype.replace('devtools-chrome-e10s', 'e10s-devtools-chrome')
-    testtype = testtype.replace('[TC] Android 4.3 API15+ ', '')
-
-    # mochitest-gl-1 <-- Android 4.3 armv7 API 15+ mozilla-inbound opt test mochitest-gl-1
-    # mochitest-webgl-9  <-- test-android-4.3-arm7-api-15/opt-mochitest-webgl-9
-    testtype = testtype.replace('webgl-', 'gl-')
-
+            testtype = convert_job_type_name_to_testtype(job_type_name)
     return testtype
 
 
@@ -125,6 +94,8 @@ def get_reference_data_names(project="autoland", build_system="taskcluster"):
 
         if is_job_blacklisted(testtype):
             ignored_jobs.append(job['ref_data_name'])
+            if testtype:
+                logger.debug('get_reference_data_names: blacklisted testtype {} for job {}'.format(testtype, job))
             continue
 
         key = unique_key(testtype=testtype,

--- a/treeherder/seta/common.py
+++ b/treeherder/seta/common.py
@@ -1,3 +1,9 @@
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+
 class DuplicateKeyError(Exception):
     pass
 
@@ -23,3 +29,50 @@ def job_priority_index(job_priorities):
         jp_index[key] = {'pk': jp.id, 'build_system_type': jp.buildsystem}
 
     return jp_index
+
+
+# The order of this is list is important as the more specific patterns
+# will be processed before the less specific ones. This must be kept up
+# to date with SETA_SUPPORTED_TC_JOBTYPES in settings.py.
+RE_JOB_TYPE_NAMES = [
+    {'name': 'test',         'pattern': re.compile('test-[^/]+/[^-]+-(.*)$')},
+    {'name': 'desktop-test', 'pattern': re.compile('desktop-test-[^/]+/[^-]+-(.*)$')},
+    {'name': 'android-test', 'pattern': re.compile('android-test-[^/]+/[^-]+-(.*)$')},
+    {'name': 'source-test',  'pattern': re.compile('(source-test-[^/]+)(?:/.*)?$')},
+    {'name': 'build',        'pattern': re.compile('(build-[^/]+)/[^-]+$')},
+    {'name': 'spidermonkey', 'pattern': re.compile('(spidermonkey-[^/]+)/[^-]+$')},
+    {'name': 'iris',         'pattern': re.compile('(iris-[^/]+)/[^-]+$')},
+    {'name': 'webrender',    'pattern': re.compile('(webrender-.*)-(?:opt|debug|pgo)$')},
+]
+
+
+def convert_job_type_name_to_testtype(job_type_name):
+    '''job_type_names are essentially free form though there are
+    several patterns used in job_type_names.
+
+    test-<platform>/<buildtype>-<testtype> test-linux1804-64-shippable-qr/opt-reftest-e10s-5
+    build-<platform>/<buildtype>           build-linux64-asan-fuzzing/opt
+    <testtype>-<buildtype>                 webrender-android-hw-p2-debug
+
+    Prior to Bug 1608427, only non-build tasks were eligible for
+    optimization using seta strategies and Treeherder's handling of
+    possible task labels failed to properly account for the different
+    job_type_names possible with build tasks. While investigating this
+    failure to support build tasks, it was discovered that other test
+    tasks did not match the expected job_type_name pattern. This
+    function ensures that job_type_names are converted to seta
+    testtypes in a consistent fashion.
+    '''
+    testtype = None
+    if not job_type_name.startswith('[funsize'):
+        for re_job_type_name in RE_JOB_TYPE_NAMES:
+            m = re_job_type_name['pattern'].match(job_type_name)
+            if m:
+                testtype = m.group(1)
+                break
+    if not testtype:
+        logger.warning('convert_job_type_name_to_testtype("{}") not matched. '
+                       'Using job_type_name as is.'.format(
+                           job_type_name, testtype))
+        testtype = job_type_name
+    return testtype

--- a/treeherder/seta/job_priorities.py
+++ b/treeherder/seta/job_priorities.py
@@ -42,7 +42,7 @@ class SETAJobPriorities:
                 # e.g. desktop-test-linux64-pgo/opt-reftest-13 or builder name
                 jobs.append(ref_data_names_map[key])
             else:
-                logger.warning('Job priority (%s) not found in accepted jobs list', jp)
+                logger.warning('Job priority key %s for (%s) not found in accepted jobs list', key, jp)
 
         return jobs
 

--- a/treeherder/seta/preseed.json
+++ b/treeherder/seta/preseed.json
@@ -70,5 +70,13 @@
     "priority": 5,
     "expiration_date": "*",
     "buildsystem": "taskcluster"
+  },
+  {
+    "buildtype": "debug",
+    "testtype": "build-android-x86-fuzzing/debug",
+    "platform": "android-4-2-x86",
+    "priority": 5,
+    "expiration_date": "*",
+    "buildsystem": "taskcluster"
   }
 ]

--- a/treeherder/seta/preseed.py
+++ b/treeherder/seta/preseed.py
@@ -2,13 +2,51 @@ import json
 import logging
 import os
 
-from treeherder.etl.seta import (get_reference_data_names,
-                                 transform)
+from treeherder.etl.seta import get_reference_data_names
+from treeherder.seta.common import convert_job_type_name_to_testtype
 from treeherder.seta.models import JobPriority
 from treeherder.seta.settings import (SETA_LOW_VALUE_PRIORITY,
                                       THE_FUTURE)
 
 logger = logging.getLogger(__name__)
+
+'''preseed.json entries have fields: buildtype, testtype, platform,
+priority, expiration_date. They must match the corresponding entry in
+runnable-jobs.json.
+
+buildtype should match the attribute name in the runnable jobs collection.
+
+testtype should match the full task label.
+
+platform should match the platform.
+
+priority can be 1 to signify high value tasks or 5 to signify low
+value tasks. The default priority is 1.
+
+expiration_date must be "*" to signify no expiration.
+
+buildsystem should always be "taskcluster".
+
+Example:
+
+runnable-jobs.json:
+"build-android-x86_64-asan-fuzzing/opt": {
+  "collection": {
+    "asan": true
+  },
+  "platform": "android-5-0-x86_64",
+  "symbol": "Bof"
+},
+entry in preseed.json
+{
+  "buildtype": "asan",
+  "testtype":  "build-android-x86_64-asan-fuzzing/opt",
+  "platform":  "android-5-0-x86_64",
+  "priority":  5,
+  "expiration_date": "*",
+  "buildsytem": "taskcluster"
+}
+'''
 
 
 def validate_preseed_entry(entry, ref_names):
@@ -31,12 +69,17 @@ def validate_preseed_entry(entry, ref_names):
     assert len(potential_matches) > 0, \
         Exception("%s is not valid. Please check runnable_jobs.json from a Gecko decision task.", entry["testtype"])
 
-    # XXX: Same transformation as in treeherder.etl.seta.parse_testtype
+    testtype = convert_job_type_name_to_testtype(entry["testtype"])
+    if not testtype:
+        logger.warning("Preseed.json entry testtype %s is not a valid task name:", entry["testtype"])
+        raise Exception("preseed.json entry contains invalid testtype. Please check output above.")
+
     unique_identifier = (
-        transform(entry["testtype"]).split('-{buildtype}'.format(buildtype=entry["buildtype"]))[-1],
+        testtype,
         entry["buildtype"],
         entry["platform"],
     )
+
     try:
         ref_names[unique_identifier]
     except KeyError:
@@ -46,15 +89,7 @@ def validate_preseed_entry(entry, ref_names):
 
 
 def load_preseed(validate=False):
-    """ Update JobPriority information from preseed.json
-
-    The preseed data has these fields: buildtype, testtype, platform, priority, expiration_date
-    The expiration_date field defaults to 2 weeks when inserted in the table
-    The expiration_date field has the format "YYYY-MM-DD", however, it can have "*" to indicate to never expire
-    The default priority is 1, however, if we want to force coalescing we can do that
-    The fields buildtype, testtype and platform can have * which makes ut match  all flavors of
-    the * field. For example: (linux64, pgo, *) matches all Linux 64 pgo tests
-    """
+    """ Update JobPriority information from preseed.json"""
     logger.info("About to load preseed.json")
 
     preseed = preseed_data()
@@ -70,7 +105,13 @@ def load_preseed(validate=False):
 
         for field in ('testtype', 'buildtype', 'platform'):
             if job[field] != '*':
-                queryset = queryset.filter(**{field: job[field]})
+                # The JobPriority table does not contain the raw
+                # testtype value seen in the preseed.json file. We
+                # must convert the job[field] value to the appropriate
+                # value before performing the query.
+                field_value = convert_job_type_name_to_testtype(job[field]) \
+                    if field == 'testtype' else job[field]
+                queryset = queryset.filter(**{field: field_value})
 
         # Deal with the case where we have a new entry in preseed
         if not queryset:
@@ -94,8 +135,11 @@ def create_new_entry(job):
         job['expiration_date'] = THE_FUTURE
 
     logger.info("Adding a new job priority to the database: %s", job)
+
+    testtype = convert_job_type_name_to_testtype(job['testtype'])
+
     JobPriority.objects.create(
-        testtype=job['testtype'],
+        testtype=testtype,
         buildtype=job['buildtype'],
         platform=job['platform'],
         priority=job['priority'],

--- a/treeherder/seta/settings.py
+++ b/treeherder/seta/settings.py
@@ -5,15 +5,18 @@ THE_FUTURE = datetime.datetime(2100, 12, 31)
 # repos that SETA supports
 SETA_PROJECTS = [
     'autoland',
-    'try'
+    'try',
 ]
 
 # for taskcluster, only jobs that start with any of these names
 # will be supported i.e. may be optimized out by SETA
 SETA_SUPPORTED_TC_JOBTYPES = [
     'test-',
+    'source-test-',
     'desktop-test',
-    'android-test,'
+    'android-test',
+    'iris-',
+    'webrender-',
     'build-android-x86-fuzzing',
     'build-android-x86_64-asan-fuzzing',
     'build-linux64-asan-fuzzing-ccov',
@@ -45,7 +48,7 @@ SETA_UNSUPPORTED_PLATFORMS = [
     'windows8-32',  # We don't test 32-bit builds on Windows 8 test infra
     'Win 6.3.9600 x86_64',
     'linux64-stylo',
-    'windowsxp'
+    'windowsxp',
 ]
 
 # testtypes listed here will not be supported by SETA
@@ -58,11 +61,11 @@ SETA_UNSUPPORTED_TESTTYPES = [
     'Opt',
     'Debug',
     'Dbg',
-    '(opt)'
+    '(opt)',
     'PGO Opt',
     'Valgrind Opt',
     'Artifact Opt',
-    '(debug)'
+    '(debug)',
 ]
 
 # SETA job priority values
@@ -72,7 +75,7 @@ SETA_LOW_VALUE_PRIORITY = 5
 # analyze_failures retrieves jobs marked 'fixed by commit' for these repos
 SETA_FIXED_BY_COMMIT_REPOS = [
     'autoland',
-    'mozilla-central'
+    'mozilla-central',
 ]
 
 # analyze_failures retrieves jobs marked 'fixed by commit' for the past N days

--- a/treeherder/seta/update_job_priority.py
+++ b/treeherder/seta/update_job_priority.py
@@ -41,7 +41,10 @@ def _unique_key(job):
     This makes sure that we use a consistent key between our code and selecting jobs from the
     table.
     """
-    return unique_key(testtype=str(job['testtype']),
+    testtype = str(job['testtype'])
+    if not testtype:
+        raise Exception('Bad job {}'.format(job))
+    return unique_key(testtype=testtype,
                       buildtype=str(job['platform_option']),
                       platform=str(job['platform']))
 


### PR DESCRIPTION
…sks.

This reverts commit 4a864d278993ab2b974f8fc9c06ee77ccf8823c7.

We had problems with android-hw raptor tests being over scheduled and reverted this last night. I just landed a patch to make android-hw raptor low value which should prevent a re-occurrence. Otherwise this is reversion of the reversion with no other changes.