### PR TITLE
Bug 1627088 - Rename known intermittents to known issues

### DIFF
--- a/tests/ui/mock/push_health.json
+++ b/tests/ui/mock/push_health.json
@@ -824,7 +824,7 @@
             "passFailRatio": 0
           }
         ],
-        "intermittent": [
+        "knownIssues": [
           {
             "testName": "@ __abort_with_payload + 0xa",
             "action": "crash",

--- a/tests/ui/push-health/Job_test.jsx
+++ b/tests/ui/push-health/Job_test.jsx
@@ -8,7 +8,7 @@ const repoName = 'try';
 const failJob =
   pushHealth.metrics.tests.details.needInvestigation[0].failJobs[0];
 const failBuild = pushHealth.metrics.builds.details[0];
-const passJob = pushHealth.metrics.tests.details.intermittent[0].passJobs[0];
+const passJob = pushHealth.metrics.tests.details.knownIssues[0].passJobs[0];
 
 describe('Job', () => {
   const testJob = job => (

--- a/tests/ui/push-health/TestFailure_test.jsx
+++ b/tests/ui/push-health/TestFailure_test.jsx
@@ -12,7 +12,7 @@ import TestFailure from '../../../ui/push-health/TestFailure';
 import pushHealth from '../mock/push_health';
 
 const repoName = 'autoland';
-const crashFailure = pushHealth.metrics.tests.details.intermittent[0];
+const crashFailure = pushHealth.metrics.tests.details.knownIssues[0];
 const testFailure = pushHealth.metrics.tests.details.needInvestigation[2];
 
 beforeEach(() => {

--- a/treeherder/push_health/classification.py
+++ b/treeherder/push_health/classification.py
@@ -1,3 +1,8 @@
+# Grouping names/keys for failures.
+KNOWN_ISSUES = 'knownIssues'
+NEED_INVESTIGATION = 'needInvestigation'
+
+
 def set_classifications(failures, intermittent_history, fixed_by_commit_history):
     for failure in failures:
         set_intermittent(failure, intermittent_history)
@@ -63,8 +68,8 @@ def get_log_lines(failure):
 
 def get_grouped(failures):
     classified = {
-        'needInvestigation': [],
-        'intermittent': [],
+        NEED_INVESTIGATION: [],
+        KNOWN_ISSUES: [],
     }
 
     for failure in failures:
@@ -72,9 +77,11 @@ def get_grouped(failures):
 
         if ((is_intermittent and failure['confidence'] == 100) or
                 failure['passFailRatio'] > .5):
-            classified['intermittent'].append(failure)
+            classified[KNOWN_ISSUES].append(failure)
+        elif failure['failedInParent']:
+            classified[KNOWN_ISSUES].append(failure)
         else:
-            classified['needInvestigation'].append(failure)
+            classified[NEED_INVESTIGATION].append(failure)
             # If it needs investigation, we, by definition, don't have 100% confidence.
             failure['confidence'] = min(failure['confidence'], 90)
 

--- a/treeherder/push_health/tests.py
+++ b/treeherder/push_health/tests.py
@@ -77,7 +77,7 @@ def get_history(failure_classification_id, push_date, num_days, option_map, repo
 
 
 # For each failure item in ``tests``, we have 3 categories of jobs that are associated with it in order
-# to help determine if the test is 'intermittent' or not:
+# to help determine if the test is a known issue or not:
 #
 # 1. failJobs: These are jobs where this test has specifically failed in the job
 #    (it has a FailureLine record with the tests name).

--- a/treeherder/push_health/usage.py
+++ b/treeherder/push_health/usage.py
@@ -2,6 +2,7 @@ import logging
 
 from treeherder.config import settings
 from treeherder.model.models import Push
+from treeherder.push_health.classification import NEED_INVESTIGATION
 from treeherder.utils.http import make_request
 from treeherder.webapp.api.serializers import PushSerializer
 
@@ -17,7 +18,7 @@ def get_peak(facet):
             peak = max
             date = item['endTimeSeconds']
 
-    return {'needInvestigation': peak, 'time': date}
+    return {NEED_INVESTIGATION: peak, 'time': date}
 
 
 def get_latest(facet):
@@ -25,7 +26,7 @@ def get_latest(facet):
         if item['inspectedCount'] > 0:
             latest = item['results'][-1]
             return {
-                'needInvestigation': latest['max'],
+                NEED_INVESTIGATION: latest['max'],
                 'time': item['endTimeSeconds']
             }
 

--- a/ui/push-health/TestMetric.jsx
+++ b/ui/push-health/TestMetric.jsx
@@ -21,9 +21,9 @@ export default class TestMetric extends React.PureComponent {
       showParentMatches,
     } = this.props;
     const { name, result, details } = data;
-    const { needInvestigation, intermittent, unsupported } = details;
+    const { needInvestigation, knownIssues, unsupported } = details;
     let filteredNeedInvestigation = needInvestigation;
-    let filteredIntermittent = intermittent;
+    let filteredIntermittent = knownIssues;
 
     if (searchStr.length || !showParentMatches) {
       filteredNeedInvestigation = filterTests(
@@ -32,7 +32,7 @@ export default class TestMetric extends React.PureComponent {
         showParentMatches,
       );
       filteredIntermittent = filterTests(
-        intermittent,
+        knownIssues,
         searchStr,
         showParentMatches,
       );
@@ -63,13 +63,13 @@ export default class TestMetric extends React.PureComponent {
           />
           <ClassificationGroup
             group={filteredIntermittent}
-            name="Known Intermittent"
+            name="Known Issues"
             repo={repo}
             currentRepo={currentRepo}
             revision={revision}
             className="mb-5"
             headerColor="darker-secondary"
-            unfilteredLength={intermittent.length}
+            unfilteredLength={knownIssues.length}
             expanded={false}
             user={user}
             hasRetriggerAll


### PR DESCRIPTION
This gives a better name to this section, because not all items will be 'intermittent'.  Some are now items that also fail in the parent push.