### PR TITLE
Bug 1615330 - Load test paths on URL changes

### DIFF
--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -170,10 +170,16 @@ class Push extends React.PureComponent {
     )}`;
   }
 
-  handleUrlChanges = () => {
+  handleUrlChanges = async () => {
     const { push } = this.props;
-    const collapsedPushes = getUrlParam('collapsedPushes') || '';
+    const allParams = getAllUrlParams();
+    const collapsedPushes = allParams.get('collapsedPushes') || '';
 
+    if (allParams.has('test_paths')) {
+      await this.fetchTestManifests();
+    } else {
+      this.setState({ taskNameToTestPaths: {} });
+    }
     this.setState({ collapsed: collapsedPushes.includes(push.id) });
   };
 


### PR DESCRIPTION
Currently, this only works when you load the page with that URL param.  This change will load them also when you add the filtering in the app.