### PR TITLE
Revert "Bug 1615540 - Remove AWFY from Perfherder"

### DIFF
--- a/treeherder/perf/fixtures/performance_bug_templates.yaml
+++ b/treeherder/perf/fixtures/performance_bug_templates.yaml
@@ -72,6 +72,27 @@
 
       To learn more about the regressing test(s), please see: https://wiki.mozilla.org/AWSY/Tests
 - model: perf.PerformanceBugTemplate
+  pk: 5
+  fields:
+    framework: 5
+    keywords: perf, perf-alert, regression
+    default_component: Performance
+    default_product: Testing
+    text: |
+      We have detected an awfy regression from push:
+
+      {{ revisionHref }}
+
+      As author of one of the patches included in that push, we need your help to address this regression.
+
+      {{ alertSummary }}
+
+      You can find links to graphs and comparison views for each of the above tests at: {{ alertHref }}
+
+      On the page above you can see an alert for each affected platform as well as a link to a graph showing the history of scores for this test. There is also a link to a treeherder page showing the jobs in a pushlog format.
+
+      To learn more about the regressing test(s), please see: https://www.arewefastyet.com/
+- model: perf.PerformanceBugTemplate
   pk: 6
   fields:
     framework: 6

--- a/treeherder/perf/fixtures/performance_framework.json
+++ b/treeherder/perf/fixtures/performance_framework.json
@@ -24,6 +24,14 @@
     }
   },
   {
+    "pk": 5,
+    "model": "perf.PerformanceFramework",
+    "fields": {
+      "name": "awfy",
+      "enabled": true
+    }
+  },
+  {
     "pk": 6,
     "model": "perf.PerformanceFramework",
     "fields": {


### PR DESCRIPTION
Reverts mozilla/treeherder#6099

Per the convo in the bug, we're going to take a different approach and change the enabled field for this framework to false instead of deleting it. A filter should be added to the API to only retrieve enabled frameworks.