### PR TITLE
Add chrome-m application for Chrome Android browser.

### DIFF
--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -7,6 +7,7 @@
           "enum": [
             "firefox",
             "chrome",
+            "chrome-m",
             "chromium",
             "fennec",
             "geckoview",


### PR DESCRIPTION
This patch adds the `chrome-m` application to the list of acceptable applications in the perfherder data schema.