### PR TITLE
Bug 1626914 - Make Review Apps use Pulse credentials secret

### DIFF
--- a/app.json
+++ b/app.json
@@ -34,7 +34,6 @@
     },
     "HEROKU_REVIEW_APP": true,
     "LOGGING_LEVEL": "INFO",
-    "PULSE_URL": "amqp://treeherder-shared-pulse-user:mozilla123@pulse.mozilla.org:5671/?ssl=true",
     "PULSE_RESULSETS_QUEUE_NAME": {
       "generator": "secret"
     },

--- a/bin/pre_deploy
+++ b/bin/pre_deploy
@@ -67,10 +67,4 @@ if [[ -v NEW_RELIC_CONFIG_FILE ]]; then
                                  "$USER"
 fi
 
-echo "-----> PRE-DEPLOY: New Relic API Key check"
-if [[ -z "$NEW_RELIC_INSIGHTS_API_KEY" ]]; then
-    echo "Error: missing NEW_RELIC_INSIGHTS_API_KEY"
-    exit 1
-fi
-
 echo "-----> PRE-DEPLOY: Complete!"


### PR DESCRIPTION
In the beginning of the Heroku Review Apps it made sense to create a user/password that was shared accross apps and be publicly available (since each app would generate their own random queue names).

Unfortunately, last night, I saw a lot of alerts for queues that were overgrowing. We recently
landed some code that should be deleting queues once there are no consumers (which was not happening). This could be because we had a Review app from a long time ago create lots of queues that were not auto-deleted or someone locally is doing development with the shared credentials unknowingly creating many queues.

Either way, the new Heroku Review apps allow defining config variables (secrets) at the pipeline level and are injected in the Review apps upon creation.

I've reset the treeherder-shared-pulse-user password and created a PULSE_URL config var with the new password.