### PR TITLE
Bug 1623589 - Make filter URL handling more resilient

### DIFF
--- a/ui/helpers/filter.js
+++ b/ui/helpers/filter.js
@@ -2,7 +2,7 @@ import pick from 'lodash/pick';
 import isEqual from 'lodash/isEqual';
 
 import { thFailureResults } from './constants';
-import { parseQueryParams } from './url';
+import { extractSearchString, parseQueryParams } from './url';
 
 // used with field-filters to determine how to match the value against the
 // job field.
@@ -100,11 +100,11 @@ export const hasUrlFilterChanges = function hasUrlFilterChanges(
   newURL,
 ) {
   const oldFilters = pick(
-    parseQueryParams(oldURL.split('?')[1]),
+    parseQueryParams(extractSearchString(oldURL)),
     allFilterParams,
   );
   const newFilters = pick(
-    parseQueryParams(newURL.split('?')[1]),
+    parseQueryParams(extractSearchString(newURL)),
     allFilterParams,
   );
 

--- a/ui/helpers/location.js
+++ b/ui/helpers/location.js
@@ -1,8 +1,13 @@
 import { thDefaultRepo } from './constants';
-import { createQueryParams, getApiUrl, uiJobsUrlBase } from './url';
+import {
+  createQueryParams,
+  extractSearchString,
+  getApiUrl,
+  uiJobsUrlBase,
+} from './url';
 
 export const getQueryString = function getQueryString() {
-  return window.location.hash.split('?')[1];
+  return extractSearchString(window.location.hash);
 };
 
 export const getAllUrlParams = function getAllUrlParams() {

--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -120,6 +120,12 @@ export const parseQueryParams = function parseQueryParams(search) {
   );
 };
 
+export const extractSearchString = function getQueryString(url) {
+  const parts = url.split('?');
+
+  return parts[parts.length - 1];
+};
+
 // `api` requires a preceding forward slash
 export const createApiUrl = function createApiUrl(api, params) {
   const apiUrl = getApiUrl(api);

--- a/ui/models/filter.js
+++ b/ui/models/filter.js
@@ -113,7 +113,9 @@ export default class FilterModel {
    * will get updates.
    */
   push = () => {
-    window.location.hash = `#/jobs?${this.getFilterQueryString()}`;
+    const { origin } = window.location;
+
+    window.location.href = `${origin}/#/jobs?${this.getFilterQueryString()}`;
   };
 
   setOnlySuperseded = () => {


### PR DESCRIPTION
Doing a simple split and taking the `1`th element was a bit fragile.  We want the last element.  So this helps with the weird URL mentioned in the bug.  But it would be good to move away from the hashed URLs that we currently use (a holdover from AngularJS).  I opened [Bug 1623951](https://bugzilla.mozilla.org/show_bug.cgi?id=1623951)

I also updated the `push` function in `models/filter.js` to correct this weird case of having an extra `?` character before the hash.  I was not able to figure out a way that it got there in this case.  But can be sure we take it out.  :)