### PR TITLE
Bug 1627271 - Order 'Similar Jobs' first by push id, then by task's sart time

### DIFF
--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -467,7 +467,7 @@ class JobsProjectViewSet(viewsets.ViewSet):
                                      *self._default_select_related)).qs
 
         # similar jobs we want in descending order from most recent
-        jobs = jobs.order_by('-start_time')
+        jobs = jobs.order_by('-push_id', '-start_time')
 
         response_body = self._get_job_list_response(jobs, offset, count,
                                                     return_type)


### PR DESCRIPTION
The most common issue with failed tasks except intermittent failures are
check-in related issues. Until now, the tasks in 'Similar Jobs' were ordered by
the task's start time which was confusing if tasks had been requested to run
again ("retrigger") because the list jumped between pushes. With the new order
by pushes, issues can be more easily associated with a push/check-in.

The downside is that infrastructure related issues are harder to spot but in
general these don't affect only one kind of task (which the 'Similar Jobs' tab
focuses on).