### PR TITLE
Review apps: Adjust ALLOWED_HOSTS

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -105,6 +105,7 @@ if DEBUG:
 # Heroku-review-app (defined in app.json)
 if env("HEROKU_REVIEW_APP", default=False):
     SITE_URL = "https://{}.herokuapp.com".format(env("HEROKU_APP_NAME"))
+    ALLOWED_HOSTS = [SITE_URL]
 
 # Middleware
 MIDDLEWARE = [middleware for middleware in [


### PR DESCRIPTION
It seems that Heroku Review apps have regressed and they are not being added to ALLOWED_HOSTS, thus,
making the web deployment have lost of errors (one of them below):

> ERROR [django.security.DisallowedHost:77] Invalid HTTP_HOST header: 'treeherder-pulse-lsiten-afvimm.herokuapp.com'. You may need to add 'treeherder-pulse-lsiten-afvimm.herokuapp.com' to ALLOWED_HOSTS.

This change can be manually tested like this:

```shell
% export HEROKU_REVIEW_APP=1
% export HEROKU_APP_NAME=treeherder-foo
% python -c "from treeherder.config import settings; print(settings.ALLOWED_HOSTS)"
['https://treeherder-foo.herokuapp.com']
```