### PR TITLE
Bug 1618521 - Push Health no test name ellipses

### DIFF
--- a/treeherder/push_health/utils.py
+++ b/treeherder/push_health/utils.py
@@ -6,7 +6,7 @@ def clean_test(action, test, signature, message):
         elif action == 'crash':
             clean_name = signature
         elif action == 'log':
-            clean_name = message if len(message) < 50 else '{}...'.format(message[:50])
+            clean_name = message
 
     except UnicodeEncodeError:
         return ''

--- a/ui/push-health/GroupedTests.jsx
+++ b/ui/push-health/GroupedTests.jsx
@@ -80,7 +80,7 @@ class GroupedTests extends PureComponent {
                 />
                 <Button
                   id={`group-${group.id}`}
-                  className="text-center text-monospace border-0"
+                  className="text-center text-break text-wrap text-monospace border-0"
                   title="Click to expand for test detail"
                   outline
                 >


### PR DESCRIPTION
It doesn't look like the `message` field will get that large.  And if it does, let's just text wrap in the button/heading.