### PR TITLE
Show the correct task id for actions.

### DIFF
--- a/ui/job-view/CustomJobActions.jsx
+++ b/ui/job-view/CustomJobActions.jsx
@@ -9,7 +9,6 @@ import keyBy from 'lodash/keyBy';
 // node version which pulls in a number of unwanted polyfills. See:
 // https://github.com/nodeca/js-yaml/pull/462
 import jsyaml from 'js-yaml/dist/js-yaml';
-import { slugid } from 'taskcluster-client-web';
 import tcLibUrls from 'taskcluster-lib-urls';
 import {
   Button,
@@ -148,7 +147,6 @@ class CustomJobActions extends React.PureComponent {
 
     TaskclusterModel.submit({
       action,
-      actionTaskId: slugid(),
       decisionTaskId,
       taskId: originalTaskId,
       task: originalTask,

--- a/ui/models/job.js
+++ b/ui/models/job.js
@@ -1,4 +1,3 @@
-import { slugid } from 'taskcluster-client-web';
 import groupBy from 'lodash/groupBy';
 
 import { createQueryParams, getApiUrl } from '../helpers/url';
@@ -110,7 +109,6 @@ export default class JobModel {
 
         TaskclusterModel.load(decisionTaskId, null, currentRepo, testMode)
           .then(async results => {
-            const actionTaskId = slugid();
             const taskLabels = value.map(job => job.job_type_name);
 
             let retriggerAction = results.actions.find(
@@ -132,7 +130,6 @@ export default class JobModel {
 
             await TaskclusterModel.submit({
               action: retriggerAction,
-              actionTaskId,
               decisionTaskId,
               taskId: null,
               task: null,
@@ -141,7 +138,7 @@ export default class JobModel {
               currentRepo,
               testMode,
             })
-              .then(() =>
+              .then(actionTaskId =>
                 notify(
                   `Request sent to retrigger/add new jobs via actions.json (${actionTaskId})`,
                 ),

--- a/ui/models/taskcluster.js
+++ b/ui/models/taskcluster.js
@@ -1,6 +1,6 @@
 import defaults from 'lodash/defaults';
 import jsone from 'json-e';
-import { Auth, Hooks } from 'taskcluster-client-web';
+import { Auth, Hooks, slugid } from 'taskcluster-client-web';
 import { satisfiesExpression } from 'taskcluster-lib-scopes';
 
 import taskcluster, { tcCredentialsMessage } from '../helpers/taskcluster';
@@ -17,7 +17,6 @@ export default class TaskclusterModel {
 
   static async submit({
     action,
-    actionTaskId,
     decisionTaskId,
     taskId,
     task,
@@ -39,6 +38,7 @@ export default class TaskclusterModel {
     const queue = taskcluster.getQueue(rootUrl, testMode);
 
     if (action.kind === 'task') {
+      const actionTaskId = slugid();
       context.task = task;
       context.ownTaskId = actionTaskId;
       const actionTask = jsone(action.task, context);


### PR DESCRIPTION
Before actions were generated by triggering hooks, treeherder generated action tasks directly. When doing this, the calling code generated the task id, and then used that to link to the task. Now that things are generated via hooks, refactor things so the calling code gets the task id from the code triggering the hook.