### PR TITLE
Bug 1629139 - Update Pulse Docs and allow skip of ingestion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
       - PULSE_AUTO_DELETE_QUEUES=True
       - DATABASE_URL=mysql://root@mysql:3306/treeherder
       - BROKER_URL=amqp://guest:guest@rabbitmq//
+      - SKIP_INGESTION=${SKIP_INGESTION:-False}
     entrypoint: './docker/entrypoint.sh'
     command: ./manage.py pulse_listener_pushes
     volumes:
@@ -124,6 +125,7 @@ services:
       - PULSE_AUTO_DELETE_QUEUES=True
       - DATABASE_URL=mysql://root@mysql:3306/treeherder
       - BROKER_URL=amqp://guest:guest@rabbitmq//
+      - SKIP_INGESTION=${SKIP_INGESTION:-False}
     entrypoint: './docker/entrypoint.sh'
     command: ./manage.py pulse_listener_tasks
     volumes:
@@ -139,7 +141,7 @@ services:
     environment:
       - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672//
       - DATABASE_URL=mysql://root@mysql:3306/treeherder
-      - PROJECTS_TO_INGEST=autoland
+      - PROJECTS_TO_INGEST=${PROJECTS_TO_INGEST:-autoland}
     entrypoint: './docker/entrypoint.sh'
     command: celery worker -A treeherder --uid=nobody --gid=nogroup --without-gossip --without-mingle --without-heartbeat -Q store_pulse_pushes,store_pulse_tasks --concurrency=1 --loglevel=WARNING
     volumes:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -124,6 +124,13 @@ Alternatively, you can `export` that value in your terminal prior to executing
 DATABASE_URL=mysql://user:password@hostname/treeherder docker-compose up
 ```
 
+<!-- prettier-ignore -->
+!!! note
+    If you are using a database on one of our instances (production, stage or prototype) then
+    you should also disable data ingestion via Pulse.  It will ONLY ingest to your local DB,
+    even if `DATABASE_URL` is set.  But it will use your system's resources unnecessarily.
+    To skip data ingestion, set the var `SKIP_INGESTION=True`
+
 ### Deleting the MySql database
 
 The MySql database is kept locally and is not destroyed when the Docker containers are destroyed.

--- a/docs/pulseload.md
+++ b/docs/pulseload.md
@@ -1,124 +1,66 @@
 # Loading Pulse data
 
-For ingestion from **Pulse** exchanges, on your local machine, you can choose
-to ingest from any exchange you like. Some exchanges will be registered in
-`sources.py` for use by the Treeherder servers. You can use those to get the
-same data as Treeherder. Or you can specify your own and experiment with
-posting your own data.
+By default, running the Docker container with `docker-compose up` will ingest data
+from the `autoland` repo using a shared [Pulse Guardian] user.  You can configure this the following ways:
 
-## The Simple Case
+1. Specify a custom set of repositories for which to ingest data
+2. Create a custom **Pulse User** on [Pulse Guardian]
 
-If you just want to get the same data that Treeherder gets, then you have 3 steps:
+## Custom list of Repositories
 
-1. Create a user on [Pulse Guardian] if you don't already have one, and determine a Pulse URL for it
-2. Run a backend Docker container to read Pushes
-3. Run a backend Docker container to read Tasks
-4. Run a backend Docker container for **Celery**
+Set the environment variable of `PROJECTS_TO_INGEST`:
 
-### 1. Pulse Guardian
+```bash
+export PROJECTS_TO_INGEST=autoland,try
+```
+
+## Pulse Guardian
 
 Visit [Pulse Guardian], sign in, and create a **Pulse User**. It will ask you to set a
 username and password. Remember these as you'll use them in the next step.
-Unfortunately, **Pulse** doesn't support creating queues with a guest account, so
-this step is necessary.
+This is recommended, because using the default value **MAY** cause you to miss some data,
+if it was already ingested by another user  Unfortunately, **Pulse** doesn't support creating
+queues with a guest account.
 
 If your **Pulse User** was username: `foo` and password: `bar`, your Pulse URL
 would be:
 
 `amqp://foo:bar@pulse.mozilla.org:5671/?ssl=1`
 
-### 2. Read Pushes
+<!-- prettier-ignore -->
+!!! note
+    Be sure you do **NOT** use quotes when setting the value of PULSE_URL.  Otherwise, you may get an
+    error: ``KeyError: 'No such transport: '``
 
-You will need the root URL for the Taskcluster deployment, such as `https://firefox-ci-tc.services.mozilla.com`.
-
-NOTE: If you use PULSE_URL you will not need to configure the other env variables.
-
-On your localhost set PULSE_URL or PULSE_PUSH_SOURCES as follows, subsituting the appropriate URLs:
-
-```bash
-export PULSE_URL=<pulse url>
-# OR
-export PULSE_PUSH_SOURCES='[{"root_url": "<root url>", "github": true, "hgmo": true, "pulse_url": "<pulse url>"}]'
-```
-
-If the deployment doesn't connect with github or `hg.mozilla.org`, omit the `github` and `hgmo` properties, respectively.
-
-Next, run the Treeherder management command to read Pushes from the default **Pulse**
-exchange:
+On your localhost set PULSE_URL as follows, subsituting the url above:
 
 ```bash
-docker-compose run -e PULSE_URL backend ./manage.py pulse_listener_pushes
-# OR
-docker-compose run -e PULSE_PUSH_SOURCES backend ./manage.py pulse_listener_pushes
+export PULSE_URL=amqp://foo:bar@pulse.mozilla.org:5671/?ssl=1
 ```
 
-You will see a list of the exchanges it has mounted to and a message for each
-push as it is read. This process does not ingest the push into Treeherder. It
-adds that Push message to a local **Celery** queue for ingestion. They will be
-ingested in step 5.
+See [Starting a local Treeherder instance] for more info.
 
-### 4. Read Tasks
+[starting a local treeherder instance]: installation.md#starting-a-local-treeherder-instance
 
-As in step 3, open a new terminal and this time create `PULSE_TASK_SOURCES`:
+## Advanced Celery Configuration
 
-```bash
-export PULSE_URL=<pulse url>
-# OR
-export PULSE_TASK_SOURCES='[{"root_url": "<root url>", "pulse_url": "<pulse url>"}]'
-```
+If you only want to ingest the Pushes and Tasks, then the default will do that for you.
+But if you want to do other processing like parsing logs, etc, then you can specify the other queues
+you would like to process.
 
-Then run the management command for listing to jobs:
-
-```bash
-docker-compose run -e PULSE_URL backend ./manage.py pulse_listener_pushes
-# OR
-docker-compose run -e PULSE_TASK_SOURCES backend ./manage.py pulse_listener_tasks
-```
-
-You will again see the list of exchanges that your queue is now mounted to and
-a message for each Job as it is read into your local **Celery** queue.
-
-### 5. Celery
-
-Open your next terminal. You don't need to set your environment variable
-in this one. Just run **Celery**:
+Open a new terminal window. To run all the queues do:
 
 ```bash
 docker-compose run backend celery -A treeherder worker -B --concurrency 5
 ```
 
-That's it! With those processes running, you will begin ingesting Treeherder
-data. To see the data, you will need to run the Treeherder UI and API.
-See [Starting a local Treeherder instance] for more info.
-
-[starting a local treeherder instance]: installation.md#starting-a-local-treeherder-instance
-
-## Advanced Configuration
-
-### Changing which Data to Ingest
-
-Both `PULSE_TASK_SOURCES` and `PULSE_PUSH_SOURCES` are JSON arrays containing the sources from which you wish to ingest.
-`PULSE_PUSH_SOURCES` allows configuration of the types of pushes to listen for -- `github` or `hgmo`.
-
-### Advanced Celery options
-
-If you only want to ingest the Pushes and Tasks, but don't care about log parsing
-and all the other processing Treeherder does, then you can minimize the **Celery**
-task. You will need:
+You will see a list of activated queues.  If you wanted to narrow that down, then note
+which queues you'd like to run and add them to a comma-separated list.  For instance, to
+only do Log Parsing:
 
 ```bash
-celery -A treeherder worker -B -Q pushlog,store_pulse_tasks,store_pulse_pushes --concurrency 5
+celery -A treeherder worker -B -Q log_parser,log_parser_fail --concurrency 5
 ```
-
-- The `pushlog` queue loads up to the last 10 Mercurial pushes that exist.
-- The `store_pulse_pushes` queue will ingest all the pushes from the exchanges
-  specified in `push_sources`. This can be Mercurial and Github
-- The `store_pulse_tasks` queue will ingest all the jobs from the exchanges
-  specified in `task_sources` (or `PULSE_TASK_SOURCES`).
-
-<!-- prettier-ignore -->
-!!! note
-    Any job that comes from Pulse that does not have an associated push will be skipped.
 
 ## Posting Data
 

--- a/treeherder/etl/management/commands/pulse_listener_pushes.py
+++ b/treeherder/etl/management/commands/pulse_listener_pushes.py
@@ -17,6 +17,9 @@ class Command(BaseCommand):
     help = "Read pushes from a set of pulse exchanges and queue for ingestion"
 
     def handle(self, *args, **options):
+        if env.bool('SKIP_INGESTION', default=False):
+            self.stdout.write("Skipping ingestion of Pulse Pushes")
+            return
         # Specifies the Pulse services from which Treeherder will ingest push
         # information.  Sources can include properties `hgmo`, `github`, or both, to
         # listen to events from those sources.  The value is a JSON array of the form

--- a/treeherder/etl/management/commands/pulse_listener_tasks.py
+++ b/treeherder/etl/management/commands/pulse_listener_tasks.py
@@ -17,6 +17,9 @@ class Command(BaseCommand):
     help = "Read jobs from a set of pulse exchanges and queue for ingestion"
 
     def handle(self, *args, **options):
+        if env.bool('SKIP_INGESTION', default=False):
+            self.stdout.write("Skipping ingestion of Pulse Tasks")
+            return
         # Specifies the Pulse services from which Treeherder will consume task
         # information.  This value is a JSON array of the form [{pulse_url: ..,
         # root_url: ..}, ..]


### PR DESCRIPTION
This does a few things:

1. Updates the Pulse docs to reflect how things work now for local development
2. Allow the user to set an env var to ingest more than just `autoland`
3. Allow the user to skip the data ingestion, especially if they're hooking up to a remote DB like `treeherder-stage`