### PR TITLE
Automatically assign code reviewers for some code paths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+# Visit https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+# for learning about the syntax
+
+# Dot files
+.*                                      @armenzg
+docker/*                                @armenzg
+treeherder/etl/management/commands/*    @armenzg
+ui/push-health/*                        @camd
+ui/intermittent-failures/*              @sarah-clements
+ui/intermittents-commenter/*            @sarah-clements


### PR DESCRIPTION
CC @klahnakoski @sarah-clements for FYI
Sarah, I also tried creating a team for contributors but it requires first to make them org members. I've asked around and this is the cleanest solution.

Contributors even with 'Read' access cannot ask a reviewer on PRs.

Using CODEOWNERS enables automatic review request when the file paths match.

More info found in here:
https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners