### PR TITLE
Add task_id and retry_id to project bound Jobs API

### DIFF
--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -69,7 +69,9 @@ def test_job_list(client, eleven_jobs_stored, test_repository,
         "tier",
         "last_modified",
         "ref_data_name",
-        "signature"
+        "signature",
+        "task_id",
+        "retry_id"
     ]
     for job in jobs:
         assert set(job.keys()) == set(exp_keys)

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -184,6 +184,7 @@ class JobsProjectViewSet(viewsets.ViewSet):
         'machine',
         'signature',
         'repository',
+        'taskcluster_metadata'
     ]
 
     _property_query_mapping = [
@@ -221,6 +222,8 @@ class JobsProjectViewSet(viewsets.ViewSet):
         ('submit_timestamp', 'submit_time', to_timestamp),
         ('tier', 'tier', None),
         ('who', 'who', None),
+        ('task_id', 'taskcluster_metadata__task_id', None),
+        ('retry_id', 'taskcluster_metadata__retry_id', None),
     ]
 
     _option_collection_hash_idx = [pq[0] for pq in _property_query_mapping].index(


### PR DESCRIPTION
Currently both `api/project/<project>/jobs/<jobId>/` and `api/jobs/` APIs returns taskcluster metadata but the latter requires users to piece together the data due to its special formatting. 

This change to `api/project/<project>/jobs` will give users more options for retrieving this data (and it doesn't appear to affect query time with local testing). 

Note about the use of retry_id: even though retry is legacy language for run, we use still use it in the other Job APIs so I kept it for consistency. 
