### PR TITLE
Bug 1628070 - Fix cache_failure_history management command

### DIFF
--- a/treeherder/model/management/commands/cache_failure_history.py
+++ b/treeherder/model/management/commands/cache_failure_history.py
@@ -7,11 +7,13 @@ from treeherder.push_health.tests import (
     fixed_by_commit_history_days,
     get_history,
     intermittent_history_days,
+    CACHE_KEY_ROOT,
 )
 from treeherder.webapp.api.utils import REPO_GROUPS
 
 
 class Command(BaseCommand):
+    # TODO: This command will go away when we migrate to mozci for our backend (Bug 1626746).  But fixing for now.
     help = """Caches history of intermittent and fixed_by_commit failure lines"""
 
     def add_arguments(self, parser):
@@ -42,15 +44,15 @@ class Command(BaseCommand):
         for day in range(days):
             push_date = datetime.datetime.now().date() - datetime.timedelta(days=day)
 
-            int_hist, cache_key = get_history(
-                4, push_date, intermittent_history_days, option_map, repository_ids, True
-            )
-            self.debug('Cached failure history for {}'.format(cache_key))
+            get_history(4, push_date, intermittent_history_days, option_map, repository_ids, True)
 
-            fbc_hist, cache_key = get_history(
+            self.debug(f'Cached failure history for {CACHE_KEY_ROOT}:{4}:{push_date}')
+
+            get_history(
                 2, push_date, fixed_by_commit_history_days, option_map, repository_ids, True
             )
-            self.debug('Cached failure history for {}'.format(cache_key))
+
+            self.debug(f'Cached failure history for {CACHE_KEY_ROOT}:{2}:{push_date}')
 
     def debug(self, msg):
         if self.is_debug:

--- a/treeherder/push_health/tests.py
+++ b/treeherder/push_health/tests.py
@@ -16,6 +16,7 @@ from treeherder.webapp.api.utils import REPO_GROUPS
 
 logger = logging.getLogger(__name__)
 
+CACHE_KEY_ROOT = 'failure_history'
 ONE_WEEK_IN_SECONDS = 604800
 intermittent_history_days = 14
 fixed_by_commit_history_days = 30
@@ -32,7 +33,7 @@ def get_history(
 ):
     start_date = push_date - datetime.timedelta(days=num_days)
     end_date = push_date - datetime.timedelta(days=2)
-    cache_key = 'failure_history:{}:{}'.format(failure_classification_id, push_date)
+    cache_key = f'{CACHE_KEY_ROOT}:{failure_classification_id}:{push_date}'
     previous_failures_json = cache.get(cache_key)
 
     if not previous_failures_json or force_update:


### PR DESCRIPTION
Looks like `black` fixed up a bunch of formatting.  I'll comment on the sections that actually had code changes.

**Note**: Most of this code will go away once we migrate to `mozci`.  But fixing for now anyway.