### PR TITLE
Fix console error 'a' descendent of 'a'

### DIFF
--- a/ui/job-view/headerbars/NotificationsMenu.jsx
+++ b/ui/job-view/headerbars/NotificationsMenu.jsx
@@ -65,7 +65,6 @@ class NotificationsMenu extends React.Component {
           {storedNotifications.length ? (
             storedNotifications.map(notification => (
               <DropdownItem
-                tag="a"
                 className="pl-0 notification-dropdown-line"
                 key={`${notification.created}${notification.message}`}
               >


### PR DESCRIPTION
This tag had been throwing an error on the console for a while.  I think the `tag="a"` was added here by mistake.  Mellina added it a while back for a11y.  But the item already has an `<a>` tag, so this shouldn't be needed.