### PR TITLE
Bug 1623165 - Push Health Perf and Commit History UI cleanup

### DIFF
--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -16,7 +16,6 @@ from treeherder.model.models import (Job,
 from treeherder.push_health.builds import get_build_failures
 from treeherder.push_health.compare import get_commit_history
 from treeherder.push_health.linting import get_lint_failures
-from treeherder.push_health.performance import get_perf_failures
 from treeherder.push_health.tests import get_test_failures
 from treeherder.push_health.usage import get_usage
 from treeherder.webapp.api.serializers import PushSerializer
@@ -220,14 +219,12 @@ class PushViewSet(viewsets.ViewSet):
         push_health_test_failures = get_test_failures(push, REPO_GROUPS['trunk'])
         push_health_lint_failures = get_lint_failures(push)
         push_health_build_failures = get_build_failures(push)
-        push_health_perf_failures = get_perf_failures(push)
 
         return Response({
             'needInvestigation':
                 len(push_health_test_failures['needInvestigation']) +
                 len(push_health_build_failures) +
-                len(push_health_lint_failures) +
-                len(push_health_perf_failures),
+                len(push_health_lint_failures),
             'unsupported': len(push_health_test_failures['unsupported']),
         })
 
@@ -267,11 +264,8 @@ class PushViewSet(viewsets.ViewSet):
         lint_failures = get_lint_failures(push)
         lint_result = 'fail' if len(lint_failures) else 'pass'
 
-        perf_failures = get_perf_failures(push)
-        perf_result = 'fail' if len(perf_failures) else 'pass'
-
         push_result = 'pass'
-        for metric_result in [test_result, lint_result, build_result, perf_result]:
+        for metric_result in [test_result, lint_result, build_result]:
             if metric_result == 'indeterminate' and push_result != 'fail':
                 push_result = metric_result
             elif metric_result == 'fail':
@@ -309,11 +303,6 @@ class PushViewSet(viewsets.ViewSet):
                     'name': 'Builds',
                     'result': build_result,
                     'details': build_failures,
-                },
-                'performance': {
-                    'name': 'Performance',
-                    'result': perf_result,
-                    'details': perf_failures,
                 },
             },
             'status': push.get_status(),

--- a/ui/push-health/CommitHistory.jsx
+++ b/ui/push-health/CommitHistory.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Alert, Col } from 'reactstrap';
+import { Alert, Button, Col } from 'reactstrap';
 
 import PushHealthStatus from '../shared/PushHealthStatus';
 import { RevisionList } from '../shared/RevisionList';
@@ -14,6 +14,7 @@ class CommitHistory extends React.PureComponent {
 
     this.state = {
       clipboardVisible: false,
+      showAllRevisions: false,
     };
   }
 
@@ -36,7 +37,7 @@ class CommitHistory extends React.PureComponent {
       revision,
       currentRepo,
     } = this.props;
-    const { clipboardVisible } = this.state;
+    const { clipboardVisible, showAllRevisions } = this.state;
     const parentRepoModel = new RepositoryModel(parentRepository);
     const parentLinkUrl = exactMatch
       ? `${getJobsUrl({
@@ -88,12 +89,32 @@ class CommitHistory extends React.PureComponent {
           </Col>
         </div>
         <h5 className="mt-4">Commit revisions</h5>
-        <RevisionList
-          revision={revision}
-          revisions={revisions.slice(0, 20)}
-          revisionCount={revisionCount}
-          repo={currentRepo}
-        />
+        {revisions.length <= 5 || showAllRevisions ? (
+          <RevisionList
+            revision={revision}
+            revisions={revisions.slice(0, 20)}
+            revisionCount={revisionCount}
+            repo={currentRepo}
+          />
+        ) : (
+          <span>
+            <RevisionList
+              revision={revision}
+              revisions={revisions.slice(0, 5)}
+              revisionCount={revisionCount}
+              repo={currentRepo}
+            />
+            <Button
+              outline
+              color="darker-secondary"
+              onClick={() =>
+                this.setState({ showAllRevisions: !showAllRevisions })
+              }
+            >
+              Show more...
+            </Button>
+          </span>
+        )}
       </React.Fragment>
     );
   }


### PR DESCRIPTION
Disable the Performance metric area.  Leave the library in-place because we will be enhancing it later.

Move the `Commit History` metric closer to the top and expanded by default to improve discoverability.  I wanted to minimize the noise, though, so if there are more than 5 commits, I show the first 5 and add a "more..." type button.