### PR TITLE
Bug 1618836 - Integrate the backfill logic in the PerfSheriffBot

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import datetime
 import json
 import os
 import platform
-from os.path import join
+from os.path import join, dirname
 
 import kombu
 import pytest
@@ -35,6 +35,7 @@ from treeherder.perf.models import (
 from treeherder.services.pulse.exchange import get_exchange
 
 IS_WINDOWS = "windows" in platform.system().lower()
+SAMPLE_DATA_PATH = join(dirname(__file__), 'sample_data')
 
 
 def pytest_addoption(parser):
@@ -798,3 +799,13 @@ class JSONFixtureLoader:
         fixture_path = join(*self._prior_dirs, fixture_filename)
         with open(fixture_path, 'r') as f:
             return json.load(f)
+
+
+class SampleDataJSONLoader:
+    def __init__(self, *sub_dirs):
+        global SAMPLE_DATA_PATH
+
+        self.load_json = JSONFixtureLoader(SAMPLE_DATA_PATH, *sub_dirs)
+
+    def __call__(self, fixture_filename):
+        return self.load_json(fixture_filename)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import os
 import platform
+from os.path import join
 
 import kombu
 import pytest
@@ -787,3 +788,13 @@ def backfill_record_context():
             },
         ]
     }
+
+
+class JSONFixtureLoader:
+    def __init__(self, *prior_dirs):
+        self._prior_dirs = prior_dirs
+
+    def __call__(self, fixture_filename):
+        fixture_path = join(*self._prior_dirs, fixture_filename)
+        with open(fixture_path, 'r') as f:
+            return json.load(f)

--- a/tests/perfalert/test_alerts/test_secretary_tool.py
+++ b/tests/perfalert/test_alerts/test_secretary_tool.py
@@ -5,7 +5,8 @@ import simplejson as json
 from mock import Mock, patch
 
 from treeherder.perf.models import BackfillRecord, BackfillReport, PerformanceSettings
-from treeherder.perf.secretary_tool import SecretaryTool, default_serializer
+from treeherder.perf.secretary_tool import SecretaryTool
+from treeherder.utils import default_serializer
 
 
 @pytest.fixture

--- a/tests/perfalert/test_perf_sheriff_bot.py
+++ b/tests/perfalert/test_perf_sheriff_bot.py
@@ -2,7 +2,6 @@ import json
 from copy import copy, deepcopy
 from datetime import datetime, timedelta
 from json import JSONDecodeError
-from os.path import dirname, join
 
 import pytest
 
@@ -14,11 +13,9 @@ from treeherder.perf.models import BackfillRecord, BackfillReport, PerformanceSe
 from treeherder.perf.perf_sheriff_bot import PerfSheriffBot
 from treeherder.perf.secretary_tool import SecretaryTool
 
-from tests.conftest import JSONFixtureLoader
+from tests.conftest import SampleDataJSONLoader
 
-SAMPLE_DATA_PATH = join(dirname(dirname(__file__)), 'sample_data')
-
-load_json_fixture = JSONFixtureLoader(SAMPLE_DATA_PATH, 'perf_sheriff_bot')
+load_json_fixture = SampleDataJSONLoader('perf_sheriff_bot')
 
 EPOCH = datetime.utcfromtimestamp(0)
 

--- a/tests/perfalert/test_perf_sheriff_bot.py
+++ b/tests/perfalert/test_perf_sheriff_bot.py
@@ -1,0 +1,243 @@
+import json
+from copy import copy, deepcopy
+from datetime import datetime, timedelta
+from json import JSONDecodeError
+from os.path import dirname, join
+
+import pytest
+
+from django.db import models
+
+from treeherder.model.models import Job
+from treeherder.perf.exceptions import MaxRuntimeExceeded
+from treeherder.perf.models import BackfillRecord, BackfillReport, PerformanceSettings
+from treeherder.perf.perf_sheriff_bot import PerfSheriffBot
+from treeherder.perf.secretary_tool import SecretaryTool
+
+from tests.conftest import JSONFixtureLoader
+
+SAMPLE_DATA_PATH = join(dirname(dirname(__file__)), 'sample_data')
+
+load_json_fixture = JSONFixtureLoader(SAMPLE_DATA_PATH, 'perf_sheriff_bot')
+
+EPOCH = datetime.utcfromtimestamp(0)
+
+# TODO: remove when features enabled
+FEATURE_FLAGS = {
+    'backfill_tool_disabled': False,
+    'secretary_tool_disabled': False,
+}
+# -> up to here
+
+
+@pytest.fixture(scope="module")
+def record_context_sample():
+    # contains 5 data points that can be backfilled
+    return load_json_fixture('recordContext.json')
+
+
+@pytest.fixture(params=['totally_broken_json', 'missing_job_fields', 'null_job_fields'])
+def broken_context_str(record_context_sample: dict, request) -> list:
+    context_str = json.dumps(record_context_sample)
+    specific = request.param
+
+    if specific == 'totally_broken_json':
+        return copy(context_str).replace(r'"', '<')
+
+    else:
+        record_copy = deepcopy(record_context_sample)
+        if specific == 'missing_job_fields':
+            for data_point in record_copy:
+                del data_point['job_id']
+
+        elif specific == 'null_job_fields':
+            for data_point in record_copy:
+                data_point['job_id'] = None
+        return json.dumps(record_copy)
+
+
+def has_changed(orm_object: models.Model) -> bool:
+    """
+    Checks if the ORM object's underlying table row
+    has changed since last database sync.
+    """
+    db_obj = orm_object.__class__.objects.get(pk=orm_object.pk)
+    for f in orm_object._meta.local_fields:
+        if orm_object.__getattribute__(f.name) != db_obj.__getattribute__(f.name):
+            return True
+    return False
+
+
+@pytest.fixture
+def preliminary_record(test_perf_alert):
+    report = BackfillReport.objects.create(summary=test_perf_alert.summary)
+    return BackfillRecord.objects.create(alert=test_perf_alert, report=report)
+
+
+@pytest.fixture
+def record_ready_for_processing(test_perf_alert, record_context_sample):
+    report = BackfillReport.objects.create(summary=test_perf_alert.summary)
+    record = BackfillRecord.objects.create(
+        alert=test_perf_alert, report=report, status=BackfillRecord.READY_FOR_PROCESSING,
+    )
+    record.set_context(record_context_sample)
+    record.save()
+    return record
+
+
+@pytest.fixture
+def report_maintainer_mock():
+    return type('', (), {'provide_updated_reports': lambda *params: []})
+
+
+@pytest.fixture
+def backfill_tool_mock():
+    def backfill_job(job_id):
+        if job_id is None:
+            raise Job.DoesNotExist
+        return 'RANDOM_TASK_ID'
+
+    return type('', (), {'backfill_job': backfill_job})
+
+
+@pytest.fixture
+def secretary():
+    return SecretaryTool()
+
+
+@pytest.fixture
+def sheriff_settings(secretary, db):
+    secretary.validate_settings()
+    return PerformanceSettings.objects.get(name='perf_sheriff_bot')
+
+
+@pytest.fixture
+def empty_sheriff_settings(secretary):
+    all_of_them = 1_000_000_000
+    secretary.validate_settings()
+    secretary.consume_backfills(on_platform='linux', amount=all_of_them)
+    return PerformanceSettings.objects.get(name='perf_sheriff_bot')
+
+
+def test_assert_can_run_throws_exception_when_runtime_exceeded(
+    report_maintainer_mock,
+    backfill_tool_mock,
+    secretary,
+    record_ready_for_processing,
+    sheriff_settings,
+):
+    no_time_left = timedelta(seconds=0)
+    sheriff_settings = PerfSheriffBot(
+        report_maintainer_mock, backfill_tool_mock, secretary, no_time_left, **FEATURE_FLAGS
+    )
+
+    with pytest.raises(MaxRuntimeExceeded):
+        sheriff_settings.assert_can_run()
+
+
+def test_assert_can_run_doesnt_throw_exception_when_enough_time_left(
+    report_maintainer_mock,
+    backfill_tool_mock,
+    secretary,
+    record_ready_for_processing,
+    sheriff_settings,
+):
+    enough_time_left = timedelta(minutes=10)
+    sheriff_settings = PerfSheriffBot(
+        report_maintainer_mock, backfill_tool_mock, secretary, enough_time_left, **FEATURE_FLAGS
+    )
+
+    try:
+        sheriff_settings.assert_can_run()
+    except MaxRuntimeExceeded:
+        pytest.fail()
+
+
+def test_records_and_db_limits_remain_unchanged_if_no_records_suitable_for_backfill(
+    report_maintainer_mock, backfill_tool_mock, secretary, sheriff_settings, preliminary_record
+):
+    sheriff_bot = PerfSheriffBot(
+        report_maintainer_mock, backfill_tool_mock, secretary, **FEATURE_FLAGS
+    )
+    sheriff_bot._backfill()
+
+    assert not has_changed(preliminary_record)
+    assert not has_changed(sheriff_settings)
+
+
+def test_records_remain_unchanged_if_no_backfills_left(
+    report_maintainer_mock,
+    backfill_tool_mock,
+    secretary,
+    record_ready_for_processing,
+    empty_sheriff_settings,
+):
+    sheriff_bot = PerfSheriffBot(
+        report_maintainer_mock, backfill_tool_mock, secretary, **FEATURE_FLAGS
+    )
+    sheriff_bot._backfill()
+
+    assert not has_changed(record_ready_for_processing)
+
+
+def test_records_and_db_limits_remain_unchanged_if_runtime_exceeded(
+    report_maintainer_mock,
+    backfill_tool_mock,
+    secretary,
+    record_ready_for_processing,
+    sheriff_settings,
+):
+    no_time_left = timedelta(seconds=0)
+    sheriff_bot = PerfSheriffBot(
+        report_maintainer_mock, backfill_tool_mock, secretary, no_time_left, **FEATURE_FLAGS
+    )
+    try:
+        sheriff_bot.sheriff(since=EPOCH, frameworks=['raptor', 'talos'], repositories=['autoland'])
+    except MaxRuntimeExceeded:
+        pass
+
+    assert not has_changed(record_ready_for_processing)
+    assert not has_changed(sheriff_settings)
+
+
+def test_db_limits_update_if_backfills_left(
+    report_maintainer_mock,
+    backfill_tool_mock,
+    secretary,
+    record_ready_for_processing,
+    sheriff_settings,
+):
+    initial_backfills = secretary.backfills_left(on_platform='linux')
+    sheriff_bot = PerfSheriffBot(
+        report_maintainer_mock, backfill_tool_mock, secretary, **FEATURE_FLAGS
+    )
+    sheriff_bot._backfill()
+
+    record_ready_for_processing.refresh_from_db()
+    assert record_ready_for_processing.status == BackfillRecord.BACKFILLED
+    assert (initial_backfills - 5) == secretary.backfills_left(on_platform='linux')
+
+
+def test_backfilling_gracefully_handles_invalid_json_contexts_without_blowing_up(
+    report_maintainer_mock,
+    backfill_tool_mock,
+    secretary,
+    record_ready_for_processing,
+    sheriff_settings,
+    broken_context_str,  # Note: parametrizes the test
+):
+    record_ready_for_processing.context = broken_context_str
+    record_ready_for_processing.save()
+
+    sheriff_bot = PerfSheriffBot(
+        report_maintainer_mock, backfill_tool_mock, secretary, **FEATURE_FLAGS
+    )
+    try:
+        sheriff_bot.sheriff(since=EPOCH, frameworks=['raptor', 'talos'], repositories=['autoland'])
+    except (JSONDecodeError, KeyError, Job.DoesNotExist):
+        pytest.fail()
+
+    record_ready_for_processing.refresh_from_db()
+
+    assert record_ready_for_processing.status == BackfillRecord.FAILED
+    assert not has_changed(sheriff_settings)

--- a/tests/sample_data/perf_sheriff_bot/recordContext.json
+++ b/tests/sample_data/perf_sheriff_bot/recordContext.json
@@ -1,0 +1,42 @@
+[
+  {
+    "perf_datum_id": 1108712367,
+    "value": 268.0,
+    "job_id": 297821610,
+    "push_id": 685440,
+    "push_timestamp": "2020-04-15 20:35:43",
+    "push__revision": "9d27f85c23cb252ee9a832582cde377f0b3ff77c"
+  },
+  {
+    "perf_datum_id": 1108893046,
+    "value": 268.0,
+    "job_id": 297848522,
+    "push_id": 685589,
+    "push_timestamp": "2020-04-15 23:44:30",
+    "push__revision": "0a072dacccf525d295161de62cd8c3f7e583b458"
+  },
+  {
+    "perf_datum_id": 1109456575,
+    "value": 252.0,
+    "job_id": 297937917,
+    "push_id": 685943,
+    "push_timestamp": "2020-04-16 12:30:58",
+    "push__revision": "563408c858a186c9b1ac351fddea589ecec351c2"
+  },
+  {
+    "perf_datum_id": 1109802338,
+    "value": 253.0,
+    "job_id": 297987902,
+    "push_id": 686184,
+    "push_timestamp": "2020-04-16 18:38:12",
+    "push__revision": "28fc014e05465eaf9bb08f11ce4326534347450b"
+  },
+  {
+    "perf_datum_id": 1110097942,
+    "value": 252.0,
+    "job_id": 298032850,
+    "push_id": 686380,
+    "push_timestamp": "2020-04-16 23:42:18",
+    "push__revision": "d2fa90f1c8f187994d18b419526a793609b3a6b0"
+  }
+]

--- a/tests/services/test_taskcluster.py
+++ b/tests/services/test_taskcluster.py
@@ -1,13 +1,9 @@
-from os.path import dirname, join
-
 import pytest
 
-from tests.conftest import JSONFixtureLoader
+from tests.conftest import SampleDataJSONLoader
 from treeherder.services.taskcluster import TaskclusterModel
 
-SAMPLE_DATA_PATH = join(dirname(dirname(__file__)), 'sample_data')
-
-load_json_fixture = JSONFixtureLoader(SAMPLE_DATA_PATH, 'perf_sheriff_bot')
+load_json_fixture = SampleDataJSONLoader('perf_sheriff_bot')
 
 
 @pytest.fixture(scope="module")

--- a/tests/services/test_taskcluster.py
+++ b/tests/services/test_taskcluster.py
@@ -1,17 +1,13 @@
-import json
 from os.path import dirname, join
 
 import pytest
 
+from tests.conftest import JSONFixtureLoader
 from treeherder.services.taskcluster import TaskclusterModel
 
 SAMPLE_DATA_PATH = join(dirname(dirname(__file__)), 'sample_data')
 
-
-def load_json_fixture(from_file):
-    fixture_path = join(SAMPLE_DATA_PATH, 'perf_sheriff_bot', from_file)
-    with open(fixture_path, 'r') as f:
-        return json.load(f)
+load_json_fixture = JSONFixtureLoader(SAMPLE_DATA_PATH, 'perf_sheriff_bot')
 
 
 @pytest.fixture(scope="module")

--- a/treeherder/perf/alerts.py
+++ b/treeherder/perf/alerts.py
@@ -21,6 +21,7 @@ from treeherder.perf.models import (
     PerformanceSignature,
 )
 from treeherder.perfalert.perfalert import RevisionDatum, detect_changes
+from treeherder.utils import default_serializer
 
 
 def get_alert_properties(prev_value, new_value, lower_is_better):
@@ -412,7 +413,7 @@ class BackfillReportMaintainer:
             BackfillRecord.objects.create(
                 alert=alert,
                 report=backfill_report,
-                context=json.dumps(retrigger_context, default=str),
+                context=json.dumps(retrigger_context, default=default_serializer),
             )
 
     def _summaries_requiring_reports(self, timestamp: datetime) -> QuerySet:

--- a/treeherder/perf/perf_sheriff_bot.py
+++ b/treeherder/perf/perf_sheriff_bot.py
@@ -54,7 +54,6 @@ class PerfSheriffBot:
     def sheriff(self, since: datetime, frameworks: List[str], repositories: List[str]):
         self.assert_can_run()
 
-        logger.info(f'{self.__class__.__name__} now performs sheriff duty.')
         # secretary tool checks the status of all backfilled jobs
 
         # reporter tool should always run *(only handles preliminary records/reports)*
@@ -67,9 +66,7 @@ class PerfSheriffBot:
 
     def runtime_exceeded(self) -> bool:
         elapsed_runtime = datetime.now() - self._woke_up_time
-        if self._max_runtime <= elapsed_runtime:
-            return True
-        return False
+        return self._max_runtime <= elapsed_runtime
 
     def assert_can_run(self):
         if self.runtime_exceeded():

--- a/treeherder/perf/perf_sheriff_bot.py
+++ b/treeherder/perf/perf_sheriff_bot.py
@@ -1,10 +1,18 @@
-from datetime import datetime
-from typing import List
+import logging
+from datetime import datetime, timedelta
+from json import JSONDecodeError
+from logging import INFO, WARNING
+from typing import List, Tuple
 
 from django.conf import settings
 from taskcluster.helper import TaskclusterConfig
 
-from treeherder.perf.alerts import BackfillReport
+from treeherder.perf.alerts import BackfillRecord, BackfillReport, BackfillReportMaintainer
+from treeherder.perf.backfill_tool import BackfillTool
+from treeherder.perf.exceptions import CannotBackfill, MaxRuntimeExceeded
+from treeherder.perf.secretary_tool import SecretaryTool
+
+logger = logging.getLogger(__name__)
 
 CLIENT_ID = settings.PERF_SHERIFF_BOT_CLIENT_ID
 ACCESS_TOKEN = settings.PERF_SHERIFF_BOT_ACCESS_TOKEN
@@ -15,13 +23,132 @@ class PerfSheriffBot:
     Wrapper class used to aggregate the reporting of backfill reports.
     """
 
-    def __init__(self, report_maintainer):
-        self.report_maintainer = report_maintainer
+    DEFAULT_MAX_RUNTIME = timedelta(minutes=50)
 
-    def report(
+    def __init__(
+        self,
+        report_maintainer: BackfillReportMaintainer,
+        backfill_tool: BackfillTool,
+        secretary_tool: SecretaryTool,
+        max_runtime: timedelta = None,
+        backfill_tool_disabled: bool = True,
+        secretary_tool_disabled: bool = True,
+    ):
+        self.report_maintainer = report_maintainer
+        self.backfill_tool = backfill_tool
+        self.secretary = secretary_tool
+        self._woke_up_time = datetime.now()
+        self._max_runtime = self.DEFAULT_MAX_RUNTIME if max_runtime is None else max_runtime
+
+        # TODO: feature flags; remove when enabled ->
+        self.__backfill_tool_disabled = backfill_tool_disabled
+        self.__secretary_tool_disabled = secretary_tool_disabled
+
+        # extra precautions
+        if self.__backfill_tool_disabled:
+            self.backfill_tool = None
+        if self.__secretary_tool_disabled:
+            self.secretary = None
+        # -> up to here
+
+    def sheriff(self, since: datetime, frameworks: List[str], repositories: List[str]):
+        self.assert_can_run()
+
+        logger.info(f'{self.__class__.__name__} now performs sheriff duty.')
+        # secretary tool checks the status of all backfilled jobs
+
+        # reporter tool should always run *(only handles preliminary records/reports)*
+        self._report(since, frameworks, repositories)
+        self.assert_can_run()
+
+        # backfill tool follows
+        self._backfill()
+        self.assert_can_run()
+
+    def runtime_exceeded(self) -> bool:
+        elapsed_runtime = datetime.now() - self._woke_up_time
+        if self._max_runtime <= elapsed_runtime:
+            return True
+        return False
+
+    def assert_can_run(self):
+        if self.runtime_exceeded():
+            raise MaxRuntimeExceeded(f'Max runtime for {self.__class__.__name__} exceeded')
+
+    def _report(
         self, since: datetime, frameworks: List[str], repositories: List[str]
     ) -> List[BackfillReport]:
         return self.report_maintainer.provide_updated_reports(since, frameworks, repositories)
+
+    def _backfill(self):
+        # TODO: feature flags; remove when enabled ->
+        if self.__backfill_tool_disabled or self.__secretary_tool_disabled:
+            return
+        # -> up to here
+
+        left = self.secretary.backfills_left(on_platform='linux')
+        total_consumed = 0
+
+        records_to_backfill = BackfillRecord.objects.filter(
+            status=BackfillRecord.READY_FOR_PROCESSING
+        )
+        for record in records_to_backfill:
+            if left <= 0 or self.runtime_exceeded():
+                break
+            left, consumed = self._backfill_record(record, left)
+            total_consumed += consumed
+
+        self.secretary.consume_backfills('linux', total_consumed)
+        logger.debug(f'{self.__class__.__name__} has {left} backfills left.')
+
+    def _backfill_record(self, record: BackfillRecord, left: int) -> Tuple[int, int]:
+        consumed = 0
+
+        try:
+            context = record.get_context()
+        except JSONDecodeError:
+            logger.warning(f'Failed to backfill record {record.id}: invalid JSON context.')
+            record.status = BackfillRecord.FAILED
+            record.save()
+        else:
+            for data_point in context:
+                if left <= 0 or self.runtime_exceeded():
+                    break
+                try:
+                    self.backfill_tool.backfill_job(data_point['job_id'])
+                    left, consumed = left - 1, consumed + 1
+                except (KeyError, CannotBackfill, Exception) as ex:
+                    logger.debug(f'Failed to backfill record {record.id}: {ex}')
+
+            success, outcome = self._note_backfill_outcome(record, len(context), consumed)
+            log_level = INFO if success else WARNING
+            logger.log(log_level, f'{outcome} (for backfill record {record.id})')
+
+        return left, consumed
+
+    def _note_backfill_outcome(
+        self, record: BackfillRecord, to_backfill: int, actually_backfilled: int
+    ) -> Tuple[bool, str]:
+        success = False
+
+        if actually_backfilled == to_backfill:
+            record.status = BackfillRecord.BACKFILLED
+            success = True
+            outcome = 'Backfilled all data points'
+        else:
+            record.status = BackfillRecord.FAILED
+            if actually_backfilled == 0:
+                outcome = 'Backfill attempts on all data points failed right upon request.'
+            elif actually_backfilled < to_backfill:
+                outcome = 'Backfill attempts on some data points failed right upon request.'
+            else:
+                raise ValueError(
+                    f'Cannot have backfilled more than available attempts ({actually_backfilled} out of {to_backfill}).'
+                )
+
+        record.set_log_details({'action': 'BACKFILL', 'outcome': outcome})
+        record.save()
+        return success, outcome
 
     def _is_queue_overloaded(
         self, provisioner_id: str, worker_type: str, acceptable_limit=100

--- a/treeherder/perf/secretary_tool.py
+++ b/treeherder/perf/secretary_tool.py
@@ -10,11 +10,13 @@ from treeherder.utils import default_serializer
 logger = logging.getLogger(__name__)
 
 
-# TODO: update the backfill status using data
-# TODO: consider making this a singleton
+# TODO: update the backfill status using data (bug 1626548)
+# TODO: consider making this a singleton (bug 1639112)
 class SecretaryTool:
     """
-    Tool used for doing the secretary work in the Performance Sheriff Bot.
+    * marks which records can be backfilled
+    * provides & maintains backfill limits
+    * notes outcome of backfills (successful/unsuccessful)
     """
 
     TIME_TO_MATURE = timedelta(hours=4)

--- a/treeherder/utils/__init__.py
+++ b/treeherder/utils/__init__.py
@@ -1,0 +1,6 @@
+from datetime import datetime
+
+
+def default_serializer(val):
+    if isinstance(val, datetime):
+        return val.isoformat()


### PR DESCRIPTION
This PR's main purpose is to simply integrate [Bug 1612547 - Define component for doing backfills using existing reports](https://bugzilla.mozilla.org/show_bug.cgi?id=1612547).
It's fully integrated, but hidden behind 2 feature flags. The feature flags are only allowing this PR to work during coverage tests.

*(Once the rest of PerfSheriffBot's dependencies are integrated in the PRs that follow, we'll simply remove the feature flags & fully enable this one.)*

