### PR TITLE
Apply black formating to the whole repo

### DIFF
--- a/lints/queuelint.py
+++ b/lints/queuelint.py
@@ -36,8 +36,14 @@ if settings_queues != procfile_queues:
     print("ERROR - mismatches found")
     missing_procfile = procfile_queues - settings_queues
     if missing_procfile:
-        print("The following queues were in the Procfile, but not in the settings file:\n%s\n" % "\n".join(missing_procfile))
+        print(
+            "The following queues were in the Procfile, but not in the settings file:\n%s\n"
+            % "\n".join(missing_procfile)
+        )
     missing_settings = settings_queues - procfile_queues
     if missing_settings:
-        print("The following queues were in the settings, but not in the Procfile:\n%s\n" % "\n".join(missing_settings))
+        print(
+            "The following queues were in the settings, but not in the Procfile:\n%s\n"
+            % "\n".join(missing_settings)
+        )
     sys.exit(1)

--- a/manage.py
+++ b/manage.py
@@ -21,7 +21,9 @@ warnings.filterwarnings('ignore', category=DeprecationWarning, module='markdown.
 # jinja2/runtime.py -> https://github.com/pallets/jinja/pull/867
 # orderedmultidict/orderedmultidict.py -> https://github.com/gruns/orderedmultidict/pull/20
 # promise/promise_list.py -> https://github.com/syrusakbary/promise/pull/67
-warnings.filterwarnings('ignore', category=DeprecationWarning, message=r'Using or importing the ABCs .*')
+warnings.filterwarnings(
+    'ignore', category=DeprecationWarning, message=r'Using or importing the ABCs .*'
+)
 
 # "the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses"
 warnings.filterwarnings('ignore', category=DeprecationWarning, module='celery.utils.imports')

--- a/misc/compare_pushes.py
+++ b/misc/compare_pushes.py
@@ -16,7 +16,7 @@ logger.setLevel(logging.INFO)
 HOSTS = {
     "localhost": "http://localhost:8000",
     "stage": "https://treeherder.allizom.org",
-    "production": "https://treeherder.mozilla.org"
+    "production": "https://treeherder.mozilla.org",
 }
 
 
@@ -46,24 +46,28 @@ def main(args):
             difference = DeepDiff(pushes[index], production_pushes[index])
             if difference:
                 logger.info(difference.to_json())
-                logger.info("{}/#/jobs?repo={}&revision={}".format(
-                            compare_to_client.server_url,
-                            _project,
-                            pushes[index]["revision"]))
-                logger.info("{}/#/jobs?repo={}&revision={}".format(
-                            production_client.server_url,
-                            _project,
-                            production_pushes[index]["revision"]))
+                logger.info(
+                    "{}/#/jobs?repo={}&revision={}".format(
+                        compare_to_client.server_url, _project, pushes[index]["revision"]
+                    )
+                )
+                logger.info(
+                    "{}/#/jobs?repo={}&revision={}".format(
+                        production_client.server_url, _project, production_pushes[index]["revision"]
+                    )
+                )
 
 
 def get_args():
-    parser = argparse.ArgumentParser("Compare a push from a Treeherder instance to the production instance.")
-    parser.add_argument("--host",
-                        default="stage",
-                        help="Host to compare. It defaults to stage")
-    parser.add_argument("--projects",
-                        default="android-components,fenix",
-                        help="Projects (comma separated) to compare. It defaults to android-components & fenix")
+    parser = argparse.ArgumentParser(
+        "Compare a push from a Treeherder instance to the production instance."
+    )
+    parser.add_argument("--host", default="stage", help="Host to compare. It defaults to stage")
+    parser.add_argument(
+        "--projects",
+        default="android-components,fenix",
+        help="Projects (comma separated) to compare. It defaults to android-components & fenix",
+    )
 
     args = parser.parse_args()
     return args

--- a/misc/compare_tasks.py
+++ b/misc/compare_tasks.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 HOSTS = {
     "localhost": "http://localhost:8000",
     "stage": "https://treeherder.allizom.org",
-    "production": "https://treeherder.mozilla.org"
+    "production": "https://treeherder.mozilla.org",
 }
 
 
@@ -58,19 +58,26 @@ def print_url_to_taskcluster(job_guid):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser("Compare a push from a Treeherder instance to the production instance.")
-    parser.add_argument("--host", default="localhost",
-                        help="Host to compare. It defaults to localhost")
-    parser.add_argument("--revision", required=True,
-                        help="Revision to compare")
-    parser.add_argument("--project", default="mozilla-central",
-                        help="Project to compare. It defaults to mozilla-central")
+    parser = argparse.ArgumentParser(
+        "Compare a push from a Treeherder instance to the production instance."
+    )
+    parser.add_argument(
+        "--host", default="localhost", help="Host to compare. It defaults to localhost"
+    )
+    parser.add_argument("--revision", required=True, help="Revision to compare")
+    parser.add_argument(
+        "--project",
+        default="mozilla-central",
+        help="Project to compare. It defaults to mozilla-central",
+    )
 
     args = parser.parse_args()
 
     th_instance = TreeherderClient(server_url=HOSTS[args.host])
     th_instance_pushid = th_instance.get_pushes(args.project, revision=args.revision)[0]["id"]
-    th_instance_jobs = th_instance.get_jobs(args.project, push_id=th_instance_pushid, count=None) or []
+    th_instance_jobs = (
+        th_instance.get_jobs(args.project, push_id=th_instance_pushid, count=None) or []
+    )
 
     production = TreeherderClient(server_url=HOSTS["production"])
     production_pushid = production.get_pushes(args.project, revision=args.revision)[0]["id"]
@@ -103,7 +110,9 @@ if __name__ == "__main__":
     logger.info("We have found: %s jobs on the production instance.", len(production_jobs))
 
     if production_dict:
-        logger.info("There are the first 10 production jobs we do not have th_instancely. Follow the link to investigate.")
+        logger.info(
+            "There are the first 10 production jobs we do not have th_instancely. Follow the link to investigate."
+        )
         for job in list(production_dict.values())[0:10]:
             print_url_to_taskcluster(job["job_guid"])
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,10 @@
 [flake8]
 exclude = */.*/,.*/,__pycache__,node_modules
 # E129: visually indented line with same indent as next logical line
+# E203 whitespace before ':'
+# E231: missing whitespace after ','
 # E501: line too long
-extend_ignore = E129,E501
+extend_ignore = E129,E203,E231,E501
 max-line-length = 100
 
 [tool:pytest]

--- a/tests/autoclassify/test_classify_failures.py
+++ b/tests/autoclassify/test_classify_failures.py
@@ -1,16 +1,14 @@
 from treeherder.autoclassify.autoclassify import match_errors
-from treeherder.autoclassify.matchers import (crash_signature_matcher,
-                                              precise_matcher)
-from treeherder.model.models import (BugJobMap,
-                                     ClassifiedFailure,
-                                     JobNote,
-                                     TextLogError,
-                                     TextLogErrorMatch)
+from treeherder.autoclassify.matchers import crash_signature_matcher, precise_matcher
+from treeherder.model.models import (
+    BugJobMap,
+    ClassifiedFailure,
+    JobNote,
+    TextLogError,
+    TextLogErrorMatch,
+)
 
-from .utils import (crash_line,
-                    create_lines,
-                    log_line,
-                    test_line)
+from .utils import crash_line, create_lines, log_line, test_line
 
 
 def do_autoclassify(job, test_failure_lines, matchers, status="testfailed"):
@@ -24,18 +22,18 @@ def do_autoclassify(job, test_failure_lines, matchers, status="testfailed"):
         item.refresh_from_db()
 
 
-def test_classify_test_failure(text_log_errors_failure_lines,
-                               classified_failures,
-                               test_job_2):
+def test_classify_test_failure(text_log_errors_failure_lines, classified_failures, test_job_2):
     # Ensure that running autoclassify on a new job classifies lines that
     # exactly match previous classifications
 
     # The first two lines match classified failures created in teh fixtures
-    lines = [(test_line, {}),
-             (test_line, {"subtest": "subtest2"}),
-             (test_line, {"status": "TIMEOUT"}),
-             (test_line, {"expected": "ERROR"}),
-             (test_line, {"message": "message2"})]
+    lines = [
+        (test_line, {}),
+        (test_line, {"subtest": "subtest2"}),
+        (test_line, {"status": "TIMEOUT"}),
+        (test_line, {"expected": "ERROR"}),
+        (test_line, {"message": "message2"}),
+    ]
     test_error_lines, test_failure_lines = create_lines(test_job_2, lines)
 
     do_autoclassify(test_job_2, test_failure_lines, [precise_matcher])
@@ -43,25 +41,28 @@ def test_classify_test_failure(text_log_errors_failure_lines,
     expected_classified = test_error_lines[:2], test_failure_lines[:2]
     expected_unclassified = test_error_lines[2:], test_failure_lines[2:]
 
-    for (error_line, failure_line), expected in zip(zip(*expected_classified),
-                                                    classified_failures):
+    for (error_line, failure_line), expected in zip(zip(*expected_classified), classified_failures):
         assert list(error_line.classified_failures.values_list('id', flat=True)) == [expected.id]
-        assert list(failure_line.error.classified_failures.values_list('id', flat=True)) == [expected.id]
+        assert list(failure_line.error.classified_failures.values_list('id', flat=True)) == [
+            expected.id
+        ]
 
     for error_line, failure_line in zip(*expected_unclassified):
         assert error_line.classified_failures.count() == 0
         assert failure_line.error.classified_failures.count() == 0
 
 
-def test_no_autoclassify_job_success(text_log_errors_failure_lines,
-                                     classified_failures,
-                                     test_job_2):
+def test_no_autoclassify_job_success(
+    text_log_errors_failure_lines, classified_failures, test_job_2
+):
     # Ensure autoclassification doesn't occur for successful jobs
-    lines = [(test_line, {}),
-             (test_line, {"subtest": "subtest2"}),
-             (test_line, {"status": "TIMEOUT"}),
-             (test_line, {"expected": "ERROR"}),
-             (test_line, {"message": "message2"})]
+    lines = [
+        (test_line, {}),
+        (test_line, {"subtest": "subtest2"}),
+        (test_line, {"status": "TIMEOUT"}),
+        (test_line, {"expected": "ERROR"}),
+        (test_line, {"message": "message2"}),
+    ]
     test_error_lines, test_failure_lines = create_lines(test_job_2, lines)
 
     do_autoclassify(test_job_2, test_failure_lines, [precise_matcher], status="success")
@@ -69,10 +70,11 @@ def test_no_autoclassify_job_success(text_log_errors_failure_lines,
     expected_classified = [], []
     expected_unclassified = test_error_lines, test_failure_lines
 
-    for (error_line, failure_line), expected in zip(zip(*expected_classified),
-                                                    classified_failures):
+    for (error_line, failure_line), expected in zip(zip(*expected_classified), classified_failures):
         assert list(error_line.classified_failures.values_list('id', flat=True)) == [expected.id]
-        assert list(failure_line.error.classified_failures.values_list('id', flat=True)) == [expected.id]
+        assert list(failure_line.error.classified_failures.values_list('id', flat=True)) == [
+            expected.id
+        ]
 
     for error_line, failure_line in zip(*expected_unclassified):
         assert error_line.classified_failures.count() == 0
@@ -95,38 +97,32 @@ def test_autoclassify_update_job_classification(failure_lines, classified_failur
     assert BugJobMap.objects.filter(job=test_job_2).count() == 0
 
 
-def test_autoclassify_no_update_job_classification(test_job, test_job_2,
-                                                   text_log_errors_failure_lines,
-                                                   classified_failures):
+def test_autoclassify_no_update_job_classification(
+    test_job, test_job_2, text_log_errors_failure_lines, classified_failures
+):
 
     lines = [(test_line, {})]
     test_error_lines, test_failure_lines = create_lines(test_job_2, lines)
-    TextLogError.objects.create(step=test_error_lines[0].step,
-                                line="Some error that isn't in the structured logs",
-                                line_number=2)
+    TextLogError.objects.create(
+        step=test_error_lines[0].step,
+        line="Some error that isn't in the structured logs",
+        line_number=2,
+    )
 
     do_autoclassify(test_job_2, test_failure_lines, [precise_matcher])
 
     assert JobNote.objects.filter(job=test_job_2).count() == 0
 
 
-def test_autoclassified_after_manual_classification(test_user,
-                                                    test_job_2,
-                                                    text_log_errors_failure_lines,
-                                                    failure_classifications, bugs):
+def test_autoclassified_after_manual_classification(
+    test_user, test_job_2, text_log_errors_failure_lines, failure_classifications, bugs
+):
     lines = [(test_line, {})]
     test_error_lines, test_failure_lines = create_lines(test_job_2, lines)
     bug = bugs.first()
 
-    BugJobMap.create(
-        job_id=test_job_2.id,
-        bug_id=bug.id,
-        user=test_user
-    )
-    JobNote.objects.create(job=test_job_2,
-                           failure_classification_id=4,
-                           user=test_user,
-                           text="")
+    BugJobMap.create(job_id=test_job_2.id, bug_id=bug.id, user=test_user)
+    JobNote.objects.create(job=test_job_2, failure_classification_id=4, user=test_user, text="")
 
     for error_line, failure_line in zip(test_error_lines, test_failure_lines):
         error_line.refresh_from_db()
@@ -145,17 +141,14 @@ def test_autoclassified_after_manual_classification(test_user,
     assert fl1.text_log_error_metadata.best_is_verified
 
 
-def test_autoclassified_no_update_after_manual_classification_1(test_job_2,
-                                                                test_user,
-                                                                failure_classifications):
+def test_autoclassified_no_update_after_manual_classification_1(
+    test_job_2, test_user, failure_classifications
+):
     # Line type won't be detected by the matchers we have registered
     lines = [(log_line, {})]
     test_error_lines, test_failure_lines = create_lines(test_job_2, lines)
 
-    JobNote.objects.create(job=test_job_2,
-                           failure_classification_id=4,
-                           user=test_user,
-                           text="")
+    JobNote.objects.create(job=test_job_2, failure_classification_id=4, user=test_user, text="")
 
     for error_line, failure_line in zip(test_error_lines, test_failure_lines):
         error_line.refresh_from_db()
@@ -165,17 +158,15 @@ def test_autoclassified_no_update_after_manual_classification_1(test_job_2,
     assert not test_failure_lines[0].error.matches.all().exists()
 
 
-def test_autoclassified_no_update_after_manual_classification_2(test_user, test_job_2,
-                                                                failure_classifications):
+def test_autoclassified_no_update_after_manual_classification_2(
+    test_user, test_job_2, failure_classifications
+):
     # Too many failure lines
-    _, test_failure_lines = create_lines(test_job_2,
-                                         [(log_line, {}),
-                                          (test_line, {"subtest": "subtest2"})])
+    _, test_failure_lines = create_lines(
+        test_job_2, [(log_line, {}), (test_line, {"subtest": "subtest2"})]
+    )
 
-    JobNote.objects.create(job=test_job_2,
-                           failure_classification_id=4,
-                           user=test_user,
-                           text="")
+    JobNote.objects.create(job=test_job_2, failure_classification_id=4, user=test_user, text="")
 
     for item in test_failure_lines:
         item.refresh_from_db()
@@ -183,18 +174,16 @@ def test_autoclassified_no_update_after_manual_classification_2(test_user, test_
     assert not test_failure_lines[0].error.matches.all().exists()
 
 
-def test_classify_skip_ignore(test_job_2,
-                              text_log_errors_failure_lines,
-                              classified_failures):
+def test_classify_skip_ignore(test_job_2, text_log_errors_failure_lines, classified_failures):
 
     text_log_errors, failure_lines = text_log_errors_failure_lines
     text_log_errors[1].metadata.best_is_verified = True
     text_log_errors[1].metadata.best_classification = None
     text_log_errors[1].metadata.save()
 
-    _, test_failure_lines = create_lines(test_job_2,
-                                         [(test_line, {}),
-                                          (test_line, {"subtest": "subtest2"})])
+    _, test_failure_lines = create_lines(
+        test_job_2, [(test_line, {}), (test_line, {"subtest": "subtest2"})]
+    )
 
     do_autoclassify(test_job_2, test_failure_lines, [precise_matcher])
 
@@ -209,9 +198,9 @@ def test_classify_skip_ignore(test_job_2,
 
 
 def test_classify_multiple(test_job_2, failure_lines, classified_failures):
-    _, test_failure_lines = create_lines(test_job_2,
-                                         [(test_line, {}),
-                                          (test_line, {"message": "message 1.2"})])
+    _, test_failure_lines = create_lines(
+        test_job_2, [(test_line, {}), (test_line, {"message": "message 1.2"})]
+    )
 
     expected_classified_precise = [test_failure_lines[0]]
 
@@ -223,27 +212,34 @@ def test_classify_multiple(test_job_2, failure_lines, classified_failures):
 
 
 def test_classify_crash(test_repository, test_job, test_job_2, test_matcher):
-    error_lines_ref, failure_lines_ref = create_lines(test_job,
-                                                      [(crash_line, {})])
+    error_lines_ref, failure_lines_ref = create_lines(test_job, [(crash_line, {})])
 
-    _, failure_lines = create_lines(test_job_2,
-                                    [(crash_line, {}),
-                                     (crash_line, {"test": "test1"}),
-                                     (crash_line, {"signature": "signature1"}),
-                                     (crash_line, {"signature": None})])
+    _, failure_lines = create_lines(
+        test_job_2,
+        [
+            (crash_line, {}),
+            (crash_line, {"test": "test1"}),
+            (crash_line, {"signature": "signature1"}),
+            (crash_line, {"signature": None}),
+        ],
+    )
 
     classified_failure = ClassifiedFailure.objects.create()
-    TextLogErrorMatch.objects.create(text_log_error=error_lines_ref[0],
-                                     classified_failure=classified_failure,
-                                     matcher_name=test_matcher.__class__.__name__,
-                                     score=1.0)
+    TextLogErrorMatch.objects.create(
+        text_log_error=error_lines_ref[0],
+        classified_failure=classified_failure,
+        matcher_name=test_matcher.__class__.__name__,
+        score=1.0,
+    )
     do_autoclassify(test_job_2, failure_lines, [crash_signature_matcher])
 
     expected_classified = failure_lines[0:2]
     expected_unclassified = failure_lines[2:]
 
     for actual in expected_classified:
-        assert list(actual.error.classified_failures.values_list('id', flat=True)) == [classified_failure.id]
+        assert list(actual.error.classified_failures.values_list('id', flat=True)) == [
+            classified_failure.id
+        ]
 
     for item in expected_unclassified:
         assert item.error.classified_failures.count() == 0

--- a/tests/autoclassify/test_matchers.py
+++ b/tests/autoclassify/test_matchers.py
@@ -4,12 +4,9 @@ from first import first
 
 from treeherder.autoclassify.matchers import precise_matcher
 from treeherder.autoclassify.utils import score_matches
-from treeherder.model.models import (FailureLine,
-                                     TextLogErrorMatch,
-                                     TextLogErrorMetadata)
+from treeherder.model.models import FailureLine, TextLogErrorMatch, TextLogErrorMetadata
 
-from .utils import (create_failure_lines,
-                    create_text_log_errors)
+from .utils import create_failure_lines, create_text_log_errors
 
 
 def test_precise_matcher_with_matches(classified_failures):

--- a/tests/autoclassify/test_utils.py
+++ b/tests/autoclassify/test_utils.py
@@ -7,7 +7,7 @@ def test_time_boxed_enough_budget():
     an_iterable = range(3)
 
     def quick_sleep(x):
-        time.sleep(.1)
+        time.sleep(0.1)
         return x
 
     items = list(time_boxed(quick_sleep, an_iterable, time_budget=5000))

--- a/tests/autoclassify/utils.py
+++ b/tests/autoclassify/utils.py
@@ -2,15 +2,23 @@ import datetime
 
 from mozlog.formatters.tbplformatter import TbplFormatter
 
-from treeherder.model.models import (FailureLine,
-                                     Job,
-                                     JobLog,
-                                     TextLogError,
-                                     TextLogErrorMetadata,
-                                     TextLogStep)
+from treeherder.model.models import (
+    FailureLine,
+    Job,
+    JobLog,
+    TextLogError,
+    TextLogErrorMetadata,
+    TextLogStep,
+)
 
-test_line = {"action": "test_result", "test": "test1", "subtest": "subtest1",
-             "status": "FAIL", "expected": "PASS", "message": "message1"}
+test_line = {
+    "action": "test_result",
+    "test": "test1",
+    "subtest": "subtest1",
+    "status": "FAIL",
+    "expected": "PASS",
+    "message": "message1",
+}
 log_line = {"action": "log", "level": "ERROR", "message": "message1"}
 crash_line = {"action": "crash", "signature": "signature", "test": "test1"}
 group_line = {"action": "test_groups"}
@@ -21,8 +29,7 @@ def create_lines(test_job, lines):
     failure_lines = create_failure_lines(test_job, lines)
 
     for error_line, failure_line in zip(error_lines, failure_lines):
-        TextLogErrorMetadata.objects.create(text_log_error=error_line,
-                                            failure_line=failure_line)
+        TextLogErrorMetadata.objects.create(text_log_error=error_line, failure_line=failure_line)
 
     test_job.autoclassify_status = Job.CROSSREFERENCED
     test_job.save()
@@ -30,13 +37,10 @@ def create_lines(test_job, lines):
     return error_lines, failure_lines
 
 
-def create_failure_lines(job, failure_line_list,
-                         start_line=0):
+def create_failure_lines(job, failure_line_list, start_line=0):
     failure_lines = []
     for i, (base_data, updates) in enumerate(failure_line_list[start_line:]):
-        data = {"job_guid": job.guid,
-                "repository": job.repository,
-                "line": i + start_line}
+        data = {"job_guid": job.guid, "repository": job.repository, "line": i + start_line}
         data.update(base_data)
         data.update(updates)
         failure_line = FailureLine(**data)
@@ -44,7 +48,7 @@ def create_failure_lines(job, failure_line_list,
             job=job,
             name='{}{}'.format(base_data.get('test'), job.id),
             url='bar{}'.format(i),
-            status=1
+            status=1,
         )
         print('create jobLog for job id: {}'.format(job.id))
         failure_line.job_log = job_log
@@ -82,7 +86,8 @@ def create_text_log_errors(job, failure_line_list):
         finished_line_number=10,
         started=datetime.datetime.now(),
         finished=datetime.datetime.now(),
-        result=TextLogStep.TEST_FAILED)
+        result=TextLogStep.TEST_FAILED,
+    )
 
     formatter = TbplFormatter()
     errors = []
@@ -90,9 +95,9 @@ def create_text_log_errors(job, failure_line_list):
         data = get_data(base_data, updates)
         if not data:
             continue
-        error = TextLogError.objects.create(step=step,
-                                            line=formatter(data).split("\n")[0],
-                                            line_number=i)
+        error = TextLogError.objects.create(
+            step=step, line=formatter(data).split("\n")[0], line_number=i
+        )
         errors.append(error)
 
     return errors

--- a/tests/client/test_perfherder_client.py
+++ b/tests/client/test_perfherder_client.py
@@ -6,7 +6,6 @@ from treeherder.client.thclient import PerfherderClient
 
 
 class PerfherderClientTest(unittest.TestCase):
-
     @responses.activate
     def test_get_performance_signatures(self):
         pc = PerfherderClient()
@@ -14,34 +13,33 @@ class PerfherderClientTest(unittest.TestCase):
         content = {
             'signature1': {'cheezburgers': 1},
             'signature2': {'hamburgers': 2},
-            'signature3': {'cheezburgers': 2}
+            'signature3': {'cheezburgers': 2},
         }
         responses.add(responses.GET, url, json=content, match_querystring=True, status=200)
 
         sigs = pc.get_performance_signatures('mozilla-central')
         self.assertEqual(len(sigs), 3)
-        self.assertEqual(sigs.get_signature_hashes(), ['signature1',
-                                                       'signature2',
-                                                       'signature3'])
-        self.assertEqual(sigs.get_property_names(),
-                         set(['cheezburgers', 'hamburgers']))
+        self.assertEqual(sigs.get_signature_hashes(), ['signature1', 'signature2', 'signature3'])
+        self.assertEqual(sigs.get_property_names(), set(['cheezburgers', 'hamburgers']))
         self.assertEqual(sigs.get_property_values('cheezburgers'), set([1, 2]))
 
     @responses.activate
     def test_get_performance_data(self):
         pc = PerfherderClient()
 
-        url = '{}?{}'.format(pc._get_endpoint_url(pc.PERFORMANCE_DATA_ENDPOINT, project='mozilla-central'),
-                             'signatures=signature1&signatures=signature2')
+        url = '{}?{}'.format(
+            pc._get_endpoint_url(pc.PERFORMANCE_DATA_ENDPOINT, project='mozilla-central'),
+            'signatures=signature1&signatures=signature2',
+        )
         content = {
             'signature1': [{'value': 1}, {'value': 2}],
-            'signature2': [{'value': 2}, {'value': 1}]
+            'signature2': [{'value': 2}, {'value': 1}],
         }
         responses.add(responses.GET, url, json=content, match_querystring=True, status=200)
 
-        series_list = pc.get_performance_data('mozilla-central',
-                                              signatures=['signature1',
-                                                          'signature2'])
+        series_list = pc.get_performance_data(
+            'mozilla-central', signatures=['signature1', 'signature2']
+        )
         self.assertEqual(len(series_list), 2)
         self.assertEqual(series_list['signature1']['value'], [1, 2])
         self.assertEqual(series_list['signature2']['value'], [2, 1])

--- a/tests/client/test_treeherder_client.py
+++ b/tests/client/test_treeherder_client.py
@@ -6,24 +6,16 @@ from treeherder.client.thclient import TreeherderClient
 
 
 class TreeherderClientTest(unittest.TestCase):
-    JOB_RESULTS = [{"jobDetail1": 1},
-                   {"jobDetail2": 2},
-                   {"jobDetail3": 3}
-                   ]
-    PUSHES = [{"push1": 1},
-              {"push2": 2},
-              {"push3": 3}
-              ]
+    JOB_RESULTS = [{"jobDetail1": 1}, {"jobDetail2": 2}, {"jobDetail3": 3}]
+    PUSHES = [{"push1": 1}, {"push2": 2}, {"push3": 3}]
 
     @responses.activate
     def test_get_job(self):
         tdc = TreeherderClient()
         url = tdc._get_endpoint_url(tdc.JOBS_ENDPOINT, project='mozilla-inbound')
         content = {
-            "meta": {"count": 3,
-                     "repository": "mozilla-inbound",
-                     "offset": 0},
-            "results": self.JOB_RESULTS
+            "meta": {"count": 3, "repository": "mozilla-inbound", "offset": 0},
+            "results": self.JOB_RESULTS,
         }
         responses.add(responses.GET, url, json=content, match_querystring=True, status=200)
 
@@ -36,9 +28,8 @@ class TreeherderClientTest(unittest.TestCase):
         tdc = TreeherderClient()
         url = tdc._get_endpoint_url(tdc.PUSH_ENDPOINT, project='mozilla-inbound')
         content = {
-            "meta": {"count": 3, "repository": "mozilla-inbound",
-                     "offset": 0},
-            "results": self.PUSHES
+            "meta": {"count": 3, "repository": "mozilla-inbound", "offset": 0},
+            "results": self.PUSHES,
         }
         responses.add(responses.GET, url, json=content, match_querystring=True, status=200)
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -30,9 +30,7 @@ def completed_job():
 
 
 @pytest.fixture
-def pending_jobs_stored(
-        test_repository, failure_classifications, pending_job,
-        push_stored):
+def pending_jobs_stored(test_repository, failure_classifications, pending_job, push_stored):
     """
     stores a list of buildapi pending jobs into the jobs store
     """
@@ -42,9 +40,7 @@ def pending_jobs_stored(
 
 
 @pytest.fixture
-def running_jobs_stored(
-        test_repository, failure_classifications, running_job,
-        push_stored):
+def running_jobs_stored(test_repository, failure_classifications, running_job, push_stored):
     """
     stores a list of buildapi running jobs
     """
@@ -54,9 +50,7 @@ def running_jobs_stored(
 
 
 @pytest.fixture
-def completed_jobs_stored(
-        test_repository, failure_classifications, completed_job,
-        push_stored):
+def completed_jobs_stored(test_repository, failure_classifications, completed_job, push_stored):
     """
     stores a list of buildapi completed jobs
     """

--- a/tests/e2e/test_job_ingestion.py
+++ b/tests/e2e/test_job_ingestion.py
@@ -9,11 +9,7 @@ from tests.test_utils import add_log_response
 from treeherder.etl.jobs import store_job_data
 from treeherder.log_parser.parsers import StepParser
 from treeherder.model.error_summary import get_error_summary
-from treeherder.model.models import (Job,
-                                     JobDetail,
-                                     JobLog,
-                                     TextLogError,
-                                     TextLogStep)
+from treeherder.model.models import Job, JobDetail, JobLog, TextLogError, TextLogStep
 
 # TODO: Turn these into end to end taskcluster tests as part of removing buildbot
 # support in bug 1443251, or else delete them if they're duplicating coverage.
@@ -24,25 +20,41 @@ def text_log_summary_dict():
     return {
         "step_data": {
             "steps": [
-                {"name": "Clone gecko tc-vcs ",
-                 "started_linenumber": 1,
-                 "finished_linenumber": 100000,
-                 "started": "2016-07-13 16:09:31",
-                 "finished": "2016-07-13 16:09:31",
-                 "result": "testfailed",
-                 "errors": [
-                     {"line": "12:34:13     INFO -  Assertion failure: addr % CellSize == 0, at ../../../js/src/gc/Heap.h:1041", "linenumber": 61918},
-                     {"line": "12:34:24  WARNING -  TEST-UNEXPECTED-FAIL | file:///builds/slave/talos-slave/test/build/tests/jsreftest/tests/jsreftest.html?test=ecma_5/JSON/parse-array-gc.js | Exited with code 1 during test run", "linenumber": 61919},
-                     {"line": "12:34:37  WARNING -  PROCESS-CRASH | file:///builds/slave/talos-slave/test/build/tests/jsreftest/tests/jsreftest.html?test=ecma_5/JSON/parse-array-gc.js | application crashed [@ js::gc::Cell::tenuredZone() const]", "linenumber": 61922},
-                     {"line": "12:34:38    ERROR - Return code: 256", "linenumber": 64435}
-                 ]},
-                {"name": "Build ./build-b2g-desktop.sh /home/worker/workspace", "started_linenumber": 1, "finished_linenumber": 1, "result": "success",
-                 "started": "2016-07-13 16:09:31",
-                 "finished": "2016-07-13 16:09:31"}
+                {
+                    "name": "Clone gecko tc-vcs ",
+                    "started_linenumber": 1,
+                    "finished_linenumber": 100000,
+                    "started": "2016-07-13 16:09:31",
+                    "finished": "2016-07-13 16:09:31",
+                    "result": "testfailed",
+                    "errors": [
+                        {
+                            "line": "12:34:13     INFO -  Assertion failure: addr % CellSize == 0, at ../../../js/src/gc/Heap.h:1041",
+                            "linenumber": 61918,
+                        },
+                        {
+                            "line": "12:34:24  WARNING -  TEST-UNEXPECTED-FAIL | file:///builds/slave/talos-slave/test/build/tests/jsreftest/tests/jsreftest.html?test=ecma_5/JSON/parse-array-gc.js | Exited with code 1 during test run",
+                            "linenumber": 61919,
+                        },
+                        {
+                            "line": "12:34:37  WARNING -  PROCESS-CRASH | file:///builds/slave/talos-slave/test/build/tests/jsreftest/tests/jsreftest.html?test=ecma_5/JSON/parse-array-gc.js | application crashed [@ js::gc::Cell::tenuredZone() const]",
+                            "linenumber": 61922,
+                        },
+                        {"line": "12:34:38    ERROR - Return code: 256", "linenumber": 64435},
+                    ],
+                },
+                {
+                    "name": "Build ./build-b2g-desktop.sh /home/worker/workspace",
+                    "started_linenumber": 1,
+                    "finished_linenumber": 1,
+                    "result": "success",
+                    "started": "2016-07-13 16:09:31",
+                    "finished": "2016-07-13 16:09:31",
+                },
             ],
-            "errors_truncated": False
+            "errors_truncated": False,
         },
-        "logurl": "https://queue.taskcluster.net/v1/task/nhxC4hC3RE6LSVWTZT4rag/runs/0/artifacts/public/logs/live_backing.log"
+        "logurl": "https://queue.taskcluster.net/v1/task/nhxC4hC3RE6LSVWTZT4rag/runs/0/artifacts/public/logs/live_backing.log",
     }
 
 
@@ -52,8 +64,9 @@ def check_job_log(test_repository, job_guid, parse_status):
     assert job_logs[0].status == parse_status
 
 
-def test_store_job_with_unparsed_log(test_repository, failure_classifications,
-                                     push_stored, monkeypatch, activate_responses):
+def test_store_job_with_unparsed_log(
+    test_repository, failure_classifications, push_stored, monkeypatch, activate_responses
+):
     """
     test submitting a job with an unparsed log parses the log,
     generates an appropriate set of text log steps, and calls
@@ -62,11 +75,10 @@ def test_store_job_with_unparsed_log(test_repository, failure_classifications,
 
     # create a wrapper around get_error_summary that records whether
     # it's been called
-    mock_get_error_summary = MagicMock(name='get_error_summary',
-                                       wraps=get_error_summary)
+    mock_get_error_summary = MagicMock(name='get_error_summary', wraps=get_error_summary)
     import treeherder.model.error_summary
-    monkeypatch.setattr(treeherder.model.error_summary, 'get_error_summary',
-                        mock_get_error_summary)
+
+    monkeypatch.setattr(treeherder.model.error_summary, 'get_error_summary', mock_get_error_summary)
     log_url = add_log_response("mozilla-central-macosx64-debug-bm65-build1-build15.txt.gz")
 
     job_guid = 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
@@ -76,12 +88,10 @@ def test_store_job_with_unparsed_log(test_repository, failure_classifications,
         'job': {
             'job_guid': job_guid,
             'state': 'completed',
-            'log_references': [{
-                'url': log_url,
-                'name': 'buildbot_text',
-                'parse_status': 'pending'
-            }]
-        }
+            'log_references': [
+                {'url': log_url, 'name': 'buildbot_text', 'parse_status': 'pending'}
+            ],
+        },
     }
     store_job_data(test_repository, [job_data])
 
@@ -94,9 +104,9 @@ def test_store_job_with_unparsed_log(test_repository, failure_classifications,
     assert len(get_error_summary(Job.objects.get(id=1))) == 2
 
 
-def test_store_job_pending_to_completed_with_unparsed_log(test_repository, push_stored,
-                                                          failure_classifications,
-                                                          activate_responses):
+def test_store_job_pending_to_completed_with_unparsed_log(
+    test_repository, push_stored, failure_classifications, activate_responses
+):
 
     job_guid = 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
 
@@ -104,10 +114,7 @@ def test_store_job_pending_to_completed_with_unparsed_log(test_repository, push_
     job_data = {
         'project': test_repository.name,
         'revision': push_stored[0]['revision'],
-        'job': {
-            'job_guid': job_guid,
-            'state': 'running'
-        }
+        'job': {'job_guid': job_guid, 'state': 'running'},
     }
     store_job_data(test_repository, [job_data])
     # should have no text log errors or bug suggestions
@@ -122,12 +129,10 @@ def test_store_job_pending_to_completed_with_unparsed_log(test_repository, push_
         'job': {
             'job_guid': job_guid,
             'state': 'completed',
-            'log_references': [{
-                'url': log_url,
-                'name': 'buildbot_text',
-                'parse_status': 'pending'
-            }]
-        }
+            'log_references': [
+                {'url': log_url, 'name': 'buildbot_text', 'parse_status': 'pending'}
+            ],
+        },
     }
     store_job_data(test_repository, [job_data])
 
@@ -136,9 +141,9 @@ def test_store_job_pending_to_completed_with_unparsed_log(test_repository, push_
     assert len(get_error_summary(Job.objects.get(guid=job_guid))) == 2
 
 
-def test_store_job_with_parsed_log(test_repository, push_stored,
-                                   failure_classifications,
-                                   monkeypatch):
+def test_store_job_with_parsed_log(
+    test_repository, push_stored, failure_classifications, monkeypatch
+):
     """
     test submitting a job with a pre-parsed log gets job_log_url
     parse_status of "parsed" and does not parse, even though no text_log_summary
@@ -157,12 +162,14 @@ def test_store_job_with_parsed_log(test_repository, push_stored,
         'job': {
             'job_guid': job_guid,
             'state': 'completed',
-            'log_references': [{
-                'url': 'http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/...',
-                'name': 'buildbot_text',
-                'parse_status': 'parsed'
-            }]
-        }
+            'log_references': [
+                {
+                    'url': 'http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/...',
+                    'name': 'buildbot_text',
+                    'parse_status': 'parsed',
+                }
+            ],
+        },
     }
 
     store_job_data(test_repository, [job_data])
@@ -172,12 +179,8 @@ def test_store_job_with_parsed_log(test_repository, push_stored,
 
 
 def test_store_job_with_text_log_summary_artifact_parsed(
-        test_repository,
-        failure_classifications,
-        push_stored,
-        monkeypatch,
-        text_log_summary_dict,
-        ):
+    test_repository, failure_classifications, push_stored, monkeypatch, text_log_summary_dict,
+):
     """
     test submitting a job with a pre-parsed log gets parse_status of
     "parsed" and doesn't parse the log, but we get the expected set of
@@ -194,18 +197,22 @@ def test_store_job_with_text_log_summary_artifact_parsed(
         'job': {
             'job_guid': job_guid,
             'state': 'completed',
-            'log_references': [{
-                'url': 'http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/...',
-                'name': 'buildbot_text',
-                'parse_status': 'parsed'
-            }],
-            'artifacts': [{
-                "blob": json.dumps(text_log_summary_dict),
-                "type": "json",
-                "name": "text_log_summary",
-                "job_guid": job_guid
-            }]
-        }
+            'log_references': [
+                {
+                    'url': 'http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/...',
+                    'name': 'buildbot_text',
+                    'parse_status': 'parsed',
+                }
+            ],
+            'artifacts': [
+                {
+                    "blob": json.dumps(text_log_summary_dict),
+                    "type": "json",
+                    "name": "text_log_summary",
+                    "job_guid": job_guid,
+                }
+            ],
+        },
     }
 
     store_job_data(test_repository, [job_data])
@@ -218,12 +225,8 @@ def test_store_job_with_text_log_summary_artifact_parsed(
 
 
 def test_store_job_with_text_log_summary_artifact_pending(
-        test_repository,
-        failure_classifications,
-        push_stored,
-        monkeypatch,
-        text_log_summary_dict,
-        ):
+    test_repository, failure_classifications, push_stored, monkeypatch, text_log_summary_dict,
+):
     """
     test submitting a job with a log set to pending, but with a text_log_summary.
 
@@ -241,18 +244,22 @@ def test_store_job_with_text_log_summary_artifact_pending(
         'job': {
             'job_guid': job_guid,
             'state': 'completed',
-            'log_references': [{
-                'url': 'http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/...',
-                'name': 'buildbot_text',
-                'parse_status': 'pending'
-            }],
-            'artifacts': [{
-                "blob": json.dumps(text_log_summary_dict),
-                "type": "json",
-                "name": "text_log_summary",
-                "job_guid": job_guid
-            }]
-        }
+            'log_references': [
+                {
+                    'url': 'http://ftp.mozilla.org/pub/mozilla.org/spidermonkey/...',
+                    'name': 'buildbot_text',
+                    'parse_status': 'pending',
+                }
+            ],
+            'artifacts': [
+                {
+                    "blob": json.dumps(text_log_summary_dict),
+                    "type": "json",
+                    "name": "text_log_summary",
+                    "job_guid": job_guid,
+                }
+            ],
+        },
     }
 
     store_job_data(test_repository, [job_data])
@@ -265,11 +272,8 @@ def test_store_job_with_text_log_summary_artifact_pending(
 
 
 def test_store_job_artifacts_by_add_artifact(
-        test_repository,
-        failure_classifications,
-        push_stored,
-        monkeypatch,
-        ):
+    test_repository, failure_classifications, push_stored, monkeypatch,
+):
     """
     test submitting a job with artifacts added by ``add_artifact``
 
@@ -283,25 +287,31 @@ def test_store_job_artifacts_by_add_artifact(
     mock_parse = MagicMock(name="parse_line")
     monkeypatch.setattr(StepParser, 'parse_line', mock_parse)
 
-    tls_blob = json.dumps({
-        "logurl": "https://autophone-dev.s3.amazonaws.com/pub/mozilla.org/mobile/tinderbox-builds/mozilla-inbound-android-api-9/1432676531/en-US/autophone-autophone-s1s2-s1s2-nytimes-local.ini-1-nexus-one-1.log",
-        "step_data": {
-            "steps": [{
-                "name": "foobar",
-                "result": "testfailed",
-                "started_linenumber": 1,
-                "finished_linenumber": 100000,
-                "started": "2016-07-13 16:09:31",
-                "finished": "2016-07-13 16:09:31",
-                "errors": [
-                    {"line": "TEST_UNEXPECTED_FAIL | /sdcard/tests/autophone/s1s2test/nytimes.com/index.html | Failed to get uncached measurement.", "linenumber": 64435}
+    tls_blob = json.dumps(
+        {
+            "logurl": "https://autophone-dev.s3.amazonaws.com/pub/mozilla.org/mobile/tinderbox-builds/mozilla-inbound-android-api-9/1432676531/en-US/autophone-autophone-s1s2-s1s2-nytimes-local.ini-1-nexus-one-1.log",
+            "step_data": {
+                "steps": [
+                    {
+                        "name": "foobar",
+                        "result": "testfailed",
+                        "started_linenumber": 1,
+                        "finished_linenumber": 100000,
+                        "started": "2016-07-13 16:09:31",
+                        "finished": "2016-07-13 16:09:31",
+                        "errors": [
+                            {
+                                "line": "TEST_UNEXPECTED_FAIL | /sdcard/tests/autophone/s1s2test/nytimes.com/index.html | Failed to get uncached measurement.",
+                                "linenumber": 64435,
+                            }
+                        ],
+                    }
                 ]
-            }]
+            },
         }
-    })
+    )
 
-    ji_blob = json.dumps({"job_details": [{"title": "mytitle",
-                                           "value": "myvalue"}]})
+    ji_blob = json.dumps({"job_details": [{"title": "mytitle", "value": "myvalue"}]})
     pb_blob = json.dumps({"build_url": "feh", "chunk": 1, "config_file": "mah"})
 
     job_guid = 'd22c74d4aa6d2a1dcba96d95dccbd5fdca70cf33'
@@ -316,25 +326,15 @@ def test_store_job_artifacts_by_add_artifact(
                     'blob': tls_blob,
                     'job_guid': job_guid,
                 },
-                {
-                    'name': 'Job Info',
-                    'type': 'json',
-                    'blob': ji_blob,
-                    'job_guid': job_guid,
-                },
-                {
-                    'name': 'privatebuild',
-                    'type': 'json',
-                    'blob': pb_blob,
-                    'job_guid': job_guid,
-                },
+                {'name': 'Job Info', 'type': 'json', 'blob': ji_blob, 'job_guid': job_guid,},
+                {'name': 'privatebuild', 'type': 'json', 'blob': pb_blob, 'job_guid': job_guid,},
             ],
             "job_guid": job_guid,
             "log_references": [
                 {
                     "name": "autophone-nexus-one-1.log",
                     "parse_status": "parsed",
-                    "url": "https://autophone-dev.s3.amazonaws.com/pub/mozilla.org/mobile/tinderbox-builds/mozilla-inbound-android-api-9/1432676531/en-US/autophone-autophone-s1s2-s1s2-nytimes-local.ini-1-nexus-one-1.log"
+                    "url": "https://autophone-dev.s3.amazonaws.com/pub/mozilla.org/mobile/tinderbox-builds/mozilla-inbound-android-api-9/1432676531/en-US/autophone-autophone-s1s2-s1s2-nytimes-local.ini-1-nexus-one-1.log",
                 }
             ],
             "state": "completed",
@@ -349,7 +349,7 @@ def test_store_job_artifacts_by_add_artifact(
         'job': 1,
         'title': 'mytitle',
         'value': 'myvalue',
-        'url': None
+        'url': None,
     }
 
     assert TextLogStep.objects.count() == 1
@@ -361,7 +361,7 @@ def test_store_job_artifacts_by_add_artifact(
         'name': 'foobar',
         'result': 1,
         'started_line_number': 1,
-        'finished_line_number': 100000
+        'finished_line_number': 100000,
     }
 
     assert TextLogError.objects.count() == 1
@@ -388,11 +388,7 @@ def test_store_job_with_tier(test_repository, failure_classifications, push_stor
     job_data = {
         'project': test_repository.name,
         'revision': push_stored[0]['revision'],
-        'job': {
-            'job_guid': job_guid,
-            'state': 'completed',
-            'tier': 3,
-        }
+        'job': {'job_guid': job_guid, 'state': 'completed', 'tier': 3,},
     }
 
     store_job_data(test_repository, [job_data])
@@ -407,10 +403,7 @@ def test_store_job_with_default_tier(test_repository, failure_classifications, p
     job_data = {
         'project': test_repository.name,
         'revision': push_stored[0]['revision'],
-        'job': {
-            'job_guid': job_guid,
-            'state': 'completed',
-        }
+        'job': {'job_guid': job_guid, 'state': 'completed',},
     }
 
     store_job_data(test_repository, [job_data])

--- a/tests/e2e/test_jobs_loaded.py
+++ b/tests/e2e/test_jobs_loaded.py
@@ -2,9 +2,7 @@ from django.urls import reverse
 
 
 def test_pending_job_available(test_repository, pending_jobs_stored, client):
-    resp = client.get(
-        reverse("jobs-list", kwargs={"project": test_repository.name})
-    )
+    resp = client.get(reverse("jobs-list", kwargs={"project": test_repository.name}))
     assert resp.status_code == 200
     jobs = resp.json()
 
@@ -14,9 +12,7 @@ def test_pending_job_available(test_repository, pending_jobs_stored, client):
 
 
 def test_running_job_available(test_repository, running_jobs_stored, client):
-    resp = client.get(
-        reverse("jobs-list", kwargs={"project": test_repository.name})
-    )
+    resp = client.get(reverse("jobs-list", kwargs={"project": test_repository.name}))
     assert resp.status_code == 200
     jobs = resp.json()
 
@@ -26,9 +22,7 @@ def test_running_job_available(test_repository, running_jobs_stored, client):
 
 
 def test_completed_job_available(test_repository, completed_jobs_stored, client):
-    resp = client.get(
-        reverse("jobs-list", kwargs={"project": test_repository.name})
-    )
+    resp = client.get(reverse("jobs-list", kwargs={"project": test_repository.name}))
     assert resp.status_code == 200
     jobs = resp.json()
 
@@ -36,16 +30,15 @@ def test_completed_job_available(test_repository, completed_jobs_stored, client)
     assert jobs['results'][0]['state'] == 'completed'
 
 
-def test_pending_stored_to_running_loaded(test_repository, pending_jobs_stored,
-                                          running_jobs_stored, client):
+def test_pending_stored_to_running_loaded(
+    test_repository, pending_jobs_stored, running_jobs_stored, client
+):
     """
     tests a job transition from pending to running
     given a loaded pending job, if I store and load the same job with status running,
     the latter is shown in the jobs endpoint
     """
-    resp = client.get(
-        reverse("jobs-list", kwargs={"project": test_repository.name})
-    )
+    resp = client.get(reverse("jobs-list", kwargs={"project": test_repository.name}))
     assert resp.status_code == 200
     jobs = resp.json()
 
@@ -53,14 +46,13 @@ def test_pending_stored_to_running_loaded(test_repository, pending_jobs_stored,
     assert jobs['results'][0]['state'] == 'running'
 
 
-def test_finished_job_to_running(test_repository, completed_jobs_stored,
-                                 running_jobs_stored, client):
+def test_finished_job_to_running(
+    test_repository, completed_jobs_stored, running_jobs_stored, client
+):
     """
     tests that a job finished cannot change state
     """
-    resp = client.get(
-        reverse("jobs-list", kwargs={"project": test_repository.name})
-    )
+    resp = client.get(reverse("jobs-list", kwargs={"project": test_repository.name}))
     assert resp.status_code == 200
     jobs = resp.json()
 
@@ -68,15 +60,12 @@ def test_finished_job_to_running(test_repository, completed_jobs_stored,
     assert jobs['results'][0]['state'] == 'completed'
 
 
-def test_running_job_to_pending(test_repository, running_jobs_stored,
-                                pending_jobs_stored, client):
+def test_running_job_to_pending(test_repository, running_jobs_stored, pending_jobs_stored, client):
     """
     tests that a job transition from pending to running
     cannot happen
     """
-    resp = client.get(
-        reverse("jobs-list", kwargs={"project": test_repository.name})
-    )
+    resp = client.get(reverse("jobs-list", kwargs={"project": test_repository.name}))
     assert resp.status_code == 200
     jobs = resp.json()
 

--- a/tests/e2e/test_perf_ingestion.py
+++ b/tests/e2e/test_perf_ingestion.py
@@ -1,9 +1,7 @@
 import copy
 
 from treeherder.etl.jobs import store_job_data
-from treeherder.perf.models import (PerformanceDatum,
-                                    PerformanceFramework,
-                                    PerformanceSignature)
+from treeherder.perf.models import PerformanceDatum, PerformanceFramework, PerformanceSignature
 
 # TODO: Turn these into end to end taskcluster tests as part of removing buildbot
 # support in bug 1443251, or else delete them if they're duplicating coverage.
@@ -21,25 +19,29 @@ def test_store_perf_artifact(test_repository, failure_classifications, push_stor
             'state': 'completed',
             'project': test_repository.name,
             'option_collection': {'opt': True},
-            'artifacts': [{
-                'blob': {
-                    "performance_data": {
-                        "framework": {"name": "cheezburger"},
-                        "suites": [{
-                            "name": "cheezburger metrics",
-                            "value": 10.0,
-                            "subtests": [
-                                {"name": "test1", "value": 20.0},
-                                {"name": "test2", "value": 30.0}
-                            ]
-                        }]
-                    }
-                },
-                'type': 'json',
-                'name': 'performance_data',
-                'job_guid': job_guid
-            }]
-        }
+            'artifacts': [
+                {
+                    'blob': {
+                        "performance_data": {
+                            "framework": {"name": "cheezburger"},
+                            "suites": [
+                                {
+                                    "name": "cheezburger metrics",
+                                    "value": 10.0,
+                                    "subtests": [
+                                        {"name": "test1", "value": 20.0},
+                                        {"name": "test2", "value": 30.0},
+                                    ],
+                                }
+                            ],
+                        }
+                    },
+                    'type': 'json',
+                    'name': 'performance_data',
+                    'job_guid': job_guid,
+                }
+            ],
+        },
     }
 
     store_job_data(test_repository, [job_data])
@@ -54,14 +56,13 @@ def test_store_perf_artifact_multiple(test_repository, failure_classifications, 
     PerformanceFramework.objects.get_or_create(name='cheezburger', enabled=True)
     perfobj = {
         "framework": {"name": "cheezburger"},
-        "suites": [{
-            "name": "cheezburger metrics",
-            "value": 10.0,
-            "subtests": [
-                {"name": "test1", "value": 20.0},
-                {"name": "test2", "value": 30.0}
-            ]
-        }]
+        "suites": [
+            {
+                "name": "cheezburger metrics",
+                "value": 10.0,
+                "subtests": [{"name": "test1", "value": 20.0}, {"name": "test2", "value": 30.0}],
+            }
+        ],
     }
     perfobj2 = copy.deepcopy(perfobj)
     perfobj2['suites'][0]['name'] = "cheezburger metrics 2"
@@ -74,15 +75,15 @@ def test_store_perf_artifact_multiple(test_repository, failure_classifications, 
             'state': 'completed',
             'project': test_repository.name,
             'option_collection': {'opt': True},
-            'artifacts': [{
-                'blob': {
-                    "performance_data": [perfobj, perfobj2]
-                },
-                'type': 'json',
-                'name': 'performance_data',
-                'job_guid': job_guid
-            }]
-        }
+            'artifacts': [
+                {
+                    'blob': {"performance_data": [perfobj, perfobj2]},
+                    'type': 'json',
+                    'name': 'performance_data',
+                    'job_guid': job_guid,
+                }
+            ],
+        },
     }
 
     store_job_data(test_repository, [job_data])

--- a/tests/etl/conftest.py
+++ b/tests/etl/conftest.py
@@ -12,10 +12,12 @@ def perf_push(test_repository):
         repository=test_repository,
         revision='1234abcd',
         author='foo@bar.com',
-        time=datetime.datetime.now())
+        time=datetime.datetime.now(),
+    )
 
 
 @pytest.fixture
 def perf_job(perf_push, failure_classifications, generic_reference_data):
-    return create_generic_job('myfunguid', perf_push.repository,
-                              perf_push.id, generic_reference_data)
+    return create_generic_job(
+        'myfunguid', perf_push.repository, perf_push.id, generic_reference_data
+    )

--- a/tests/etl/test_job_ingestion.py
+++ b/tests/etl/test_job_ingestion.py
@@ -4,16 +4,14 @@ import pytest
 
 from tests import test_utils
 from tests.sample_data_generator import job_data
-from treeherder.etl.jobs import (_remove_existing_jobs,
-                                 store_job_data)
+from treeherder.etl.jobs import _remove_existing_jobs, store_job_data
 from treeherder.etl.push import store_push_data
-from treeherder.model.models import (Job,
-                                     JobLog)
+from treeherder.model.models import Job, JobLog
 
 
-def test_ingest_single_sample_job(test_repository, failure_classifications,
-                                  sample_data, sample_push,
-                                  mock_log_parser):
+def test_ingest_single_sample_job(
+    test_repository, failure_classifications, sample_data, sample_push, mock_log_parser
+):
     """Process a single job structure in the job_data.txt file"""
     job_data = sample_data.job_data[:1]
     test_utils.do_job_ingestion(test_repository, job_data, sample_push)
@@ -24,8 +22,9 @@ def test_ingest_single_sample_job(test_repository, failure_classifications,
     assert job.signature.signature == '4dabe44cc898e585228c43ea21337a9b00f5ddf7'
 
 
-def test_ingest_all_sample_jobs(test_repository, failure_classifications,
-                                sample_data, sample_push, mock_log_parser):
+def test_ingest_all_sample_jobs(
+    test_repository, failure_classifications, sample_data, sample_push, mock_log_parser
+):
     """
     Process each job structure in the job_data.txt file and verify.
     """
@@ -33,11 +32,9 @@ def test_ingest_all_sample_jobs(test_repository, failure_classifications,
     test_utils.do_job_ingestion(test_repository, job_data, sample_push)
 
 
-def test_ingest_twice_log_parsing_status_changed(test_repository,
-                                                 failure_classifications,
-                                                 sample_data,
-                                                 sample_push,
-                                                 mock_log_parser):
+def test_ingest_twice_log_parsing_status_changed(
+    test_repository, failure_classifications, sample_data, sample_push, mock_log_parser
+):
     """Process a single job twice, but change the log parsing status between,
     verify that nothing changes"""
     job_data = sample_data.job_data[:1]
@@ -56,12 +53,14 @@ def test_ingest_twice_log_parsing_status_changed(test_repository,
 
 
 @pytest.mark.parametrize("same_ingestion_cycle", [False, True])
-def test_ingest_running_to_retry_sample_job(test_repository,
-                                            failure_classifications,
-                                            sample_data,
-                                            sample_push,
-                                            mock_log_parser,
-                                            same_ingestion_cycle):
+def test_ingest_running_to_retry_sample_job(
+    test_repository,
+    failure_classifications,
+    sample_data,
+    sample_push,
+    mock_log_parser,
+    same_ingestion_cycle,
+):
     """Process a single job structure in the job_data.txt file"""
     store_push_data(test_repository, sample_push)
 
@@ -101,15 +100,17 @@ def test_ingest_running_to_retry_sample_job(test_repository,
     assert job.guid == job_data[-1]['job']['job_guid']
 
 
-@pytest.mark.parametrize("ingestion_cycles", [[(0, 1), (1, 2), (2, 3)],
-                                              [(0, 2), (2, 3)],
-                                              [(0, 3)], [(0, 1), (1, 3)]])
-def test_ingest_running_to_retry_to_success_sample_job(test_repository,
-                                                       failure_classifications,
-                                                       sample_data,
-                                                       sample_push,
-                                                       mock_log_parser,
-                                                       ingestion_cycles):
+@pytest.mark.parametrize(
+    "ingestion_cycles", [[(0, 1), (1, 2), (2, 3)], [(0, 2), (2, 3)], [(0, 3)], [(0, 1), (1, 3)]]
+)
+def test_ingest_running_to_retry_to_success_sample_job(
+    test_repository,
+    failure_classifications,
+    sample_data,
+    sample_push,
+    mock_log_parser,
+    ingestion_cycles,
+):
     # verifies that retries to success work, no matter how jobs are batched
     store_push_data(test_repository, sample_push)
 
@@ -121,10 +122,10 @@ def test_ingest_running_to_retry_to_success_sample_job(test_repository,
 
     job_data = []
     for (state, result, job_guid) in [
-            ('running', 'unknown', job_guid_root),
-            ('completed', 'retry',
-             job_guid_root + "_" + str(job['end_timestamp'])[-5:]),
-            ('completed', 'success', job_guid_root)]:
+        ('running', 'unknown', job_guid_root),
+        ('completed', 'retry', job_guid_root + "_" + str(job['end_timestamp'])[-5:]),
+        ('completed', 'success', job_guid_root),
+    ]:
         new_job_datum = copy.deepcopy(job_datum)
         new_job_datum['job']['state'] = state
         new_job_datum['job']['result'] = result
@@ -140,12 +141,17 @@ def test_ingest_running_to_retry_to_success_sample_job(test_repository,
     assert JobLog.objects.count() == 2
 
 
-@pytest.mark.parametrize("ingestion_cycles", [[(0, 1), (1, 3), (3, 4)],
-                                              [(0, 3), (3, 4)],
-                                              [(0, 2), (2, 4)]])
+@pytest.mark.parametrize(
+    "ingestion_cycles", [[(0, 1), (1, 3), (3, 4)], [(0, 3), (3, 4)], [(0, 2), (2, 4)]]
+)
 def test_ingest_running_to_retry_to_success_sample_job_multiple_retries(
-        test_repository, failure_classifications, sample_data, sample_push,
-        mock_log_parser, ingestion_cycles):
+    test_repository,
+    failure_classifications,
+    sample_data,
+    sample_push,
+    mock_log_parser,
+    ingestion_cycles,
+):
     # this verifies that if we ingest multiple retries:
     # (1) nothing errors out
     # (2) we end up with three jobs (the original + 2 retry jobs)
@@ -160,12 +166,11 @@ def test_ingest_running_to_retry_to_success_sample_job_multiple_retries(
 
     job_data = []
     for (state, result, job_guid) in [
-            ('running', 'unknown', job_guid_root),
-            ('completed', 'retry',
-             job_guid_root + "_" + str(job['end_timestamp'])[-5:]),
-            ('completed', 'retry',
-             job_guid_root + "_12345"),
-            ('completed', 'success', job_guid_root)]:
+        ('running', 'unknown', job_guid_root),
+        ('completed', 'retry', job_guid_root + "_" + str(job['end_timestamp'])[-5:]),
+        ('completed', 'retry', job_guid_root + "_12345"),
+        ('completed', 'success', job_guid_root),
+    ]:
         new_job_datum = copy.deepcopy(job_datum)
         new_job_datum['job']['state'] = state
         new_job_datum['job']['result'] = result
@@ -183,10 +188,9 @@ def test_ingest_running_to_retry_to_success_sample_job_multiple_retries(
     assert JobLog.objects.count() == 3
 
 
-def test_ingest_retry_sample_job_no_running(test_repository,
-                                            failure_classifications,
-                                            sample_data, sample_push,
-                                            mock_log_parser):
+def test_ingest_retry_sample_job_no_running(
+    test_repository, failure_classifications, sample_data, sample_push, mock_log_parser
+):
     """Process a single job structure in the job_data.txt file"""
     job_data = copy.deepcopy(sample_data.job_data[:1])
     job = job_data[0]['job']
@@ -209,23 +213,23 @@ def test_ingest_retry_sample_job_no_running(test_repository,
     assert job.guid == retry_guid
 
 
-def test_bad_date_value_ingestion(test_repository, failure_classifications,
-                                  sample_push, mock_log_parser):
+def test_bad_date_value_ingestion(
+    test_repository, failure_classifications, sample_push, mock_log_parser
+):
     """
     Test ingesting a job blob with bad date value
 
     """
-    blob = job_data(start_timestamp="foo",
-                    revision=sample_push[0]['revision'])
+    blob = job_data(start_timestamp="foo", revision=sample_push[0]['revision'])
 
     store_push_data(test_repository, sample_push[:1])
     store_job_data(test_repository, [blob])
     # if no exception, we are good.
 
 
-def test_remove_existing_jobs_single_existing(test_repository, failure_classifications,
-                                              sample_data, sample_push,
-                                              mock_log_parser):
+def test_remove_existing_jobs_single_existing(
+    test_repository, failure_classifications, sample_data, sample_push, mock_log_parser
+):
     """Remove single existing job prior to loading"""
 
     job_data = sample_data.job_data[:1]
@@ -236,10 +240,9 @@ def test_remove_existing_jobs_single_existing(test_repository, failure_classific
     assert data == []
 
 
-def test_remove_existing_jobs_one_existing_one_new(test_repository, failure_classifications,
-                                                   sample_data,
-                                                   sample_push,
-                                                   mock_log_parser):
+def test_remove_existing_jobs_one_existing_one_new(
+    test_repository, failure_classifications, sample_data, sample_push, mock_log_parser
+):
     """Remove single existing job prior to loading"""
 
     job_data = sample_data.job_data[:1]
@@ -251,8 +254,9 @@ def test_remove_existing_jobs_one_existing_one_new(test_repository, failure_clas
     assert Job.objects.count() == 1
 
 
-def test_ingest_job_default_tier(test_repository, sample_data, sample_push,
-                                 failure_classifications, mock_log_parser):
+def test_ingest_job_default_tier(
+    test_repository, sample_data, sample_push, failure_classifications, mock_log_parser
+):
     """Tier is set to 1 by default"""
     job_data = sample_data.job_data[:1]
     store_push_data(test_repository, sample_push)
@@ -261,8 +265,9 @@ def test_ingest_job_default_tier(test_repository, sample_data, sample_push,
     assert job.tier == 1
 
 
-def test_ingesting_skip_existing(test_repository, failure_classifications, sample_data,
-                                 sample_push, mock_log_parser):
+def test_ingesting_skip_existing(
+    test_repository, failure_classifications, sample_data, sample_push, mock_log_parser
+):
     """Remove single existing job prior to loading"""
     job_data = sample_data.job_data[:1]
     test_utils.do_job_ingestion(test_repository, job_data, sample_push)
@@ -272,9 +277,9 @@ def test_ingesting_skip_existing(test_repository, failure_classifications, sampl
     assert Job.objects.count() == 2
 
 
-def test_ingest_job_with_updated_job_group(test_repository, failure_classifications,
-                                           sample_data, mock_log_parser,
-                                           push_stored):
+def test_ingest_job_with_updated_job_group(
+    test_repository, failure_classifications, sample_data, mock_log_parser, push_stored
+):
     """
     The job_type and job_group for a job is independent of any other job_type
     and job_group combination.

--- a/tests/etl/test_load_artifacts.py
+++ b/tests/etl/test_load_artifacts.py
@@ -1,9 +1,7 @@
 import json
 
 from treeherder.etl.artifact import store_job_artifacts
-from treeherder.model.models import (JobDetail,
-                                     TextLogError,
-                                     TextLogStep)
+from treeherder.model.models import JobDetail, TextLogError, TextLogStep
 
 
 def test_load_long_job_details(test_job):
@@ -11,56 +9,51 @@ def test_load_long_job_details(test_job):
         """Get the field's max_length for the JobDetail model"""
         return JobDetail._meta.get_field(field).max_length
 
-    (long_title, long_value, long_url) = ('t' * (2 * max_length("title")),
-                                          'v' * (2 * max_length("value")),
-                                          'https://' + ('u' * (2 * max_length("url"))))
+    (long_title, long_value, long_url) = (
+        't' * (2 * max_length("title")),
+        'v' * (2 * max_length("value")),
+        'https://' + ('u' * (2 * max_length("url"))),
+    )
     ji_artifact = {
         'type': 'json',
         'name': 'Job Info',
-        'blob': json.dumps({
-            'job_details': [{
-                'title': long_title,
-                'value': long_value,
-                'url': long_url
-            }]
-        }),
-        'job_guid': test_job.guid
+        'blob': json.dumps(
+            {'job_details': [{'title': long_title, 'value': long_value, 'url': long_url}]}
+        ),
+        'job_guid': test_job.guid,
     }
     store_job_artifacts([ji_artifact])
 
     assert JobDetail.objects.count() == 1
 
     jd = JobDetail.objects.first()
-    assert jd.title == long_title[:max_length("title")]
-    assert jd.value == long_value[:max_length("value")]
-    assert jd.url == long_url[:max_length("url")]
+    assert jd.title == long_title[: max_length("title")]
+    assert jd.value == long_value[: max_length("value")]
+    assert jd.url == long_url[: max_length("url")]
 
 
 def test_load_textlog_summary_twice(test_repository, test_job):
     text_log_summary_artifact = {
         'type': 'json',
         'name': 'text_log_summary',
-        'blob': json.dumps({
-            'step_data': {
-                "steps": [
-                    {
-                        'name': 'foo',
-                        'started': '2016-05-10 12:44:23.103904',
-                        'started_linenumber': 8,
-                        'finished_linenumber': 10,
-                        'finished': '2016-05-10 12:44:23.104394',
-                        'result': 'success',
-                        'errors': [
-                            {
-                                "line": '07:51:28  WARNING - foobar',
-                                "linenumber": 1587
-                            }
-                        ]
-                    }
-                ]
+        'blob': json.dumps(
+            {
+                'step_data': {
+                    "steps": [
+                        {
+                            'name': 'foo',
+                            'started': '2016-05-10 12:44:23.103904',
+                            'started_linenumber': 8,
+                            'finished_linenumber': 10,
+                            'finished': '2016-05-10 12:44:23.104394',
+                            'result': 'success',
+                            'errors': [{"line": '07:51:28  WARNING - foobar', "linenumber": 1587}],
+                        }
+                    ]
+                }
             }
-        }),
-        'job_guid': test_job.guid
+        ),
+        'job_guid': test_job.guid,
     }
 
     store_job_artifacts([text_log_summary_artifact])
@@ -77,33 +70,35 @@ def test_load_non_ascii_textlog_errors(test_job):
     text_log_summary_artifact = {
         'type': 'json',
         'name': 'text_log_summary',
-        'blob': json.dumps({
-            'step_data': {
-                "steps": [
-                    {
-                        'name': 'foo',
-                        'started': '2016-05-10 12:44:23.103904',
-                        'started_linenumber': 8,
-                        'finished_linenumber': 10,
-                        'finished': '2016-05-10 12:44:23.104394',
-                        'result': 'success',
-                        'errors': [
-                            {
-                                # non-ascii character
-                                "line": '07:51:28  WARNING - \U000000c3',
-                                "linenumber": 1587
-                            },
-                            {
-                                # astral character (i.e. higher than ucs2)
-                                "line": '07:51:29  WARNING - \U0001d400',
-                                "linenumber": 1588
-                            }
-                        ]
-                    }
-                ]
+        'blob': json.dumps(
+            {
+                'step_data': {
+                    "steps": [
+                        {
+                            'name': 'foo',
+                            'started': '2016-05-10 12:44:23.103904',
+                            'started_linenumber': 8,
+                            'finished_linenumber': 10,
+                            'finished': '2016-05-10 12:44:23.104394',
+                            'result': 'success',
+                            'errors': [
+                                {
+                                    # non-ascii character
+                                    "line": '07:51:28  WARNING - \U000000c3',
+                                    "linenumber": 1587,
+                                },
+                                {
+                                    # astral character (i.e. higher than ucs2)
+                                    "line": '07:51:29  WARNING - \U0001d400',
+                                    "linenumber": 1588,
+                                },
+                            ],
+                        }
+                    ]
+                }
             }
-        }),
-        'job_guid': test_job.guid
+        ),
+        'job_guid': test_job.guid,
     }
     store_job_artifacts([text_log_summary_artifact])
 

--- a/tests/etl/test_perf_data_load.py
+++ b/tests/etl/test_perf_data_load.py
@@ -9,9 +9,7 @@ from tests.etl.test_perf_data_adapters import _verify_signature
 from tests.test_utils import create_generic_job
 from treeherder.etl.perf import store_performance_artifact
 from treeherder.model.models import Push
-from treeherder.perf.models import (PerformanceDatum,
-                                    PerformanceFramework,
-                                    PerformanceSignature)
+from treeherder.perf.models import PerformanceDatum, PerformanceFramework, PerformanceSignature
 
 FRAMEWORK_NAME = 'cheezburger'
 MEASUREMENT_UNIT = 'ms'
@@ -38,48 +36,32 @@ def sample_perf_artifact():
                             'name': 'test1',
                             'value': 20.0,
                             'unit': MEASUREMENT_UNIT,
-                            'lowerIsBetter': True
+                            'lowerIsBetter': True,
                         },
                         {
                             'name': 'test2',
                             'value': 30.0,
                             'unit': MEASUREMENT_UNIT,
-                            'lowerIsBetter': False
+                            'lowerIsBetter': False,
                         },
-                        {
-                            'name': 'test3',
-                            'value': 40.0,
-                            'unit': MEASUREMENT_UNIT,
-                        }
-                    ]
+                        {'name': 'test3', 'value': 40.0, 'unit': MEASUREMENT_UNIT,},
+                    ],
                 },
                 {
                     'name': 'cheezburger metrics 2',
                     'lowerIsBetter': False,
                     'value': 10.0,
                     'unit': MEASUREMENT_UNIT,
-                    'subtests': [
-                        {
-                            'name': 'test1',
-                            'value': 20.0,
-                            'unit': MEASUREMENT_UNIT,
-                        }
-                    ]
+                    'subtests': [{'name': 'test1', 'value': 20.0, 'unit': MEASUREMENT_UNIT,}],
                 },
                 {
                     'name': 'cheezburger metrics 3',
                     'value': 10.0,
                     'unit': MEASUREMENT_UNIT,
-                    'subtests': [
-                        {
-                            'name': 'test1',
-                            'value': 20.0,
-                            'unit': MEASUREMENT_UNIT
-                        }
-                    ]
-                }
-            ]
-        }
+                    'subtests': [{'name': 'test1', 'value': 20.0, 'unit': MEASUREMENT_UNIT}],
+                },
+            ],
+        },
     }
 
 
@@ -99,28 +81,24 @@ def sample_perf_artifact_with_new_unit():
                     'value': 10.0,
                     'unit': UPDATED_MEASUREMENT_UNIT,
                     'subtests': [
-                            {
-                                'name': 'test1',
-                                'value': 20.0,
-                                'unit': UPDATED_MEASUREMENT_UNIT,
-                                'lowerIsBetter': True
-                            },
-                            {
-                                'name': 'test2',
-                                'value': 30.0,
-                                'unit': MEASUREMENT_UNIT,
-                                'lowerIsBetter': False
-                            },
-                            {
-                                'name': 'test3',
-                                'value': 40.0,
-                                'unit': MEASUREMENT_UNIT,
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
+                        {
+                            'name': 'test1',
+                            'value': 20.0,
+                            'unit': UPDATED_MEASUREMENT_UNIT,
+                            'lowerIsBetter': True,
+                        },
+                        {
+                            'name': 'test2',
+                            'value': 30.0,
+                            'unit': MEASUREMENT_UNIT,
+                            'lowerIsBetter': False,
+                        },
+                        {'name': 'test3', 'value': 40.0, 'unit': MEASUREMENT_UNIT,},
+                    ],
+                }
+            ],
+        },
+    }
 
 
 @pytest.fixture
@@ -130,13 +108,14 @@ def later_perf_push(test_repository):
         repository=test_repository,
         revision='1234abcd12',
         author='foo@bar.com',
-        time=later_timestamp)
+        time=later_timestamp,
+    )
 
 
 def _verify_datum(suitename, testname, value, push_timestamp):
     datum = PerformanceDatum.objects.get(
-        signature=PerformanceSignature.objects.get(suite=suitename,
-                                                   test=testname))
+        signature=PerformanceSignature.objects.get(suite=suitename, test=testname)
+    )
     assert datum.value == value
     assert datum.push_timestamp == push_timestamp
 
@@ -145,15 +124,19 @@ def _prepare_test_data(datum):
     PerformanceFramework.objects.get_or_create(name=FRAMEWORK_NAME, enabled=True)
     # the perf data adapter expects unserialized performance data
     submit_datum = copy.copy(datum)
-    submit_datum['blob'] = json.dumps({
-        'performance_data': submit_datum['blob']
-    })
+    submit_datum['blob'] = json.dumps({'performance_data': submit_datum['blob']})
     perf_datum = datum['blob']
     return perf_datum, submit_datum
 
 
-def test_ingest_workflow(test_repository,
-                         perf_push, later_perf_push, perf_job, generic_reference_data, sample_perf_artifact):
+def test_ingest_workflow(
+    test_repository,
+    perf_push,
+    later_perf_push,
+    perf_job,
+    generic_reference_data,
+    sample_perf_artifact,
+):
     perf_datum, submit_datum = _prepare_test_data(sample_perf_artifact)
 
     store_performance_artifact(perf_job, submit_datum)
@@ -164,93 +147,104 @@ def test_ingest_workflow(test_repository,
     assert FRAMEWORK_NAME == framework.name
     for suite in perf_datum['suites']:
         # verify summary, then subtests
-        _verify_signature(test_repository.name,
-                          perf_datum['framework']['name'],
-                          suite['name'],
-                          '',
-                          'my_option_hash',
-                          'my_platform',
-                          suite.get('lowerIsBetter', True),
-                          suite.get('extraOptions'),
-                          suite.get('unit'),
-                          perf_push.time)
+        _verify_signature(
+            test_repository.name,
+            perf_datum['framework']['name'],
+            suite['name'],
+            '',
+            'my_option_hash',
+            'my_platform',
+            suite.get('lowerIsBetter', True),
+            suite.get('extraOptions'),
+            suite.get('unit'),
+            perf_push.time,
+        )
         _verify_datum(suite['name'], '', suite['value'], perf_push.time)
         for subtest in suite['subtests']:
-            _verify_signature(test_repository.name,
-                              perf_datum['framework']['name'],
-                              suite['name'],
-                              subtest['name'],
-                              'my_option_hash',
-                              'my_platform',
-                              subtest.get('lowerIsBetter', True),
-                              suite.get('extraOptions'),
-                              suite.get('unit'),
-                              perf_push.time)
-            _verify_datum(suite['name'], subtest['name'], subtest['value'],
-                          perf_push.time)
+            _verify_signature(
+                test_repository.name,
+                perf_datum['framework']['name'],
+                suite['name'],
+                subtest['name'],
+                'my_option_hash',
+                'my_platform',
+                subtest.get('lowerIsBetter', True),
+                suite.get('extraOptions'),
+                suite.get('unit'),
+                perf_push.time,
+            )
+            _verify_datum(suite['name'], subtest['name'], subtest['value'], perf_push.time)
 
 
 def test_hash_remains_unchanged(test_repository, perf_job, sample_perf_artifact):
     _, submit_datum = _prepare_test_data(sample_perf_artifact)
     store_performance_artifact(perf_job, submit_datum)
 
-    summary_signature = PerformanceSignature.objects.get(
-        suite='cheezburger metrics', test='')
+    summary_signature = PerformanceSignature.objects.get(suite='cheezburger metrics', test='')
     # Ensure we don't inadvertently change the way we generate signature hashes.
     assert summary_signature.signature_hash == 'f451f0c9000a7f99e5dc2f05792bfdb0e11d0cac'
     subtest_signatures = PerformanceSignature.objects.filter(
-        parent_signature=summary_signature).values_list('signature_hash', flat=True)
+        parent_signature=summary_signature
+    ).values_list('signature_hash', flat=True)
     assert len(subtest_signatures) == 3
 
 
-def test_timestamp_can_be_updated(test_repository, perf_job, later_perf_push, generic_reference_data,
-                                  sample_perf_artifact):
+def test_timestamp_can_be_updated(
+    test_repository, perf_job, later_perf_push, generic_reference_data, sample_perf_artifact
+):
     _, submit_datum = _prepare_test_data(sample_perf_artifact)
     store_performance_artifact(perf_job, submit_datum)
 
     # send another datum, a little later, verify that signature is changed accordingly
-    later_job = create_generic_job('lateguid', test_repository,
-                                   later_perf_push.id, generic_reference_data)
+    later_job = create_generic_job(
+        'lateguid', test_repository, later_perf_push.id, generic_reference_data
+    )
     store_performance_artifact(later_job, submit_datum)
 
-    signature = PerformanceSignature.objects.get(
-        suite='cheezburger metrics',
-        test='test1')
+    signature = PerformanceSignature.objects.get(suite='cheezburger metrics', test='test1')
     assert signature.last_updated == later_perf_push.time
 
 
-def test_measurement_unit_can_be_updated(test_repository, later_perf_push, perf_job, generic_reference_data,
-                                         sample_perf_artifact, sample_perf_artifact_with_new_unit):
+def test_measurement_unit_can_be_updated(
+    test_repository,
+    later_perf_push,
+    perf_job,
+    generic_reference_data,
+    sample_perf_artifact,
+    sample_perf_artifact_with_new_unit,
+):
     _, submit_datum = _prepare_test_data(sample_perf_artifact)
     store_performance_artifact(perf_job, submit_datum)
 
     _, updated_submit_datum = _prepare_test_data(sample_perf_artifact_with_new_unit)
-    later_job = create_generic_job('lateguid', test_repository,
-                                   later_perf_push.id, generic_reference_data)
+    later_job = create_generic_job(
+        'lateguid', test_repository, later_perf_push.id, generic_reference_data
+    )
     store_performance_artifact(later_job, updated_submit_datum)
 
-    summary_signature = PerformanceSignature.objects.get(
-        suite='cheezburger metrics', test='')
+    summary_signature = PerformanceSignature.objects.get(suite='cheezburger metrics', test='')
     updated_subtest_signature = PerformanceSignature.objects.get(
-        suite='cheezburger metrics',
-        test='test1')
+        suite='cheezburger metrics', test='test1'
+    )
     assert summary_signature.measurement_unit == UPDATED_MEASUREMENT_UNIT
     assert updated_subtest_signature.measurement_unit == UPDATED_MEASUREMENT_UNIT
 
     # no side effects when parent/sibling signatures
     # change measurement units
     not_changed_subtest_signature = PerformanceSignature.objects.get(
-        suite='cheezburger metrics',
-        test='test2')
+        suite='cheezburger metrics', test='test2'
+    )
     assert not_changed_subtest_signature.measurement_unit == MEASUREMENT_UNIT
 
 
-def test_changing_extra_options_decouples_perf_signatures(test_repository, later_perf_push, perf_job,
-                                                          generic_reference_data, sample_perf_artifact):
+def test_changing_extra_options_decouples_perf_signatures(
+    test_repository, later_perf_push, perf_job, generic_reference_data, sample_perf_artifact
+):
     updated_perf_artifact = copy.deepcopy(sample_perf_artifact)
     updated_perf_artifact['blob']['suites'][0]['extraOptions'] = ['different-extra-options']
-    later_job = create_generic_job('lateguid', test_repository,
-                                   later_perf_push.id, generic_reference_data)
+    later_job = create_generic_job(
+        'lateguid', test_repository, later_perf_push.id, generic_reference_data
+    )
     _, submit_datum = _prepare_test_data(sample_perf_artifact)
     _, updated_submit_datum = _prepare_test_data(updated_perf_artifact)
 

--- a/tests/etl/test_perf_schema.py
+++ b/tests/etl/test_perf_schema.py
@@ -4,33 +4,52 @@ import jsonschema
 import pytest
 
 
-@pytest.mark.parametrize(('suite_value', 'test_value', 'expected_fail'),
-                         [({}, {}, True),
-                          ({'value': 1234}, {}, True),
-                          ({}, {'value': 1234}, False),
-                          ({'value': 1234}, {'value': 1234}, False),
-                          ({'value': float('inf')}, {}, True),
-                          ({}, {'value': float('inf')}, True),
-                          ({'value': 1234,
-                            'extraOptions': [
-                                # has >45 characters
-                                ['android-api-53211-with-google-play-services-and-some-random-other-extra-information']
-                            ]}, {'value': 1234}, True),
-                          ({'value': 1234,
-                            'extraOptions': ['1', '2', '3', '4', '5', '6', '7', '8', '9']}, {'value': 1234}, True),
-                          ({'value': 1234,
-                            'extraOptions': ['1', '2', '3', '4', '5', '6', '7', '8']}, {'value': 1234}, False)])
+@pytest.mark.parametrize(
+    ('suite_value', 'test_value', 'expected_fail'),
+    [
+        ({}, {}, True),
+        ({'value': 1234}, {}, True),
+        ({}, {'value': 1234}, False),
+        ({'value': 1234}, {'value': 1234}, False),
+        ({'value': float('inf')}, {}, True),
+        ({}, {'value': float('inf')}, True),
+        (
+            {
+                'value': 1234,
+                'extraOptions': [
+                    # has >45 characters
+                    [
+                        'android-api-53211-with-google-play-services-and-some-random-other-extra-information'
+                    ]
+                ],
+            },
+            {'value': 1234},
+            True,
+        ),
+        (
+            {'value': 1234, 'extraOptions': ['1', '2', '3', '4', '5', '6', '7', '8', '9']},
+            {'value': 1234},
+            True,
+        ),
+        (
+            {'value': 1234, 'extraOptions': ['1', '2', '3', '4', '5', '6', '7', '8']},
+            {'value': 1234},
+            False,
+        ),
+    ],
+)
 def test_perf_schema(suite_value, test_value, expected_fail):
     with open('schemas/performance-artifact.json') as f:
         perf_schema = json.load(f)
 
     datum = {
-        "framework": {"name": "talos"}, "suites": [{
-            "name": "basic_compositor_video",
-            "subtests": [{
-                "name": "240p.120fps.mp4_scale_fullscreen_startup"
-            }]
-        }]
+        "framework": {"name": "talos"},
+        "suites": [
+            {
+                "name": "basic_compositor_video",
+                "subtests": [{"name": "240p.120fps.mp4_scale_fullscreen_startup"}],
+            }
+        ],
     }
     datum['suites'][0].update(suite_value)
     datum['suites'][0]['subtests'][0].update(test_value)

--- a/tests/etl/test_push_loader.py
+++ b/tests/etl/test_push_loader.py
@@ -5,11 +5,13 @@ import os
 import pytest
 import responses
 
-from treeherder.etl.push_loader import (GithubPullRequestTransformer,
-                                        GithubPushTransformer,
-                                        HgPushTransformer,
-                                        PulsePushError,
-                                        PushLoader)
+from treeherder.etl.push_loader import (
+    GithubPullRequestTransformer,
+    GithubPushTransformer,
+    HgPushTransformer,
+    PulsePushError,
+    PushLoader,
+)
 from treeherder.model.models import Push
 
 
@@ -46,26 +48,22 @@ def transformed_hg_push(sample_data):
 @pytest.fixture
 def mock_github_pr_commits(activate_responses):
     tests_folder = os.path.dirname(os.path.dirname(__file__))
-    path = os.path.join(
-        tests_folder,
-        "sample_data/pulse_consumer",
-        "github_pr_commits.json"
-    )
+    path = os.path.join(tests_folder, "sample_data/pulse_consumer", "github_pr_commits.json")
     with open(path) as f:
         mocked_content = f.read()
-    responses.add(responses.GET, "https://api.github.com/repos/mozilla/test_treeherder/pulls/1692/commits",
-                  body=mocked_content, status=200,
-                  content_type='application/json')
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/mozilla/test_treeherder/pulls/1692/commits",
+        body=mocked_content,
+        status=200,
+        content_type='application/json',
+    )
 
 
 @pytest.fixture
 def mock_github_push_compare(activate_responses):
     tests_folder = os.path.dirname(os.path.dirname(__file__))
-    path = os.path.join(
-        tests_folder,
-        "sample_data/pulse_consumer",
-        "github_push_compare.json"
-    )
+    path = os.path.join(tests_folder, "sample_data/pulse_consumer", "github_push_compare.json")
     with open(path) as f:
         mocked_content = json.load(f)
 
@@ -74,35 +72,46 @@ def mock_github_push_compare(activate_responses):
         "https://api.github.com/repos/mozilla-mobile/android-components/compare/"
         "7285afe57ae6207fdb5d6db45133dac2053b7820..."
         "5fdb785b28b356f50fc1d9cb180d401bb03fc1f1",
-        json=mocked_content[0], status=200, match_querystring=False,
-        content_type='application/json')
+        json=mocked_content[0],
+        status=200,
+        match_querystring=False,
+        content_type='application/json',
+    )
     responses.add(
         responses.GET,
         "https://api.github.com/repos/servo/servo/compare/"
         "4c25e02f26f7536edbf23a360d56604fb9507378..."
         "ad9bfc2a62b70b9f3dbb1c3a5969f30bacce3d74",
-        json=mocked_content[1], status=200, match_querystring=False,
-        content_type='application/json')
+        json=mocked_content[1],
+        status=200,
+        match_querystring=False,
+        content_type='application/json',
+    )
 
 
 @pytest.fixture
 def mock_hg_push_commits(activate_responses):
     tests_folder = os.path.dirname(os.path.dirname(__file__))
-    path = os.path.join(
-        tests_folder,
-        "sample_data/pulse_consumer",
-        "hg_push_commits.json"
-    )
+    path = os.path.join(tests_folder, "sample_data/pulse_consumer", "hg_push_commits.json")
     with open(path) as f:
         mocked_content = f.read()
-    responses.add(responses.GET, "https://hg.mozilla.org/try/json-pushes",
-                  body=mocked_content, status=200, match_querystring=False,
-                  content_type='application/json')
+    responses.add(
+        responses.GET,
+        "https://hg.mozilla.org/try/json-pushes",
+        body=mocked_content,
+        status=200,
+        match_querystring=False,
+        content_type='application/json',
+    )
 
 
-@pytest.mark.parametrize("exchange, transformer_class", [
-    ("exchange/taskcluster-github/v1/push", GithubPushTransformer),
-    ("exchange/taskcluster-github/v1/pull-request", GithubPullRequestTransformer)])
+@pytest.mark.parametrize(
+    "exchange, transformer_class",
+    [
+        ("exchange/taskcluster-github/v1/push", GithubPushTransformer),
+        ("exchange/taskcluster-github/v1/pull-request", GithubPullRequestTransformer),
+    ],
+)
 def test_get_transformer_class(exchange, transformer_class):
     rsl = PushLoader()
     assert rsl.get_transformer_class(exchange) == transformer_class
@@ -114,22 +123,23 @@ def test_unsupported_exchange():
         rsl.get_transformer_class("meh")
 
 
-def test_ingest_github_pull_request(test_repository, github_pr, transformed_github_pr,
-                                    mock_github_pr_commits):
+def test_ingest_github_pull_request(
+    test_repository, github_pr, transformed_github_pr, mock_github_pr_commits
+):
     xformer = GithubPullRequestTransformer(github_pr)
     push = xformer.transform(test_repository.name)
     assert transformed_github_pr == push
 
 
-def test_ingest_github_push(test_repository, github_push, transformed_github_push,
-                            mock_github_push_compare):
+def test_ingest_github_push(
+    test_repository, github_push, transformed_github_push, mock_github_push_compare
+):
     xformer = GithubPushTransformer(github_push[0]["payload"])
     push = xformer.transform(test_repository.name)
     assert transformed_github_push == push
 
 
-def test_ingest_hg_push(test_repository, hg_push, transformed_hg_push,
-                        mock_hg_push_commits):
+def test_ingest_hg_push(test_repository, hg_push, transformed_hg_push, mock_hg_push_commits):
     xformer = HgPushTransformer(hg_push)
     push = xformer.transform(test_repository.name)
     assert transformed_hg_push == push
@@ -140,7 +150,9 @@ def test_ingest_hg_push_good_repo(hg_push, test_repository, mock_hg_push_commits
     """Test graceful handling of an unknown HG repo"""
     hg_push["payload"]["repo_url"] = "https://hg.mozilla.org/mozilla-central"
     assert Push.objects.count() == 0
-    PushLoader().process(hg_push, "exchange/hgpushes/v1", "https://firefox-ci-tc.services.mozilla.com")
+    PushLoader().process(
+        hg_push, "exchange/hgpushes/v1", "https://firefox-ci-tc.services.mozilla.com"
+    )
     assert Push.objects.count() == 1
 
 
@@ -148,7 +160,9 @@ def test_ingest_hg_push_good_repo(hg_push, test_repository, mock_hg_push_commits
 def test_ingest_hg_push_bad_repo(hg_push):
     """Test graceful handling of an unknown HG repo"""
     hg_push["payload"]["repo_url"] = "https://bad.repo.com"
-    PushLoader().process(hg_push, "exchange/hgpushes/v1", "https://firefox-ci-tc.services.mozilla.com")
+    PushLoader().process(
+        hg_push, "exchange/hgpushes/v1", "https://firefox-ci-tc.services.mozilla.com"
+    )
     assert Push.objects.count() == 0
 
 
@@ -156,34 +170,48 @@ def test_ingest_hg_push_bad_repo(hg_push):
 def test_ingest_github_push_bad_repo(github_push):
     """Test graceful handling of an unknown GH repo"""
     github_push[0]["payload"]["details"]["event.head.repo.url"] = "https://bad.repo.com"
-    PushLoader().process(github_push[0]["payload"], github_push[0]["exchange"], "https://firefox-ci-tc.services.mozilla.com")
+    PushLoader().process(
+        github_push[0]["payload"],
+        github_push[0]["exchange"],
+        "https://firefox-ci-tc.services.mozilla.com",
+    )
     assert Push.objects.count() == 0
 
 
 @pytest.mark.django_db
 def test_ingest_github_push_merge_commit(github_push, test_repository, mock_github_push_compare):
     """Test a a merge push which will require hitting the network for the right info"""
-    test_repository.url = github_push[1]["payload"]["details"]["event.head.repo.url"].replace(".git", "")
+    test_repository.url = github_push[1]["payload"]["details"]["event.head.repo.url"].replace(
+        ".git", ""
+    )
     test_repository.branch = github_push[1]["payload"]["details"]["event.base.repo.branch"]
     test_repository.save()
-    PushLoader().process(github_push[1]["payload"], github_push[1]["exchange"], "https://firefox-ci-tc.services.mozilla.com")
+    PushLoader().process(
+        github_push[1]["payload"],
+        github_push[1]["exchange"],
+        "https://firefox-ci-tc.services.mozilla.com",
+    )
     assert Push.objects.count() == 1
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("branch, expected_pushes", [
-    ("master", 1),
-    ("bar", 1),
-    ("baz", 0),
-    ("foo", 1),
-])
-def test_ingest_github_push_comma_separated_branches(branch, expected_pushes, github_push, test_repository,
-                                                     mock_github_push_compare):
+@pytest.mark.parametrize(
+    "branch, expected_pushes", [("master", 1), ("bar", 1), ("baz", 0), ("foo", 1),]
+)
+def test_ingest_github_push_comma_separated_branches(
+    branch, expected_pushes, github_push, test_repository, mock_github_push_compare
+):
     """Test a repository accepting pushes for multiple branches"""
-    test_repository.url = github_push[0]["payload"]["details"]["event.head.repo.url"].replace(".git", "")
+    test_repository.url = github_push[0]["payload"]["details"]["event.head.repo.url"].replace(
+        ".git", ""
+    )
     test_repository.branch = "master,foo,bar"
     test_repository.save()
     github_push[0]["payload"]["details"]["event.base.repo.branch"] = branch
     assert Push.objects.count() == 0
-    PushLoader().process(github_push[0]["payload"], github_push[0]["exchange"], "https://firefox-ci-tc.services.mozilla.com")
+    PushLoader().process(
+        github_push[0]["payload"],
+        github_push[0]["exchange"],
+        "https://firefox-ci-tc.services.mozilla.com",
+    )
     assert Push.objects.count() == expected_pushes

--- a/tests/etl/test_pushlog.py
+++ b/tests/etl/test_pushlog.py
@@ -5,21 +5,23 @@ import responses
 from django.core.cache import cache
 
 from treeherder.etl.pushlog import HgPushlogProcess
-from treeherder.model.models import (Commit,
-                                     Push)
+from treeherder.model.models import Commit, Push
 
 
-def test_ingest_hg_pushlog(test_repository, test_base_dir,
-                           activate_responses):
+def test_ingest_hg_pushlog(test_repository, test_base_dir, activate_responses):
     """ingesting a number of pushes should populate push and revisions"""
 
     pushlog_path = os.path.join(test_base_dir, 'sample_data', 'hg_pushlog.json')
     with open(pushlog_path) as f:
         pushlog_content = f.read()
     pushlog_fake_url = "http://www.thisismypushlog.com"
-    responses.add(responses.GET, pushlog_fake_url,
-                  body=pushlog_content, status=200,
-                  content_type='application/json')
+    responses.add(
+        responses.GET,
+        pushlog_fake_url,
+        body=pushlog_content,
+        status=200,
+        content_type='application/json',
+    )
 
     process = HgPushlogProcess()
 
@@ -30,8 +32,7 @@ def test_ingest_hg_pushlog(test_repository, test_base_dir,
     assert Commit.objects.count() == 15
 
 
-def test_ingest_hg_pushlog_already_stored(test_repository, test_base_dir,
-                                          activate_responses):
+def test_ingest_hg_pushlog_already_stored(test_repository, test_base_dir, activate_responses):
     """test that trying to ingest a push already stored doesn't doesn't affect
     all the pushes in the request,
     e.g. trying to store [A,B] with A already stored, B will be stored"""
@@ -46,11 +47,14 @@ def test_ingest_hg_pushlog_already_stored(test_repository, test_base_dir,
 
     # store the first push only
     first_push_json = json.dumps({"lastpushid": 1, "pushes": {"1": first_push}})
-    responses.add(responses.GET, pushlog_fake_url,
-                  body=first_push_json, status=200,
-                  content_type='application/json',
-                  match_querystring=True,
-                  )
+    responses.add(
+        responses.GET,
+        pushlog_fake_url,
+        body=first_push_json,
+        status=200,
+        content_type='application/json',
+        match_querystring=True,
+    )
 
     process = HgPushlogProcess()
     process.run(pushlog_fake_url, test_repository.name)
@@ -66,8 +70,10 @@ def test_ingest_hg_pushlog_already_stored(test_repository, test_base_dir,
         responses.GET,
         pushlog_fake_url + "&startID=1",
         body=first_and_second_push_json,
-        status=200, content_type='application/json',
-        match_querystring=True)
+        status=200,
+        content_type='application/json',
+        match_querystring=True,
+    )
 
     process = HgPushlogProcess()
 
@@ -76,20 +82,22 @@ def test_ingest_hg_pushlog_already_stored(test_repository, test_base_dir,
     assert Push.objects.count() == 2
 
 
-def test_ingest_hg_pushlog_cache_last_push(test_repository,
-                                           test_base_dir,
-                                           activate_responses):
+def test_ingest_hg_pushlog_cache_last_push(test_repository, test_base_dir, activate_responses):
     """
     ingesting a number of pushes should cache the top revision of the last push
     """
 
-    pushlog_path = os.path.join(test_base_dir, 'sample_data',
-                                'hg_pushlog.json')
+    pushlog_path = os.path.join(test_base_dir, 'sample_data', 'hg_pushlog.json')
     with open(pushlog_path) as f:
         pushlog_content = f.read()
     pushlog_fake_url = "http://www.thisismypushlog.com"
-    responses.add(responses.GET, pushlog_fake_url, body=pushlog_content,
-                  status=200, content_type='application/json')
+    responses.add(
+        responses.GET,
+        pushlog_fake_url,
+        body=pushlog_content,
+        status=200,
+        content_type='application/json',
+    )
 
     process = HgPushlogProcess()
     process.run(pushlog_fake_url, test_repository.name)
@@ -102,8 +110,7 @@ def test_ingest_hg_pushlog_cache_last_push(test_repository,
     assert cache.get(cache_key) == max_push_id
 
 
-def test_empty_json_pushes(test_repository, test_base_dir,
-                           activate_responses):
+def test_empty_json_pushes(test_repository, test_base_dir, activate_responses):
     """
     Gracefully handle getting an empty list of pushes from json-pushes
 
@@ -113,11 +120,14 @@ def test_empty_json_pushes(test_repository, test_base_dir,
 
     # store the first push only
     empty_push_json = json.dumps({"lastpushid": 123, "pushes": {}})
-    responses.add(responses.GET, pushlog_fake_url,
-                  body=empty_push_json, status=200,
-                  content_type='application/json',
-                  match_querystring=True,
-                  )
+    responses.add(
+        responses.GET,
+        pushlog_fake_url,
+        body=empty_push_json,
+        status=200,
+        content_type='application/json',
+        match_querystring=True,
+    )
 
     process = HgPushlogProcess()
     process.run(pushlog_fake_url, test_repository.name)

--- a/tests/etl/test_runnable_jobs.py
+++ b/tests/etl/test_runnable_jobs.py
@@ -1,8 +1,10 @@
 import responses
 
-from treeherder.etl.runnable_jobs import (RUNNABLE_JOBS_URL,
-                                          TASKCLUSTER_INDEX_URL,
-                                          _taskcluster_runnable_jobs)
+from treeherder.etl.runnable_jobs import (
+    RUNNABLE_JOBS_URL,
+    TASKCLUSTER_INDEX_URL,
+    _taskcluster_runnable_jobs,
+)
 
 TASK_ID = 'AFq3FRt4TyiTwIN7fUqOQg'
 CONTENT1 = {'taskId': TASK_ID}
@@ -19,11 +21,11 @@ API_RETURN = {
     'platform_option': 'opt',
     'ref_data_name': JOB_NAME,
     'state': 'runnable',
-    'result': 'runnable'
+    'result': 'runnable',
 }
 RUNNABLE_JOBS_CONTENTS = {
     JOB_NAME: {
-        'collection':  {'opt': True},
+        'collection': {'opt': True},
         'groupName': API_RETURN['job_group_name'],
         'groupSymbol': API_RETURN['job_group_symbol'],
         'platform': API_RETURN['platform'],
@@ -39,10 +41,20 @@ def test_taskcluster_runnable_jobs(test_repository):
     """
     repo = test_repository.name
 
-    responses.add(responses.GET, TASKCLUSTER_INDEX_URL % repo,
-                  json=CONTENT1, match_querystring=True, status=200)
-    responses.add(responses.GET, RUNNABLE_JOBS_URL,
-                  json=RUNNABLE_JOBS_CONTENTS, match_querystring=True, status=200)
+    responses.add(
+        responses.GET,
+        TASKCLUSTER_INDEX_URL % repo,
+        json=CONTENT1,
+        match_querystring=True,
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        RUNNABLE_JOBS_URL,
+        json=RUNNABLE_JOBS_CONTENTS,
+        match_querystring=True,
+        status=200,
+    )
     jobs_ret = _taskcluster_runnable_jobs(repo)
 
     assert len(jobs_ret) == 1

--- a/tests/etl/test_text.py
+++ b/tests/etl/test_text.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-from treeherder.etl.text import (astral_filter,
-                                 filter_re)
+from treeherder.etl.text import astral_filter, filter_re
 
 
 def test_filter_re_matching():

--- a/tests/intermittents_commenter/test_commenter.py
+++ b/tests/intermittents_commenter/test_commenter.py
@@ -13,8 +13,9 @@ def test_intermittents_commenter(bug_data):
 
     process = Commenter(weekly_mode=True, dry_run=True)
     params = {'include_fields': 'product%2C+component%2C+priority%2C+whiteboard%2C+id'}
-    url = '{}/rest/bug?id={}&include_fields={}'.format(settings.BZ_API_URL, bug_data['bug_id'],
-                                                       params['include_fields'])
+    url = '{}/rest/bug?id={}&include_fields={}'.format(
+        settings.BZ_API_URL, bug_data['bug_id'], params['include_fields']
+    )
 
     content = {
         "bugs": [
@@ -23,18 +24,15 @@ def test_intermittents_commenter(bug_data):
                 u"priority": u"P3",
                 u"product": u"Testing",
                 u"whiteboard": u"[stockwell infra] [see summary at comment 92]",
-                u"id": bug_data['bug_id']
+                u"id": bug_data['bug_id'],
             }
         ],
-        "faults": []
+        "faults": [],
     }
 
-    responses.add(responses.Response(
-                    method='GET',
-                    url=url,
-                    json=content,
-                    match_querystring=True,
-                    status=200))
+    responses.add(
+        responses.Response(method='GET', url=url, json=content, match_querystring=True, status=200)
+    )
 
     resp = process.fetch_bug_details(bug_data['bug_id'])
     assert resp == content['bugs']

--- a/tests/log_parser/test_artifact_builder_collection.py
+++ b/tests/log_parser/test_artifact_builder_collection.py
@@ -2,37 +2,31 @@ import pytest
 import responses
 
 from tests.test_utils import add_log_response
-from treeherder.log_parser.artifactbuildercollection import (MAX_DOWNLOAD_SIZE_IN_BYTES,
-                                                             ArtifactBuilderCollection,
-                                                             LogSizeException)
+from treeherder.log_parser.artifactbuildercollection import (
+    MAX_DOWNLOAD_SIZE_IN_BYTES,
+    ArtifactBuilderCollection,
+    LogSizeException,
+)
 from treeherder.log_parser.artifactbuilders import BuildbotLogViewArtifactBuilder
 
 
 def test_builders_as_list():
     """test that passing in a list of builders works"""
     builder = BuildbotLogViewArtifactBuilder()
-    lpc = ArtifactBuilderCollection(
-        "foo-url",
-        builders=[builder]
-    )
+    lpc = ArtifactBuilderCollection("foo-url", builders=[builder])
     assert lpc.builders == [builder]
 
 
 def test_builders_as_single_still_list():
     """test that passing in a single builder becomes a list"""
     builder = BuildbotLogViewArtifactBuilder()
-    lpc = ArtifactBuilderCollection(
-        "foo-url",
-        builders=builder
-    )
+    lpc = ArtifactBuilderCollection("foo-url", builders=builder)
     assert lpc.builders == [builder]
 
 
 def test_default_builders():
     """test no builders"""
-    lpc = ArtifactBuilderCollection(
-        "foo-url",
-    )
+    lpc = ArtifactBuilderCollection("foo-url",)
     assert isinstance(lpc.builders, list)
     assert len(lpc.builders) == 3
 
@@ -49,17 +43,8 @@ def test_all_builders_complete():
 
     lpc.parse()
     exp = {
-        "text_log_summary": {
-            "step_data": {
-                "steps": [],
-                "errors_truncated": False
-            },
-            "logurl": url,
-        },
-        "Job Info": {
-            "job_details": [],
-            "logurl": url,
-        }
+        "text_log_summary": {"step_data": {"steps": [], "errors_truncated": False}, "logurl": url,},
+        "Job Info": {"job_details": [], "logurl": url,},
     }
 
     assert exp == lpc.artifacts
@@ -76,7 +61,7 @@ def test_log_download_size_limit():
         adding_headers={
             'Content-Encoding': 'gzip',
             'Content-Length': str(MAX_DOWNLOAD_SIZE_IN_BYTES + 1),
-        }
+        },
     )
     lpc = ArtifactBuilderCollection(url)
 

--- a/tests/log_parser/test_crossreference_error_lines.py
+++ b/tests/log_parser/test_crossreference_error_lines.py
@@ -1,20 +1,18 @@
 from django.core.management import call_command
 
-from treeherder.model.models import (FailureLine,
-                                     TextLogError)
+from treeherder.model.models import FailureLine, TextLogError
 
-from ..autoclassify.utils import (create_failure_lines,
-                                  create_text_log_errors,
-                                  group_line,
-                                  test_line)
+from ..autoclassify.utils import create_failure_lines, create_text_log_errors, group_line, test_line
 
 
 def test_crossreference_error_lines(test_job):
-    lines = [(test_line, {}),
-             (test_line, {"subtest": "subtest2"}),
-             (test_line, {"status": "TIMEOUT"}),
-             (test_line, {"expected": "ERROR"}),
-             (test_line, {"message": "message2"})]
+    lines = [
+        (test_line, {}),
+        (test_line, {"subtest": "subtest2"}),
+        (test_line, {"status": "TIMEOUT"}),
+        (test_line, {"expected": "ERROR"}),
+        (test_line, {"message": "message2"}),
+    ]
 
     create_failure_lines(test_job, lines)
     create_text_log_errors(test_job, lines)
@@ -33,35 +31,36 @@ def test_crossreference_error_lines(test_job):
 
 
 def test_crossreference_error_lines_truncated(test_job):
-    lines = [(test_line, {}),
-             (test_line, {"subtest": "subtest2"}),
-             (test_line, {"status": "TIMEOUT"}),
-             (test_line, {"expected": "ERROR"}),
-             (test_line, {"message": "message2"}),
-             ]
+    lines = [
+        (test_line, {}),
+        (test_line, {"subtest": "subtest2"}),
+        (test_line, {"status": "TIMEOUT"}),
+        (test_line, {"expected": "ERROR"}),
+        (test_line, {"message": "message2"}),
+    ]
 
     create_text_log_errors(test_job, lines)
-    create_failure_lines(test_job,
-                         lines[:-1] + [({"action": "truncated"}, {})])
+    create_failure_lines(test_job, lines[:-1] + [({"action": "truncated"}, {})])
 
     call_command('crossreference_error_lines', str(test_job.id))
 
     error_lines = TextLogError.objects.filter(step__job=test_job).all()
     failure_lines = FailureLine.objects.all()
 
-    for failure_line, error_line in zip(failure_lines[:len(failure_lines)-1], error_lines):
+    for failure_line, error_line in zip(failure_lines[: len(failure_lines) - 1], error_lines):
         assert error_line.metadata.failure_line == failure_line
         assert error_line.metadata.best_is_verified is False
         assert error_line.metadata.best_classification is None
 
 
 def test_crossreference_error_lines_missing(test_job):
-    lines = [(test_line, {}),
-             (test_line, {"subtest": "subtest2"}),
-             (test_line, {"status": "TIMEOUT"}),
-             (test_line, {"expected": "ERROR"}),
-             (test_line, {"message": "message2"}),
-             ]
+    lines = [
+        (test_line, {}),
+        (test_line, {"subtest": "subtest2"}),
+        (test_line, {"status": "TIMEOUT"}),
+        (test_line, {"expected": "ERROR"}),
+        (test_line, {"message": "message2"}),
+    ]
 
     create_failure_lines(test_job, lines[1:])
     create_text_log_errors(test_job, lines)
@@ -78,12 +77,14 @@ def test_crossreference_error_lines_missing(test_job):
 
 
 def test_crossreference_error_lines_leading_groups(test_job):
-    lines = [(group_line, {}),
-             (test_line, {}),
-             (test_line, {"subtest": "subtest2"}),
-             (test_line, {"status": "TIMEOUT"}),
-             (test_line, {"expected": "ERROR"}),
-             (test_line, {"message": "message2"})]
+    lines = [
+        (group_line, {}),
+        (test_line, {}),
+        (test_line, {"subtest": "subtest2"}),
+        (test_line, {"status": "TIMEOUT"}),
+        (test_line, {"expected": "ERROR"}),
+        (test_line, {"message": "message2"}),
+    ]
 
     create_failure_lines(test_job, lines)
     create_text_log_errors(test_job, lines)

--- a/tests/log_parser/test_error_parser.py
+++ b/tests/log_parser/test_error_parser.py
@@ -34,7 +34,7 @@ NON_ERROR_TEST_CASES = (
     "[taskcluster:info] Starting task",
     "[taskcluster] Starting task",
     "01:22:41     INFO -  ImportError: No module named pygtk",
-    "01:22:41     INFO -  ImportError: No module named pygtk\r\n"
+    "01:22:41     INFO -  ImportError: No module named pygtk\r\n",
 )
 
 

--- a/tests/log_parser/test_log_view_artifact_builder.py
+++ b/tests/log_parser/test_log_view_artifact_builder.py
@@ -39,204 +39,152 @@ def do_test(log):
 def test_crashtest_passing():
     """Process a job with a single log reference."""
 
-    do_test(
-        "mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50"
-    )
+    do_test("mozilla-central_fedora-b2g_test-crashtest-1-bm54-tests1-linux-build50")
 
 
 def test_mochitest_pass():
     """Process a job with a single log reference."""
 
-    do_test(
-        "mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141"
-    )
+    do_test("mozilla-central_mountainlion_test-mochitest-2-bm77-tests1-macosx-build141")
 
 
 def test_duration_gt_1hr():
-    do_test(
-        "mozilla-central-win32-pgo-bm85-build1-build111"
-    )
+    do_test("mozilla-central-win32-pgo-bm85-build1-build111")
 
 
 @slow
 def test_mochitest_fail():
     """Process a job with a single log reference."""
 
-    do_test(
-        "mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12"
-    )
+    do_test("mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12")
 
 
 def test_mochitest_process_crash():
     """Test a mochitest log that has PROCESS-CRASH """
 
-    do_test(
-        "mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122"
-    )
+    do_test("mozilla-inbound_ubuntu64_vm-debug_test-mochitest-other-bm53-tests1-linux-build122")
 
 
 @slow
 def test_jetpack_fail():
     """Process a job with a single log reference."""
 
-    do_test(
-        "ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16"
-    )
+    do_test("ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16")
 
 
 @slow
 def test_crash_1():
     """Test from old log parser"""
-    do_test(
-        "crash-1"
-    )
+    do_test("crash-1")
 
 
 @slow
 def test_crash_2():
     """Test from old log parser"""
-    do_test(
-        "crash-2"
-    )
+    do_test("crash-2")
 
 
 @slow
 def test_crash_mac_1():
     """Test from old log parser"""
-    do_test(
-        "crash-mac-1"
-    )
+    do_test("crash-mac-1")
 
 
 @slow
 def test_crashtest_timeout():
     """Test from old log parser"""
-    do_test(
-        "crashtest-timeout"
-    )
+    do_test("crashtest-timeout")
 
 
 @slow
 def test_jsreftest_fail():
     """Test from old log parser"""
-    do_test(
-        "jsreftest-fail"
-    )
+    do_test("jsreftest-fail")
 
 
 @slow
 def test_jsreftest_timeout_crash():
     """Test from old log parser"""
-    do_test(
-        "jsreftest-timeout-crash"
-    )
+    do_test("jsreftest-timeout-crash")
 
 
 @slow
 def test_leaks_1():
     """Test from old log parser"""
-    do_test(
-        "leaks-1"
-    )
+    do_test("leaks-1")
 
 
 @slow
 def test_mochitest_test_end():
     """Test from old log parser"""
-    do_test(
-        "mochitest-test-end"
-    )
+    do_test("mochitest-test-end")
 
 
 @slow
 def test_multiple_timeouts():
     """Test from old log parser"""
-    do_test(
-        "multiple-timeouts"
-    )
+    do_test("multiple-timeouts")
 
 
 @slow
 def test_opt_objc_exception():
     """Test from old log parser"""
-    do_test(
-        "opt-objc-exception"
-    )
+    do_test("opt-objc-exception")
 
 
 @slow
 def test_reftest_fail_crash():
     """Test from old log parser"""
-    do_test(
-        "reftest-fail-crash"
-    )
+    do_test("reftest-fail-crash")
 
 
 @slow
 def test_reftest_jserror():
     """Test from old log parser"""
-    do_test(
-        "reftest-jserror"
-    )
+    do_test("reftest-jserror")
 
 
 @slow
 def test_reftest_opt_fail():
     """Test from old log parser"""
-    do_test(
-        "reftest-opt-fail"
-    )
+    do_test("reftest-opt-fail")
 
 
 @slow
 def test_reftest_timeout():
     """Test from old log parser"""
-    do_test(
-        "reftest-timeout"
-    )
+    do_test("reftest-timeout")
 
 
 @slow
 def test_tinderbox_exception():
     """Test from old log parser"""
-    do_test(
-        "tinderbox-exception"
-    )
+    do_test("tinderbox-exception")
 
 
 def test_xpcshell_crash():
     """Test from old log parser"""
-    do_test(
-        "xpcshell-crash"
-    )
+    do_test("xpcshell-crash")
 
 
 def test_xpcshell_multiple():
     """Test from old log parser"""
-    do_test(
-        "xpcshell-multiple"
-    )
+    do_test("xpcshell-multiple")
 
 
 def test_xpcshell_timeout():
     """Test from old log parser"""
-    do_test(
-        "xpcshell-timeout"
-    )
+    do_test("xpcshell-timeout")
 
 
 def test_extreme_log_line_length_truncation():
     """This log has lines that are huge.  Ensure we truncate the lines to 100"""
-    do_test(
-        "mozilla-central_ubuntu64_hw_test-androidx86-set-4-bm103-tests1-linux-build369"
-    )
+    do_test("mozilla-central_ubuntu64_hw_test-androidx86-set-4-bm103-tests1-linux-build369")
 
 
 def test_too_many_error_lines_truncation():
     """This log has a large number of lines that match the error regex. Ensure we truncate to 100 lines."""
-    do_test(
-        "large-number-of-error-lines"
-    )
+    do_test("large-number-of-error-lines")
 
 
 def test_taskcluster_missing_finish_marker():
@@ -246,6 +194,4 @@ def test_taskcluster_missing_finish_marker():
     between the step markers that should result in unnamed steps being created
     to house any errors within them.
     """
-    do_test(
-        "taskcluster-missing-finish-step-marker"
-    )
+    do_test("taskcluster-missing-finish-step-marker")

--- a/tests/log_parser/test_performance_artifact_builder.py
+++ b/tests/log_parser/test_performance_artifact_builder.py
@@ -15,9 +15,10 @@ def test_performance_log_parsing():
 
     # first two have only one artifact, second has two artifacts
     for (logfile, num_perf_artifacts) in [
-            ('mozilla-inbound-android-api-11-debug-bm91-build1-build1317.txt.gz', 1),
-            ('try_ubuntu64_hw_test-chromez-bm103-tests1-linux-build1429.txt.gz', 1),
-            ('mozilla-inbound-linux64-bm72-build1-build225.txt.gz', 2)]:
+        ('mozilla-inbound-android-api-11-debug-bm91-build1-build1317.txt.gz', 1),
+        ('try_ubuntu64_hw_test-chromez-bm103-tests1-linux-build1429.txt.gz', 1),
+        ('mozilla-inbound-linux64-bm72-build1-build225.txt.gz', 2),
+    ]:
         url = add_log_response(logfile)
 
         builder = BuildbotPerformanceDataArtifactBuilder(url=url)

--- a/tests/log_parser/test_performance_parser.py
+++ b/tests/log_parser/test_performance_parser.py
@@ -1,7 +1,6 @@
 import json
 
-from treeherder.log_parser.parsers import (EmptyPerformanceData,
-                                           PerformanceParser)
+from treeherder.log_parser.parsers import EmptyPerformanceData, PerformanceParser
 
 
 def test_performance_log_parsing_malformed_perfherder_data():
@@ -20,15 +19,14 @@ def test_performance_log_parsing_malformed_perfherder_data():
         pass
 
     valid_perfherder_data = {
-        "framework": {"name": "talos"}, "suites": [{
-            "name": "basic_compositor_video",
-            "subtests": [{
-                "name": "240p.120fps.mp4_scale_fullscreen_startup",
-                "value": 1234
-            }]
-        }]
+        "framework": {"name": "talos"},
+        "suites": [
+            {
+                "name": "basic_compositor_video",
+                "subtests": [{"name": "240p.120fps.mp4_scale_fullscreen_startup", "value": 1234}],
+            }
+        ],
     }
-    parser.parse_line('PERFHERDER_DATA: {}'.format(
-        json.dumps(valid_perfherder_data)), 3)
+    parser.parse_line('PERFHERDER_DATA: {}'.format(json.dumps(valid_perfherder_data)), 3)
 
     assert parser.get_artifact() == [valid_perfherder_data]

--- a/tests/log_parser/test_store_failure_lines.py
+++ b/tests/log_parser/test_store_failure_lines.py
@@ -5,11 +5,8 @@ import responses
 from django.conf import settings
 from requests.exceptions import HTTPError
 
-from treeherder.log_parser.failureline import (store_failure_lines,
-                                               write_failure_lines)
-from treeherder.model.models import (FailureLine,
-                                     Group,
-                                     JobLog)
+from treeherder.log_parser.failureline import store_failure_lines, write_failure_lines
+from treeherder.model.models import FailureLine, Group, JobLog
 
 from ..sampledata import SampleData
 
@@ -19,8 +16,7 @@ def test_store_error_summary(activate_responses, test_repository, test_job):
     log_url = 'http://my-log.mozilla.org'
 
     with open(log_path) as log_handler:
-        responses.add(responses.GET, log_url,
-                      body=log_handler.read(), status=200)
+        responses.add(responses.GET, log_url, body=log_handler.read(), status=200)
 
     log_obj = JobLog.objects.create(job=test_job, name="errorsummary_json", url=log_url)
 
@@ -45,8 +41,7 @@ def test_store_error_summary_default_group(activate_responses, test_repository, 
         resp_body = json.load(log_handler)
 
     resp_body["group"] = "default"
-    responses.add(responses.GET, log_url,
-                  body=json.dumps(resp_body), status=200)
+    responses.add(responses.GET, log_url, body=json.dumps(resp_body), status=200)
 
     log_obj = JobLog.objects.create(job=test_job, name="errorsummary_json", url=log_url)
 
@@ -59,16 +54,14 @@ def test_store_error_summary_default_group(activate_responses, test_repository, 
     assert failure.group.all().first().name == "default"
 
 
-def test_store_error_summary_truncated(activate_responses, test_repository,
-                                       test_job, monkeypatch):
+def test_store_error_summary_truncated(activate_responses, test_repository, test_job, monkeypatch):
     log_path = SampleData().get_log_path("plain-chunked_errorsummary_10_lines.log")
     log_url = 'http://my-log.mozilla.org'
 
     monkeypatch.setattr(settings, 'FAILURE_LINES_CUTOFF', 5)
 
     with open(log_path) as log_handler:
-        responses.add(responses.GET, log_url,
-                      body=log_handler.read(), status=200)
+        responses.add(responses.GET, log_url, body=log_handler.read(), status=200)
 
     log_obj = JobLog.objects.create(job=test_job, name="errorsummary_json", url=log_url)
 
@@ -93,8 +86,13 @@ def test_store_error_summary_astral(activate_responses, test_repository, test_jo
     log_url = 'http://my-log.mozilla.org'
 
     with open(log_path, encoding='utf8') as log_handler:
-        responses.add(responses.GET, log_url, content_type="text/plain;charset=utf-8",
-                      body=log_handler.read(), status=200)
+        responses.add(
+            responses.GET,
+            log_url,
+            content_type="text/plain;charset=utf-8",
+            body=log_handler.read(),
+            status=200,
+        )
 
     log_obj = JobLog.objects.create(job=test_job, name="errorsummary_json", url=log_url)
 
@@ -110,7 +108,10 @@ def test_store_error_summary_astral(activate_responses, test_repository, test_jo
 
     assert failure.repository == test_repository
 
-    assert failure.test == u"toolkit/content/tests/widgets/test_videocontrols_video_direction.html <U+01F346>"
+    assert (
+        failure.test
+        == u"toolkit/content/tests/widgets/test_videocontrols_video_direction.html <U+01F346>"
+    )
     assert failure.subtest == u"Test timed out. <U+010081>"
     assert failure.message == u"<U+0F0151>"
     assert failure.stack.endswith("<U+0F0151>")
@@ -123,8 +124,7 @@ def test_store_error_summary_404(activate_responses, test_repository, test_job):
     log_url = 'http://my-log.mozilla.org'
 
     with open(log_path) as log_handler:
-        responses.add(responses.GET, log_url,
-                      body=log_handler.read(), status=404)
+        responses.add(responses.GET, log_url, body=log_handler.read(), status=404)
 
     log_obj = JobLog.objects.create(job=test_job, name="errorsummary_json", url=log_url)
 
@@ -139,8 +139,7 @@ def test_store_error_summary_500(activate_responses, test_repository, test_job):
     log_url = 'http://my-log.mozilla.org'
 
     with open(log_path) as log_handler:
-        responses.add(responses.GET, log_url,
-                      body=log_handler.read(), status=500)
+        responses.add(responses.GET, log_url, body=log_handler.read(), status=500)
 
     log_obj = JobLog.objects.create(job=test_job, name="errorsummary_json", url=log_url)
 
@@ -155,17 +154,15 @@ def test_store_error_summary_duplicate(activate_responses, test_repository, test
     log_url = 'http://my-log.mozilla.org'
     log_obj = JobLog.objects.create(job=test_job, name="errorsummary_json", url=log_url)
 
-    write_failure_lines(log_obj, [{"action": "log",
-                                   "level": "debug",
-                                   "message": "test",
-                                   "line": 1}])
-    write_failure_lines(log_obj, [{"action": "log",
-                                   "level": "debug",
-                                   "message": "test",
-                                   "line": 1},
-                                  {"action": "log",
-                                   "level": "debug",
-                                   "message": "test 1",
-                                   "line": 2}])
+    write_failure_lines(
+        log_obj, [{"action": "log", "level": "debug", "message": "test", "line": 1}]
+    )
+    write_failure_lines(
+        log_obj,
+        [
+            {"action": "log", "level": "debug", "message": "test", "line": 1},
+            {"action": "log", "level": "debug", "message": "test 1", "line": 2},
+        ],
+    )
 
     assert FailureLine.objects.count() == 2

--- a/tests/log_parser/test_tasks.py
+++ b/tests/log_parser/test_tasks.py
@@ -4,9 +4,7 @@ from tests.test_utils import add_log_response
 from treeherder.etl.jobs import store_job_data
 from treeherder.etl.push import store_push_data
 from treeherder.model.error_summary import get_error_summary
-from treeherder.model.models import (Job,
-                                     JobDetail,
-                                     TextLogError)
+from treeherder.model.models import Job, JobDetail, TextLogError
 
 from ..sampledata import SampleData
 
@@ -45,9 +43,9 @@ def test_parse_log(test_repository, failure_classifications, jobs_with_local_log
     print(JobDetail.objects.count() == 4)
 
 
-def test_create_error_summary(failure_classifications,
-                              jobs_with_local_log, sample_push,
-                              test_repository):
+def test_create_error_summary(
+    failure_classifications, jobs_with_local_log, sample_push, test_repository
+):
     """
     check that a bug suggestions artifact gets inserted when running
     a parse_log task for a failed job, and that the number of

--- a/tests/log_parser/test_tinderbox_print_parser.py
+++ b/tests/log_parser/test_tinderbox_print_parser.py
@@ -14,49 +14,52 @@ TINDERBOX_TEST_CASES = (
             'libxul_link:2918047744'
             '</a>'
         ),
-        [{
-            'content_type': 'link',
-            'title': None,
-            'url': 'http://graphs.mozilla.org/graph.html#tests=[[205,63,8]]',
-            'value': 'libxul_link:2918047744'
-        }]
+        [
+            {
+                'content_type': 'link',
+                'title': None,
+                'url': 'http://graphs.mozilla.org/graph.html#tests=[[205,63,8]]',
+                'value': 'libxul_link:2918047744',
+            }
+        ],
     ),
-
     (
         (
             'TinderboxPrint: sources.xml: http://stage.mozilla.org/pub/mozilla.org/'
             'b2g/manifests/depend/mozilla-central/hamachi-eng/20140718040333/'
             'sources-5d0aad07bd13e04de0cd7befc0e2b83a.xml'
         ),
-        [{
-            'content_type': 'link',
-            'title': 'sources.xml',
-            'url': (
-                'http://stage.mozilla.org/pub/mozilla.org/'
-                'b2g/manifests/depend/mozilla-central/hamachi-eng/20140718040333/'
-                'sources-5d0aad07bd13e04de0cd7befc0e2b83a.xml'
-            ),
-            'value': (
-                'http://stage.mozilla.org/pub/mozilla.org/'
-                'b2g/manifests/depend/mozilla-central/hamachi-eng/20140718040333/'
-                'sources-5d0aad07bd13e04de0cd7befc0e2b83a.xml'
-            )
-        }]
+        [
+            {
+                'content_type': 'link',
+                'title': 'sources.xml',
+                'url': (
+                    'http://stage.mozilla.org/pub/mozilla.org/'
+                    'b2g/manifests/depend/mozilla-central/hamachi-eng/20140718040333/'
+                    'sources-5d0aad07bd13e04de0cd7befc0e2b83a.xml'
+                ),
+                'value': (
+                    'http://stage.mozilla.org/pub/mozilla.org/'
+                    'b2g/manifests/depend/mozilla-central/hamachi-eng/20140718040333/'
+                    'sources-5d0aad07bd13e04de0cd7befc0e2b83a.xml'
+                ),
+            }
+        ],
     ),
-
     (
         (
             'TinderboxPrint: mozharness_revlink: '
             'https://hg.mozilla.org/build/mozharness/rev/16ba958057a8'
         ),
-        [{
-            'content_type': 'link',
-            'title': 'mozharness_revlink',
-            'url': 'https://hg.mozilla.org/build/mozharness/rev/16ba958057a8',
-            'value': 'https://hg.mozilla.org/build/mozharness/rev/16ba958057a8'
-        }]
+        [
+            {
+                'content_type': 'link',
+                'title': 'mozharness_revlink',
+                'url': 'https://hg.mozilla.org/build/mozharness/rev/16ba958057a8',
+                'value': 'https://hg.mozilla.org/build/mozharness/rev/16ba958057a8',
+            }
+        ],
     ),
-
     (
         (
             'TinderboxPrint: '
@@ -65,17 +68,18 @@ TINDERBOX_TEST_CASES = (
             'wpt_structured_full.log'
             '</a>: uploaded'
         ),
-        [{
-            'content_type': 'link',
-            'title': 'artifact uploaded',
-            'url': (
-                'http://mozilla-releng-blobs.s3.amazonaws.com'
-                '/blobs/cedar/sha512/9123cb277dbf1eb6d90'
-            ),
-            'value': 'wpt_structured_full.log'
-        }]
+        [
+            {
+                'content_type': 'link',
+                'title': 'artifact uploaded',
+                'url': (
+                    'http://mozilla-releng-blobs.s3.amazonaws.com'
+                    '/blobs/cedar/sha512/9123cb277dbf1eb6d90'
+                ),
+                'value': 'wpt_structured_full.log',
+            }
+        ],
     ),
-
     (
         (
             'TinderboxPrint: '
@@ -84,44 +88,47 @@ TINDERBOX_TEST_CASES = (
             'libxul_link:2918047744'
             '</a>'
         ),
-        [{
-            'content_type': 'link',
-            'title': None,
-            'url': 'http://graphs.mozilla.org/graph.html#tests=[[205,63,8]]',
-            'value': 'libxul_link:2918047744'
-        }]
+        [
+            {
+                'content_type': 'link',
+                'title': None,
+                'url': 'http://graphs.mozilla.org/graph.html#tests=[[205,63,8]]',
+                'value': 'libxul_link:2918047744',
+            }
+        ],
     ),
-
     (
         (
             'TinderboxPrint: '
             'xpcshell-xpcshell<br/>2153/<em class="testfail">1</em>&nbsp;'
             '<em class="testfail">CRASH</em>'
         ),
-        [{
-            'content_type': 'raw_html',
-            'title': 'xpcshell-xpcshell',
-            'value': (
-                '2153/<em class="testfail">1</em>&nbsp;'
-                '<em class="testfail">CRASH</em>'
-            )
-        }]
+        [
+            {
+                'content_type': 'raw_html',
+                'title': 'xpcshell-xpcshell',
+                'value': (
+                    '2153/<em class="testfail">1</em>&nbsp;' '<em class="testfail">CRASH</em>'
+                ),
+            }
+        ],
     ),
-
     (
         (
             'TinderboxPrint: hazard results: '
             'https://ftp-ssl.mozilla.org/pub/mozilla.org/firefox/tinderbox-builds/'
             'mozilla-central-linux64-br-haz/20150226025813'
         ),
-        [{
-            'content_type': 'link',
-            'title': 'hazard results',
-            'url': 'https://ftp-ssl.mozilla.org/pub/mozilla.org/firefox/tinderbox-builds/'
-                   'mozilla-central-linux64-br-haz/20150226025813',
-            'value': 'https://ftp-ssl.mozilla.org/pub/mozilla.org/firefox/tinderbox-builds/'
-                     'mozilla-central-linux64-br-haz/20150226025813'
-        }]
+        [
+            {
+                'content_type': 'link',
+                'title': 'hazard results',
+                'url': 'https://ftp-ssl.mozilla.org/pub/mozilla.org/firefox/tinderbox-builds/'
+                'mozilla-central-linux64-br-haz/20150226025813',
+                'value': 'https://ftp-ssl.mozilla.org/pub/mozilla.org/firefox/tinderbox-builds/'
+                'mozilla-central-linux64-br-haz/20150226025813',
+            }
+        ],
     ),
 )
 

--- a/tests/log_parser/test_utils.py
+++ b/tests/log_parser/test_utils.py
@@ -6,66 +6,32 @@ import simplejson as json
 from django.db.utils import DataError
 from jsonschema import ValidationError
 
-from treeherder.log_parser.utils import (MAX_LENGTH,
-                                         SECOND_MAX_LENGTH,
-                                         _lookup_extra_options_max,
-                                         validate_perf_data)
+from treeherder.log_parser.utils import (
+    MAX_LENGTH,
+    SECOND_MAX_LENGTH,
+    _lookup_extra_options_max,
+    validate_perf_data,
+)
 
 LENGTH_OK = {
-        'framework': {},
-        'suites': [
-            {
-                'extraOptions': [
-                    '.' * 45,
-                    '.' * 100,
-                ],
-                'name': 'testing',
-                'subtests': []
-            }
-        ] * 3
-    }
+    'framework': {},
+    'suites': [{'extraOptions': ['.' * 45, '.' * 100,], 'name': 'testing', 'subtests': []}] * 3,
+}
 
 LONGER_THAN_ALL_MAX = {
-        'framework': {},
-        'suites': [
-            {
-                'extraOptions': [
-                    '.' * 46,
-                    '.' * 101,
-                ],
-                'name': 'testing',
-                'subtests': []
-            }
-        ]
-    }
+    'framework': {},
+    'suites': [{'extraOptions': ['.' * 46, '.' * 101,], 'name': 'testing', 'subtests': []}],
+}
 
 LONGER_THAN_BIGGER_MAX = {
-        'framework': {},
-        'suites': [
-            {
-                'extraOptions': [
-                    '.' * 45,
-                    '.' * 101,
-                ],
-                'name': 'testing',
-                'subtests': []
-            }
-        ]
-    }
+    'framework': {},
+    'suites': [{'extraOptions': ['.' * 45, '.' * 101,], 'name': 'testing', 'subtests': []}],
+}
 
 LONGER_THAN_SMALLER_MAX = {
-        'framework': {},
-        'suites': [
-            {
-                'extraOptions': [
-                    '.' * 46,
-                    '.' * 100,
-                ],
-                'name': 'testing',
-                'subtests': []
-            }
-        ] * 3
-    }
+    'framework': {},
+    'suites': [{'extraOptions': ['.' * 46, '.' * 100,], 'name': 'testing', 'subtests': []}] * 3,
+}
 
 
 def test_smaller_than_bigger():
@@ -85,7 +51,9 @@ def test_validate_perf_schema_no_exception():
         pytest.fail(str(exc))
 
 
-@pytest.mark.parametrize('data', (LONGER_THAN_ALL_MAX, LONGER_THAN_BIGGER_MAX, LONGER_THAN_SMALLER_MAX))
+@pytest.mark.parametrize(
+    'data', (LONGER_THAN_ALL_MAX, LONGER_THAN_BIGGER_MAX, LONGER_THAN_SMALLER_MAX)
+)
 def test_validate_perf_schema(data):
     for datum in data:
         with pytest.raises(ValidationError):

--- a/tests/model/test_backfill_report.py
+++ b/tests/model/test_backfill_report.py
@@ -2,8 +2,7 @@ import json
 
 from django.utils.timezone import now as django_now
 
-from treeherder.perf.models import (BackfillRecord,
-                                    BackfillReport)
+from treeherder.perf.models import BackfillRecord, BackfillReport
 
 
 class TestBackfillReportClass:
@@ -18,8 +17,9 @@ class TestBackfillReportClass:
 
         assert backfill_record.is_outdated is True
 
-    def test_last_updated_is_synced_with_child_records(self, test_perf_alert,
-                                                       backfill_record_context):
+    def test_last_updated_is_synced_with_child_records(
+        self, test_perf_alert, backfill_record_context
+    ):
         test_summary = test_perf_alert.summary
         context_dump = json.dumps(backfill_record_context)
 
@@ -27,9 +27,9 @@ class TestBackfillReportClass:
         last_updated_before_new_record = backfill_report.last_updated
 
         # this should re update the report
-        BackfillRecord.objects.create(alert=test_perf_alert,
-                                      report=backfill_report,
-                                      context=context_dump)
+        BackfillRecord.objects.create(
+            alert=test_perf_alert, report=backfill_report, context=context_dump
+        )
         assert last_updated_before_new_record < backfill_report.last_updated
 
         # record bulk deletes count as report updates too
@@ -39,9 +39,9 @@ class TestBackfillReportClass:
         assert last_updated_before_expelling_records < backfill_report.last_updated
 
         # deleting single record counts are report update too
-        new_backfill_record = BackfillRecord.objects.create(alert=test_perf_alert,
-                                                            report=backfill_report,
-                                                            context=context_dump)
+        new_backfill_record = BackfillRecord.objects.create(
+            alert=test_perf_alert, report=backfill_report, context=context_dump
+        )
         last_updated_before_single_record_delete = backfill_report.last_updated
 
         new_backfill_record.delete()

--- a/tests/model/test_bugscache.py
+++ b/tests/model/test_bugscache.py
@@ -1,7 +1,6 @@
 import json
 import os
-from datetime import (datetime,
-                      timedelta)
+from datetime import datetime, timedelta
 
 import pytest
 from django.db import connection
@@ -12,11 +11,7 @@ from treeherder.model.models import Bugscache
 
 @pytest.fixture
 def sample_bugs(test_base_dir):
-    filename = os.path.join(
-        test_base_dir,
-        'sample_data',
-        'bug_list.json'
-    )
+    filename = os.path.join(test_base_dir, 'sample_data', 'bug_list.json')
     with open(filename) as f:
         return json.load(f)
 
@@ -40,38 +35,23 @@ def _update_bugscache(bug_list):
 
 
 BUG_SEARCHES = (
-    (
-        "test_popup_preventdefault_chrome.xul",
-        [455091]
-    ),
-    (
-        "test_popup_preventdefault_chrome.xul foo bar",
-        []
-    ),
+    ("test_popup_preventdefault_chrome.xul", [455091]),
+    ("test_popup_preventdefault_chrome.xul foo bar", []),
     (
         "test_switch_frame.py TestSwitchFrame.test_should_be_able_to_carry_on_working_if_the_frame_is_deleted",
-        [1054669, 1078237]
+        [1054669, 1078237],
     ),
     (
         "command timed out: 3600 seconds without output running ['/tools/buildbot/bin/python', 'scripts/scrip",
-        [1054456]
+        [1054456],
     ),
     (
         "[taskcluster:error]  Command \" [./test-macosx.sh --no-read-buildbot-config --installer-url=https://q",
-        [100]
+        [100],
     ),
-    (
-        "should not be match_d",
-        []
-    ),
-    (
-        "should not be match%d",
-        []
-    ),
-    (
-        "should not be matche=d",
-        []
-    ),
+    ("should not be match_d", []),
+    ("should not be match%d", []),
+    ("should not be matche=d", []),
 )
 
 
@@ -138,8 +118,9 @@ def test_bug_properties(transactional_db, sample_bugs):
         bug['last_change_time'] = fifty_days_ago
     _update_bugscache(bug_list)
 
-    expected_keys = set(['crash_signature', 'resolution', 'summary', 'keywords', 'os', 'id',
-                         'status', 'whiteboard'])
+    expected_keys = set(
+        ['crash_signature', 'resolution', 'summary', 'keywords', 'os', 'id', 'status', 'whiteboard']
+    )
 
     suggestions = Bugscache.search(search_term)
     assert set(suggestions['open_recent'][0].keys()) == expected_keys

--- a/tests/model/test_classified_failure.py
+++ b/tests/model/test_classified_failure.py
@@ -2,14 +2,15 @@ from decimal import Decimal
 
 from django.contrib.auth.models import User
 
-from tests.autoclassify.utils import (create_lines,
-                                      test_line)
+from tests.autoclassify.utils import create_lines, test_line
 from treeherder.autoclassify.autoclassify import mark_best_classification
-from treeherder.model.models import (BugJobMap,
-                                     ClassifiedFailure,
-                                     FailureLine,
-                                     TextLogErrorMatch,
-                                     TextLogErrorMetadata)
+from treeherder.model.models import (
+    BugJobMap,
+    ClassifiedFailure,
+    FailureLine,
+    TextLogErrorMatch,
+    TextLogErrorMetadata,
+)
 
 
 def test_set_bug(classified_failures):
@@ -75,9 +76,7 @@ def test_update_autoclassification_bug(test_job, test_job_2, classified_failures
 
     # Create a BugJobMap
     BugJobMap.create(
-        job_id=test_job.id,
-        bug_id=1234,
-        user=user,
+        job_id=test_job.id, bug_id=1234, user=user,
     )
     mark_best_classification(text_log_errors[0], classified_failure)
     assert classified_failure.bug_number is None
@@ -87,9 +86,7 @@ def test_update_autoclassification_bug(test_job, test_job_2, classified_failures
     metadata.save()
 
     BugJobMap.create(
-        job_id=test_job_2.id,
-        bug_id=1234,
-        user=user,
+        job_id=test_job_2.id, bug_id=1234, user=user,
     )
     classified_failure.refresh_from_db()
     assert classified_failure.bug_number == 1234

--- a/tests/model/test_cycle_data.py
+++ b/tests/model/test_cycle_data.py
@@ -5,26 +5,33 @@ from django.core.management import call_command
 from django.db.models import Max
 
 from tests import test_utils
-from tests.autoclassify.utils import (create_failure_lines,
-                                      test_line)
-from treeherder.model.management.commands.cycle_data import (MINIMUM_PERFHERDER_EXPIRE_INTERVAL,
-                                                             PerfherderCycler)
-from treeherder.model.models import (FailureLine,
-                                     Job,
-                                     JobDetail,
-                                     JobGroup,
-                                     JobLog,
-                                     JobType,
-                                     Machine,
-                                     Push)
+from tests.autoclassify.utils import create_failure_lines, test_line
+from treeherder.model.management.commands.cycle_data import (
+    MINIMUM_PERFHERDER_EXPIRE_INTERVAL,
+    PerfherderCycler,
+)
+from treeherder.model.models import (
+    FailureLine,
+    Job,
+    JobDetail,
+    JobGroup,
+    JobLog,
+    JobType,
+    Machine,
+    Push,
+)
 from treeherder.perf.exceptions import MaxRuntimeExceeded
-from treeherder.perf.models import (PerformanceDatum,
-                                    PerformanceDatumManager,
-                                    PerformanceSignature)
+from treeherder.perf.models import PerformanceDatum, PerformanceDatumManager, PerformanceSignature
 
 
-def test_cycle_all_data(test_repository, failure_classifications, sample_data,
-                        sample_push, mock_log_parser, failure_lines):
+def test_cycle_all_data(
+    test_repository,
+    failure_classifications,
+    sample_data,
+    sample_push,
+    mock_log_parser,
+    failure_lines,
+):
     """
     Test cycling the sample data
     """
@@ -46,8 +53,14 @@ def test_cycle_all_data(test_repository, failure_classifications, sample_data,
     assert JobLog.objects.count() == 0
 
 
-def test_cycle_all_but_one_job(test_repository, failure_classifications, sample_data,
-                               sample_push, mock_log_parser, failure_lines):
+def test_cycle_all_but_one_job(
+    test_repository,
+    failure_classifications,
+    sample_data,
+    sample_push,
+    mock_log_parser,
+    failure_lines,
+):
     """
     Test cycling all but one job in a group of jobs to confirm there are no
     unexpected deletions
@@ -62,15 +75,16 @@ def test_cycle_all_but_one_job(test_repository, failure_classifications, sample_
     job_not_deleted.save()
 
     extra_objects = {
-        'failure_lines': (FailureLine,
-                          create_failure_lines(
-                              job_not_deleted,
-                              [(test_line, {}),
-                               (test_line, {"subtest": "subtest2"})])),
-        'job_details': (JobDetail, [JobDetail.objects.create(
-            job=job_not_deleted,
-            title='test',
-            value='testvalue')])
+        'failure_lines': (
+            FailureLine,
+            create_failure_lines(
+                job_not_deleted, [(test_line, {}), (test_line, {"subtest": "subtest2"})]
+            ),
+        ),
+        'job_details': (
+            JobDetail,
+            [JobDetail.objects.create(job=job_not_deleted, title='test', value='testvalue')],
+        ),
     }
 
     # set other job's submit time to be a week ago from now
@@ -78,24 +92,23 @@ def test_cycle_all_but_one_job(test_repository, failure_classifications, sample_
     for job in Job.objects.all().exclude(id=job_not_deleted.id):
         job.submit_time = cycle_date_ts
         job.save()
-    num_job_logs_to_be_deleted = JobLog.objects.all().exclude(
-        job__id=job_not_deleted.id).count()
+    num_job_logs_to_be_deleted = JobLog.objects.all().exclude(job__id=job_not_deleted.id).count()
     num_job_logs_before = JobLog.objects.count()
 
     call_command('cycle_data', 'from:treeherder', sleep_time=0, days=1, debug=True, chunk_size=1)
 
     assert Job.objects.count() == 1
-    assert JobLog.objects.count() == (num_job_logs_before -
-                                      num_job_logs_to_be_deleted)
+    assert JobLog.objects.count() == (num_job_logs_before - num_job_logs_to_be_deleted)
 
     for (object_type, objects) in extra_objects.values():
         actual = set(item.id for item in object_type.objects.all())
         expected = set(item.id for item in objects)
-        assert (actual == expected)
+        assert actual == expected
 
 
-def test_cycle_all_data_in_chunks(test_repository, failure_classifications, sample_data,
-                                  sample_push, mock_log_parser):
+def test_cycle_all_data_in_chunks(
+    test_repository, failure_classifications, sample_data, sample_push, mock_log_parser
+):
     """
     Test cycling the sample data in chunks.
     """
@@ -108,8 +121,7 @@ def test_cycle_all_data_in_chunks(test_repository, failure_classifications, samp
         job.submit_time = cycle_date_ts
         job.save()
 
-    create_failure_lines(Job.objects.get(id=1),
-                         [(test_line, {})] * 7)
+    create_failure_lines(Job.objects.get(id=1), [(test_line, {})] * 7)
 
     call_command('cycle_data', 'from:treeherder', sleep_time=0, days=1, chunk_size=3)
 
@@ -119,9 +131,9 @@ def test_cycle_all_data_in_chunks(test_repository, failure_classifications, samp
     assert JobDetail.objects.count() == 0
 
 
-def test_cycle_job_model_reference_data(test_repository, failure_classifications,
-                                        sample_data, sample_push,
-                                        mock_log_parser):
+def test_cycle_job_model_reference_data(
+    test_repository, failure_classifications, sample_data, sample_push, mock_log_parser
+):
     job_data = sample_data.job_data[:20]
     test_utils.do_job_ingestion(test_repository, job_data, sample_push, False)
 
@@ -144,14 +156,18 @@ def test_cycle_job_model_reference_data(test_repository, failure_classifications
     assert Machine.objects.filter(id=m_id).count() == 0
 
     # assert that we still have everything that shouldn't have been cycled
-    assert JobType.objects.filter(id__in=original_job_type_ids).count() == len(original_job_type_ids)
-    assert JobGroup.objects.filter(id__in=original_job_group_ids).count() == len(original_job_group_ids)
+    assert JobType.objects.filter(id__in=original_job_type_ids).count() == len(
+        original_job_type_ids
+    )
+    assert JobGroup.objects.filter(id__in=original_job_group_ids).count() == len(
+        original_job_group_ids
+    )
     assert Machine.objects.filter(id__in=original_machine_ids).count() == len(original_machine_ids)
 
 
-def test_cycle_job_with_performance_data(test_repository, failure_classifications,
-                                         test_job, mock_log_parser,
-                                         test_perf_signature):
+def test_cycle_job_with_performance_data(
+    test_repository, failure_classifications, test_job, mock_log_parser, test_perf_signature
+):
     # build a date that will cause the data to be cycled
     test_job.submit_time = datetime.datetime.now() - datetime.timedelta(weeks=1)
     test_job.save()
@@ -163,7 +179,8 @@ def test_cycle_job_with_performance_data(test_repository, failure_classification
         job=test_job,
         signature=test_perf_signature,
         push_timestamp=test_job.push.time,
-        value=1.0)
+        value=1.0,
+    )
 
     call_command('cycle_data', 'from:treeherder', sleep_time=0, days=1, chunk_size=3)
 
@@ -175,23 +192,32 @@ def test_cycle_job_with_performance_data(test_repository, failure_classification
     assert p.job is None
 
 
-@pytest.mark.parametrize('repository_name, command_options, subcommand_options, should_expire',
-                         [('autoland', '--days=365', None, True),
-                          ('mozilla-inbound', '--days=365', None, True),
-                          ('mozilla-beta', '--days=365', None, True),
-                          ('mozilla-central', '--days=365', None, True),
-                          ('autoland', '--days=401', None, False),
-                          ])
-def test_cycle_performance_data(test_repository, repository_name, push_stored,
-                                test_perf_signature, command_options, subcommand_options,
-                                should_expire):
+@pytest.mark.parametrize(
+    'repository_name, command_options, subcommand_options, should_expire',
+    [
+        ('autoland', '--days=365', None, True),
+        ('mozilla-inbound', '--days=365', None, True),
+        ('mozilla-beta', '--days=365', None, True),
+        ('mozilla-central', '--days=365', None, True),
+        ('autoland', '--days=401', None, False),
+    ],
+)
+def test_cycle_performance_data(
+    test_repository,
+    repository_name,
+    push_stored,
+    test_perf_signature,
+    command_options,
+    subcommand_options,
+    should_expire,
+):
     test_repository.name = repository_name
     test_repository.save()
 
     expired_timestamp = datetime.datetime.now() - datetime.timedelta(days=400)
 
     test_perf_signature_2 = PerformanceSignature.objects.create(
-        signature_hash='b'*40,
+        signature_hash='b' * 40,
         repository=test_perf_signature.repository,
         framework=test_perf_signature.framework,
         platform=test_perf_signature.platform,
@@ -199,7 +225,8 @@ def test_cycle_performance_data(test_repository, repository_name, push_stored,
         suite=test_perf_signature.suite,
         test='test 2',
         last_updated=expired_timestamp,
-        has_subtests=False)
+        has_subtests=False,
+    )
 
     push1 = Push.objects.get(id=1)
     push1.time = datetime.datetime.now()
@@ -217,7 +244,8 @@ def test_cycle_performance_data(test_repository, repository_name, push_stored,
         job=None,
         signature=test_perf_signature,
         push_timestamp=push1.time,
-        value=1.0)
+        value=1.0,
+    )
 
     # the performance datum that which we're targetting
     PerformanceDatum.objects.create(
@@ -227,15 +255,20 @@ def test_cycle_performance_data(test_repository, repository_name, push_stored,
         job=None,
         signature=test_perf_signature_2,
         push_timestamp=push2.time,
-        value=1.0)
+        value=1.0,
+    )
 
-    command = filter(lambda arg: arg is not None,
-                     ['cycle_data', command_options, 'from:perfherder', subcommand_options])
+    command = filter(
+        lambda arg: arg is not None,
+        ['cycle_data', command_options, 'from:perfherder', subcommand_options],
+    )
     call_command(*list(command))  # test repository isn't a main one
 
     if should_expire:
         assert list(PerformanceDatum.objects.values_list('id', flat=True)) == [1]
-        assert list(PerformanceSignature.objects.values_list('id', flat=True)) == [test_perf_signature.id]
+        assert list(PerformanceSignature.objects.values_list('id', flat=True)) == [
+            test_perf_signature.id
+        ]
     else:
         assert PerformanceDatum.objects.count() == 2
         assert PerformanceSignature.objects.count() == 2
@@ -249,12 +282,14 @@ def test_performance_cycler_quit_indicator():
     max_five_minutes = datetime.timedelta(minutes=5)
 
     with pytest.raises(MaxRuntimeExceeded):
-        PerformanceDatumManager._maybe_quit(started_at=ten_minutes_ago,
-                                            max_overall_runtime=max_one_second)
+        PerformanceDatumManager._maybe_quit(
+            started_at=ten_minutes_ago, max_overall_runtime=max_one_second
+        )
 
     try:
-        PerformanceDatumManager._maybe_quit(started_at=two_seconds_ago,
-                                            max_overall_runtime=max_five_minutes)
+        PerformanceDatumManager._maybe_quit(
+            started_at=two_seconds_ago, max_overall_runtime=max_five_minutes
+        )
     except MaxRuntimeExceeded:
         pytest.fail('Performance cycling shouldn\'t have quit')
 
@@ -264,13 +299,9 @@ def test_performance_cycler_doesnt_delete_too_recent_data():
     dangerously_recent = 40
 
     with pytest.raises(ValueError):
-        PerfherderCycler(days=dangerously_recent,
-                         chunk_size=1000,
-                         sleep_time=0)
+        PerfherderCycler(days=dangerously_recent, chunk_size=1000, sleep_time=0)
 
     try:
-        PerfherderCycler(days=down_to_last_year,
-                         chunk_size=1000,
-                         sleep_time=0)
+        PerfherderCycler(days=down_to_last_year, chunk_size=1000, sleep_time=0)
     except ValueError:
         pytest.fail('Should be able to expire data older than one year')

--- a/tests/model/test_error_summary.py
+++ b/tests/model/test_error_summary.py
@@ -1,7 +1,6 @@
 import pytest
 
-from treeherder.model.error_summary import (get_crash_signature,
-                                            get_error_search_term)
+from treeherder.model.error_summary import get_crash_signature, get_error_search_term
 
 PIPE_DELIMITED_LINE_TEST_CASES = (
     (
@@ -10,7 +9,7 @@ PIPE_DELIMITED_LINE_TEST_CASES = (
             '| chrome://mochitests/content/browser/browser/components/loop/test/mochitest/browser_fxa_login.js '
             '| Check settings tab URL - Got http://mochi.test:8888/browser/browser/components/loop/test/mochitest/loop_fxa.sjs'
         ),
-        'browser_fxa_login.js'
+        'browser_fxa_login.js',
     ),
     (
         (
@@ -18,7 +17,7 @@ PIPE_DELIMITED_LINE_TEST_CASES = (
             '| file:///C:/slave/test/build/tests/reftest/tests/layout/reftests/layers/component-alpha-exit-1.html '
             '| image comparison (==), max difference: 255, number of differing pixels: 251'
         ),
-        'component-alpha-exit-1.html'
+        'component-alpha-exit-1.html',
     ),
     (
         (
@@ -26,7 +25,7 @@ PIPE_DELIMITED_LINE_TEST_CASES = (
             '| /tests/dom/media/tests/mochitest/test_dataChannel_basicAudio.html '
             '| undefined assertion name - Result logged after SimpleTest.finish()'
         ),
-        'test_dataChannel_basicAudio.html'
+        'test_dataChannel_basicAudio.html',
     ),
     (
         (
@@ -34,7 +33,7 @@ PIPE_DELIMITED_LINE_TEST_CASES = (
             r"| mainthreadio "
             r"| File 'c:\users\cltbld~1.t-w' was accessed and we were not expecting it: {'Count': 6, 'Duration': 0.112512, 'RunCount': 6}"
         ),
-        'mainthreadio'
+        'mainthreadio',
     ),
     (
         (
@@ -43,7 +42,7 @@ PIPE_DELIMITED_LINE_TEST_CASES = (
             "http://10.0.2.2:8854/tests/dom/canvas/test/reftest/wrapper.html?green.png "
             "| application crashed [@ jemalloc_crash]"
         ),
-        'webgl-resize-test.html'
+        'webgl-resize-test.html',
     ),
     (
         (
@@ -52,7 +51,7 @@ PIPE_DELIMITED_LINE_TEST_CASES = (
             "http://10.0.2.2:8854/tests/dom/canvas/test/reftest/wrapper.html?green.png "
             "| application crashed [@ jemalloc_crash]"
         ),
-        'webgl-resize-test.html'
+        'webgl-resize-test.html',
     ),
     (
         (
@@ -61,7 +60,7 @@ PIPE_DELIMITED_LINE_TEST_CASES = (
             "| /tests/dom/events/test/pointerevents/pointerevent_touch-action-table-test_touch-manual.html "
             "| touch-action attribute test on the cell: assert_true: scroll received while shouldn't expected true got false"
         ),
-        'pointerevent_touch-action-table-test_touch-manual.html'
+        'pointerevent_touch-action-table-test_touch-manual.html',
     ),
     (
         (
@@ -70,8 +69,8 @@ PIPE_DELIMITED_LINE_TEST_CASES = (
             "| /tests/dom/events/test/pointerevents/pointerevent_touch-action-table-test_touch-manual.html "
             "| touch-action attribute test on the cell: assert_true: scroll received while shouldn't expected true got false"
         ),
-        'pointerevent_touch-action-table-test_touch-manual.html'
-    )
+        'pointerevent_touch-action-table-test_touch-manual.html',
+    ),
 )
 
 
@@ -90,7 +89,7 @@ LEAK_LINE_TEST_CASES = (
             '(BackstagePass, CallbackObject, DOMEventTargetHelper, '
             'EventListenerManager, EventTokenBucket, ...)'
         ),
-        'BackstagePass, CallbackObject, DOMEventTargetHelper, EventListenerManager, EventTokenBucket, ...'
+        'BackstagePass, CallbackObject, DOMEventTargetHelper, EventListenerManager, EventTokenBucket, ...',
     ),
     (
         (
@@ -99,7 +98,7 @@ LEAK_LINE_TEST_CASES = (
             '(AsyncLatencyLogger, AsyncTransactionTrackersHolder, AudioOutputObserver, '
             'BufferRecycleBin, CipherSuiteChangeObserver, ...)'
         ),
-        'AsyncLatencyLogger, AsyncTransactionTrackersHolder, AudioOutputObserver, BufferRecycleBin, CipherSui'
+        'AsyncLatencyLogger, AsyncTransactionTrackersHolder, AudioOutputObserver, BufferRecycleBin, CipherSui',
     ),
     (
         (
@@ -107,7 +106,7 @@ LEAK_LINE_TEST_CASES = (
             '| LeakSanitizer | leak at '
             'MakeUnique, nsThread::nsChainedEventQueue::nsChainedEventQueue, nsThread, nsThreadManager::Init'
         ),
-        'MakeUnique, nsThread::nsChainedEventQueue::nsChainedEventQueue, nsThread, nsThreadManager::Init'
+        'MakeUnique, nsThread::nsChainedEventQueue::nsChainedEventQueue, nsThread, nsThreadManager::Init',
     ),
 )
 
@@ -122,11 +121,11 @@ def test_get_leak_search_term(line, exp_search_term):
 FULL_LINE_FALLBACK_TEST_CASES = (
     (
         'Automation Error: No crash directory (/mnt/sdcard/tests/profile/minidumps/) found on remote device',
-        'Automation Error: No crash directory (/mnt/sdcard/tests/profile/minidumps/) found on remote device'
+        'Automation Error: No crash directory (/mnt/sdcard/tests/profile/minidumps/) found on remote device',
     ),
     (
         'PROCESS-CRASH | Automation Error: Missing end of test marker (process crashed?)',
-        'PROCESS-CRASH | Automation Error: Missing end of test marker (process crashed?)'
+        'PROCESS-CRASH | Automation Error: Missing end of test marker (process crashed?)',
     ),
 )
 
@@ -153,7 +152,7 @@ LONG_LINE_TEST_CASES = (
         (
             'command timed out: 2400 seconds without output running '
             '[\'/tools/buildbot/bin/python\', \'scripts/scrip'
-        )
+        ),
     ),
     (
         (
@@ -161,7 +160,7 @@ LONG_LINE_TEST_CASES = (
             '| test_switch_frame.py TestSwitchFrame.test_should_be_able_to_carry_on_working_if_the_frame_is_deleted_from_under_us '
             '| AssertionError: 0 != 1'
         ),
-        'test_switch_frame.py TestSwitchFrame.test_should_be_able_to_carry_on_working_if_the_frame_is_deleted'
+        'test_switch_frame.py TestSwitchFrame.test_should_be_able_to_carry_on_working_if_the_frame_is_deleted',
     ),
 )
 
@@ -182,7 +181,7 @@ CRASH_LINE_TEST_CASES = (
             'jsreftest.html?test=test262/ch11/11.4/11.4.1/11.4.1-4.a-6.js | '
             'application crashed [@ nsInputStreamPump::OnStateStop()]'
         ),
-        'nsInputStreamPump::OnStateStop()'
+        'nsInputStreamPump::OnStateStop()',
     ),
 )
 
@@ -197,18 +196,15 @@ def test_get_crash_signature(line, exp_search_term):
 BLACKLIST_TEST_CASES = (
     (
         'TEST-UNEXPECTED-FAIL | remoteautomation.py | application timed out after 330 seconds with no output',
-        'TEST-UNEXPECTED-FAIL | remoteautomation.py | application timed out after 330 seconds with no output'
+        'TEST-UNEXPECTED-FAIL | remoteautomation.py | application timed out after 330 seconds with no output',
     ),
-    (
-        'Return code: 1',
-        None
-    ),
+    ('Return code: 1', None),
     (
         (
             'REFTEST PROCESS-CRASH | file:///home/worker/workspace/build/tests/reftest/tests/layout/reftests/font-inflation/video-1.html '
             '| application crashed [@ mozalloc_abort]'
         ),
-        'video-1.html'
+        'video-1.html',
     ),
 )
 

--- a/tests/model/test_job_notes.py
+++ b/tests/model/test_job_notes.py
@@ -8,8 +8,7 @@ def test_note_deletion(test_job_with_notes):
 
     # delete second failure classification, verify that we now have first one
     # (after reloading job)
-    JobNote.objects.get(job=test_job_with_notes,
-                        failure_classification_id=3).delete()
+    JobNote.objects.get(job=test_job_with_notes, failure_classification_id=3).delete()
     test_job_with_notes.refresh_from_db()
     assert test_job_with_notes.failure_classification_id == 2
 

--- a/tests/model/test_suite_public_name.py
+++ b/tests/model/test_suite_public_name.py
@@ -7,25 +7,55 @@ SAME_SUITE = 'same suite'
 SAME_TEST = 'same test'
 
 
-@pytest.mark.parametrize("suite_public_name, suite_public_name_2,"
-                         "test_public_name, test_public_name_2,"
-                         "suite, suite_2, test, test_2", [
-                                 (SAME_SUITE_PUBLIC_NAME, SAME_SUITE_PUBLIC_NAME,
-                                  SAME_TEST_PUBLIC_NAME, SAME_TEST_PUBLIC_NAME,
-                                  SAME_SUITE, SAME_SUITE, 'test', 'test_2'),
-
-                                 (SAME_SUITE_PUBLIC_NAME, SAME_SUITE_PUBLIC_NAME,
-                                  SAME_TEST_PUBLIC_NAME, SAME_TEST_PUBLIC_NAME,
-                                  'suite', 'suite_2', SAME_TEST, SAME_TEST),
-
-                                 (SAME_SUITE_PUBLIC_NAME, SAME_SUITE_PUBLIC_NAME,
-                                  SAME_TEST_PUBLIC_NAME, SAME_TEST_PUBLIC_NAME,
-                                  'suite', 'suite_2', 'test', 'test_2'),
-                         ])
-def test_trigger_public_suite_name_constraint(test_perf_signature, test_perf_signature_2,
-                                              suite_public_name, suite_public_name_2,
-                                              test_public_name, test_public_name_2,
-                                              suite, suite_2, test, test_2):
+@pytest.mark.parametrize(
+    "suite_public_name, suite_public_name_2,"
+    "test_public_name, test_public_name_2,"
+    "suite, suite_2, test, test_2",
+    [
+        (
+            SAME_SUITE_PUBLIC_NAME,
+            SAME_SUITE_PUBLIC_NAME,
+            SAME_TEST_PUBLIC_NAME,
+            SAME_TEST_PUBLIC_NAME,
+            SAME_SUITE,
+            SAME_SUITE,
+            'test',
+            'test_2',
+        ),
+        (
+            SAME_SUITE_PUBLIC_NAME,
+            SAME_SUITE_PUBLIC_NAME,
+            SAME_TEST_PUBLIC_NAME,
+            SAME_TEST_PUBLIC_NAME,
+            'suite',
+            'suite_2',
+            SAME_TEST,
+            SAME_TEST,
+        ),
+        (
+            SAME_SUITE_PUBLIC_NAME,
+            SAME_SUITE_PUBLIC_NAME,
+            SAME_TEST_PUBLIC_NAME,
+            SAME_TEST_PUBLIC_NAME,
+            'suite',
+            'suite_2',
+            'test',
+            'test_2',
+        ),
+    ],
+)
+def test_trigger_public_suite_name_constraint(
+    test_perf_signature,
+    test_perf_signature_2,
+    suite_public_name,
+    suite_public_name_2,
+    test_public_name,
+    test_public_name_2,
+    suite,
+    suite_2,
+    test,
+    test_2,
+):
     test_perf_signature.suite_public_name = suite_public_name
     test_perf_signature.test_public_name = test_public_name
     test_perf_signature.suite = suite
@@ -42,35 +72,78 @@ def test_trigger_public_suite_name_constraint(test_perf_signature, test_perf_sig
         test_perf_signature_2.save()
 
 
-@pytest.mark.parametrize("suite_public_name, suite_public_name_2,"
-                         "test_public_name, test_public_name_2,"
-                         "suite, suite_2, test, test_2", [
-                                 (None, None, None, None, 'suite', 'suite_2', 'test', 'test_2'),
-                                 ('suite_public_name', 'suite_public_name_2', None, None,
-                                  'suite', 'suite_2', 'test', 'test_2'),
-                                 (None, None, 'test', 'test_2', 'suite', 'suite_2', 'test', 'test_2'),
-                                 ('suite_public_name', None, 'test', None, 'suite', 'suite_2', 'test', 'test_2'),
-
-                                 ('suite_public_name', 'suite_public_name_2',
-                                  SAME_TEST_PUBLIC_NAME, SAME_TEST_PUBLIC_NAME,
-                                  'suite', 'suite_2', 'test', 'test_2'),
-
-                                 (SAME_SUITE_PUBLIC_NAME, SAME_SUITE_PUBLIC_NAME,
-                                  'test_public_name', 'test_public_name_2',
-                                  'suite', 'suite_2', 'test', 'test_2'),
-
-                                 ('suite_public_name', 'suite_public_name_2',
-                                  SAME_TEST_PUBLIC_NAME, SAME_TEST_PUBLIC_NAME,
-                                  SAME_SUITE, SAME_SUITE, SAME_TEST, SAME_TEST),
-
-                                 ('suite_public_name', 'suite_public_name_2',
-                                  'test_public_name', 'test_public_name_2',
-                                  'suite', 'suite_2', 'test', 'test_2'),
-                         ])
-def test_do_not_trigger_public_suite_name_constraint(test_perf_signature, test_perf_signature_2,
-                                                     suite_public_name, suite_public_name_2,
-                                                     test_public_name, test_public_name_2,
-                                                     suite, suite_2, test, test_2):
+@pytest.mark.parametrize(
+    "suite_public_name, suite_public_name_2,"
+    "test_public_name, test_public_name_2,"
+    "suite, suite_2, test, test_2",
+    [
+        (None, None, None, None, 'suite', 'suite_2', 'test', 'test_2'),
+        (
+            'suite_public_name',
+            'suite_public_name_2',
+            None,
+            None,
+            'suite',
+            'suite_2',
+            'test',
+            'test_2',
+        ),
+        (None, None, 'test', 'test_2', 'suite', 'suite_2', 'test', 'test_2'),
+        ('suite_public_name', None, 'test', None, 'suite', 'suite_2', 'test', 'test_2'),
+        (
+            'suite_public_name',
+            'suite_public_name_2',
+            SAME_TEST_PUBLIC_NAME,
+            SAME_TEST_PUBLIC_NAME,
+            'suite',
+            'suite_2',
+            'test',
+            'test_2',
+        ),
+        (
+            SAME_SUITE_PUBLIC_NAME,
+            SAME_SUITE_PUBLIC_NAME,
+            'test_public_name',
+            'test_public_name_2',
+            'suite',
+            'suite_2',
+            'test',
+            'test_2',
+        ),
+        (
+            'suite_public_name',
+            'suite_public_name_2',
+            SAME_TEST_PUBLIC_NAME,
+            SAME_TEST_PUBLIC_NAME,
+            SAME_SUITE,
+            SAME_SUITE,
+            SAME_TEST,
+            SAME_TEST,
+        ),
+        (
+            'suite_public_name',
+            'suite_public_name_2',
+            'test_public_name',
+            'test_public_name_2',
+            'suite',
+            'suite_2',
+            'test',
+            'test_2',
+        ),
+    ],
+)
+def test_do_not_trigger_public_suite_name_constraint(
+    test_perf_signature,
+    test_perf_signature_2,
+    suite_public_name,
+    suite_public_name_2,
+    test_public_name,
+    test_public_name_2,
+    suite,
+    suite_2,
+    test,
+    test_2,
+):
     test_perf_signature.suite_public_name = suite_public_name
     test_perf_signature.test_public_name = test_public_name
     test_perf_signature.suite = suite

--- a/tests/perfalert/test_alert_modification.py
+++ b/tests/perfalert/test_alert_modification.py
@@ -3,13 +3,12 @@ import datetime
 import pytest
 from django.core.exceptions import ValidationError
 
-from treeherder.perf.models import (PerformanceAlert,
-                                    PerformanceAlertSummary,
-                                    PerformanceSignature)
+from treeherder.perf.models import PerformanceAlert, PerformanceAlertSummary, PerformanceSignature
 
 
-def test_summary_modification(test_repository, test_perf_signature,
-                              test_perf_alert_summary, test_perf_alert):
+def test_summary_modification(
+    test_repository, test_perf_signature, test_perf_alert_summary, test_perf_alert
+):
     (s, a) = (test_perf_alert_summary, test_perf_alert)
 
     assert s.bug_number is None
@@ -29,19 +28,20 @@ def test_summary_modification(test_repository, test_perf_signature,
     assert s.status == PerformanceAlertSummary.UNTRIAGED
 
 
-def test_summary_status(test_repository, test_perf_signature,
-                        test_perf_alert_summary, test_perf_framework):
+def test_summary_status(
+    test_repository, test_perf_signature, test_perf_alert_summary, test_perf_framework
+):
     signature1 = test_perf_signature
     signature2 = PerformanceSignature.objects.create(
         repository=test_repository,
-        signature_hash=(40*'u'),
+        signature_hash=(40 * 'u'),
         framework=test_perf_signature.framework,
         platform=test_perf_signature.platform,
         option_collection=test_perf_signature.option_collection,
         suite='mysuite_2',
         test='mytest_2',
         has_subtests=False,
-        last_updated=datetime.datetime.now()
+        last_updated=datetime.datetime.now(),
     )
     s = test_perf_alert_summary
 
@@ -53,7 +53,8 @@ def test_summary_status(test_repository, test_perf_signature,
         amount_abs=50.0,
         prev_value=100.0,
         new_value=150.0,
-        t_value=20.0)
+        t_value=20.0,
+    )
 
     # this is the test case
     # ignore downstream and reassigned to update the summary status
@@ -68,15 +69,17 @@ def test_summary_status(test_repository, test_perf_signature,
         amount_abs=50.0,
         prev_value=100.0,
         new_value=150.0,
-        t_value=20.0)
+        t_value=20.0,
+    )
     b.status = PerformanceAlert.ACKNOWLEDGED
     b.save()
     s = PerformanceAlertSummary.objects.get(id=1)
     assert s.status == PerformanceAlertSummary.IMPROVEMENT
 
 
-def test_alert_modification(test_perf_signature, test_perf_alert_summary,
-                            push_stored, test_perf_alert):
+def test_alert_modification(
+    test_perf_signature, test_perf_alert_summary, push_stored, test_perf_alert
+):
     p = test_perf_alert
     s2 = PerformanceAlertSummary.objects.create(
         id=2,
@@ -85,7 +88,8 @@ def test_alert_modification(test_perf_signature, test_perf_alert_summary,
         push_id=4,
         created=datetime.datetime.now(),
         framework=test_perf_alert_summary.framework,
-        manually_created=False)
+        manually_created=False,
+    )
 
     assert p.related_summary is None
     assert p.status == PerformanceAlert.UNTRIAGED

--- a/tests/perfalert/test_alerts/test_alerts_picker.py
+++ b/tests/perfalert/test_alerts/test_alerts_picker.py
@@ -21,7 +21,7 @@ def test_many_various_alerts():
         'osx-10-10-shippable',
         'osx-10-10-shippable',
         'android-hw-pix-7-1-android-aarch64',
-        'android-hw-pix-7-1-android-aarch64'
+        'android-hw-pix-7-1-android-aarch64',
     )
 
     reversed_magnitudes = list(reversed(range(len(alerts))))
@@ -37,10 +37,7 @@ def test_many_various_alerts():
 @pytest.fixture
 def test_few_various_alerts():
     alerts = [Mock(spec=PerformanceAlert) for i in range(2)]
-    platforms = (
-        'windows7-32-shippable',
-        'linux64-shippable-qr'
-    )
+    platforms = ('windows7-32-shippable', 'linux64-shippable-qr')
     reversed_magnitudes = list(reversed(range(len(alerts))))
     toggle = True
     for idx, alert in enumerate(alerts):
@@ -59,7 +56,7 @@ def test_few_regressions():
         'windows7-32-shippable',
         'linux64-shippable-qr',
         'osx-10-10-shippable',
-        'android-hw-pix-7-1-android-aarch64'
+        'android-hw-pix-7-1-android-aarch64',
     )
     reversed_magnitudes = list(reversed(range(len(alerts))))
     for idx, alert in enumerate(alerts):
@@ -96,45 +93,42 @@ def test_init():
         AlertsPicker(
             max_alerts=0,
             max_improvements=2,
-            platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android')
+            platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android'),
         )
 
     with pytest.raises(ValueError):
         AlertsPicker(
             max_alerts=3,
             max_improvements=0,
-            platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android')
+            platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android'),
         )
 
     with pytest.raises(ValueError):
-        AlertsPicker(
-            max_alerts=3,
-            max_improvements=5,
-            platforms_of_interest=tuple()
-        )
+        AlertsPicker(max_alerts=3, max_improvements=5, platforms_of_interest=tuple())
 
     with pytest.raises(ValueError):
-        AlertsPicker(
-            max_alerts=0,
-            max_improvements=0,
-            platforms_of_interest=tuple()
-        )
+        AlertsPicker(max_alerts=0, max_improvements=0, platforms_of_interest=tuple())
 
 
-def test_extract_important_alerts(test_bad_platform_names, test_few_improvements, test_few_regressions):
+def test_extract_important_alerts(
+    test_bad_platform_names, test_few_improvements, test_few_regressions
+):
     def count_alert_types(alerts):
         return Counter([alert.is_regression for alert in alerts])
+
     picker = AlertsPicker(
         max_alerts=5,
         max_improvements=2,
-        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android')
+        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android'),
     )
 
-    expected_platforms_order = ('windows10-64-shippable',
-                                'windows7-32-shippable',
-                                'linux64-shippable-qr',
-                                'osx-10-10-shippable',
-                                'windows10-64-shippable')
+    expected_platforms_order = (
+        'windows10-64-shippable',
+        'windows7-32-shippable',
+        'linux64-shippable-qr',
+        'osx-10-10-shippable',
+        'windows10-64-shippable',
+    )
     expected_magnitudes_order = (4, 3, 2, 1, 4)
 
     with pytest.raises(ValueError):
@@ -152,14 +146,16 @@ def test_extract_important_alerts(test_bad_platform_names, test_few_improvements
         assert alert.amount_pct == expected_magnitudes_order[idx]
 
 
-def test_ensure_alerts_variety(test_few_regressions, test_few_improvements, test_many_various_alerts, test_few_various_alerts):
+def test_ensure_alerts_variety(
+    test_few_regressions, test_few_improvements, test_many_various_alerts, test_few_various_alerts
+):
     def count_alert_types(alerts):
         return Counter([alert.is_regression for alert in alerts])
 
     picker = AlertsPicker(
         max_alerts=5,
         max_improvements=2,
-        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android')
+        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android'),
     )
 
     selected_alerts = picker._ensure_alerts_variety(test_few_regressions)
@@ -187,7 +183,7 @@ def test_ensure_alerts_variety(test_few_regressions, test_few_improvements, test
     picker = AlertsPicker(
         max_alerts=1,
         max_improvements=2,
-        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android')
+        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android'),
     )
 
     selected_alerts = picker._ensure_alerts_variety(test_few_various_alerts)
@@ -197,29 +193,30 @@ def test_ensure_alerts_variety(test_few_regressions, test_few_improvements, test
     assert number_of[False] == 0
 
 
-@pytest.mark.parametrize(('max_alerts, expected_alerts_platforms'), [
-    (5, ('windows10', 'windows7', 'linux', 'osx', 'android')),
-    (8, ('windows10', 'windows7', 'linux', 'osx', 'android',
-         'windows10', 'windows7', 'linux'))
-])
+@pytest.mark.parametrize(
+    ('max_alerts, expected_alerts_platforms'),
+    [
+        (5, ('windows10', 'windows7', 'linux', 'osx', 'android')),
+        (8, ('windows10', 'windows7', 'linux', 'osx', 'android', 'windows10', 'windows7', 'linux')),
+    ],
+)
 def test_ensure_platform_variety(test_many_various_alerts, max_alerts, expected_alerts_platforms):
     picker = AlertsPicker(
         max_alerts=max_alerts,
         max_improvements=2,
-        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android')
+        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android'),
     )
 
     picked_alerts = picker._ensure_platform_variety(test_many_various_alerts)
     for idx, platform in enumerate(expected_alerts_platforms):
-        assert (picked_alerts[idx].series_signature.platform.platform
-                .startswith(platform))
+        assert picked_alerts[idx].series_signature.platform.platform.startswith(platform)
 
 
 def test_os_relevance():
     picker = AlertsPicker(
         max_alerts=5,
         max_improvements=2,
-        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android')
+        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android'),
     )
     assert 5 == picker._os_relevance('windows10')
     assert 4 == picker._os_relevance('windows7')
@@ -235,7 +232,7 @@ def test_has_relevant_platform(test_many_various_alerts, test_bad_platform_names
     picker = AlertsPicker(
         max_alerts=5,
         max_improvements=2,
-        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android')
+        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android'),
     )
 
     for alert in test_many_various_alerts:
@@ -248,7 +245,7 @@ def test_extract_by_relevant_platforms(test_many_various_alerts, test_bad_platfo
     picker = AlertsPicker(
         max_alerts=5,
         max_improvements=2,
-        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android')
+        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android'),
     )
     all_alerts = test_many_various_alerts + test_bad_platform_names
 
@@ -260,22 +257,25 @@ def test_extract_by_relevant_platforms(test_many_various_alerts, test_bad_platfo
 def test_multi_criterion_sort(test_many_various_alerts):
     def count_alert_types(alerts):
         return Counter([alert.is_regression for alert in alerts])
+
     picker = AlertsPicker(
         max_alerts=5,
         max_improvements=2,
-        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android')
+        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android'),
     )
 
-    expected_platforms_order = ('windows10-64-shippable',
-                                'windows7-32-shippable',
-                                'linux64-shippable-qr',
-                                'osx-10-10-shippable',
-                                'android-hw-pix-7-1-android-aarch64',
-                                'windows10-64-shippable',
-                                'windows7-32-shippable',
-                                'linux64-shippable-qr',
-                                'osx-10-10-shippable',
-                                'android-hw-pix-7-1-android-aarch64')
+    expected_platforms_order = (
+        'windows10-64-shippable',
+        'windows7-32-shippable',
+        'linux64-shippable-qr',
+        'osx-10-10-shippable',
+        'android-hw-pix-7-1-android-aarch64',
+        'windows10-64-shippable',
+        'windows7-32-shippable',
+        'linux64-shippable-qr',
+        'osx-10-10-shippable',
+        'android-hw-pix-7-1-android-aarch64',
+    )
     expected_magnitudes_order = (9, 7, 5, 3, 1, 8, 6, 4, 2, 0)
 
     ordered_alerts = picker._multi_criterion_sort(reversed(test_many_various_alerts))

--- a/tests/perfalert/test_alerts/test_backfill_report_maintainer.py
+++ b/tests/perfalert/test_alerts/test_backfill_report_maintainer.py
@@ -6,15 +6,14 @@ from unittest.mock import Mock
 
 import pytest
 
-from treeherder.model.models import (MachinePlatform,
-                                     Option,
-                                     OptionCollection)
-from treeherder.perf.alerts import (AlertsPicker,
-                                    BackfillReportMaintainer)
-from treeherder.perf.models import (BackfillRecord,
-                                    BackfillReport,
-                                    PerformanceAlert,
-                                    PerformanceSignature)
+from treeherder.model.models import MachinePlatform, Option, OptionCollection
+from treeherder.perf.alerts import AlertsPicker, BackfillReportMaintainer
+from treeherder.perf.models import (
+    BackfillRecord,
+    BackfillReport,
+    PerformanceAlert,
+    PerformanceSignature,
+)
 
 LETTERS = string.ascii_lowercase
 EPOCH = datetime.datetime.utcfromtimestamp(0)
@@ -24,9 +23,11 @@ RANDOM_STRINGS = set()
 @pytest.fixture(scope='module')
 def alerts_picker():
     # real-world instance
-    return AlertsPicker(max_alerts=5,
-                        max_improvements=2,
-                        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android'))
+    return AlertsPicker(
+        max_alerts=5,
+        max_improvements=2,
+        platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android'),
+    )
 
 
 @pytest.fixture
@@ -38,25 +39,19 @@ def mock_backfill_context_fetcher(backfill_record_context):
 @pytest.fixture
 def option_collection():
     option = Option.objects.create(name='opt')
-    return OptionCollection.objects.create(
-        option_collection_hash='my_option_hash',
-        option=option)
+    return OptionCollection.objects.create(option_collection_hash='my_option_hash', option=option)
 
 
 @pytest.fixture
 def relevant_platform():
-    return MachinePlatform.objects.create(
-        os_name='win',
-        platform='windows10',
-        architecture='x86')
+    return MachinePlatform.objects.create(os_name='win', platform='windows10', architecture='x86')
 
 
 @pytest.fixture
 def irrelevant_platform():
     return MachinePlatform.objects.create(
-        os_name='OS_OF_NO_INTEREST',
-        platform='PLATFORM_OF_NO_INTEREST',
-        architecture='x86')
+        os_name='OS_OF_NO_INTEREST', platform='PLATFORM_OF_NO_INTEREST', architecture='x86'
+    )
 
 
 @pytest.fixture
@@ -74,8 +69,14 @@ def unique_random_string():
 
 
 @pytest.fixture
-def create_perf_signature(test_repository, test_perf_framework, option_collection, relevant_platform,
-                          irrelevant_platform, unique_random_string):
+def create_perf_signature(
+    test_repository,
+    test_perf_framework,
+    option_collection,
+    relevant_platform,
+    irrelevant_platform,
+    unique_random_string,
+):
     def _create_perf_signature(relevant=True):
         platform = relevant_platform if relevant else irrelevant_platform
 
@@ -88,7 +89,7 @@ def create_perf_signature(test_repository, test_perf_framework, option_collectio
             suite=unique_random_string(),
             test=unique_random_string(),
             has_subtests=False,
-            last_updated=datetime.datetime.now()
+            last_updated=datetime.datetime.now(),
         )
         return signature
 
@@ -108,93 +109,95 @@ def create_alerts(create_perf_signature):
                 amount_abs=50.0,
                 prev_value=100.0,
                 new_value=150.0,
-                t_value=20.0)
+                t_value=20.0,
+            )
             alerts.append(alert)
         return alerts
 
     return _create_alerts
 
 
-def test_reports_are_generated_for_relevant_alerts_only(test_perf_alert_summary,
-                                                        test_perf_framework,
-                                                        test_repository,
-                                                        create_alerts,
-                                                        alerts_picker,
-                                                        mock_backfill_context_fetcher):
-    create_alerts(test_perf_alert_summary,  # irrelevant alert
-                  relevant=False,
-                  amount=1)
+def test_reports_are_generated_for_relevant_alerts_only(
+    test_perf_alert_summary,
+    test_perf_framework,
+    test_repository,
+    create_alerts,
+    alerts_picker,
+    mock_backfill_context_fetcher,
+):
+    create_alerts(test_perf_alert_summary, relevant=False, amount=1)  # irrelevant alert
 
-    report_maintainer = BackfillReportMaintainer(alerts_picker,
-                                                 mock_backfill_context_fetcher)
+    report_maintainer = BackfillReportMaintainer(alerts_picker, mock_backfill_context_fetcher)
 
-    report_maintainer.provide_updated_reports(since=EPOCH,
-                                              frameworks=[test_perf_framework.name],
-                                              repositories=[test_repository.name])
+    report_maintainer.provide_updated_reports(
+        since=EPOCH, frameworks=[test_perf_framework.name], repositories=[test_repository.name]
+    )
 
     assert not BackfillReport.objects.exists()
 
 
-def test_running_report_twice_on_unchanged_data_doesnt_change_anything(test_perf_alert_summary,
-                                                                       test_perf_framework,
-                                                                       test_repository,
-                                                                       create_alerts,
-                                                                       alerts_picker,
-                                                                       mock_backfill_context_fetcher):
+def test_running_report_twice_on_unchanged_data_doesnt_change_anything(
+    test_perf_alert_summary,
+    test_perf_framework,
+    test_repository,
+    create_alerts,
+    alerts_picker,
+    mock_backfill_context_fetcher,
+):
     create_alerts(test_perf_alert_summary, amount=3)  # relevant alerts
-    create_alerts(test_perf_alert_summary,  # irrelevant alert
-                  relevant=False,
-                  amount=1)
+    create_alerts(test_perf_alert_summary, relevant=False, amount=1)  # irrelevant alert
 
     assert not BackfillReport.objects.exists()
 
-    report_maintainer = BackfillReportMaintainer(alerts_picker,
-                                                 mock_backfill_context_fetcher)
+    report_maintainer = BackfillReportMaintainer(alerts_picker, mock_backfill_context_fetcher)
 
     # run report once
-    report_maintainer.provide_updated_reports(since=EPOCH,
-                                              frameworks=[test_perf_framework.name],
-                                              repositories=[test_repository.name])
-    initial_records_timestamps, initial_report_timestamps = __fetch_report_timestamps(test_perf_alert_summary)
+    report_maintainer.provide_updated_reports(
+        since=EPOCH, frameworks=[test_perf_framework.name], repositories=[test_repository.name]
+    )
+    initial_records_timestamps, initial_report_timestamps = __fetch_report_timestamps(
+        test_perf_alert_summary
+    )
 
     # run report twice (no changes happened on underlying data)
-    report_maintainer.provide_updated_reports(since=EPOCH,
-                                              frameworks=[test_perf_framework.name],
-                                              repositories=[test_repository.name])
+    report_maintainer.provide_updated_reports(
+        since=EPOCH, frameworks=[test_perf_framework.name], repositories=[test_repository.name]
+    )
     records_timestamps, report_timestamps = __fetch_report_timestamps(test_perf_alert_summary)
 
     assert initial_report_timestamps == report_timestamps
     assert initial_records_timestamps == records_timestamps
 
 
-def test_reports_are_updated_after_alert_summaries_change(test_perf_alert_summary,
-                                                          test_perf_framework,
-                                                          test_repository,
-                                                          create_alerts,
-                                                          alerts_picker,
-                                                          mock_backfill_context_fetcher):
-    relevant_alerts = create_alerts(test_perf_alert_summary, amount=3)  # relevant alerts, all regressions
-    create_alerts(test_perf_alert_summary,  # irrelevant alert
-                  relevant=False,
-                  amount=1)
+def test_reports_are_updated_after_alert_summaries_change(
+    test_perf_alert_summary,
+    test_perf_framework,
+    test_repository,
+    create_alerts,
+    alerts_picker,
+    mock_backfill_context_fetcher,
+):
+    relevant_alerts = create_alerts(
+        test_perf_alert_summary, amount=3
+    )  # relevant alerts, all regressions
+    create_alerts(test_perf_alert_summary, relevant=False, amount=1)  # irrelevant alert
 
     assert not BackfillReport.objects.exists()
 
-    report_maintainer = BackfillReportMaintainer(alerts_picker,
-                                                 mock_backfill_context_fetcher)
+    report_maintainer = BackfillReportMaintainer(alerts_picker, mock_backfill_context_fetcher)
 
-    report_maintainer.provide_updated_reports(since=EPOCH,
-                                              frameworks=[test_perf_framework.name],
-                                              repositories=[test_repository.name])
+    report_maintainer.provide_updated_reports(
+        since=EPOCH, frameworks=[test_perf_framework.name], repositories=[test_repository.name]
+    )
 
     assert BackfillReport.objects.count() == 1
     assert BackfillRecord.objects.count() == 3
 
     # new alerts will cause report updates
     create_alerts(test_perf_alert_summary, amount=3)  # relevant alerts
-    report_maintainer.provide_updated_reports(since=EPOCH,
-                                              frameworks=[test_perf_framework.name],
-                                              repositories=[test_repository.name])
+    report_maintainer.provide_updated_reports(
+        since=EPOCH, frameworks=[test_perf_framework.name], repositories=[test_repository.name]
+    )
 
     assert BackfillRecord.objects.count() == 5
 
@@ -202,10 +205,12 @@ def test_reports_are_updated_after_alert_summaries_change(test_perf_alert_summar
     alert = relevant_alerts[0]
     alert.status = PerformanceAlert.ACKNOWLEDGED
     alert.save()
-    initial_report_timestamps, initial_records_timestamps = __fetch_report_timestamps(test_perf_alert_summary)
-    report_maintainer.provide_updated_reports(since=EPOCH,
-                                              frameworks=[test_perf_framework.name],
-                                              repositories=[test_repository.name])
+    initial_report_timestamps, initial_records_timestamps = __fetch_report_timestamps(
+        test_perf_alert_summary
+    )
+    report_maintainer.provide_updated_reports(
+        since=EPOCH, frameworks=[test_perf_framework.name], repositories=[test_repository.name]
+    )
 
     report_timestamps, records_timestmaps = __fetch_report_timestamps(test_perf_alert_summary)
     assert initial_report_timestamps != report_timestamps

--- a/tests/perfalert/test_alerts/test_generate_alerts.py
+++ b/tests/perfalert/test_alerts/test_generate_alerts.py
@@ -5,17 +5,26 @@ import pytest
 
 from treeherder.model.models import Push
 from treeherder.perf.alerts import generate_new_alerts_in_series
-from treeherder.perf.models import (PerformanceAlert,
-                                    PerformanceAlertSummary,
-                                    PerformanceDatum,
-                                    PerformanceSignature)
+from treeherder.perf.models import (
+    PerformanceAlert,
+    PerformanceAlertSummary,
+    PerformanceDatum,
+    PerformanceSignature,
+)
 
 
-def _verify_alert(alertid, expected_push_id, expected_prev_push_id,
-                  expected_signature, expected_prev_value,
-                  expected_new_value, expected_is_regression,
-                  expected_status, expected_summary_status,
-                  expected_classifier):
+def _verify_alert(
+    alertid,
+    expected_push_id,
+    expected_prev_push_id,
+    expected_signature,
+    expected_prev_value,
+    expected_new_value,
+    expected_is_regression,
+    expected_status,
+    expected_summary_status,
+    expected_classifier,
+):
     alert = PerformanceAlert.objects.get(id=alertid)
     assert alert.prev_value == expected_prev_value
     assert alert.new_value == expected_new_value
@@ -31,81 +40,139 @@ def _verify_alert(alertid, expected_push_id, expected_prev_push_id,
     assert summary.status == expected_summary_status
 
 
-def _generate_performance_data(test_repository, test_perf_signature,
-                               test_issue_tracker, generic_reference_data,
-                               base_timestamp, start_id, value, amount):
-    for (t, v) in zip([i for i in range(start_id, start_id + amount)],
-                      [value for i in range(start_id, start_id + amount)]):
+def _generate_performance_data(
+    test_repository,
+    test_perf_signature,
+    test_issue_tracker,
+    generic_reference_data,
+    base_timestamp,
+    start_id,
+    value,
+    amount,
+):
+    for (t, v) in zip(
+        [i for i in range(start_id, start_id + amount)],
+        [value for i in range(start_id, start_id + amount)],
+    ):
         push, _ = Push.objects.get_or_create(
             repository=test_repository,
             revision='1234abcd%s' % t,
             defaults={
                 'author': 'foo@bar.com',
-                'time': datetime.datetime.fromtimestamp(base_timestamp + t)
-            })
+                'time': datetime.datetime.fromtimestamp(base_timestamp + t),
+            },
+        )
         PerformanceDatum.objects.create(
             repository=test_repository,
             result_set_id=t,
             push=push,
             signature=test_perf_signature,
-            push_timestamp=datetime.datetime.utcfromtimestamp(
-                base_timestamp + t),
-            value=v)
+            push_timestamp=datetime.datetime.utcfromtimestamp(base_timestamp + t),
+            value=v,
+        )
 
 
-def test_detect_alerts_in_series(test_repository,
-                                 test_issue_tracker,
-                                 failure_classifications,
-                                 generic_reference_data,
-                                 test_perf_signature):
+def test_detect_alerts_in_series(
+    test_repository,
+    test_issue_tracker,
+    failure_classifications,
+    generic_reference_data,
+    test_perf_signature,
+):
 
     base_time = time.time()  # generate it based off current time
     INTERVAL = 30
-    _generate_performance_data(test_repository,
-                               test_perf_signature,
-                               test_issue_tracker,
-                               generic_reference_data,
-                               base_time, 1, 0.5, int(INTERVAL / 2))
-    _generate_performance_data(test_repository,
-                               test_perf_signature,
-                               test_issue_tracker,
-                               generic_reference_data,
-                               base_time, int(INTERVAL / 2) + 1, 1.0, int(INTERVAL / 2))
+    _generate_performance_data(
+        test_repository,
+        test_perf_signature,
+        test_issue_tracker,
+        generic_reference_data,
+        base_time,
+        1,
+        0.5,
+        int(INTERVAL / 2),
+    )
+    _generate_performance_data(
+        test_repository,
+        test_perf_signature,
+        test_issue_tracker,
+        generic_reference_data,
+        base_time,
+        int(INTERVAL / 2) + 1,
+        1.0,
+        int(INTERVAL / 2),
+    )
 
     generate_new_alerts_in_series(test_perf_signature)
 
     assert PerformanceAlert.objects.count() == 1
     assert PerformanceAlertSummary.objects.count() == 1
-    _verify_alert(1, (INTERVAL/2)+1, (INTERVAL/2), test_perf_signature, 0.5,
-                  1.0, True, PerformanceAlert.UNTRIAGED,
-                  PerformanceAlertSummary.UNTRIAGED, None)
+    _verify_alert(
+        1,
+        (INTERVAL / 2) + 1,
+        (INTERVAL / 2),
+        test_perf_signature,
+        0.5,
+        1.0,
+        True,
+        PerformanceAlert.UNTRIAGED,
+        PerformanceAlertSummary.UNTRIAGED,
+        None,
+    )
 
     # verify that no new alerts generated if we rerun
     generate_new_alerts_in_series(test_perf_signature)
     assert PerformanceAlert.objects.count() == 1
     assert PerformanceAlertSummary.objects.count() == 1
-    _verify_alert(1, (INTERVAL/2)+1, (INTERVAL/2), test_perf_signature, 0.5,
-                  1.0, True, PerformanceAlert.UNTRIAGED,
-                  PerformanceAlertSummary.UNTRIAGED, None)
+    _verify_alert(
+        1,
+        (INTERVAL / 2) + 1,
+        (INTERVAL / 2),
+        test_perf_signature,
+        0.5,
+        1.0,
+        True,
+        PerformanceAlert.UNTRIAGED,
+        PerformanceAlertSummary.UNTRIAGED,
+        None,
+    )
 
     # add data that should be enough to generate a new alert if we rerun
-    _generate_performance_data(test_repository,
-                               test_perf_signature,
-                               test_issue_tracker,
-                               generic_reference_data,
-                               base_time, (INTERVAL+1), 2.0, INTERVAL)
+    _generate_performance_data(
+        test_repository,
+        test_perf_signature,
+        test_issue_tracker,
+        generic_reference_data,
+        base_time,
+        (INTERVAL + 1),
+        2.0,
+        INTERVAL,
+    )
     generate_new_alerts_in_series(test_perf_signature)
 
     assert PerformanceAlert.objects.count() == 2
     assert PerformanceAlertSummary.objects.count() == 2
-    _verify_alert(2, INTERVAL+1, INTERVAL, test_perf_signature, 1.0, 2.0,
-                  True, PerformanceAlert.UNTRIAGED,
-                  PerformanceAlertSummary.UNTRIAGED, None)
+    _verify_alert(
+        2,
+        INTERVAL + 1,
+        INTERVAL,
+        test_perf_signature,
+        1.0,
+        2.0,
+        True,
+        PerformanceAlert.UNTRIAGED,
+        PerformanceAlertSummary.UNTRIAGED,
+        None,
+    )
 
 
 def test_detect_alerts_in_series_with_retriggers(
-        test_repository, test_issue_tracker,
-        failure_classifications, generic_reference_data, test_perf_signature):
+    test_repository,
+    test_issue_tracker,
+    failure_classifications,
+    generic_reference_data,
+    test_perf_signature,
+):
 
     # sometimes we detect an alert in the middle of a series
     # where there are retriggers, make sure we handle this case
@@ -116,45 +183,83 @@ def test_detect_alerts_in_series_with_retriggers(
     # mix)
     base_time = time.time()  # generate it based off current time
     for i in range(20):
-        _generate_performance_data(test_repository,
-                                   test_perf_signature,
-                                   test_issue_tracker,
-                                   generic_reference_data,
-                                   base_time, 1, 0.5, 1)
+        _generate_performance_data(
+            test_repository,
+            test_perf_signature,
+            test_issue_tracker,
+            generic_reference_data,
+            base_time,
+            1,
+            0.5,
+            1,
+        )
     for i in range(5):
-        _generate_performance_data(test_repository,
-                                   test_perf_signature,
-                                   test_issue_tracker,
-                                   generic_reference_data,
-                                   base_time, 2, 0.5, 1)
+        _generate_performance_data(
+            test_repository,
+            test_perf_signature,
+            test_issue_tracker,
+            generic_reference_data,
+            base_time,
+            2,
+            0.5,
+            1,
+        )
     for i in range(15):
-        _generate_performance_data(test_repository,
-                                   test_perf_signature,
-                                   test_issue_tracker,
-                                   generic_reference_data,
-                                   base_time, 2, 1.0, 1)
+        _generate_performance_data(
+            test_repository,
+            test_perf_signature,
+            test_issue_tracker,
+            generic_reference_data,
+            base_time,
+            2,
+            1.0,
+            1,
+        )
 
     generate_new_alerts_in_series(test_perf_signature)
-    _verify_alert(1, 2, 1, test_perf_signature, 0.5, 0.875, True,
-                  PerformanceAlert.UNTRIAGED,
-                  PerformanceAlertSummary.UNTRIAGED, None)
+    _verify_alert(
+        1,
+        2,
+        1,
+        test_perf_signature,
+        0.5,
+        0.875,
+        True,
+        PerformanceAlert.UNTRIAGED,
+        PerformanceAlertSummary.UNTRIAGED,
+        None,
+    )
 
 
 def test_no_alerts_with_old_data(
-        test_repository, test_issue_tracker,
-        failure_classifications, generic_reference_data, test_perf_signature):
+    test_repository,
+    test_issue_tracker,
+    failure_classifications,
+    generic_reference_data,
+    test_perf_signature,
+):
     base_time = 0  # 1970, too old!
     INTERVAL = 30
-    _generate_performance_data(test_repository,
-                               test_perf_signature,
-                               test_issue_tracker,
-                               generic_reference_data,
-                               base_time, 1, 0.5, int(INTERVAL / 2))
-    _generate_performance_data(test_repository,
-                               test_perf_signature,
-                               test_issue_tracker,
-                               generic_reference_data,
-                               base_time, int(INTERVAL / 2) + 1, 1.0, int(INTERVAL / 2))
+    _generate_performance_data(
+        test_repository,
+        test_perf_signature,
+        test_issue_tracker,
+        generic_reference_data,
+        base_time,
+        1,
+        0.5,
+        int(INTERVAL / 2),
+    )
+    _generate_performance_data(
+        test_repository,
+        test_perf_signature,
+        test_issue_tracker,
+        generic_reference_data,
+        base_time,
+        int(INTERVAL / 2) + 1,
+        1.0,
+        int(INTERVAL / 2),
+    )
 
     generate_new_alerts_in_series(test_perf_signature)
 
@@ -163,8 +268,12 @@ def test_no_alerts_with_old_data(
 
 
 def test_custom_alert_threshold(
-        test_repository, test_issue_tracker,
-        failure_classifications, generic_reference_data, test_perf_signature):
+    test_repository,
+    test_issue_tracker,
+    failure_classifications,
+    generic_reference_data,
+    test_perf_signature,
+):
 
     test_perf_signature.alert_threshold = 200.0
     test_perf_signature.save()
@@ -174,21 +283,36 @@ def test_custom_alert_threshold(
     # of 200% that should only generate 1
     INTERVAL = 60
     base_time = time.time()
-    _generate_performance_data(test_repository,
-                               test_perf_signature,
-                               test_issue_tracker,
-                               generic_reference_data,
-                               base_time, 1, 0.5, int(INTERVAL / 3))
-    _generate_performance_data(test_repository,
-                               test_perf_signature,
-                               test_issue_tracker,
-                               generic_reference_data,
-                               base_time, int(INTERVAL / 3) + 1, 0.6, int(INTERVAL / 3))
-    _generate_performance_data(test_repository,
-                               test_perf_signature,
-                               test_issue_tracker,
-                               generic_reference_data,
-                               base_time, 2 * int(INTERVAL / 3) + 1, 2.0, int(INTERVAL / 3))
+    _generate_performance_data(
+        test_repository,
+        test_perf_signature,
+        test_issue_tracker,
+        generic_reference_data,
+        base_time,
+        1,
+        0.5,
+        int(INTERVAL / 3),
+    )
+    _generate_performance_data(
+        test_repository,
+        test_perf_signature,
+        test_issue_tracker,
+        generic_reference_data,
+        base_time,
+        int(INTERVAL / 3) + 1,
+        0.6,
+        int(INTERVAL / 3),
+    )
+    _generate_performance_data(
+        test_repository,
+        test_perf_signature,
+        test_issue_tracker,
+        generic_reference_data,
+        base_time,
+        2 * int(INTERVAL / 3) + 1,
+        2.0,
+        int(INTERVAL / 3),
+    )
 
     generate_new_alerts_in_series(test_perf_signature)
 
@@ -196,14 +320,16 @@ def test_custom_alert_threshold(
     assert PerformanceAlertSummary.objects.count() == 1
 
 
-@pytest.mark.parametrize(('new_value', 'expected_num_alerts'),
-                         [(1.0, 1), (0.25, 0)])
-def test_alert_change_type_absolute(test_repository,
-                                    test_issue_tracker,
-                                    failure_classifications,
-                                    generic_reference_data,
-                                    test_perf_signature, new_value,
-                                    expected_num_alerts):
+@pytest.mark.parametrize(('new_value', 'expected_num_alerts'), [(1.0, 1), (0.25, 0)])
+def test_alert_change_type_absolute(
+    test_repository,
+    test_issue_tracker,
+    failure_classifications,
+    generic_reference_data,
+    test_perf_signature,
+    new_value,
+    expected_num_alerts,
+):
     # modify the test signature to say that we alert on absolute value
     # (as opposed to percentage change)
     test_perf_signature.alert_change_type = PerformanceSignature.ALERT_ABS
@@ -212,13 +338,26 @@ def test_alert_change_type_absolute(test_repository,
 
     base_time = time.time()  # generate it based off current time
     INTERVAL = 30
-    _generate_performance_data(test_repository, test_perf_signature,
-                               test_issue_tracker, generic_reference_data,
-                               base_time, 1, 0.5, int(INTERVAL / 2))
-    _generate_performance_data(test_repository, test_perf_signature,
-                               test_issue_tracker, generic_reference_data,
-                               base_time, int(INTERVAL / 2) + 1, new_value,
-                               int(INTERVAL / 2))
+    _generate_performance_data(
+        test_repository,
+        test_perf_signature,
+        test_issue_tracker,
+        generic_reference_data,
+        base_time,
+        1,
+        0.5,
+        int(INTERVAL / 2),
+    )
+    _generate_performance_data(
+        test_repository,
+        test_perf_signature,
+        test_issue_tracker,
+        generic_reference_data,
+        base_time,
+        int(INTERVAL / 2) + 1,
+        new_value,
+        int(INTERVAL / 2),
+    )
 
     generate_new_alerts_in_series(test_perf_signature)
 

--- a/tests/perfalert/test_alerts/test_identify_retriggerables.py
+++ b/tests/perfalert/test_alerts/test_identify_retriggerables.py
@@ -32,7 +32,8 @@ def gapped_performance_data(test_perf_signature, eleven_jobs_stored, test_perf_a
         push_ids_to_keep=[1, 2, 4, 7, 9],
         highlighted_push_id=4,
         perf_alert=test_perf_alert,
-        perf_signature=test_perf_signature)
+        perf_signature=test_perf_signature,
+    )
 
 
 @pytest.fixture
@@ -56,11 +57,14 @@ def single_performance_datum(test_perf_signature, eleven_jobs_stored, test_perf_
         push_ids_to_keep=[4],
         highlighted_push_id=4,
         perf_alert=test_perf_alert,
-        perf_signature=test_perf_signature)
+        perf_signature=test_perf_signature,
+    )
 
 
 @pytest.fixture
-def retriggerable_and_nonretriggerable_performance_data(test_perf_signature, eleven_jobs_stored, test_perf_alert):
+def retriggerable_and_nonretriggerable_performance_data(
+    test_perf_signature, eleven_jobs_stored, test_perf_alert
+):
     """
     Graph view looks like:
 
@@ -78,10 +82,14 @@ def retriggerable_and_nonretriggerable_performance_data(test_perf_signature, ele
     out_of_retrigger_range = datetime.datetime(year=2014, month=1, day=1)
 
     prepare_graph_data_scenario(
-        push_ids_to_keep=[4, NON_RETRIGGERABLE_JOB_ID],  # generally, fixture job ids == parent push id
+        push_ids_to_keep=[
+            4,
+            NON_RETRIGGERABLE_JOB_ID,
+        ],  # generally, fixture job ids == parent push id
         highlighted_push_id=4,
         perf_alert=test_perf_alert,
-        perf_signature=test_perf_signature)
+        perf_signature=test_perf_signature,
+    )
 
     # make 2nd data point recent enough so it
     # won't get selected for retriggering
@@ -117,7 +125,7 @@ def prepare_graph_data_scenario(push_ids_to_keep, highlighted_push_id, perf_aler
             job=job,
             push=job.push,
             repository=job.repository,
-            signature=perf_signature
+            signature=perf_signature,
         )
         perf_datum.push.time = job.push.time
         perf_datum.push.save()
@@ -166,7 +174,9 @@ def test_identify_retriggerables_as_unit():
 
 # Component tests
 def test_identify_retriggerables_selects_all_data_points(gapped_performance_data, test_perf_alert):
-    identify_retriggerables = IdentifyAlertRetriggerables(max_data_points=5, time_interval=ONE_DAY_INTERVAL)
+    identify_retriggerables = IdentifyAlertRetriggerables(
+        max_data_points=5, time_interval=ONE_DAY_INTERVAL
+    )
     data_points_to_retrigger = identify_retriggerables(test_perf_alert)
 
     assert len(data_points_to_retrigger) == 5
@@ -181,8 +191,12 @@ def test_identify_retriggerables_selects_all_data_points(gapped_performance_data
     assert max_push_timestamp <= datetime.datetime(year=2013, month=11, day=14)
 
 
-def test_identify_retriggerables_selects_even_single_data_point(single_performance_datum, test_perf_alert):
-    identify_retriggerables = IdentifyAlertRetriggerables(max_data_points=5, time_interval=ONE_DAY_INTERVAL)
+def test_identify_retriggerables_selects_even_single_data_point(
+    single_performance_datum, test_perf_alert
+):
+    identify_retriggerables = IdentifyAlertRetriggerables(
+        max_data_points=5, time_interval=ONE_DAY_INTERVAL
+    )
     data_points_to_retrigger = identify_retriggerables(test_perf_alert)
 
     assert len(data_points_to_retrigger) == 1
@@ -190,8 +204,11 @@ def test_identify_retriggerables_selects_even_single_data_point(single_performan
 
 
 def test_identify_retriggerables_doesnt_select_out_of_range_data_points(
-        retriggerable_and_nonretriggerable_performance_data, test_perf_alert):
-    identify_retriggerables = IdentifyAlertRetriggerables(max_data_points=5, time_interval=ONE_DAY_INTERVAL)
+    retriggerable_and_nonretriggerable_performance_data, test_perf_alert
+):
+    identify_retriggerables = IdentifyAlertRetriggerables(
+        max_data_points=5, time_interval=ONE_DAY_INTERVAL
+    )
     data_points_to_retrigger = identify_retriggerables(test_perf_alert)
 
     job_ids_to_retrigger = set(map(get_key("job_id"), data_points_to_retrigger))

--- a/tests/perfalert/test_alerts/test_secretary_tool.py
+++ b/tests/perfalert/test_alerts/test_secretary_tool.py
@@ -1,39 +1,32 @@
-from datetime import (datetime,
-                      timedelta)
+from datetime import datetime, timedelta
 
 import pytest
 import simplejson as json
-from mock import (Mock,
-                  patch)
+from mock import Mock, patch
 
-from treeherder.perf.models import (BackfillRecord,
-                                    BackfillReport,
-                                    PerformanceSettings)
-from treeherder.perf.secretary_tool import (SecretaryTool,
-                                            default_serializer)
+from treeherder.perf.models import BackfillRecord, BackfillReport, PerformanceSettings
+from treeherder.perf.secretary_tool import SecretaryTool, default_serializer
 
 
 @pytest.fixture
 def performance_settings(db):
     settings = {
-            "limits": 500,
-            "last_reset_date": datetime.utcnow(),
-        }
+        "limits": 500,
+        "last_reset_date": datetime.utcnow(),
+    }
     return PerformanceSettings.objects.create(
-        name="perf_sheriff_bot",
-        settings=json.dumps(settings, default=default_serializer),
+        name="perf_sheriff_bot", settings=json.dumps(settings, default=default_serializer),
     )
 
 
 @pytest.fixture
 def expired_performance_settings(db):
     settings = {
-            "limits": 500,
-            "last_reset_date": datetime.utcnow() - timedelta(days=30),
-        }
+        "limits": 500,
+        "last_reset_date": datetime.utcnow() - timedelta(days=30),
+    }
     return PerformanceSettings.objects.create(
-        name="perf_sheriff_bot",
-        settings=json.dumps(settings, default=default_serializer),
+        name="perf_sheriff_bot", settings=json.dumps(settings, default=default_serializer),
     )
 
 
@@ -46,7 +39,9 @@ def create_record():
     return _create_record
 
 
-def test_secretary_tool_updates_only_matured_reports(test_perf_alert, test_perf_alert_2, create_record):
+def test_secretary_tool_updates_only_matured_reports(
+    test_perf_alert, test_perf_alert_2, create_record
+):
     # create new report with records
     create_record(test_perf_alert)
     # create mature report with records

--- a/tests/perfalert/test_analyze.py
+++ b/tests/perfalert/test_analyze.py
@@ -3,33 +3,37 @@ import os
 import pytest
 
 from tests.sampledata import SampleData
-from treeherder.perfalert.perfalert import (RevisionDatum,
-                                            analyze,
-                                            calc_t,
-                                            default_weights,
-                                            detect_changes,
-                                            linear_weights)
+from treeherder.perfalert.perfalert import (
+    RevisionDatum,
+    analyze,
+    calc_t,
+    default_weights,
+    detect_changes,
+    linear_weights,
+)
 
 
-@pytest.mark.parametrize(("revision_data", "weight_fn",
-                          "expected"), [
-    # common-cases (one revision, one value)
-    ([], default_weights, {"avg": 0.0, "n": 0, "variance": 0.0}),
-    ([[3.0]], default_weights, {"avg": 3.0, "n": 1, "variance": 0.0}),
-    ([[1.0], [2.0], [3.0], [4.0]], default_weights, {"avg": 2.5, "n": 4,
-                                                     "variance": 5.0/3.0}),
-    ([[1.0], [2.0], [3.0], [4.0]], linear_weights, {"avg": 2.0,
-                                                    "n": 4,
-                                                    "variance": 2.0}),
-    # trickier cases (multiple data per revision)
-    ([[1.0, 3.0], [4.0, 4.0]], default_weights, {"avg": 3.0, "n": 4,
-                                                 "variance": 2.0}),
-    ([[2.0, 3.0], [4.0, 4.0]], linear_weights, {"avg": 3.0, "n": 4,
-                                                "variance": 1.0}),
-    ])
+@pytest.mark.parametrize(
+    ("revision_data", "weight_fn", "expected"),
+    [
+        # common-cases (one revision, one value)
+        ([], default_weights, {"avg": 0.0, "n": 0, "variance": 0.0}),
+        ([[3.0]], default_weights, {"avg": 3.0, "n": 1, "variance": 0.0}),
+        (
+            [[1.0], [2.0], [3.0], [4.0]],
+            default_weights,
+            {"avg": 2.5, "n": 4, "variance": 5.0 / 3.0},
+        ),
+        ([[1.0], [2.0], [3.0], [4.0]], linear_weights, {"avg": 2.0, "n": 4, "variance": 2.0}),
+        # trickier cases (multiple data per revision)
+        ([[1.0, 3.0], [4.0, 4.0]], default_weights, {"avg": 3.0, "n": 4, "variance": 2.0}),
+        ([[2.0, 3.0], [4.0, 4.0]], linear_weights, {"avg": 3.0, "n": 4, "variance": 1.0}),
+    ],
+)
 def test_analyze_fn(revision_data, weight_fn, expected):
-    data = [RevisionDatum(i, i, values) for (i, values) in zip(
-        range(len(revision_data)), revision_data)]
+    data = [
+        RevisionDatum(i, i, values) for (i, values) in zip(range(len(revision_data)), revision_data)
+    ]
     assert analyze(data, weight_fn) == expected
 
 
@@ -38,27 +42,32 @@ def test_weights():
     assert [linear_weights(i, 5) for i in range(5)] == [1.0, 0.8, 0.6, 0.4, 0.2]
 
 
-@pytest.mark.parametrize(("old_data", "new_data", "expected"), [
-    ([0.0, 0.0], [1.0, 2.0], 3.0),
-    ([0.0, 0.0], [0.0, 0.0], 0.0),
-    ([0.0, 0.0], [1.0, 1.0], float('inf'))
-    ])
+@pytest.mark.parametrize(
+    ("old_data", "new_data", "expected"),
+    [
+        ([0.0, 0.0], [1.0, 2.0], 3.0),
+        ([0.0, 0.0], [0.0, 0.0], 0.0),
+        ([0.0, 0.0], [1.0, 1.0], float('inf')),
+    ],
+)
 def test_calc_t(old_data, new_data, expected):
-    assert calc_t([RevisionDatum(0, 0, old_data)],
-                  [RevisionDatum(1, 1, new_data)]) == expected
+    assert calc_t([RevisionDatum(0, 0, old_data)], [RevisionDatum(1, 1, new_data)]) == expected
 
 
 def test_detect_changes():
     data = []
 
     times = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-    values = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1,  1,  1,  1,  1,  1,  1]
+    values = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1]
     for (t, v) in zip(times, values):
         data.append(RevisionDatum(t, t, [float(v)]))
 
-    result = [(d.push_timestamp, d.change_detected) for d in
-              detect_changes(data, min_back_window=5, max_back_window=5,
-                             fore_window=5, t_threshold=2)]
+    result = [
+        (d.push_timestamp, d.change_detected)
+        for d in detect_changes(
+            data, min_back_window=5, max_back_window=5, fore_window=5, t_threshold=2
+        )
+    ]
     assert result == [
         (0, False),
         (1, False),
@@ -75,7 +84,7 @@ def test_detect_changes():
         (12, False),
         (13, False),
         (14, False),
-        (15, False)
+        (15, False),
     ]
 
 
@@ -84,27 +93,33 @@ def test_detect_changes_few_revisions_many_values():
     Tests that we correctly detect a regression with
     a small number of revisions but a large number of values
     '''
-    data = [RevisionDatum(0, 0, [0]*50+[1]*30),
-            RevisionDatum(1, 1, [0]*10+[1]*30),
-            RevisionDatum(1, 1, [0]*10+[1]*30)]
-    result = [(d.push_timestamp, d.change_detected) for d in
-              detect_changes(data, min_back_window=5, max_back_window=10,
-                             fore_window=5, t_threshold=2)]
+    data = [
+        RevisionDatum(0, 0, [0] * 50 + [1] * 30),
+        RevisionDatum(1, 1, [0] * 10 + [1] * 30),
+        RevisionDatum(1, 1, [0] * 10 + [1] * 30),
+    ]
+    result = [
+        (d.push_timestamp, d.change_detected)
+        for d in detect_changes(
+            data, min_back_window=5, max_back_window=10, fore_window=5, t_threshold=2
+        )
+    ]
 
-    assert result == [(0, False),
-                      (1, True),
-                      (1, False)]
+    assert result == [(0, False), (1, True), (1, False)]
 
 
-@pytest.mark.parametrize(("filename", "expected_timestamps"), [
-    ('runs1.json', [1365019665]),
-    ('runs2.json', [1357704596, 1358971894, 1365014104]),
-    ('runs3.json', [1335293827, 1338839958]),
-    ('runs4.json', [1364922838]),
-    ('runs5.json', []),
-    ('a11y.json', [1366197637, 1367799757]),
-    ('tp5rss.json', [1372846906, 1373413365, 1373424974])
-    ])
+@pytest.mark.parametrize(
+    ("filename", "expected_timestamps"),
+    [
+        ('runs1.json', [1365019665]),
+        ('runs2.json', [1357704596, 1358971894, 1365014104]),
+        ('runs3.json', [1335293827, 1338839958]),
+        ('runs4.json', [1364922838]),
+        ('runs5.json', []),
+        ('a11y.json', [1366197637, 1367799757]),
+        ('tp5rss.json', [1372846906, 1373413365, 1373424974]),
+    ],
+)
 def test_detect_changes_historical_data(filename, expected_timestamps):
     """Parse JSON produced by http://graphs.mozilla.org/api/test/runs"""
     # Configuration for Analyzer
@@ -117,11 +132,12 @@ def test_detect_changes_historical_data(filename, expected_timestamps):
     runs = payload['test_runs']
     data = [RevisionDatum(r[2], r[2], [r[3]]) for r in runs]
 
-    results = detect_changes(data,
-                             min_back_window=MIN_BACK_WINDOW,
-                             max_back_window=MAX_BACK_WINDOW,
-                             fore_window=FORE_WINDOW,
-                             t_threshold=THRESHOLD)
-    regression_timestamps = [d.push_timestamp for d in results if
-                             d.change_detected]
+    results = detect_changes(
+        data,
+        min_back_window=MIN_BACK_WINDOW,
+        max_back_window=MAX_BACK_WINDOW,
+        fore_window=FORE_WINDOW,
+        t_threshold=THRESHOLD,
+    )
+    regression_timestamps = [d.push_timestamp for d in results if d.change_detected]
     assert regression_timestamps == expected_timestamps

--- a/tests/perfalert/test_backfill_tool.py
+++ b/tests/perfalert/test_backfill_tool.py
@@ -8,7 +8,8 @@ from treeherder.services.taskcluster import TaskclusterModel
 # BackfillTool
 def test_backfilling_job_from_try_repo_raises_exception(job_from_try):
     backfill_tool = BackfillTool(
-        TaskclusterModel('https://fakerooturl.org', 'FAKE_CLIENT_ID', 'FAKE_ACCESS_TOKEN'))
+        TaskclusterModel('https://fakerooturl.org', 'FAKE_CLIENT_ID', 'FAKE_ACCESS_TOKEN')
+    )
 
     with pytest.raises(CannotBackfill):
         backfill_tool.backfill_job(job_from_try.id)

--- a/tests/push_health/test_builds.py
+++ b/tests/push_health/test_builds.py
@@ -6,13 +6,15 @@ from treeherder.model.models import Push
 from treeherder.push_health.builds import get_build_failures
 
 
-def test_get_build_failures_with_parent(failure_classifications, test_push, test_repository, sample_data, mock_log_parser):
+def test_get_build_failures_with_parent(
+    failure_classifications, test_push, test_repository, sample_data, mock_log_parser
+):
     parent_revision = 'abcdef77949168d16c03a4cba167678b7ab65f76'
     parent_push = Push.objects.create(
         revision=parent_revision,
         repository=test_repository,
         author='foo@bar.baz',
-        time=datetime.datetime.now()
+        time=datetime.datetime.now(),
     )
 
     jobs = sample_data.job_data[20:25]

--- a/tests/push_health/test_classification.py
+++ b/tests/push_health/test_classification.py
@@ -20,14 +20,17 @@ def test_intermittent_win7_reftest():
     assert failures[0]['suggestedClassification'] == 'intermittent'
 
 
-@pytest.mark.parametrize(('history', 'confidence', 'classification', 'fcid'), [
-    ({'foo': {'bing': {'baz': 2}}}, 100, 'intermittent', 1),
-    ({'foo': {'bing': {'bee': 2}}}, 75, 'intermittent', 1),
-    ({'foo': {'bee': {'bee': 2}}}, 50, 'intermittent', 1),
-    ({'fee': {'bee': {'bee': 2}}}, 0, 'New Failure', 1),
-    # no match, but job has been classified as intermittent by hand.
-    ({'fee': {'bee': {'bee': 2}}}, 100, 'intermittent', 4),
-])
+@pytest.mark.parametrize(
+    ('history', 'confidence', 'classification', 'fcid'),
+    [
+        ({'foo': {'bing': {'baz': 2}}}, 100, 'intermittent', 1),
+        ({'foo': {'bing': {'bee': 2}}}, 75, 'intermittent', 1),
+        ({'foo': {'bee': {'bee': 2}}}, 50, 'intermittent', 1),
+        ({'fee': {'bee': {'bee': 2}}}, 0, 'New Failure', 1),
+        # no match, but job has been classified as intermittent by hand.
+        ({'fee': {'bee': {'bee': 2}}}, 100, 'intermittent', 4),
+    ],
+)
 def test_intermittent_confidence(history, confidence, classification, fcid):
     """test that a failed test is classified as intermittent, confidence 100"""
     failures = [

--- a/tests/push_health/test_compare.py
+++ b/tests/push_health/test_compare.py
@@ -3,8 +3,7 @@ import datetime
 import responses
 
 from treeherder.model.models import Push
-from treeherder.push_health.compare import (get_commit_history,
-                                            get_response_object)
+from treeherder.push_health.compare import get_commit_history, get_response_object
 
 
 def test_get_response_object(test_push, test_repository):
@@ -23,32 +22,37 @@ def test_get_commit_history_automationrelevance(test_push, test_repository):
         revision=parent_revision,
         repository=test_repository,
         author='foo@bar.baz',
-        time=datetime.datetime.now()
+        time=datetime.datetime.now(),
     )
 
-    autorel_commits = {'changesets': [
-        {
-            'author': 'Cheech Marin <cheech.marin@gmail.com>', 'backsoutnodes': [],
-            'desc': 'Bug 1612891 - Suppress parsing easing error in early returns of ConvertKeyframeSequence.\n\nWe add a stack based class and supress the exception of parsing easing\nin the destructor, to avoid hitting the potential assertions.\n\nDifferential Revision: https://phabricator.services.mozilla.com/D64268\nDifferential Diff: PHID-DIFF-c4e7dcfpalwiem7bxsnk',
-            'node': '3ca259f9cbdea763e64f10e286e58b271d89ab9d',
-            'parents': [parent_revision],
-        },
-        {
-            'author': 'libmozevent <release-mgmt-analysis@mozilla.com>',
-            'desc': 'try_task_config for https://phabricator.services.mozilla.com/D64268\nDifferential Diff: PHID-DIFF-c4e7dcfpalwiem7bxsnk',
-            'node': '18f68eb12ebbd88fe3a4fc3afe7df6529a0153fb',
-            'parents': ['3ca259f9cbdea763e64f10e286e58b271d89ab9d'],
-        }
-    ], 'visible': True}
+    autorel_commits = {
+        'changesets': [
+            {
+                'author': 'Cheech Marin <cheech.marin@gmail.com>',
+                'backsoutnodes': [],
+                'desc': 'Bug 1612891 - Suppress parsing easing error in early returns of ConvertKeyframeSequence.\n\nWe add a stack based class and supress the exception of parsing easing\nin the destructor, to avoid hitting the potential assertions.\n\nDifferential Revision: https://phabricator.services.mozilla.com/D64268\nDifferential Diff: PHID-DIFF-c4e7dcfpalwiem7bxsnk',
+                'node': '3ca259f9cbdea763e64f10e286e58b271d89ab9d',
+                'parents': [parent_revision],
+            },
+            {
+                'author': 'libmozevent <release-mgmt-analysis@mozilla.com>',
+                'desc': 'try_task_config for https://phabricator.services.mozilla.com/D64268\nDifferential Diff: PHID-DIFF-c4e7dcfpalwiem7bxsnk',
+                'node': '18f68eb12ebbd88fe3a4fc3afe7df6529a0153fb',
+                'parents': ['3ca259f9cbdea763e64f10e286e58b271d89ab9d'],
+            },
+        ],
+        'visible': True,
+    }
 
     autorel_url = 'https://hg.mozilla.org/{}/json-automationrelevance/{}'.format(
-        test_repository.name, test_revision)
+        test_repository.name, test_revision
+    )
     responses.add(
         responses.GET,
         autorel_url,
         json=autorel_commits,
         content_type='application/json',
-        status=200
+        status=200,
     )
 
     history = get_commit_history(test_repository, test_revision, test_push)
@@ -58,37 +62,38 @@ def test_get_commit_history_automationrelevance(test_push, test_repository):
 
 
 @responses.activate
-def test_get_commit_history_parent_different_repo(
-        test_push,
-        test_repository,
-        test_repository_2
-        ):
+def test_get_commit_history_parent_different_repo(test_push, test_repository, test_repository_2):
     test_revision = '4c45a777949168d16c03a4cba167678b7ab65f76'
     parent_revision = 'abcdef77949168d16c03a4cba167678b7ab65f76'
     Push.objects.create(
         revision=parent_revision,
         repository=test_repository_2,
         author='foo@bar.baz',
-        time=datetime.datetime.now()
+        time=datetime.datetime.now(),
     )
 
-    autorel_commits = {'changesets': [
-        {
-            'author': 'Cheech Marin <cheech.marin@gmail.com>', 'backsoutnodes': [],
-            'desc': 'Bug 1612891 - Suppress parsing easing error in early returns of ConvertKeyframeSequence.\n\nWe add a stack based class and supress the exception of parsing easing\nin the destructor, to avoid hitting the potential assertions.\n\nDifferential Revision: https://phabricator.services.mozilla.com/D64268\nDifferential Diff: PHID-DIFF-c4e7dcfpalwiem7bxsnk',
-            'node': '3ca259f9cbdea763e64f10e286e58b271d89ab9d',
-            'parents': [parent_revision],
-        },
-    ], 'visible': True}
+    autorel_commits = {
+        'changesets': [
+            {
+                'author': 'Cheech Marin <cheech.marin@gmail.com>',
+                'backsoutnodes': [],
+                'desc': 'Bug 1612891 - Suppress parsing easing error in early returns of ConvertKeyframeSequence.\n\nWe add a stack based class and supress the exception of parsing easing\nin the destructor, to avoid hitting the potential assertions.\n\nDifferential Revision: https://phabricator.services.mozilla.com/D64268\nDifferential Diff: PHID-DIFF-c4e7dcfpalwiem7bxsnk',
+                'node': '3ca259f9cbdea763e64f10e286e58b271d89ab9d',
+                'parents': [parent_revision],
+            },
+        ],
+        'visible': True,
+    }
 
     autorel_url = 'https://hg.mozilla.org/{}/json-automationrelevance/{}'.format(
-        test_repository.name, test_revision)
+        test_repository.name, test_revision
+    )
     responses.add(
         responses.GET,
         autorel_url,
         json=autorel_commits,
         content_type='application/json',
-        status=200
+        status=200,
     )
 
     history = get_commit_history(test_repository, test_revision, test_push)
@@ -105,37 +110,37 @@ def test_get_commit_history_json_pushes(test_push, test_repository):
         revision=parent_revision,
         repository=test_repository,
         author='foo@bar.baz',
-        time=datetime.datetime.now()
+        time=datetime.datetime.now(),
     )
 
     autorel_url = 'https://hg.mozilla.org/{}/json-automationrelevance/{}'.format(
-        test_repository.name, test_revision)
-    responses.add(
-        responses.GET,
-        autorel_url,
-        json={},
-        content_type='application/json',
-        status=500
+        test_repository.name, test_revision
     )
+    responses.add(responses.GET, autorel_url, json={}, content_type='application/json', status=500)
 
     jsonpushes_commits = {
-        'pushes': {'108872': {'changesets': [
-            {
-                'author': 'Hiro Protagonist <hprotagonist@gmail.com>',
-                'desc': 'Bug 1617666 - Use a separate Debugger to improve performance of eval.',
-                'node': '4fb5e268cf7440332e917e431f14e8bb6dc41a0d',
-                'parents': [parent_revision],
+        'pushes': {
+            '108872': {
+                'changesets': [
+                    {
+                        'author': 'Hiro Protagonist <hprotagonist@gmail.com>',
+                        'desc': 'Bug 1617666 - Use a separate Debugger to improve performance of eval.',
+                        'node': '4fb5e268cf7440332e917e431f14e8bb6dc41a0d',
+                        'parents': [parent_revision],
+                    }
+                ]
             }
-        ]}}
+        }
     }
     commits_url = '{}/json-pushes?version=2&full=1&changeset={}'.format(
-        test_repository.url, test_revision)
+        test_repository.url, test_revision
+    )
     responses.add(
         responses.GET,
         commits_url,
         json=jsonpushes_commits,
         content_type='application/json',
-        status=200
+        status=200,
     )
 
     history = get_commit_history(test_repository, test_revision, test_push)
@@ -150,17 +155,27 @@ def test_get_commit_history_not_found(test_push, test_repository):
     # Does not exist as a Push in the DB.
     parent_revision = 'abcdef77949168d16c03a4cba167678b7ab65f76'
     commits_url = '{}/json-pushes?version=2&full=1&changeset={}'.format(
-        test_repository.url, test_revision)
-    commits = {'pushes': {1: {'changesets': [
-        {
-            'author': 'Boris Chiou <boris.chiou@gmail.com>', 'backsoutnodes': [],
-            'desc': 'Bug 1612891 - Suppress parsing easing error in early returns of ConvertKeyframeSequence.\n\nWe add a stack based class and supress the exception of parsing easing\nin the destructor, to avoid hitting the potential assertions.\n\nDifferential Revision: https://phabricator.services.mozilla.com/D64268\nDifferential Diff: PHID-DIFF-c4e7dcfpalwiem7bxsnk',
-            'node': '3ca259f9cbdea763e64f10e286e58b271d89ab9d',
-            'parents': [parent_revision],
-        },
-    ]}}}
+        test_repository.url, test_revision
+    )
+    commits = {
+        'pushes': {
+            1: {
+                'changesets': [
+                    {
+                        'author': 'Boris Chiou <boris.chiou@gmail.com>',
+                        'backsoutnodes': [],
+                        'desc': 'Bug 1612891 - Suppress parsing easing error in early returns of ConvertKeyframeSequence.\n\nWe add a stack based class and supress the exception of parsing easing\nin the destructor, to avoid hitting the potential assertions.\n\nDifferential Revision: https://phabricator.services.mozilla.com/D64268\nDifferential Diff: PHID-DIFF-c4e7dcfpalwiem7bxsnk',
+                        'node': '3ca259f9cbdea763e64f10e286e58b271d89ab9d',
+                        'parents': [parent_revision],
+                    },
+                ]
+            }
+        }
+    }
 
-    responses.add(responses.GET, commits_url, json=commits, content_type='application/json', status=200)
+    responses.add(
+        responses.GET, commits_url, json=commits, content_type='application/json', status=200
+    )
 
     parent = get_commit_history(test_repository, test_revision, test_push)
     assert parent['parentSha'] == parent_revision

--- a/tests/push_health/test_linting.py
+++ b/tests/push_health/test_linting.py
@@ -6,24 +6,28 @@ from treeherder.model.models import Push
 from treeherder.push_health.linting import get_lint_failures
 
 
-def test_get_linting_failures_with_parent(failure_classifications, test_push, test_repository, sample_data, mock_log_parser):
+def test_get_linting_failures_with_parent(
+    failure_classifications, test_push, test_repository, sample_data, mock_log_parser
+):
     parent_revision = 'abcdef77949168d16c03a4cba167678b7ab65f76'
     parent_push = Push.objects.create(
         revision=parent_revision,
         repository=test_repository,
         author='foo@bar.baz',
-        time=datetime.datetime.now()
+        time=datetime.datetime.now(),
     )
 
     jobs = sample_data.job_data[20:22]
 
     for blob in jobs:
         blob['revision'] = test_push.revision
-        blob['job'].update({
-            'result': 'testfailed',
-            'taskcluster_task_id': 'V3SVuxO8TFy37En_6HcXLs',
-            'taskcluster_retry_id': '0'
-        })
+        blob['job'].update(
+            {
+                'result': 'testfailed',
+                'taskcluster_task_id': 'V3SVuxO8TFy37En_6HcXLs',
+                'taskcluster_retry_id': '0',
+            }
+        )
         blob['job']['machine_platform']['platform'] = 'lint'
     store_job_data(test_repository, jobs)
 

--- a/tests/push_health/test_tests.py
+++ b/tests/push_health/test_tests.py
@@ -2,16 +2,9 @@ import datetime
 
 import pytest
 
-from tests.autoclassify.utils import (create_lines,
-                                      test_line)
-from treeherder.model.models import (FailureLine,
-                                     Job,
-                                     Push,
-                                     Repository,
-                                     TaskclusterMetadata)
-from treeherder.push_health.tests import (get_test_failures,
-                                          has_job,
-                                          has_line)
+from tests.autoclassify.utils import create_lines, test_line
+from treeherder.model.models import FailureLine, Job, Push, Repository, TaskclusterMetadata
+from treeherder.push_health.tests import get_test_failures, has_job, has_line
 
 
 @pytest.mark.parametrize(('find_it',), [(True,), (False,)])
@@ -44,10 +37,9 @@ def test_has_line(find_it):
         assert not has_line(line, line_list)
 
 
-def test_get_test_failures_no_parent(failure_classifications,
-                                     test_repository,
-                                     test_job,
-                                     text_log_error_lines):
+def test_get_test_failures_no_parent(
+    failure_classifications, test_repository, test_job, text_log_error_lines
+):
     test_job.result = 'testfailed'
     test_job.save()
     print(test_job.taskcluster_metadata.task_id)
@@ -61,11 +53,9 @@ def test_get_test_failures_no_parent(failure_classifications,
     assert not need_investigation[0]['failedInParent']
 
 
-def test_get_test_failures_with_parent(failure_classifications,
-                                       test_repository,
-                                       test_job,
-                                       mock_log_parser,
-                                       text_log_error_lines):
+def test_get_test_failures_with_parent(
+    failure_classifications, test_repository, test_job, mock_log_parser, text_log_error_lines
+):
     test_job.result = 'testfailed'
     test_job.save()
 
@@ -73,18 +63,14 @@ def test_get_test_failures_with_parent(failure_classifications,
         revision='abcdef77949168d16c03a4cba167678b7ab65f76',
         repository=test_repository,
         author='foo@bar.baz',
-        time=datetime.datetime.now()
+        time=datetime.datetime.now(),
     )
     parent_job = Job.objects.first()
     parent_job.pk = None
     parent_job.push = parent_push
     parent_job.guid = 'wazzon chokey?'
     parent_job.save()
-    TaskclusterMetadata.objects.create(
-        job=parent_job,
-        task_id='V3SVuxO8TFy37En_6HcXLs',
-        retry_id=0
-    )
+    TaskclusterMetadata.objects.create(job=parent_job, task_id='V3SVuxO8TFy37En_6HcXLs', retry_id=0)
 
     create_lines(parent_job, [(test_line, {})])
 

--- a/tests/push_health/test_usage.py
+++ b/tests/push_health/test_usage.py
@@ -7,9 +7,7 @@ import responses
 
 from treeherder.config import settings
 from treeherder.model.models import Push
-from treeherder.push_health.usage import (get_latest,
-                                          get_peak,
-                                          get_usage)
+from treeherder.push_health.usage import get_latest, get_peak, get_usage
 
 
 @pytest.fixture
@@ -35,15 +33,18 @@ def test_latest(push_usage):
 @responses.activate
 def test_get_usage(push_usage, test_repository):
     nrql = "SELECT%20max(needInvestigation)%20FROM%20push_health_need_investigation%20FACET%20revision%20SINCE%201%20DAY%20AGO%20TIMESERIES%20where%20repo%3D'{}'%20AND%20appName%3D'{}'".format(
-        'try', 'treeherder-prod')
+        'try', 'treeherder-prod'
+    )
     new_relic_url = '{}?nrql={}'.format(settings.NEW_RELIC_INSIGHTS_API_URL, nrql)
 
     responses.add(
         responses.GET,
         new_relic_url,
         body=json.dumps(push_usage),
-        status=200, content_type='application/json',
-        match_querystring=True)
+        status=200,
+        content_type='application/json',
+        match_querystring=True,
+    )
 
     # create the Pushes that match the usage response
     for rev in [
@@ -56,7 +57,7 @@ def test_get_usage(push_usage, test_repository):
             revision=rev,
             repository=test_repository,
             author='phydeaux@dog.org',
-            time=datetime.datetime.now()
+            time=datetime.datetime.now(),
         )
 
     usage = get_usage()

--- a/tests/push_health/test_utils.py
+++ b/tests/push_health/test_utils.py
@@ -1,61 +1,93 @@
 import pytest
 
-from treeherder.push_health.utils import (clean_config,
-                                          clean_platform,
-                                          clean_test,
-                                          is_valid_failure_line)
+from treeherder.push_health.utils import (
+    clean_config,
+    clean_platform,
+    clean_test,
+    is_valid_failure_line,
+)
 
 
-@pytest.mark.parametrize(('action', 'test', 'signature', 'message', 'expected'), [
-     ('test_result', 'dis/dat/da/odder/ting', 'sig', 'mess', 'dis/dat/da/odder/ting'),
-     ('crash', 'dis/dat/da/odder/ting', 'sig', 'mess', 'sig'),
-     ('log', 'dis/dat/da/odder/ting', 'sig', 'mess', 'mess'),
-     ('meh', 'dis/dat/da/odder/ting', 'sig', 'mess', 'Non-Test Error'),
-     ('test_result', 'pid:dis/dat/da/odder/ting', 'sig', 'mess', None),
-     ('test_result', 'tests/layout/this == tests/layout/that', 'sig', 'mess', 'layout/this == layout/that'),
-     ('test_result', 'tests/layout/this != tests/layout/that', 'sig', 'mess', 'layout/this != layout/that'),
-     ('test_result', 'build/tests/reftest/tests/this != build/tests/reftest/tests/that', 'sig', 'mess', 'this != that'),
-     ('test_result', 'http://10.0.5.5/tests/this != http://10.0.5.5/tests/that', 'sig', 'mess', 'this != that'),
-     ('test_result', 'build/tests/reftest/tests/this', 'sig', 'mess', 'this'),
-     ('test_result', 'test=jsreftest.html', 'sig', 'mess', 'jsreftest.html'),
-     ('test_result', 'http://10.0.5.5/tests/this/thing', 'sig', 'mess', 'this/thing'),
-     ('test_result', 'http://localhost:5000/tests/this/thing', 'sig', 'mess', 'thing'),
-     ('test_result', 'thing is done (finished)', 'sig', 'mess', 'thing is done'),
-     ('test_result', 'Last test finished', 'sig', 'mess', None),
-     ('test_result', '(SimpleTest/TestRunner.js)', 'sig', 'mess', None),
-     ('test_result', '/this\\thing\\there', 'sig', 'mess', 'this/thing/there'),
-    ])
+@pytest.mark.parametrize(
+    ('action', 'test', 'signature', 'message', 'expected'),
+    [
+        ('test_result', 'dis/dat/da/odder/ting', 'sig', 'mess', 'dis/dat/da/odder/ting'),
+        ('crash', 'dis/dat/da/odder/ting', 'sig', 'mess', 'sig'),
+        ('log', 'dis/dat/da/odder/ting', 'sig', 'mess', 'mess'),
+        ('meh', 'dis/dat/da/odder/ting', 'sig', 'mess', 'Non-Test Error'),
+        ('test_result', 'pid:dis/dat/da/odder/ting', 'sig', 'mess', None),
+        (
+            'test_result',
+            'tests/layout/this == tests/layout/that',
+            'sig',
+            'mess',
+            'layout/this == layout/that',
+        ),
+        (
+            'test_result',
+            'tests/layout/this != tests/layout/that',
+            'sig',
+            'mess',
+            'layout/this != layout/that',
+        ),
+        (
+            'test_result',
+            'build/tests/reftest/tests/this != build/tests/reftest/tests/that',
+            'sig',
+            'mess',
+            'this != that',
+        ),
+        (
+            'test_result',
+            'http://10.0.5.5/tests/this != http://10.0.5.5/tests/that',
+            'sig',
+            'mess',
+            'this != that',
+        ),
+        ('test_result', 'build/tests/reftest/tests/this', 'sig', 'mess', 'this'),
+        ('test_result', 'test=jsreftest.html', 'sig', 'mess', 'jsreftest.html'),
+        ('test_result', 'http://10.0.5.5/tests/this/thing', 'sig', 'mess', 'this/thing'),
+        ('test_result', 'http://localhost:5000/tests/this/thing', 'sig', 'mess', 'thing'),
+        ('test_result', 'thing is done (finished)', 'sig', 'mess', 'thing is done'),
+        ('test_result', 'Last test finished', 'sig', 'mess', None),
+        ('test_result', '(SimpleTest/TestRunner.js)', 'sig', 'mess', None),
+        ('test_result', '/this\\thing\\there', 'sig', 'mess', 'this/thing/there'),
+    ],
+)
 def test_clean_test(action, test, signature, message, expected):
     assert expected == clean_test(action, test, signature, message)
 
 
-@pytest.mark.parametrize(('config', 'expected'), [
-     ('opt', 'opt'),
-     ('debug', 'debug'),
-     ('asan', 'asan'),
-     ('pgo', 'opt'),
-     ('shippable', 'opt'),
-    ])
+@pytest.mark.parametrize(
+    ('config', 'expected'),
+    [('opt', 'opt'), ('debug', 'debug'), ('asan', 'asan'), ('pgo', 'opt'), ('shippable', 'opt'),],
+)
 def test_clean_config(config, expected):
     assert expected == clean_config(config)
 
 
-@pytest.mark.parametrize(('platform', 'expected'), [
-     ('macosx64 opt and such', 'osx-10-10 opt and such'),
-     ('linux doohickey', 'linux doohickey'),
-     ('windows gizmo', 'windows gizmo'),
-    ])
+@pytest.mark.parametrize(
+    ('platform', 'expected'),
+    [
+        ('macosx64 opt and such', 'osx-10-10 opt and such'),
+        ('linux doohickey', 'linux doohickey'),
+        ('windows gizmo', 'windows gizmo'),
+    ],
+)
 def test_clean_platform(platform, expected):
     assert expected == clean_platform(platform)
 
 
-@pytest.mark.parametrize(('line', 'expected'), [
-     ('Return code:', False),
-     ('unexpected status', False),
-     ('unexpected crashes', False),
-     ('exit status', False),
-     ('Finished in', False),
-     ('expect magic', True),
-  ])
+@pytest.mark.parametrize(
+    ('line', 'expected'),
+    [
+        ('Return code:', False),
+        ('unexpected status', False),
+        ('unexpected crashes', False),
+        ('exit status', False),
+        ('Finished in', False),
+        ('expect magic', True),
+    ],
+)
 def test_is_valid_failure_line(line, expected):
     assert expected == is_valid_failure_line(line)

--- a/tests/sample_data_generator.py
+++ b/tests/sample_data_generator.py
@@ -8,45 +8,25 @@ from datetime import timedelta
 
 def job_data(**kwargs):
     jobs_obj = {
-        "revision": kwargs.get("revision",
-                               "24fd64b8251fac5cf60b54a915bffa7e51f636b5"),
+        "revision": kwargs.get("revision", "24fd64b8251fac5cf60b54a915bffa7e51f636b5"),
         "job": {
-
             u"build_platform": build_platform(**kwargs.pop("build_platform", {})),
-
             u"submit_timestamp": kwargs.pop("submit_timestamp", submit_timestamp()),
-
             u"start_timestamp": kwargs.pop("start_timestamp", start_timestamp()),
-
             u"name": kwargs.pop("name", u"mochitest-5"),
-
-            u"option_collection": option_collection(
-                **kwargs.pop("option_collection", {})),
-
+            u"option_collection": option_collection(**kwargs.pop("option_collection", {})),
             u"log_references": log_references(kwargs.pop("log_references", [])),
-
             u"who": kwargs.pop("who", u"sendchange-unittest"),
-
             u"reason": kwargs.pop("reason", u"scheduler"),
-
             u"artifact": kwargs.pop("artifact", {}),
-
-            u"machine_platform": machine_platform(
-                **kwargs.pop("machine_platform", {})),
-
+            u"machine_platform": machine_platform(**kwargs.pop("machine_platform", {})),
             u"machine": kwargs.pop("machine", u"talos-r3-xp-088"),
-
             u"state": kwargs.pop("state", u"completed"),
-
             u"result": kwargs.pop("result", 0),
-
-            u"job_guid": kwargs.pop(
-                u"job_guid", u"f3e3a9e6526881c39a3b2b6ff98510f213b3d4ed"),
-
+            u"job_guid": kwargs.pop(u"job_guid", u"f3e3a9e6526881c39a3b2b6ff98510f213b3d4ed"),
             u"product_name": kwargs.pop("product_name", u"firefox"),
-
             u"end_timestamp": kwargs.pop("end_timestamp", end_timestamp()),
-        }
+        },
     }
 
     # defaults.update(kwargs)
@@ -55,9 +35,7 @@ def job_data(**kwargs):
 
 
 def to_seconds(td):
-    return (td.microseconds +
-            (td.seconds + td.days * 24 * 3600) * 10 ** 6
-            ) / 10 ** 6
+    return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10 ** 6) / 10 ** 6
 
 
 def get_timestamp_days_ago(days_ago):
@@ -85,9 +63,7 @@ def option_collection(**kwargs):
     Return a sample data structure, with default values.
 
     """
-    defaults = {
-        u"debug": True
-    }
+    defaults = {u"debug": True}
 
     defaults.update(kwargs)
 
@@ -96,12 +72,7 @@ def option_collection(**kwargs):
 
 def log_references(log_refs=None):
     if not log_refs:
-        log_refs = [
-            {
-                u"url": u"http://ftp.mozilla.org/pub/...",
-                u"name": u"unittest"
-            }
-        ]
+        log_refs = [{u"url": u"http://ftp.mozilla.org/pub/...", u"name": u"unittest"}]
     return log_refs
 
 

--- a/tests/sampledata.py
+++ b/tests/sampledata.py
@@ -3,72 +3,92 @@ import os
 
 
 class SampleData:
-
     @classmethod
     def get_perf_data(cls, filename):
-        with open("{0}/sample_data/artifacts/performance/{1}".format(
-                os.path.dirname(__file__), filename)) as f:
+        with open(
+            "{0}/sample_data/artifacts/performance/{1}".format(os.path.dirname(__file__), filename)
+        ) as f:
             return json.load(f)
 
     def __init__(self):
-        self.job_data_file = "{0}/sample_data/job_data.txt".format(
-            os.path.dirname(__file__)
-        )
+        self.job_data_file = "{0}/sample_data/job_data.txt".format(os.path.dirname(__file__))
 
-        self.push_data_file = "{0}/sample_data/push_data.json".format(
-            os.path.dirname(__file__)
-        )
+        self.push_data_file = "{0}/sample_data/push_data.json".format(os.path.dirname(__file__))
 
-        self.logs_dir = "{0}/sample_data/logs".format(
-            os.path.dirname(__file__)
-        )
+        self.logs_dir = "{0}/sample_data/logs".format(os.path.dirname(__file__))
 
-        with open("{0}/sample_data/artifacts/text_log_summary.json".format(
-                  os.path.dirname(__file__))) as f:
+        with open(
+            "{0}/sample_data/artifacts/text_log_summary.json".format(os.path.dirname(__file__))
+        ) as f:
             self.text_log_summary = json.load(f)
 
-        with open("{0}/sample_data/pulse_consumer/taskcluster_pulse_messages.json".format(
-                  os.path.dirname(__file__))) as f:
+        with open(
+            "{0}/sample_data/pulse_consumer/taskcluster_pulse_messages.json".format(
+                os.path.dirname(__file__)
+            )
+        ) as f:
             self.taskcluster_pulse_messages = json.load(f)
 
-        with open("{0}/sample_data/pulse_consumer/taskcluster_tasks.json".format(
-                  os.path.dirname(__file__))) as f:
+        with open(
+            "{0}/sample_data/pulse_consumer/taskcluster_tasks.json".format(
+                os.path.dirname(__file__)
+            )
+        ) as f:
             self.taskcluster_tasks = json.load(f)
 
-        with open("{0}/sample_data/pulse_consumer/taskcluster_transformed_jobs.json".format(
-                  os.path.dirname(__file__))) as f:
+        with open(
+            "{0}/sample_data/pulse_consumer/taskcluster_transformed_jobs.json".format(
+                os.path.dirname(__file__)
+            )
+        ) as f:
             self.taskcluster_transformed_jobs = json.load(f)
 
-        with open("{0}/sample_data/pulse_consumer/job_data.json".format(
-                  os.path.dirname(__file__))) as f:
+        with open(
+            "{0}/sample_data/pulse_consumer/job_data.json".format(os.path.dirname(__file__))
+        ) as f:
             self.pulse_jobs = json.load(f)
 
-        with open("{0}/sample_data/pulse_consumer/transformed_job_data.json".format(
-                  os.path.dirname(__file__))) as f:
+        with open(
+            "{0}/sample_data/pulse_consumer/transformed_job_data.json".format(
+                os.path.dirname(__file__)
+            )
+        ) as f:
             self.transformed_pulse_jobs = json.load(f)
 
-        with open("{0}/sample_data/pulse_consumer/github_push.json".format(
-                  os.path.dirname(__file__))) as f:
+        with open(
+            "{0}/sample_data/pulse_consumer/github_push.json".format(os.path.dirname(__file__))
+        ) as f:
             self.github_push = json.load(f)
 
-        with open("{0}/sample_data/pulse_consumer/transformed_gh_push.json".format(
-                  os.path.dirname(__file__))) as f:
+        with open(
+            "{0}/sample_data/pulse_consumer/transformed_gh_push.json".format(
+                os.path.dirname(__file__)
+            )
+        ) as f:
             self.transformed_github_push = json.load(f)
 
-        with open("{0}/sample_data/pulse_consumer/github_pr.json".format(
-                  os.path.dirname(__file__))) as f:
+        with open(
+            "{0}/sample_data/pulse_consumer/github_pr.json".format(os.path.dirname(__file__))
+        ) as f:
             self.github_pr = json.load(f)
 
-        with open("{0}/sample_data/pulse_consumer/transformed_gh_pr.json".format(
-                  os.path.dirname(__file__))) as f:
+        with open(
+            "{0}/sample_data/pulse_consumer/transformed_gh_pr.json".format(
+                os.path.dirname(__file__)
+            )
+        ) as f:
             self.transformed_github_pr = json.load(f)
 
-        with open("{0}/sample_data/pulse_consumer/hg_push.json".format(
-                  os.path.dirname(__file__))) as f:
+        with open(
+            "{0}/sample_data/pulse_consumer/hg_push.json".format(os.path.dirname(__file__))
+        ) as f:
             self.hg_push = json.load(f)
 
-        with open("{0}/sample_data/pulse_consumer/transformed_hg_push.json".format(
-                  os.path.dirname(__file__))) as f:
+        with open(
+            "{0}/sample_data/pulse_consumer/transformed_hg_push.json".format(
+                os.path.dirname(__file__)
+            )
+        ) as f:
             self.transformed_hg_push = json.load(f)
 
         self.job_data = []

--- a/tests/selenium/pages/base.py
+++ b/tests/selenium/pages/base.py
@@ -1,10 +1,8 @@
-from pypom import (Page,
-                   Region)
+from pypom import Page, Region
 from selenium.webdriver.common.by import By
 
 
 class Base(Page):
-
     @property
     def header(self):
         return self.Header(self)
@@ -21,11 +19,9 @@ class Base(Page):
             # Initially try to compare with the text of the menu item.
             # But if there's an image instead of just text, then compare the
             # ``alt`` property of the image instead.
-            self.wait.until(lambda _: self.is_element_displayed(
-                *self._app_menu_locator))
+            self.wait.until(lambda _: self.is_element_displayed(*self._app_menu_locator))
             menu = self.find_element(*self._app_menu_locator).text
-            return menu if menu else self.find_element(
-                *self._app_logo_locator).get_attribute("alt")
+            return menu if menu else self.find_element(*self._app_logo_locator).get_attribute("alt")
 
         def switch_app(self):
             self.find_element(*self._app_menu_locator).click()

--- a/tests/selenium/pages/perfherder.py
+++ b/tests/selenium/pages/perfherder.py
@@ -14,6 +14,7 @@ class Perfherder(Base):
     def switch_to_treeherder(self):
         self.header.switch_app()
         from pages.treeherder import Treeherder
+
         return Treeherder(self.driver, self.base_url).wait_for_page_to_load()
 
     class GraphTooltip(Region):

--- a/tests/selenium/pages/treeherder.py
+++ b/tests/selenium/pages/treeherder.py
@@ -43,19 +43,16 @@ class Treeherder(Base):
 
     @property
     def active_watched_repo(self):
-        self.wait.until(lambda _: self.is_element_displayed(
-            *self._active_watched_repo_locator))
+        self.wait.until(lambda _: self.is_element_displayed(*self._active_watched_repo_locator))
         return self.find_element(*self._active_watched_repo_locator).text
 
     @property
     def all_jobs(self):
-        return list(itertools.chain.from_iterable(
-            r.jobs for r in self.pushes))
+        return list(itertools.chain.from_iterable(r.jobs for r in self.pushes))
 
     @property
     def all_job_groups(self):
-        return list(itertools.chain.from_iterable(
-            r.job_groups for r in self.pushes))
+        return list(itertools.chain.from_iterable(r.job_groups for r in self.pushes))
 
     def clear_filter(self, method='pointer'):
         if method == 'keyboard':
@@ -139,6 +136,7 @@ class Treeherder(Base):
     def switch_to_perfherder(self):
         self.header.switch_app()
         from pages.perfherder import Perfherder
+
         return Perfherder(self.driver, self.base_url).wait_for_page_to_load()
 
     def toggle_failures(self):
@@ -237,7 +235,10 @@ class Treeherder(Base):
 
         @property
         def job_groups(self):
-            return [self.JobGroup(self.page, root=el) for el in self.find_elements(*self._job_groups_locator)]
+            return [
+                self.JobGroup(self.page, root=el)
+                for el in self.find_elements(*self._job_groups_locator)
+            ]
 
         @property
         def jobs(self):
@@ -245,7 +246,9 @@ class Treeherder(Base):
 
         @property
         def commits(self):
-            return [self.page.Commit(self.page, el) for el in self.find_elements(*self._commits_locator)]
+            return [
+                self.page.Commit(self.page, el) for el in self.find_elements(*self._commits_locator)
+            ]
 
         def filter_by_author(self):
             self.find_element(*self._author_locator).click()
@@ -270,7 +273,6 @@ class Treeherder(Base):
             self.page.wait_for_page_to_load()
 
         class Job(Region):
-
             def click(self):
                 self.root.click()
                 self.wait.until(lambda _: self.page.details_panel.is_open)
@@ -299,7 +301,10 @@ class Treeherder(Base):
 
             @property
             def jobs(self):
-                return [Treeherder.ResultSet.Job(self.page, root=el) for el in self.find_elements(*self._jobs_locator)]
+                return [
+                    Treeherder.ResultSet.Job(self.page, root=el)
+                    for el in self.find_elements(*self._jobs_locator)
+                ]
 
     class Commit(Region):
 
@@ -334,9 +339,11 @@ class Treeherder(Base):
 
         @property
         def is_open(self):
-            return self.root.is_displayed() and \
-                not self.find_elements(*self._loading_locator) and \
-                self.job_details.result
+            return (
+                self.root.is_displayed()
+                and not self.find_elements(*self._loading_locator)
+                and self.job_details.result
+            )
 
         @property
         def job_details(self):
@@ -345,7 +352,10 @@ class Treeherder(Base):
         class SummaryPanel(Region):
 
             _root_locator = (By.ID, 'summary-panel')
-            _keywords_locator = (By.CSS_SELECTOR, 'a[title="Filter jobs containing these keywords"]')
+            _keywords_locator = (
+                By.CSS_SELECTOR,
+                'a[title="Filter jobs containing these keywords"]',
+            )
             _log_viewer_locator = (By.CLASS_NAME, 'logviewer-btn')
             _result_locator = (By.CSS_SELECTOR, '#result-status-pane div:nth-of-type(1) span')
 
@@ -371,4 +381,5 @@ class Treeherder(Base):
                 self.driver.switch_to.window(handles[0])
 
                 from pages.log_viewer import LogViewer
+
                 return LogViewer(self.driver).wait_for_page_to_load()

--- a/tests/selenium/test_expand_job_group.py
+++ b/tests/selenium/test_expand_job_group.py
@@ -9,10 +9,7 @@ def test_jobs(eleven_job_blobs, create_jobs):
     job_blobs = []
     for guid in [b['job']['job_guid'] for b in eleven_job_blobs]:
         job = copy.deepcopy(eleven_job_blobs[0])
-        job['job'].update({
-            'job_guid': guid,
-            'job_symbol': 'job',
-            'group_symbol': 'Group'})
+        job['job'].update({'job_guid': guid, 'job_symbol': 'job', 'group_symbol': 'Group'})
         job_blobs.append(job)
     return create_jobs(job_blobs)
 

--- a/tests/selenium/test_log_viewer.py
+++ b/tests/selenium/test_log_viewer.py
@@ -14,10 +14,8 @@ def test_job(eleven_job_blobs, create_jobs):
 @pytest.fixture(name='log')
 def fixture_log(test_job):
     return JobLog.objects.create(
-        job=test_job,
-        name='log1',
-        url='https://example.com',
-        status=JobLog.PARSED)
+        job=test_job, name='log1', url='https://example.com', status=JobLog.PARSED
+    )
 
 
 def test_open_log_viewer(base_url, selenium, log):

--- a/tests/selenium/test_select_unclassified_job.py
+++ b/tests/selenium/test_select_unclassified_job.py
@@ -8,7 +8,7 @@ RESULTS = ['testfailed', 'busted', 'exception']
 def test_jobs(eleven_job_blobs, create_jobs):
     for i, status in enumerate(RESULTS):
         eleven_job_blobs[i]['job']['result'] = status
-    return create_jobs(eleven_job_blobs[0:len(RESULTS)])
+    return create_jobs(eleven_job_blobs[0 : len(RESULTS)])
 
 
 def test_select_next_unclassified_job(base_url, selenium, test_jobs):

--- a/tests/services/pulse/test_consumers.py
+++ b/tests/services/pulse/test_consumers.py
@@ -2,15 +2,13 @@ import pytest
 from django.conf import settings
 
 from tests.conftest import IS_WINDOWS
-from treeherder.services.pulse.consumers import (Consumers,
-                                                 PulseConsumer)
+from treeherder.services.pulse.consumers import Consumers, PulseConsumer
 
 from .utils import create_and_destroy_exchange
 
 
 def test_Consumers():
     class TestConsumer:
-
         def prepare(self):
             self.prepared = True
 
@@ -41,5 +39,11 @@ def test_PulseConsumer(pulse_connection):
             pass
 
     with create_and_destroy_exchange(pulse_connection, "foobar"):
-        cons = TestConsumer({"root_url": "https://firefox-ci-tc.services.mozilla.com", "pulse_url": settings.CELERY_BROKER_URL}, None)
+        cons = TestConsumer(
+            {
+                "root_url": "https://firefox-ci-tc.services.mozilla.com",
+                "pulse_url": settings.CELERY_BROKER_URL,
+            },
+            None,
+        )
         cons.prepare()

--- a/tests/services/test_taskcluster.py
+++ b/tests/services/test_taskcluster.py
@@ -1,14 +1,11 @@
 import json
-from os.path import (dirname,
-                     join)
+from os.path import dirname, join
 
 import pytest
 
 from treeherder.services.taskcluster import TaskclusterModel
 
-SAMPLE_DATA_PATH = join(
-    dirname(dirname(__file__)),
-    'sample_data')
+SAMPLE_DATA_PATH = join(dirname(dirname(__file__)), 'sample_data')
 
 
 def load_json_fixture(from_file):
@@ -18,38 +15,43 @@ def load_json_fixture(from_file):
 
 
 @pytest.fixture(scope="module")
-def actions_json(): return load_json_fixture('initialActions.json')
+def actions_json():
+    return load_json_fixture('initialActions.json')
 
 
 @pytest.fixture(scope="module")
-def expected_actions_json(): return load_json_fixture('reducedActions.json')
+def expected_actions_json():
+    return load_json_fixture('reducedActions.json')
 
 
 @pytest.fixture(scope="module")
-def original_task(): return load_json_fixture('originalTask.json')
+def original_task():
+    return load_json_fixture('originalTask.json')
 
 
 @pytest.fixture(scope="module")
-def expected_backfill_task(): return load_json_fixture('backfilltask.json')
+def expected_backfill_task():
+    return load_json_fixture('backfilltask.json')
 
 
 # TaskclusterModel
 def test_filter_relevant_actions(actions_json, original_task, expected_actions_json):
-    reduced_actions_json = TaskclusterModel._filter_relevant_actions(actions_json,
-                                                                     original_task)
+    reduced_actions_json = TaskclusterModel._filter_relevant_actions(actions_json, original_task)
 
     assert reduced_actions_json == expected_actions_json
 
 
 def test_task_in_context():
     # match
-    tag_set_list, task_tags = [load_json_fixture(f)
-                               for f in ("matchingTagSetList.json", "matchingTaskTags.json")]
+    tag_set_list, task_tags = [
+        load_json_fixture(f) for f in ("matchingTagSetList.json", "matchingTaskTags.json")
+    ]
     assert TaskclusterModel._task_in_context(tag_set_list, task_tags) is True
 
     # mismatch
-    tag_set_list, task_tags = [load_json_fixture(f)
-                               for f in ("mismatchingTagSetList.json", "mismatchingTaskTags.json")]
+    tag_set_list, task_tags = [
+        load_json_fixture(f) for f in ("mismatchingTagSetList.json", "mismatchingTaskTags.json")
+    ]
     assert TaskclusterModel._task_in_context(tag_set_list, task_tags) is False
 
 

--- a/tests/seta/conftest.py
+++ b/tests/seta/conftest.py
@@ -1,11 +1,9 @@
 import pytest
 
-from treeherder.model.models import (Job,
-                                     JobNote)
+from treeherder.model.models import Job, JobNote
 from treeherder.seta.common import job_priority_index
 from treeherder.seta.models import JobPriority
-from treeherder.seta.settings import (SETA_HIGH_VALUE_PRIORITY,
-                                      SETA_LOW_VALUE_PRIORITY)
+from treeherder.seta.settings import SETA_HIGH_VALUE_PRIORITY, SETA_LOW_VALUE_PRIORITY
 from treeherder.seta.update_job_priority import _sanitize_data
 
 
@@ -13,38 +11,44 @@ from treeherder.seta.update_job_priority import _sanitize_data
 def runnable_jobs_data():
     repository_name = 'test_treeherder_jobs'
     runnable_jobs = [
-            {
-                "build_system_type": "buildbot",
-                "job_type_name": "W3C Web Platform Tests",
-                "platform": "windows8-64",
-                "platform_option": "debug",
-                "ref_data_name": "Windows 8 64-bit {} debug test web-platform-tests-1".format(repository_name),
-            }, {
-                "build_system_type": "buildbot",
-                "job_type_name": "Reftest e10s",
-                "platform": "linux32",
-                "platform_option": "opt",
-                "ref_data_name": "Ubuntu VM 12.04 {} opt test reftest-e10s-1".format(repository_name),
-            }, {
-                "build_system_type": "buildbot",
-                "job_type_name": "Build",
-                "platform": "osx-10-7",
-                "platform_option": "opt",
-                "ref_data_name": "OS X 10.7 {} build".format(repository_name),
-            }, {
-                "build_system_type": "taskcluster",
-                "job_type_name": "test-linux32/opt-reftest-e10s-1",
-                "platform": "linux32",
-                "platform_option": "opt",
-                "ref_data_name": "test-linux32/opt-reftest-e10s-1",
-            }, {
-                "build_system_type": "taskcluster",
-                "job_type_name": "test-linux64/opt-reftest-e10s-2",
-                "platform": "linux64",
-                "platform_option": "opt",
-                "ref_data_name": "test-linux64/opt-reftest-e10s-2",
-            }
-        ]
+        {
+            "build_system_type": "buildbot",
+            "job_type_name": "W3C Web Platform Tests",
+            "platform": "windows8-64",
+            "platform_option": "debug",
+            "ref_data_name": "Windows 8 64-bit {} debug test web-platform-tests-1".format(
+                repository_name
+            ),
+        },
+        {
+            "build_system_type": "buildbot",
+            "job_type_name": "Reftest e10s",
+            "platform": "linux32",
+            "platform_option": "opt",
+            "ref_data_name": "Ubuntu VM 12.04 {} opt test reftest-e10s-1".format(repository_name),
+        },
+        {
+            "build_system_type": "buildbot",
+            "job_type_name": "Build",
+            "platform": "osx-10-7",
+            "platform_option": "opt",
+            "ref_data_name": "OS X 10.7 {} build".format(repository_name),
+        },
+        {
+            "build_system_type": "taskcluster",
+            "job_type_name": "test-linux32/opt-reftest-e10s-1",
+            "platform": "linux32",
+            "platform_option": "opt",
+            "ref_data_name": "test-linux32/opt-reftest-e10s-1",
+        },
+        {
+            "build_system_type": "taskcluster",
+            "job_type_name": "test-linux64/opt-reftest-e10s-2",
+            "platform": "linux64",
+            "platform_option": "opt",
+            "ref_data_name": "test-linux64/opt-reftest-e10s-2",
+        },
+    ]
 
     return runnable_jobs
 
@@ -56,7 +60,7 @@ def tc_latest_gecko_decision_index(test_repository):
         "taskId": "XVDNiP07RNaaEghhvkZJWg",
         "rank": 0,
         "data": {},
-        "expires": "2018-01-04T20:36:11.375Z"
+        "expires": "2018-01-04T20:36:11.375Z",
     }
 
 
@@ -82,13 +86,15 @@ def all_job_priorities_stored(job_priority_list):
 def job_priority_list(sanitized_data):
     jp_list = []
     for datum in sanitized_data:
-        jp_list.append(JobPriority(
-            testtype=datum['testtype'],
-            buildtype=datum['platform_option'],
-            platform=datum['platform'],
-            buildsystem=datum['build_system_type'],
-            priority=SETA_HIGH_VALUE_PRIORITY,
-        ))
+        jp_list.append(
+            JobPriority(
+                testtype=datum['testtype'],
+                buildtype=datum['platform_option'],
+                platform=datum['platform'],
+                buildsystem=datum['build_system_type'],
+                priority=SETA_HIGH_VALUE_PRIORITY,
+            )
+        )
         # Mark the reftest-e10s-2 TC job as low priority (unique to TC)
         if datum['testtype'] == 'reftest-e10s-2':
             jp_list[-1].priority = SETA_LOW_VALUE_PRIORITY
@@ -105,8 +111,9 @@ def jp_index_fixture(job_priority_list):
 
 
 @pytest.fixture
-def fifteen_jobs_with_notes(eleven_jobs_stored, taskcluster_jobs_stored, test_user,
-                            failure_classifications):
+def fifteen_jobs_with_notes(
+    eleven_jobs_stored, taskcluster_jobs_stored, test_user, failure_classifications
+):
     """provide 15 jobs with job notes."""
     counter = 0
     for job in Job.objects.all():
@@ -114,54 +121,56 @@ def fifteen_jobs_with_notes(eleven_jobs_stored, taskcluster_jobs_stored, test_us
 
         # add 5 valid job notes related to 'this is revision x'
         if counter < 6:
-            JobNote.objects.create(job=job,
-                                   failure_classification_id=2,
-                                   user=test_user, text="this is revision x")
+            JobNote.objects.create(
+                job=job, failure_classification_id=2, user=test_user, text="this is revision x"
+            )
             continue
 
         # add 3 valid job notes with raw revision 31415926535
         if counter < 9:
-            JobNote.objects.create(job=job,
-                                   failure_classification_id=2,
-                                   user=test_user, text="314159265358")
+            JobNote.objects.create(
+                job=job, failure_classification_id=2, user=test_user, text="314159265358"
+            )
             continue
 
         # Add 3 job notes with full url to revision, expected to map to 31415926535
         if counter < 12:
-            JobNote.objects.create(job=job,
-                                   failure_classification_id=2,
-                                   user=test_user, text="http://hg.mozilla.org/mozilla-central/314159265358")
+            JobNote.objects.create(
+                job=job,
+                failure_classification_id=2,
+                user=test_user,
+                text="http://hg.mozilla.org/mozilla-central/314159265358",
+            )
             continue
 
         # Add 1 valid job with trailing slash, expected to map to 31415926535
         if counter < 13:
-            JobNote.objects.create(job=job,
-                                   failure_classification_id=2,
-                                   user=test_user, text="http://hg.mozilla.org/mozilla-central/314159265358/")
+            JobNote.objects.create(
+                job=job,
+                failure_classification_id=2,
+                user=test_user,
+                text="http://hg.mozilla.org/mozilla-central/314159265358/",
+            )
             continue
 
         # Add 1 job with invalid revision text, expect it to be ignored
         if counter < 14:
             # We will ignore this based on text length
-            JobNote.objects.create(job=job,
-                                   failure_classification_id=2,
-                                   user=test_user, text="too short")
+            JobNote.objects.create(
+                job=job, failure_classification_id=2, user=test_user, text="too short"
+            )
             continue
 
         # Add 1 job with no revision text, expect it to be ignored
         if counter < 15:
             # We will ignore this based on blank note
-            JobNote.objects.create(job=job,
-                                   failure_classification_id=2,
-                                   user=test_user, text="")
+            JobNote.objects.create(job=job, failure_classification_id=2, user=test_user, text="")
             continue
 
         # Add 1 more job with invalid revision text, expect it to be ignored
         if counter < 16:
             # We will ignore this based on effectively blank note
-            JobNote.objects.create(job=job,
-                                   failure_classification_id=2,
-                                   user=test_user, text="/")
+            JobNote.objects.create(job=job, failure_classification_id=2, user=test_user, text="/")
             continue
 
         # if we have any more jobs defined it will break this test, ignore
@@ -186,7 +195,8 @@ def failures_fixed_by_commit():
             (u'b2g_mozilla-release_inari_dep', u'opt', u'b2g-device-image'),
             (u'b2g_mozilla-release_nexus-4_dep', u'opt', u'b2g-device-image'),
             (u'mochitest-devtools-chrome-3', u'debug', u'linux64'),
-        ]}
+        ],
+    }
 
 
 @pytest.fixture

--- a/tests/seta/test_analyze_failures.py
+++ b/tests/seta/test_analyze_failures.py
@@ -4,7 +4,9 @@ from treeherder.seta.analyze_failures import get_failures_fixed_by_commit
 
 
 @pytest.mark.django_db()
-def test_analyze_failures(fifteen_jobs_with_notes, failures_fixed_by_commit, patched_seta_fixed_by_commit_repos):
+def test_analyze_failures(
+    fifteen_jobs_with_notes, failures_fixed_by_commit, patched_seta_fixed_by_commit_repos
+):
     ret = get_failures_fixed_by_commit()
     exp = failures_fixed_by_commit
 

--- a/tests/seta/test_job_priorities.py
+++ b/tests/seta/test_job_priorities.py
@@ -3,23 +3,25 @@ import datetime
 import pytest
 from mock import patch
 
-from treeherder.seta.job_priorities import (SetaError,
-                                            seta_job_scheduling)
+from treeherder.seta.job_priorities import SetaError, seta_job_scheduling
 
 
 @pytest.mark.django_db()
 @patch('treeherder.seta.job_priorities.SETAJobPriorities._validate_request', return_value=None)
 @patch('treeherder.etl.seta.list_runnable_jobs')
-def test_gecko_decision_task(runnable_jobs_list, validate_request,
-                             test_repository, runnable_jobs_data,
-                             all_job_priorities_stored):
+def test_gecko_decision_task(
+    runnable_jobs_list,
+    validate_request,
+    test_repository,
+    runnable_jobs_data,
+    all_job_priorities_stored,
+):
     '''
     When the Gecko decision task calls SETA it will return all jobs that are less likely to catch
     a regression (low value jobs).
     '''
     runnable_jobs_list.return_value = runnable_jobs_data
-    jobs = seta_job_scheduling(project=test_repository.name,
-                               build_system_type='taskcluster')
+    jobs = seta_job_scheduling(project=test_repository.name, build_system_type='taskcluster')
     assert len(jobs['jobtypes'][str(datetime.date.today())]) == 1
 
 
@@ -31,5 +33,7 @@ def test_gecko_decision_task_invalid_repo():
     with pytest.raises(SetaError) as exception_info:
         seta_job_scheduling(project='mozilla-repo-x', build_system_type='taskcluster')
 
-    assert str(exception_info.value) == "The specified project repo 'mozilla-repo-x' " \
-                                        "is not supported by SETA."
+    assert (
+        str(exception_info.value) == "The specified project repo 'mozilla-repo-x' "
+        "is not supported by SETA."
+    )

--- a/tests/seta/test_models.py
+++ b/tests/seta/test_models.py
@@ -12,22 +12,26 @@ YESTERDAY = timezone.now() - datetime.timedelta(days=1)
 
 # JobPriority tests
 def test_expired_job_priority():
-    jp = JobPriority(testtype='web-platform-tests-1',
-                     buildtype='opt',
-                     platform='windows8-64',
-                     priority=1,
-                     expiration_date=YESTERDAY,
-                     buildsystem='taskcluster')
+    jp = JobPriority(
+        testtype='web-platform-tests-1',
+        buildtype='opt',
+        platform='windows8-64',
+        priority=1,
+        expiration_date=YESTERDAY,
+        buildsystem='taskcluster',
+    )
     assert jp.has_expired()
 
 
 def test_not_expired_job_priority():
-    jp = JobPriority(testtype='web-platform-tests-1',
-                     buildtype='opt',
-                     platform='windows8-64',
-                     priority=1,
-                     expiration_date=TOMORROW,
-                     buildsystem='taskcluster')
+    jp = JobPriority(
+        testtype='web-platform-tests-1',
+        buildtype='opt',
+        platform='windows8-64',
+        priority=1,
+        expiration_date=TOMORROW,
+        buildsystem='taskcluster',
+    )
     assert not jp.has_expired()
 
 
@@ -41,7 +45,8 @@ def test_null_testtype():
             platform='windows8-64',
             priority=1,
             expiration_date=TOMORROW,
-            buildsystem='taskcluster')
+            buildsystem='taskcluster',
+        )
 
 
 @pytest.mark.django_db()
@@ -53,5 +58,6 @@ def test_null_expiration_date():
         platform='windows8-64',
         priority=1,
         expiration_date=None,
-        buildsystem='taskcluster')
+        buildsystem='taskcluster',
+    )
     assert jp.expiration_date is None

--- a/tests/seta/test_update_job_priority.py
+++ b/tests/seta/test_update_job_priority.py
@@ -2,11 +2,13 @@ import pytest
 from mock import patch
 
 from treeherder.seta.models import JobPriority
-from treeherder.seta.update_job_priority import (_initialize_values,
-                                                 _sanitize_data,
-                                                 _unique_key,
-                                                 _update_table,
-                                                 query_sanitized_data)
+from treeherder.seta.update_job_priority import (
+    _initialize_values,
+    _sanitize_data,
+    _unique_key,
+    _update_table,
+    query_sanitized_data,
+)
 
 
 def test_unique_key():
@@ -14,7 +16,7 @@ def test_unique_key():
         'build_system_type': 'buildbot',
         'platform': 'windows8-64',
         'platform_option': 'opt',
-        'testtype': 'web-platform-tests-1'
+        'testtype': 'web-platform-tests-1',
     }
     assert _unique_key(new_job), ('web-platform-tests-1', 'opt', 'windows8-64')
 
@@ -48,8 +50,7 @@ def test_initialize_values_no_data():
 
 @patch.object(JobPriority, 'save')
 @patch('treeherder.seta.update_job_priority._initialize_values')
-def test_update_table_empty_table(initial_values, jp_save,
-                                  sanitized_data):
+def test_update_table_empty_table(initial_values, jp_save, sanitized_data):
     '''
     We test that starting from an empty table
     '''
@@ -67,21 +68,31 @@ def test_update_table_job_from_other_buildsysten(all_job_priorities_stored):
         'build_system_type': 'buildbot',
         'platform': 'linux64',
         'platform_option': 'opt',
-        'testtype': 'reftest-e10s-2'
+        'testtype': 'reftest-e10s-2',
     }
     # Before calling update_table the priority is only for TaskCluster
-    assert len(JobPriority.objects.filter(
-            buildsystem='taskcluster',
-            buildtype=data['platform_option'],
-            platform=data['platform'],
-            testtype=data['testtype'],
-    )) == 1
+    assert (
+        len(
+            JobPriority.objects.filter(
+                buildsystem='taskcluster',
+                buildtype=data['platform_option'],
+                platform=data['platform'],
+                testtype=data['testtype'],
+            )
+        )
+        == 1
+    )
     # We are checking that only 1 job was updated
     ret_val = _update_table([data])
     assert ret_val == (0, 0, 1)
-    assert len(JobPriority.objects.filter(
-            buildsystem='*',
-            buildtype=data['platform_option'],
-            platform=data['platform'],
-            testtype=data['testtype'],
-    )) == 1
+    assert (
+        len(
+            JobPriority.objects.filter(
+                buildsystem='*',
+                buildtype=data['platform_option'],
+                platform=data['platform'],
+                testtype=data['testtype'],
+            )
+        )
+        == 1
+    )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -22,9 +22,7 @@ BUGFILER_API_URL = "https://thisisnotbugzilla.org"
 # access.  But if we use the defaults in config.settings, we also get the
 # ``ModelBackend``, which will try to access the DB.  This ensures we don't
 # do that, since we don't have any tests that use the ``ModelBackend``.
-AUTHENTICATION_BACKENDS = (
-    'treeherder.auth.backends.AuthBackend',
-)
+AUTHENTICATION_BACKENDS = ('treeherder.auth.backends.AuthBackend',)
 
 # For Push Health Usage dashboard
 NEW_RELIC_INSIGHTS_API_KEY = "123"

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -40,7 +40,9 @@ def test_get_tls_redis_url():
     https://devcenter.heroku.com/articles/securing-heroku-redis#connecting-directly-to-stunnel
     """
     REDIS_URL = 'redis://h:abc8069@ec2-12-34-56-78.compute-1.amazonaws.com:8069'
-    TLS_REDIS_URL = 'rediss://h:abc8069@ec2-12-34-56-78.compute-1.amazonaws.com:8070?ssl_cert_reqs=none'
+    TLS_REDIS_URL = (
+        'rediss://h:abc8069@ec2-12-34-56-78.compute-1.amazonaws.com:8070?ssl_cert_reqs=none'
+    )
     assert get_tls_redis_url(REDIS_URL) == TLS_REDIS_URL
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,8 +9,7 @@ from treeherder.etl.push import store_push_data
 from treeherder.model import models
 
 
-def do_job_ingestion(test_repository, job_data, sample_push,
-                     verify_data=True):
+def do_job_ingestion(test_repository, job_data, sample_push, verify_data=True):
     """
     Ingest ``job_data`` which will be JSON job blobs.
 
@@ -57,18 +56,24 @@ def do_job_ingestion(test_repository, job_data, sample_push,
             job = blob['job']
 
             build_platforms_ref.add(
-                "-".join([
-                    job.get('build_platform', {}).get('os_name', 'unknown'),
-                    job.get('build_platform', {}).get('platform', 'unknown'),
-                    job.get('build_platform', {}).get('architecture', 'unknown')
-                ]))
+                "-".join(
+                    [
+                        job.get('build_platform', {}).get('os_name', 'unknown'),
+                        job.get('build_platform', {}).get('platform', 'unknown'),
+                        job.get('build_platform', {}).get('architecture', 'unknown'),
+                    ]
+                )
+            )
 
             machine_platforms_ref.add(
-                "-".join([
-                    job.get('machine_platform', {}).get('os_name', 'unknown'),
-                    job.get('machine_platform', {}).get('platform', 'unknown'),
-                    job.get('machine_platform', {}).get('architecture', 'unknown')
-                ]))
+                "-".join(
+                    [
+                        job.get('machine_platform', {}).get('os_name', 'unknown'),
+                        job.get('machine_platform', {}).get('platform', 'unknown'),
+                        job.get('machine_platform', {}).get('architecture', 'unknown'),
+                    ]
+                )
+            )
 
             machines_ref.add(job.get('machine', 'unknown'))
 
@@ -110,11 +115,8 @@ def verify_build_platforms(build_platforms_ref):
     build_platforms_set = set()
     for build_platform in models.BuildPlatform.objects.all():
         build_platforms_set.add(
-            "-".join([
-                build_platform.os_name,
-                build_platform.platform,
-                build_platform.architecture
-            ]))
+            "-".join([build_platform.os_name, build_platform.platform, build_platform.architecture])
+        )
 
     assert build_platforms_ref.issubset(build_platforms_set)
 
@@ -124,11 +126,10 @@ def verify_machine_platforms(machine_platforms_ref):
     machine_platforms_set = set()
     for machine_platform in models.MachinePlatform.objects.all():
         machine_platforms_set.add(
-            "-".join([
-                machine_platform.os_name,
-                machine_platform.platform,
-                machine_platform.architecture
-            ]))
+            "-".join(
+                [machine_platform.os_name, machine_platform.platform, machine_platform.architecture]
+            )
+        )
 
     assert machine_platforms_ref.issubset(machine_platforms_set)
 
@@ -161,8 +162,7 @@ def verify_products(products_ref):
 
 def verify_pushes(test_repository, pushes_ref):
 
-    return pushes_ref.issubset(models.Push.objects.values_list(
-        'revision', flat=True))
+    return pushes_ref.issubset(models.Push.objects.values_list('revision', flat=True))
 
 
 def verify_log_urls(test_repository, log_urls_ref):
@@ -173,8 +173,9 @@ def verify_log_urls(test_repository, log_urls_ref):
 
 
 def verify_superseded(expected_superseded_job_guids):
-    superseeded_guids = models.Job.objects.filter(
-        result='superseded').values_list('guid', flat=True)
+    superseeded_guids = models.Job.objects.filter(result='superseded').values_list(
+        'guid', flat=True
+    )
     assert set(superseeded_guids) == expected_superseded_job_guids
 
 
@@ -209,7 +210,8 @@ def create_generic_job(guid, repository, push_id, generic_reference_data):
         submit_time=job_time,
         start_time=job_time,
         end_time=job_time,
-        tier=1)
+        tier=1,
+    )
 
 
 def add_log_response(filename):
@@ -225,9 +227,6 @@ def add_log_response(filename):
             responses.GET,
             log_url,
             body=content,
-            adding_headers={
-                'Content-Encoding': 'gzip',
-                'Content-Length': str(len(content)),
-            }
+            adding_headers={'Content-Encoding': 'gzip', 'Content-Length': str(len(content)),},
         )
     return log_url

--- a/tests/test_worker/test_pulse_tasks.py
+++ b/tests/test_worker/test_pulse_tasks.py
@@ -9,9 +9,9 @@ from treeherder.model.models import Job
 
 
 @pytest.mark.skip("Test needs fixing in bug: 1307289 (plus upgrade from jobs to tasks)")
-def test_retry_missing_revision_succeeds(sample_data, sample_push,
-                                         test_repository, mock_log_parser,
-                                         monkeypatch):
+def test_retry_missing_revision_succeeds(
+    sample_data, sample_push, test_repository, mock_log_parser, monkeypatch
+):
     """
     Ensure that when the missing push exists after a retry, that the job
     is then ingested.

--- a/tests/utils/test_queryset.py
+++ b/tests/utils/test_queryset.py
@@ -1,8 +1,6 @@
-from tests.autoclassify.utils import (create_failure_lines,
-                                      test_line)
+from tests.autoclassify.utils import create_failure_lines, test_line
 from treeherder.model.models import FailureLine
-from treeherder.utils.queryset import (chunked_qs,
-                                       chunked_qs_reverse)
+from treeherder.utils.queryset import chunked_qs, chunked_qs_reverse
 
 
 def test_chunked_qs(test_job):

--- a/tests/utils/test_taskcluster_lib_scopes.py
+++ b/tests/utils/test_taskcluster_lib_scopes.py
@@ -1,65 +1,69 @@
 import pytest
 
-from treeherder.utils.taskcluster_lib_scopes import (patternMatch,
-                                                     satisfiesExpression)
+from treeherder.utils.taskcluster_lib_scopes import patternMatch, satisfiesExpression
 
 
 # satisfiesExpression()
-@pytest.mark.parametrize('scopeset, expression', [
-    [[], {'AllOf': []}],
-    [['A'], {'AllOf': ['A']}],
-    [['A', 'B'], 'A'],
-    [['a*', 'b*', 'c*'], 'abc'],
-    [['abc'], {'AnyOf': ['abc', 'def']}],
-    [['def'], {'AnyOf': ['abc', 'def']}],
-    [['abc', 'def'], {'AnyOf': ['abc', 'def']}],
-    [['abc*'], {'AnyOf': ['abc', 'def']}],
-    [['abc*'], {'AnyOf': ['abc']}],
-    [['abc*', 'def*'], {'AnyOf': ['abc', 'def']}],
-    [['foo'], {'AllOf': [{'AnyOf': [{'AllOf': ['foo']}, {'AllOf': ['bar']}]}]}],
-    [['a*', 'b*', 'c*'], {'AnyOf': ['cfoo', 'dfoo']}],
-    [['a*', 'b*', 'c*'], {'AnyOf': ['bx', 'by']}],
-    [['a*', 'b*', 'c*'], {'AllOf': ['bx', 'cx']}],
-    # complex expression with only
-    # some AnyOf branches matching
+@pytest.mark.parametrize(
+    'scopeset, expression',
     [
-        ['a*', 'b*', 'c*'],
-        {'AnyOf': [
-            {'AllOf': ['ax', 'jx']},  # doesn't match
-            {'AllOf': ['bx', 'cx']},  # does match
-            'bbb',
-        ]},
+        [[], {'AllOf': []}],
+        [['A'], {'AllOf': ['A']}],
+        [['A', 'B'], 'A'],
+        [['a*', 'b*', 'c*'], 'abc'],
+        [['abc'], {'AnyOf': ['abc', 'def']}],
+        [['def'], {'AnyOf': ['abc', 'def']}],
+        [['abc', 'def'], {'AnyOf': ['abc', 'def']}],
+        [['abc*'], {'AnyOf': ['abc', 'def']}],
+        [['abc*'], {'AnyOf': ['abc']}],
+        [['abc*', 'def*'], {'AnyOf': ['abc', 'def']}],
+        [['foo'], {'AllOf': [{'AnyOf': [{'AllOf': ['foo']}, {'AllOf': ['bar']}]}]}],
+        [['a*', 'b*', 'c*'], {'AnyOf': ['cfoo', 'dfoo']}],
+        [['a*', 'b*', 'c*'], {'AnyOf': ['bx', 'by']}],
+        [['a*', 'b*', 'c*'], {'AllOf': ['bx', 'cx']}],
+        # complex expression with only
+        # some AnyOf branches matching
+        [
+            ['a*', 'b*', 'c*'],
+            {
+                'AnyOf': [
+                    {'AllOf': ['ax', 'jx']},  # doesn't match
+                    {'AllOf': ['bx', 'cx']},  # does match
+                    'bbb',
+                ]
+            },
+        ],
     ],
-])
+)
 def test_expression_is_satisfied(scopeset, expression):
     assert satisfiesExpression(scopeset, expression) is True
 
 
-@pytest.mark.parametrize('scopeset, expression', [
-      [[], {'AnyOf': []}],
-      [[], 'missing-scope'],
-      [['wrong-scope'], 'missing-scope'],
-      [['ghi'], {'AnyOf': ['abc', 'def']}],
-      [['ghi*'], {'AnyOf': ['abc', 'def']}],
-      [['ghi', 'fff'], {'AnyOf': ['abc', 'def']}],
-      [['ghi*', 'fff*'], {'AnyOf': ['abc', 'def']}],
-      [['abc'], {'AnyOf': ['ghi']}],
-      [['abc*'], {'AllOf': ['abc', 'ghi']}],
-      [[''], {'AnyOf': ['abc', 'def']}],
-      [['abc:def'], {'AnyOf': ['abc', 'def']}],
-      [['xyz', 'abc'], {'AllOf': [{'AnyOf': [{'AllOf': ['foo']}, {'AllOf': ['bar']}]}]}],
-      [['a*', 'b*', 'c*'], {'AllOf': ['bx', 'cx', {'AnyOf': ['xxx', 'yyyy']}]}],
-])
+@pytest.mark.parametrize(
+    'scopeset, expression',
+    [
+        [[], {'AnyOf': []}],
+        [[], 'missing-scope'],
+        [['wrong-scope'], 'missing-scope'],
+        [['ghi'], {'AnyOf': ['abc', 'def']}],
+        [['ghi*'], {'AnyOf': ['abc', 'def']}],
+        [['ghi', 'fff'], {'AnyOf': ['abc', 'def']}],
+        [['ghi*', 'fff*'], {'AnyOf': ['abc', 'def']}],
+        [['abc'], {'AnyOf': ['ghi']}],
+        [['abc*'], {'AllOf': ['abc', 'ghi']}],
+        [[''], {'AnyOf': ['abc', 'def']}],
+        [['abc:def'], {'AnyOf': ['abc', 'def']}],
+        [['xyz', 'abc'], {'AllOf': [{'AnyOf': [{'AllOf': ['foo']}, {'AllOf': ['bar']}]}]}],
+        [['a*', 'b*', 'c*'], {'AllOf': ['bx', 'cx', {'AnyOf': ['xxx', 'yyyy']}]}],
+    ],
+)
 def test_expression_is_not_satisfied(scopeset, expression):
     assert not satisfiesExpression(scopeset, expression)
 
 
-@pytest.mark.parametrize('scopeset', [
-    None,
-    'scopeset_argument',
-    ('scopeset', 'argument'),
-    {'scopeset', 'argument'},
-])
+@pytest.mark.parametrize(
+    'scopeset', [None, 'scopeset_argument', ('scopeset', 'argument'), {'scopeset', 'argument'},]
+)
 def test_wrong_scopeset_type_raises_exception(scopeset):
     with pytest.raises(TypeError):
         satisfiesExpression(scopeset, 'in-tree:hook-action:{hook_group_id}/{hook_id}')
@@ -70,18 +74,16 @@ def test_identical_scope_and_pattern_are_matching():
     assert patternMatch('mock:scope', 'mock:scope') is True
 
 
-@pytest.mark.parametrize('pattern, scope', [
-    ('matching*', 'matching'),
-    ('matching*', 'matching/scope')
-])
+@pytest.mark.parametrize(
+    'pattern, scope', [('matching*', 'matching'), ('matching*', 'matching/scope')]
+)
 def test_starred_patterns_are_matching(pattern, scope):
     assert patternMatch(pattern, scope) is True
 
 
-@pytest.mark.parametrize('pattern, scope', [
-    ('matching*', 'mismatching'),
-    ('match*ing', 'matching'),
-    ('*matching', 'matching')
-])
+@pytest.mark.parametrize(
+    'pattern, scope',
+    [('matching*', 'mismatching'), ('match*ing', 'matching'), ('*matching', 'matching')],
+)
 def test_starred_patterns_dont_matching(pattern, scope):
     assert not patternMatch(pattern, scope)

--- a/tests/webapp/api/test_bug_job_map_api.py
+++ b/tests/webapp/api/test_bug_job_map_api.py
@@ -3,16 +3,15 @@ import json
 import pytest
 from django.urls import reverse
 
-from treeherder.model.models import (BugJobMap,
-                                     Job)
+from treeherder.model.models import BugJobMap, Job
 
 
-@pytest.mark.parametrize('test_no_auth,test_duplicate_handling', [
-    (True, False),
-    (False, False),
-    (False, True)])
-def test_create_bug_job_map(client, test_job, test_user, bugs,
-                            test_no_auth, test_duplicate_handling):
+@pytest.mark.parametrize(
+    'test_no_auth,test_duplicate_handling', [(True, False), (False, False), (False, True)]
+)
+def test_create_bug_job_map(
+    client, test_job, test_user, bugs, test_no_auth, test_duplicate_handling
+):
     """
     test creating a single note via endpoint
     """
@@ -20,11 +19,7 @@ def test_create_bug_job_map(client, test_job, test_user, bugs,
     if not test_no_auth:
         client.force_authenticate(user=test_user)
 
-    submit_obj = {
-        u"job_id": test_job.id,
-        u"bug_id": bug.id,
-        u"type": u"manual"
-    }
+    submit_obj = {u"job_id": test_job.id, u"bug_id": bug.id, u"type": u"manual"}
 
     # if testing duplicate handling, submit twice
     if test_duplicate_handling:
@@ -35,7 +30,7 @@ def test_create_bug_job_map(client, test_job, test_user, bugs,
     for _ in range(num_times):
         resp = client.post(
             reverse("bug-job-map-list", kwargs={"project": test_job.repository.name}),
-            data=submit_obj
+            data=submit_obj,
         )
 
     if test_no_auth:
@@ -59,31 +54,28 @@ def test_bug_job_map_list(client, test_repository, eleven_jobs_stored, test_user
     expected = list()
 
     for (i, job) in enumerate(jobs):
-        bjm = BugJobMap.create(
-            job_id=job.id,
-            bug_id=bugs[i].id,
-            user=test_user,
-        )
+        bjm = BugJobMap.create(job_id=job.id, bug_id=bugs[i].id, user=test_user,)
 
-        expected.append({
-            "job_id": job.id,
-            "bug_id": bugs[i].id,
-            "created": bjm.created.isoformat(),
-            "who": test_user.email
-        })
+        expected.append(
+            {
+                "job_id": job.id,
+                "bug_id": bugs[i].id,
+                "created": bjm.created.isoformat(),
+                "who": test_user.email,
+            }
+        )
 
     # verify that API works with different combinations of job_id= parameters
     for job_range in [(0, 1), (0, 2), (0, 9)]:
         resp = client.get(
             reverse("bug-job-map-list", kwargs={"project": test_repository.name}),
-            data={'job_id': [job.id for job in
-                             jobs[job_range[0]:job_range[1]]]})
+            data={'job_id': [job.id for job in jobs[job_range[0] : job_range[1]]]},
+        )
         assert resp.status_code == 200
-        assert resp.json() == expected[job_range[0]:job_range[1]]
+        assert resp.json() == expected[job_range[0] : job_range[1]]
 
 
-def test_bug_job_map_detail(client, eleven_jobs_stored, test_repository,
-                            test_user, bugs):
+def test_bug_job_map_detail(client, eleven_jobs_stored, test_repository, test_user, bugs):
     """
     test retrieving a list of bug_job_map
     """
@@ -91,19 +83,12 @@ def test_bug_job_map_detail(client, eleven_jobs_stored, test_repository,
     bug = bugs[0]
     expected = list()
 
-    bjm = BugJobMap.create(
-        job_id=job.id,
-        bug_id=bug.id,
-        user=test_user,
-    )
+    bjm = BugJobMap.create(job_id=job.id, bug_id=bug.id, user=test_user,)
 
     pk = "{0}-{1}".format(job.id, bug.id)
 
     resp = client.get(
-        reverse("bug-job-map-detail", kwargs={
-            "project": test_repository.name,
-            "pk": pk
-        })
+        reverse("bug-job-map-detail", kwargs={"project": test_repository.name, "pk": pk})
     )
     assert resp.status_code == 200
 
@@ -111,14 +96,15 @@ def test_bug_job_map_detail(client, eleven_jobs_stored, test_repository,
         "job_id": job.id,
         "bug_id": bug.id,
         "created": bjm.created.isoformat(),
-        "who": test_user.email
+        "who": test_user.email,
     }
     assert resp.json() == expected
 
 
 @pytest.mark.parametrize('test_no_auth', [True, False])
-def test_bug_job_map_delete(client, eleven_jobs_stored, test_repository,
-                            test_user, test_no_auth, bugs):
+def test_bug_job_map_delete(
+    client, eleven_jobs_stored, test_repository, test_user, test_no_auth, bugs
+):
     """
     test deleting a bug_job_map object
     """
@@ -126,9 +112,7 @@ def test_bug_job_map_delete(client, eleven_jobs_stored, test_repository,
     bug = bugs[0]
 
     BugJobMap.create(
-        job_id=job.id,
-        bug_id=bug.id,
-        user=test_user,
+        job_id=job.id, bug_id=bug.id, user=test_user,
     )
 
     if not test_no_auth:
@@ -137,10 +121,7 @@ def test_bug_job_map_delete(client, eleven_jobs_stored, test_repository,
     pk = "{0}-{1}".format(job.id, bug.id)
 
     resp = client.delete(
-        reverse("bug-job-map-detail", kwargs={
-            "project": test_repository.name,
-            "pk": pk
-        })
+        reverse("bug-job-map-detail", kwargs={"project": test_repository.name, "pk": pk})
     )
 
     if test_no_auth:
@@ -160,7 +141,7 @@ def test_bug_job_map_bad_job_id(client, test_repository):
 
     resp = client.get(
         reverse("bug-job-map-list", kwargs={"project": test_repository.name}),
-        data={'job_id': bad_job_id}
+        data={'job_id': bad_job_id},
     )
 
     assert resp.status_code == 400

--- a/tests/webapp/api/test_bugzilla.py
+++ b/tests/webapp/api/test_bugzilla.py
@@ -18,18 +18,22 @@ def test_create_bug(client, eleven_jobs_stored, activate_responses, test_user):
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
         assert requestdata['type'] == "defect"
         assert requestdata['product'] == "Bugzilla"
-        assert requestdata['description'] == u"**Filed by:** {}\nIntermittent Description".format(test_user.email.replace('@', " [at] "))
+        assert requestdata['description'] == u"**Filed by:** {}\nIntermittent Description".format(
+            test_user.email.replace('@', " [at] ")
+        )
         assert requestdata['component'] == "Administration"
         assert requestdata['summary'] == u"Intermittent summary"
         assert requestdata['comment_tags'] == "treeherder"
         assert requestdata['version'] == "4.0.17"
         assert requestdata['keywords'] == ["intermittent-failure"]
         resp_body = {"id": 323}
-        return(200, headers, json.dumps(resp_body))
+        return (200, headers, json.dumps(resp_body))
 
     responses.add_callback(
-        responses.POST, "https://thisisnotbugzilla.org/rest/bug",
-        callback=request_callback, match_querystring=False,
+        responses.POST,
+        "https://thisisnotbugzilla.org/rest/bug",
+        callback=request_callback,
+        match_querystring=False,
         content_type="application/json",
     )
 
@@ -46,7 +50,7 @@ def test_create_bug(client, eleven_jobs_stored, activate_responses, test_user):
             "comment": u"Intermittent Description",
             "comment_tags": "treeherder",
             "keywords": ["intermittent-failure"],
-        }
+        },
     )
     assert resp.status_code == 200
     assert resp.json()['success'] == 323
@@ -64,18 +68,24 @@ def test_create_bug_with_unicode(client, eleven_jobs_stored, activate_responses,
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
         assert requestdata['type'] == "defect"
         assert requestdata['product'] == "Bugzilla"
-        assert requestdata['description'] == u"**Filed by:** {}\nIntermittent “description” string".format(test_user.email.replace('@', " [at] "))
+        assert requestdata[
+            'description'
+        ] == u"**Filed by:** {}\nIntermittent “description” string".format(
+            test_user.email.replace('@', " [at] ")
+        )
         assert requestdata['component'] == "Administration"
         assert requestdata['summary'] == u"Intermittent “summary”"
         assert requestdata['comment_tags'] == "treeherder"
         assert requestdata['version'] == "4.0.17"
         assert requestdata['keywords'] == ["intermittent-failure"]
         resp_body = {"id": 323}
-        return(200, headers, json.dumps(resp_body))
+        return (200, headers, json.dumps(resp_body))
 
     responses.add_callback(
-        responses.POST, "https://thisisnotbugzilla.org/rest/bug",
-        callback=request_callback, match_querystring=False,
+        responses.POST,
+        "https://thisisnotbugzilla.org/rest/bug",
+        callback=request_callback,
+        match_querystring=False,
         content_type="application/json",
     )
 
@@ -92,7 +102,7 @@ def test_create_bug_with_unicode(client, eleven_jobs_stored, activate_responses,
             "comment": u"Intermittent “description” string",
             "comment_tags": "treeherder",
             "keywords": ["intermittent-failure"],
-        }
+        },
     )
     assert resp.status_code == 200
     assert resp.json()['success'] == 323
@@ -110,7 +120,9 @@ def test_create_crash_bug(client, eleven_jobs_stored, activate_responses, test_u
         assert requestheaders['x-bugzilla-api-key'] == "12345helloworld"
         assert requestdata['type'] == "defect"
         assert requestdata['product'] == "Bugzilla"
-        assert requestdata['description'] == u"**Filed by:** {}\nIntermittent Description".format(test_user.email.replace('@', " [at] "))
+        assert requestdata['description'] == u"**Filed by:** {}\nIntermittent Description".format(
+            test_user.email.replace('@', " [at] ")
+        )
         assert requestdata['component'] == "Administration"
         assert requestdata['summary'] == u"Intermittent summary"
         assert requestdata['comment_tags'] == "treeherder"
@@ -119,11 +131,13 @@ def test_create_crash_bug(client, eleven_jobs_stored, activate_responses, test_u
         assert requestdata['cf_crash_signature'] == "[@crashsig]"
         assert requestdata['priority'] == '--'
         resp_body = {"id": 323}
-        return(200, headers, json.dumps(resp_body))
+        return (200, headers, json.dumps(resp_body))
 
     responses.add_callback(
-        responses.POST, "https://thisisnotbugzilla.org/rest/bug",
-        callback=request_callback, match_querystring=False,
+        responses.POST,
+        "https://thisisnotbugzilla.org/rest/bug",
+        callback=request_callback,
+        match_querystring=False,
         content_type="application/json",
     )
 
@@ -142,7 +156,7 @@ def test_create_crash_bug(client, eleven_jobs_stored, activate_responses, test_u
             "crash_signature": "[@crashsig]",
             "priority": "--",
             "keywords": ["intermittent-failure", "crash"],
-        }
+        },
     )
     assert resp.status_code == 200
     assert resp.json()['success'] == 323
@@ -170,11 +184,13 @@ def test_create_unauthenticated_bug(client, eleven_jobs_stored, activate_respons
         assert requestdata['blocks'] == "1234"
         assert requestdata['see_also'] == "12345"
         resp_body = {"id": 323}
-        return(200, headers, json.dumps(resp_body))
+        return (200, headers, json.dumps(resp_body))
 
     responses.add_callback(
-        responses.POST, "https://thisisnotbugzilla.org/rest/bug",
-        callback=request_callback, match_querystring=False,
+        responses.POST,
+        "https://thisisnotbugzilla.org/rest/bug",
+        callback=request_callback,
+        match_querystring=False,
         content_type="application/json",
     )
 
@@ -192,13 +208,15 @@ def test_create_unauthenticated_bug(client, eleven_jobs_stored, activate_respons
             "depends_on": "123",
             "blocks": "1234",
             "see_also": "12345",
-        }
+        },
     )
     assert resp.status_code == 403
     assert resp.json()['detail'] == "Authentication credentials were not provided."
 
 
-def test_create_bug_with_long_crash_signature(client, eleven_jobs_stored, activate_responses, test_user):
+def test_create_bug_with_long_crash_signature(
+    client, eleven_jobs_stored, activate_responses, test_user
+):
     """
     test successfully creating a bug in bugzilla
     """
@@ -221,11 +239,13 @@ def test_create_bug_with_long_crash_signature(client, eleven_jobs_stored, activa
         assert requestdata['blocks'] == "1234"
         assert requestdata['see_also'] == "12345"
         resp_body = {"id": 323}
-        return(200, headers, json.dumps(resp_body))
+        return (200, headers, json.dumps(resp_body))
 
     responses.add_callback(
-        responses.POST, "https://thisisnotbugzilla.org/rest/bug",
-        callback=request_callback, match_querystring=False,
+        responses.POST,
+        "https://thisisnotbugzilla.org/rest/bug",
+        callback=request_callback,
+        match_querystring=False,
         content_type="application/json",
     )
 
@@ -247,7 +267,7 @@ def test_create_bug_with_long_crash_signature(client, eleven_jobs_stored, activa
             "depends_on": "123",
             "blocks": "1234",
             "see_also": "12345",
-        }
+        },
     )
     assert resp.status_code == 400
     assert resp.json()['failure'] == "Crash signature can't be more than 2048 characters."

--- a/tests/webapp/api/test_changelog_api.py
+++ b/tests/webapp/api/test_changelog_api.py
@@ -3,8 +3,7 @@ from datetime import datetime
 from django.db import transaction
 from django.urls import reverse
 
-from treeherder.changelog.models import (Changelog,
-                                         ChangelogFile)
+from treeherder.changelog.models import Changelog, ChangelogFile
 
 
 def test_changelog_list(client, test_job_with_notes):

--- a/tests/webapp/api/test_csp_report.py
+++ b/tests/webapp/api/test_csp_report.py
@@ -11,13 +11,11 @@ def test_valid_report(client):
             'document-uri': 'http://localhost:8000/',
             'original-policy': '...',
             'referrer': '',
-            'violated-directive': 'connect-src'
+            'violated-directive': 'connect-src',
         }
     }
     response = client.post(
-        reverse('csp-report'),
-        data=json.dumps(valid_report),
-        content_type='application/csp-report',
+        reverse('csp-report'), data=json.dumps(valid_report), content_type='application/csp-report',
     )
     assert response.status_code == 200
 

--- a/tests/webapp/api/test_intermittent_failures_api.py
+++ b/tests/webapp/api/test_intermittent_failures_api.py
@@ -4,10 +4,7 @@ from treeherder.model.models import BugJobMap
 
 
 def test_failures(bug_data, client):
-    expected = [{
-        'bug_count': 1,
-        'bug_id': bug_data['bug_id']
-    }]
+    expected = [{'bug_count': 1, 'bug_id': bug_data['bug_id']}]
 
     resp = client.get(reverse('failures') + bug_data['query_string'])
     assert resp.status_code == 200
@@ -15,21 +12,24 @@ def test_failures(bug_data, client):
 
 
 def test_failures_by_bug(bug_data, client):
-    expected = [{
-        'bug_id': bug_data['bug_id'],
-        'build_type': bug_data['option'].name,
-        'job_id': bug_data['job'].id,
-        'push_time': bug_data['job'].push.time.strftime('%Y-%m-%d %H:%M:%S'),
-        'platform': bug_data['job'].machine_platform.platform,
-        'revision': bug_data['job'].push.revision,
-        'test_suite': bug_data['job'].signature.job_type_name,
-        'tree': bug_data['job'].repository.name,
-        'machine_name': bug_data['job'].machine.name,
-        'lines': []
-    }]
+    expected = [
+        {
+            'bug_id': bug_data['bug_id'],
+            'build_type': bug_data['option'].name,
+            'job_id': bug_data['job'].id,
+            'push_time': bug_data['job'].push.time.strftime('%Y-%m-%d %H:%M:%S'),
+            'platform': bug_data['job'].machine_platform.platform,
+            'revision': bug_data['job'].push.revision,
+            'test_suite': bug_data['job'].signature.job_type_name,
+            'tree': bug_data['job'].repository.name,
+            'machine_name': bug_data['job'].machine.name,
+            'lines': [],
+        }
+    ]
 
-    resp = client.get(reverse('failures-by-bug') + bug_data['query_string'] + '&bug={}'.format(
-        bug_data['bug_id']))
+    resp = client.get(
+        reverse('failures-by-bug') + bug_data['query_string'] + '&bug={}'.format(bug_data['bug_id'])
+    )
     assert resp.status_code == 200
     assert resp.json() == expected
 
@@ -39,19 +39,22 @@ def test_failure_count_by_bug(bug_data, client, test_run_data):
     bugs = list(BugJobMap.objects.all())
 
     for bug in bugs:
-        if (bug.job.repository.name == bug_data['tree'] and
-            bug.bug_id == bug_data['bug_id'] and
-            bug.job.push.time.strftime('%Y-%m-%d') == test_run_data['push_time']):
+        if (
+            bug.job.repository.name == bug_data['tree']
+            and bug.bug_id == bug_data['bug_id']
+            and bug.job.push.time.strftime('%Y-%m-%d') == test_run_data['push_time']
+        ):
             failure_count += 1
 
     expected = {
-      'date': test_run_data['push_time'],
-      'test_runs': test_run_data['test_runs'],
-      'failure_count': failure_count,
+        'date': test_run_data['push_time'],
+        'test_runs': test_run_data['test_runs'],
+        'failure_count': failure_count,
     }
 
-    resp = client.get(reverse('failure-count') + bug_data['query_string'] + '&bug={}'.format(
-        bug_data['bug_id']))
+    resp = client.get(
+        reverse('failure-count') + bug_data['query_string'] + '&bug={}'.format(bug_data['bug_id'])
+    )
     assert resp.status_code == 200
     assert resp.json()[0] == expected
 
@@ -60,9 +63,11 @@ def test_failure_count(bug_data, client, test_run_data):
     failure_count = 0
 
     for job in list(bug_data['jobs']):
-        if (job.repository.name == bug_data['tree'] and
-            job.failure_classification_id == 4 and
-            job.push.time.strftime('%Y-%m-%d') == test_run_data['push_time']):
+        if (
+            job.repository.name == bug_data['tree']
+            and job.failure_classification_id == 4
+            and job.push.time.strftime('%Y-%m-%d') == test_run_data['push_time']
+        ):
             failure_count += 1
 
     expected = {

--- a/tests/webapp/api/test_job_log_url_api.py
+++ b/tests/webapp/api/test_job_log_url_api.py
@@ -4,35 +4,26 @@ from tests.test_utils import create_generic_job
 from treeherder.model.models import JobLog
 
 
-def test_get_job_log_urls(test_repository, push_stored,
-                          failure_classifications,
-                          generic_reference_data, client):
-    job1 = create_generic_job('1234', test_repository, 1,
-                              generic_reference_data)
-    job2 = create_generic_job('5678', test_repository, 1,
-                              generic_reference_data)
+def test_get_job_log_urls(
+    test_repository, push_stored, failure_classifications, generic_reference_data, client
+):
+    job1 = create_generic_job('1234', test_repository, 1, generic_reference_data)
+    job2 = create_generic_job('5678', test_repository, 1, generic_reference_data)
 
-    JobLog.objects.create(job=job1,
-                          name='test_log_1',
-                          url='http://google.com',
-                          status=JobLog.PENDING)
-    JobLog.objects.create(job=job1,
-                          name='test_log_2',
-                          url='http://yahoo.com',
-                          status=JobLog.PARSED)
-    JobLog.objects.create(job=job2,
-                          name='test_log_3',
-                          url='http://yahoo.com',
-                          status=JobLog.PARSED)
+    JobLog.objects.create(
+        job=job1, name='test_log_1', url='http://google.com', status=JobLog.PENDING
+    )
+    JobLog.objects.create(job=job1, name='test_log_2', url='http://yahoo.com', status=JobLog.PARSED)
+    JobLog.objects.create(job=job2, name='test_log_3', url='http://yahoo.com', status=JobLog.PARSED)
 
-    resp = client.get(reverse('job-log-url-list',
-                      kwargs={"project": test_repository.name}) +
-                      '?job_id=1')
+    resp = client.get(
+        reverse('job-log-url-list', kwargs={"project": test_repository.name}) + '?job_id=1'
+    )
     assert resp.status_code == 200
     assert len(resp.json()) == 2
 
-    resp = client.get(reverse('job-log-url-list',
-                      kwargs={"project": test_repository.name}) +
-                      '?job_id=1&job_id=2')
+    resp = client.get(
+        reverse('job-log-url-list', kwargs={"project": test_repository.name}) + '?job_id=1&job_id=2'
+    )
     assert resp.status_code == 200
     assert len(resp.json()) == 3

--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -5,27 +5,22 @@ from dateutil import parser
 from django.urls import reverse
 from rest_framework.status import HTTP_400_BAD_REQUEST
 
-from treeherder.model.models import (Job,
-                                     TextLogError,
-                                     TextLogStep)
+from treeherder.model.models import Job, TextLogError, TextLogStep
 
 
-@pytest.mark.parametrize(('offset', 'count', 'expected_num'),
-                         [(None, None, 10),
-                          (None, 5, 5),
-                          (5, None, 6),
-                          (0, 5, 5),
-                          (10, 10, 1)])
-def test_job_list(client, eleven_jobs_stored, test_repository,
-                  offset, count, expected_num):
+@pytest.mark.parametrize(
+    ('offset', 'count', 'expected_num'),
+    [(None, None, 10), (None, 5, 5), (5, None, 6), (0, 5, 5), (10, 10, 1)],
+)
+def test_job_list(client, eleven_jobs_stored, test_repository, offset, count, expected_num):
     """
     test retrieving a list of json blobs from the jobs-list
     endpoint.
     """
-    url = reverse("jobs-list",
-                  kwargs={"project": test_repository.name})
-    params = '&'.join(['{}={}'.format(k, v) for k, v in
-                       [('offset', offset), ('count', count)] if v])
+    url = reverse("jobs-list", kwargs={"project": test_repository.name})
+    params = '&'.join(
+        ['{}={}'.format(k, v) for k, v in [('offset', offset), ('count', count)] if v]
+    )
     if params:
         url += '?{}'.format(params)
     resp = client.get(url)
@@ -71,7 +66,7 @@ def test_job_list(client, eleven_jobs_stored, test_repository,
         "ref_data_name",
         "signature",
         "task_id",
-        "retry_id"
+        "retry_id",
     ]
     for job in jobs:
         assert set(job.keys()) == set(exp_keys)
@@ -81,8 +76,7 @@ def test_job_list_bad_project(client, transactional_db):
     """
     test retrieving a job list with a bad project throws 404.
     """
-    badurl = reverse("jobs-list",
-                     kwargs={"project": "badproject"})
+    badurl = reverse("jobs-list", kwargs={"project": "badproject"})
 
     resp = client.get(badurl)
     assert resp.status_code == 404
@@ -92,8 +86,7 @@ def test_job_list_equals_filter(client, eleven_jobs_stored, test_repository):
     """
     test retrieving a job list with a querystring filter.
     """
-    url = reverse("jobs-list",
-                  kwargs={"project": test_repository.name})
+    url = reverse("jobs-list", kwargs={"project": test_repository.name})
     final_url = url + "?job_guid=f1c75261017c7c5ce3000931dce4c442fe0a1297"
 
     resp = client.get(final_url)
@@ -123,7 +116,10 @@ job_filter_values = [
     (u'option_collection_hash', u'32faaecac742100f7753f0c1d0aa0add01b4046b'),
     (u'platform', u'osx-10-7'),
     (u'reason', u'scheduler'),
-    (u'ref_data_name', u'Rev4 MacOSX Lion 10.7 mozilla-release debug test mochitest-browser-chrome'),
+    (
+        u'ref_data_name',
+        u'Rev4 MacOSX Lion 10.7 mozilla-release debug test mochitest-browser-chrome',
+    ),
     (u'result', u'success'),
     (u'result_set_id', 4),
     (u'signature', u'aebe9066ff1c765815ec0513a3389238c80ef166'),
@@ -131,7 +127,7 @@ job_filter_values = [
     (u'state', u'completed'),
     (u'submit_timestamp', 1384356854),
     (u'tier', 1),
-    (u'who', u'tests-mozilla-release-lion-debug-unittest')
+    (u'who', u'tests-mozilla-release-lion-debug-unittest'),
 ]
 
 
@@ -146,8 +142,7 @@ def test_job_list_filter_fields(client, eleven_jobs_stored, test_repository, fie
     The field of ``last_modified`` is auto-generated, so just skipping that
     to make this test easy.
     """
-    url = reverse("jobs-list",
-                  kwargs={"project": test_repository.name})
+    url = reverse("jobs-list", kwargs={"project": test_repository.name})
     final_url = url + "?{}={}".format(fieldname, expected)
     resp = client.get(final_url)
     assert resp.status_code == 200
@@ -159,11 +154,12 @@ def test_job_list_in_filter(client, eleven_jobs_stored, test_repository):
     """
     test retrieving a job list with a querystring filter.
     """
-    url = reverse("jobs-list",
-                  kwargs={"project": test_repository.name})
-    final_url = url + ("?job_guid__in="
-                       "f1c75261017c7c5ce3000931dce4c442fe0a1297,"
-                       "9abb6f7d54a49d763c584926377f09835c5e1a32")
+    url = reverse("jobs-list", kwargs={"project": test_repository.name})
+    final_url = url + (
+        "?job_guid__in="
+        "f1c75261017c7c5ce3000931dce4c442fe0a1297,"
+        "9abb6f7d54a49d763c584926377f09835c5e1a32"
+    )
 
     resp = client.get(final_url)
     assert resp.status_code == 200
@@ -176,23 +172,19 @@ def test_job_detail(client, test_job):
     endpoint.
     """
     resp = client.get(
-        reverse("jobs-detail",
-                kwargs={"project": test_job.repository.name,
-                        "pk": test_job.id})
+        reverse("jobs-detail", kwargs={"project": test_job.repository.name, "pk": test_job.id})
     )
     assert resp.status_code == 200
     assert isinstance(resp.json(), dict)
     assert resp.json()["id"] == test_job.id
 
     resp = client.get(
-        reverse("jobs-detail",
-                kwargs={"project": test_job.repository.name,
-                        "pk": test_job.id})
+        reverse("jobs-detail", kwargs={"project": test_job.repository.name, "pk": test_job.id})
     )
     assert resp.status_code == 200
     assert resp.json()["taskcluster_metadata"] == {
         "task_id": 'V3SVuxO8TFy37En_6HcXLs',
-        "retry_id": 0
+        "retry_id": 0,
     }
 
 
@@ -201,8 +193,7 @@ def test_job_detail_bad_project(client, transactional_db):
     test retrieving a single job from the jobs-detail
     endpoint.
     """
-    badurl = reverse("jobs-detail",
-                     kwargs={"project": "badproject", "pk": 1})
+    badurl = reverse("jobs-detail", kwargs={"project": "badproject", "pk": 1})
     resp = client.get(badurl)
     assert resp.status_code == 404
 
@@ -213,36 +204,37 @@ def test_job_detail_not_found(client, test_repository):
     endpoint.
     """
     resp = client.get(
-        reverse("jobs-detail",
-                kwargs={"project": test_repository.name, "pk": -32767}),
+        reverse("jobs-detail", kwargs={"project": test_repository.name, "pk": -32767}),
     )
     assert resp.status_code == 404
 
 
 def test_text_log_steps_and_errors(client, test_job):
 
-    TextLogStep.objects.create(job=test_job,
-                               name='step1',
-                               started=datetime.datetime.utcfromtimestamp(0),
-                               finished=datetime.datetime.utcfromtimestamp(100),
-                               started_line_number=1,
-                               finished_line_number=100,
-                               result=TextLogStep.SUCCESS)
-    step2 = TextLogStep.objects.create(job=test_job,
-                                       name='step2',
-                                       started=datetime.datetime.utcfromtimestamp(101),
-                                       finished=datetime.datetime.utcfromtimestamp(200),
-                                       started_line_number=101,
-                                       finished_line_number=200,
-                                       result=TextLogStep.TEST_FAILED)
-    TextLogError.objects.create(step=step2, line='failure 1',
-                                line_number=101)
-    TextLogError.objects.create(step=step2, line='failure 2',
-                                line_number=102)
+    TextLogStep.objects.create(
+        job=test_job,
+        name='step1',
+        started=datetime.datetime.utcfromtimestamp(0),
+        finished=datetime.datetime.utcfromtimestamp(100),
+        started_line_number=1,
+        finished_line_number=100,
+        result=TextLogStep.SUCCESS,
+    )
+    step2 = TextLogStep.objects.create(
+        job=test_job,
+        name='step2',
+        started=datetime.datetime.utcfromtimestamp(101),
+        finished=datetime.datetime.utcfromtimestamp(200),
+        started_line_number=101,
+        finished_line_number=200,
+        result=TextLogStep.TEST_FAILED,
+    )
+    TextLogError.objects.create(step=step2, line='failure 1', line_number=101)
+    TextLogError.objects.create(step=step2, line='failure 2', line_number=102)
     resp = client.get(
-        reverse("jobs-text-log-steps",
-                kwargs={"project": test_job.repository.name,
-                        "pk": test_job.id})
+        reverse(
+            "jobs-text-log-steps", kwargs={"project": test_job.repository.name, "pk": test_job.id}
+        )
     )
     assert resp.status_code == 200
     assert resp.json() == [
@@ -254,7 +246,7 @@ def test_text_log_steps_and_errors(client, test_job):
             'name': 'step1',
             'result': 'success',
             'started': '1970-01-01T00:00:00',
-            'started_line_number': 1
+            'started_line_number': 1,
         },
         {
             'errors': [
@@ -265,11 +257,11 @@ def test_text_log_steps_and_errors(client, test_job):
                     'bug_suggestions': {
                         'search': 'failure 1',
                         'search_terms': ['failure 1'],
-                        'bugs': {'open_recent': [], 'all_others': []}
+                        'bugs': {'open_recent': [], 'all_others': []},
                     },
                     'metadata': None,
                     'matches': [],
-                    'classified_failures': []
+                    'classified_failures': [],
                 },
                 {
                     'id': 2,
@@ -278,12 +270,12 @@ def test_text_log_steps_and_errors(client, test_job):
                     'bug_suggestions': {
                         'search': 'failure 2',
                         'search_terms': ['failure 2'],
-                        'bugs': {'open_recent': [], 'all_others': []}
+                        'bugs': {'open_recent': [], 'all_others': []},
                     },
                     'metadata': None,
                     'matches': [],
-                    'classified_failures': []
-                }
+                    'classified_failures': [],
+                },
             ],
             'finished': '1970-01-01T00:03:20',
             'finished_line_number': 200,
@@ -291,35 +283,37 @@ def test_text_log_steps_and_errors(client, test_job):
             'name': 'step2',
             'result': 'testfailed',
             'started': '1970-01-01T00:01:41',
-            'started_line_number': 101
-        }
+            'started_line_number': 101,
+        },
     ]
 
 
 def test_text_log_errors(client, test_job):
 
-    TextLogStep.objects.create(job=test_job,
-                               name='step1',
-                               started=datetime.datetime.utcfromtimestamp(0),
-                               finished=datetime.datetime.utcfromtimestamp(100),
-                               started_line_number=1,
-                               finished_line_number=100,
-                               result=TextLogStep.SUCCESS)
-    step2 = TextLogStep.objects.create(job=test_job,
-                                       name='step2',
-                                       started=datetime.datetime.utcfromtimestamp(101),
-                                       finished=datetime.datetime.utcfromtimestamp(200),
-                                       started_line_number=101,
-                                       finished_line_number=200,
-                                       result=TextLogStep.TEST_FAILED)
-    TextLogError.objects.create(step=step2, line='failure 1',
-                                line_number=101)
-    TextLogError.objects.create(step=step2, line='failure 2',
-                                line_number=102)
+    TextLogStep.objects.create(
+        job=test_job,
+        name='step1',
+        started=datetime.datetime.utcfromtimestamp(0),
+        finished=datetime.datetime.utcfromtimestamp(100),
+        started_line_number=1,
+        finished_line_number=100,
+        result=TextLogStep.SUCCESS,
+    )
+    step2 = TextLogStep.objects.create(
+        job=test_job,
+        name='step2',
+        started=datetime.datetime.utcfromtimestamp(101),
+        finished=datetime.datetime.utcfromtimestamp(200),
+        started_line_number=101,
+        finished_line_number=200,
+        result=TextLogStep.TEST_FAILED,
+    )
+    TextLogError.objects.create(step=step2, line='failure 1', line_number=101)
+    TextLogError.objects.create(step=step2, line='failure 2', line_number=102)
     resp = client.get(
-        reverse("jobs-text-log-errors",
-                kwargs={"project": test_job.repository.name,
-                        "pk": test_job.id})
+        reverse(
+            "jobs-text-log-errors", kwargs={"project": test_job.repository.name, "pk": test_job.id}
+        )
     )
     assert resp.status_code == 200
     assert resp.json() == [
@@ -330,11 +324,11 @@ def test_text_log_errors(client, test_job):
             'bug_suggestions': {
                 'search': 'failure 1',
                 'search_terms': ['failure 1'],
-                'bugs': {'open_recent': [], 'all_others': []}
+                'bugs': {'open_recent': [], 'all_others': []},
             },
             'metadata': None,
             'matches': [],
-            'classified_failures': []
+            'classified_failures': [],
         },
         {
             'id': 2,
@@ -343,32 +337,29 @@ def test_text_log_errors(client, test_job):
             'bug_suggestions': {
                 'search': 'failure 2',
                 'search_terms': ['failure 2'],
-                'bugs': {'open_recent': [], 'all_others': []}
+                'bugs': {'open_recent': [], 'all_others': []},
             },
             'metadata': None,
             'matches': [],
-            'classified_failures': []
-        }
+            'classified_failures': [],
+        },
     ]
 
 
-@pytest.mark.parametrize(('offset', 'count', 'expected_num'),
-                         [(None, None, 3),
-                          (None, 2, 2),
-                          (1, None, 2),
-                          (0, 1, 1),
-                          (2, 10, 1)])
-def test_list_similar_jobs(client, eleven_jobs_stored,
-                           offset, count, expected_num):
+@pytest.mark.parametrize(
+    ('offset', 'count', 'expected_num'),
+    [(None, None, 3), (None, 2, 2), (1, None, 2), (0, 1, 1), (2, 10, 1)],
+)
+def test_list_similar_jobs(client, eleven_jobs_stored, offset, count, expected_num):
     """
     test retrieving similar jobs
     """
     job = Job.objects.get(id=1)
 
-    url = reverse("jobs-similar-jobs",
-                  kwargs={"project": job.repository.name, "pk": job.id})
-    params = '&'.join(['{}={}'.format(k, v) for k, v in
-                       [('offset', offset), ('count', count)] if v])
+    url = reverse("jobs-similar-jobs", kwargs={"project": job.repository.name, "pk": job.id})
+    params = '&'.join(
+        ['{}={}'.format(k, v) for k, v in [('offset', offset), ('count', count)] if v]
+    )
     if params:
         url += '?{}'.format(params)
     resp = client.get(url)
@@ -384,22 +375,26 @@ def test_list_similar_jobs(client, eleven_jobs_stored,
     assert len(similar_jobs['results']) == expected_num
 
 
-@pytest.mark.parametrize('lm_key,lm_value,exp_status, exp_job_count', [
-    ("last_modified__gt", "2016-07-18T22:16:58.000", 200, 8),
-    ("last_modified__lt", "2016-07-18T22:16:58.000", 200, 3),
-    ("last_modified__gt", "-Infinity", HTTP_400_BAD_REQUEST, 0),
-    ("last_modified__gt", "whatever", HTTP_400_BAD_REQUEST, 0),
-    ])
-def test_last_modified(client, eleven_jobs_stored, test_repository,
-                       lm_key, lm_value, exp_status, exp_job_count):
+@pytest.mark.parametrize(
+    'lm_key,lm_value,exp_status, exp_job_count',
+    [
+        ("last_modified__gt", "2016-07-18T22:16:58.000", 200, 8),
+        ("last_modified__lt", "2016-07-18T22:16:58.000", 200, 3),
+        ("last_modified__gt", "-Infinity", HTTP_400_BAD_REQUEST, 0),
+        ("last_modified__gt", "whatever", HTTP_400_BAD_REQUEST, 0),
+    ],
+)
+def test_last_modified(
+    client, eleven_jobs_stored, test_repository, lm_key, lm_value, exp_status, exp_job_count
+):
     try:
         param_date = parser.parse(lm_value)
         newer_date = param_date - datetime.timedelta(minutes=10)
 
         # modify job last_modified for 3 jobs
-        Job.objects.filter(
-            id__in=[j.id for j in Job.objects.all()[:3]]).update(
-                last_modified=newer_date)
+        Job.objects.filter(id__in=[j.id for j in Job.objects.all()[:3]]).update(
+            last_modified=newer_date
+        )
     except ValueError:
         # no problem.  these params are the wrong
         pass

--- a/tests/webapp/api/test_note_api.py
+++ b/tests/webapp/api/test_note_api.py
@@ -3,8 +3,7 @@ import json
 import pytest
 from django.urls import reverse
 
-from treeherder.model.models import (Job,
-                                     JobNote)
+from treeherder.model.models import Job, JobNote
 
 
 def test_note_list(client, test_job_with_notes):
@@ -12,22 +11,23 @@ def test_note_list(client, test_job_with_notes):
     test retrieving a list of notes from the note-list endpoint
     """
     resp = client.get(
-        reverse("note-list", kwargs={
-            "project": test_job_with_notes.repository.name
-        }),
-        {"job_id": test_job_with_notes.id}
+        reverse("note-list", kwargs={"project": test_job_with_notes.repository.name}),
+        {"job_id": test_job_with_notes.id},
     )
 
     assert resp.status_code == 200
     assert isinstance(resp.json(), list)
-    assert resp.json() == [{
-        "id": note.id,
-        "job_id": note.job.id,
-        "failure_classification_id": note.failure_classification.id,
-        "who": note.user.email,
-        "created": note.created.isoformat(),
-        "text": note.text
-    } for note in JobNote.objects.filter(job=test_job_with_notes)]
+    assert resp.json() == [
+        {
+            "id": note.id,
+            "job_id": note.job.id,
+            "failure_classification_id": note.failure_classification.id,
+            "who": note.user.email,
+            "created": note.created.isoformat(),
+            "text": note.text,
+        }
+        for note in JobNote.objects.filter(job=test_job_with_notes)
+    ]
 
 
 def test_note_detail(client, test_job_with_notes):
@@ -38,11 +38,7 @@ def test_note_detail(client, test_job_with_notes):
     note = JobNote.objects.get(id=1)
 
     resp = client.get(
-        reverse("note-detail",
-                kwargs={
-                    "project": test_job_with_notes.repository.name,
-                    "pk": 1
-                })
+        reverse("note-detail", kwargs={"project": test_job_with_notes.repository.name, "pk": 1})
     )
 
     assert resp.status_code == 200
@@ -53,7 +49,7 @@ def test_note_detail(client, test_job_with_notes):
         "failure_classification_id": 2,
         "who": note.user.email,
         "created": note.created.isoformat(),
-        "text": "you look like a man-o-lantern"
+        "text": "you look like a man-o-lantern",
     }
 
 
@@ -63,8 +59,7 @@ def test_note_detail_not_found(client, test_repository):
     endpoint.
     """
     resp = client.get(
-        reverse("note-detail",
-                kwargs={"project": test_repository.name, "pk": -32767}),
+        reverse("note-detail", kwargs={"project": test_repository.name, "pk": -32767}),
     )
     assert resp.status_code == 404
 
@@ -74,10 +69,7 @@ def test_note_detail_bad_project(client, test_repository):
     test retrieving a HTTP 404 from the note-detail
     endpoint.
     """
-    resp = client.get(
-        reverse("note-detail",
-                kwargs={"project": "foo", "pk": -32767}),
-    )
+    resp = client.get(reverse("note-detail", kwargs={"project": "foo", "pk": -32767}),)
     assert resp.status_code == 404
 
 
@@ -95,7 +87,7 @@ def test_create_note(client, test_job, test_user, test_no_auth):
             "job_id": test_job.id,
             "failure_classification_id": 2,
             "who": test_user.email,
-            "text": "you look like a man-o-lantern"
+            "text": "you look like a man-o-lantern",
         },
     )
 
@@ -117,13 +109,13 @@ def test_create_note(client, test_job, test_user, test_no_auth):
 
         # verify that the job's last_modified field got updated
         old_last_modified = test_job.last_modified
-        assert old_last_modified < Job.objects.values_list(
-            'last_modified', flat=True).get(id=test_job.id)
+        assert old_last_modified < Job.objects.values_list('last_modified', flat=True).get(
+            id=test_job.id
+        )
 
 
 @pytest.mark.parametrize('test_no_auth', [True, False])
-def test_delete_note(client, test_job_with_notes, test_repository,
-                     test_sheriff, test_no_auth):
+def test_delete_note(client, test_job_with_notes, test_repository, test_sheriff, test_no_auth):
     """
     test deleting a single note via endpoint
     """
@@ -133,8 +125,9 @@ def test_delete_note(client, test_job_with_notes, test_repository,
     notes_count = JobNote.objects.count()
 
     resp = client.delete(
-        reverse("note-detail", kwargs={"project": test_repository.name,
-                                       "pk": test_job_with_notes.id}),
+        reverse(
+            "note-detail", kwargs={"project": test_repository.name, "pk": test_job_with_notes.id}
+        ),
     )
     new_notes_count = JobNote.objects.count()
 

--- a/tests/webapp/api/test_option_collection_hash.py
+++ b/tests/webapp/api/test_option_collection_hash.py
@@ -12,5 +12,5 @@ def test_option_collection_list(client, sample_option_collections):
     assert len(response) == 2
     assert response == [
         {'option_collection_hash': 'option_hash1', 'options': [{'name': 'opt1'}]},
-        {'option_collection_hash': 'option_hash2', 'options': [{'name': 'opt2'}]}
+        {'option_collection_hash': 'option_hash2', 'options': [{'name': 'opt2'}]},
     ]

--- a/tests/webapp/api/test_performance_alertsummary_api.py
+++ b/tests/webapp/api/test_performance_alertsummary_api.py
@@ -19,7 +19,7 @@ def test_repository_onhold(transactional_db):
         codebase="gecko",
         repository_group_id=1,
         description="",
-        performance_alerts_enabled=True
+        performance_alerts_enabled=True,
     )
     return r
 
@@ -31,7 +31,8 @@ def test_perf_alert_summary_onhold(test_repository_onhold, test_perf_framework):
             repository=test_repository_onhold,
             revision='1234abcd{}'.format(i),
             author='foo@bar.com',
-            time=datetime.datetime.now())
+            time=datetime.datetime.now(),
+        )
 
     return PerformanceAlertSummary.objects.create(
         repository=test_repository_onhold,
@@ -39,12 +40,14 @@ def test_perf_alert_summary_onhold(test_repository_onhold, test_perf_framework):
         prev_push_id=1,
         push_id=2,
         manually_created=False,
-        created=datetime.datetime.now())
+        created=datetime.datetime.now(),
+    )
 
 
 @pytest.fixture
 def test_perf_alert_onhold(test_perf_signature, test_perf_alert_summary_onhold):
     from treeherder.perf.models import PerformanceAlert
+
     return PerformanceAlert.objects.create(
         summary=test_perf_alert_summary_onhold,
         series_signature=test_perf_signature,
@@ -53,11 +56,11 @@ def test_perf_alert_onhold(test_perf_signature, test_perf_alert_summary_onhold):
         amount_abs=50.0,
         prev_value=100.0,
         new_value=150.0,
-        t_value=20.0)
+        t_value=20.0,
+    )
 
 
-def test_alert_summaries_get(client, test_perf_alert_summary,
-                             test_perf_alert):
+def test_alert_summaries_get(client, test_perf_alert_summary, test_perf_alert):
     # verify that we get the performance summary + alert on GET
     resp = client.get(reverse('performance-alert-summaries-list'))
     assert resp.status_code == 200
@@ -66,51 +69,60 @@ def test_alert_summaries_get(client, test_perf_alert_summary,
     assert resp.json()['next'] is None
     assert resp.json()['previous'] is None
     assert len(resp.json()['results']) == 1
-    assert set(resp.json()['results'][0].keys()) == set([
-        'alerts',
-        'bug_number',
-        'bug_updated',
-        'issue_tracker',
-        'notes',
-        'assignee_username',
-        'assignee_email',
-        'framework',
-        'id',
-        'created',
-        'prev_push_id',
-        'related_alerts',
-        'repository',
-        'push_id',
-        'status',
-        'revision',
-        'push_timestamp',
-        'prev_push_revision'
-    ])
+    assert set(resp.json()['results'][0].keys()) == set(
+        [
+            'alerts',
+            'bug_number',
+            'bug_updated',
+            'issue_tracker',
+            'notes',
+            'assignee_username',
+            'assignee_email',
+            'framework',
+            'id',
+            'created',
+            'prev_push_id',
+            'related_alerts',
+            'repository',
+            'push_id',
+            'status',
+            'revision',
+            'push_timestamp',
+            'prev_push_revision',
+        ]
+    )
     assert len(resp.json()['results'][0]['alerts']) == 1
-    assert set(resp.json()['results'][0]['alerts'][0].keys()) == set([
-        'id',
-        'status',
-        'series_signature',
-        'is_regression',
-        'starred',
-        'manually_created',
-        'prev_value',
-        'new_value',
-        't_value',
-        'amount_abs',
-        'amount_pct',
-        'summary_id',
-        'related_summary_id',
-        'classifier',
-        'classifier_email',
-        'backfill_record'
-    ])
+    assert set(resp.json()['results'][0]['alerts'][0].keys()) == set(
+        [
+            'id',
+            'status',
+            'series_signature',
+            'is_regression',
+            'starred',
+            'manually_created',
+            'prev_value',
+            'new_value',
+            't_value',
+            'amount_abs',
+            'amount_pct',
+            'summary_id',
+            'related_summary_id',
+            'classifier',
+            'classifier_email',
+            'backfill_record',
+        ]
+    )
     assert resp.json()['results'][0]['related_alerts'] == []
 
 
-def test_alert_summaries_get_onhold(client, test_perf_alert_summary,
-                                    test_perf_alert, test_perf_alert_summary_onhold,
-                                    test_perf_alert_onhold, test_repository_onhold):
+def test_alert_summaries_get_onhold(
+    client,
+    test_perf_alert_summary,
+    test_perf_alert,
+    test_perf_alert_summary_onhold,
+    test_perf_alert_onhold,
+    test_repository_onhold,
+):
     # verify that we get the performance summary + alert on GET
     resp = client.get(reverse('performance-alert-summaries-list'))
     assert resp.status_code == 200
@@ -119,91 +131,98 @@ def test_alert_summaries_get_onhold(client, test_perf_alert_summary,
     assert resp.json()['next'] is None
     assert resp.json()['previous'] is None
     assert len(resp.json()['results']) == 1
-    assert set(resp.json()['results'][0].keys()) == set([
-        'alerts',
-        'bug_number',
-        'bug_updated',
-        'issue_tracker',
-        'notes',
-        'assignee_username',
-        'assignee_email',
-        'framework',
-        'id',
-        'created',
-        'prev_push_id',
-        'related_alerts',
-        'repository',
-        'push_id',
-        'status',
-        'revision',
-        'push_timestamp',
-        'prev_push_revision'
-    ])
+    assert set(resp.json()['results'][0].keys()) == set(
+        [
+            'alerts',
+            'bug_number',
+            'bug_updated',
+            'issue_tracker',
+            'notes',
+            'assignee_username',
+            'assignee_email',
+            'framework',
+            'id',
+            'created',
+            'prev_push_id',
+            'related_alerts',
+            'repository',
+            'push_id',
+            'status',
+            'revision',
+            'push_timestamp',
+            'prev_push_revision',
+        ]
+    )
     assert len(resp.json()['results'][0]['alerts']) == 1
-    assert set(resp.json()['results'][0]['alerts'][0].keys()) == set([
-        'id',
-        'status',
-        'series_signature',
-        'is_regression',
-        'starred',
-        'manually_created',
-        'prev_value',
-        'new_value',
-        't_value',
-        'amount_abs',
-        'amount_pct',
-        'summary_id',
-        'related_summary_id',
-        'classifier',
-        'classifier_email',
-        'backfill_record'
-    ])
+    assert set(resp.json()['results'][0]['alerts'][0].keys()) == set(
+        [
+            'id',
+            'status',
+            'series_signature',
+            'is_regression',
+            'starred',
+            'manually_created',
+            'prev_value',
+            'new_value',
+            't_value',
+            'amount_abs',
+            'amount_pct',
+            'summary_id',
+            'related_summary_id',
+            'classifier',
+            'classifier_email',
+            'backfill_record',
+        ]
+    )
     assert resp.json()['results'][0]['related_alerts'] == []
 
 
-def test_alert_summaries_put(client, test_repository, test_perf_signature,
-                             test_perf_alert_summary, test_user, test_sheriff):
+def test_alert_summaries_put(
+    client, test_repository, test_perf_signature, test_perf_alert_summary, test_user, test_sheriff
+):
     # verify that we fail if not authenticated
-    resp = client.put(reverse('performance-alert-summaries-list') + '1/', {
-        'status': 1
-    })
+    resp = client.put(reverse('performance-alert-summaries-list') + '1/', {'status': 1})
     assert resp.status_code == 403
     assert PerformanceAlertSummary.objects.get(id=1).status == 0
 
     # verify that we fail if authenticated, but not staff
     client.force_authenticate(user=test_user)
-    resp = client.put(reverse('performance-alert-summaries-list') + '1/', {
-        'status': 1
-    })
+    resp = client.put(reverse('performance-alert-summaries-list') + '1/', {'status': 1})
     assert resp.status_code == 403
     assert PerformanceAlertSummary.objects.get(id=1).status == 0
 
     # verify that we succeed if authenticated + staff
     client.force_authenticate(user=test_sheriff)
-    resp = client.put(reverse('performance-alert-summaries-list') + '1/', {
-        'status': 1
-    })
+    resp = client.put(reverse('performance-alert-summaries-list') + '1/', {'status': 1})
     assert resp.status_code == 200
     assert PerformanceAlertSummary.objects.get(id=1).status == 1
 
     # verify we can set assignee
     client.force_authenticate(user=test_sheriff)
-    resp = client.put(reverse('performance-alert-summaries-list') + '1/', {
-        'assignee_username': test_user.username
-    })
+    resp = client.put(
+        reverse('performance-alert-summaries-list') + '1/',
+        {'assignee_username': test_user.username},
+    )
     assert resp.status_code == 200
     assert PerformanceAlertSummary.objects.get(id=1).assignee == test_user
 
 
-def test_alert_summary_post(client, test_repository, test_issue_tracker,
-                            push_stored, test_perf_signature, test_user, test_sheriff):
+def test_alert_summary_post(
+    client,
+    test_repository,
+    test_issue_tracker,
+    push_stored,
+    test_perf_signature,
+    test_user,
+    test_sheriff,
+):
     # this blob should be sufficient to create a new alert summary (assuming
     # the user of this API is authorized to do so!)
     post_blob = {
         'repository_id': test_repository.id,
         'framework_id': test_perf_signature.framework.id,
         'prev_push_id': 1,
-        'push_id': 2
+        'push_id': 2,
     }
 
     # verify that we fail if not authenticated
@@ -237,16 +256,17 @@ def test_alert_summary_post(client, test_repository, test_issue_tracker,
     assert PerformanceAlertSummary.objects.count() == 1
 
 
-@pytest.mark.parametrize('modification',
-                         [{'notes': 'human created notes'},
-                          {'bug_number': 123456, 'issue_tracker': 1}])
-def test_alert_summary_timestamps_via_endpoints(authorized_sheriff_client, test_perf_alert_summary, modification):
+@pytest.mark.parametrize(
+    'modification', [{'notes': 'human created notes'}, {'bug_number': 123456, 'issue_tracker': 1}]
+)
+def test_alert_summary_timestamps_via_endpoints(
+    authorized_sheriff_client, test_perf_alert_summary, modification
+):
     assert test_perf_alert_summary.first_triaged is None
 
     # when editing notes & linking bugs
     resp = authorized_sheriff_client.put(
-        reverse('performance-alert-summaries-list') + '1/',
-        modification
+        reverse('performance-alert-summaries-list') + '1/', modification
     )
     assert resp.status_code == 200
     test_perf_alert_summary.refresh_from_db()
@@ -256,15 +276,16 @@ def test_alert_summary_timestamps_via_endpoints(authorized_sheriff_client, test_
     assert test_perf_alert_summary.created < test_perf_alert_summary.last_updated
 
 
-def test_bug_number_and_timestamp_on_setting_value(authorized_sheriff_client, test_perf_alert_summary):
+def test_bug_number_and_timestamp_on_setting_value(
+    authorized_sheriff_client, test_perf_alert_summary
+):
     assert test_perf_alert_summary.first_triaged is None
     assert test_perf_alert_summary.bug_number is None
     assert test_perf_alert_summary.bug_updated is None
 
     # link a bug
     resp = authorized_sheriff_client.put(
-        reverse('performance-alert-summaries-list') + '1/',
-        {'bug_number': 123456}
+        reverse('performance-alert-summaries-list') + '1/', {'bug_number': 123456}
     )
     assert resp.status_code == 200
     test_perf_alert_summary.refresh_from_db()
@@ -274,7 +295,9 @@ def test_bug_number_and_timestamp_on_setting_value(authorized_sheriff_client, te
     assert test_perf_alert_summary.bug_updated is not None
 
 
-def test_bug_number_and_timestamp_on_overriding(authorized_sheriff_client, test_perf_alert_summary_with_bug):
+def test_bug_number_and_timestamp_on_overriding(
+    authorized_sheriff_client, test_perf_alert_summary_with_bug
+):
     assert test_perf_alert_summary_with_bug.bug_number == 123456
     assert test_perf_alert_summary_with_bug.bug_updated < datetime.datetime.now()
 
@@ -282,8 +305,7 @@ def test_bug_number_and_timestamp_on_overriding(authorized_sheriff_client, test_
 
     # update the existing bug number
     resp = authorized_sheriff_client.put(
-        reverse('performance-alert-summaries-list') + '1/',
-        {'bug_number': 987654}
+        reverse('performance-alert-summaries-list') + '1/', {'bug_number': 987654}
     )
 
     assert resp.status_code == 200
@@ -294,15 +316,15 @@ def test_bug_number_and_timestamp_on_overriding(authorized_sheriff_client, test_
     assert test_perf_alert_summary_with_bug.bug_updated > bug_linking_time
 
 
-def test_bug_number_and_timestamp_dont_update_from_other_modifications(authorized_sheriff_client,
-                                                                       test_perf_alert_summary):
+def test_bug_number_and_timestamp_dont_update_from_other_modifications(
+    authorized_sheriff_client, test_perf_alert_summary
+):
     assert test_perf_alert_summary.bug_number is None
     assert test_perf_alert_summary.bug_updated is None
 
     # link a bug
     resp = authorized_sheriff_client.put(
-        reverse('performance-alert-summaries-list') + '1/',
-        {'notes': 'human created notes'}
+        reverse('performance-alert-summaries-list') + '1/', {'notes': 'human created notes'}
     )
     assert resp.status_code == 200
     test_perf_alert_summary.refresh_from_db()

--- a/tests/webapp/api/test_performance_bug_template_api.py
+++ b/tests/webapp/api/test_performance_bug_template_api.py
@@ -1,7 +1,6 @@
 from django.urls import reverse
 
-from treeherder.perf.models import (PerformanceBugTemplate,
-                                    PerformanceFramework)
+from treeherder.perf.models import PerformanceBugTemplate, PerformanceFramework
 
 
 def test_perf_bug_template_api(client, test_perf_framework):
@@ -15,7 +14,7 @@ def test_perf_bug_template_api(client, test_perf_framework):
             'default_component': "dfcom{}".format(i),
             'default_product': "dfprod{}".format(i),
             'cc_list': "foo{}@bar.com".format(i),
-            'text': "my great text {}".format(i)
+            'text': "my great text {}".format(i),
         }
         PerformanceBugTemplate.objects.create(framework=framework, **dict)
         dict['framework'] = framework.id
@@ -27,7 +26,8 @@ def test_perf_bug_template_api(client, test_perf_framework):
     assert resp.json() == template_dicts
 
     # test that we can get just one (the usual case, probably)
-    resp = client.get(reverse('performance-bug-template-list') +
-                      '?framework={}'.format(test_perf_framework.id))
+    resp = client.get(
+        reverse('performance-bug-template-list') + '?framework={}'.format(test_perf_framework.id)
+    )
     assert resp.status_code == 200
     assert resp.json() == [template_dicts[0]]

--- a/tests/webapp/api/test_performance_data_api.py
+++ b/tests/webapp/api/test_performance_data_api.py
@@ -3,11 +3,8 @@ import datetime
 import pytest
 from django.urls import reverse
 
-from treeherder.model.models import (MachinePlatform,
-                                     Push)
-from treeherder.perf.models import (PerformanceDatum,
-                                    PerformanceFramework,
-                                    PerformanceSignature)
+from treeherder.model.models import MachinePlatform, Push
+from treeherder.perf.models import PerformanceDatum, PerformanceFramework, PerformanceSignature
 
 NOW = datetime.datetime.now()
 ONE_DAY_AGO = NOW - datetime.timedelta(days=1)
@@ -20,7 +17,7 @@ def summary_perf_signature(test_perf_signature):
     # summary performance signature don't have test value
     signature = PerformanceSignature.objects.create(
         repository=test_perf_signature.repository,
-        signature_hash=(40*'s'),
+        signature_hash=(40 * 's'),
         framework=test_perf_signature.framework,
         platform=test_perf_signature.platform,
         option_collection=test_perf_signature.option_collection,
@@ -28,7 +25,7 @@ def summary_perf_signature(test_perf_signature):
         test='',
         extra_options='e10s shell',
         has_subtests=True,
-        last_updated=datetime.datetime.now()
+        last_updated=datetime.datetime.now(),
     )
     test_perf_signature.parent_signature = signature
     test_perf_signature.save()
@@ -39,8 +36,7 @@ def summary_perf_signature(test_perf_signature):
 def test_perf_signature_same_hash_different_framework(test_perf_signature):
     # a new signature, same as the test_perf_signature in every
     # way, except it belongs to a different "framework"
-    new_framework = PerformanceFramework.objects.create(
-        name='test_talos_2', enabled=True)
+    new_framework = PerformanceFramework.objects.create(name='test_talos_2', enabled=True)
     new_signature = PerformanceSignature.objects.create(
         repository=test_perf_signature.repository,
         signature_hash=test_perf_signature.signature_hash,
@@ -50,16 +46,16 @@ def test_perf_signature_same_hash_different_framework(test_perf_signature):
         suite=test_perf_signature.suite,
         test=test_perf_signature.test,
         has_subtests=test_perf_signature.has_subtests,
-        last_updated=test_perf_signature.last_updated
+        last_updated=test_perf_signature.last_updated,
     )
     return new_signature
 
 
-def test_no_summary_performance_data(client, test_perf_signature,
-                                     test_repository):
+def test_no_summary_performance_data(client, test_perf_signature, test_repository):
 
-    resp = client.get(reverse('performance-signatures-list',
-                              kwargs={"project": test_repository.name}))
+    resp = client.get(
+        reverse('performance-signatures-list', kwargs={"project": test_repository.name})
+    )
     assert resp.status_code == 200
     assert resp.json() == {
         test_perf_signature.signature_hash: {
@@ -78,10 +74,12 @@ def test_no_summary_performance_data(client, test_perf_signature,
 
 
 def test_performance_platforms(client, test_perf_signature):
-    resp = client.get(reverse('performance-signatures-platforms-list',
-                              kwargs={
-                                  "project": test_perf_signature.repository.name
-                              }))
+    resp = client.get(
+        reverse(
+            'performance-signatures-platforms-list',
+            kwargs={"project": test_perf_signature.repository.name},
+        )
+    )
     assert resp.status_code == 200
     assert resp.json() == ['win7']
 
@@ -90,10 +88,13 @@ def test_performance_platforms_expired_test(client, test_perf_signature):
     # check that we have no performance platform if the signatures are too old
     test_perf_signature.last_updated = datetime.datetime.utcfromtimestamp(0)
     test_perf_signature.save()
-    resp = client.get(reverse('performance-signatures-platforms-list',
-                              kwargs={
-                                  "project": test_perf_signature.repository.name
-                              }) + '?interval={}'.format(86400))
+    resp = client.get(
+        reverse(
+            'performance-signatures-platforms-list',
+            kwargs={"project": test_perf_signature.repository.name},
+        )
+        + '?interval={}'.format(86400)
+    )
     assert resp.status_code == 200
     assert resp.json() == []
 
@@ -101,10 +102,7 @@ def test_performance_platforms_expired_test(client, test_perf_signature):
 def test_performance_platforms_framework_filtering(client, test_perf_signature):
     # check framework filtering
     framework2 = PerformanceFramework.objects.create(name='test_talos2', enabled=True)
-    platform2 = MachinePlatform.objects.create(
-        os_name='win',
-        platform='win7-a',
-        architecture='x86')
+    platform2 = MachinePlatform.objects.create(os_name='win', platform='win7-a', architecture='x86')
     PerformanceSignature.objects.create(
         repository=test_perf_signature.repository,
         signature_hash=test_perf_signature.signature_hash,
@@ -114,35 +112,43 @@ def test_performance_platforms_framework_filtering(client, test_perf_signature):
         suite=test_perf_signature.suite,
         test=test_perf_signature.test,
         has_subtests=test_perf_signature.has_subtests,
-        last_updated=test_perf_signature.last_updated)
+        last_updated=test_perf_signature.last_updated,
+    )
 
     # by default should return both
-    resp = client.get(reverse('performance-signatures-platforms-list',
-                              kwargs={
-                                  "project": test_perf_signature.repository.name
-                              }))
+    resp = client.get(
+        reverse(
+            'performance-signatures-platforms-list',
+            kwargs={"project": test_perf_signature.repository.name},
+        )
+    )
     assert resp.status_code == 200
     assert sorted(resp.json()) == ['win7', 'win7-a']
 
     # if we specify just one framework, should only return one
-    resp = client.get(reverse('performance-signatures-platforms-list',
-                              kwargs={
-                                  "project": test_perf_signature.repository.name
-                              }) + '?framework={}'.format(framework2.id))
+    resp = client.get(
+        reverse(
+            'performance-signatures-platforms-list',
+            kwargs={"project": test_perf_signature.repository.name},
+        )
+        + '?framework={}'.format(framework2.id)
+    )
     assert resp.status_code == 200
     assert resp.json() == ['win7-a']
 
 
-def test_summary_performance_data(client, test_repository,
-                                  summary_perf_signature,
-                                  test_perf_signature):
+def test_summary_performance_data(
+    client, test_repository, summary_perf_signature, test_perf_signature
+):
     summary_signature_hash = summary_perf_signature.signature_hash
-    resp = client.get(reverse('performance-signatures-list',
-                              kwargs={"project": test_repository.name}))
+    resp = client.get(
+        reverse('performance-signatures-list', kwargs={"project": test_repository.name})
+    )
     assert resp.status_code == 200
 
-    resp = client.get(reverse('performance-signatures-list',
-                              kwargs={"project": test_repository.name}))
+    resp = client.get(
+        reverse('performance-signatures-list', kwargs={"project": test_repository.name})
+    )
     assert resp.status_code == 200
 
     assert len(resp.data.keys()) == 2
@@ -154,7 +160,7 @@ def test_summary_performance_data(client, test_repository,
             'suite': signature.suite,
             'option_collection_hash': signature.option_collection.option_collection_hash,
             'framework_id': signature.framework_id,
-            'machine_platform': signature.platform.platform
+            'machine_platform': signature.platform.platform,
         }
         if signature.test:
             expected['test'] = signature.test
@@ -175,32 +181,40 @@ def test_summary_performance_data(client, test_repository,
         assert resp.data[signature.signature_hash] == expected
 
 
-def test_filter_signatures_by_framework(client, test_repository, test_perf_signature,
-                                        test_perf_signature_same_hash_different_framework):
+def test_filter_signatures_by_framework(
+    client, test_repository, test_perf_signature, test_perf_signature_same_hash_different_framework
+):
     signature2 = test_perf_signature_same_hash_different_framework
 
     # Filter by original framework
-    resp = client.get(reverse('performance-signatures-list',
-                              kwargs={"project": test_repository.name}) +
-                      '?framework=%s' % test_perf_signature.framework.id,
-                      )
+    resp = client.get(
+        reverse('performance-signatures-list', kwargs={"project": test_repository.name})
+        + '?framework=%s' % test_perf_signature.framework.id,
+    )
     assert resp.status_code == 200
     assert len(resp.data.keys()) == 1
-    assert resp.data[test_perf_signature.signature_hash]['framework_id'] == test_perf_signature.framework.id
+    assert (
+        resp.data[test_perf_signature.signature_hash]['framework_id']
+        == test_perf_signature.framework.id
+    )
 
     # Filter by new framework
-    resp = client.get(reverse('performance-signatures-list',
-                              kwargs={"project": test_repository.name}) +
-                      '?framework=%s' % signature2.framework.id,
-                      )
+    resp = client.get(
+        reverse('performance-signatures-list', kwargs={"project": test_repository.name})
+        + '?framework=%s' % signature2.framework.id,
+    )
     assert resp.status_code == 200
     assert len(resp.data.keys()) == 1
     assert resp.data[signature2.signature_hash]['framework_id'] == signature2.framework.id
 
 
-def test_filter_data_by_framework(client, test_repository, test_perf_signature,
-                                  push_stored,
-                                  test_perf_signature_same_hash_different_framework):
+def test_filter_data_by_framework(
+    client,
+    test_repository,
+    test_perf_signature,
+    push_stored,
+    test_perf_signature_same_hash_different_framework,
+):
     signature2 = test_perf_signature_same_hash_different_framework
     push = Push.objects.get(id=1)
     for signature in [test_perf_signature, signature2]:
@@ -210,35 +224,40 @@ def test_filter_data_by_framework(client, test_repository, test_perf_signature,
             result_set_id=1,
             signature=signature,
             value=0.0,
-            push_timestamp=push.time)
+            push_timestamp=push.time,
+        )
 
     # No filtering, return two datapoints (this behaviour actually sucks,
     # but it's "by design" for now, see bug 1265709)
-    resp = client.get(reverse('performance-data-list',
-                              kwargs={"project": test_repository.name}) +
-                      '?signatures=' + test_perf_signature.signature_hash)
+    resp = client.get(
+        reverse('performance-data-list', kwargs={"project": test_repository.name})
+        + '?signatures='
+        + test_perf_signature.signature_hash
+    )
     assert resp.status_code == 200
     datums = resp.data[test_perf_signature.signature_hash]
     assert len(datums) == 2
     assert set(datum['signature_id'] for datum in datums) == {1, 2}
 
     # Filtering by first framework
-    resp = client.get(reverse('performance-data-list',
-                              kwargs={"project": test_repository.name}) +
-                      '?signatures={}&framework={}'.format(
-                          test_perf_signature.signature_hash,
-                          test_perf_signature.framework.id))
+    resp = client.get(
+        reverse('performance-data-list', kwargs={"project": test_repository.name})
+        + '?signatures={}&framework={}'.format(
+            test_perf_signature.signature_hash, test_perf_signature.framework.id
+        )
+    )
     assert resp.status_code == 200
     datums = resp.data[test_perf_signature.signature_hash]
     assert len(datums) == 1
     assert datums[0]['signature_id'] == 1
 
     # Filtering by second framework
-    resp = client.get(reverse('performance-data-list',
-                              kwargs={"project": test_repository.name}) +
-                      '?signatures={}&framework={}'.format(
-                          test_perf_signature.signature_hash,
-                          signature2.framework.id))
+    resp = client.get(
+        reverse('performance-data-list', kwargs={"project": test_repository.name})
+        + '?signatures={}&framework={}'.format(
+            test_perf_signature.signature_hash, signature2.framework.id
+        )
+    )
     assert resp.status_code == 200
     datums = resp.data[test_perf_signature.signature_hash]
     assert len(datums) == 1
@@ -247,61 +266,70 @@ def test_filter_data_by_framework(client, test_repository, test_perf_signature,
 
 def test_filter_signatures_by_interval(client, test_perf_signature):
     # interval for the last 24 hours, only one signature exists last updated within that timeframe
-    resp = client.get(reverse('performance-signatures-list',
-                              kwargs={
-                                  "project": test_perf_signature.repository.name
-                              }) + '?interval={}'.format(86400))
+    resp = client.get(
+        reverse(
+            'performance-signatures-list', kwargs={"project": test_perf_signature.repository.name}
+        )
+        + '?interval={}'.format(86400)
+    )
     assert resp.status_code == 200
     assert len(resp.json().keys()) == 1
     assert resp.json()[test_perf_signature.signature_hash]['id'] == 1
 
 
-@pytest.mark.parametrize('start_date, end_date, exp_count, exp_id', [
-    (SEVEN_DAYS_AGO, ONE_DAY_AGO, 1, 1),
-    (THREE_DAYS_AGO, '', 1, 1),
-    (ONE_DAY_AGO, '', 0, 0)])
-def test_filter_signatures_by_range(client, test_perf_signature,
-                                    start_date, end_date, exp_count, exp_id):
+@pytest.mark.parametrize(
+    'start_date, end_date, exp_count, exp_id',
+    [(SEVEN_DAYS_AGO, ONE_DAY_AGO, 1, 1), (THREE_DAYS_AGO, '', 1, 1), (ONE_DAY_AGO, '', 0, 0)],
+)
+def test_filter_signatures_by_range(
+    client, test_perf_signature, start_date, end_date, exp_count, exp_id
+):
     # set signature last updated to 3 days ago
     test_perf_signature.last_updated = THREE_DAYS_AGO
     test_perf_signature.save()
 
-    resp = client.get(reverse('performance-signatures-list',
-                              kwargs={
-                                  "project": test_perf_signature.repository.name
-                              }) + '?start_date={}&end_date={}'.format(start_date, end_date))
+    resp = client.get(
+        reverse(
+            'performance-signatures-list', kwargs={"project": test_perf_signature.repository.name}
+        )
+        + '?start_date={}&end_date={}'.format(start_date, end_date)
+    )
     assert resp.status_code == 200
     assert len(resp.json().keys()) == exp_count
     if exp_count != 0:
         assert resp.json()[test_perf_signature.signature_hash]['id'] == exp_id
 
 
-@pytest.mark.parametrize('interval, exp_datums_len, exp_push_ids', [
-    (86400, 1, [1]),
-    (86400 * 3, 2, [2, 1])])
-def test_filter_data_by_interval(client, test_repository, test_perf_signature,
-                                 interval, exp_datums_len, exp_push_ids):
+@pytest.mark.parametrize(
+    'interval, exp_datums_len, exp_push_ids', [(86400, 1, [1]), (86400 * 3, 2, [2, 1])]
+)
+def test_filter_data_by_interval(
+    client, test_repository, test_perf_signature, interval, exp_datums_len, exp_push_ids
+):
     # create some test data
-    for (i, timestamp) in enumerate([NOW, NOW - datetime.timedelta(days=2),
-                                     NOW - datetime.timedelta(days=7)]):
-        push = Push.objects.create(repository=test_repository,
-                                   revision='abcdefgh%s' % i,
-                                   author='foo@bar.com',
-                                   time=timestamp)
+    for (i, timestamp) in enumerate(
+        [NOW, NOW - datetime.timedelta(days=2), NOW - datetime.timedelta(days=7)]
+    ):
+        push = Push.objects.create(
+            repository=test_repository,
+            revision='abcdefgh%s' % i,
+            author='foo@bar.com',
+            time=timestamp,
+        )
         PerformanceDatum.objects.create(
             repository=test_perf_signature.repository,
             result_set_id=push.id,
             push=push,
             signature=test_perf_signature,
             value=i,
-            push_timestamp=timestamp)
+            push_timestamp=timestamp,
+        )
 
     # going back interval of 1 day, should find 1 item
-    resp = client.get(reverse('performance-data-list',
-                              kwargs={"project": test_repository.name}) +
-                      '?signature_id={}&interval={}'.format(
-                          test_perf_signature.id,
-                          interval))
+    resp = client.get(
+        reverse('performance-data-list', kwargs={"project": test_repository.name})
+        + '?signature_id={}&interval={}'.format(test_perf_signature.id, interval)
+    )
 
     assert resp.status_code == 200
     datums = resp.data[test_perf_signature.signature_hash]
@@ -310,32 +338,38 @@ def test_filter_data_by_interval(client, test_repository, test_perf_signature,
         assert datums[x]['push_id'] == exp_push_ids[x]
 
 
-@pytest.mark.parametrize('start_date, end_date, exp_datums_len, exp_push_ids', [
-    (SEVEN_DAYS_AGO, THREE_DAYS_AGO, 1, [3]),
-    (THREE_DAYS_AGO, '', 2, [2, 1])])
-def test_filter_data_by_range(client, test_repository, test_perf_signature,
-                              start_date, end_date, exp_datums_len,
-                              exp_push_ids):
+@pytest.mark.parametrize(
+    'start_date, end_date, exp_datums_len, exp_push_ids',
+    [(SEVEN_DAYS_AGO, THREE_DAYS_AGO, 1, [3]), (THREE_DAYS_AGO, '', 2, [2, 1])],
+)
+def test_filter_data_by_range(
+    client, test_repository, test_perf_signature, start_date, end_date, exp_datums_len, exp_push_ids
+):
     # create some test data
-    for (i, timestamp) in enumerate([NOW, NOW - datetime.timedelta(days=2),
-                                     NOW - datetime.timedelta(days=5)]):
-        push = Push.objects.create(repository=test_repository,
-                                   revision='abcdefgh%s' % i,
-                                   author='foo@bar.com',
-                                   time=timestamp)
+    for (i, timestamp) in enumerate(
+        [NOW, NOW - datetime.timedelta(days=2), NOW - datetime.timedelta(days=5)]
+    ):
+        push = Push.objects.create(
+            repository=test_repository,
+            revision='abcdefgh%s' % i,
+            author='foo@bar.com',
+            time=timestamp,
+        )
         PerformanceDatum.objects.create(
             repository=test_perf_signature.repository,
             result_set_id=push.id,
             push=push,
             signature=test_perf_signature,
             value=i,
-            push_timestamp=timestamp)
+            push_timestamp=timestamp,
+        )
 
-    resp = client.get(reverse('performance-data-list',
-                              kwargs={"project": test_repository.name}) +
-                      '?signature_id={}&start_date={}&end_date={}'.format(
-                          test_perf_signature.id,
-                          start_date, end_date))
+    resp = client.get(
+        reverse('performance-data-list', kwargs={"project": test_repository.name})
+        + '?signature_id={}&start_date={}&end_date={}'.format(
+            test_perf_signature.id, start_date, end_date
+        )
+    )
 
     assert resp.status_code == 200
     datums = resp.data[test_perf_signature.signature_hash]
@@ -345,23 +379,23 @@ def test_filter_data_by_range(client, test_repository, test_perf_signature,
 
 
 def test_job_ids_validity(client, test_repository):
-    resp = client.get(reverse('performance-data-list',
-                              kwargs={"project": test_repository.name}) +
-                      '?job_id=1')
+    resp = client.get(
+        reverse('performance-data-list', kwargs={"project": test_repository.name}) + '?job_id=1'
+    )
     assert resp.status_code == 200
 
-    resp = client.get(reverse('performance-data-list',
-                              kwargs={"project": test_repository.name}) +
-                      '?job_id=foo')
+    resp = client.get(
+        reverse('performance-data-list', kwargs={"project": test_repository.name}) + '?job_id=foo'
+    )
     assert resp.status_code == 400
 
 
-def test_filter_data_by_signature(client, test_repository, test_perf_signature,
-                                  summary_perf_signature):
-    push = Push.objects.create(repository=test_repository,
-                               revision='abcdefghi',
-                               author='foo@bar.com',
-                               time=NOW)
+def test_filter_data_by_signature(
+    client, test_repository, test_perf_signature, summary_perf_signature
+):
+    push = Push.objects.create(
+        repository=test_repository, revision='abcdefghi', author='foo@bar.com', time=NOW
+    )
     for (i, signature) in enumerate([test_perf_signature, summary_perf_signature]):
         PerformanceDatum.objects.create(
             repository=signature.repository,
@@ -369,16 +403,20 @@ def test_filter_data_by_signature(client, test_repository, test_perf_signature,
             push=push,
             signature=signature,
             value=i,
-            push_timestamp=NOW)
+            push_timestamp=NOW,
+        )
 
     # test that we get the expected value for all different permutations of
     # passing in signature_id and signature hash
     for (i, signature) in enumerate([test_perf_signature, summary_perf_signature]):
-        for (param, value) in [('signatures', signature.signature_hash),
-                               ('signature_id', signature.id)]:
-            resp = client.get(reverse('performance-data-list',
-                                      kwargs={"project": test_repository.name}) +
-                              '?{}={}'.format(param, value))
+        for (param, value) in [
+            ('signatures', signature.signature_hash),
+            ('signature_id', signature.id),
+        ]:
+            resp = client.get(
+                reverse('performance-data-list', kwargs={"project": test_repository.name})
+                + '?{}={}'.format(param, value)
+            )
             assert resp.status_code == 200
             assert len(resp.data.keys()) == 1
             assert len(resp.data[signature.signature_hash]) == 1
@@ -389,31 +427,37 @@ def test_filter_data_by_signature(client, test_repository, test_perf_signature,
 def test_perf_summary(client, test_perf_signature, test_perf_data):
 
     query_params1 = '?repository={}&framework={}&interval=172800&no_subtests=true&revision={}'.format(
-        test_perf_signature.repository.name, test_perf_signature.framework_id, test_perf_data[0].push.revision)
+        test_perf_signature.repository.name,
+        test_perf_signature.framework_id,
+        test_perf_data[0].push.revision,
+    )
 
     query_params2 = '?repository={}&framework={}&interval=172800&no_subtests=true&startday=2013-11-01T23%3A28%3A29&endday=2013-11-30T23%3A28%3A29'.format(
-                    test_perf_signature.repository.name, test_perf_signature.framework_id)
+        test_perf_signature.repository.name, test_perf_signature.framework_id
+    )
 
-    expected = [{
-        'signature_id': test_perf_signature.id,
-        'framework_id': test_perf_signature.framework_id,
-        'signature_hash': test_perf_signature.signature_hash,
-        'platform': test_perf_signature.platform.platform,
-        'test': test_perf_signature.test,
-        'application': test_perf_signature.application,
-        'lower_is_better': test_perf_signature.lower_is_better,
-        'has_subtests': test_perf_signature.has_subtests,
-        'tags': test_perf_signature.tags,
-        'measurement_unit': test_perf_signature.measurement_unit,
-        'values': [test_perf_data[0].value],
-        'name': 'mysuite mytest opt e10s opt',
-        'parent_signature': None,
-        'job_ids': [test_perf_data[0].job_id],
-        'suite': test_perf_signature.suite,
-        'repository_name': test_perf_signature.repository.name,
-        'repository_id': test_perf_signature.repository.id,
-        'data': []
-    }]
+    expected = [
+        {
+            'signature_id': test_perf_signature.id,
+            'framework_id': test_perf_signature.framework_id,
+            'signature_hash': test_perf_signature.signature_hash,
+            'platform': test_perf_signature.platform.platform,
+            'test': test_perf_signature.test,
+            'application': test_perf_signature.application,
+            'lower_is_better': test_perf_signature.lower_is_better,
+            'has_subtests': test_perf_signature.has_subtests,
+            'tags': test_perf_signature.tags,
+            'measurement_unit': test_perf_signature.measurement_unit,
+            'values': [test_perf_data[0].value],
+            'name': 'mysuite mytest opt e10s opt',
+            'parent_signature': None,
+            'job_ids': [test_perf_data[0].job_id],
+            'suite': test_perf_signature.suite,
+            'repository_name': test_perf_signature.repository.name,
+            'repository_id': test_perf_signature.repository.id,
+            'data': [],
+        }
+    ]
 
     resp1 = client.get(reverse('performance-summary') + query_params1)
     assert resp1.status_code == 200

--- a/tests/webapp/api/test_push_api.py
+++ b/tests/webapp/api/test_push_api.py
@@ -5,9 +5,7 @@ from django.urls import reverse
 
 from tests.conftest import IS_WINDOWS
 from treeherder.etl.push import store_push_data
-from treeherder.model.models import (FailureClassification,
-                                     JobNote,
-                                     Push)
+from treeherder.model.models import FailureClassification, JobNote, Push
 from treeherder.webapp.api import utils
 
 
@@ -16,8 +14,7 @@ def test_push_list_basic(client, eleven_jobs_stored, test_repository):
     test retrieving a list of ten json blobs from the jobs-list
     endpoint.
     """
-    resp = client.get(
-        reverse("push-list", kwargs={"project": test_repository.name}))
+    resp = client.get(reverse("push-list", kwargs={"project": test_repository.name}))
     data = resp.json()
     results = data['results']
     meta = data['meta']
@@ -26,32 +23,28 @@ def test_push_list_basic(client, eleven_jobs_stored, test_repository):
     assert isinstance(results, list)
 
     assert len(results) == 10
-    exp_keys = set([
-        u'id',
-        u'repository_id',
-        u'author',
-        u'revision',
-        u'revisions',
-        u'revision_count',
-        u'push_timestamp',
-    ])
+    exp_keys = set(
+        [
+            u'id',
+            u'repository_id',
+            u'author',
+            u'revision',
+            u'revisions',
+            u'revision_count',
+            u'push_timestamp',
+        ]
+    )
     for rs in results:
         assert set(rs.keys()) == exp_keys
 
-    assert(meta == {
-        u'count': 10,
-        u'filter_params': {},
-        u'repository': test_repository.name
-    })
+    assert meta == {u'count': 10, u'filter_params': {}, u'repository': test_repository.name}
 
 
 def test_push_list_bad_project(client, transactional_db):
     """
     test that we have a sane error when the repository does not exist
     """
-    resp = client.get(
-        reverse("push-list", kwargs={"project": "foo"}),
-    )
+    resp = client.get(reverse("push-list", kwargs={"project": "foo"}),)
     assert resp.status_code == 404
     assert resp.json() == {"detail": "No project with name foo"}
 
@@ -63,9 +56,7 @@ def test_push_list_empty_push_still_show(client, sample_push, test_repository):
     """
     store_push_data(test_repository, sample_push)
 
-    resp = client.get(
-        reverse("push-list", kwargs={"project": test_repository.name}),
-    )
+    resp = client.get(reverse("push-list", kwargs={"project": test_repository.name}),)
     assert resp.status_code == 200
     data = resp.json()
     assert len(data['results']) == 10
@@ -77,22 +68,19 @@ def test_push_list_single_short_revision(client, eleven_jobs_stored, test_reposi
     """
 
     resp = client.get(
-        reverse("push-list", kwargs={"project": test_repository.name}),
-        {"revision": "45f8637cb9f7"}
+        reverse("push-list", kwargs={"project": test_repository.name}), {"revision": "45f8637cb9f7"}
     )
     assert resp.status_code == 200
     results = resp.json()['results']
     meta = resp.json()['meta']
     assert len(results) == 1
     assert set([rs["revision"] for rs in results]) == {"45f8637cb9f78f19cb8463ff174e81756805d8cf"}
-    assert(meta == {
+    assert meta == {
         u'count': 1,
         u'revision': u'45f8637cb9f7',
-        u'filter_params': {
-            u'revisions_short_revision': "45f8637cb9f7"
-        },
-        u'repository': test_repository.name}
-    )
+        u'filter_params': {u'revisions_short_revision': "45f8637cb9f7"},
+        u'repository': test_repository.name,
+    }
 
 
 def test_push_list_single_long_revision(client, eleven_jobs_stored, test_repository):
@@ -102,21 +90,19 @@ def test_push_list_single_long_revision(client, eleven_jobs_stored, test_reposit
 
     resp = client.get(
         reverse("push-list", kwargs={"project": test_repository.name}),
-        {"revision": "45f8637cb9f78f19cb8463ff174e81756805d8cf"}
+        {"revision": "45f8637cb9f78f19cb8463ff174e81756805d8cf"},
     )
     assert resp.status_code == 200
     results = resp.json()['results']
     meta = resp.json()['meta']
     assert len(results) == 1
     assert set([rs["revision"] for rs in results]) == {"45f8637cb9f78f19cb8463ff174e81756805d8cf"}
-    assert(meta == {
+    assert meta == {
         u'count': 1,
         u'revision': u'45f8637cb9f78f19cb8463ff174e81756805d8cf',
-        u'filter_params': {
-            u'revisions_long_revision': u'45f8637cb9f78f19cb8463ff174e81756805d8cf'
-        },
-        u'repository': test_repository.name}
-    )
+        u'filter_params': {u'revisions_long_revision': u'45f8637cb9f78f19cb8463ff174e81756805d8cf'},
+        u'repository': test_repository.name,
+    }
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="timezone mixup happening somewhere")
@@ -127,7 +113,7 @@ def test_push_list_filter_by_revision(client, eleven_jobs_stored, test_repositor
 
     resp = client.get(
         reverse("push-list", kwargs={"project": test_repository.name}),
-        {"fromchange": "130965d3df6c", "tochange": "f361dcb60bbe"}
+        {"fromchange": "130965d3df6c", "tochange": "f361dcb60bbe"},
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -138,38 +124,32 @@ def test_push_list_filter_by_revision(client, eleven_jobs_stored, test_repositor
         u'130965d3df6c9a1093b4725f3b877eaef80d72bc',
         u'7f417c3505e3d2599ac9540f02e3dbee307a3963',
         u'a69390334818373e2d7e6e9c8d626a328ed37d47',
-        u'f361dcb60bbedaa01257fbca211452972f7a74b2'
+        u'f361dcb60bbedaa01257fbca211452972f7a74b2',
     }
-    assert(meta == {
+    assert meta == {
         u'count': 4,
         u'fromchange': u'130965d3df6c',
-        u'filter_params': {
-            u'push_timestamp__gte': 1384363842,
-            u'push_timestamp__lte': 1384365942
-        },
+        u'filter_params': {u'push_timestamp__gte': 1384363842, u'push_timestamp__lte': 1384365942},
         u'repository': test_repository.name,
-        u'tochange': u'f361dcb60bbe'}
-    )
+        u'tochange': u'f361dcb60bbe',
+    }
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="timezone mixup happening somewhere")
-def test_push_list_filter_by_date(client,
-                                  test_repository,
-                                  sample_push):
+def test_push_list_filter_by_date(client, test_repository, sample_push):
     """
     test retrieving a push list, filtered by a date range
     """
-    for (i, datestr) in zip([3, 4, 5, 6, 7], ["2013-08-09", "2013-08-10",
-                                              "2013-08-11", "2013-08-12",
-                                              "2013-08-13"]):
-        sample_push[i]['push_timestamp'] = utils.to_timestamp(
-            utils.to_datetime(datestr))
+    for (i, datestr) in zip(
+        [3, 4, 5, 6, 7], ["2013-08-09", "2013-08-10", "2013-08-11", "2013-08-12", "2013-08-13"]
+    ):
+        sample_push[i]['push_timestamp'] = utils.to_timestamp(utils.to_datetime(datestr))
 
     store_push_data(test_repository, sample_push)
 
     resp = client.get(
         reverse("push-list", kwargs={"project": test_repository.name}),
-        {"startdate": "2013-08-10", "enddate": "2013-08-13"}
+        {"startdate": "2013-08-10", "enddate": "2013-08-13"},
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -180,44 +160,47 @@ def test_push_list_filter_by_date(client,
         u'ce17cad5d554cfffddee13d1d8421ae9ec5aad82',
         u'7f417c3505e3d2599ac9540f02e3dbee307a3963',
         u'a69390334818373e2d7e6e9c8d626a328ed37d47',
-        u'f361dcb60bbedaa01257fbca211452972f7a74b2'
+        u'f361dcb60bbedaa01257fbca211452972f7a74b2',
     }
-    assert(meta == {
+    assert meta == {
         u'count': 4,
         u'enddate': u'2013-08-13',
         u'filter_params': {
             u'push_timestamp__gte': 1376092800.0,
-            u'push_timestamp__lt': 1376438400.0
+            u'push_timestamp__lt': 1376438400.0,
         },
         u'repository': test_repository.name,
-        u'startdate': u'2013-08-10'}
-    )
+        u'startdate': u'2013-08-10',
+    }
 
 
-@pytest.mark.parametrize('filter_param, exp_ids', [
-    ('id__lt=2', [1]),
-    ('id__lte=2', [1, 2]),
-    ('id=2', [2]),
-    ('id__gt=2', [3]),
-    ('id__gte=2', [2, 3])
-])
-def test_push_list_filter_by_id(client,
-                                test_repository,
-                                filter_param,
-                                exp_ids):
+@pytest.mark.parametrize(
+    'filter_param, exp_ids',
+    [
+        ('id__lt=2', [1]),
+        ('id__lte=2', [1, 2]),
+        ('id=2', [2]),
+        ('id__gt=2', [3]),
+        ('id__gte=2', [2, 3]),
+    ],
+)
+def test_push_list_filter_by_id(client, test_repository, filter_param, exp_ids):
     """
     test filtering by id in various ways
     """
-    for (revision, author) in [('1234abcd', 'foo@bar.com'),
-                               ('2234abcd', 'foo2@bar.com'),
-                               ('3234abcd', 'foo3@bar.com')]:
-        Push.objects.create(repository=test_repository,
-                            revision=revision,
-                            author=author,
-                            time=datetime.datetime.now())
+    for (revision, author) in [
+        ('1234abcd', 'foo@bar.com'),
+        ('2234abcd', 'foo2@bar.com'),
+        ('3234abcd', 'foo3@bar.com'),
+    ]:
+        Push.objects.create(
+            repository=test_repository,
+            revision=revision,
+            author=author,
+            time=datetime.datetime.now(),
+        )
     resp = client.get(
-        reverse("push-list", kwargs={"project": test_repository.name}) +
-        '?' + filter_param
+        reverse("push-list", kwargs={"project": test_repository.name}) + '?' + filter_param
     )
     assert resp.status_code == 200
     results = resp.json()['results']
@@ -228,16 +211,19 @@ def test_push_list_id_in(client, test_repository):
     """
     test the id__in parameter
     """
-    for (revision, author) in [('1234abcd', 'foo@bar.com'),
-                               ('2234abcd', 'foo2@bar.com'),
-                               ('3234abcd', 'foo3@bar.com')]:
-        Push.objects.create(repository=test_repository,
-                            revision=revision,
-                            author=author,
-                            time=datetime.datetime.now())
+    for (revision, author) in [
+        ('1234abcd', 'foo@bar.com'),
+        ('2234abcd', 'foo2@bar.com'),
+        ('3234abcd', 'foo3@bar.com'),
+    ]:
+        Push.objects.create(
+            repository=test_repository,
+            revision=revision,
+            author=author,
+            time=datetime.datetime.now(),
+        )
     resp = client.get(
-        reverse("push-list", kwargs={"project": test_repository.name}) +
-        '?id__in=1,2'
+        reverse("push-list", kwargs={"project": test_repository.name}) + '?id__in=1,2'
     )
     assert resp.status_code == 200
 
@@ -247,8 +233,7 @@ def test_push_list_id_in(client, test_repository):
 
     # test that we do something sane if invalid list passed in
     resp = client.get(
-        reverse("push-list", kwargs={"project": test_repository.name}) +
-        '?id__in=1,2,foobar',
+        reverse("push-list", kwargs={"project": test_repository.name}) + '?id__in=1,2,foobar',
     )
     assert resp.status_code == 400
 
@@ -260,8 +245,7 @@ def test_push_list_bad_count(client, test_repository):
     bad_count = "ZAP%n%s%n%s"
 
     resp = client.get(
-        reverse("push-list", kwargs={"project": test_repository.name}),
-        data={'count': bad_count}
+        reverse("push-list", kwargs={"project": test_repository.name}), data={'count': bad_count}
     )
 
     assert resp.status_code == 400
@@ -272,17 +256,20 @@ def test_push_author(client, test_repository):
     """
     test the author parameter
     """
-    for (revision, author) in [('1234abcd', 'foo@bar.com'),
-                               ('2234abcd', 'foo@bar.com'),
-                               ('3234abcd', 'foo2@bar.com')]:
-        Push.objects.create(repository=test_repository,
-                            revision=revision,
-                            author=author,
-                            time=datetime.datetime.now())
+    for (revision, author) in [
+        ('1234abcd', 'foo@bar.com'),
+        ('2234abcd', 'foo@bar.com'),
+        ('3234abcd', 'foo2@bar.com'),
+    ]:
+        Push.objects.create(
+            repository=test_repository,
+            revision=revision,
+            author=author,
+            time=datetime.datetime.now(),
+        )
 
     resp = client.get(
-        reverse("push-list", kwargs={"project": test_repository.name}) +
-        '?author=foo@bar.com'
+        reverse("push-list", kwargs={"project": test_repository.name}) + '?author=foo@bar.com'
     )
     assert resp.status_code == 200
 
@@ -291,8 +278,7 @@ def test_push_author(client, test_repository):
     assert set([result['id'] for result in results]) == set([1, 2])
 
     resp = client.get(
-        reverse("push-list", kwargs={"project": test_repository.name}) +
-        '?author=foo2@bar.com'
+        reverse("push-list", kwargs={"project": test_repository.name}) + '?author=foo2@bar.com'
     )
     assert resp.status_code == 200
 
@@ -301,17 +287,13 @@ def test_push_author(client, test_repository):
     assert results[0]['id'] == 3
 
 
-def test_push_list_without_jobs(client,
-                                test_repository,
-                                sample_push):
+def test_push_list_without_jobs(client, test_repository, sample_push):
     """
     test retrieving a push list without jobs
     """
     store_push_data(test_repository, sample_push)
 
-    resp = client.get(
-        reverse("push-list", kwargs={"project": test_repository.name})
-    )
+    resp = client.get(reverse("push-list", kwargs={"project": test_repository.name}))
     assert resp.status_code == 200
     data = resp.json()
     results = data['results']
@@ -323,7 +305,7 @@ def test_push_list_without_jobs(client,
     assert meta == {
         u'count': len(results),
         u'filter_params': {},
-        u'repository': test_repository.name
+        u'repository': test_repository.name,
     }
 
 
@@ -335,10 +317,7 @@ def test_push_detail(client, eleven_jobs_stored, test_repository):
 
     push = Push.objects.get(id=1)
 
-    resp = client.get(
-        reverse("push-detail",
-                kwargs={"project": test_repository.name, "pk": 1})
-    )
+    resp = client.get(reverse("push-detail", kwargs={"project": test_repository.name, "pk": 1}))
     assert resp.status_code == 200
     assert isinstance(resp.json(), dict)
     assert resp.json()["id"] == push.id
@@ -350,8 +329,7 @@ def test_push_detail_not_found(client, test_repository):
     endpoint.
     """
     resp = client.get(
-        reverse("push-detail",
-                kwargs={"project": test_repository.name, "pk": -32767}),
+        reverse("push-detail", kwargs={"project": test_repository.name, "pk": -32767}),
     )
     assert resp.status_code == 404
 
@@ -362,10 +340,7 @@ def test_push_detail_bad_project(client, test_repository):
     endpoint.
     """
     bad_pk = -32767
-    resp = client.get(
-        reverse("push-detail",
-                kwargs={"project": "foo", "pk": bad_pk}),
-    )
+    resp = client.get(reverse("push-detail", kwargs={"project": "foo", "pk": bad_pk}),)
     assert resp.status_code == 404
 
 
@@ -373,27 +348,26 @@ def test_push_status(client, test_job, test_user):
     """
     test retrieving the status of a push
     """
-    failure_classification = FailureClassification.objects.get(
-        name="fixed by commit")
+    failure_classification = FailureClassification.objects.get(name="fixed by commit")
 
     push = test_job.push
 
     resp = client.get(
-        reverse("push-status",
-                kwargs={"project": push.repository.name, "pk": push.id})
+        reverse("push-status", kwargs={"project": push.repository.name, "pk": push.id})
     )
     assert resp.status_code == 200
     assert isinstance(resp.json(), dict)
     assert resp.json() == {'success': 1, 'completed': 1, 'pending': 0, 'running': 0}
 
-    JobNote.objects.create(job=test_job,
-                           failure_classification=failure_classification,
-                           user=test_user,
-                           text='A random note')
+    JobNote.objects.create(
+        job=test_job,
+        failure_classification=failure_classification,
+        user=test_user,
+        text='A random note',
+    )
 
     resp = client.get(
-        reverse("push-status",
-                kwargs={"project": push.repository.name, "pk": push.id})
+        reverse("push-status", kwargs={"project": push.repository.name, "pk": push.id})
     )
     assert resp.status_code == 200
     assert isinstance(resp.json(), dict)

--- a/tests/webapp/api/test_version.py
+++ b/tests/webapp/api/test_version.py
@@ -26,8 +26,7 @@ def test_unsupported_version():
 def test_correct_version():
     view = RequestVersionView.as_view()
     version = settings.REST_FRAMEWORK['ALLOWED_VERSIONS'][0]
-    request = factory.get('/endpoint/',
-                          HTTP_ACCEPT='application/json; version={0}'.format(version))
+    request = factory.get('/endpoint/', HTTP_ACCEPT='application/json; version={0}'.format(version))
     response = view(request)
     assert response.data == {'version': version}
 

--- a/treeherder/auth/backends.py
+++ b/treeherder/auth/backends.py
@@ -7,8 +7,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from jose import jwt
 from rest_framework.exceptions import AuthenticationFailed
 
-from treeherder.config.settings import (AUTH0_CLIENTID,
-                                        AUTH0_DOMAIN)
+from treeherder.config.settings import AUTH0_CLIENTID, AUTH0_DOMAIN
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +28,6 @@ with open('treeherder/auth/jwks.json') as f:
 
 
 class AuthBackend:
-
     def _get_access_token_expiry(self, request):
         expiration_timestamp_in_seconds = request.META.get('HTTP_ACCESS_TOKEN_EXPIRES_AT')
 
@@ -141,7 +139,7 @@ class AuthBackend:
                     "kid": key["kid"],
                     "use": key["use"],
                     "n": key["n"],
-                    "e": key["e"]
+                    "e": key["e"],
                 }
                 break
 
@@ -156,7 +154,7 @@ class AuthBackend:
                 algorithms=['RS256'],
                 audience=AUTH0_CLIENTID,
                 access_token=access_token,
-                issuer="https://"+AUTH0_DOMAIN+"/"
+                issuer="https://" + AUTH0_DOMAIN + "/",
             )
             return user_info
         except jwt.ExpiredSignatureError:
@@ -173,7 +171,9 @@ class AuthBackend:
         now_in_seconds = int(time.time())
 
         # The session length is set to match whichever token expiration time is closer.
-        earliest_expiration_timestamp = min(access_token_expiry_timestamp, id_token_expiry_timestamp)
+        earliest_expiration_timestamp = min(
+            access_token_expiry_timestamp, id_token_expiry_timestamp
+        )
         seconds_until_expiry = earliest_expiration_timestamp - now_in_seconds
 
         if seconds_until_expiry <= 0:

--- a/treeherder/changelog/collector.py
+++ b/treeherder/changelog/collector.py
@@ -45,9 +45,7 @@ class GitHub:
             if filters:
                 for filter in filters:
                     if isinstance(filter, list) and filter[0] == "filter_by_path":
-                        commit_info = github.commit_info(
-                            owner, repository, commit["sha"]
-                        )
+                        commit_info = github.commit_info(owner, repository, commit["sha"])
                         commit["files"] = commit_info["files"]
                         break
 

--- a/treeherder/changelog/management/commands/update_changelog.py
+++ b/treeherder/changelog/management/commands/update_changelog.py
@@ -11,9 +11,7 @@ class Command(BaseCommand):
     """
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            "--days", help="Number of days to look at", type=int, default=1
-        )
+        parser.add_argument("--days", help="Number of days to look at", type=int, default=1)
 
     def handle(self, *args, **options):
         update_changelog(options["days"])

--- a/treeherder/changelog/migrations/0001_initial.py
+++ b/treeherder/changelog/migrations/0001_initial.py
@@ -8,8 +8,7 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
@@ -37,10 +36,15 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, serialize=False)),
                 ('name', models.SlugField(max_length=255)),
-                ('changelog', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='files', to='changelog.Changelog')),
+                (
+                    'changelog',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='files',
+                        to='changelog.Changelog',
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'changelog_file',
-            },
+            options={'db_table': 'changelog_file',},
         ),
     ]

--- a/treeherder/changelog/models.py
+++ b/treeherder/changelog/models.py
@@ -24,9 +24,7 @@ class Changelog(models.Model):
 
 class ChangelogFile(models.Model):
     id = models.AutoField(primary_key=True)
-    changelog = models.ForeignKey(
-        Changelog, related_name="files", on_delete=models.CASCADE
-    )
+    changelog = models.ForeignKey(Changelog, related_name="files", on_delete=models.CASCADE)
     name = models.SlugField(max_length=255)
 
     class Meta:

--- a/treeherder/changelog/tasks.py
+++ b/treeherder/changelog/tasks.py
@@ -4,8 +4,7 @@ import logging
 from django.db import transaction
 
 from treeherder.changelog.collector import collect
-from treeherder.changelog.models import (Changelog,
-                                         ChangelogFile)
+from treeherder.changelog.models import Changelog, ChangelogFile
 
 logger = logging.getLogger(__name__)
 
@@ -33,10 +32,8 @@ def update_changelog(days=1):
                 existed += 1
                 continue
             created += 1
-            [
-                ChangelogFile.objects.create(name=name, changelog=changelog)
-                for name in files
-            ]
+            [ChangelogFile.objects.create(name=name, changelog=changelog) for name in files]
 
-    logger.info("Found %d items, %d existed and %d where created." % (
-                created + existed, existed, created))
+    logger.info(
+        "Found %d items, %d existed and %d where created." % (created + existed, existed, created)
+    )

--- a/treeherder/client/setup.py
+++ b/treeherder/client/setup.py
@@ -8,8 +8,7 @@ from setuptools import setup
 def read(*names, **kwargs):
     # Taken from https://packaging.python.org/en/latest/single_source_version.html
     with io.open(
-        os.path.join(os.path.dirname(__file__), *names),
-        encoding=kwargs.get("encoding", "utf8")
+        os.path.join(os.path.dirname(__file__), *names), encoding=kwargs.get("encoding", "utf8")
     ) as fp:
         return fp.read()
 
@@ -17,34 +16,34 @@ def read(*names, **kwargs):
 def find_version(*file_paths):
     # Taken from https://packaging.python.org/en/latest/single_source_version.html
     version_file = read(*file_paths)
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
 
-setup(name='treeherder-client',
-      version=find_version('thclient', 'client.py'),
-      description='Python library to retrieve data from the Treeherder API',
-      classifiers=[
-          'Environment :: Console',
-          'Intended Audience :: Developers',
-          'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
-          'Natural Language :: English',
-          'Operating System :: OS Independent',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
-          'Topic :: Software Development :: Libraries :: Python Modules',
-      ],
-      keywords='',
-      author='Mozilla Automation and Testing Team',
-      author_email='tools@lists.mozilla.org',
-      url='https://github.com/mozilla/treeherder',
-      license='MPL',
-      packages=['thclient'],
-      python_requires='>=3',
-      install_requires=['requests==2.22.0']
-      )
+setup(
+    name='treeherder-client',
+    version=find_version('thclient', 'client.py'),
+    description='Python library to retrieve data from the Treeherder API',
+    classifiers=[
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
+    keywords='',
+    author='Mozilla Automation and Testing Team',
+    author_email='tools@lists.mozilla.org',
+    url='https://github.com/mozilla/treeherder',
+    license='MPL',
+    packages=['thclient'],
+    python_requires='>=3',
+    install_requires=['requests==2.22.0'],
+)

--- a/treeherder/client/thclient/client.py
+++ b/treeherder/client/thclient/client.py
@@ -63,7 +63,7 @@ class TreeherderClient:
                     return data
                 offset += count
                 if total is not None:
-                    count = min(total-offset, self.MAX_COUNT)
+                    count = min(total - offset, self.MAX_COUNT)
         else:
             return self._get_json(endpoint, project=project, **params)["results"]
 
@@ -74,8 +74,9 @@ class TreeherderClient:
         try:
             resp.raise_for_status()
         except HTTPError:
-            logger.error("HTTPError %s requesting %s: %s",
-                         resp.status_code, resp.request.url, resp.content)
+            logger.error(
+                "HTTPError %s requesting %s: %s", resp.status_code, resp.request.url, resp.content
+            )
             logger.debug("Request headers: %s", resp.request.headers)
             logger.debug("Response headers: %s", resp.headers)
             raise
@@ -158,8 +159,7 @@ class TreeherderClient:
 
         :param params: keyword arguments to filter results
         """
-        return self._get_json_list(self.JOB_DETAIL_ENDPOINT, None,
-                                   **params)
+        return self._get_json_list(self.JOB_DETAIL_ENDPOINT, None, **params)
 
     def get_job_log_url(self, project, **params):
         """
@@ -168,5 +168,4 @@ class TreeherderClient:
         :param project: project (repository name) to query data for
         :param params: keyword arguments to filter results
         """
-        return self._get_json(self.JOB_LOG_URL_ENDPOINT, project,
-                              **params)
+        return self._get_json(self.JOB_LOG_URL_ENDPOINT, project, **params)

--- a/treeherder/client/thclient/perfherder.py
+++ b/treeherder/client/thclient/perfherder.py
@@ -5,6 +5,7 @@ class PerformanceTimeInterval:
     '''
     Valid time intervals for Perfherder series
     '''
+
     DAY = 86400
     WEEK = 604800
     TWO_WEEKS = 1209600
@@ -18,12 +19,14 @@ class PerformanceTimeInterval:
         Helper method to return all possible valid time intervals for data
         stored by Perfherder
         '''
-        return [PerformanceTimeInterval.DAY,
-                PerformanceTimeInterval.WEEK,
-                PerformanceTimeInterval.TWO_WEEKS,
-                PerformanceTimeInterval.SIXTY_DAYS,
-                PerformanceTimeInterval.NINETY_DAYS,
-                PerformanceTimeInterval.ONE_YEAR]
+        return [
+            PerformanceTimeInterval.DAY,
+            PerformanceTimeInterval.WEEK,
+            PerformanceTimeInterval.TWO_WEEKS,
+            PerformanceTimeInterval.SIXTY_DAYS,
+            PerformanceTimeInterval.NINETY_DAYS,
+            PerformanceTimeInterval.ONE_YEAR,
+        ]
 
 
 class PerformanceSignatureCollection(dict):

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -2,17 +2,13 @@ import os
 import platform
 import re
 from datetime import timedelta
-from os.path import (abspath,
-                     dirname,
-                     join)
+from os.path import abspath, dirname, join
 
 import environ
 from furl import furl
-from kombu import (Exchange,
-                   Queue)
+from kombu import Exchange, Queue
 
-from treeherder.config.utils import (connection_should_use_tls,
-                                     get_tls_redis_url)
+from treeherder.config.utils import connection_should_use_tls, get_tls_redis_url
 
 # TODO: Switch to pathlib once using Python 3.
 SRC_DIR = dirname(dirname(dirname(abspath(__file__))))
@@ -30,7 +26,10 @@ NEW_RELIC_INSIGHTS_API_KEY = env("NEW_RELIC_INSIGHTS_API_KEY", default=None)
 NEW_RELIC_INSIGHTS_API_URL = 'https://insights-api.newrelic.com/v1/accounts/677903/query'
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = env("TREEHERDER_DJANGO_SECRET_KEY", default='secret-key-of-at-least-50-characters-to-pass-check-deploy')
+SECRET_KEY = env(
+    "TREEHERDER_DJANGO_SECRET_KEY",
+    default='secret-key-of-at-least-50-characters-to-pass-check-deploy',
+)
 
 # Delete the Pulse automatically when no consumers left
 PULSE_AUTO_DELETE_QUEUES = env.bool("PULSE_AUTO_DELETE_QUEUES", default=False)
@@ -67,12 +66,10 @@ INSTALLED_APPS = [
     # greater consistency between gunicorn and `./manage.py runserver`.
     'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
-
     # 3rd party apps
     'rest_framework',
     'corsheaders',
     'django_filters',
-
     # treeherder apps
     'treeherder.model',
     'treeherder.webapp',
@@ -104,29 +101,30 @@ if env("HEROKU_REVIEW_APP", default=False):
     ALLOWED_HOSTS = [SITE_URL]
 
 # Middleware
-MIDDLEWARE = [middleware for middleware in [
-    # Adds custom New Relic annotations. Must be first so all transactions are annotated.
-    'treeherder.middleware.NewRelicMiddleware',
-    # Redirect to HTTPS/set HSTS and other security headers.
-    'django.middleware.security.SecurityMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
-    # Allows both Django static files and those specified via `WHITENOISE_ROOT`
-    # to be served by WhiteNoise, avoiding the need for Apache/nginx on Heroku.
-    'treeherder.middleware.CustomWhiteNoise',
-    'django.middleware.gzip.GZipMiddleware',
-    'debug_toolbar.middleware.DebugToolbarMiddleware' if DEBUG else False,
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-] if middleware]
+MIDDLEWARE = [
+    middleware
+    for middleware in [
+        # Adds custom New Relic annotations. Must be first so all transactions are annotated.
+        'treeherder.middleware.NewRelicMiddleware',
+        # Redirect to HTTPS/set HSTS and other security headers.
+        'django.middleware.security.SecurityMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        'corsheaders.middleware.CorsMiddleware',
+        # Allows both Django static files and those specified via `WHITENOISE_ROOT`
+        # to be served by WhiteNoise, avoiding the need for Apache/nginx on Heroku.
+        'treeherder.middleware.CustomWhiteNoise',
+        'django.middleware.gzip.GZipMiddleware',
+        'debug_toolbar.middleware.DebugToolbarMiddleware' if DEBUG else False,
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+    ]
+    if middleware
+]
 
 # Templating
-TEMPLATES = [{
-    'BACKEND': 'django.template.backends.django.DjangoTemplates',
-    'APP_DIRS': True,
-}]
+TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'APP_DIRS': True,}]
 
 # Database
 # The database config is defined using environment variables of form:
@@ -134,7 +132,9 @@ TEMPLATES = [{
 #   'mysql://username:password@host:optional_port/database_name'
 #
 # which django-environ converts into the Django DB settings dict format.
-LOCALHOST_MYSQL_HOST = 'mysql://root@{}:3306/treeherder'.format('localhost' if IS_WINDOWS else '127.0.0.1')
+LOCALHOST_MYSQL_HOST = 'mysql://root@{}:3306/treeherder'.format(
+    'localhost' if IS_WINDOWS else '127.0.0.1'
+)
 DATABASES = {
     'default': env.db_url('DATABASE_URL', default=LOCALHOST_MYSQL_HOST),
 }
@@ -158,7 +158,7 @@ for alias in DATABASES:
         # option contains STRICT_TRANS_TABLES. That option escalates warnings into errors when data are
         # truncated upon insertion, so Django highly recommends activating a strict mode for MySQL to
         # prevent data loss (either STRICT_TRANS_TABLES or STRICT_ALL_TABLES).
-        'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"
+        'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
     }
     if connection_should_use_tls(DATABASES[alias]['HOST']):
         # Use TLS when connecting to RDS.
@@ -221,22 +221,11 @@ LOGOUT_REDIRECT_URL = '/'
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
-    'filters': {
-        'require_debug_true': {
-            '()': 'django.utils.log.RequireDebugTrue',
-        },
-    },
+    'filters': {'require_debug_true': {'()': 'django.utils.log.RequireDebugTrue',},},
     'formatters': {
-        'standard': {
-            'format': "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
-        },
+        'standard': {'format': "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",},
     },
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'standard'
-        },
-    },
+    'handlers': {'console': {'class': 'logging.StreamHandler', 'formatter': 'standard'},},
     'loggers': {
         'django': {
             'filters': ['require_debug_true'],
@@ -244,21 +233,14 @@ LOGGING = {
             'level': 'INFO',
             'propagate': True,
         },
-        'django.request': {
-            'handlers': ['console'],
-            'level': 'WARNING',
-            'propagate': True,
-        },
+        'django.request': {'handlers': ['console'], 'level': 'WARNING', 'propagate': True,},
         'treeherder': {
             'handlers': ['console'],
             'level': LOGGING_LEVEL,
             'propagate': LOGGING_LEVEL != 'WARNING',
         },
-        'kombu': {
-            'handlers': ['console'],
-            'level': 'WARNING',
-        },
-    }
+        'kombu': {'handlers': ['console'], 'level': 'WARNING',},
+    },
 }
 
 # SECURITY
@@ -283,7 +265,7 @@ SILENCED_SYSTEM_CHECKS = [
     # We can't set CSRF_COOKIE_HTTPONLY to True since the requests to the API
     # made using Angular's `httpProvider` require access to the cookie.
     'security.W017',
-    'security.W019'
+    'security.W019',
 ]
 
 # User Agents
@@ -368,17 +350,13 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'fetch-push-logs',
         'schedule': timedelta(minutes=5),
         'relative': True,
-        'options': {
-            "queue": "pushlog"
-        }
+        'options': {"queue": "pushlog"},
     },
     'seta-analyze-failures': {
         'task': 'seta-analyze-failures',
         'schedule': timedelta(days=1),
         'relative': True,
-        'options': {
-            'queue': "seta_analyze_failures"
-        }
+        'options': {'queue': "seta_analyze_failures"},
     },
 }
 

--- a/treeherder/config/urls.py
+++ b/treeherder/config/urls.py
@@ -1,6 +1,5 @@
 from django.conf import settings
-from django.conf.urls import (include,
-                              url)
+from django.conf.urls import include, url
 from rest_framework.documentation import include_docs_urls
 
 from treeherder.webapp.api import urls as api_urls
@@ -12,6 +11,7 @@ urlpatterns = [
 
 if settings.DEBUG:
     import debug_toolbar
+
     urlpatterns += [
         url(r'^__debug__/', include(debug_toolbar.urls)),
     ]

--- a/treeherder/etl/bugzilla.py
+++ b/treeherder/etl/bugzilla.py
@@ -14,8 +14,10 @@ def fetch_intermittent_bugs(offset, limit):
     params = {
         'keywords': 'intermittent-failure',
         'chfieldfrom': '-1y',
-        'include_fields': ('id,summary,status,resolution,op_sys,cf_crash_signature,'
-                           'keywords,last_change_time, whiteboard'),
+        'include_fields': (
+            'id,summary,status,resolution,op_sys,cf_crash_signature,'
+            'keywords,last_change_time, whiteboard'
+        ),
         'offset': offset,
         'limit': limit,
     }
@@ -24,7 +26,6 @@ def fetch_intermittent_bugs(offset, limit):
 
 
 class BzApiBugProcess:
-
     def run(self):
         bug_list = []
 
@@ -43,8 +44,7 @@ class BzApiBugProcess:
 
         if bug_list:
             bugs_stored = set(Bugscache.objects.values_list('id', flat=True))
-            old_bugs = bugs_stored.difference(set(bug['id']
-                                                  for bug in bug_list))
+            old_bugs = bugs_stored.difference(set(bug['id'] for bug in bug_list))
             Bugscache.objects.filter(id__in=old_bugs).delete()
 
             for bug in bug_list:
@@ -62,8 +62,10 @@ class BzApiBugProcess:
                             'keywords': ",".join(bug['keywords']),
                             'os': bug.get('op_sys', ''),
                             'modified': dateutil.parser.parse(
-                                bug['last_change_time'], ignoretz=True),
+                                bug['last_change_time'], ignoretz=True
+                            ),
                             'whiteboard': bug.get('whiteboard', '')[:max_whiteboard_length],
-                        })
+                        },
+                    )
                 except Exception as e:
                     logger.error("error inserting bug '%s' into db: %s", bug, e)

--- a/treeherder/etl/exceptions.py
+++ b/treeherder/etl/exceptions.py
@@ -1,5 +1,4 @@
 class CollectionNotStoredException(Exception):
-
     def __init__(self, error_list, *args, **kwargs):
         """
         error_list contains dictionaries, each containing
@@ -10,8 +9,10 @@ class CollectionNotStoredException(Exception):
 
     def __str__(self):
         return "\n".join(
-            ["[{project}] Error storing {collection} data: {message}".format(
-                **error) for error in self.error_list]
+            [
+                "[{project}] Error storing {collection} data: {message}".format(**error)
+                for error in self.error_list
+            ]
         )
 
 

--- a/treeherder/etl/jobs.py
+++ b/treeherder/etl/jobs.py
@@ -9,23 +9,24 @@ import newrelic.agent
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.utils import IntegrityError
 
-from treeherder.etl.artifact import (serialize_artifact_json_blobs,
-                                     store_job_artifacts)
+from treeherder.etl.artifact import serialize_artifact_json_blobs, store_job_artifacts
 from treeherder.etl.common import get_guid_root
-from treeherder.model.models import (BuildPlatform,
-                                     FailureClassification,
-                                     Job,
-                                     JobGroup,
-                                     JobLog,
-                                     JobType,
-                                     Machine,
-                                     MachinePlatform,
-                                     Option,
-                                     OptionCollection,
-                                     Product,
-                                     Push,
-                                     ReferenceDataSignatures,
-                                     TaskclusterMetadata)
+from treeherder.model.models import (
+    BuildPlatform,
+    FailureClassification,
+    Job,
+    JobGroup,
+    JobLog,
+    JobType,
+    Machine,
+    MachinePlatform,
+    Option,
+    OptionCollection,
+    Product,
+    Push,
+    ReferenceDataSignatures,
+    TaskclusterMetadata,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -51,8 +52,8 @@ def _remove_existing_jobs(data):
 
     guids = [datum['job']['job_guid'] for datum in data]
     state_map = {
-        guid: state for (guid, state) in Job.objects.filter(
-            guid__in=guids).values_list('guid', 'state')
+        guid: state
+        for (guid, state) in Job.objects.filter(guid__in=guids).values_list('guid', 'state')
     }
 
     for datum in data:
@@ -64,8 +65,8 @@ def _remove_existing_jobs(data):
             # or completed to any other state
             current_state = state_map[job['job_guid']]
             if current_state == 'completed' or (
-                    job['state'] == 'pending' and
-                    current_state == 'running'):
+                job['state'] == 'pending' and current_state == 'running'
+            ):
                 continue
             new_data.append(datum)
 
@@ -86,20 +87,18 @@ def _load_job(repository, job_datum, push_id):
     build_platform, _ = BuildPlatform.objects.get_or_create(
         os_name=job_datum.get('build_platform', {}).get('os_name', 'unknown'),
         platform=job_datum.get('build_platform', {}).get('platform', 'unknown'),
-        architecture=job_datum.get('build_platform', {}).get('architecture',
-                                                             'unknown'))
+        architecture=job_datum.get('build_platform', {}).get('architecture', 'unknown'),
+    )
 
     machine_platform, _ = MachinePlatform.objects.get_or_create(
         os_name=job_datum.get('machine_platform', {}).get('os_name', 'unknown'),
         platform=job_datum.get('machine_platform', {}).get('platform', 'unknown'),
-        architecture=job_datum.get('machine_platform', {}).get('architecture',
-                                                               'unknown'))
+        architecture=job_datum.get('machine_platform', {}).get('architecture', 'unknown'),
+    )
 
     option_names = job_datum.get('option_collection', [])
-    option_collection_hash = OptionCollection.calculate_hash(
-        option_names)
-    if not OptionCollection.objects.filter(
-            option_collection_hash=option_collection_hash).exists():
+    option_collection_hash = OptionCollection.calculate_hash(option_names)
+    if not OptionCollection.objects.filter(option_collection_hash=option_collection_hash).exists():
         # in the unlikely event that we haven't seen this set of options
         # before, add the appropriate database rows
         options = []
@@ -108,19 +107,19 @@ def _load_job(repository, job_datum, push_id):
             options.append(option)
         for option in options:
             OptionCollection.objects.create(
-                option_collection_hash=option_collection_hash,
-                option=option)
+                option_collection_hash=option_collection_hash, option=option
+            )
 
-    machine, _ = Machine.objects.get_or_create(
-        name=job_datum.get('machine', 'unknown'))
+    machine, _ = Machine.objects.get_or_create(name=job_datum.get('machine', 'unknown'))
 
     job_type, _ = JobType.objects.get_or_create(
-        symbol=job_datum.get('job_symbol') or 'unknown',
-        name=job_datum.get('name') or 'unknown')
+        symbol=job_datum.get('job_symbol') or 'unknown', name=job_datum.get('name') or 'unknown'
+    )
 
     job_group, _ = JobGroup.objects.get_or_create(
         name=job_datum.get('group_name') or 'unknown',
-        symbol=job_datum.get('group_symbol') or 'unknown')
+        symbol=job_datum.get('group_symbol') or 'unknown',
+    )
 
     product_name = job_datum.get('product_name', 'unknown')
     if not product_name.strip():
@@ -143,19 +142,32 @@ def _load_job(repository, job_datum, push_id):
 
     reference_data_name = job_datum.get('reference_data_name', None)
 
-    default_failure_classification = FailureClassification.objects.get(
-        name='not classified')
+    default_failure_classification = FailureClassification.objects.get(name='not classified')
 
     sh = sha1()
-    sh.update(''.join(
-        map(str,
-            [build_system_type, repository.name, build_platform.os_name,
-             build_platform.platform, build_platform.architecture,
-             machine_platform.os_name, machine_platform.platform,
-             machine_platform.architecture,
-             job_group.name, job_group.symbol, job_type.name,
-             job_type.symbol, option_collection_hash,
-             reference_data_name])).encode('utf-8'))
+    sh.update(
+        ''.join(
+            map(
+                str,
+                [
+                    build_system_type,
+                    repository.name,
+                    build_platform.os_name,
+                    build_platform.platform,
+                    build_platform.architecture,
+                    machine_platform.os_name,
+                    machine_platform.platform,
+                    machine_platform.architecture,
+                    job_group.name,
+                    job_group.symbol,
+                    job_type.name,
+                    job_type.symbol,
+                    option_collection_hash,
+                    reference_data_name,
+                ],
+            )
+        ).encode('utf-8')
+    )
     signature_hash = sh.hexdigest()
 
     # Should be the buildername in the case of buildbot (if not provided
@@ -167,7 +179,8 @@ def _load_job(repository, job_datum, push_id):
         name=reference_data_name,
         signature=signature_hash,
         build_system_type=build_system_type,
-        repository=repository.name, defaults={
+        repository=repository.name,
+        defaults={
             'first_submission_timestamp': time.time(),
             'build_os_name': build_platform.os_name,
             'build_platform': build_platform.platform,
@@ -179,19 +192,17 @@ def _load_job(repository, job_datum, push_id):
             'job_group_symbol': job_group.symbol,
             'job_type_name': job_type.name,
             'job_type_symbol': job_type.symbol,
-            'option_collection_hash': option_collection_hash
-        })
+            'option_collection_hash': option_collection_hash,
+        },
+    )
 
     tier = job_datum.get('tier') or 1
 
     result = job_datum.get('result', 'unknown')
 
-    submit_time = datetime.fromtimestamp(
-        _get_number(job_datum.get('submit_timestamp')))
-    start_time = datetime.fromtimestamp(
-        _get_number(job_datum.get('start_timestamp')))
-    end_time = datetime.fromtimestamp(
-        _get_number(job_datum.get('end_timestamp')))
+    submit_time = datetime.fromtimestamp(_get_number(job_datum.get('submit_timestamp')))
+    start_time = datetime.fromtimestamp(_get_number(job_datum.get('start_timestamp')))
+    end_time = datetime.fromtimestamp(_get_number(job_datum.get('end_timestamp')))
 
     # first, try to create the job with the given guid (if it doesn't
     # exist yet)
@@ -224,8 +235,8 @@ def _load_job(repository, job_datum, push_id):
                 "start_time": start_time,
                 "end_time": end_time,
                 "last_modified": datetime.now(),
-                "push_id": push_id
-            }
+                "push_id": push_id,
+            },
         )
     # Can't just use the ``job`` we would get from the ``get_or_create``
     # because we need to try the job_guid_root instance first for update,
@@ -241,7 +252,8 @@ def _load_job(repository, job_datum, push_id):
             TaskclusterMetadata.objects.create(
                 job=job,
                 task_id=job_datum['taskcluster_task_id'],
-                retry_id=job_datum['taskcluster_retry_id'])
+                retry_id=job_datum['taskcluster_retry_id'],
+            )
         except IntegrityError:
             pass
 
@@ -263,12 +275,12 @@ def _load_job(repository, job_datum, push_id):
         start_time=start_time,
         end_time=end_time,
         last_modified=datetime.now(),
-        push_id=push_id)
+        push_id=push_id,
+    )
 
     artifacts = job_datum.get('artifacts', [])
 
-    has_text_log_summary = any(x for x in artifacts
-                               if x['name'] == 'text_log_summary')
+    has_text_log_summary = any(x for x in artifacts if x['name'] == 'text_log_summary')
     if artifacts:
         artifacts = serialize_artifact_json_blobs(artifacts)
 
@@ -276,8 +288,7 @@ def _load_job(repository, job_datum, push_id):
         # present in the beginning
         for artifact in artifacts:
             if not all(k in artifact for k in ("name", "type", "blob")):
-                raise ValueError(
-                    "Artifact missing properties: {}".format(artifact))
+                raise ValueError("Artifact missing properties: {}".format(artifact))
             # Ensure every artifact has a ``job_guid`` value.
             # It is legal to submit an artifact that doesn't have a
             # ``job_guid`` value.  But, if missing, it should inherit that
@@ -304,19 +315,16 @@ def _load_job(repository, job_datum, push_id):
             if has_text_log_summary and name == 'buildbot_text':
                 parse_status = JobLog.PARSED
             else:
-                parse_status_map = dict([(k, v) for (v, k) in
-                                         JobLog.STATUSES])
-                mapped_status = parse_status_map.get(
-                    log.get('parse_status'))
+                parse_status_map = dict([(k, v) for (v, k) in JobLog.STATUSES])
+                mapped_status = parse_status_map.get(log.get('parse_status'))
                 if mapped_status:
                     parse_status = mapped_status
                 else:
                     parse_status = JobLog.PENDING
 
             jl, _ = JobLog.objects.get_or_create(
-                job=job, name=name, url=url, defaults={
-                    'status': parse_status
-                })
+                job=job, name=name, url=url, defaults={'status': parse_status}
+            )
 
             job_logs.append(jl)
 
@@ -334,11 +342,7 @@ def _schedule_log_parsing(job, job_logs, result):
     # importing here to avoid an import loop
     from treeherder.log_parser.tasks import parse_logs
 
-    task_types = {
-        "errorsummary_json",
-        "buildbot_text",
-        "builds-4h"
-    }
+    task_types = {"errorsummary_json", "buildbot_text", "builds-4h"}
 
     job_log_ids = []
     for job_log in job_logs:
@@ -365,8 +369,7 @@ def _schedule_log_parsing(job, job_logs, result):
         queue = 'log_parser'
         priority = "normal"
 
-    parse_logs.apply_async(queue=queue,
-                           args=[job.id, job_log_ids, priority])
+    parse_logs.apply_async(queue=queue, args=[job.id, job_log_ids, priority])
 
 
 def store_job_data(repository, originalData):
@@ -484,5 +487,5 @@ def store_job_data(repository, originalData):
     if superseded_job_guid_placeholders:
         for (job_guid, superseded_by_guid) in superseded_job_guid_placeholders:
             Job.objects.filter(guid=superseded_by_guid).update(
-                result='superseded',
-                state='completed')
+                result='superseded', state='completed'
+            )

--- a/treeherder/etl/management/commands/heroku_environment.py
+++ b/treeherder/etl/management/commands/heroku_environment.py
@@ -42,26 +42,23 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 # These are environment variables that need to be set
-MUST_BE_SET = {
-    "treeherder-stage": [
-        "NEW_RELIC_INSIGHTS_API_KEY",
-        "THIS_ONE_WILL_FAIL"
-    ]
-}
+MUST_BE_SET = {"treeherder-stage": ["NEW_RELIC_INSIGHTS_API_KEY", "THIS_ONE_WILL_FAIL"]}
 
 # These are environment variables that need to be set to a specific value
 MUST_BE_SET_TO = {
     "treeherder-stage": {
         "BUGZILLA_API_URL": "https://bugzilla.mozilla.org",
-        "THIS_ONE_WILL_FAIL": "foo"
+        "THIS_ONE_WILL_FAIL": "foo",
     }
 }
 
 
 def request(path="", method="GET"):
-    return make_request("https://api.heroku.com/apps/{}".format(path), method=method, headers={
-        'Accept': 'application/vnd.heroku+json; version=3'
-    })
+    return make_request(
+        "https://api.heroku.com/apps/{}".format(path),
+        method=method,
+        headers={'Accept': 'application/vnd.heroku+json; version=3'},
+    )
 
 
 def authenticate():
@@ -69,7 +66,9 @@ def authenticate():
         request(method="POST")
     except requests.exceptions.HTTPError as error:
         if error.response.status_code == 401:
-            logger.critical("Run heroku auth:login to authenticate the terminal before calling this script.")
+            logger.critical(
+                "Run heroku auth:login to authenticate the terminal before calling this script."
+            )
             sys.exit(-1)
 
 
@@ -80,11 +79,9 @@ def get_config_vars(app_name):
 
 class Command(BaseCommand):
     """Management command to validate Heroku environment variables."""
+
     def add_arguments(self, parser):
-        parser.add_argument(
-            "--app",
-            help="Heroku app name"
-        )
+        parser.add_argument("--app", help="Heroku app name")
 
     def handle(self, *args, **options):
         app_name = options["app"]

--- a/treeherder/etl/management/commands/publish_to_pulse.py
+++ b/treeherder/etl/management/commands/publish_to_pulse.py
@@ -2,8 +2,7 @@ import logging
 from urllib.parse import urlparse
 
 from django.core.management.base import BaseCommand
-from kombu import (Connection,
-                   Exchange)
+from kombu import Connection, Exchange
 from kombu.messaging import Producer
 
 logger = logging.getLogger(__name__)
@@ -16,11 +15,16 @@ class Command(BaseCommand):
     This is primarily intended as a mechanism to test new or changed jobs
     to ensure they validate and will show as expected in the Treeherder UI.
     """
+
     help = "Publish jobs to a pulse exchange"
 
     def add_arguments(self, parser):
-        parser.add_argument('routing_key', help="The routing key for publishing. Ex: 'mozilla-inbound.staging'")
-        parser.add_argument('connection_url', help="The Pulse url. Ex: 'amqp://guest:guest@localhost:5672/'")
+        parser.add_argument(
+            'routing_key', help="The routing key for publishing. Ex: 'mozilla-inbound.staging'"
+        )
+        parser.add_argument(
+            'connection_url', help="The Pulse url. Ex: 'amqp://guest:guest@localhost:5672/'"
+        )
         parser.add_argument('payload_file', help="Path to the file that holds the job payload JSON")
 
     def handle(self, *args, **options):
@@ -33,10 +37,7 @@ class Command(BaseCommand):
 
         connection = Connection(connection_url)
         exchange = Exchange(exchange_name, type="topic")
-        producer = Producer(connection,
-                            exchange,
-                            routing_key=routing_key,
-                            auto_declare=True)
+        producer = Producer(connection, exchange, routing_key=routing_key, auto_declare=True)
 
         self.stdout.write("Published to exchange: {}".format(exchange_name))
 

--- a/treeherder/etl/management/commands/pulse_listener.py
+++ b/treeherder/etl/management/commands/pulse_listener.py
@@ -1,8 +1,7 @@
 import environ
 from django.core.management.base import BaseCommand
 
-from treeherder.services.pulse import (JointConsumer,
-                                       prepare_joint_consumers)
+from treeherder.services.pulse import JointConsumer, prepare_joint_consumers
 
 env = environ.Env()
 
@@ -14,6 +13,7 @@ class Command(BaseCommand):
     ```store_pulse_pushes```which does the actual storing of the pushes
     in the database.
     """
+
     help = "Read tasks and pushes from a set of pulse exchanges and queue for ingestion"
 
     def handle(self, *args, **options):
@@ -23,11 +23,16 @@ class Command(BaseCommand):
         # [{pulse_url: .., hgmo: true, root_url: ..}, ..]
         pulse_sources = env.json(
             "PULSE_SOURCES",
-            default=[{"root_url": "https://firefox-ci-tc.services.mozilla.com",
-                      "github": True,
-                      "hgmo": True,
-                      "pulse_url": env("PULSE_URL"),
-                      "tasks": True}])
+            default=[
+                {
+                    "root_url": "https://firefox-ci-tc.services.mozilla.com",
+                    "github": True,
+                    "hgmo": True,
+                    "pulse_url": env("PULSE_URL"),
+                    "tasks": True,
+                }
+            ],
+        )
 
         listener_params = (JointConsumer, pulse_sources, [lambda key: "#.{}".format(key), None])
         consumer = prepare_joint_consumers(listener_params)

--- a/treeherder/etl/management/commands/pulse_listener_pushes.py
+++ b/treeherder/etl/management/commands/pulse_listener_pushes.py
@@ -1,8 +1,7 @@
 import environ
 from django.core.management.base import BaseCommand
 
-from treeherder.services.pulse import (PushConsumer,
-                                       prepare_consumers)
+from treeherder.services.pulse import PushConsumer, prepare_consumers
 
 env = environ.Env()
 
@@ -14,6 +13,7 @@ class Command(BaseCommand):
     This adds the pushes to a celery queue called ``store_pulse_pushes`` which
     does the actual storing of the pushes in the database.
     """
+
     help = "Read pushes from a set of pulse exchanges and queue for ingestion"
 
     def handle(self, *args, **options):
@@ -26,12 +26,17 @@ class Command(BaseCommand):
         # [{pulse_url: .., hgmo: true, root_url: ..}, ..]
         push_sources = env.json(
             "PULSE_PUSH_SOURCES",
-            default=[{"root_url": "https://firefox-ci-tc.services.mozilla.com", "github": True, "hgmo": True, "pulse_url": env("PULSE_URL")}])
-
-        consumers = prepare_consumers(
-            PushConsumer,
-            push_sources,
+            default=[
+                {
+                    "root_url": "https://firefox-ci-tc.services.mozilla.com",
+                    "github": True,
+                    "hgmo": True,
+                    "pulse_url": env("PULSE_URL"),
+                }
+            ],
         )
+
+        consumers = prepare_consumers(PushConsumer, push_sources,)
 
         try:
             consumers.run()

--- a/treeherder/etl/management/commands/pulse_listener_tasks.py
+++ b/treeherder/etl/management/commands/pulse_listener_tasks.py
@@ -1,8 +1,7 @@
 import environ
 from django.core.management.base import BaseCommand
 
-from treeherder.services.pulse import (TaskConsumer,
-                                       prepare_consumers)
+from treeherder.services.pulse import TaskConsumer, prepare_consumers
 
 env = environ.Env()
 
@@ -14,6 +13,7 @@ class Command(BaseCommand):
     This adds the jobs to a celery queue called ``store_pulse_tasks`` which
     does the actual storing of the jobs in the database.
     """
+
     help = "Read jobs from a set of pulse exchanges and queue for ingestion"
 
     def handle(self, *args, **options):
@@ -25,13 +25,15 @@ class Command(BaseCommand):
         # root_url: ..}, ..]
         task_sources = env.json(
             "PULSE_TASK_SOURCES",
-            default=[{"root_url": "https://firefox-ci-tc.services.mozilla.com", "pulse_url": env("PULSE_URL")}])
-
-        consumers = prepare_consumers(
-            TaskConsumer,
-            task_sources,
-            lambda key: "#.{}".format(key),
+            default=[
+                {
+                    "root_url": "https://firefox-ci-tc.services.mozilla.com",
+                    "pulse_url": env("PULSE_URL"),
+                }
+            ],
         )
+
+        consumers = prepare_consumers(TaskConsumer, task_sources, lambda key: "#.{}".format(key),)
 
         try:
             consumers.run()

--- a/treeherder/etl/push.py
+++ b/treeherder/etl/push.py
@@ -3,8 +3,7 @@ from datetime import datetime
 
 from django.db import transaction
 
-from treeherder.model.models import (Commit,
-                                     Push)
+from treeherder.model.models import Commit, Push
 
 logger = logging.getLogger(__name__)
 
@@ -12,25 +11,22 @@ logger = logging.getLogger(__name__)
 def store_push(repository, push_dict):
     push_revision = push_dict.get('revision')
     if not push_dict.get('revision'):
-        raise ValueError("Push must have a revision "
-                         "associated with it!")
+        raise ValueError("Push must have a revision " "associated with it!")
     with transaction.atomic():
         push, _ = Push.objects.update_or_create(
             repository=repository,
             revision=push_revision,
             defaults={
                 'author': push_dict['author'],
-                'time': datetime.utcfromtimestamp(
-                    push_dict['push_timestamp'])
-            })
+                'time': datetime.utcfromtimestamp(push_dict['push_timestamp']),
+            },
+        )
         for revision in push_dict['revisions']:
             Commit.objects.update_or_create(
                 push=push,
                 revision=revision['revision'],
-                defaults={
-                    'author': revision['author'],
-                    'comments': revision['comment']
-                })
+                defaults={'author': revision['author'], 'comments': revision['comment']},
+            )
 
 
 def store_push_data(repository, pushes):

--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -37,11 +37,9 @@ class HgPushlogProcess:
         # we only want to ingest the last 200 commits for each push,
         # to protect against the 5000+ commit merges on release day uplift.
         for commit in push['changesets'][-200:]:
-            commits.append({
-                'revision': commit['node'],
-                'author': commit['author'],
-                'comment': commit['desc'],
-            })
+            commits.append(
+                {'revision': commit['node'], 'author': commit['author'], 'comment': commit['desc'],}
+            )
 
         return {
             'revision': commits[-1]["revision"],
@@ -59,9 +57,13 @@ class HgPushlogProcess:
 
         if not changeset and last_push_id:
             startid_url = "{}&startID={}".format(source_url, last_push_id)
-            logger.info("Extracted last push for '%s', '%s', from cache, "
-                        "attempting to get changes only from that point at: %s",
-                        repository_name, last_push_id, startid_url)
+            logger.info(
+                "Extracted last push for '%s', '%s', from cache, "
+                "attempting to get changes only from that point at: %s",
+                repository_name,
+                last_push_id,
+                startid_url,
+            )
             # Use the cached ``last_push_id`` value (saved from the last time
             # this API was called) for this repo.  Use that value as the
             # ``startID`` to get all new pushes from that point forward.
@@ -79,19 +81,23 @@ class HgPushlogProcess:
                     "due to Mercurial repo reset. Getting latest changes for '%s' instead",
                     extracted_content['lastpushid'],
                     last_push_id,
-                    repository_name
+                    repository_name,
                 )
                 cache.delete(cache_key)
                 extracted_content = self.extract(source_url)
         else:
             if changeset:
-                logger.info("Getting all pushes for '%s' corresponding to "
-                            "changeset '%s'", repository_name, changeset)
-                extracted_content = self.extract(source_url + "&changeset=" +
-                                                 changeset)
+                logger.info(
+                    "Getting all pushes for '%s' corresponding to " "changeset '%s'",
+                    repository_name,
+                    changeset,
+                )
+                extracted_content = self.extract(source_url + "&changeset=" + changeset)
             else:
-                logger.warning("Unable to get last push from cache for '%s', "
-                               "getting all pushes", repository_name)
+                logger.warning(
+                    "Unable to get last push from cache for '%s', " "getting all pushes",
+                    repository_name,
+                )
                 extracted_content = self.extract(source_url)
 
         pushes = extracted_content['pushes']
@@ -117,11 +123,13 @@ class HgPushlogProcess:
                 store_push(repository, self.transform_push(push))
             except Exception:
                 newrelic.agent.record_exception()
-                errors.append({
-                    "project": repository,
-                    "collection": "result_set",
-                    "message": traceback.format_exc()
-                })
+                errors.append(
+                    {
+                        "project": repository,
+                        "collection": "result_set",
+                        "message": traceback.format_exc(),
+                    }
+                )
 
         if errors:
             raise CollectionNotStoredException(errors)

--- a/treeherder/etl/runnable_jobs.py
+++ b/treeherder/etl/runnable_jobs.py
@@ -30,8 +30,9 @@ def _taskcluster_runnable_jobs(project):
         try:
             tc_graph = fetch_json(tc_graph_url)
         except requests.exceptions.HTTPError as e:
-            logger.info('HTTPError %s when getting taskgraph at %s',
-                        e.response.status_code, tc_graph_url)
+            logger.info(
+                'HTTPError %s when getting taskgraph at %s', e.response.status_code, tc_graph_url
+            )
             continue
 
         return [

--- a/treeherder/etl/seta.py
+++ b/treeherder/etl/seta.py
@@ -3,13 +3,14 @@ import logging
 from django.core.cache import cache
 
 from treeherder.etl.runnable_jobs import list_runnable_jobs
-from treeherder.seta.common import (convert_job_type_name_to_testtype,
-                                    unique_key)
+from treeherder.seta.common import convert_job_type_name_to_testtype, unique_key
 from treeherder.seta.models import JobPriority
-from treeherder.seta.settings import (SETA_REF_DATA_NAMES_CACHE_TIMEOUT,
-                                      SETA_SUPPORTED_TC_JOBTYPES,
-                                      SETA_UNSUPPORTED_PLATFORMS,
-                                      SETA_UNSUPPORTED_TESTTYPES)
+from treeherder.seta.settings import (
+    SETA_REF_DATA_NAMES_CACHE_TIMEOUT,
+    SETA_SUPPORTED_TC_JOBTYPES,
+    SETA_UNSUPPORTED_PLATFORMS,
+    SETA_UNSUPPORTED_TESTTYPES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +87,7 @@ def get_reference_data_names(project="autoland", build_system="taskcluster"):
             build_system_type=job['build_system_type'],
             job_type_name=job['job_type_name'],
             platform_option=job['platform_option'],
-            ref_data_name=job['ref_data_name']
+            ref_data_name=job['ref_data_name'],
         )
 
         if not valid_platform(job['platform']):
@@ -95,12 +96,16 @@ def get_reference_data_names(project="autoland", build_system="taskcluster"):
         if is_job_blacklisted(testtype):
             ignored_jobs.append(job['ref_data_name'])
             if testtype:
-                logger.debug('get_reference_data_names: blacklisted testtype {} for job {}'.format(testtype, job))
+                logger.debug(
+                    'get_reference_data_names: blacklisted testtype {} for job {}'.format(
+                        testtype, job
+                    )
+                )
             continue
 
-        key = unique_key(testtype=testtype,
-                         buildtype=job['platform_option'],
-                         platform=job['platform'])
+        key = unique_key(
+            testtype=testtype, buildtype=job['platform_option'], platform=job['platform']
+        )
 
         if build_system == '*':
             ref_data_names[key] = job['ref_data_name']

--- a/treeherder/etl/taskcluster_pulse/parse_route.py
+++ b/treeherder/etl/taskcluster_pulse/parse_route.py
@@ -26,10 +26,10 @@ def parseRoute(route):
         id = parsedRoute[4]
 
     pushInfo = {
-      "destination": parsedRoute[0],
-      "id": int(id) if id else 0,
-      "project": parsedProject,
-      "revision": parsedRoute[3],
+        "destination": parsedRoute[0],
+        "id": int(id) if id else 0,
+        "project": parsedProject,
+        "revision": parsedRoute[3],
     }
 
     if owner and parsedProject:

--- a/treeherder/etl/tasks/pulse_tasks.py
+++ b/treeherder/etl/tasks/pulse_tasks.py
@@ -15,7 +15,9 @@ from treeherder.workers.task import retryable_task
 
 
 @retryable_task(name='store-pulse-tasks', max_retries=10)
-def store_pulse_tasks(pulse_job, exchange, routing_key, root_url='https://firefox-ci-tc.services.mozilla.com'):
+def store_pulse_tasks(
+    pulse_job, exchange, routing_key, root_url='https://firefox-ci-tc.services.mozilla.com'
+):
     """
     Fetches tasks from Taskcluster
     """
@@ -23,18 +25,18 @@ def store_pulse_tasks(pulse_job, exchange, routing_key, root_url='https://firefo
     newrelic.agent.add_custom_parameter("exchange", exchange)
     newrelic.agent.add_custom_parameter("routing_key", routing_key)
     # handleMessage expects messages in this format
-    runs = loop.run_until_complete(handleMessage({
-        "exchange": exchange,
-        "payload": pulse_job,
-        "root_url": root_url,
-    }))
+    runs = loop.run_until_complete(
+        handleMessage({"exchange": exchange, "payload": pulse_job, "root_url": root_url,})
+    )
     for run in runs:
         if run:
             JobLoader().process_job(run, root_url)
 
 
 @retryable_task(name='store-pulse-pushes', max_retries=10)
-def store_pulse_pushes(body, exchange, routing_key, root_url='https://firefox-ci-tc.services.mozilla.com'):
+def store_pulse_pushes(
+    body, exchange, routing_key, root_url='https://firefox-ci-tc.services.mozilla.com'
+):
     """
     Fetches the pushes pending from pulse exchanges and loads them.
     """

--- a/treeherder/etl/tasks/pushlog_tasks.py
+++ b/treeherder/etl/tasks/pushlog_tasks.py
@@ -10,12 +10,8 @@ def fetch_push_logs():
     """
     Run several fetch_hg_push_log subtasks, one per repository
     """
-    for repo in Repository.objects.filter(dvcs_type='hg',
-                                          active_status="active"):
-        fetch_hg_push_log.apply_async(
-            args=(repo.name, repo.url),
-            queue='pushlog'
-        )
+    for repo in Repository.objects.filter(dvcs_type='hg', active_status="active"):
+        fetch_hg_push_log.apply_async(args=(repo.name, repo.url), queue='pushlog')
 
 
 @task(name='fetch-hg-push-logs', soft_time_limit=10 * 60)

--- a/treeherder/extract/extract_perf.py
+++ b/treeherder/extract/extract_perf.py
@@ -2,11 +2,8 @@ from jx_bigquery import bigquery
 from jx_mysql.mysql import MySQL
 from jx_mysql.mysql_snowflake_extractor import MySqlSnowflakeExtractor
 from mo_files import File
-from mo_json import (json2value,
-                     value2json)
-from mo_logs import (Log,
-                     constants,
-                     startup)
+from mo_json import json2value, value2json
+from mo_logs import Log, constants, startup
 from mo_sql import SQL
 from mo_times import Timer
 from redis import Redis

--- a/treeherder/extract/management/commands/extract_alerts.py
+++ b/treeherder/extract/management/commands/extract_alerts.py
@@ -5,31 +5,27 @@ from treeherder.extract.extract_alerts import ExtractAlerts
 
 class Command(BaseCommand):
     """Management command to extract alerts"""
+
     help = "Extract recent alerts from Treeherder, and push them to BigQuery"
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--force",
-            action='store_true',
-            dest="force",
-            help="Ignore changed schema"
+            "--force", action='store_true', dest="force", help="Ignore changed schema"
         )
         parser.add_argument(
             "--restart",
             action='store_true',
             dest="restart",
-            help="start extraction from the beginning"
+            help="start extraction from the beginning",
         )
         parser.add_argument(
             "--merge",
             action='store_true',
             dest="merge",
-            help="merge shards at startup (so previous data is available)"
+            help="merge shards at startup (so previous data is available)",
         )
 
     def handle(self, *args, **options):
         ExtractAlerts().run(
-            force=options.get("force"),
-            restart=options.get("restart"),
-            merge=options.get("merge")
+            force=options.get("force"), restart=options.get("restart"), merge=options.get("merge")
         )

--- a/treeherder/extract/management/commands/extract_jobs.py
+++ b/treeherder/extract/management/commands/extract_jobs.py
@@ -5,31 +5,25 @@ from treeherder.extract.extract_jobs import ExtractJobs
 
 class Command(BaseCommand):
     """Management command to extract jobs"""
+
     help = "Extract recent jobs from Treeherder, and push them to BigQuery"
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--force",
-            action='store_true',
-            dest="force",
-            help="Ignore changed schema"
+            "--force", action='store_true', dest="force", help="Ignore changed schema"
         )
         parser.add_argument(
             "--restart",
             action='store_true',
             dest="restart",
-            help="start extraction from the beginning"
+            help="start extraction from the beginning",
         )
-        parser.add_argument(
-            "--start",
-            dest="start",
-            help="date/time to start extraction"
-        )
+        parser.add_argument("--start", dest="start", help="date/time to start extraction")
         parser.add_argument(
             "--merge",
             action='store_true',
             dest="merge",
-            help="merge shards at startup (so previous data is available)"
+            help="merge shards at startup (so previous data is available)",
         )
 
     def handle(self, *args, **options):
@@ -38,5 +32,4 @@ class Command(BaseCommand):
             restart=options.get("restart"),
             start=options.get("start"),
             merge=options.get("merge"),
-
         )

--- a/treeherder/extract/management/commands/extract_perf.py
+++ b/treeherder/extract/management/commands/extract_perf.py
@@ -5,31 +5,27 @@ from treeherder.extract.extract_perf import ExtractPerf
 
 class Command(BaseCommand):
     """Management command to extract jobs"""
+
     help = "Extract recently changed jobs from Treeherder, and push them to BigQuery"
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--force",
-            action='store_true',
-            dest="force",
-            help="Ignore changed schema"
+            "--force", action='store_true', dest="force", help="Ignore changed schema"
         )
         parser.add_argument(
             "--restart",
             action='store_true',
             dest="restart",
-            help="start extraction from the beginning"
+            help="start extraction from the beginning",
         )
         parser.add_argument(
             "--merge",
             action='store_true',
             dest="merge",
-            help="merge shards at startup (so previous data is available)"
+            help="merge shards at startup (so previous data is available)",
         )
 
     def handle(self, *args, **options):
         ExtractPerf().run(
-            force=options.get("force"),
-            restart=options.get("restart"),
-            merge=options.get("merge")
+            force=options.get("force"), restart=options.get("restart"), merge=options.get("merge")
         )

--- a/treeherder/intermittents_commenter/management/commands/run_intermittents_commenter.py
+++ b/treeherder/intermittents_commenter/management/commands/run_intermittents_commenter.py
@@ -11,8 +11,21 @@ class Command(BaseCommand):
        default is daily and non-test mode, use flags for weekly, auto and test mode."""
 
     def add_arguments(self, parser):
-        parser.add_argument('-m', '--mode', dest='mode', nargs='?', choices=['weekly', 'auto'], default=False, help='generate comment summaries based on auto or weekly mode; defaults to daily')
-        parser.add_argument('--dry-run', action='store_true', dest='dry_run', help='output comments to stdout rather than submitting to Bugzilla')
+        parser.add_argument(
+            '-m',
+            '--mode',
+            dest='mode',
+            nargs='?',
+            choices=['weekly', 'auto'],
+            default=False,
+            help='generate comment summaries based on auto or weekly mode; defaults to daily',
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            dest='dry_run',
+            help='output comments to stdout rather than submitting to Bugzilla',
+        )
 
     def handle(self, *args, **options):
         mode = options['mode']

--- a/treeherder/log_parser/artifactbuildercollection.py
+++ b/treeherder/log_parser/artifactbuildercollection.py
@@ -4,9 +4,11 @@ import newrelic.agent
 
 from treeherder.utils.http import make_request
 
-from .artifactbuilders import (BuildbotJobArtifactBuilder,
-                               BuildbotLogViewArtifactBuilder,
-                               BuildbotPerformanceDataArtifactBuilder)
+from .artifactbuilders import (
+    BuildbotJobArtifactBuilder,
+    BuildbotLogViewArtifactBuilder,
+    BuildbotPerformanceDataArtifactBuilder,
+)
 from .parsers import EmptyPerformanceData
 
 logger = logging.getLogger(__name__)
@@ -82,7 +84,7 @@ BuildbotPerformanceDataArtifactBuilder
             self.builders = [
                 BuildbotLogViewArtifactBuilder(url=self.url),
                 BuildbotJobArtifactBuilder(url=self.url),
-                BuildbotPerformanceDataArtifactBuilder(url=self.url)
+                BuildbotPerformanceDataArtifactBuilder(url=self.url),
             ]
 
     def parse(self):
@@ -96,17 +98,15 @@ BuildbotPerformanceDataArtifactBuilder
             download_size_in_bytes = int(response.headers.get('Content-Length', -1))
 
             # Temporary annotation of log size to help set thresholds in bug 1295997.
+            newrelic.agent.add_custom_parameter('unstructured_log_size', download_size_in_bytes)
             newrelic.agent.add_custom_parameter(
-                'unstructured_log_size',
-                download_size_in_bytes
-            )
-            newrelic.agent.add_custom_parameter(
-                'unstructured_log_encoding',
-                response.headers.get('Content-Encoding', 'None')
+                'unstructured_log_encoding', response.headers.get('Content-Encoding', 'None')
             )
 
             if download_size_in_bytes > MAX_DOWNLOAD_SIZE_IN_BYTES:
-                raise LogSizeException('Download size of %i bytes exceeds limit' % download_size_in_bytes)
+                raise LogSizeException(
+                    'Download size of %i bytes exceeds limit' % download_size_in_bytes
+                )
 
             # Lines must be explicitly decoded since `iter_lines()`` returns bytes by default
             # and we cannot use its `decode_unicode=True` mode, since otherwise Unicode newline

--- a/treeherder/log_parser/artifactbuilders.py
+++ b/treeherder/log_parser/artifactbuilders.py
@@ -1,8 +1,6 @@
 import logging
 
-from .parsers import (PerformanceParser,
-                      StepParser,
-                      TinderboxPrintParser)
+from .parsers import PerformanceParser, StepParser, TinderboxPrintParser
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +16,7 @@ class ArtifactBuilderBase:
     the url to the log file to add to its own artifact.
 
     """
+
     MAX_LINE_LENGTH = 500
 
     def __init__(self, url=None):
@@ -27,9 +26,7 @@ class ArtifactBuilderBase:
         ``url`` - The url this log comes from.  It's optional, but it gets
                   added to the artifact.
         """
-        self.artifact = {
-            "logurl": url
-        }
+        self.artifact = {"logurl": url}
         self.lineno = 0
         self.parser = None
         self.name = "Generic Artifact"
@@ -46,7 +43,7 @@ class ArtifactBuilderBase:
         # if the MAX_LINE_LENGTH is applied the data structure could be
         # truncated, preventing it from being ingested.
         if 'PERFHERDER_DATA' not in line:
-            line = line[:self.MAX_LINE_LENGTH]
+            line = line[: self.MAX_LINE_LENGTH]
 
         self.parser.parse_line(line, self.lineno)
         self.lineno += 1

--- a/treeherder/log_parser/crossreference.py
+++ b/treeherder/log_parser/crossreference.py
@@ -1,15 +1,11 @@
 import logging
 from functools import partial
 
-from django.db import (IntegrityError,
-                       transaction)
+from django.db import IntegrityError, transaction
 from first import first
 from mozlog.formatters.tbplformatter import TbplFormatter
 
-from treeherder.model.models import (FailureLine,
-                                     Job,
-                                     TextLogError,
-                                     TextLogErrorMetadata)
+from treeherder.model.models import FailureLine, Job, TextLogError, TextLogErrorMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -56,8 +52,9 @@ def _crossreference(job):
     for error in text_log_errors:
         if repr_str and error.line.strip().endswith(repr_str):
             logger.debug("Matched '%s'", error.line)
-            TextLogErrorMetadata.objects.get_or_create(text_log_error=error,
-                                                       failure_line=failure_line)
+            TextLogErrorMetadata.objects.get_or_create(
+                text_log_error=error, failure_line=failure_line
+            )
             failure_line, repr_str = next(match_iter)
         else:
             logger.debug("Failed to match '%s'", error.line)
@@ -67,8 +64,11 @@ def _crossreference(job):
         # We can have a line without a pattern at the end if the log is truncated
         if failure_line is None:
             break
-        logger.warning("Crossreference %s: Failed to match structured line '%s' to an unstructured line",
-                       job.id, repr_str)
+        logger.warning(
+            "Crossreference %s: Failed to match structured line '%s' to an unstructured line",
+            job.id,
+            repr_str,
+        )
 
     return True
 

--- a/treeherder/log_parser/failureline.py
+++ b/treeherder/log_parser/failureline.py
@@ -5,14 +5,11 @@ from itertools import islice
 import newrelic.agent
 from django.conf import settings
 from django.db import transaction
-from django.db.utils import (IntegrityError,
-                             OperationalError)
+from django.db.utils import IntegrityError, OperationalError
 from requests.exceptions import HTTPError
 
 from treeherder.etl.text import astral_filter
-from treeherder.model.models import (FailureLine,
-                                     Group,
-                                     JobLog)
+from treeherder.model.models import FailureLine, Group, JobLog
 from treeherder.utils.http import fetch_text
 
 logger = logging.getLogger(__name__)
@@ -31,8 +28,7 @@ def fetch_log(job_log):
     except HTTPError as e:
         job_log.update_status(JobLog.FAILED)
         if e.response is not None and e.response.status_code in (403, 404):
-            logger.warning("Unable to retrieve log for %s: %s",
-                           job_log.url, e)
+            logger.warning("Unable to retrieve log for %s: %s", job_log.url, e)
             return
         raise
 
@@ -44,7 +40,7 @@ def fetch_log(job_log):
 
 def write_failure_lines(job_log, log_iter):
     failure_lines_cutoff = settings.FAILURE_LINES_CUTOFF
-    log_list = list(islice(log_iter, failure_lines_cutoff+1))
+    log_list = list(islice(log_iter, failure_lines_cutoff + 1))
 
     if len(log_list) > failure_lines_cutoff:
         # Alter the N+1th log line to indicate the list was truncated.
@@ -67,9 +63,10 @@ def write_failure_lines(job_log, log_iter):
 
             def exclude_lines(log_list):
                 exclude = set(
-                    FailureLine.objects.filter(job_log=job_log,
-                                               line__in=[item["line"] for item in log_list])
-                    .values_list("line", flat=True))
+                    FailureLine.objects.filter(
+                        job_log=job_log, line__in=[item["line"] for item in log_list]
+                    ).values_list("line", flat=True)
+                )
                 return (item for item in log_list if item["line"] not in exclude)
 
             transformer = exclude_lines
@@ -83,21 +80,33 @@ def write_failure_lines(job_log, log_iter):
     return failure_lines
 
 
-_failure_line_keys = ["action", "line", "test", "subtest", "status",
-                      "expected", "message", "signature", "level",
-                      "stack", "stackwalk_stdout", "stackwalk_stderr"]
+_failure_line_keys = [
+    "action",
+    "line",
+    "test",
+    "subtest",
+    "status",
+    "expected",
+    "message",
+    "signature",
+    "level",
+    "stack",
+    "stackwalk_stdout",
+    "stackwalk_stderr",
+]
 
 
 def get_kwargs(failure_line):
-    return {key: failure_line[key] for key in _failure_line_keys
-            if key in failure_line}
+    return {key: failure_line[key] for key in _failure_line_keys if key in failure_line}
 
 
 def create_failure_line(job_log, failure_line):
-    fl = FailureLine.objects.create(repository=job_log.job.repository,
-                                    job_guid=job_log.job.guid,
-                                    job_log=job_log,
-                                    **get_kwargs(failure_line))
+    fl = FailureLine.objects.create(
+        repository=job_log.job.repository,
+        job_guid=job_log.job.guid,
+        job_log=job_log,
+        **get_kwargs(failure_line),
+    )
     if "group" in failure_line:
         # Omit the filename before storing.
         group_path = failure_line["group"].rsplit("/", 1)[0]
@@ -107,14 +116,16 @@ def create_failure_line(job_log, failure_line):
         if "\\" in group_path or ":" in group_path or len(group_path) > 255:
             newrelic.agent.record_custom_event(
                 "malformed_test_group",
-                {"message": "Group paths must be relative, with no backslashes and <255 chars",
-                 "group": failure_line["group"],
-                 "group_path": group_path,
-                 "length": len(group_path),
-                 "repository": fl.repository,
-                 "job_guid": fl.job_guid,
-                 "failure_line_id": fl.id
-                 })
+                {
+                    "message": "Group paths must be relative, with no backslashes and <255 chars",
+                    "group": failure_line["group"],
+                    "group_path": group_path,
+                    "length": len(group_path),
+                    "repository": fl.repository,
+                    "job_guid": fl.job_guid,
+                    "failure_line_id": fl.id,
+                },
+            )
 
         # Save the value regardless
         group, _ = Group.objects.get_or_create(name=group_path[:255])
@@ -124,16 +135,14 @@ def create_failure_line(job_log, failure_line):
 
 
 def create(job_log, log_list):
-    failure_lines = [create_failure_line(job_log, failure_line)
-                     for failure_line in log_list]
+    failure_lines = [create_failure_line(job_log, failure_line) for failure_line in log_list]
     job_log.update_status(JobLog.PARSED)
     return failure_lines
 
 
 def replace_astral(log_list):
     for item in log_list:
-        for key in ["test", "subtest", "message", "stack", "stackwalk_stdout",
-                    "stackwalk_stderr"]:
+        for key in ["test", "subtest", "message", "stack", "stackwalk_stdout", "stackwalk_stderr"]:
             if key in item:
                 item[key] = astral_filter(item[key])
         yield item

--- a/treeherder/log_parser/management/commands/crossreference_error_lines.py
+++ b/treeherder/log_parser/management/commands/crossreference_error_lines.py
@@ -1,7 +1,6 @@
 import logging
 
-from django.core.management.base import (BaseCommand,
-                                         CommandError)
+from django.core.management.base import BaseCommand, CommandError
 
 from treeherder.log_parser.crossreference import crossreference_job
 from treeherder.model.models import Job

--- a/treeherder/log_parser/management/commands/crossreference_missing.py
+++ b/treeherder/log_parser/management/commands/crossreference_missing.py
@@ -39,7 +39,8 @@ class Command(BaseCommand):
 
             connection.connect()
             with connection.cursor() as c:
-                c.execute("""SELECT job.id FROM job
+                c.execute(
+                    """SELECT job.id FROM job
                 INNER JOIN text_log_step ON text_log_step.job_id = job.id
                 INNER JOIN text_log_error as tle ON tle.step_id = text_log_step.id
                 INNER JOIN failure_line ON job.guid = failure_line.job_guid
@@ -54,7 +55,9 @@ class Command(BaseCommand):
                   job.id > %s AND
                   job.result NOT IN ('success', 'skipped', 'retry', 'usercancel', 'unknown', 'superseded')
                 GROUP BY job.id
-                ORDER BY job.id DESC;""", [job_id])
+                ORDER BY job.id DESC;""",
+                    [job_id],
+                )
                 rows = c.fetchall()
 
             connection.close()
@@ -85,4 +88,5 @@ def _crossreference_job(job_id):
         crossreference_job(job)
     except Exception:
         import traceback
+
         traceback.print_exc()

--- a/treeherder/log_parser/management/commands/test_parse_log.py
+++ b/treeherder/log_parser/management/commands/test_parse_log.py
@@ -8,6 +8,7 @@ from treeherder.log_parser.artifactbuildercollection import ArtifactBuilderColle
 
 class Command(BaseCommand):
     """Management command to test log parsing"""
+
     help = """
     Tests the artifact parser by downloading a specified URL, parsing it,
     and then printing the JSON structure representing its result
@@ -21,7 +22,7 @@ class Command(BaseCommand):
             dest='profile',
             type=int,
             default=None,
-            help='Profile running command a number of times'
+            help='Profile running command a number of times',
         )
 
     def handle(self, *args, **options):
@@ -43,5 +44,5 @@ class Command(BaseCommand):
 
         if options['profile']:
             print("Timings: %s" % times)
-            print("Average: %s" % (sum(times)/len(times)))
+            print("Average: %s" % (sum(times) / len(times)))
             print("Total: %s" % sum(times))

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -1,20 +1,11 @@
 import os
 
 import simplejson as json
-from jsonschema import (ValidationError,
-                        validate)
+from jsonschema import ValidationError, validate
 
 
 def _lookup_extra_options_max(schema):
-    return (
-        schema
-        ["definitions"]
-        ["suite_schema"]
-        ["properties"]
-        ["extraOptions"]
-        ["items"]
-        ["maxLength"]
-    )
+    return schema["definitions"]["suite_schema"]["properties"]["extraOptions"]["items"]["maxLength"]
 
 
 with open(os.path.join('schemas', 'performance-artifact.json')) as f:

--- a/treeherder/model/error_summary.py
+++ b/treeherder/model/error_summary.py
@@ -3,8 +3,7 @@ import re
 
 from django.core.cache import cache
 
-from treeherder.model.models import (Bugscache,
-                                     TextLogError)
+from treeherder.model.models import Bugscache, TextLogError
 
 logger = logging.getLogger(__name__)
 
@@ -15,9 +14,7 @@ BUG_SUGGESTION_CACHE_TIMEOUT = 86400
 
 LEAK_RE = re.compile(r'\d+ bytes leaked \((.+)\)$|leak at (.+)$')
 CRASH_RE = re.compile(r'.+ application crashed \[@ (.+)\]$')
-MOZHARNESS_RE = re.compile(
-    r'^\d+:\d+:\d+[ ]+(?:DEBUG|INFO|WARNING|ERROR|CRITICAL|FATAL) - [ ]?'
-)
+MOZHARNESS_RE = re.compile(r'^\d+:\d+:\d+[ ]+(?:DEBUG|INFO|WARNING|ERROR|CRITICAL|FATAL) - [ ]?')
 REFTEST_RE = re.compile(r'\s+[=!]=\s+.*')
 OUTPUT_RE = re.compile(r'^\s*(?:GECKO\(\d+\)|PID \d+)\s*$')
 
@@ -75,8 +72,7 @@ def bug_suggestions_line(err, term_cache=None):
             term_cache[search_term] = Bugscache.search(search_term)
         bugs = term_cache[search_term]
 
-    if not bugs or not (bugs['open_recent'] or
-                        bugs['all_others']):
+    if not bugs or not (bugs['open_recent'] or bugs['all_others']):
         # no suggestions, try to use
         # the crash signature as search term
         crash_signature = get_crash_signature(clean_line)
@@ -204,7 +200,7 @@ def is_helpful_search_term(search_term):
         'TypeError: content is null',
         'leakcheck',
         'ImportError: No module named pygtk',
-        '# TBPL FAILURE #'
+        '# TBPL FAILURE #',
     ]
 
     return len(search_term) > 4 and search_term not in blacklist

--- a/treeherder/model/management/commands/cache_failure_history.py
+++ b/treeherder/model/management/commands/cache_failure_history.py
@@ -3,9 +3,11 @@ import datetime
 from django.core.management.base import BaseCommand
 
 from treeherder.model.models import OptionCollection
-from treeherder.push_health.tests import (fixed_by_commit_history_days,
-                                          get_history,
-                                          intermittent_history_days)
+from treeherder.push_health.tests import (
+    fixed_by_commit_history_days,
+    get_history,
+    intermittent_history_days,
+)
 from treeherder.webapp.api.utils import REPO_GROUPS
 
 
@@ -18,7 +20,7 @@ class Command(BaseCommand):
             action='store_true',
             dest='debug',
             default=False,
-            help='Write debug messages to stdout'
+            help='Write debug messages to stdout',
         )
         parser.add_argument(
             '--days',
@@ -26,7 +28,7 @@ class Command(BaseCommand):
             dest='days',
             default=5,
             type=int,
-            help='Number of history sets to store (one for each day prior to today)'
+            help='Number of history sets to store (one for each day prior to today)',
         )
 
     def handle(self, *args, **options):
@@ -41,21 +43,13 @@ class Command(BaseCommand):
             push_date = datetime.datetime.now().date() - datetime.timedelta(days=day)
 
             int_hist, cache_key = get_history(
-                4,
-                push_date,
-                intermittent_history_days,
-                option_map,
-                repository_ids,
-                True)
+                4, push_date, intermittent_history_days, option_map, repository_ids, True
+            )
             self.debug('Cached failure history for {}'.format(cache_key))
 
             fbc_hist, cache_key = get_history(
-                2,
-                push_date,
-                fixed_by_commit_history_days,
-                option_map,
-                repository_ids,
-                True)
+                2, push_date, fixed_by_commit_history_days, option_map, repository_ids, True
+            )
             self.debug('Cached failure history for {}'.format(cache_key))
 
     def debug(self, msg):

--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -4,10 +4,7 @@ import logging
 from django.core.management.base import BaseCommand
 from django.db.utils import OperationalError
 
-from treeherder.model.models import (Job,
-                                     JobGroup,
-                                     JobType,
-                                     Machine)
+from treeherder.model.models import Job, JobGroup, JobType, Machine
 from treeherder.perf.models import PerformanceDatum
 
 logging.basicConfig(format='%(levelname)s:%(message)s')
@@ -24,8 +21,7 @@ logger = logging.getLogger(__name__)
 class DataCycler:
     source = ''
 
-    def __init__(self, days, chunk_size, sleep_time, is_debug=None,
-                 logger=None, **kwargs):
+    def __init__(self, days, chunk_size, sleep_time, is_debug=None, logger=None, **kwargs):
         self.cycle_interval = datetime.timedelta(days=days)
         self.chunk_size = chunk_size
         self.sleep_time = sleep_time
@@ -43,9 +39,9 @@ class TreeherderCycler(DataCycler):
         self.logger.warning("Cycling jobs across all repositories")
 
         try:
-            rs_deleted = Job.objects.cycle_data(self.cycle_interval,
-                                                self.chunk_size,
-                                                self.sleep_time)
+            rs_deleted = Job.objects.cycle_data(
+                self.cycle_interval, self.chunk_size, self.sleep_time
+            )
             self.logger.warning("Deleted {} jobs".format(rs_deleted))
         except OperationalError as e:
             self.logger.error("Error running cycle_data: {}".format(e))
@@ -60,13 +56,15 @@ class TreeherderCycler(DataCycler):
             used_ids = Job.objects.only(id_name).values_list(id_name, flat=True).distinct()
             unused_ids = model.objects.exclude(id__in=used_ids).values_list('id', flat=True)
 
-            self.logger.warning('Removing {} records from {}'.format(len(unused_ids), model.__name__))
+            self.logger.warning(
+                'Removing {} records from {}'.format(len(unused_ids), model.__name__)
+            )
 
             while len(unused_ids):
-                delete_ids = unused_ids[:self.chunk_size]
+                delete_ids = unused_ids[: self.chunk_size]
                 self.logger.warning('deleting {} of {}'.format(len(delete_ids), len(unused_ids)))
                 model.objects.filter(id__in=delete_ids).delete()
-                unused_ids = unused_ids[self.chunk_size:]
+                unused_ids = unused_ids[self.chunk_size :]
 
         prune('job_type_id', JobType)
         prune('job_group_id', JobGroup)
@@ -77,21 +75,21 @@ class PerfherderCycler(DataCycler):
     source = PERFHERDER.title()
     max_runtime = datetime.timedelta(hours=23)
 
-    def __init__(self, days, chunk_size, sleep_time, is_debug=None,
-                 logger=None, **kwargs):
+    def __init__(self, days, chunk_size, sleep_time, is_debug=None, logger=None, **kwargs):
         super().__init__(days, chunk_size, sleep_time, is_debug, logger)
         if days < MINIMUM_PERFHERDER_EXPIRE_INTERVAL:
-            raise ValueError('Cannot remove performance data that is more recent than {} days'
-                             .format(MINIMUM_PERFHERDER_EXPIRE_INTERVAL))
+            raise ValueError(
+                'Cannot remove performance data that is more recent than {} days'.format(
+                    MINIMUM_PERFHERDER_EXPIRE_INTERVAL
+                )
+            )
 
     def cycle(self):
         started_at = datetime.datetime.now()
 
-        PerformanceDatum.objects.cycle_data(self.cycle_interval,
-                                            self.chunk_size,
-                                            self.logger,
-                                            started_at,
-                                            self.max_runtime)
+        PerformanceDatum.objects.cycle_data(
+            self.cycle_interval, self.chunk_size, self.logger, started_at, self.max_runtime
+        )
 
 
 class Command(BaseCommand):
@@ -107,7 +105,7 @@ class Command(BaseCommand):
             action='store_true',
             dest='is_debug',
             default=False,
-            help='Write debug messages to stdout'
+            help='Write debug messages to stdout',
         )
         parser.add_argument(
             '--days',
@@ -116,7 +114,9 @@ class Command(BaseCommand):
             default=120,
             type=int,
             help='Data cycle interval expressed in days. '
-                 'Minimum {} days when expiring performance data.'.format(MINIMUM_PERFHERDER_EXPIRE_INTERVAL)
+            'Minimum {} days when expiring performance data.'.format(
+                MINIMUM_PERFHERDER_EXPIRE_INTERVAL
+            ),
         )
         parser.add_argument(
             '--chunk-size',
@@ -124,8 +124,9 @@ class Command(BaseCommand):
             dest='chunk_size',
             default=100,
             type=int,
-            help=('Define the size of the chunks '
-                  'Split the job deletes into chunks of this size')
+            help=(
+                'Define the size of the chunks ' 'Split the job deletes into chunks of this size'
+            ),
         )
         parser.add_argument(
             '--sleep-time',
@@ -133,11 +134,11 @@ class Command(BaseCommand):
             dest='sleep_time',
             default=0,
             type=int,
-            help='How many seconds to pause between each query. Ignored when cycling performance data.'
+            help='How many seconds to pause between each query. Ignored when cycling performance data.',
         )
         subparsers = parser.add_subparsers(
-            description='Data producers from which to expire data',
-            dest='data_source')
+            description='Data producers from which to expire data', dest='data_source'
+        )
         subparsers.add_parser(TREEHERDER_SUBCOMMAND)  # default subcommand even if not provided
 
         # Perfherder will have its own specifics

--- a/treeherder/model/management/commands/import_reference_data.py
+++ b/treeherder/model/management/commands/import_reference_data.py
@@ -1,17 +1,19 @@
 from django.core.management.base import BaseCommand
 
 from treeherder.client.thclient import TreeherderClient
-from treeherder.model.models import (BuildPlatform,
-                                     FailureClassification,
-                                     JobGroup,
-                                     JobType,
-                                     Machine,
-                                     MachinePlatform,
-                                     Option,
-                                     OptionCollection,
-                                     Product,
-                                     Repository,
-                                     RepositoryGroup)
+from treeherder.model.models import (
+    BuildPlatform,
+    FailureClassification,
+    JobGroup,
+    JobType,
+    Machine,
+    MachinePlatform,
+    Option,
+    OptionCollection,
+    Product,
+    Repository,
+    RepositoryGroup,
+)
 
 
 class Command(BaseCommand):
@@ -23,7 +25,7 @@ class Command(BaseCommand):
             action='store',
             dest='server',
             default='https://treeherder.mozilla.org',
-            help='Server to get data from, default https://treeherder.mozilla.org'
+            help='Server to get data from, default https://treeherder.mozilla.org',
         )
 
     def handle(self, *args, **options):
@@ -33,16 +35,15 @@ class Command(BaseCommand):
         for (uuid, props) in c.get_option_collection_hash().items():
             for prop in props:
                 option, _ = Option.objects.get_or_create(name=prop['name'])
-                OptionCollection.objects.get_or_create(
-                    option_collection_hash=uuid,
-                    option=option)
+                OptionCollection.objects.get_or_create(option_collection_hash=uuid, option=option)
 
         # machine platforms
         for machine_platform in c.get_machine_platforms():
             MachinePlatform.objects.get_or_create(
                 os_name=machine_platform['os_name'],
                 platform=machine_platform['platform'],
-                architecture=machine_platform['architecture'])
+                architecture=machine_platform['architecture'],
+            )
 
         # machine
         for machine in c.get_machines():
@@ -51,8 +52,9 @@ class Command(BaseCommand):
                 name=machine['name'],
                 defaults={
                     'first_timestamp': machine['first_timestamp'],
-                    'last_timestamp': machine['last_timestamp']
-                })
+                    'last_timestamp': machine['last_timestamp'],
+                },
+            )
 
         # job group
         for job_group in c.get_job_groups():
@@ -60,9 +62,8 @@ class Command(BaseCommand):
                 id=job_group['id'],
                 symbol=job_group['symbol'],
                 name=job_group['name'],
-                defaults={
-                    'description': job_group['description']
-                })
+                defaults={'description': job_group['description']},
+            )
 
         # job type
         for job_type in c.get_job_types():
@@ -70,27 +71,24 @@ class Command(BaseCommand):
                 id=job_type['id'],
                 symbol=job_type['symbol'],
                 name=job_type['name'],
-                defaults={
-                    'description': job_type['description']
-                })
+                defaults={'description': job_type['description']},
+            )
 
         # product
         for product in c.get_products():
             Product.objects.get_or_create(
                 id=product['id'],
                 name=product['name'],
-                defaults={
-                    'description': product['description']
-                })
+                defaults={'description': product['description']},
+            )
 
         # failure classification
         for failure_classification in c.get_failure_classifications():
             FailureClassification.objects.get_or_create(
                 id=failure_classification['id'],
                 name=failure_classification['name'],
-                defaults={
-                    'description': failure_classification['description']
-                })
+                defaults={'description': failure_classification['description']},
+            )
 
         # build platform
         for build_platform in c.get_build_platforms():
@@ -99,15 +97,16 @@ class Command(BaseCommand):
                 os_name=build_platform['os_name'],
                 defaults={
                     'platform': build_platform['platform'],
-                    'architecture': build_platform['architecture']
-                })
+                    'architecture': build_platform['architecture'],
+                },
+            )
 
         # repository and repository group
         for repository in c.get_repositories():
             rgroup, _ = RepositoryGroup.objects.get_or_create(
                 name=repository['repository_group']['name'],
-                description=repository['repository_group']['description']
-                )
+                description=repository['repository_group']['description'],
+            )
             Repository.objects.get_or_create(
                 id=repository['id'],
                 repository_group=rgroup,
@@ -117,5 +116,6 @@ class Command(BaseCommand):
                 defaults={
                     'codebase': repository['codebase'],
                     'description': repository['description'],
-                    'active_status': repository['active_status']
-                })
+                    'active_status': repository['active_status'],
+                },
+            )

--- a/treeherder/model/management/commands/load_initial_data.py
+++ b/treeherder/model/management/commands/load_initial_data.py
@@ -6,11 +6,13 @@ class Command(BaseCommand):
     help = "Load initial data into the master db"
 
     def handle(self, *args, **options):
-        call_command('loaddata',
-                     'repository_group',
-                     'repository',
-                     'failure_classification',
-                     'issue_tracker',
-                     'performance_framework',
-                     'performance_bug_templates')
+        call_command(
+            'loaddata',
+            'repository_group',
+            'repository',
+            'failure_classification',
+            'issue_tracker',
+            'performance_framework',
+            'performance_bug_templates',
+        )
         call_command('load_preseed')

--- a/treeherder/model/migrations/0001_squashed_0022_modify_bugscache_and_bugjobmap.py
+++ b/treeherder/model/migrations/0001_squashed_0022_modify_bugscache_and_bugjobmap.py
@@ -23,9 +23,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=100, unique=True)),
                 ('description', models.TextField(blank=True)),
             ],
-            options={
-                'db_table': 'repository_group',
-            },
+            options={'db_table': 'repository_group',},
         ),
         migrations.CreateModel(
             name='Repository',
@@ -37,42 +35,65 @@ class Migration(migrations.Migration):
                 ('branch', models.CharField(db_index=True, max_length=50, null=True)),
                 ('codebase', models.CharField(blank=True, db_index=True, max_length=50)),
                 ('description', models.TextField(blank=True)),
-                ('active_status', models.CharField(blank=True, db_index=True, default='active', max_length=7)),
+                (
+                    'active_status',
+                    models.CharField(blank=True, db_index=True, default='active', max_length=7),
+                ),
                 ('performance_alerts_enabled', models.BooleanField(default=False)),
-                ('repository_group', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.RepositoryGroup')),
+                (
+                    'repository_group',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.RepositoryGroup'
+                    ),
+                ),
                 ('expire_performance_data', models.BooleanField(default=True)),
                 ('is_try_repo', models.BooleanField(default=False)),
             ],
-            options={
-                'db_table': 'repository',
-                'verbose_name_plural': 'repositories',
-            },
+            options={'db_table': 'repository', 'verbose_name_plural': 'repositories',},
         ),
         migrations.CreateModel(
             name='Push',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
                 ('revision', models.CharField(max_length=40)),
                 ('author', models.CharField(max_length=150)),
                 ('time', models.DateTimeField(db_index=True)),
-                ('repository', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Repository')),
+                (
+                    'repository',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.Repository'
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'push',
-            },
+            options={'db_table': 'push',},
         ),
         migrations.CreateModel(
             name='Commit',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
                 ('revision', models.CharField(max_length=40)),
                 ('author', models.CharField(max_length=150)),
                 ('comments', models.TextField()),
-                ('push', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='commits', to='model.Push')),
+                (
+                    'push',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='commits',
+                        to='model.Push',
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'commit',
-            },
+            options={'db_table': 'commit',},
         ),
         migrations.CreateModel(
             name='Bugscache',
@@ -87,10 +108,7 @@ class Migration(migrations.Migration):
                 ('modified', models.DateTimeField()),
                 ('whiteboard', models.CharField(blank=True, default='', max_length=100)),
             ],
-            options={
-                'db_table': 'bugscache',
-                'verbose_name_plural': 'bugscache',
-            },
+            options={'db_table': 'bugscache', 'verbose_name_plural': 'bugscache',},
         ),
         migrations.CreateModel(
             name='BuildPlatform',
@@ -100,9 +118,7 @@ class Migration(migrations.Migration):
                 ('platform', models.CharField(db_index=True, max_length=100)),
                 ('architecture', models.CharField(blank=True, db_index=True, max_length=25)),
             ],
-            options={
-                'db_table': 'build_platform',
-            },
+            options={'db_table': 'build_platform',},
         ),
         migrations.CreateModel(
             name='ClassifiedFailure',
@@ -112,9 +128,7 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
             ],
-            options={
-                'db_table': 'classified_failure',
-            },
+            options={'db_table': 'classified_failure',},
         ),
         migrations.CreateModel(
             name='FailureClassification',
@@ -122,9 +136,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True, serialize=False)),
                 ('name', models.CharField(max_length=100, unique=True)),
             ],
-            options={
-                'db_table': 'failure_classification',
-            },
+            options={'db_table': 'failure_classification',},
         ),
         migrations.CreateModel(
             name='JobGroup',
@@ -134,9 +146,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=100)),
                 ('description', models.TextField(blank=True)),
             ],
-            options={
-                'db_table': 'job_group',
-            },
+            options={'db_table': 'job_group',},
         ),
         migrations.CreateModel(
             name='JobType',
@@ -146,9 +156,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=100)),
                 ('description', models.TextField(blank=True)),
             ],
-            options={
-                'db_table': 'job_type',
-            },
+            options={'db_table': 'job_type',},
         ),
         migrations.CreateModel(
             name='Machine',
@@ -156,9 +164,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True, serialize=False)),
                 ('name', models.CharField(max_length=100, unique=True)),
             ],
-            options={
-                'db_table': 'machine',
-            },
+            options={'db_table': 'machine',},
         ),
         migrations.CreateModel(
             name='MachinePlatform',
@@ -168,9 +174,7 @@ class Migration(migrations.Migration):
                 ('platform', models.CharField(db_index=True, max_length=100)),
                 ('architecture', models.CharField(blank=True, db_index=True, max_length=25)),
             ],
-            options={
-                'db_table': 'machine_platform',
-            },
+            options={'db_table': 'machine_platform',},
         ),
         migrations.CreateModel(
             name='Product',
@@ -178,14 +182,17 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True, serialize=False)),
                 ('name', models.CharField(max_length=100, unique=True)),
             ],
-            options={
-                'db_table': 'product',
-            },
+            options={'db_table': 'product',},
         ),
         migrations.CreateModel(
             name='ReferenceDataSignatures',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
                 ('name', models.CharField(max_length=255)),
                 ('signature', models.CharField(db_index=True, max_length=50)),
                 ('build_os_name', models.CharField(db_index=True, max_length=25)),
@@ -198,7 +205,10 @@ class Migration(migrations.Migration):
                 ('job_group_symbol', models.CharField(blank=True, db_index=True, max_length=25)),
                 ('job_type_name', models.CharField(db_index=True, max_length=100)),
                 ('job_type_symbol', models.CharField(blank=True, db_index=True, max_length=25)),
-                ('option_collection_hash', models.CharField(blank=True, db_index=True, max_length=64)),
+                (
+                    'option_collection_hash',
+                    models.CharField(blank=True, db_index=True, max_length=64),
+                ),
                 ('build_system_type', models.CharField(blank=True, db_index=True, max_length=25)),
                 ('repository', models.CharField(db_index=True, max_length=50)),
                 ('first_submission_timestamp', models.IntegerField(db_index=True)),
@@ -226,21 +236,92 @@ class Migration(migrations.Migration):
                 ('last_modified', models.DateTimeField(auto_now=True, db_index=True)),
                 ('running_eta', models.PositiveIntegerField(default=None, null=True)),
                 ('tier', models.PositiveIntegerField()),
-                ('build_platform', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='jobs', to='model.BuildPlatform')),
-                ('failure_classification', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='jobs', to='model.FailureClassification')),
-                ('job_type', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='jobs', to='model.JobType')),
-                ('machine', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Machine')),
-                ('machine_platform', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.MachinePlatform')),
-                ('product', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Product')),
-                ('push', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='jobs', to='model.Push')),
-                ('repository', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Repository')),
-                ('signature', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.ReferenceDataSignatures')),
-                ('autoclassify_status', models.IntegerField(choices=[(0, 'pending'), (1, 'crossreferenced'), (2, 'autoclassified'), (3, 'skipped'), (255, 'failed')], default=0)),
-                ('job_group', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='jobs', to='model.JobGroup')),
+                (
+                    'build_platform',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='jobs',
+                        to='model.BuildPlatform',
+                    ),
+                ),
+                (
+                    'failure_classification',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='jobs',
+                        to='model.FailureClassification',
+                    ),
+                ),
+                (
+                    'job_type',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='jobs',
+                        to='model.JobType',
+                    ),
+                ),
+                (
+                    'machine',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.Machine'
+                    ),
+                ),
+                (
+                    'machine_platform',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.MachinePlatform'
+                    ),
+                ),
+                (
+                    'product',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.Product'
+                    ),
+                ),
+                (
+                    'push',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='jobs',
+                        to='model.Push',
+                    ),
+                ),
+                (
+                    'repository',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.Repository'
+                    ),
+                ),
+                (
+                    'signature',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to='model.ReferenceDataSignatures',
+                    ),
+                ),
+                (
+                    'autoclassify_status',
+                    models.IntegerField(
+                        choices=[
+                            (0, 'pending'),
+                            (1, 'crossreferenced'),
+                            (2, 'autoclassified'),
+                            (3, 'skipped'),
+                            (255, 'failed'),
+                        ],
+                        default=0,
+                    ),
+                ),
+                (
+                    'job_group',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='jobs',
+                        to='model.JobGroup',
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'job',
-            },
+            options={'db_table': 'job',},
         ),
         migrations.CreateModel(
             name='BugJobMap',
@@ -248,12 +329,20 @@ class Migration(migrations.Migration):
                 ('id', models.BigAutoField(primary_key=True, serialize=False)),
                 ('bug_id', models.PositiveIntegerField(db_index=True)),
                 ('created', models.DateTimeField(default=django.utils.timezone.now)),
-                ('job', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Job')),
-                ('user', models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                (
+                    'job',
+                    models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Job'),
+                ),
+                (
+                    'user',
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'bug_job_map',
-            },
+            options={'db_table': 'bug_job_map',},
         ),
         migrations.CreateModel(
             name='JobDetail',
@@ -262,24 +351,44 @@ class Migration(migrations.Migration):
                 ('title', models.CharField(max_length=70, null=True)),
                 ('value', models.CharField(max_length=125)),
                 ('url', models.URLField(max_length=512, null=True)),
-                ('job', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='job_details', to='model.Job')),
+                (
+                    'job',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='job_details',
+                        to='model.Job',
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'job_detail',
-            },
+            options={'db_table': 'job_detail',},
         ),
         migrations.CreateModel(
             name='JobLog',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
                 ('name', models.CharField(max_length=50)),
                 ('url', models.URLField(max_length=255)),
-                ('status', models.IntegerField(choices=[(0, 'pending'), (1, 'parsed'), (2, 'failed')], default=0)),
-                ('job', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='job_log', to='model.Job')),
+                (
+                    'status',
+                    models.IntegerField(
+                        choices=[(0, 'pending'), (1, 'parsed'), (2, 'failed')], default=0
+                    ),
+                ),
+                (
+                    'job',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='job_log',
+                        to='model.Job',
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'job_log',
-            },
+            options={'db_table': 'job_log',},
         ),
         migrations.CreateModel(
             name='JobNote',
@@ -287,13 +396,27 @@ class Migration(migrations.Migration):
                 ('id', models.BigAutoField(primary_key=True, serialize=False)),
                 ('text', models.TextField()),
                 ('created', models.DateTimeField(default=django.utils.timezone.now)),
-                ('failure_classification', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.FailureClassification')),
-                ('job', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Job')),
-                ('user', models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                (
+                    'failure_classification',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to='model.FailureClassification',
+                    ),
+                ),
+                (
+                    'job',
+                    models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Job'),
+                ),
+                (
+                    'user',
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'job_note',
-            },
+            options={'db_table': 'job_note',},
         ),
         migrations.CreateModel(
             name='Option',
@@ -301,20 +424,21 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True, serialize=False)),
                 ('name', models.CharField(max_length=100, unique=True)),
             ],
-            options={
-                'db_table': 'option',
-            },
+            options={'db_table': 'option',},
         ),
         migrations.CreateModel(
             name='OptionCollection',
             fields=[
                 ('id', models.AutoField(primary_key=True, serialize=False)),
                 ('option_collection_hash', models.CharField(max_length=40)),
-                ('option', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Option')),
+                (
+                    'option',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.Option'
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'option_collection',
-            },
+            options={'db_table': 'option_collection',},
         ),
         migrations.CreateModel(
             name='RunnableJob',
@@ -324,78 +448,206 @@ class Migration(migrations.Migration):
                 ('ref_data_name', models.CharField(max_length=255)),
                 ('build_system_type', models.CharField(max_length=25)),
                 ('last_touched', models.DateTimeField(auto_now=True)),
-                ('build_platform', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.BuildPlatform')),
-                ('job_type', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.JobType')),
-                ('machine_platform', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.MachinePlatform')),
-                ('repository', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Repository')),
-                ('job_group', models.ForeignKey(default=2, on_delete=django.db.models.deletion.CASCADE, to='model.JobGroup')),
+                (
+                    'build_platform',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.BuildPlatform'
+                    ),
+                ),
+                (
+                    'job_type',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.JobType'
+                    ),
+                ),
+                (
+                    'machine_platform',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.MachinePlatform'
+                    ),
+                ),
+                (
+                    'repository',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.Repository'
+                    ),
+                ),
+                (
+                    'job_group',
+                    models.ForeignKey(
+                        default=2, on_delete=django.db.models.deletion.CASCADE, to='model.JobGroup'
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'runnable_job',
-            },
+            options={'db_table': 'runnable_job',},
         ),
         migrations.CreateModel(
             name='FailureLine',
             fields=[
                 ('id', models.BigAutoField(primary_key=True, serialize=False)),
                 ('job_guid', models.CharField(max_length=50)),
-                ('action', models.CharField(choices=[('test_result', 'test_result'), ('log', 'log'), ('crash', 'crash'), ('truncated', 'truncated')], max_length=11)),
+                (
+                    'action',
+                    models.CharField(
+                        choices=[
+                            ('test_result', 'test_result'),
+                            ('log', 'log'),
+                            ('crash', 'crash'),
+                            ('truncated', 'truncated'),
+                        ],
+                        max_length=11,
+                    ),
+                ),
                 ('line', models.PositiveIntegerField()),
                 ('test', models.TextField(blank=True, null=True)),
                 ('subtest', models.TextField(blank=True, null=True)),
-                ('status', models.CharField(choices=[('PASS', 'PASS'), ('FAIL', 'FAIL'), ('OK', 'OK'), ('ERROR', 'ERROR'), ('TIMEOUT', 'TIMEOUT'), ('CRASH', 'CRASH'), ('ASSERT', 'ASSERT'), ('SKIP', 'SKIP'), ('NOTRUN', 'NOTRUN')], max_length=7)),
-                ('expected', models.CharField(blank=True, choices=[('PASS', 'PASS'), ('FAIL', 'FAIL'), ('OK', 'OK'), ('ERROR', 'ERROR'), ('TIMEOUT', 'TIMEOUT'), ('CRASH', 'CRASH'), ('ASSERT', 'ASSERT'), ('SKIP', 'SKIP'), ('NOTRUN', 'NOTRUN')], max_length=7, null=True)),
+                (
+                    'status',
+                    models.CharField(
+                        choices=[
+                            ('PASS', 'PASS'),
+                            ('FAIL', 'FAIL'),
+                            ('OK', 'OK'),
+                            ('ERROR', 'ERROR'),
+                            ('TIMEOUT', 'TIMEOUT'),
+                            ('CRASH', 'CRASH'),
+                            ('ASSERT', 'ASSERT'),
+                            ('SKIP', 'SKIP'),
+                            ('NOTRUN', 'NOTRUN'),
+                        ],
+                        max_length=7,
+                    ),
+                ),
+                (
+                    'expected',
+                    models.CharField(
+                        blank=True,
+                        choices=[
+                            ('PASS', 'PASS'),
+                            ('FAIL', 'FAIL'),
+                            ('OK', 'OK'),
+                            ('ERROR', 'ERROR'),
+                            ('TIMEOUT', 'TIMEOUT'),
+                            ('CRASH', 'CRASH'),
+                            ('ASSERT', 'ASSERT'),
+                            ('SKIP', 'SKIP'),
+                            ('NOTRUN', 'NOTRUN'),
+                        ],
+                        max_length=7,
+                        null=True,
+                    ),
+                ),
                 ('message', models.TextField(blank=True, null=True)),
                 ('signature', models.TextField(blank=True, null=True)),
-                ('level', models.CharField(blank=True, choices=[('PASS', 'PASS'), ('FAIL', 'FAIL'), ('OK', 'OK'), ('ERROR', 'ERROR'), ('TIMEOUT', 'TIMEOUT'), ('CRASH', 'CRASH'), ('ASSERT', 'ASSERT'), ('SKIP', 'SKIP'), ('NOTRUN', 'NOTRUN')], max_length=8, null=True)),
+                (
+                    'level',
+                    models.CharField(
+                        blank=True,
+                        choices=[
+                            ('PASS', 'PASS'),
+                            ('FAIL', 'FAIL'),
+                            ('OK', 'OK'),
+                            ('ERROR', 'ERROR'),
+                            ('TIMEOUT', 'TIMEOUT'),
+                            ('CRASH', 'CRASH'),
+                            ('ASSERT', 'ASSERT'),
+                            ('SKIP', 'SKIP'),
+                            ('NOTRUN', 'NOTRUN'),
+                        ],
+                        max_length=8,
+                        null=True,
+                    ),
+                ),
                 ('stack', models.TextField(blank=True, null=True)),
                 ('stackwalk_stdout', models.TextField(blank=True, null=True)),
                 ('stackwalk_stderr', models.TextField(blank=True, null=True)),
                 ('best_is_verified', models.BooleanField(default=False)),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
-                ('best_classification', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='best_for_lines', to='model.ClassifiedFailure')),
-                ('job_log', models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='failure_line', to='model.JobLog')),
-                ('repository', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Repository')),
+                (
+                    'best_classification',
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name='best_for_lines',
+                        to='model.ClassifiedFailure',
+                    ),
+                ),
+                (
+                    'job_log',
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='failure_line',
+                        to='model.JobLog',
+                    ),
+                ),
+                (
+                    'repository',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.Repository'
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'failure_line',
-            },
+            options={'db_table': 'failure_line',},
         ),
         migrations.CreateModel(
             name='Matcher',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
                 ('name', models.CharField(max_length=50, unique=True)),
             ],
-            options={
-                'db_table': 'matcher',
-            },
+            options={'db_table': 'matcher',},
         ),
         migrations.CreateModel(
             name='FailureMatch',
             fields=[
                 ('id', models.BigAutoField(primary_key=True, serialize=False)),
-                ('score', models.DecimalField(blank=True, decimal_places=2, max_digits=3, null=True)),
-                ('classified_failure', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='matches', to='model.ClassifiedFailure')),
-                ('failure_line', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='matches', to='model.FailureLine')),
-                ('matcher', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Matcher')),
+                (
+                    'score',
+                    models.DecimalField(blank=True, decimal_places=2, max_digits=3, null=True),
+                ),
+                (
+                    'classified_failure',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='matches',
+                        to='model.ClassifiedFailure',
+                    ),
+                ),
+                (
+                    'failure_line',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='matches',
+                        to='model.FailureLine',
+                    ),
+                ),
+                (
+                    'matcher',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.Matcher'
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'failure_match',
-                'verbose_name_plural': 'failure matches',
-            },
+            options={'db_table': 'failure_match', 'verbose_name_plural': 'failure matches',},
         ),
         migrations.CreateModel(
             name='Group',
             fields=[
                 ('id', models.BigAutoField(primary_key=True, serialize=False)),
                 ('name', models.CharField(max_length=255, unique=True)),
-                ('failure_lines', models.ManyToManyField(related_name='group', to='model.FailureLine')),
+                (
+                    'failure_lines',
+                    models.ManyToManyField(related_name='group', to='model.FailureLine'),
+                ),
             ],
-            options={
-                'db_table': 'group',
-            },
+            options={'db_table': 'group',},
         ),
         migrations.CreateModel(
             name='TextLogStep',
@@ -406,12 +658,32 @@ class Migration(migrations.Migration):
                 ('finished', models.DateTimeField(null=True)),
                 ('started_line_number', models.PositiveIntegerField()),
                 ('finished_line_number', models.PositiveIntegerField()),
-                ('result', models.IntegerField(choices=[(0, 'success'), (1, 'testfailed'), (2, 'busted'), (3, 'skipped'), (4, 'exception'), (5, 'retry'), (6, 'usercancel'), (7, 'unknown'), (8, 'superseded')])),
-                ('job', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='text_log_step', to='model.Job')),
+                (
+                    'result',
+                    models.IntegerField(
+                        choices=[
+                            (0, 'success'),
+                            (1, 'testfailed'),
+                            (2, 'busted'),
+                            (3, 'skipped'),
+                            (4, 'exception'),
+                            (5, 'retry'),
+                            (6, 'usercancel'),
+                            (7, 'unknown'),
+                            (8, 'superseded'),
+                        ]
+                    ),
+                ),
+                (
+                    'job',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='text_log_step',
+                        to='model.Job',
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'text_log_step',
-            },
+            options={'db_table': 'text_log_step',},
         ),
         migrations.CreateModel(
             name='TextLogError',
@@ -419,20 +691,47 @@ class Migration(migrations.Migration):
                 ('id', models.BigAutoField(primary_key=True, serialize=False)),
                 ('line', models.TextField()),
                 ('line_number', models.PositiveIntegerField()),
-                ('step', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='errors', to='model.TextLogStep')),
+                (
+                    'step',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='errors',
+                        to='model.TextLogStep',
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'text_log_error',
-            },
+            options={'db_table': 'text_log_error',},
         ),
         migrations.CreateModel(
             name='TextLogErrorMatch',
             fields=[
                 ('id', models.BigAutoField(primary_key=True, serialize=False)),
-                ('score', models.DecimalField(blank=True, decimal_places=2, max_digits=3, null=True)),
-                ('classified_failure', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='error_matches', to='model.ClassifiedFailure')),
-                ('matcher', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Matcher')),
-                ('text_log_error', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='matches', to='model.TextLogError')),
+                (
+                    'score',
+                    models.DecimalField(blank=True, decimal_places=2, max_digits=3, null=True),
+                ),
+                (
+                    'classified_failure',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='error_matches',
+                        to='model.ClassifiedFailure',
+                    ),
+                ),
+                (
+                    'matcher',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.Matcher'
+                    ),
+                ),
+                (
+                    'text_log_error',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='matches',
+                        to='model.TextLogError',
+                    ),
+                ),
             ],
             options={
                 'db_table': 'text_log_error_match',
@@ -442,55 +741,90 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='TaskclusterMetadata',
             fields=[
-                ('job', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, primary_key=True, related_name='taskcluster_metadata', serialize=False, to='model.Job')),
-                ('task_id', models.CharField(max_length=22, validators=[django.core.validators.MinLengthValidator(22)])),
+                (
+                    'job',
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        primary_key=True,
+                        related_name='taskcluster_metadata',
+                        serialize=False,
+                        to='model.Job',
+                    ),
+                ),
+                (
+                    'task_id',
+                    models.CharField(
+                        max_length=22, validators=[django.core.validators.MinLengthValidator(22)]
+                    ),
+                ),
                 ('retry_id', models.PositiveIntegerField()),
             ],
-            options={
-                'db_table': 'taskcluster_metadata',
-            },
+            options={'db_table': 'taskcluster_metadata',},
         ),
         migrations.CreateModel(
             name='TextLogErrorMetadata',
             fields=[
-                ('text_log_error', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, primary_key=True, related_name='_metadata', serialize=False, to='model.TextLogError')),
+                (
+                    'text_log_error',
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        primary_key=True,
+                        related_name='_metadata',
+                        serialize=False,
+                        to='model.TextLogError',
+                    ),
+                ),
                 ('best_is_verified', models.BooleanField(default=False)),
-                ('best_classification', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='best_for_errors', to='model.ClassifiedFailure')),
-                ('failure_line', models.OneToOneField(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='text_log_error_metadata', to='model.FailureLine')),
+                (
+                    'best_classification',
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name='best_for_errors',
+                        to='model.ClassifiedFailure',
+                    ),
+                ),
+                (
+                    'failure_line',
+                    models.OneToOneField(
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='text_log_error_metadata',
+                        to='model.FailureLine',
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'text_log_error_metadata',
-            },
+            options={'db_table': 'text_log_error_metadata',},
         ),
         migrations.AddField(
             model_name='classifiedfailure',
             name='failure_lines',
-            field=models.ManyToManyField(related_name='classified_failures', through='model.FailureMatch', to='model.FailureLine'),
+            field=models.ManyToManyField(
+                related_name='classified_failures',
+                through='model.FailureMatch',
+                to='model.FailureLine',
+            ),
         ),
         migrations.AddField(
             model_name='classifiedfailure',
             name='text_log_errors',
-            field=models.ManyToManyField(related_name='classified_failures', through='model.TextLogErrorMatch', to='model.TextLogError'),
+            field=models.ManyToManyField(
+                related_name='classified_failures',
+                through='model.TextLogErrorMatch',
+                to='model.TextLogError',
+            ),
         ),
         migrations.AlterUniqueTogether(
             name='referencedatasignatures',
             unique_together=set([('name', 'signature', 'build_system_type', 'repository')]),
         ),
         migrations.AlterUniqueTogether(
-            name='machineplatform',
-            unique_together=set([('os_name', 'platform', 'architecture')]),
+            name='machineplatform', unique_together=set([('os_name', 'platform', 'architecture')]),
         ),
+        migrations.AlterUniqueTogether(name='jobtype', unique_together=set([('name', 'symbol')]),),
+        migrations.AlterUniqueTogether(name='jobgroup', unique_together=set([('name', 'symbol')]),),
         migrations.AlterUniqueTogether(
-            name='jobtype',
-            unique_together=set([('name', 'symbol')]),
-        ),
-        migrations.AlterUniqueTogether(
-            name='jobgroup',
-            unique_together=set([('name', 'symbol')]),
-        ),
-        migrations.AlterUniqueTogether(
-            name='buildplatform',
-            unique_together=set([('os_name', 'platform', 'architecture')]),
+            name='buildplatform', unique_together=set([('os_name', 'platform', 'architecture')]),
         ),
         migrations.AlterUniqueTogether(
             name='textlogstep',
@@ -501,56 +835,55 @@ class Migration(migrations.Migration):
             unique_together=set([('text_log_error', 'classified_failure', 'matcher')]),
         ),
         migrations.AlterUniqueTogether(
-            name='textlogerror',
-            unique_together=set([('step', 'line_number')]),
+            name='textlogerror', unique_together=set([('step', 'line_number')]),
         ),
         migrations.AlterUniqueTogether(
-            name='runnablejob',
-            unique_together=set([('ref_data_name', 'build_system_type')]),
+            name='runnablejob', unique_together=set([('ref_data_name', 'build_system_type')]),
         ),
         migrations.AlterUniqueTogether(
-            name='push',
-            unique_together=set([('repository', 'revision')]),
+            name='push', unique_together=set([('repository', 'revision')]),
         ),
         migrations.AlterUniqueTogether(
-            name='optioncollection',
-            unique_together=set([('option_collection_hash', 'option')]),
+            name='optioncollection', unique_together=set([('option_collection_hash', 'option')]),
         ),
         migrations.AlterUniqueTogether(
-            name='joblog',
-            unique_together=set([('job', 'name', 'url')]),
+            name='joblog', unique_together=set([('job', 'name', 'url')]),
         ),
         migrations.AlterUniqueTogether(
-            name='jobdetail',
-            unique_together=set([('title', 'value', 'job')]),
+            name='jobdetail', unique_together=set([('title', 'value', 'job')]),
         ),
         migrations.AlterIndexTogether(
             name='job',
-            index_together=set([('repository', 'option_collection_hash', 'job_type', 'start_time'), ('repository', 'build_platform', 'job_type', 'start_time'), ('repository', 'submit_time'), ('machine_platform', 'option_collection_hash', 'push'), ('repository', 'build_platform', 'option_collection_hash', 'job_type', 'start_time'), ('repository', 'job_type', 'start_time')]),
+            index_together=set(
+                [
+                    ('repository', 'option_collection_hash', 'job_type', 'start_time'),
+                    ('repository', 'build_platform', 'job_type', 'start_time'),
+                    ('repository', 'submit_time'),
+                    ('machine_platform', 'option_collection_hash', 'push'),
+                    (
+                        'repository',
+                        'build_platform',
+                        'option_collection_hash',
+                        'job_type',
+                        'start_time',
+                    ),
+                    ('repository', 'job_type', 'start_time'),
+                ]
+            ),
         ),
         migrations.AlterUniqueTogether(
             name='failurematch',
             unique_together=set([('failure_line', 'classified_failure', 'matcher')]),
         ),
         migrations.AlterUniqueTogether(
-            name='failureline',
-            unique_together=set([('job_log', 'line')]),
+            name='failureline', unique_together=set([('job_log', 'line')]),
         ),
         migrations.AlterIndexTogether(
-            name='failureline',
-            index_together=set([('job_guid', 'repository')]),
+            name='failureline', index_together=set([('job_guid', 'repository')]),
         ),
-        migrations.AlterUniqueTogether(
-            name='commit',
-            unique_together=set([('push', 'revision')]),
-        ),
-        migrations.AlterUniqueTogether(
-            name='bugjobmap',
-            unique_together=set([('job', 'bug_id')]),
-        ),
-
+        migrations.AlterUniqueTogether(name='commit', unique_together=set([('push', 'revision')]),),
+        migrations.AlterUniqueTogether(name='bugjobmap', unique_together=set([('job', 'bug_id')]),),
         # Manually created migrations.
-
         # Since Django doesn't natively support creating FULLTEXT indices.
         migrations.RunSQL(
             [
@@ -577,11 +910,13 @@ class Migration(migrations.Migration):
             state_operations=[
                 migrations.AlterIndexTogether(
                     name='failureline',
-                    index_together=set([
-                        ('test', 'subtest', 'status', 'expected', 'created'),
-                        ('job_guid', 'repository'),
-                        ('signature', 'test', 'created'),
-                    ])
+                    index_together=set(
+                        [
+                            ('test', 'subtest', 'status', 'expected', 'created'),
+                            ('job_guid', 'repository'),
+                            ('signature', 'test', 'created'),
+                        ]
+                    ),
                 ),
             ],
         ),

--- a/treeherder/model/migrations/0002_add_bugjobmap_model_manager.py
+++ b/treeherder/model/migrations/0002_add_bugjobmap_model_manager.py
@@ -12,9 +12,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterModelManagers(
-            name='bugjobmap',
-            managers=[
-                ('failures', django.db.models.manager.Manager()),
-            ],
+            name='bugjobmap', managers=[('failures', django.db.models.manager.Manager()),],
         ),
     ]

--- a/treeherder/model/migrations/0006_drop_matcher_fks.py
+++ b/treeherder/model/migrations/0006_drop_matcher_fks.py
@@ -10,12 +10,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name='failurematch',
-            name='matcher',
-        ),
-        migrations.RemoveField(
-            model_name='textlogerrormatch',
-            name='matcher',
-        ),
+        migrations.RemoveField(model_name='failurematch', name='matcher',),
+        migrations.RemoveField(model_name='textlogerrormatch', name='matcher',),
     ]

--- a/treeherder/model/migrations/0007_remove_m2m_between_classified_failures_and_failure_match.py
+++ b/treeherder/model/migrations/0007_remove_m2m_between_classified_failures_and_failure_match.py
@@ -10,8 +10,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name='classifiedfailure',
-            name='failure_lines',
-        ),
+        migrations.RemoveField(model_name='classifiedfailure', name='failure_lines',),
     ]

--- a/treeherder/model/migrations/0008_remove_failure_match.py
+++ b/treeherder/model/migrations/0008_remove_failure_match.py
@@ -10,19 +10,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterUniqueTogether(
-            name='failurematch',
-            unique_together=set([]),
-        ),
-        migrations.RemoveField(
-            model_name='failurematch',
-            name='classified_failure',
-        ),
-        migrations.RemoveField(
-            model_name='failurematch',
-            name='failure_line',
-        ),
-        migrations.DeleteModel(
-            name='FailureMatch',
-        ),
+        migrations.AlterUniqueTogether(name='failurematch', unique_together=set([]),),
+        migrations.RemoveField(model_name='failurematch', name='classified_failure',),
+        migrations.RemoveField(model_name='failurematch', name='failure_line',),
+        migrations.DeleteModel(name='FailureMatch',),
     ]

--- a/treeherder/model/migrations/0009_add_manager_to_push_and_job.py
+++ b/treeherder/model/migrations/0009_add_manager_to_push_and_job.py
@@ -12,15 +12,9 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterModelManagers(
-            name='push',
-            managers=[
-                ('failures', django.db.models.manager.Manager()),
-            ],
+            name='push', managers=[('failures', django.db.models.manager.Manager()),],
         ),
         migrations.AlterModelManagers(
-            name='job',
-            managers=[
-                ('failures', django.db.models.manager.Manager()),
-            ],
+            name='job', managers=[('failures', django.db.models.manager.Manager()),],
         ),
     ]

--- a/treeherder/model/migrations/0010_remove_runnable_job.py
+++ b/treeherder/model/migrations/0010_remove_runnable_job.py
@@ -10,31 +10,11 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterUniqueTogether(
-            name='runnablejob',
-            unique_together=set([]),
-        ),
-        migrations.RemoveField(
-            model_name='runnablejob',
-            name='build_platform',
-        ),
-        migrations.RemoveField(
-            model_name='runnablejob',
-            name='job_group',
-        ),
-        migrations.RemoveField(
-            model_name='runnablejob',
-            name='job_type',
-        ),
-        migrations.RemoveField(
-            model_name='runnablejob',
-            name='machine_platform',
-        ),
-        migrations.RemoveField(
-            model_name='runnablejob',
-            name='repository',
-        ),
-        migrations.DeleteModel(
-            name='RunnableJob',
-        ),
+        migrations.AlterUniqueTogether(name='runnablejob', unique_together=set([]),),
+        migrations.RemoveField(model_name='runnablejob', name='build_platform',),
+        migrations.RemoveField(model_name='runnablejob', name='job_group',),
+        migrations.RemoveField(model_name='runnablejob', name='job_type',),
+        migrations.RemoveField(model_name='runnablejob', name='machine_platform',),
+        migrations.RemoveField(model_name='runnablejob', name='repository',),
+        migrations.DeleteModel(name='RunnableJob',),
     ]

--- a/treeherder/model/migrations/0011_remove_matcher_table.py
+++ b/treeherder/model/migrations/0011_remove_matcher_table.py
@@ -10,7 +10,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.DeleteModel(
-            name='Matcher',
-        ),
+        migrations.DeleteModel(name='Matcher',),
     ]

--- a/treeherder/model/migrations/0014_add_job_log_status_skipped_size.py
+++ b/treeherder/model/migrations/0014_add_job_log_status_skipped_size.py
@@ -13,6 +13,9 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='joblog',
             name='status',
-            field=models.IntegerField(choices=[(0, 'pending'), (1, 'parsed'), (2, 'failed'), (3, 'skipped-size')], default=0),
+            field=models.IntegerField(
+                choices=[(0, 'pending'), (1, 'parsed'), (2, 'failed'), (3, 'skipped-size')],
+                default=0,
+            ),
         ),
     ]

--- a/treeherder/model/migrations/0015_add_repository_tc_root_url.py
+++ b/treeherder/model/migrations/0015_add_repository_tc_root_url.py
@@ -14,7 +14,9 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='repository',
             name='tc_root_url',
-            field=models.CharField(db_index=True, default='https://taskcluster.net', max_length=255),
+            field=models.CharField(
+                db_index=True, default='https://taskcluster.net', max_length=255
+            ),
             # only apply this default when migrating; after this users must supply their
             # own rootUrl (and by the time you're reading this, `taskcluster.net` is likely
             # no longer operating)

--- a/treeherder/perf/backfill_tool.py
+++ b/treeherder/perf/backfill_tool.py
@@ -10,7 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 class BackfillTool:
-
     def __init__(self, taskcluster_model: TaskclusterModel):
         self.tc_model = taskcluster_model
 
@@ -30,7 +29,7 @@ class BackfillTool:
             task_id=task_id_to_backfill,
             decision_task_id=decision_task_id,
             input={},
-            root_url=job.repository.tc_root_url
+            root_url=job.repository.tc_root_url,
         )
         return task_id
 

--- a/treeherder/perf/management/commands/create_test_perf_data.py
+++ b/treeherder/perf/management/commands/create_test_perf_data.py
@@ -5,8 +5,7 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
 from treeherder.model.models import Push
-from treeherder.perf.models import (PerformanceDatum,
-                                    PerformanceSignature)
+from treeherder.perf.models import PerformanceDatum, PerformanceSignature
 
 
 class Command(BaseCommand):
@@ -14,11 +13,13 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        confirm = input("""
+        confirm = input(
+            """
 You have a requested a load of test performance data, this is a destructive
 operation that should only be performed on a development instance.
 
-Type 'yes' to continue, or 'no' to cancel: """)
+Type 'yes' to continue, or 'no' to cancel: """
+        )
         if confirm != "yes":
             return
 
@@ -36,11 +37,13 @@ Type 'yes' to continue, or 'no' to cancel: """)
             repository=s.repository,
             revision='1234abcd',
             author='foo@bar.com',
-            time=datetime.datetime.now())
+            time=datetime.datetime.now(),
+        )
 
-        for (t, v) in zip([i for i in range(INTERVAL)],
-                          ([0.5 for i in range(int(INTERVAL / 2))] +
-                           [1.0 for i in range(int(INTERVAL / 2))])):
+        for (t, v) in zip(
+            [i for i in range(INTERVAL)],
+            ([0.5 for i in range(int(INTERVAL / 2))] + [1.0 for i in range(int(INTERVAL / 2))]),
+        ):
             PerformanceDatum.objects.create(
                 repository=s.repository,
                 result_set_id=t,
@@ -48,4 +51,5 @@ Type 'yes' to continue, or 'no' to cancel: """)
                 signature=s,
                 push_timestamp=datetime.datetime.utcfromtimestamp(now + (t * 60 * 60)),
                 push_id=1,
-                value=v)
+                value=v,
+            )

--- a/treeherder/perf/management/commands/generate_alerts.py
+++ b/treeherder/perf/management/commands/generate_alerts.py
@@ -1,5 +1,4 @@
-from django.core.management.base import (BaseCommand,
-                                         CommandError)
+from django.core.management.base import BaseCommand, CommandError
 
 from treeherder.model import models
 from treeherder.perf.alerts import generate_new_alerts_in_series
@@ -17,27 +16,24 @@ class Command(BaseCommand):
         parser.add_argument(
             '--project',
             action='append',
-            help='Project to get signatures from (specify multiple times to get multiple projects'
+            help='Project to get signatures from (specify multiple times to get multiple projects',
         )
         parser.add_argument(
             '--signature',
             action='append',
-            help='Signature hashes to process, defaults to all non-subtests'
+            help='Signature hashes to process, defaults to all non-subtests',
         )
 
     def handle(self, *args, **options):
         if not options['project']:
-            raise CommandError("Must specify at least one project with "
-                               "--project")
+            raise CommandError("Must specify at least one project with " "--project")
         for project in options['project']:
             repository = models.Repository.objects.get(name=project)
 
-            signatures = PerformanceSignature.objects.filter(
-                repository=repository)
+            signatures = PerformanceSignature.objects.filter(repository=repository)
 
             if options['signature']:
-                signatures_to_process = signatures.filter(
-                    signature_hash__in=options['signature'])
+                signatures_to_process = signatures.filter(signature_hash__in=options['signature'])
             else:
                 hashes_to_ignore = set()
                 # if doing everything, only handle series which are not a
@@ -46,11 +42,13 @@ class Command(BaseCommand):
                 for signature in signatures:
                     # Don't alert on subtests which have a summary
                     hashes_to_ignore.update(
-                        signature.extra_properties.get('subtest_signatures',
-                                                       []))
-                signatures_to_process = [signature for signature in signatures
-                                         if signature.signature_hash not in
-                                         hashes_to_ignore]
+                        signature.extra_properties.get('subtest_signatures', [])
+                    )
+                signatures_to_process = [
+                    signature
+                    for signature in signatures
+                    if signature.signature_hash not in hashes_to_ignore
+                ]
 
             for signature in signatures_to_process:
                 generate_new_alerts_in_series(signature)

--- a/treeherder/perf/management/commands/import_perf_data.py
+++ b/treeherder/perf/management/commands/import_perf_data.py
@@ -7,28 +7,32 @@ from multiprocessing import Process
 from django.core.management.base import BaseCommand
 from django.db import connections
 
-from treeherder.model.models import (BuildPlatform,
-                                     FailureClassification,
-                                     Job,
-                                     JobGroup,
-                                     JobType,
-                                     Machine,
-                                     MachinePlatform,
-                                     Option,
-                                     OptionCollection,
-                                     Product,
-                                     Push,
-                                     ReferenceDataSignatures,
-                                     Repository,
-                                     RepositoryGroup)
-from treeherder.perf.models import (BackfillRecord,
-                                    BackfillReport,
-                                    IssueTracker,
-                                    PerformanceAlert,
-                                    PerformanceAlertSummary,
-                                    PerformanceDatum,
-                                    PerformanceFramework,
-                                    PerformanceSignature)
+from treeherder.model.models import (
+    BuildPlatform,
+    FailureClassification,
+    Job,
+    JobGroup,
+    JobType,
+    Machine,
+    MachinePlatform,
+    Option,
+    OptionCollection,
+    Product,
+    Push,
+    ReferenceDataSignatures,
+    Repository,
+    RepositoryGroup,
+)
+from treeherder.perf.models import (
+    BackfillRecord,
+    BackfillReport,
+    IssueTracker,
+    PerformanceAlert,
+    PerformanceAlertSummary,
+    PerformanceDatum,
+    PerformanceFramework,
+    PerformanceSignature,
+)
 
 LOG_EVERY = 5  # seconds
 
@@ -39,16 +43,18 @@ def occasional_log(message, seconds=LOG_EVERY):
         print(message)
 
 
-def progress_notifier(item_processor, iterable: list, item_name: str, tabs_no=0,):
+def progress_notifier(
+    item_processor, iterable: list, item_name: str, tabs_no=0,
+):
     total_items = len(iterable)
-    print('{0}Fetching {1} {2} item(s)...'.format('\t'*tabs_no, total_items, item_name))
+    print('{0}Fetching {1} {2} item(s)...'.format('\t' * tabs_no, total_items, item_name))
 
     prev_percentage = None
     for idx, item in enumerate(iterable):
         item_processor(item)
         percentage = int((idx + 1) * 100 / total_items)
         if percentage % 10 == 0 and percentage != prev_percentage:
-            print('{0}Fetched {1}% of {2} item(s)'.format('\t'*tabs_no, percentage, item_name))
+            print('{0}Fetched {1}% of {2} item(s)'.format('\t' * tabs_no, percentage, item_name))
             prev_percentage = percentage
 
 
@@ -62,7 +68,7 @@ def _ignore_assignee(table_name, model):
 
 SENSITIVE_TABLES_MAP = {
     'performance_alert': _ignore_classifier,
-    'performance_alert_summary': _ignore_assignee
+    'performance_alert_summary': _ignore_assignee,
 }
 
 
@@ -114,96 +120,105 @@ class DecentSizedData(Data):
     def fillup_target(self, **filters):
         print('Fetching all affordable data...\n')
         # TODO: JSON dump the list
-        print('From tables {0}'.format(
-            ', '.join([model._meta.db_table
-                       for model in self.DECENT_SIZED_TABLES])))
+        print(
+            'From tables {0}'.format(
+                ', '.join([model._meta.db_table for model in self.DECENT_SIZED_TABLES])
+            )
+        )
 
         self.delete_local_data()
         self.save_local_data()
 
 
 class MassiveData(Data):
-    BIG_SIZED_TABLES = [BackfillReport,
-                        BackfillRecord,
-                        PerformanceAlertSummary,
-                        PerformanceAlert,
-                        ReferenceDataSignatures,
-                        PerformanceDatum,
-                        PerformanceSignature,
-                        Job,
-                        JobGroup,
-                        JobType,
-                        Push,
-                        BuildPlatform,
-                        Machine]
+    BIG_SIZED_TABLES = [
+        BackfillReport,
+        BackfillRecord,
+        PerformanceAlertSummary,
+        PerformanceAlert,
+        ReferenceDataSignatures,
+        PerformanceDatum,
+        PerformanceSignature,
+        Job,
+        JobGroup,
+        JobType,
+        Push,
+        BuildPlatform,
+        Machine,
+    ]
 
-    priority_dict = {'reference_data_signature': {'download_order': 1,
-                                                  'model': ReferenceDataSignatures},
-                     'push': {'download_order': 1,
-                              'model': Push},
-                     'build_platform': {'download_order': 1,
-                                        'model': BuildPlatform},
-                     'machine': {'download_order': 1,
-                                 'model': Machine},
-                     'job_group': {'download_order': 1,
-                                   'model': JobGroup},
-                     'job_type': {'download_order': 1,
-                                  'model': JobType},
-                     'performance_signature': {'download_order': 2,
-                                               'model': PerformanceSignature},
-                     'job': {'download_order': 2,
-                             'model': Job},
-                     'performance_alert_summary': {'download_order': 2,
-                                                   'model': PerformanceAlertSummary},
-                     'performance_datum': {'download_order': 3,
-                                           'model': PerformanceDatum},
-                     'performance_alert': {'download_order': 3,
-                                           'model': PerformanceAlert},
-                     'backfill_report': {'download_order': 3,
-                                         'model': BackfillReport},
-                     'backfill_record': {'download_order': 4,
-                                         'model': BackfillRecord}}
+    priority_dict = {
+        'reference_data_signature': {'download_order': 1, 'model': ReferenceDataSignatures},
+        'push': {'download_order': 1, 'model': Push},
+        'build_platform': {'download_order': 1, 'model': BuildPlatform},
+        'machine': {'download_order': 1, 'model': Machine},
+        'job_group': {'download_order': 1, 'model': JobGroup},
+        'job_type': {'download_order': 1, 'model': JobType},
+        'performance_signature': {'download_order': 2, 'model': PerformanceSignature},
+        'job': {'download_order': 2, 'model': Job},
+        'performance_alert_summary': {'download_order': 2, 'model': PerformanceAlertSummary},
+        'performance_datum': {'download_order': 3, 'model': PerformanceDatum},
+        'performance_alert': {'download_order': 3, 'model': PerformanceAlert},
+        'backfill_report': {'download_order': 3, 'model': BackfillReport},
+        'backfill_record': {'download_order': 4, 'model': BackfillRecord},
+    }
 
-    def __init__(self, source, target, num_workers, frameworks, repositories, time_window,
-                 progress_notifier=None, **kwargs):
+    def __init__(
+        self,
+        source,
+        target,
+        num_workers,
+        frameworks,
+        repositories,
+        time_window,
+        progress_notifier=None,
+        **kwargs,
+    ):
 
         super().__init__(source, target, progress_notifier, **kwargs)
         self.time_window = time_window
         self.num_workers = num_workers
 
         oldest_day = datetime.datetime.now() - self.time_window
-        self.query_set = (PerformanceAlertSummary.objects
-                          .using(self.source)
-                          .select_related('framework', 'repository')
-                          .filter(created__gte=oldest_day))
+        self.query_set = (
+            PerformanceAlertSummary.objects.using(self.source)
+            .select_related('framework', 'repository')
+            .filter(created__gte=oldest_day)
+        )
 
         if frameworks:
             self.query_set = self.query_set.filter(framework__name__in=frameworks)
         if repositories:
             self.query_set = self.query_set.filter(repository__name__in=repositories)
 
-        self.frameworks = (frameworks if frameworks is not None
-                           else list(PerformanceFramework.objects
-                                     .using(self.source)
-                                     .values_list('name', flat=True)))
-        self.repositories = (repositories if repositories is not None
-                             else list(Repository.objects
-                                       .using(self.source)
-                                       .values_list('name', flat=True)))
+        self.frameworks = (
+            frameworks
+            if frameworks is not None
+            else list(
+                PerformanceFramework.objects.using(self.source).values_list('name', flat=True)
+            )
+        )
+        self.repositories = (
+            repositories
+            if repositories is not None
+            else list(Repository.objects.using(self.source).values_list('name', flat=True))
+        )
         interproc_instance = interproc()
-        self.models_instances = {'reference_data_signature': interproc_instance.list(),
-                                 'performance_alert': interproc_instance.list(),
-                                 'job': interproc_instance.list(),
-                                 'job_type': interproc_instance.list(),
-                                 'job_group': interproc_instance.list(),
-                                 'performance_datum': interproc_instance.list(),
-                                 'performance_alert_summary': interproc_instance.list(),
-                                 'push': interproc_instance.list(),
-                                 'build_platform': interproc_instance.list(),
-                                 'machine': interproc_instance.list(),
-                                 'performance_signature': interproc_instance.list(),
-                                 'backfill_report': interproc_instance.list(),
-                                 'backfill_record': interproc_instance.list()}
+        self.models_instances = {
+            'reference_data_signature': interproc_instance.list(),
+            'performance_alert': interproc_instance.list(),
+            'job': interproc_instance.list(),
+            'job_type': interproc_instance.list(),
+            'job_group': interproc_instance.list(),
+            'performance_datum': interproc_instance.list(),
+            'performance_alert_summary': interproc_instance.list(),
+            'push': interproc_instance.list(),
+            'build_platform': interproc_instance.list(),
+            'machine': interproc_instance.list(),
+            'performance_signature': interproc_instance.list(),
+            'backfill_report': interproc_instance.list(),
+            'backfill_record': interproc_instance.list(),
+        }
 
     def delete_local_data(self):
         for model in self.BIG_SIZED_TABLES:
@@ -211,13 +226,17 @@ class MassiveData(Data):
             model.objects.using(self.target).all().delete()
 
     def save_local_data(self):
-        priority_dict = collections.OrderedDict(sorted(self.priority_dict.items(),
-                                                       key=lambda item: item[1]['download_order']))
+        priority_dict = collections.OrderedDict(
+            sorted(self.priority_dict.items(), key=lambda item: item[1]['download_order'])
+        )
 
         for table_name, properties in priority_dict.items():
             print('Saving {0} data...'.format(table_name))
-            model_values = properties['model'].objects.using(self.source).filter(
-                pk__in=self.models_instances[table_name])
+            model_values = (
+                properties['model']
+                .objects.using(self.source)
+                .filter(pk__in=self.models_instances[table_name])
+            )
             self._ignore_sensitive_fields(table_name, model_values)
             properties['model'].objects.using(self.target).bulk_create(model_values)
 
@@ -249,14 +268,14 @@ class MassiveData(Data):
         processes_list = []
         num_workers = min(self.num_workers, alert_summaries_len)
         try:
-            stop_idx = step_size = math.ceil(alert_summaries_len/num_workers)
+            stop_idx = step_size = math.ceil(alert_summaries_len / num_workers)
         except ZeroDivisionError:
             raise RuntimeError('No alert summaries to fetch.')
 
         start_idx = 0
         for idx in range(num_workers):
             alerts = alert_summaries[start_idx:stop_idx]
-            p = Process(target=self.db_worker, args=(idx+1, alerts))
+            p = Process(target=self.db_worker, args=(idx + 1, alerts))
             processes_list.append(p)
 
             start_idx, stop_idx = stop_idx, stop_idx + step_size
@@ -281,10 +300,11 @@ class MassiveData(Data):
         self.update_list('performance_alert_summary', alert_summary)
         self.update_list('backfill_report', alert_summary)
         # bring in all its alerts
-        alerts = list(PerformanceAlert.objects
-                      .using(self.source)
-                      .select_related('series_signature')
-                      .filter(summary=alert_summary))
+        alerts = list(
+            PerformanceAlert.objects.using(self.source)
+            .select_related('series_signature')
+            .filter(summary=alert_summary)
+        )
 
         self.progress_notifier(self.bring_in_alert, alerts, 'alert', 2)
 
@@ -298,19 +318,18 @@ class MassiveData(Data):
             if alert.related_summary not in self.models_instances['performance_alert_summary']:
                 # if the alert summary identified isn't registered yet
                 # register it with all its alerts
-                self.progress_notifier(self.bring_in_alert_summary, [alert.related_summary],
-                                       'alert summary', 1)
+                self.progress_notifier(
+                    self.bring_in_alert_summary, [alert.related_summary], 'alert summary', 1
+                )
 
         # pull parent signature first
         parent_signature = alert.series_signature.parent_signature
         if parent_signature:
-            self.bring_in_performance_data(alert.created,
-                                           parent_signature)
+            self.bring_in_performance_data(alert.created, parent_signature)
             self.update_list('performance_signature', parent_signature)
 
         # then signature itself
-        self.bring_in_performance_data(alert.created,
-                                       alert.series_signature)
+        self.bring_in_performance_data(alert.created, alert.series_signature)
         self.update_list('performance_signature', alert.series_signature)
 
         # then alert itself
@@ -320,14 +339,17 @@ class MassiveData(Data):
         self.models_instances['backfill_record'].append(alert.id)
 
     def bring_in_performance_data(self, time_of_alert, performance_signature):
-        performance_data = list(PerformanceDatum.objects
-                                .using(self.source)
-                                .filter(repository=performance_signature.repository,
-                                        signature=performance_signature,
-                                        push_timestamp__gte=(time_of_alert - self.time_window)))
+        performance_data = list(
+            PerformanceDatum.objects.using(self.source).filter(
+                repository=performance_signature.repository,
+                signature=performance_signature,
+                push_timestamp__gte=(time_of_alert - self.time_window),
+            )
+        )
 
-        self.progress_notifier(self.bring_in_performance_datum, performance_data,
-                               'performance datum', 3)
+        self.progress_notifier(
+            self.bring_in_performance_datum, performance_data, 'performance datum', 3
+        )
 
     def bring_in_performance_datum(self, performance_datum):
         if performance_datum.id in self.models_instances['performance_datum']:
@@ -342,7 +364,7 @@ class MassiveData(Data):
         if job.id in self.models_instances['job']:
             return
 
-        occasional_log('{0}Fetching job #{1}'.format('\t'*4, job.id))
+        occasional_log('{0}Fetching job #{1}'.format('\t' * 4, job.id))
 
         self.update_list('reference_data_signature', job.signature)
         self.update_list('build_platform', job.build_platform)
@@ -364,31 +386,14 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--num-workers',
-            action='store',
-            dest='num_workers',
-            type=int,
-            default=4
+            '--num-workers', action='store', dest='num_workers', type=int, default=4
         )
 
-        parser.add_argument(
-            '--time-window',
-            action='store',
-            type=int,
-            default=1
-        )
+        parser.add_argument('--time-window', action='store', type=int, default=1)
 
-        parser.add_argument(
-            '--frameworks',
-            nargs='+',
-            default=None
-        )
+        parser.add_argument('--frameworks', nargs='+', default=None)
 
-        parser.add_argument(
-            '--repositories',
-            nargs='+',
-            default=None
-        )
+        parser.add_argument('--repositories', nargs='+', default=None)
 
     def handle(self, *args, **options):
 
@@ -398,13 +403,15 @@ class Command(BaseCommand):
         repositories = options['repositories']
 
         affordable_data = DecentSizedData(source='upstream', target='default')
-        subseted_data = MassiveData(source='upstream',
-                                    target='default',
-                                    progress_notifier=progress_notifier,
-                                    time_window=time_window,
-                                    num_workers=num_workers,
-                                    frameworks=frameworks,
-                                    repositories=repositories)
+        subseted_data = MassiveData(
+            source='upstream',
+            target='default',
+            progress_notifier=progress_notifier,
+            time_window=time_window,
+            num_workers=num_workers,
+            frameworks=frameworks,
+            repositories=repositories,
+        )
 
         affordable_data.fillup_target()
         subseted_data.fillup_target(last_n_days=time_window)

--- a/treeherder/perf/management/commands/reassign_perf_data.py
+++ b/treeherder/perf/management/commands/reassign_perf_data.py
@@ -1,11 +1,7 @@
-from django.core.management.base import (BaseCommand,
-                                         CommandError)
-from django.db import (connection,
-                       transaction)
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connection, transaction
 
-from treeherder.perf.models import (PerformanceAlert,
-                                    PerformanceDatum,
-                                    PerformanceSignature)
+from treeherder.perf.models import PerformanceAlert, PerformanceDatum, PerformanceSignature
 
 RAPTOR_TP6_SUBTESTS = 'raptor-tp6-subtests'
 USE_CASES = [RAPTOR_TP6_SUBTESTS]
@@ -30,13 +26,13 @@ class Command(BaseCommand):
         parser.add_argument(
             '--from',
             action='append',
-            help='Original signature (specify multiple times to get multiple signatures)'
+            help='Original signature (specify multiple times to get multiple signatures)',
         )
         parser.add_argument(
             '--to',
             action='append',
             help='New signature we want to move performance data to '
-                 '(specify multiple times to get multiple signatures)'
+            '(specify multiple times to get multiple signatures)',
         )
         parser.add_argument(
             '--for',
@@ -45,12 +41,14 @@ class Command(BaseCommand):
             metavar='USE CASE',
             help='''Rename "old" Raptor tp6 subtests, by pointing perf alerts & datum to new signatures.
                  Cannot be used in conjunction with --from/--to arguments.
-                 Available use cases: {}'''.format(','.join(USE_CASES))
+                 Available use cases: {}'''.format(
+                ','.join(USE_CASES)
+            ),
         )
         parser.add_argument(
             '--keep-leftovers',
             action='store_true',
-            help='Keep database rows even if they become useless after the script runs'
+            help='Keep database rows even if they become useless after the script runs',
         )
 
     def handle(self, *args, **options):
@@ -112,12 +110,13 @@ class Command(BaseCommand):
                old_signature.option_collection_id = new_signature.option_collection_id AND
                old_signature.extra_options = new_signature.extra_options AND
                old_signature.lower_is_better = new_signature.lower_is_better AND
-               old_signature.has_subtests = new_signature.has_subtests"""\
-            .format(tp6_name_pattern='raptor-tp6%',
-                    mozilla_central=self.mozilla_central,
-                    mozilla_inbound=self.mozilla_inbound,
-                    mozilla_beta=self.mozilla_beta,
-                    autoland=self.autoland)
+               old_signature.has_subtests = new_signature.has_subtests""".format(
+            tp6_name_pattern='raptor-tp6%',
+            mozilla_central=self.mozilla_central,
+            mozilla_inbound=self.mozilla_inbound,
+            mozilla_beta=self.mozilla_beta,
+            autoland=self.autoland,
+        )
 
         with connection.cursor() as cursor:
             cursor.execute(query_for_signature_pairs)
@@ -131,4 +130,6 @@ class Command(BaseCommand):
         with transaction.atomic():
             for from_sign, to_sign in signature_pairs:
                 PerformanceDatum.objects.filter(signature_id=from_sign).update(signature_id=to_sign)
-                PerformanceAlert.objects.filter(series_signature_id=from_sign).update(series_signature_id=to_sign)
+                PerformanceAlert.objects.filter(series_signature_id=from_sign).update(
+                    series_signature_id=to_sign
+                )

--- a/treeherder/perf/management/commands/synthesize_backfill_report.py
+++ b/treeherder/perf/management/commands/synthesize_backfill_report.py
@@ -1,14 +1,14 @@
 from argparse import ArgumentError
-from datetime import (datetime,
-                      timedelta)
-from typing import (List,
-                    Tuple)
+from datetime import datetime, timedelta
+from typing import List, Tuple
 
 from django.core.management.base import BaseCommand
 
-from treeherder.perf.alerts import (AlertsPicker,
-                                    BackfillReportMaintainer,
-                                    IdentifyAlertRetriggerables)
+from treeherder.perf.alerts import (
+    AlertsPicker,
+    BackfillReportMaintainer,
+    IdentifyAlertRetriggerables,
+)
 from treeherder.perf.models import PerformanceFramework
 from treeherder.perf.perf_sheriff_bot import PerfSheriffBot
 
@@ -23,45 +23,49 @@ class Command(BaseCommand):
             action='store',
             type=int,
             default=60,
-            help="How far back to look for alerts to retrigger (expressed in minutes)."
+            help="How far back to look for alerts to retrigger (expressed in minutes).",
         )
 
         parser.add_argument(
             '--frameworks',
             nargs='+',
             default=None,
-            help="Defaults to all registered performance frameworks."
+            help="Defaults to all registered performance frameworks.",
         )
 
         parser.add_argument(
             '--repositories',
             nargs='+',
             default=Command.repos_to_retrigger_on,
-            help=f"Defaults to {Command.repos_to_retrigger_on}."
+            help=f"Defaults to {Command.repos_to_retrigger_on}.",
         )
 
     def handle(self, *args, **options):
         frameworks, repositories, since, days_to_lookup = self._parse_args(**options)
         self._validate_args(frameworks, repositories)
-        alerts_picker = AlertsPicker(max_alerts=5,
-                                     max_improvements=2,
-                                     platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android'))
-        backfill_context_fetcher = IdentifyAlertRetriggerables(max_data_points=5,
-                                                               time_interval=days_to_lookup)
+        alerts_picker = AlertsPicker(
+            max_alerts=5,
+            max_improvements=2,
+            platforms_of_interest=('windows10', 'windows7', 'linux', 'osx', 'android'),
+        )
+        backfill_context_fetcher = IdentifyAlertRetriggerables(
+            max_data_points=5, time_interval=days_to_lookup
+        )
         report_maintainer = BackfillReportMaintainer(alerts_picker, backfill_context_fetcher)
         perf_sheriff_bot = PerfSheriffBot(report_maintainer)
         perf_sheriff_bot.report(since, frameworks, repositories)
 
     def _parse_args(self, **options) -> Tuple[List, List, datetime, timedelta]:
-        return (options['frameworks'],
-                options['repositories'],
-                datetime.now() - timedelta(minutes=options['time_window']),
-                timedelta(days=1))
+        return (
+            options['frameworks'],
+            options['repositories'],
+            datetime.now() - timedelta(minutes=options['time_window']),
+            timedelta(days=1),
+        )
 
     def _validate_args(self, frameworks: List[str], repositories: List[str]):
         if frameworks:
-            available_frameworks = set(PerformanceFramework.objects.
-                                       values_list('name', flat=True))
+            available_frameworks = set(PerformanceFramework.objects.values_list('name', flat=True))
             if not set(frameworks).issubset(available_frameworks):
                 raise ArgumentError('Unknown framework provided.')
         if repositories:

--- a/treeherder/perf/management/commands/test_analyze_perf.py
+++ b/treeherder/perf/management/commands/test_analyze_perf.py
@@ -1,11 +1,8 @@
 from django.conf import settings
-from django.core.management.base import (BaseCommand,
-                                         CommandError)
+from django.core.management.base import BaseCommand, CommandError
 
-from treeherder.client.thclient import (PerfherderClient,
-                                        PerformanceTimeInterval)
-from treeherder.perfalert.perfalert import (RevisionDatum,
-                                            detect_changes)
+from treeherder.client.thclient import PerfherderClient, PerformanceTimeInterval
+from treeherder.perfalert.perfalert import RevisionDatum, detect_changes
 
 
 class Command(BaseCommand):
@@ -20,59 +17,71 @@ class Command(BaseCommand):
             action='store',
             dest='server',
             default=settings.SITE_URL,
-            help='Server to get data from, default to local instance'
+            help='Server to get data from, default to local instance',
         )
         parser.add_argument(
             '--time-interval',
             action='store',
             default=PerformanceTimeInterval.WEEK,
             type=int,
-            help='Time interval to test alert code on (defaults to one week)'
+            help='Time interval to test alert code on (defaults to one week)',
         )
         parser.add_argument(
             '--project',
             action='append',
-            help='Project to get signatures from (specify multiple time to get multiple projects'
+            help='Project to get signatures from (specify multiple time to get multiple projects',
         )
         parser.add_argument(
             '--signature',
             action='store',
-            help='Signature hash to process, defaults to all non-subtests'
+            help='Signature hash to process, defaults to all non-subtests',
         )
 
     @staticmethod
     def _get_series_description(option_collection_hash, series_properties):
         testname = series_properties.get('test', 'summary')
-        option_hash_strs = [o['name'] for o in option_collection_hash[
-            series_properties['option_collection_hash']]]
-        test_options = (series_properties.get('test_options', []) +
-                        option_hash_strs)
-        return " ".join([str(s) for s in [series_properties['suite'],
-                                          testname] + test_options])
+        option_hash_strs = [
+            o['name'] for o in option_collection_hash[series_properties['option_collection_hash']]
+        ]
+        test_options = series_properties.get('test_options', []) + option_hash_strs
+        return " ".join([str(s) for s in [series_properties['suite'], testname] + test_options])
 
     def handle(self, *args, **options):
         if not options['project']:
-            raise CommandError("Must specify at least one project with "
-                               "--project")
+            raise CommandError("Must specify at least one project with " "--project")
 
         pc = PerfherderClient(server_url=options['server'])
 
         option_collection_hash = pc.get_option_collection_hash()
 
         # print csv header
-        print(','.join(["project", "platform", "signature", "series",
-                        "testrun_id", "push_timestamp", "change",
-                        "percent change", "t-value", "revision"]))
+        print(
+            ','.join(
+                [
+                    "project",
+                    "platform",
+                    "signature",
+                    "series",
+                    "testrun_id",
+                    "push_timestamp",
+                    "change",
+                    "percent change",
+                    "t-value",
+                    "revision",
+                ]
+            )
+        )
 
         for project in options['project']:
             if options['signature']:
                 signatures = [options['signature']]
                 signature_data = pc.get_performance_signatures(
-                    project, signatures=signatures,
-                    interval=options['time_interval'])
+                    project, signatures=signatures, interval=options['time_interval']
+                )
             else:
                 signature_data = pc.get_performance_signatures(
-                    project, interval=options['time_interval'])
+                    project, interval=options['time_interval']
+                )
                 signatures = []
                 signatures_to_ignore = set()
                 # if doing everything, only handle summary series
@@ -81,21 +90,22 @@ class Command(BaseCommand):
                     if 'subtest_signatures' in properties:
                         # Don't alert on subtests which have a summary
                         signatures_to_ignore.update(properties['subtest_signatures'])
-                signatures = [signature for signature in signatures
-                              if signature not in signatures_to_ignore]
+                signatures = [
+                    signature for signature in signatures if signature not in signatures_to_ignore
+                ]
 
             for signature in signatures:
                 series = pc.get_performance_data(
-                    project, signatures=signature,
-                    interval=options['time_interval'])[signature]
+                    project, signatures=signature, interval=options['time_interval']
+                )[signature]
 
                 series_properties = signature_data.get(signature)
 
                 data = []
 
                 for (push_id, timestamp, value) in zip(
-                        series['result_set_id'], series['push_timestamp'],
-                        series['value']):
+                    series['result_set_id'], series['push_timestamp'], series['value']
+                ):
                     data.append(RevisionDatum(timestamp, value, testrun_id=push_id))
 
                 for r in detect_changes(data):
@@ -105,15 +115,30 @@ class Command(BaseCommand):
                         initial_value = r.historical_stats['avg']
                         new_value = r.forward_stats['avg']
                         if initial_value != 0:
-                            pct_change = 100.0 * abs(new_value - initial_value) / float(initial_value)
+                            pct_change = (
+                                100.0 * abs(new_value - initial_value) / float(initial_value)
+                            )
                         else:
                             pct_change = 0.0
-                        delta = (new_value - initial_value)
-                        print(','.join(map(
-                            str,
-                            [project, series_properties['machine_platform'],
-                             signature, self._get_series_description(
-                                 option_collection_hash,
-                                 series_properties),
-                             r.testrun_id, r.push_timestamp, delta,
-                             pct_change, r.t, revision[0:12]])))
+                        delta = new_value - initial_value
+                        print(
+                            ','.join(
+                                map(
+                                    str,
+                                    [
+                                        project,
+                                        series_properties['machine_platform'],
+                                        signature,
+                                        self._get_series_description(
+                                            option_collection_hash, series_properties
+                                        ),
+                                        r.testrun_id,
+                                        r.push_timestamp,
+                                        delta,
+                                        pct_change,
+                                        r.t,
+                                        revision[0:12],
+                                    ],
+                                )
+                            )
+                        )

--- a/treeherder/perf/migrations/0001_squashed_0005_permit_github_links.py
+++ b/treeherder/perf/migrations/0001_squashed_0005_permit_github_links.py
@@ -23,42 +23,61 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=255)),
                 ('task_base_url', models.URLField(max_length=512)),
             ],
-            options={
-                'db_table': 'issue_tracker',
-            },
+            options={'db_table': 'issue_tracker',},
         ),
         migrations.CreateModel(
             name='PerformanceFramework',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
                 ('name', models.SlugField(max_length=255, unique=True)),
                 ('enabled', models.BooleanField(default=False)),
             ],
-            options={
-                'db_table': 'performance_framework',
-            },
+            options={'db_table': 'performance_framework',},
         ),
         migrations.CreateModel(
             name='PerformanceBugTemplate',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
                 ('keywords', models.CharField(max_length=255)),
                 ('status_whiteboard', models.CharField(max_length=255)),
                 ('default_component', models.CharField(max_length=255)),
                 ('default_product', models.CharField(max_length=255)),
                 ('cc_list', models.CharField(max_length=255)),
                 ('text', models.TextField(max_length=4096)),
-                ('framework', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, to='perf.PerformanceFramework')),
+                (
+                    'framework',
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE, to='perf.PerformanceFramework'
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'performance_bug_template',
-            },
+            options={'db_table': 'performance_bug_template',},
         ),
         migrations.CreateModel(
             name='PerformanceSignature',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('signature_hash', models.CharField(max_length=40, validators=[django.core.validators.MinLengthValidator(40)])),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
+                (
+                    'signature_hash',
+                    models.CharField(
+                        max_length=40, validators=[django.core.validators.MinLengthValidator(40)]
+                    ),
+                ),
                 ('suite', models.CharField(max_length=80)),
                 ('test', models.CharField(blank=True, max_length=80)),
                 ('lower_is_better', models.BooleanField(default=True)),
@@ -66,37 +85,91 @@ class Migration(migrations.Migration):
                 ('has_subtests', models.BooleanField()),
                 ('extra_options', models.CharField(blank=True, max_length=60)),
                 ('should_alert', models.NullBooleanField()),
-                ('alert_change_type', models.IntegerField(choices=[(0, 'percentage'), (1, 'absolute')], null=True)),
+                (
+                    'alert_change_type',
+                    models.IntegerField(choices=[(0, 'percentage'), (1, 'absolute')], null=True),
+                ),
                 ('alert_threshold', models.FloatField(null=True)),
                 ('min_back_window', models.IntegerField(null=True)),
                 ('max_back_window', models.IntegerField(null=True)),
                 ('fore_window', models.IntegerField(null=True)),
-                ('framework', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='perf.PerformanceFramework')),
-                ('option_collection', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.OptionCollection')),
-                ('parent_signature', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='subtests', to='perf.PerformanceSignature')),
-                ('platform', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.MachinePlatform')),
-                ('repository', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Repository')),
+                (
+                    'framework',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='perf.PerformanceFramework'
+                    ),
+                ),
+                (
+                    'option_collection',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.OptionCollection'
+                    ),
+                ),
+                (
+                    'parent_signature',
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='subtests',
+                        to='perf.PerformanceSignature',
+                    ),
+                ),
+                (
+                    'platform',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.MachinePlatform'
+                    ),
+                ),
+                (
+                    'repository',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.Repository'
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'performance_signature',
-            },
+            options={'db_table': 'performance_signature',},
         ),
         migrations.CreateModel(
             name='PerformanceDatum',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
                 ('value', models.FloatField()),
                 ('push_timestamp', models.DateTimeField()),
                 ('ds_job_id', models.PositiveIntegerField(db_column='ds_job_id', null=True)),
                 ('result_set_id', models.PositiveIntegerField(null=True)),
-                ('job', models.ForeignKey(default=None, null=True, on_delete=django.db.models.deletion.SET_NULL, to='model.Job')),
-                ('push', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Push')),
-                ('repository', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Repository')),
-                ('signature', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='perf.PerformanceSignature')),
+                (
+                    'job',
+                    models.ForeignKey(
+                        default=None,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to='model.Job',
+                    ),
+                ),
+                (
+                    'push',
+                    models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Push'),
+                ),
+                (
+                    'repository',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.Repository'
+                    ),
+                ),
+                (
+                    'signature',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='perf.PerformanceSignature'
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'performance_datum',
-            },
+            options={'db_table': 'performance_datum',},
         ),
         migrations.CreateModel(
             name='PerformanceAlertSummary',
@@ -104,38 +177,134 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True, serialize=False)),
                 ('manually_created', models.BooleanField(default=False)),
                 ('last_updated', models.DateTimeField(db_index=True)),
-                ('status', models.IntegerField(choices=[(0, 'Untriaged'), (1, 'Downstream'), (3, 'Invalid'), (4, 'Improvement'), (5, 'Investigating'), (6, "Won't fix"), (7, 'Fixed'), (8, 'Backed out')], default=0)),
+                (
+                    'status',
+                    models.IntegerField(
+                        choices=[
+                            (0, 'Untriaged'),
+                            (1, 'Downstream'),
+                            (3, 'Invalid'),
+                            (4, 'Improvement'),
+                            (5, 'Investigating'),
+                            (6, "Won't fix"),
+                            (7, 'Fixed'),
+                            (8, 'Backed out'),
+                        ],
+                        default=0,
+                    ),
+                ),
                 ('bug_number', models.PositiveIntegerField(null=True)),
-                ('framework', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='perf.PerformanceFramework')),
-                ('prev_push', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='+', to='model.Push')),
-                ('push', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='+', to='model.Push')),
-                ('repository', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='model.Repository')),
-                ('issue_tracker', models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, to='perf.IssueTracker')),
+                (
+                    'framework',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='perf.PerformanceFramework'
+                    ),
+                ),
+                (
+                    'prev_push',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='+',
+                        to='model.Push',
+                    ),
+                ),
+                (
+                    'push',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='+',
+                        to='model.Push',
+                    ),
+                ),
+                (
+                    'repository',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='model.Repository'
+                    ),
+                ),
+                (
+                    'issue_tracker',
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        to='perf.IssueTracker',
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'performance_alert_summary',
-            },
+            options={'db_table': 'performance_alert_summary',},
         ),
         migrations.CreateModel(
             name='PerformanceAlert',
             fields=[
                 ('id', models.AutoField(primary_key=True, serialize=False)),
                 ('is_regression', models.BooleanField()),
-                ('status', models.IntegerField(choices=[(0, 'Untriaged'), (1, 'Downstream'), (2, 'Reassigned'), (3, 'Invalid'), (4, 'Acknowledged')], default=0)),
-                ('amount_pct', models.FloatField(help_text='Amount in percentage that series has changed')),
-                ('amount_abs', models.FloatField(help_text='Absolute amount that series has changed')),
-                ('prev_value', models.FloatField(help_text='Previous value of series before change')),
+                (
+                    'status',
+                    models.IntegerField(
+                        choices=[
+                            (0, 'Untriaged'),
+                            (1, 'Downstream'),
+                            (2, 'Reassigned'),
+                            (3, 'Invalid'),
+                            (4, 'Acknowledged'),
+                        ],
+                        default=0,
+                    ),
+                ),
+                (
+                    'amount_pct',
+                    models.FloatField(help_text='Amount in percentage that series has changed'),
+                ),
+                (
+                    'amount_abs',
+                    models.FloatField(help_text='Absolute amount that series has changed'),
+                ),
+                (
+                    'prev_value',
+                    models.FloatField(help_text='Previous value of series before change'),
+                ),
                 ('new_value', models.FloatField(help_text='New value of series after change')),
-                ('t_value', models.FloatField(help_text="t value out of analysis indicating confidence that change is 'real'", null=True)),
+                (
+                    't_value',
+                    models.FloatField(
+                        help_text="t value out of analysis indicating confidence that change is 'real'",
+                        null=True,
+                    ),
+                ),
                 ('manually_created', models.BooleanField(default=False)),
-                ('classifier', models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
-                ('related_summary', models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='related_alerts', to='perf.PerformanceAlertSummary')),
-                ('series_signature', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='perf.PerformanceSignature'),),
-                ('summary', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='alerts', to='perf.PerformanceAlertSummary')),
+                (
+                    'classifier',
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    'related_summary',
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='related_alerts',
+                        to='perf.PerformanceAlertSummary',
+                    ),
+                ),
+                (
+                    'series_signature',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to='perf.PerformanceSignature'
+                    ),
+                ),
+                (
+                    'summary',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='alerts',
+                        to='perf.PerformanceAlertSummary',
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'performance_alert',
-            },
+            options={'db_table': 'performance_alert',},
         ),
         migrations.AlterUniqueTogether(
             name='performancesignature',
@@ -147,14 +316,15 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterIndexTogether(
             name='performancedatum',
-            index_together=set([('repository', 'signature', 'push_timestamp'), ('repository', 'signature', 'push')]),
+            index_together=set(
+                [('repository', 'signature', 'push_timestamp'), ('repository', 'signature', 'push')]
+            ),
         ),
         migrations.AlterUniqueTogether(
             name='performancealertsummary',
             unique_together=set([('repository', 'framework', 'prev_push', 'push')]),
         ),
         migrations.AlterUniqueTogether(
-            name='performancealert',
-            unique_together=set([('summary', 'series_signature')]),
+            name='performancealert', unique_together=set([('summary', 'series_signature')]),
         ),
     ]

--- a/treeherder/perf/migrations/0007_star_performancealert.py
+++ b/treeherder/perf/migrations/0007_star_performancealert.py
@@ -11,8 +11,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
-            model_name='performancealert',
-            name='starred',
-            field=models.BooleanField(default=False),
+            model_name='performancealert', name='starred', field=models.BooleanField(default=False),
         ),
     ]

--- a/treeherder/perf/migrations/0008_add_confirming_state.py
+++ b/treeherder/perf/migrations/0008_add_confirming_state.py
@@ -13,11 +13,34 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='performancealert',
             name='status',
-            field=models.IntegerField(choices=[(0, 'Untriaged'), (1, 'Downstream'), (2, 'Reassigned'), (3, 'Invalid'), (4, 'Acknowledged'), (5, 'Confirming')], default=0),
+            field=models.IntegerField(
+                choices=[
+                    (0, 'Untriaged'),
+                    (1, 'Downstream'),
+                    (2, 'Reassigned'),
+                    (3, 'Invalid'),
+                    (4, 'Acknowledged'),
+                    (5, 'Confirming'),
+                ],
+                default=0,
+            ),
         ),
         migrations.AlterField(
             model_name='performancealertsummary',
             name='status',
-            field=models.IntegerField(choices=[(0, 'Untriaged'), (1, 'Downstream'), (3, 'Invalid'), (4, 'Improvement'), (5, 'Investigating'), (6, "Won't fix"), (7, 'Fixed'), (8, 'Backed out'), (9, 'Confirming')], default=0),
+            field=models.IntegerField(
+                choices=[
+                    (0, 'Untriaged'),
+                    (1, 'Downstream'),
+                    (3, 'Invalid'),
+                    (4, 'Improvement'),
+                    (5, 'Investigating'),
+                    (6, "Won't fix"),
+                    (7, 'Fixed'),
+                    (8, 'Backed out'),
+                    (9, 'Confirming'),
+                ],
+                default=0,
+            ),
         ),
     ]

--- a/treeherder/perf/migrations/0009_non_nullable_issue_tracker.py
+++ b/treeherder/perf/migrations/0009_non_nullable_issue_tracker.py
@@ -14,6 +14,8 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='performancealertsummary',
             name='issue_tracker',
-            field=models.ForeignKey(default=1, on_delete=django.db.models.deletion.PROTECT, to='perf.IssueTracker'),
+            field=models.ForeignKey(
+                default=1, on_delete=django.db.models.deletion.PROTECT, to='perf.IssueTracker'
+            ),
         ),
     ]

--- a/treeherder/perf/migrations/0010_fix_signature_uniqueness.py
+++ b/treeherder/perf/migrations/0010_fix_signature_uniqueness.py
@@ -13,6 +13,20 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterUniqueTogether(
             name='performancesignature',
-            unique_together=set([('repository', 'framework', 'platform', 'option_collection', 'suite', 'test', 'last_updated', 'extra_options'), ('repository', 'framework', 'signature_hash')]),
+            unique_together=set(
+                [
+                    (
+                        'repository',
+                        'framework',
+                        'platform',
+                        'option_collection',
+                        'suite',
+                        'test',
+                        'last_updated',
+                        'extra_options',
+                    ),
+                    ('repository', 'framework', 'signature_hash'),
+                ]
+            ),
         ),
     ]

--- a/treeherder/perf/migrations/0012_rename_summary_last_updated.py
+++ b/treeherder/perf/migrations/0012_rename_summary_last_updated.py
@@ -11,8 +11,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RenameField(
-            model_name='performancealertsummary',
-            old_name='last_updated',
-            new_name='created',
+            model_name='performancealertsummary', old_name='last_updated', new_name='created',
         ),
     ]

--- a/treeherder/perf/migrations/0013_add_alert_timestamps.py
+++ b/treeherder/perf/migrations/0013_add_alert_timestamps.py
@@ -11,9 +11,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
-            model_name='performancealert',
-            name='created',
-            field=models.DateTimeField(null=True),
+            model_name='performancealert', name='created', field=models.DateTimeField(null=True),
         ),
         migrations.AlterField(
             model_name='performancealert',

--- a/treeherder/perf/migrations/0016_modify_alertsummary_status_choices.py
+++ b/treeherder/perf/migrations/0016_modify_alertsummary_status_choices.py
@@ -13,6 +13,20 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='performancealertsummary',
             name='status',
-            field=models.IntegerField(choices=[(0, 'Untriaged'), (1, 'Downstream'), (2, 'Reassigned'), (3, 'Invalid'), (4, 'Improvement'), (5, 'Investigating'), (6, "Won't fix"), (7, 'Fixed'), (8, 'Backed out'), (9, 'Confirming')], default=0),
+            field=models.IntegerField(
+                choices=[
+                    (0, 'Untriaged'),
+                    (1, 'Downstream'),
+                    (2, 'Reassigned'),
+                    (3, 'Invalid'),
+                    (4, 'Improvement'),
+                    (5, 'Investigating'),
+                    (6, "Won't fix"),
+                    (7, 'Fixed'),
+                    (8, 'Backed out'),
+                    (9, 'Confirming'),
+                ],
+                default=0,
+            ),
         ),
     ]

--- a/treeherder/perf/migrations/0017_assignment_support_for_alert_summaries.py
+++ b/treeherder/perf/migrations/0017_assignment_support_for_alert_summaries.py
@@ -16,6 +16,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='performancealertsummary',
             name='assignee',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='assigned_alerts', to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='assigned_alerts',
+                to=settings.AUTH_USER_MODEL,
+            ),
         ),
     ]

--- a/treeherder/perf/migrations/0019_remove_confirming_state.py
+++ b/treeherder/perf/migrations/0019_remove_confirming_state.py
@@ -14,12 +14,32 @@ class Migration(migrations.Migration):
             model_name='performancealert',
             name='status',
             field=models.IntegerField(
-                choices=[(0, 'Untriaged'), (1, 'Downstream'), (2, 'Reassigned'), (3, 'Invalid'), (4, 'Acknowledged')],
-                default=0),
+                choices=[
+                    (0, 'Untriaged'),
+                    (1, 'Downstream'),
+                    (2, 'Reassigned'),
+                    (3, 'Invalid'),
+                    (4, 'Acknowledged'),
+                ],
+                default=0,
+            ),
         ),
         migrations.AlterField(
             model_name='performancealertsummary',
             name='status',
-            field=models.IntegerField(choices=[(0, 'Untriaged'), (1, 'Downstream'), (2, 'Reassigned'), (3, 'Invalid'), (4, 'Improvement'), (5, 'Investigating'), (6, "Won't fix"), (7, 'Fixed'), (8, 'Backed out')], default=0),
+            field=models.IntegerField(
+                choices=[
+                    (0, 'Untriaged'),
+                    (1, 'Downstream'),
+                    (2, 'Reassigned'),
+                    (3, 'Invalid'),
+                    (4, 'Improvement'),
+                    (5, 'Investigating'),
+                    (6, "Won't fix"),
+                    (7, 'Fixed'),
+                    (8, 'Backed out'),
+                ],
+                default=0,
+            ),
         ),
     ]

--- a/treeherder/perf/migrations/0020_add_application_field.py
+++ b/treeherder/perf/migrations/0020_add_application_field.py
@@ -14,10 +14,27 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='performancesignature',
             name='application',
-            field=models.CharField(help_text="Application that runs the signature's tests. Generally used to record browser's name, but not necessarily.", max_length=10, null=True),
+            field=models.CharField(
+                help_text="Application that runs the signature's tests. Generally used to record browser's name, but not necessarily.",
+                max_length=10,
+                null=True,
+            ),
         ),
         migrations.AlterUniqueTogether(
             name='performancesignature',
-            unique_together={('repository', 'framework', 'signature_hash'), ('repository', 'suite', 'test', 'framework', 'application', 'platform', 'option_collection', 'extra_options', 'last_updated')},
+            unique_together={
+                ('repository', 'framework', 'signature_hash'),
+                (
+                    'repository',
+                    'suite',
+                    'test',
+                    'framework',
+                    'application',
+                    'platform',
+                    'option_collection',
+                    'extra_options',
+                    'last_updated',
+                ),
+            },
         ),
     ]

--- a/treeherder/perf/migrations/0021_remove_application_from_constraint.py
+++ b/treeherder/perf/migrations/0021_remove_application_from_constraint.py
@@ -13,6 +13,18 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterUniqueTogether(
             name='performancesignature',
-            unique_together={('repository', 'framework', 'signature_hash'), ('repository', 'suite', 'test', 'framework', 'platform', 'option_collection', 'extra_options', 'last_updated')},
+            unique_together={
+                ('repository', 'framework', 'signature_hash'),
+                (
+                    'repository',
+                    'suite',
+                    'test',
+                    'framework',
+                    'platform',
+                    'option_collection',
+                    'extra_options',
+                    'last_updated',
+                ),
+            },
         ),
     ]

--- a/treeherder/perf/migrations/0022_add_test_display_names.py
+++ b/treeherder/perf/migrations/0022_add_test_display_names.py
@@ -23,6 +23,27 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='performancesignature',
-            unique_together={('repository', 'suite', 'test', 'framework', 'platform', 'option_collection', 'extra_options', 'last_updated'), ('repository', 'suite_public_name', 'test_public_name', 'framework', 'platform', 'option_collection', 'extra_options'), ('repository', 'framework', 'signature_hash')},
+            unique_together={
+                (
+                    'repository',
+                    'suite',
+                    'test',
+                    'framework',
+                    'platform',
+                    'option_collection',
+                    'extra_options',
+                    'last_updated',
+                ),
+                (
+                    'repository',
+                    'suite_public_name',
+                    'test_public_name',
+                    'framework',
+                    'platform',
+                    'option_collection',
+                    'extra_options',
+                ),
+                ('repository', 'framework', 'signature_hash'),
+            },
         ),
     ]

--- a/treeherder/perf/migrations/0024_support_backfill_reports.py
+++ b/treeherder/perf/migrations/0024_support_backfill_reports.py
@@ -14,24 +14,45 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='BackfillReport',
             fields=[
-                ('summary', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, primary_key=True, related_name='backfill_report', serialize=False, to='perf.PerformanceAlertSummary')),
+                (
+                    'summary',
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        primary_key=True,
+                        related_name='backfill_report',
+                        serialize=False,
+                        to='perf.PerformanceAlertSummary',
+                    ),
+                ),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('last_updated', models.DateTimeField(auto_now=True)),
             ],
-            options={
-                'db_table': 'backfill_report',
-            },
+            options={'db_table': 'backfill_report',},
         ),
         migrations.CreateModel(
             name='BackfillRecord',
             fields=[
-                ('alert', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, primary_key=True, related_name='backfill_record', serialize=False, to='perf.PerformanceAlert')),
+                (
+                    'alert',
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        primary_key=True,
+                        related_name='backfill_record',
+                        serialize=False,
+                        to='perf.PerformanceAlert',
+                    ),
+                ),
                 ('context', models.TextField()),
                 ('created', models.DateTimeField(auto_now_add=True)),
-                ('report', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='records', to='perf.BackfillReport')),
+                (
+                    'report',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='records',
+                        to='perf.BackfillReport',
+                    ),
+                ),
             ],
-            options={
-                'db_table': 'backfill_record',
-            },
+            options={'db_table': 'backfill_record',},
         ),
     ]

--- a/treeherder/perf/migrations/0026_add_backfill_record_status.py
+++ b/treeherder/perf/migrations/0026_add_backfill_record_status.py
@@ -19,6 +19,15 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='backfillrecord',
             name='status',
-            field=models.IntegerField(choices=[(0, 'Preliminary'), (1, 'Ready for processing'), (2, 'Backfilled'), (3, 'Finished'), (4, 'Failed')], default=0),
+            field=models.IntegerField(
+                choices=[
+                    (0, 'Preliminary'),
+                    (1, 'Ready for processing'),
+                    (2, 'Backfilled'),
+                    (3, 'Finished'),
+                    (4, 'Failed'),
+                ],
+                default=0,
+            ),
         ),
     ]

--- a/treeherder/perf/migrations/0027_support_perfherder_settings.py
+++ b/treeherder/perf/migrations/0027_support_perfherder_settings.py
@@ -17,8 +17,6 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=255)),
                 ('settings', models.TextField()),
             ],
-            options={
-                'db_table': 'performance_settings',
-            },
+            options={'db_table': 'performance_settings',},
         ),
     ]

--- a/treeherder/perf/migrations/0028_default_application_to_empty_str.py
+++ b/treeherder/perf/migrations/0028_default_application_to_empty_str.py
@@ -13,6 +13,10 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='performancesignature',
             name='application',
-            field=models.CharField(default='', help_text="Application that runs the signature's tests. Generally used to record browser's name, but not necessarily.", max_length=10),
+            field=models.CharField(
+                default='',
+                help_text="Application that runs the signature's tests. Generally used to record browser's name, but not necessarily.",
+                max_length=10,
+            ),
         ),
     ]

--- a/treeherder/perf/migrations/0029_add_frozen_to_report.py
+++ b/treeherder/perf/migrations/0029_add_frozen_to_report.py
@@ -11,8 +11,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
-            model_name='backfillreport',
-            name='frozen',
-            field=models.BooleanField(default=False),
+            model_name='backfillreport', name='frozen', field=models.BooleanField(default=False),
         ),
     ]

--- a/treeherder/perf/migrations/0030_add_application_to_contraints.py
+++ b/treeherder/perf/migrations/0030_add_application_to_contraints.py
@@ -13,6 +13,28 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterUniqueTogether(
             name='performancesignature',
-            unique_together={('repository', 'suite', 'test', 'framework', 'platform', 'option_collection', 'extra_options', 'last_updated', 'application'), ('repository', 'framework', 'signature_hash'), ('repository', 'suite_public_name', 'test_public_name', 'framework', 'platform', 'option_collection', 'extra_options')},
+            unique_together={
+                (
+                    'repository',
+                    'suite',
+                    'test',
+                    'framework',
+                    'platform',
+                    'option_collection',
+                    'extra_options',
+                    'last_updated',
+                    'application',
+                ),
+                ('repository', 'framework', 'signature_hash'),
+                (
+                    'repository',
+                    'suite_public_name',
+                    'test_public_name',
+                    'framework',
+                    'platform',
+                    'option_collection',
+                    'extra_options',
+                ),
+            },
         ),
     ]

--- a/treeherder/perf/perf_sheriff_bot.py
+++ b/treeherder/perf/perf_sheriff_bot.py
@@ -14,15 +14,18 @@ class PerfSheriffBot:
     """
     Wrapper class used to aggregate the reporting of backfill reports.
     """
+
     def __init__(self, report_maintainer):
         self.report_maintainer = report_maintainer
 
-    def report(self, since: datetime,
-               frameworks: List[str],
-               repositories: List[str]) -> List[BackfillReport]:
+    def report(
+        self, since: datetime, frameworks: List[str], repositories: List[str]
+    ) -> List[BackfillReport]:
         return self.report_maintainer.provide_updated_reports(since, frameworks, repositories)
 
-    def _is_queue_overloaded(self, provisioner_id: str, worker_type: str, acceptable_limit=100) -> bool:
+    def _is_queue_overloaded(
+        self, provisioner_id: str, worker_type: str, acceptable_limit=100
+    ) -> bool:
         '''
         Helper method for PerfSheriffBot to check load on processing queue.
         Usage example: _queue_is_too_loaded('gecko-3', 'b-linux')

--- a/treeherder/perf/secretary_tool.py
+++ b/treeherder/perf/secretary_tool.py
@@ -1,13 +1,10 @@
 import logging
-from datetime import (datetime,
-                      timedelta)
+from datetime import datetime, timedelta
 
 import simplejson as json
 from django.conf import settings as django_settings
 
-from treeherder.perf.models import (BackfillRecord,
-                                    BackfillReport,
-                                    PerformanceSettings)
+from treeherder.perf.models import BackfillRecord, BackfillReport, PerformanceSettings
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +14,7 @@ class SecretaryTool:
     """
     Tool used for doing the secretary work in the Performance Sheriff Bot.
     """
+
     TIME_TO_MATURE = timedelta(hours=4)
 
     def __init__(self):
@@ -25,12 +23,13 @@ class SecretaryTool:
     @classmethod
     def validate_settings(cls):
         perf_sheriff_settings, created = PerformanceSettings.objects.get_or_create(
-            name="perf_sheriff_bot",
-            defaults={"settings": cls._get_default_settings()},
+            name="perf_sheriff_bot", defaults={"settings": cls._get_default_settings()},
         )
 
         if created:
-            logger.info("Performance settings for perf_sheriff_bot not found. Creating with defaults.")
+            logger.info(
+                "Performance settings for perf_sheriff_bot not found. Creating with defaults."
+            )
             return
 
         # reset limits if the settings expired
@@ -45,7 +44,9 @@ class SecretaryTool:
     def mark_reports_for_backfill(cls):
         # get the backfill reports that are mature, but not frozen
         mature_date_limit = datetime.utcnow() - cls.TIME_TO_MATURE
-        mature_reports = BackfillReport.objects.filter(frozen=False, last_updated__lte=mature_date_limit)
+        mature_reports = BackfillReport.objects.filter(
+            frozen=False, last_updated__lte=mature_date_limit
+        )
 
         for report in mature_reports:
             should_freeze = False
@@ -71,7 +72,11 @@ class SecretaryTool:
             "last_reset_date": datetime.utcnow(),
         }
 
-        return json.dumps(default_settings, default=default_serializer) if as_json else default_settings
+        return (
+            json.dumps(default_settings, default=default_serializer)
+            if as_json
+            else default_settings
+        )
 
 
 def default_serializer(val):

--- a/treeherder/perfalert/perfalert/__init__.py
+++ b/treeherder/perfalert/perfalert/__init__.py
@@ -23,15 +23,18 @@ def analyze(revision_data, weight_fn=None):
     weighted_sum = 0
     sum_of_weights = 0
     for i in range(num_revisions):
-        weighted_sum += sum(value * weights[i] for value in
-                            revision_data[i].values)
+        weighted_sum += sum(value * weights[i] for value in revision_data[i].values)
         sum_of_weights += weights[i] * len(revision_data[i].values)
     weighted_avg = weighted_sum / sum_of_weights if num_revisions > 0 else 0.0
 
     # now that we have a weighted average, we can calculate the variance of the
     # whole series
     all_data = [v for datum in revision_data for v in datum.values]
-    variance = (sum(pow(d-weighted_avg, 2) for d in all_data) / (len(all_data)-1)) if len(all_data) > 1 else 0.0
+    variance = (
+        (sum(pow(d - weighted_avg, 2) for d in all_data) / (len(all_data) - 1))
+        if len(all_data) > 1
+        else 0.0
+    )
 
     return {"avg": weighted_avg, "n": len(all_data), "variance": variance}
 
@@ -78,6 +81,7 @@ class RevisionDatum:
     '''
     This class represents a specific revision and the set of values for it
     '''
+
     def __init__(self, push_timestamp, push_id, values):
 
         # Date code was pushed
@@ -103,15 +107,17 @@ class RevisionDatum:
         return self.push_timestamp < o.push_timestamp
 
     def __repr__(self):
-        values_str = '[ %s ]' % ', '.join(['%.3f' % value for value in
-                                           self.values])
-        return "<%s: %s, %s, %.3f, %s>" % (self.push_timestamp,
-                                           self.push_id, values_str,
-                                           self.t, self.change_detected)
+        values_str = '[ %s ]' % ', '.join(['%.3f' % value for value in self.values])
+        return "<%s: %s, %s, %.3f, %s>" % (
+            self.push_timestamp,
+            self.push_id,
+            values_str,
+            self.t,
+            self.change_detected,
+        )
 
 
-def detect_changes(data, min_back_window=12, max_back_window=24,
-                   fore_window=12, t_threshold=7):
+def detect_changes(data, min_back_window=12, max_back_window=24, fore_window=12, t_threshold=7):
     # Use T-Tests
     # Analyze test data using T-Tests, comparing data[i-j:i] to data[i:i+k]
     data = sorted(data)
@@ -125,10 +131,14 @@ def detect_changes(data, min_back_window=12, max_back_window=24,
         jw = []
         di.amount_prev_data = 0
         prev_indice = i - 1
-        while di.amount_prev_data < max_back_window and prev_indice >= 0 and (
-                (i - prev_indice) <= min(max(last_seen_regression,
-                                             min_back_window),
-                                         max_back_window)):
+        while (
+            di.amount_prev_data < max_back_window
+            and prev_indice >= 0
+            and (
+                (i - prev_indice)
+                <= min(max(last_seen_regression, min_back_window), max_back_window)
+            )
+        ):
             jw.append(data[prev_indice])
             di.amount_prev_data += len(jw[-1].values)
             prev_indice -= 1
@@ -167,12 +177,12 @@ def detect_changes(data, min_back_window=12, max_back_window=24,
             continue
 
         # Check the adjacent points
-        prev = data[i-1]
+        prev = data[i - 1]
         if prev.t > di.t:
             continue
         # next may or may not exist if it's the last in the series
-        if (i+1) < len(data):
-            next = data[i+1]
+        if (i + 1) < len(data):
+            next = data[i + 1]
             if next.t > di.t:
                 continue
 

--- a/treeherder/perfalert/setup.py
+++ b/treeherder/perfalert/setup.py
@@ -22,5 +22,5 @@ setup(
     license='MPL',
     packages=['perfalert'],
     zip_safe=False,
-    install_requires=[]
+    install_requires=[],
 )

--- a/treeherder/push_health/builds.py
+++ b/treeherder/push_health/builds.py
@@ -4,11 +4,9 @@ from treeherder.push_health.utils import mark_failed_in_parent
 
 
 def get_build_failures(push, parent_push=None):
-    build_failures = Job.objects.filter(
-        push=push,
-        tier__lte=2,
-        result='busted',
-    ).select_related('machine_platform', 'taskcluster_metadata')
+    build_failures = Job.objects.filter(push=push, tier__lte=2, result='busted',).select_related(
+        'machine_platform', 'taskcluster_metadata'
+    )
 
     failures = [job_to_dict(job) for job in build_failures]
 

--- a/treeherder/push_health/classification.py
+++ b/treeherder/push_health/classification.py
@@ -11,7 +11,9 @@ def set_classifications(failures, intermittent_history, fixed_by_commit_history)
 
 def set_fixed_by_commit(failure, fixed_by_commit_history):
     # Not perfect, could have intermittent that is cause of fbc
-    if failure['testName'] in fixed_by_commit_history.keys() and not is_classified_intermittent(failure):
+    if failure['testName'] in fixed_by_commit_history.keys() and not is_classified_intermittent(
+        failure
+    ):
         failure['suggestedClassification'] = 'fixedByCommit'
         return True
     return False
@@ -37,8 +39,10 @@ def set_intermittent(failure, previous_failures):
 
     # TODO: how many unique regression in win7*reftest*
     # Marking all win7 reftest failures as int, too many font issues
-    if confidence == 0 and platform == 'windows7-32' and (
-        'opt-reftest' in job_name or 'debug-reftest' in job_name
+    if (
+        confidence == 0
+        and platform == 'windows7-32'
+        and ('opt-reftest' in job_name or 'debug-reftest' in job_name)
     ):
         confidence = 50
 
@@ -75,8 +79,7 @@ def get_grouped(failures):
     for failure in failures:
         is_intermittent = failure['suggestedClassification'] == 'intermittent'
 
-        if ((is_intermittent and failure['confidence'] == 100) or
-                failure['passFailRatio'] > .5):
+        if (is_intermittent and failure['confidence'] == 100) or failure['passFailRatio'] > 0.5:
             classified[KNOWN_ISSUES].append(failure)
         elif failure['failedInParent']:
             classified[KNOWN_ISSUES].append(failure)

--- a/treeherder/push_health/compare.py
+++ b/treeherder/push_health/compare.py
@@ -1,7 +1,6 @@
 import logging
 
-from treeherder.model.models import (Commit,
-                                     Push)
+from treeherder.model.models import Commit, Push
 from treeherder.utils.http import fetch_json
 from treeherder.webapp.api.serializers import RepositorySerializer
 
@@ -34,15 +33,17 @@ def get_response_object(parent_sha, revisions, revision_count, push, repository)
         'parentPush': None,
     }
     if push:
-        resp.update({
-            # This will be the revision of the Parent, as long as we could find a Push in
-            # Treeherder for it.
-            'parentPushRevision': push.revision,
-            'id': push.id,
-            'jobCounts': push.get_status(),
-            'exactMatch': parent_sha == push.revision,
-            'parentPush': push,
-        })
+        resp.update(
+            {
+                # This will be the revision of the Parent, as long as we could find a Push in
+                # Treeherder for it.
+                'parentPushRevision': push.revision,
+                'id': push.id,
+                'jobCounts': push.get_status(),
+                'exactMatch': parent_sha == push.revision,
+                'parentPush': push,
+            }
+        )
     return resp
 
 
@@ -60,7 +61,9 @@ def get_commits(repository, revision):
     try:
         autorel_resp = fetch_json(
             'https://hg.mozilla.org/{}/json-automationrelevance/{}'.format(
-                repository.name, revision))
+                repository.name, revision
+            )
+        )
 
         return list(autorel_resp["changesets"])
     except Exception:
@@ -68,8 +71,8 @@ def get_commits(repository, revision):
 
         try:
             json_pushes_resp = fetch_json(
-                '{}/json-pushes?version=2&full=1&changeset={}'.format(
-                    repository.url, revision))
+                '{}/json-pushes?version=2&full=1&changeset={}'.format(repository.url, revision)
+            )
             changesets = list(json_pushes_resp["pushes"].values())[0]['changesets']
             changesets.reverse()
 
@@ -115,6 +118,4 @@ def get_commit_history(repository, revision, push):
 
     # We can't find any mention of this commit, so return what we have.  Hope
     # for the best that it's in the same repository as the push in question.
-    return get_response_object(
-        parent_sha, revisions, revision_count, None, repository
-    )
+    return get_response_object(parent_sha, revisions, revision_count, None, repository)

--- a/treeherder/push_health/filter.py
+++ b/treeherder/push_health/filter.py
@@ -1,8 +1,6 @@
 def filter_failure(failure):
     # TODO: Add multiple filters, as needed
-    filters = [
-        filter_job_type_names
-    ]
+    filters = [filter_job_type_names]
 
     for test_filter in filters:
         if not test_filter(failure):

--- a/treeherder/push_health/performance.py
+++ b/treeherder/push_health/performance.py
@@ -1,15 +1,11 @@
-from treeherder.model.models import (Job,
-                                     JobGroup)
+from treeherder.model.models import Job, JobGroup
 from treeherder.push_health.similar_jobs import job_to_dict
 
 
 def get_perf_failures(push):
     perf_groups = JobGroup.objects.filter(name__contains='performance')
     perf_failures = Job.objects.filter(
-        push=push,
-        tier__lte=2,
-        result='testfailed',
-        job_group__in=perf_groups
+        push=push, tier__lte=2, result='testfailed', job_group__in=perf_groups
     ).select_related('machine_platform', 'taskcluster_metadata')
 
     return [job_to_dict(job) for job in perf_failures]

--- a/treeherder/push_health/usage.py
+++ b/treeherder/push_health/usage.py
@@ -25,16 +25,14 @@ def get_latest(facet):
     for item in reversed(facet['timeSeries']):
         if item['inspectedCount'] > 0:
             latest = item['results'][-1]
-            return {
-                NEED_INVESTIGATION: latest['max'],
-                'time': item['endTimeSeconds']
-            }
+            return {NEED_INVESTIGATION: latest['max'], 'time': item['endTimeSeconds']}
 
 
 def get_usage():
 
     nrql = "SELECT%20max(needInvestigation)%20FROM%20push_health_need_investigation%20FACET%20revision%20SINCE%201%20DAY%20AGO%20TIMESERIES%20where%20repo%3D'{}'%20AND%20appName%3D'{}'".format(
-        'try', 'treeherder-prod')
+        'try', 'treeherder-prod'
+    )
     new_relic_url = '{}?nrql={}'.format(settings.NEW_RELIC_INSIGHTS_API_URL, nrql)
     headers = {
         'Accept': 'application/json',
@@ -51,10 +49,13 @@ def get_usage():
     push_revisions = [facet['name'] for facet in data['facets']]
     pushes = Push.objects.filter(revision__in=push_revisions)
 
-    results = [{
-        'push': PushSerializer(pushes.get(revision=facet['name'])).data,
-        'peak': get_peak(facet),
-        'latest': get_latest(facet)
-    } for facet in data['facets']]
+    results = [
+        {
+            'push': PushSerializer(pushes.get(revision=facet['name'])).data,
+            'peak': get_peak(facet),
+            'latest': get_latest(facet),
+        }
+        for facet in data['facets']
+    ]
 
     return results

--- a/treeherder/push_health/utils.py
+++ b/treeherder/push_health/utils.py
@@ -31,8 +31,7 @@ def clean_test(action, test, signature, message):
         if 'tests/layout/' in left and 'tests/layout/' in right:
             left = 'layout%s' % left.split('tests/layout')[1]
             right = 'layout%s' % right.split('tests/layout')[1]
-        elif 'build/tests/reftest/tests/' in left and \
-             'build/tests/reftest/tests/' in right:
+        elif 'build/tests/reftest/tests/' in left and 'build/tests/reftest/tests/' in right:
             left = '%s' % left.split('build/tests/reftest/tests/')[1]
             right = '%s' % right.split('build/tests/reftest/tests/')[1]
         elif clean_name.startswith('http://10.0'):
@@ -59,8 +58,7 @@ def clean_test(action, test, signature, message):
 
     # Now that we don't bail on a blank test_name, these filters
     # may sometimes apply.
-    if clean_name in ['Last test finished',
-                      '(SimpleTest/TestRunner.js)']:
+    if clean_name in ['Last test finished', '(SimpleTest/TestRunner.js)']:
         return None
 
     clean_name = clean_name.strip()
@@ -93,16 +91,18 @@ def clean_platform(platform):
 
 
 def is_valid_failure_line(line):
-    skip_lines = ['Return code:', 'unexpected status', 'unexpected crashes', 'exit status', 'Finished in']
+    skip_lines = [
+        'Return code:',
+        'unexpected status',
+        'unexpected crashes',
+        'exit status',
+        'Finished in',
+    ]
     return not any(skip_line in line for skip_line in skip_lines)
 
 
 def get_job_key(job):
-    return '{}-{}-{}'.format(
-        job['job_type_name'],
-        job['platform'],
-        job['option_collection_hash']
-    )
+    return '{}-{}-{}'.format(job['job_type_name'], job['platform'], job['option_collection_hash'])
 
 
 def mark_failed_in_parent(failures, parent_failures):

--- a/treeherder/services/elasticsearch/__init__.py
+++ b/treeherder/services/elasticsearch/__init__.py
@@ -1,12 +1,14 @@
 from .connection import es_conn
-from .helpers import (all_documents,
-                      bulk,
-                      count_index,
-                      get_document,
-                      index,
-                      refresh_index,
-                      reinit_index,
-                      search)
+from .helpers import (
+    all_documents,
+    bulk,
+    count_index,
+    get_document,
+    index,
+    refresh_index,
+    reinit_index,
+    search,
+)
 
 __all__ = [
     'all_documents',

--- a/treeherder/services/elasticsearch/utils.py
+++ b/treeherder/services/elasticsearch/utils.py
@@ -1,4 +1,3 @@
-
 def dict_to_op(d, index_name, doc_type, op_type='index'):
     """
     Create a bulk-indexing operation from the given dictionary.

--- a/treeherder/services/pulse/__init__.py
+++ b/treeherder/services/pulse/__init__.py
@@ -1,8 +1,10 @@
-from .consumers import (JointConsumer,
-                        PushConsumer,
-                        TaskConsumer,
-                        prepare_consumers,
-                        prepare_joint_consumers)
+from .consumers import (
+    JointConsumer,
+    PushConsumer,
+    TaskConsumer,
+    prepare_consumers,
+    prepare_joint_consumers,
+)
 
 __all__ = [
     "JointConsumer",

--- a/treeherder/services/taskcluster.py
+++ b/treeherder/services/taskcluster.py
@@ -47,7 +47,7 @@ class TaskclusterModel:
             decision_task_id=decision_task_id,
             task_id=task_id,
             input=input,
-            static_action_variables=actions_context['staticActionVariables']
+            static_action_variables=actions_context['staticActionVariables'],
         )
 
     def _load(self, decision_task_id: str, task_id: str) -> dict:
@@ -67,17 +67,19 @@ class TaskclusterModel:
             'actions': self._filter_relevant_actions(actions_json, task_definition),
         }
 
-    def _submit(self,
-                action=None,
-                decision_task_id=None,
-                task_id=None,
-                input=None,
-                static_action_variables=None) -> str:
+    def _submit(
+        self,
+        action=None,
+        decision_task_id=None,
+        task_id=None,
+        input=None,
+        static_action_variables=None,
+    ) -> str:
         context = {
-                "taskGroupId": decision_task_id,
-                "taskId": task_id or None,
-                "input": input,
-         }
+            "taskGroupId": decision_task_id,
+            "taskId": task_id or None,
+            "input": input,
+        }
         context.update(static_action_variables)
         action_kind = action["kind"]
 
@@ -90,7 +92,9 @@ class TaskclusterModel:
             expression = f"in-tree:hook-action:{hook_group_id}/{hook_id}"
 
             if not satisfiesExpression(expansion["scopes"], expression):
-                raise RuntimeError(f"Action is misconfigured: decision task's scopes do not satisfy {expression}")
+                raise RuntimeError(
+                    f"Action is misconfigured: decision task's scopes do not satisfy {expression}"
+                )
 
             result = self.hooks.triggerHook(hook_group_id, hook_id, hook_payload)
             return result["status"]["taskId"]
@@ -107,8 +111,11 @@ class TaskclusterModel:
                 continue
 
             no_context_or_task_to_check = (not len(action['context'])) and (not original_task)
-            task_is_in_context = (original_task and original_task.get('tags') and
-                                  cls._task_in_context(action['context'], original_task['tags']))
+            task_is_in_context = (
+                original_task
+                and original_task.get('tags')
+                and cls._task_in_context(action['context'], original_task['tags'])
+            )
 
             if no_context_or_task_to_check or task_is_in_context:
                 relevant_actions[action_name] = action
@@ -129,10 +136,10 @@ class TaskclusterModel:
         try:
             return [a for a in action_array if a["name"] == action_name][0]
         except IndexError:
-            available_actions = ", ".join(sorted(
-                {a["name"] for a in action_array}
-            ))
-            raise LookupError(f"{action_name} action is not available for this task.  Available: {available_actions}")
+            available_actions = ", ".join(sorted({a["name"] for a in action_array}))
+            raise LookupError(
+                f"{action_name} action is not available for this task.  Available: {available_actions}"
+            )
 
     @classmethod
     def _task_in_context(cls, context: List[dict], task_tags: dict) -> bool:
@@ -150,7 +157,6 @@ class TaskclusterModel:
         @param task_tags: task's tags
         """
         return any(
-            all(tag in task_tags and task_tags[tag] == tag_set[tag]
-                for tag in tag_set.keys())
+            all(tag in task_tags and task_tags[tag] == tag_set[tag] for tag in tag_set.keys())
             for tag_set in context
         )

--- a/treeherder/seta/common.py
+++ b/treeherder/seta/common.py
@@ -35,14 +35,14 @@ def job_priority_index(job_priorities):
 # will be processed before the less specific ones. This must be kept up
 # to date with SETA_SUPPORTED_TC_JOBTYPES in settings.py.
 RE_JOB_TYPE_NAMES = [
-    {'name': 'test',         'pattern': re.compile('test-[^/]+/[^-]+-(.*)$')},
+    {'name': 'test', 'pattern': re.compile('test-[^/]+/[^-]+-(.*)$')},
     {'name': 'desktop-test', 'pattern': re.compile('desktop-test-[^/]+/[^-]+-(.*)$')},
     {'name': 'android-test', 'pattern': re.compile('android-test-[^/]+/[^-]+-(.*)$')},
-    {'name': 'source-test',  'pattern': re.compile('(source-test-[^/]+)(?:/.*)?$')},
-    {'name': 'build',        'pattern': re.compile('(build-[^/]+)/[^-]+$')},
+    {'name': 'source-test', 'pattern': re.compile('(source-test-[^/]+)(?:/.*)?$')},
+    {'name': 'build', 'pattern': re.compile('(build-[^/]+)/[^-]+$')},
     {'name': 'spidermonkey', 'pattern': re.compile('(spidermonkey-[^/]+)/[^-]+$')},
-    {'name': 'iris',         'pattern': re.compile('(iris-[^/]+)/[^-]+$')},
-    {'name': 'webrender',    'pattern': re.compile('(webrender-.*)-(?:opt|debug|pgo)$')},
+    {'name': 'iris', 'pattern': re.compile('(iris-[^/]+)/[^-]+$')},
+    {'name': 'webrender', 'pattern': re.compile('(webrender-.*)-(?:opt|debug|pgo)$')},
 ]
 
 
@@ -71,8 +71,9 @@ def convert_job_type_name_to_testtype(job_type_name):
                 testtype = m.group(1)
                 break
     if not testtype:
-        logger.warning('convert_job_type_name_to_testtype("{}") not matched. '
-                       'Using job_type_name as is.'.format(
-                           job_type_name, testtype))
+        logger.warning(
+            'convert_job_type_name_to_testtype("{}") not matched. '
+            'Using job_type_name as is.'.format(job_type_name, testtype)
+        )
         testtype = job_type_name
     return testtype

--- a/treeherder/seta/high_value_jobs.py
+++ b/treeherder/seta/high_value_jobs.py
@@ -58,8 +58,11 @@ def build_removals(active_jobs, failures, target):
                 if revision not in remaining_failures:
                     failed_revisions.append(revision)
 
-            logger.info("jobtype: %s is the root failure(s) of these %s revisions",
-                        jobtype, failed_revisions)
+            logger.info(
+                "jobtype: %s is the root failure(s) of these %s revisions",
+                jobtype,
+                failed_revisions,
+            )
 
     return low_value_jobs
 
@@ -76,9 +79,8 @@ def get_high_value_jobs(fixed_by_commit_jobs, target=100):
     active_jobs = job_priorities_to_jobtypes()
 
     low_value_jobs = build_removals(
-        active_jobs=active_jobs,
-        failures=fixed_by_commit_jobs,
-        target=target)
+        active_jobs=active_jobs, failures=fixed_by_commit_jobs, target=target
+    )
 
     # Only return high value jobs
     for low_value_job in low_value_jobs:
@@ -90,7 +92,11 @@ def get_high_value_jobs(fixed_by_commit_jobs, target=100):
     total = len(fixed_by_commit_jobs)
     total_detected = check_removal(fixed_by_commit_jobs, low_value_jobs)
     percent_detected = 100 * len(total_detected) / total
-    logger.info("We will detect %.2f%% (%s) of the %s failures",
-                percent_detected, len(total_detected), total)
+    logger.info(
+        "We will detect %.2f%% (%s) of the %s failures",
+        percent_detected,
+        len(total_detected),
+        total,
+    )
 
     return active_jobs

--- a/treeherder/seta/job_priorities.py
+++ b/treeherder/seta/job_priorities.py
@@ -1,13 +1,9 @@
 import datetime
 import logging
 
-from treeherder.etl.seta import (get_reference_data_names,
-                                 is_job_blacklisted,
-                                 valid_platform)
+from treeherder.etl.seta import get_reference_data_names, is_job_blacklisted, valid_platform
 from treeherder.seta.models import JobPriority
-from treeherder.seta.settings import (SETA_LOW_VALUE_PRIORITY,
-                                      SETA_PROJECTS,
-                                      THE_FUTURE)
+from treeherder.seta.settings import SETA_LOW_VALUE_PRIORITY, SETA_PROJECTS, THE_FUTURE
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +16,7 @@ class SETAJobPriorities:
     """
     SETA JobPriority Implementation
     """
+
     def _process(self, project, build_system, job_priorities):
         '''Return list of ref_data_name for job_priorities'''
         if not job_priorities:
@@ -42,7 +39,9 @@ class SETAJobPriorities:
                 # e.g. desktop-test-linux64-pgo/opt-reftest-13 or builder name
                 jobs.append(ref_data_names_map[key])
             else:
-                logger.warning('Job priority key %s for (%s) not found in accepted jobs list', key, jp)
+                logger.warning(
+                    'Job priority key %s for (%s) not found in accepted jobs list', key, jp
+                )
 
         return jobs
 
@@ -66,17 +65,20 @@ class SETAJobPriorities:
             if priority is None:
                 priority = SETA_LOW_VALUE_PRIORITY
             job_priorities = []
-            for jp in self._query_job_priorities(priority=priority,
-                                                 excluded_build_system_type='buildbot'):
+            for jp in self._query_job_priorities(
+                priority=priority, excluded_build_system_type='buildbot'
+            ):
                 if jp.has_expired() or jp.expiration_date == THE_FUTURE:
                     job_priorities.append(jp)
-            ref_data_names = self._process(project,
-                                           build_system='taskcluster',
-                                           job_priorities=job_priorities)
+            ref_data_names = self._process(
+                project, build_system='taskcluster', job_priorities=job_priorities
+            )
         else:
             excluded_build_system_type = None
             if build_system_type != '*':
-                excluded_build_system_type = 'taskcluster' if build_system_type == 'buildbot' else 'buildbot'
+                excluded_build_system_type = (
+                    'taskcluster' if build_system_type == 'buildbot' else 'buildbot'
+                )
             job_priorities = self._query_job_priorities(priority, excluded_build_system_type)
             ref_data_names = self._process(project, build_system_type, job_priorities)
 

--- a/treeherder/seta/management/commands/analyze_failures.py
+++ b/treeherder/seta/management/commands/analyze_failures.py
@@ -4,20 +4,29 @@ from treeherder.seta.analyze_failures import AnalyzeFailures
 
 
 class Command(BaseCommand):
-    help = 'Analyze jobs that failed and got tagged with fixed_by_commit ' \
-           'and change the priority and timeout of such job.'
+    help = (
+        'Analyze jobs that failed and got tagged with fixed_by_commit '
+        'and change the priority and timeout of such job.'
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def add_arguments(self, parser):
-        parser.add_argument("--dry-run", action="store_true", dest="dry_run",
-                            help="This mode is for analyzing failures without "
-                                 "updating the job priority table.")
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            dest="dry_run",
+            help="This mode is for analyzing failures without " "updating the job priority table.",
+        )
 
-        parser.add_argument("--ignore-failures", type=int, dest="ignore_failures", default=0,
-                            help="If a job fails less than N times we don't take that job"
-                                 "into account.")
+        parser.add_argument(
+            "--ignore-failures",
+            type=int,
+            dest="ignore_failures",
+            default=0,
+            help="If a job fails less than N times we don't take that job" "into account.",
+        )
 
     def handle(self, *args, **options):
         AnalyzeFailures(**options).run()

--- a/treeherder/seta/management/commands/load_preseed.py
+++ b/treeherder/seta/management/commands/load_preseed.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--validate",
             action="store_true",
-            help="This will validate that all entries in preseed.json are valid"
+            help="This will validate that all entries in preseed.json are valid",
         )
 
     def handle(self, *args, **options):

--- a/treeherder/seta/migrations/0001_squashed_0002_remove_task_request_and_jp_timeout.py
+++ b/treeherder/seta/migrations/0001_squashed_0002_remove_task_request_and_jp_timeout.py
@@ -7,14 +7,18 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
             name='JobPriority',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
                 ('testtype', models.CharField(max_length=128)),
                 ('buildsystem', models.CharField(max_length=64)),
                 ('buildtype', models.CharField(max_length=64)),

--- a/treeherder/seta/models.py
+++ b/treeherder/seta/models.py
@@ -60,9 +60,7 @@ class JobPriority(models.Model):
             return True
 
     def unique_identifier(self):
-        return unique_key(testtype=self.testtype,
-                          buildtype=self.buildtype,
-                          platform=self.platform)
+        return unique_key(testtype=self.testtype, buildtype=self.buildtype, platform=self.platform)
 
     def __str__(self):
         return ','.join((self.buildsystem, self.testtype, self.buildtype, self.platform))

--- a/treeherder/seta/preseed.py
+++ b/treeherder/seta/preseed.py
@@ -5,8 +5,7 @@ import os
 from treeherder.etl.seta import get_reference_data_names
 from treeherder.seta.common import convert_job_type_name_to_testtype
 from treeherder.seta.models import JobPriority
-from treeherder.seta.settings import (SETA_LOW_VALUE_PRIORITY,
-                                      THE_FUTURE)
+from treeherder.seta.settings import SETA_LOW_VALUE_PRIORITY, THE_FUTURE
 
 logger = logging.getLogger(__name__)
 
@@ -66,12 +65,16 @@ def validate_preseed_entry(entry, ref_names):
         if ref_name == entry["testtype"]:
             potential_matches.append(unique_identifier)
 
-    assert len(potential_matches) > 0, \
-        Exception("%s is not valid. Please check runnable_jobs.json from a Gecko decision task.", entry["testtype"])
+    assert len(potential_matches) > 0, Exception(
+        "%s is not valid. Please check runnable_jobs.json from a Gecko decision task.",
+        entry["testtype"],
+    )
 
     testtype = convert_job_type_name_to_testtype(entry["testtype"])
     if not testtype:
-        logger.warning("Preseed.json entry testtype %s is not a valid task name:", entry["testtype"])
+        logger.warning(
+            "Preseed.json entry testtype %s is not a valid task name:", entry["testtype"]
+        )
         raise Exception("preseed.json entry contains invalid testtype. Please check output above.")
 
     unique_identifier = (
@@ -109,8 +112,11 @@ def load_preseed(validate=False):
                 # testtype value seen in the preseed.json file. We
                 # must convert the job[field] value to the appropriate
                 # value before performing the query.
-                field_value = convert_job_type_name_to_testtype(job[field]) \
-                    if field == 'testtype' else job[field]
+                field_value = (
+                    convert_job_type_name_to_testtype(job[field])
+                    if field == 'testtype'
+                    else job[field]
+                )
                 queryset = queryset.filter(**{field: field_value})
 
         # Deal with the case where we have a new entry in preseed
@@ -144,7 +150,7 @@ def create_new_entry(job):
         platform=job['platform'],
         priority=job['priority'],
         expiration_date=job['expiration_date'],
-        buildsystem=job['buildsystem']
+        buildsystem=job['buildsystem'],
     )
 
 

--- a/treeherder/seta/settings.py
+++ b/treeherder/seta/settings.py
@@ -44,7 +44,7 @@ SETA_UNSUPPORTED_PLATFORMS = [
     'osx-10-11',
     'other',
     'taskcluster-images',
-    'windows7-64',   # We don't test 64-bit builds on Windows 7 test infra
+    'windows7-64',  # We don't test 64-bit builds on Windows 7 test infra
     'windows8-32',  # We don't test 32-bit builds on Windows 8 test infra
     'Win 6.3.9600 x86_64',
     'linux64-stylo',

--- a/treeherder/seta/tasks.py
+++ b/treeherder/seta/tasks.py
@@ -2,7 +2,7 @@ from treeherder.seta.analyze_failures import AnalyzeFailures
 from treeherder.workers.task import retryable_task
 
 
-@retryable_task(name='seta-analyze-failures', max_retries=3, soft_time_limit=5*60)
+@retryable_task(name='seta-analyze-failures', max_retries=3, soft_time_limit=5 * 60)
 def seta_analyze_failures():
     '''We analyze all starred test failures from the last four months which were fixed by a commit.'''
     AnalyzeFailures().run()

--- a/treeherder/seta/update_job_priority.py
+++ b/treeherder/seta/update_job_priority.py
@@ -12,10 +12,8 @@ Known bug:
 import logging
 
 from treeherder.etl.runnable_jobs import list_runnable_jobs
-from treeherder.etl.seta import (parse_testtype,
-                                 valid_platform)
-from treeherder.seta.common import (job_priority_index,
-                                    unique_key)
+from treeherder.etl.seta import parse_testtype, valid_platform
+from treeherder.seta.common import job_priority_index, unique_key
 from treeherder.seta.models import JobPriority
 from treeherder.seta.settings import SETA_LOW_VALUE_PRIORITY
 
@@ -44,9 +42,9 @@ def _unique_key(job):
     testtype = str(job['testtype'])
     if not testtype:
         raise Exception('Bad job {}'.format(job))
-    return unique_key(testtype=testtype,
-                      buildtype=str(job['platform_option']),
-                      platform=str(job['platform']))
+    return unique_key(
+        testtype=testtype, buildtype=str(job['platform_option']), platform=str(job['platform'])
+    )
 
 
 def _sanitize_data(runnable_jobs_data):
@@ -72,7 +70,7 @@ def _sanitize_data(runnable_jobs_data):
             build_system_type=job['build_system_type'],
             job_type_name=job['job_type_name'],
             platform_option=job['platform_option'],
-            ref_data_name=job['ref_data_name']
+            ref_data_name=job['ref_data_name'],
         )
 
         if not testtype:
@@ -143,14 +141,21 @@ def _update_table(data):
             # We already know about this job, we might need to update the build system
             # We're seeing the job again with another build system (e.g. buildbot vs
             # taskcluster). We need to change it to '*'
-            if jp_index[key]['build_system_type'] != '*' and jp_index[key]['build_system_type'] != job["build_system_type"]:
+            if (
+                jp_index[key]['build_system_type'] != '*'
+                and jp_index[key]['build_system_type'] != job["build_system_type"]
+            ):
                 db_job = JobPriority.objects.get(pk=jp_index[key]['pk'])
                 db_job.buildsystem = '*'
                 db_job.save()
 
-                logger.info('Updated %s/%s from %s to %s',
-                            db_job.testtype, db_job.buildtype,
-                            job['build_system_type'], db_job.buildsystem)
+                logger.info(
+                    'Updated %s/%s from %s to %s',
+                    db_job.testtype,
+                    db_job.buildtype,
+                    job['build_system_type'],
+                    db_job.buildsystem,
+                )
                 updated_jobs += 1
 
         else:
@@ -162,22 +167,31 @@ def _update_table(data):
                     platform=str(job["platform"]),
                     priority=priority,
                     expiration_date=expiration_date,
-                    buildsystem=job["build_system_type"]
+                    buildsystem=job["build_system_type"],
                 )
                 jobpriority.save()
-                logger.debug('New job was found (%s,%s,%s,%s)',
-                             job['testtype'], job['platform_option'], job['platform'],
-                             job["build_system_type"])
+                logger.debug(
+                    'New job was found (%s,%s,%s,%s)',
+                    job['testtype'],
+                    job['platform_option'],
+                    job['platform'],
+                    job["build_system_type"],
+                )
                 new_jobs += 1
             except Exception as error:
                 logger.warning(str(error))
                 failed_changes += 1
 
-    logger.info('We have %s new jobs and %s updated jobs out of %s total jobs processed.',
-                new_jobs, updated_jobs, total_jobs)
+    logger.info(
+        'We have %s new jobs and %s updated jobs out of %s total jobs processed.',
+        new_jobs,
+        updated_jobs,
+        total_jobs,
+    )
 
     if failed_changes != 0:
-        logger.warning('We have failed %s changes out of %s total jobs processed.',
-                       failed_changes, total_jobs)
+        logger.warning(
+            'We have failed %s changes out of %s total jobs processed.', failed_changes, total_jobs
+        )
 
     return new_jobs, failed_changes, updated_jobs

--- a/treeherder/utils/http.py
+++ b/treeherder/utils/http.py
@@ -7,16 +7,12 @@ def make_request(url, method='GET', headers=None, timeout=30, **kwargs):
     """A wrapper around requests to set defaults & call raise_for_status()."""
     headers = headers or {}
     headers['User-Agent'] = 'treeherder/{}'.format(settings.SITE_HOSTNAME)
-    response = requests.request(method,
-                                url,
-                                headers=headers,
-                                timeout=timeout,
-                                **kwargs)
+    response = requests.request(method, url, headers=headers, timeout=timeout, **kwargs)
     if response.history:
         params = {
             'url': url,
             'redirects': len(response.history),
-            'duration': sum(r.elapsed.total_seconds() for r in response.history)
+            'duration': sum(r.elapsed.total_seconds() for r in response.history),
         }
         newrelic.agent.record_custom_event('RedirectedRequest', params=params)
 
@@ -29,9 +25,7 @@ def fetch_json(url, params=None, headers=None):
         headers = {'Accept': 'application/json'}
     else:
         headers['Accept'] = 'application/json'
-    response = make_request(url,
-                            params=params,
-                            headers=headers)
+    response = make_request(url, params=params, headers=headers)
     return response.json()
 
 

--- a/treeherder/utils/taskcluster_lib_scopes.py
+++ b/treeherder/utils/taskcluster_lib_scopes.py
@@ -13,8 +13,10 @@ def satisfiesExpression(scopeset, expression):
             return any([patternMatch(s, expr) for s in scopeset])
 
         return (
-            "AllOf" in expr and all([isSatisfied(e) for e in expr["AllOf"]]) or
-            "AnyOf" in expr and any([isSatisfied(e) for e in expr["AnyOf"]])
+            "AllOf" in expr
+            and all([isSatisfied(e) for e in expr["AllOf"]])
+            or "AnyOf" in expr
+            and any([isSatisfied(e) for e in expr["AnyOf"]])
         )
 
     return isSatisfied(expression)

--- a/treeherder/webapp/api/auth.py
+++ b/treeherder/webapp/api/auth.py
@@ -1,9 +1,7 @@
 import logging
 
 import newrelic.agent
-from django.contrib.auth import (authenticate,
-                                 login,
-                                 logout)
+from django.contrib.auth import authenticate, login, logout
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import AuthenticationFailed
@@ -16,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 
 class AuthViewSet(viewsets.ViewSet):
-
     @action(detail=False)
     def login(self, request):
         """

--- a/treeherder/webapp/api/bug.py
+++ b/treeherder/webapp/api/bug.py
@@ -3,14 +3,12 @@ from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.status import HTTP_404_NOT_FOUND
 
-from treeherder.model.models import (BugJobMap,
-                                     Job)
+from treeherder.model.models import BugJobMap, Job
 
 from .serializers import BugJobMapSerializer
 
 
 class BugJobMapViewSet(viewsets.ViewSet):
-
     def create(self, request, project):
         """Add a new relation between a job and a bug."""
         job_id = int(request.data['job_id'])
@@ -18,9 +16,7 @@ class BugJobMapViewSet(viewsets.ViewSet):
 
         try:
             BugJobMap.create(
-                job_id=job_id,
-                bug_id=bug_id,
-                user=request.user,
+                job_id=job_id, bug_id=bug_id, user=request.user,
             )
             message = "Bug job map saved"
         except IntegrityError:
@@ -60,15 +56,12 @@ class BugJobMapViewSet(viewsets.ViewSet):
             # which would hide any ValueError until used by the ORM below.
             job_ids = list(map(int, request.query_params.getlist('job_id')))
         except ValueError:
-            return Response({"message": "Valid job_id required"},
-                            status=400)
+            return Response({"message": "Valid job_id required"}, status=400)
         if not job_ids:
-            return Response({"message": "At least one job_id is required"},
-                            status=400)
+            return Response({"message": "At least one job_id is required"}, status=400)
 
         jobs = Job.objects.filter(repository__name=project, id__in=job_ids)
-        bug_job_maps = BugJobMap.objects.filter(job__in=jobs).select_related(
-            'user')
+        bug_job_maps = BugJobMap.objects.filter(job__in=jobs).select_related('user')
         serializer = BugJobMapSerializer(bug_job_maps, many=True)
 
         return Response(serializer.data)

--- a/treeherder/webapp/api/bugzilla.py
+++ b/treeherder/webapp/api/bugzilla.py
@@ -11,34 +11,30 @@ from treeherder.utils.http import make_request
 
 
 class BugzillaViewSet(viewsets.ViewSet):
-
     @action(detail=False, methods=['post'])
     def create_bug(self, request):
         """
         Create a bugzilla bug with passed params
         """
         if settings.BUGFILER_API_KEY is None:
-            return Response({"failure": "Bugzilla API key not set!"},
-                            status=HTTP_400_BAD_REQUEST)
+            return Response({"failure": "Bugzilla API key not set!"}, status=HTTP_400_BAD_REQUEST)
 
         params = request.data
 
         # Arbitrarily cap crash signatures at 2048 characters to prevent perf issues on bmo
         crash_signature = params.get("crash_signature")
         if crash_signature and len(crash_signature) > 2048:
-            return Response({"failure": "Crash signature can't be more than 2048 characters."},
-                            status=HTTP_400_BAD_REQUEST)
+            return Response(
+                {"failure": "Crash signature can't be more than 2048 characters."},
+                status=HTTP_400_BAD_REQUEST,
+            )
 
         description = u"**Filed by:** {}\n{}".format(
-            request.user.email.replace('@', " [at] "),
-            params.get("comment", "")
+            request.user.email.replace('@', " [at] "), params.get("comment", "")
         ).encode("utf-8")
         summary = params.get("summary").encode("utf-8").strip()
         url = settings.BUGFILER_API_URL + "/rest/bug"
-        headers = {
-            'x-bugzilla-api-key': settings.BUGFILER_API_KEY,
-            'Accept': 'application/json'
-        }
+        headers = {'x-bugzilla-api-key': settings.BUGFILER_API_KEY, 'Accept': 'application/json'}
         data = {
             'type': "defect",
             'product': params.get("product"),

--- a/treeherder/webapp/api/csp_report.py
+++ b/treeherder/webapp/api/csp_report.py
@@ -2,8 +2,7 @@ import json
 import logging
 
 import newrelic.agent
-from django.http import (HttpResponse,
-                         HttpResponseBadRequest)
+from django.http import HttpResponse, HttpResponseBadRequest
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 

--- a/treeherder/webapp/api/intermittents_view.py
+++ b/treeherder/webapp/api/intermittents_view.py
@@ -6,15 +6,13 @@ from rest_framework import generics
 from rest_framework.response import Response
 from rest_framework.status import HTTP_400_BAD_REQUEST
 
-from treeherder.model.models import (BugJobMap,
-                                     Job,
-                                     OptionCollection,
-                                     Push,
-                                     TextLogError)
-from treeherder.webapp.api.serializers import (FailureCountSerializer,
-                                               FailuresByBugSerializer,
-                                               FailuresQueryParamsSerializer,
-                                               FailuresSerializer)
+from treeherder.model.models import BugJobMap, Job, OptionCollection, Push, TextLogError
+from treeherder.webapp.api.serializers import (
+    FailureCountSerializer,
+    FailuresByBugSerializer,
+    FailuresQueryParamsSerializer,
+    FailuresSerializer,
+)
 from treeherder.webapp.api.utils import get_end_of_day
 
 
@@ -27,19 +25,20 @@ class Failures(generics.ListAPIView):
     def list(self, request):
         query_params = FailuresQueryParamsSerializer(data=request.query_params)
         if not query_params.is_valid():
-            return Response(data=query_params.errors,
-                            status=HTTP_400_BAD_REQUEST)
+            return Response(data=query_params.errors, status=HTTP_400_BAD_REQUEST)
 
         startday = query_params.validated_data['startday']
         endday = get_end_of_day(query_params.validated_data['endday'])
         repo = query_params.validated_data['tree']
 
-        self.queryset = (BugJobMap.failures.by_date(startday, endday)
-                                           .by_repo(repo)
-                                           .values('bug_id')
-                                           .annotate(bug_count=Count('job_id'))
-                                           .values('bug_id', 'bug_count')
-                                           .order_by('-bug_count'))
+        self.queryset = (
+            BugJobMap.failures.by_date(startday, endday)
+            .by_repo(repo)
+            .values('bug_id')
+            .annotate(bug_count=Count('job_id'))
+            .values('bug_id', 'bug_count')
+            .order_by('-bug_count')
+        )
 
         serializer = self.get_serializer(self.queryset, many=True)
         return Response(data=serializer.data)
@@ -52,29 +51,39 @@ class FailuresByBug(generics.ListAPIView):
     queryset = None
 
     def list(self, request):
-        query_params = FailuresQueryParamsSerializer(data=request.query_params,
-                                                     context='requireBug')
+        query_params = FailuresQueryParamsSerializer(
+            data=request.query_params, context='requireBug'
+        )
         if not query_params.is_valid():
-            return Response(data=query_params.errors,
-                            status=HTTP_400_BAD_REQUEST)
+            return Response(data=query_params.errors, status=HTTP_400_BAD_REQUEST)
 
         startday = query_params.validated_data['startday']
         endday = get_end_of_day(query_params.validated_data['endday'])
         repo = query_params.validated_data['tree']
         bug_id = query_params.validated_data['bug']
 
-        self.queryset = (BugJobMap.failures.by_date(startday, endday)
-                                  .by_repo(repo)
-                                  .by_bug(bug_id)
-                                  .values('job__repository__name', 'job__machine_platform__platform',
-                                          'bug_id', 'job_id', 'job__push__time', 'job__push__revision',
-                                          'job__signature__job_type_name', 'job__option_collection_hash',
-                                          'job__machine__name')
-                                  .order_by('-job__push__time'))
+        self.queryset = (
+            BugJobMap.failures.by_date(startday, endday)
+            .by_repo(repo)
+            .by_bug(bug_id)
+            .values(
+                'job__repository__name',
+                'job__machine_platform__platform',
+                'bug_id',
+                'job_id',
+                'job__push__time',
+                'job__push__revision',
+                'job__signature__job_type_name',
+                'job__option_collection_hash',
+                'job__machine__name',
+            )
+            .order_by('-job__push__time')
+        )
 
-        lines = (TextLogError.objects.filter(step__job_id__in=self.queryset.values_list('job_id', flat=True),
-                                             line__contains='TEST-UNEXPECTED-FAIL')
-                                     .values_list('step__job_id', 'line'))
+        lines = TextLogError.objects.filter(
+            step__job_id__in=self.queryset.values_list('job_id', flat=True),
+            line__contains='TEST-UNEXPECTED-FAIL',
+        ).values_list('step__job_id', 'line')
 
         grouped_lines = defaultdict(list)
         for job_id, line in lines:
@@ -87,12 +96,18 @@ class FailuresByBug(generics.ListAPIView):
             item['lines'] = grouped_lines.get(item['job_id'], [])
             hash_list.add(item['job__option_collection_hash'])
 
-        hash_query = (OptionCollection.objects.filter(option_collection_hash__in=hash_list)
-                                              .select_related('option')
-                                              .values('option__name', 'option_collection_hash'))
+        hash_query = (
+            OptionCollection.objects.filter(option_collection_hash__in=hash_list)
+            .select_related('option')
+            .values('option__name', 'option_collection_hash')
+        )
 
         for item in self.queryset:
-            match = [x['option__name'] for x in hash_query if x['option_collection_hash'] == item['job__option_collection_hash']]
+            match = [
+                x['option__name']
+                for x in hash_query
+                if x['option_collection_hash'] == item['job__option_collection_hash']
+            ]
             if match:
                 item['build_type'] = match[0]
             else:
@@ -111,38 +126,44 @@ class FailureCount(generics.ListAPIView):
     def list(self, request):
         query_params = FailuresQueryParamsSerializer(data=request.query_params)
         if not query_params.is_valid():
-            return Response(data=query_params.errors,
-                            status=HTTP_400_BAD_REQUEST)
+            return Response(data=query_params.errors, status=HTTP_400_BAD_REQUEST)
 
         startday = query_params.validated_data['startday']
         endday = get_end_of_day(query_params.validated_data['endday'])
         repo = query_params.validated_data['tree']
         bug_id = query_params.validated_data['bug']
 
-        push_query = (Push.failures.filter(time__range=(startday, endday))
-                                   .by_repo(repo, False)
-                                   .annotate(date=TruncDate('time'))
-                                   .values('date')
-                                   .annotate(test_runs=Count('author'))
-                                   .values('date', 'test_runs'))
+        push_query = (
+            Push.failures.filter(time__range=(startday, endday))
+            .by_repo(repo, False)
+            .annotate(date=TruncDate('time'))
+            .values('date')
+            .annotate(test_runs=Count('author'))
+            .values('date', 'test_runs')
+        )
 
         if bug_id:
-            job_query = (BugJobMap.failures.by_date(startday, endday)
-                                           .by_repo(repo)
-                                           .by_bug(bug_id)
-                                           .annotate(date=TruncDate('job__push__time'))
-                                           .values('date')
-                                           .annotate(failure_count=Count('id'))
-                                           .values('date', 'failure_count'))
+            job_query = (
+                BugJobMap.failures.by_date(startday, endday)
+                .by_repo(repo)
+                .by_bug(bug_id)
+                .annotate(date=TruncDate('job__push__time'))
+                .values('date')
+                .annotate(failure_count=Count('id'))
+                .values('date', 'failure_count')
+            )
         else:
-            job_query = (Job.failures.filter(push__time__range=(startday, endday),
-                                             failure_classification_id=4)
-                                     .by_repo(repo, False)
-                                     .select_related('push')
-                                     .annotate(date=TruncDate('push__time'))
-                                     .values('date')
-                                     .annotate(failure_count=Count('id'))
-                                     .values('date', 'failure_count'))
+            job_query = (
+                Job.failures.filter(
+                    push__time__range=(startday, endday), failure_classification_id=4
+                )
+                .by_repo(repo, False)
+                .select_related('push')
+                .annotate(date=TruncDate('push__time'))
+                .values('date')
+                .annotate(failure_count=Count('id'))
+                .values('date', 'failure_count')
+            )
 
         # merges the push_query and job_query results into a list; if a date is found in both queries,
         # update the job_query with the test_run count, if a date is in push_query but not job_query,
@@ -154,7 +175,9 @@ class FailureCount(generics.ListAPIView):
                 match[0]['test_runs'] = push['test_runs']
                 self.queryset.append(match[0])
             else:
-                self.queryset.append({'date': push['date'], 'test_runs': push['test_runs'], 'failure_count': 0})
+                self.queryset.append(
+                    {'date': push['date'], 'test_runs': push['test_runs'], 'failure_count': 0}
+                )
 
         serializer = self.get_serializer(self.queryset, many=True)
         return Response(serializer.data)

--- a/treeherder/webapp/api/job_log_url.py
+++ b/treeherder/webapp/api/job_log_url.py
@@ -34,14 +34,12 @@ class JobLogUrlViewSet(viewsets.ViewSet):
         """
         job_ids = request.query_params.getlist('job_id')
         if not job_ids:
-            raise ParseError(
-                detail="The job_id parameter is mandatory for this endpoint")
+            raise ParseError(detail="The job_id parameter is mandatory for this endpoint")
         try:
             job_ids = [int(job_id) for job_id in job_ids]
         except ValueError:
             raise ParseError(detail="The job_id parameter(s) must be integers")
 
-        logs = JobLog.objects.filter(job__repository__name=project,
-                                     job_id__in=job_ids)
+        logs = JobLog.objects.filter(job__repository__name=project, job_id__in=job_ids)
 
         return Response([self._log_as_dict(log) for log in logs])

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -10,22 +10,20 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
-from rest_framework.status import (HTTP_400_BAD_REQUEST,
-                                   HTTP_404_NOT_FOUND)
+from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
 from treeherder.model.error_summary import get_error_summary
-from treeherder.model.models import (Job,
-                                     JobDetail,
-                                     JobLog,
-                                     OptionCollection,
-                                     Repository,
-                                     TextLogError,
-                                     TextLogStep)
-from treeherder.webapp.api import (pagination,
-                                   serializers)
-from treeherder.webapp.api.utils import (CharInFilter,
-                                         NumberInFilter,
-                                         to_timestamp)
+from treeherder.model.models import (
+    Job,
+    JobDetail,
+    JobLog,
+    OptionCollection,
+    Repository,
+    TextLogError,
+    TextLogStep,
+)
+from treeherder.webapp.api import pagination, serializers
+from treeherder.webapp.api.utils import CharInFilter, NumberInFilter, to_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -35,42 +33,30 @@ class JobFilter(django_filters.FilterSet):
     We use this gigantic class to provide the same filtering interface
     as the previous jobs API
     """
+
     id = django_filters.NumberFilter(field_name='id')
     id__in = NumberInFilter(field_name='id', lookup_expr='in')
     tier__in = NumberInFilter(field_name='tier', lookup_expr='in')
     push_id__in = NumberInFilter(field_name='push_id', lookup_expr='in')
     job_guid = django_filters.CharFilter(field_name='guid')
     job_guid__in = CharInFilter(field_name='guid', lookup_expr='in')
-    build_architecture = django_filters.CharFilter(
-        field_name='build_platform__architecture')
-    build_os = django_filters.CharFilter(
-        field_name='build_platform__os_name')
-    build_platform = django_filters.CharFilter(
-        field_name='build_platform__platform')
-    build_system_type = django_filters.CharFilter(
-        field_name='signature__build_system_type')
-    job_group_id = django_filters.NumberFilter(
-        field_name='job_group_id')
-    job_group_name = django_filters.CharFilter(
-        field_name='job_group__name')
-    job_group_symbol = django_filters.CharFilter(
-        field_name='job_group__symbol')
-    job_type_name = django_filters.CharFilter(
-        field_name='job_type__name')
-    job_type_symbol = django_filters.CharFilter(
-        field_name='job_type__symbol')
-    machine_name = django_filters.CharFilter(
-        field_name='machine__name')
+    build_architecture = django_filters.CharFilter(field_name='build_platform__architecture')
+    build_os = django_filters.CharFilter(field_name='build_platform__os_name')
+    build_platform = django_filters.CharFilter(field_name='build_platform__platform')
+    build_system_type = django_filters.CharFilter(field_name='signature__build_system_type')
+    job_group_id = django_filters.NumberFilter(field_name='job_group_id')
+    job_group_name = django_filters.CharFilter(field_name='job_group__name')
+    job_group_symbol = django_filters.CharFilter(field_name='job_group__symbol')
+    job_type_name = django_filters.CharFilter(field_name='job_type__name')
+    job_type_symbol = django_filters.CharFilter(field_name='job_type__symbol')
+    machine_name = django_filters.CharFilter(field_name='machine__name')
     machine_platform_architecture = django_filters.CharFilter(
-        field_name='machine_platform__architecture')
-    machine_platform_os = django_filters.CharFilter(
-        field_name='machine_platform__os_name')
-    platform = django_filters.CharFilter(
-        field_name='machine_platform__platform')
-    ref_data_name = django_filters.CharFilter(
-        field_name='signature__name')
-    signature = django_filters.CharFilter(
-        field_name='signature__signature')
+        field_name='machine_platform__architecture'
+    )
+    machine_platform_os = django_filters.CharFilter(field_name='machine_platform__os_name')
+    platform = django_filters.CharFilter(field_name='machine_platform__platform')
+    ref_data_name = django_filters.CharFilter(field_name='signature__name')
+    signature = django_filters.CharFilter(field_name='signature__signature')
 
     class Meta:
         model = Job
@@ -90,12 +76,10 @@ class JobFilter(django_filters.FilterSet):
             'last_modified': ['lt', 'lte', 'exact', 'gt', 'gte'],
             'submit_time': ['lt', 'lte', 'exact', 'gt', 'gte'],
             'start_time': ['lt', 'lte', 'exact', 'gt', 'gte'],
-            'end_time': ['lt', 'lte', 'exact', 'gt', 'gte']
+            'end_time': ['lt', 'lte', 'exact', 'gt', 'gte'],
         }
         filter_overrides = {
-            django_models.DateTimeField: {
-                'filter_class': django_filters.IsoDateTimeFilter
-            }
+            django_models.DateTimeField: {'filter_class': django_filters.IsoDateTimeFilter}
         }
 
 
@@ -103,6 +87,7 @@ class JobsViewSet(viewsets.ReadOnlyModelViewSet):
     """
     This viewset is the jobs endpoint.
     """
+
     _default_select_related = [
         'job_type',
         'job_group',
@@ -131,7 +116,6 @@ class JobsViewSet(viewsets.ReadOnlyModelViewSet):
         'tier',
         'taskcluster_metadata__task_id',
         'taskcluster_metadata__retry_id',
-
     ]
     _output_field_names = [
         'failure_classification_id',
@@ -152,9 +136,12 @@ class JobsViewSet(viewsets.ReadOnlyModelViewSet):
         'duration',
         'platform_option',
     ]
-    queryset = Job.objects.all().order_by('id').select_related(
-        *_default_select_related
-    ).values(*_query_field_names)
+    queryset = (
+        Job.objects.all()
+        .order_by('id')
+        .select_related(*_default_select_related)
+        .values(*_query_field_names)
+    )
     serializer_class = serializers.JobSerializer
     filterset_class = JobFilter
     pagination_class = pagination.JobPagination
@@ -184,7 +171,7 @@ class JobsProjectViewSet(viewsets.ViewSet):
         'machine',
         'signature',
         'repository',
-        'taskcluster_metadata'
+        'taskcluster_metadata',
     ]
 
     _property_query_mapping = [
@@ -227,7 +214,8 @@ class JobsProjectViewSet(viewsets.ViewSet):
     ]
 
     _option_collection_hash_idx = [pq[0] for pq in _property_query_mapping].index(
-        'option_collection_hash')
+        'option_collection_hash'
+    )
 
     def _get_job_list_response(self, job_qs, offset, count, return_type):
         '''
@@ -239,11 +227,12 @@ class JobsProjectViewSet(viewsets.ViewSet):
         '''
         option_collection_map = OptionCollection.objects.get_option_collection_map()
         results = []
-        for values in job_qs[offset:(offset+count)].values_list(
-                *[pq[1] for pq in self._property_query_mapping]):
+        for values in job_qs[offset : (offset + count)].values_list(
+            *[pq[1] for pq in self._property_query_mapping]
+        ):
             platform_option = option_collection_map.get(
-                values[self._option_collection_hash_idx],
-                "")
+                values[self._option_collection_hash_idx], ""
+            )
             # some values need to be transformed
             values = list(values)
             for (i, _) in enumerate(values):
@@ -253,20 +242,25 @@ class JobsProjectViewSet(viewsets.ViewSet):
             # append results differently depending on if we are returning
             # a dictionary or a list
             if return_type == 'dict':
-                results.append(dict(zip(
-                    [pq[0] for pq in self._property_query_mapping] +
-                    ['platform_option'],
-                    values + [platform_option])))
+                results.append(
+                    dict(
+                        zip(
+                            [pq[0] for pq in self._property_query_mapping] + ['platform_option'],
+                            values + [platform_option],
+                        )
+                    )
+                )
             else:
                 results.append(values + [platform_option])
 
-        response_dict = {
-            'results': results
-        }
+        response_dict = {'results': results}
         if return_type == 'list':
-            response_dict.update({
-                'job_property_names': [pq[0] for pq in self._property_query_mapping] + ['platform_option']
-            })
+            response_dict.update(
+                {
+                    'job_property_names': [pq[0] for pq in self._property_query_mapping]
+                    + ['platform_option']
+                }
+            )
 
         return response_dict
 
@@ -279,18 +273,16 @@ class JobsProjectViewSet(viewsets.ViewSet):
         """
         try:
             job = Job.objects.select_related(
-                *self._default_select_related + ['taskcluster_metadata']).get(
-                    repository__name=project, id=pk)
+                *self._default_select_related + ['taskcluster_metadata']
+            ).get(repository__name=project, id=pk)
         except Job.DoesNotExist:
             return Response("No job with id: {0}".format(pk), status=HTTP_404_NOT_FOUND)
 
         resp = serializers.JobProjectSerializer(job, read_only=True).data
 
-        resp["resource_uri"] = reverse("jobs-detail",
-                                       kwargs={"project": project, "pk": pk})
+        resp["resource_uri"] = reverse("jobs-detail", kwargs={"project": project, "pk": pk})
         resp["logs"] = []
-        for (name, url) in JobLog.objects.filter(job=job).values_list(
-                'name', 'url'):
+        for (name, url) in JobLog.objects.filter(job=job).values_list('name', 'url'):
             resp["logs"].append({'name': name, 'url': url})
 
         platform_option = job.get_platform_option()
@@ -303,7 +295,7 @@ class JobsProjectViewSet(viewsets.ViewSet):
             # Keep for backwards compatability
             resp['taskcluster_metadata'] = {
                 'task_id': job.taskcluster_metadata.task_id,
-                'retry_id': job.taskcluster_metadata.retry_id
+                'retry_id': job.taskcluster_metadata.retry_id,
             }
         except ObjectDoesNotExist:
             pass
@@ -334,11 +326,11 @@ class JobsProjectViewSet(viewsets.ViewSet):
                 filter_params[new_param_key] = filter_params[param_key]
                 del filter_params[param_key]
             # convert legacy timestamp parameters to time ones
-            elif param_key in ['submit_timestamp', 'start_timestamp',
-                               'end_timestamp']:
+            elif param_key in ['submit_timestamp', 'start_timestamp', 'end_timestamp']:
                 new_param_key = param_key.replace('timestamp', 'time')
                 filter_params[new_param_key] = datetime.datetime.fromtimestamp(
-                    float(filter_params[param_key]))
+                    float(filter_params[param_key])
+                )
                 del filter_params[param_key]
             # sanity check 'last modified'
             elif param_key.startswith('last_modified'):
@@ -348,15 +340,14 @@ class JobsProjectViewSet(viewsets.ViewSet):
                 except ValueError:
                     return Response(
                         "Invalid date value for `last_modified`: {}".format(datestr),
-                        status=HTTP_400_BAD_REQUEST)
+                        status=HTTP_400_BAD_REQUEST,
+                    )
 
         try:
             offset = int(filter_params.get("offset", 0))
             count = int(filter_params.get("count", 10))
         except ValueError:
-            return Response(
-                "Invalid value for offset or count",
-                status=HTTP_400_BAD_REQUEST)
+            return Response("Invalid value for offset or count", status=HTTP_400_BAD_REQUEST)
         return_type = filter_params.get("return_type", "dict").lower()
 
         if count > MAX_JOBS_COUNT:
@@ -366,18 +357,18 @@ class JobsProjectViewSet(viewsets.ViewSet):
         try:
             repository = Repository.objects.get(name=project)
         except Repository.DoesNotExist:
-            return Response({
-                "detail": "No project with name {}".format(project)
-            }, status=HTTP_404_NOT_FOUND)
-        jobs = JobFilter({k: v for (k, v) in filter_params.items()},
-                         queryset=Job.objects.filter(
-                             repository=repository).select_related(
-                                 *self._default_select_related)).qs
+            return Response(
+                {"detail": "No project with name {}".format(project)}, status=HTTP_404_NOT_FOUND
+            )
+        jobs = JobFilter(
+            {k: v for (k, v) in filter_params.items()},
+            queryset=Job.objects.filter(repository=repository).select_related(
+                *self._default_select_related
+            ),
+        ).qs
 
-        response_body = self._get_job_list_response(jobs, offset, count,
-                                                    return_type)
-        response_body["meta"] = dict(repository=project, offset=offset,
-                                     count=count)
+        response_body = self._get_job_list_response(jobs, offset, count, return_type)
+        response_body["meta"] = dict(repository=project, offset=offset, count=count)
 
         return Response(response_body)
 
@@ -387,16 +378,18 @@ class JobsProjectViewSet(viewsets.ViewSet):
         Gets a list of steps associated with this job
         """
         try:
-            job = Job.objects.get(repository__name=project,
-                                  id=pk)
+            job = Job.objects.get(repository__name=project, id=pk)
         except ObjectDoesNotExist:
             return Response("No job with id: {0}".format(pk), status=HTTP_404_NOT_FOUND)
 
-        textlog_steps = TextLogStep.objects.filter(job=job).order_by(
-            'started_line_number').prefetch_related('errors')
-        return Response(serializers.TextLogStepSerializer(textlog_steps,
-                                                          many=True,
-                                                          read_only=True).data)
+        textlog_steps = (
+            TextLogStep.objects.filter(job=job)
+            .order_by('started_line_number')
+            .prefetch_related('errors')
+        )
+        return Response(
+            serializers.TextLogStepSerializer(textlog_steps, many=True, read_only=True).data
+        )
 
     @action(detail=True, methods=['get'])
     def text_log_errors(self, request, project, pk=None):
@@ -404,20 +397,18 @@ class JobsProjectViewSet(viewsets.ViewSet):
         Gets a list of steps associated with this job
         """
         try:
-            job = Job.objects.get(repository__name=project,
-                                  id=pk)
+            job = Job.objects.get(repository__name=project, id=pk)
         except Job.DoesNotExist:
-            return Response("No job with id: {0}".format(pk),
-                            status=HTTP_404_NOT_FOUND)
-        textlog_errors = (TextLogError.objects
-                          .filter(step__job=job)
-                          .select_related("_metadata",
-                                          "_metadata__failure_line")
-                          .prefetch_related("classified_failures", "matches")
-                          .order_by('id'))
-        return Response(serializers.TextLogErrorSerializer(textlog_errors,
-                                                           many=True,
-                                                           read_only=True).data)
+            return Response("No job with id: {0}".format(pk), status=HTTP_404_NOT_FOUND)
+        textlog_errors = (
+            TextLogError.objects.filter(step__job=job)
+            .select_related("_metadata", "_metadata__failure_line")
+            .prefetch_related("classified_failures", "matches")
+            .order_by('id')
+        )
+        return Response(
+            serializers.TextLogErrorSerializer(textlog_errors, many=True, read_only=True).data
+        )
 
     @action(detail=True, methods=['get'])
     def bug_suggestions(self, request, project, pk=None):
@@ -439,15 +430,14 @@ class JobsProjectViewSet(viewsets.ViewSet):
         try:
             repository = Repository.objects.get(name=project)
         except Repository.DoesNotExist:
-            return Response({
-                "detail": "No project with name {}".format(project)
-            }, status=HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "No project with name {}".format(project)}, status=HTTP_404_NOT_FOUND
+            )
 
         try:
             job = Job.objects.get(repository=repository, id=pk)
         except ObjectDoesNotExist:
-            return Response("No job with id: {0}".format(pk),
-                            status=HTTP_404_NOT_FOUND)
+            return Response("No job with id: {0}".format(pk), status=HTTP_404_NOT_FOUND)
 
         filter_params = request.query_params.copy()
 
@@ -457,25 +447,22 @@ class JobsProjectViewSet(viewsets.ViewSet):
             # let's cap it to 50 elements
             count = int(filter_params.get("count", 50))
         except ValueError:
-            return Response("Invalid value for offset or count",
-                            status=HTTP_400_BAD_REQUEST)
+            return Response("Invalid value for offset or count", status=HTTP_400_BAD_REQUEST)
 
         return_type = filter_params.get("return_type", "dict").lower()
 
-        jobs = JobFilter({k: v for (k, v) in filter_params.items()},
-                         queryset=Job.objects.filter(
-                             job_type_id=job.job_type_id,
-                             repository=repository).exclude(
-                                 id=job.id).select_related(
-                                     *self._default_select_related)).qs
+        jobs = JobFilter(
+            {k: v for (k, v) in filter_params.items()},
+            queryset=Job.objects.filter(job_type_id=job.job_type_id, repository=repository)
+            .exclude(id=job.id)
+            .select_related(*self._default_select_related),
+        ).qs
 
         # similar jobs we want in descending order from most recent
         jobs = jobs.order_by('-push_id', '-start_time')
 
-        response_body = self._get_job_list_response(jobs, offset, count,
-                                                    return_type)
-        response_body["meta"] = dict(offset=offset, count=count,
-                                     repository=project)
+        response_body = self._get_job_list_response(jobs, offset, count, return_type)
+        response_body["meta"] = dict(offset=offset, count=count, repository=project)
 
         return Response(response_body)
 
@@ -485,6 +472,7 @@ class JobDetailViewSet(viewsets.ReadOnlyModelViewSet):
     Endpoint for retrieving metadata (e.g. links to artifacts, file sizes)
     associated with a particular job
     '''
+
     queryset = JobDetail.objects.all().select_related('job', 'job__repository')
     serializer_class = serializers.JobDetailSerializer
 
@@ -501,8 +489,16 @@ class JobDetailViewSet(viewsets.ReadOnlyModelViewSet):
 
         class Meta:
             model = JobDetail
-            fields = ['job_id', 'job_guid', 'job__guid', 'job_id__in', 'title',
-                      'value', 'push_id', 'repository']
+            fields = [
+                'job_id',
+                'job_guid',
+                'job__guid',
+                'job_id__in',
+                'title',
+                'value',
+                'push_id',
+                'repository',
+            ]
 
     filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
     filterset_class = JobDetailFilter
@@ -524,7 +520,6 @@ class JobDetailViewSet(viewsets.ReadOnlyModelViewSet):
         # unfiltered requests can potentially create huge sql queries, so
         # make sure the user passes a job id or guid
         if set(self.required_filters).isdisjoint(set(query_param_keys)):
-            raise ParseError("Must filter on one of: {}".format(
-                ", ".join(self.required_filters)))
+            raise ParseError("Must filter on one of: {}".format(", ".join(self.required_filters)))
 
         return viewsets.ReadOnlyModelViewSet.list(self, request)

--- a/treeherder/webapp/api/machine_platforms.py
+++ b/treeherder/webapp/api/machine_platforms.py
@@ -10,6 +10,7 @@ class MachinePlatformsViewSet(viewsets.ViewSet):
     """
         A ViewSet for listing all the machine platforms.
     """
+
     def list(self, request):
         platforms = MachinePlatform.objects.all()
         platforms_serializer = MachinePlatformSerializer(platforms, many=True)

--- a/treeherder/webapp/api/note.py
+++ b/treeherder/webapp/api/note.py
@@ -3,8 +3,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 from rest_framework.status import HTTP_404_NOT_FOUND
 
-from treeherder.model.models import (Job,
-                                     JobNote)
+from treeherder.model.models import Job, JobNote
 
 from .serializers import JobNoteSerializer
 
@@ -40,8 +39,7 @@ class NoteViewSet(viewsets.ViewSet):
             raise ParseError(detail="The job_id parameter must be an integer")
 
         job = Job.objects.get(repository__name=project, id=job_id)
-        serializer = JobNoteSerializer(JobNote.objects.filter(job=job),
-                                       many=True)
+        serializer = JobNoteSerializer(JobNote.objects.filter(job=job), many=True)
         return Response(serializer.data)
 
     def create(self, request, project):
@@ -49,17 +47,13 @@ class NoteViewSet(viewsets.ViewSet):
         POST method implementation
         """
         JobNote.objects.create(
-            job=Job.objects.get(repository__name=project,
-                                id=int(request.data['job_id'])),
+            job=Job.objects.get(repository__name=project, id=int(request.data['job_id'])),
             failure_classification_id=int(request.data['failure_classification_id']),
             user=request.user,
-            text=request.data.get('text', ''))
-
-        return Response(
-            {'message': 'note stored for job {0}'.format(
-                request.data['job_id']
-            )}
+            text=request.data.get('text', ''),
         )
+
+        return Response({'message': 'note stored for job {0}'.format(request.data['job_id'])})
 
     def destroy(self, request, project, pk=None):
         """
@@ -70,5 +64,4 @@ class NoteViewSet(viewsets.ViewSet):
             note.delete()
             return Response({"message": "Note deleted"})
         except JobNote.DoesNotExist:
-            return Response("No note with id: {0}".format(pk),
-                            status=HTTP_404_NOT_FOUND)
+            return Response("No note with id: {0}".format(pk), status=HTTP_404_NOT_FOUND)

--- a/treeherder/webapp/api/pagination.py
+++ b/treeherder/webapp/api/pagination.py
@@ -4,7 +4,7 @@ from rest_framework import pagination
 
 
 class IdPagination(pagination.CursorPagination):
-    ordering = ('-id')
+    ordering = '-id'
     page_size = 100
 
 

--- a/treeherder/webapp/api/permissions.py
+++ b/treeherder/webapp/api/permissions.py
@@ -8,5 +8,4 @@ class IsStaffOrReadOnly(permissions.BasePermission):
     """
 
     def has_permission(self, request, view):
-        return (request.method in permissions.SAFE_METHODS or
-                request.user and request.user.is_staff)
+        return request.method in permissions.SAFE_METHODS or request.user and request.user.is_staff

--- a/treeherder/webapp/api/refdata.py
+++ b/treeherder/webapp/api/refdata.py
@@ -13,9 +13,10 @@ from treeherder.webapp.api import serializers as th_serializers
 class RepositoryViewSet(viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata Repository model"""
-    queryset = models.Repository.objects.filter(
-        active_status='active').select_related(
-            'repository_group')
+
+    queryset = models.Repository.objects.filter(active_status='active').select_related(
+        'repository_group'
+    )
     serializer_class = th_serializers.RepositorySerializer
 
 
@@ -28,14 +29,19 @@ class OptionCollectionHashViewSet(viewsets.ViewSet):
 
         ret = []
         for (option_hash, option_names) in option_collection_map.items():
-            ret.append({'option_collection_hash': option_hash,
-                        'options': [{'name': name} for name in option_names.split(' ')]})
+            ret.append(
+                {
+                    'option_collection_hash': option_hash,
+                    'options': [{'name': name} for name in option_names.split(' ')],
+                }
+            )
         return Response(ret)
 
 
 class FailureClassificationViewSet(viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata FailureClassification model"""
+
     queryset = models.FailureClassification.objects.exclude(name="intermittent needs filing")
     serializer_class = th_serializers.FailureClassificationSerializer
 
@@ -43,6 +49,7 @@ class FailureClassificationViewSet(viewsets.ReadOnlyModelViewSet):
 class TaskclusterMetadataViewSet(viewsets.ReadOnlyModelViewSet):
 
     """ViewSet for the refdata TaskclusterMetadata model"""
+
     serializer_class = th_serializers.TaskclusterMetadataSerializer
 
     def get_queryset(self):
@@ -61,6 +68,7 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
     Info about a logged-in user.
     Used by Treeherder's UI to inspect user properties
     """
+
     serializer_class = th_serializers.UserSerializer
 
     def get_queryset(self):

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -6,8 +6,7 @@ from rest_framework import serializers
 
 from treeherder.changelog.models import Changelog
 from treeherder.model import models
-from treeherder.webapp.api.utils import (REPO_GROUPS,
-                                         to_timestamp)
+from treeherder.webapp.api.utils import REPO_GROUPS, to_timestamp
 
 
 class NoOpSerializer(serializers.Serializer):
@@ -25,14 +24,12 @@ class NoOpSerializer(serializers.Serializer):
 
 
 class UserSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = User
         fields = ["username", "is_superuser", "is_staff", "email"]
 
 
 class RepositoryGroupSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.RepositoryGroup
         fields = ('name', 'description')
@@ -47,14 +44,12 @@ class RepositorySerializer(serializers.ModelSerializer):
 
 
 class TaskclusterMetadataSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.TaskclusterMetadata
         fields = '__all__'
 
 
 class JobProjectSerializer(serializers.ModelSerializer):
-
     def to_representation(self, job):
         return {
             'build_architecture': job.build_platform.architecture,
@@ -90,7 +85,7 @@ class JobProjectSerializer(serializers.ModelSerializer):
             'state': job.state,
             'submit_timestamp': to_timestamp(job.submit_time),
             'tier': job.tier,
-            'who': job.who
+            'who': job.who,
         }
 
     class Meta:
@@ -99,7 +94,6 @@ class JobProjectSerializer(serializers.ModelSerializer):
 
 
 class JobSerializer(serializers.ModelSerializer):
-
     def to_representation(self, job):
         option_collection_map = self.context['option_collection_map']
         submit = job.pop('submit_time')
@@ -108,10 +102,12 @@ class JobSerializer(serializers.ModelSerializer):
         option_collection_hash = job.pop('option_collection_hash')
 
         ret_val = list(job.values())
-        ret_val.extend([
-            models.Job.get_duration(submit, start, end),  # duration
-            option_collection_map.get(option_collection_hash, '')  # platform option
-        ])
+        ret_val.extend(
+            [
+                models.Job.get_duration(submit, start, end),  # duration
+                option_collection_map.get(option_collection_hash, ''),  # platform option
+            ]
+        )
         return ret_val
 
     class Meta:
@@ -120,14 +116,12 @@ class JobSerializer(serializers.ModelSerializer):
 
 
 class FailureClassificationSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.FailureClassification
         fields = '__all__'
 
 
 class BugscacheSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.Bugscache
         fields = '__all__'
@@ -142,7 +136,6 @@ class ClassifiedFailureSerializer(serializers.ModelSerializer):
 
 
 class TextLogErrorMatchSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.TextLogErrorMatch
         exclude = ['text_log_error']
@@ -153,9 +146,7 @@ class FailureLineNoStackSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.FailureLine
-        exclude = ['stack',
-                   'stackwalk_stdout',
-                   'stackwalk_stderr']
+        exclude = ['stack', 'stackwalk_stdout', 'stackwalk_stderr']
 
     def to_representation(self, failure_line):
         """
@@ -212,12 +203,11 @@ class TextLogStepSerializer(serializers.ModelSerializer):
 
 class JobDetailSerializer(serializers.ModelSerializer):
 
-    job_id = serializers.PrimaryKeyRelatedField(
-        source="job", read_only=True)
+    job_id = serializers.PrimaryKeyRelatedField(source="job", read_only=True)
 
     job_guid = serializers.SlugRelatedField(
-        slug_field="guid", source="job",
-        queryset=models.Job.objects.all())
+        slug_field="guid", source="job", queryset=models.Job.objects.all()
+    )
 
     class Meta:
         model = models.JobDetail
@@ -225,8 +215,7 @@ class JobDetailSerializer(serializers.ModelSerializer):
 
 
 class BugJobMapSerializer(serializers.ModelSerializer):
-    job_id = serializers.PrimaryKeyRelatedField(
-        source="job", read_only=True)
+    job_id = serializers.PrimaryKeyRelatedField(source="job", read_only=True)
 
     class Meta:
         model = models.BugJobMap
@@ -235,40 +224,33 @@ class BugJobMapSerializer(serializers.ModelSerializer):
 
 class JobNoteSerializer(serializers.ModelSerializer):
 
-    job_id = serializers.PrimaryKeyRelatedField(
-        source="job", read_only=True)
+    job_id = serializers.PrimaryKeyRelatedField(source="job", read_only=True)
 
     # these custom fields are for backwards compatibility
     failure_classification_id = serializers.SlugRelatedField(
-        slug_field="id",
-        source="failure_classification",
-        read_only=True)
+        slug_field="id", source="failure_classification", read_only=True
+    )
 
     class Meta:
         model = models.JobNote
-        fields = ['id', 'job_id', 'failure_classification_id',
-                  'created', 'who', 'text']
+        fields = ['id', 'job_id', 'failure_classification_id', 'created', 'who', 'text']
 
 
 class CommitSerializer(serializers.ModelSerializer):
 
-    result_set_id = serializers.PrimaryKeyRelatedField(
-        source="push", read_only=True)
+    result_set_id = serializers.PrimaryKeyRelatedField(source="push", read_only=True)
     repository_id = serializers.SlugRelatedField(
-        slug_field="repository_id", source="push", read_only=True)
+        slug_field="repository_id", source="push", read_only=True
+    )
 
     class Meta:
         model = models.Commit
-        fields = ['result_set_id', 'repository_id', 'revision', 'author',
-                  'comments']
+        fields = ['result_set_id', 'repository_id', 'revision', 'author', 'comments']
 
 
 class PushSerializer(serializers.ModelSerializer):
-
     def get_revisions(self, push):
-        serializer = CommitSerializer(
-            instance=push.commits.all().order_by('-id')[:20],
-            many=True)
+        serializer = CommitSerializer(instance=push.commits.all().order_by('-id')[:20], many=True)
         return serializer.data
 
     def get_revision_count(self, push):
@@ -280,14 +262,19 @@ class PushSerializer(serializers.ModelSerializer):
     revisions = serializers.SerializerMethodField()
     revision_count = serializers.SerializerMethodField()
     push_timestamp = serializers.SerializerMethodField()
-    repository_id = serializers.PrimaryKeyRelatedField(
-        source="repository", read_only=True)
+    repository_id = serializers.PrimaryKeyRelatedField(source="repository", read_only=True)
 
     class Meta:
         model = models.Push
-        fields = ['id', 'revision', 'author',
-                  'revisions', 'revision_count', 'push_timestamp',
-                  'repository_id']
+        fields = [
+            'id',
+            'revision',
+            'author',
+            'revisions',
+            'revision_count',
+            'push_timestamp',
+            'repository_id',
+        ]
 
 
 class FailuresSerializer(serializers.ModelSerializer):
@@ -318,14 +305,22 @@ class FailuresByBugSerializer(serializers.ModelSerializer):
     push_time = serializers.CharField(source="job__push__time")
     build_type = serializers.CharField()
     machine_name = serializers.CharField(source="job__machine__name")
-    lines = serializers.ListField(
-        child=serializers.CharField()
-    )
+    lines = serializers.ListField(child=serializers.CharField())
 
     class Meta:
         model = models.BugJobMap
-        fields = ('push_time', 'platform', 'revision', 'test_suite', 'tree', 'build_type', 'job_id',
-                  'bug_id', 'machine_name', 'lines')
+        fields = (
+            'push_time',
+            'platform',
+            'revision',
+            'test_suite',
+            'tree',
+            'build_type',
+            'job_id',
+            'bug_id',
+            'machine_name',
+            'lines',
+        )
 
 
 class FailureCountSerializer(serializers.ModelSerializer):
@@ -362,7 +357,6 @@ class FailuresQueryParamsSerializer(serializers.Serializer):
 
 
 class MachinePlatformSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.MachinePlatform
         fields = ('id', 'platform')
@@ -374,6 +368,17 @@ class ChangelogSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Changelog
-        fields = ('id', 'remote_id', 'date', 'author', 'message', 'description',
-                  'owner', 'project', 'project_url', 'type', 'url',
-                  'files')
+        fields = (
+            'id',
+            'remote_id',
+            'date',
+            'author',
+            'message',
+            'description',
+            'owner',
+            'project',
+            'project_url',
+            'type',
+            'url',
+            'files',
+        )

--- a/treeherder/webapp/api/seta.py
+++ b/treeherder/webapp/api/seta.py
@@ -1,9 +1,7 @@
-from rest_framework import (status,
-                            viewsets)
+from rest_framework import status, viewsets
 from rest_framework.response import Response
 
-from treeherder.seta.job_priorities import (SetaError,
-                                            seta_job_scheduling)
+from treeherder.seta.job_priorities import SetaError, seta_job_scheduling
 
 
 class SetaJobPriorityViewSet(viewsets.ViewSet):

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -1,24 +1,25 @@
 import copy
 
-from django.conf.urls import (include,
-                              url)
+from django.conf.urls import include, url
 from rest_framework import routers
 
-from treeherder.webapp.api import (auth,
-                                   bug,
-                                   bugzilla,
-                                   changelog,
-                                   csp_report,
-                                   intermittents_view,
-                                   job_log_url,
-                                   jobs,
-                                   machine_platforms,
-                                   note,
-                                   performance_data,
-                                   push,
-                                   refdata,
-                                   seta,
-                                   text_log_error)
+from treeherder.webapp.api import (
+    auth,
+    bug,
+    bugzilla,
+    changelog,
+    csp_report,
+    intermittents_view,
+    job_log_url,
+    jobs,
+    machine_platforms,
+    note,
+    performance_data,
+    push,
+    refdata,
+    seta,
+    text_log_error,
+)
 
 # router for views that are bound to a project
 # i.e. all those views that don't involve reference data
@@ -29,55 +30,44 @@ project_bound_router = routers.SimpleRouter()
 # DEPRECATED (in process): The UI is transitioning to the /jobs/ endpoint
 # from the default_router.
 project_bound_router.register(
-    r'jobs',
-    jobs.JobsProjectViewSet,
-    basename='jobs',
+    r'jobs', jobs.JobsProjectViewSet, basename='jobs',
 )
 
 project_bound_router.register(
-    r'seta/job-priorities',
-    seta.SetaJobPriorityViewSet,
-    basename='seta-job-priorities'
+    r'seta/job-priorities', seta.SetaJobPriorityViewSet, basename='seta-job-priorities'
 )
 
 project_bound_router.register(
-    r'push',
-    push.PushViewSet,
-    basename='push',
+    r'push', push.PushViewSet, basename='push',
 )
 
 project_bound_router.register(
-    r'note',
-    note.NoteViewSet,
-    basename='note',
+    r'note', note.NoteViewSet, basename='note',
 )
 
 project_bound_router.register(
-    r'bug-job-map',
-    bug.BugJobMapViewSet,
-    basename='bug-job-map',
+    r'bug-job-map', bug.BugJobMapViewSet, basename='bug-job-map',
 )
 
 project_bound_router.register(
-    r'job-log-url',
-    job_log_url.JobLogUrlViewSet,
-    basename='job-log-url',
+    r'job-log-url', job_log_url.JobLogUrlViewSet, basename='job-log-url',
 )
 
 project_bound_router.register(
-    r'performance/data',
-    performance_data.PerformanceDatumViewSet,
-    basename='performance-data')
+    r'performance/data', performance_data.PerformanceDatumViewSet, basename='performance-data'
+)
 
 project_bound_router.register(
     r'performance/signatures',
     performance_data.PerformanceSignatureViewSet,
-    basename='performance-signatures')
+    basename='performance-signatures',
+)
 
 project_bound_router.register(
     r'performance/platforms',
     performance_data.PerformancePlatformViewSet,
-    basename='performance-signatures-platforms')
+    basename='performance-signatures-platforms',
+)
 
 
 class TextLogErrorRouter(routers.DefaultRouter):
@@ -88,54 +78,64 @@ class TextLogErrorRouter(routers.DefaultRouter):
     URL).  This router tells DRF to route those calls to a ViewSet's
     `update_many` method.
     """
+
     routes = copy.deepcopy(routers.DefaultRouter.routes)
     routes[0].mapping[u"put"] = u"update_many"
 
 
 tle_router = TextLogErrorRouter()
-tle_router.register(r'text-log-error',
-                    text_log_error.TextLogErrorViewSet,
-                    basename='text-log-error')
+tle_router.register(
+    r'text-log-error', text_log_error.TextLogErrorViewSet, basename='text-log-error'
+)
 
 
 # refdata endpoints:
 default_router = routers.DefaultRouter()
 default_router.register(r'jobs', jobs.JobsViewSet, basename='jobs')
 default_router.register(r'repository', refdata.RepositoryViewSet)
-default_router.register(r'taskclustermetadata', refdata.TaskclusterMetadataViewSet,
-                        basename='taskclustermetadata')
-default_router.register(r'optioncollectionhash', refdata.OptionCollectionHashViewSet,
-                        basename='optioncollectionhash')
+default_router.register(
+    r'taskclustermetadata', refdata.TaskclusterMetadataViewSet, basename='taskclustermetadata'
+)
+default_router.register(
+    r'optioncollectionhash', refdata.OptionCollectionHashViewSet, basename='optioncollectionhash'
+)
 default_router.register(r'failureclassification', refdata.FailureClassificationViewSet)
 default_router.register(r'user', refdata.UserViewSet, basename='user')
-default_router.register(r'machineplatforms', machine_platforms.MachinePlatformsViewSet,
-                        basename='machineplatforms')
-default_router.register(r'performance/alertsummary',
-                        performance_data.PerformanceAlertSummaryViewSet,
-                        basename='performance-alert-summaries')
-default_router.register(r'performance/alert',
-                        performance_data.PerformanceAlertViewSet,
-                        basename='performance-alerts')
-default_router.register(r'performance/framework',
-                        performance_data.PerformanceFrameworkViewSet,
-                        basename='performance-frameworks')
-default_router.register(r'performance/bug-template',
-                        performance_data.PerformanceBugTemplateViewSet,
-                        basename='performance-bug-template')
-default_router.register(r'performance/issue-tracker',
-                        performance_data.PerformanceIssueTrackerViewSet,
-                        basename='performance-issue-tracker')
-default_router.register(r'performance/validity-dashboard',
-                        performance_data.TestSuiteHealthViewSet,
-                        basename='validity-dashboard')
-default_router.register(r'bugzilla', bugzilla.BugzillaViewSet,
-                        basename='bugzilla')
-default_router.register(r'jobdetail', jobs.JobDetailViewSet,
-                        basename='jobdetail')
-default_router.register(r'auth', auth.AuthViewSet,
-                        basename='auth')
-default_router.register(r'changelog', changelog.ChangelogViewSet,
-                        basename='changelog')
+default_router.register(
+    r'machineplatforms', machine_platforms.MachinePlatformsViewSet, basename='machineplatforms'
+)
+default_router.register(
+    r'performance/alertsummary',
+    performance_data.PerformanceAlertSummaryViewSet,
+    basename='performance-alert-summaries',
+)
+default_router.register(
+    r'performance/alert', performance_data.PerformanceAlertViewSet, basename='performance-alerts'
+)
+default_router.register(
+    r'performance/framework',
+    performance_data.PerformanceFrameworkViewSet,
+    basename='performance-frameworks',
+)
+default_router.register(
+    r'performance/bug-template',
+    performance_data.PerformanceBugTemplateViewSet,
+    basename='performance-bug-template',
+)
+default_router.register(
+    r'performance/issue-tracker',
+    performance_data.PerformanceIssueTrackerViewSet,
+    basename='performance-issue-tracker',
+)
+default_router.register(
+    r'performance/validity-dashboard',
+    performance_data.TestSuiteHealthViewSet,
+    basename='validity-dashboard',
+)
+default_router.register(r'bugzilla', bugzilla.BugzillaViewSet, basename='bugzilla')
+default_router.register(r'jobdetail', jobs.JobDetailViewSet, basename='jobdetail')
+default_router.register(r'auth', auth.AuthViewSet, basename='auth')
+default_router.register(r'changelog', changelog.ChangelogViewSet, basename='changelog')
 
 urlpatterns = [
     url(r'^project/(?P<project>[\w-]{0,50})/', include(project_bound_router.urls)),
@@ -144,6 +144,10 @@ urlpatterns = [
     url(r'^failures/$', intermittents_view.Failures.as_view(), name='failures'),
     url(r'^failuresbybug/$', intermittents_view.FailuresByBug.as_view(), name='failures-by-bug'),
     url(r'^failurecount/$', intermittents_view.FailureCount.as_view(), name='failure-count'),
-    url(r'^performance/summary/$', performance_data.PerformanceSummary.as_view(), name='performance-summary'),
+    url(
+        r'^performance/summary/$',
+        performance_data.PerformanceSummary.as_view(),
+        name='performance-summary',
+    ),
     url(r'^csp-report/$', csp_report.csp_report_collector, name='csp-report'),
 ]

--- a/treeherder/webapp/api/utils.py
+++ b/treeherder/webapp/api/utils.py
@@ -1,10 +1,8 @@
 import time
-from datetime import (datetime,
-                      timedelta)
+from datetime import datetime, timedelta
 
 import django_filters
-from django.db.models import (Aggregate,
-                              CharField)
+from django.db.models import Aggregate, CharField
 
 # queries are faster when filtering a range by id rather than name
 # trunk: mozilla-central, mozilla-inbound, autoland
@@ -24,27 +22,21 @@ class GroupConcat(Aggregate):
 
     def __init__(self, expression, distinct=False, **extra):
         super().__init__(
-            expression,
-            distinct='DISTINCT ' if distinct else '',
-            output_field=CharField(),
-            **extra)
+            expression, distinct='DISTINCT ' if distinct else '', output_field=CharField(), **extra
+        )
 
 
-class NumberInFilter(django_filters.filters.BaseInFilter,
-                     django_filters.NumberFilter):
+class NumberInFilter(django_filters.filters.BaseInFilter, django_filters.NumberFilter):
     pass
 
 
-class CharInFilter(django_filters.filters.BaseInFilter,
-                   django_filters.CharFilter):
+class CharInFilter(django_filters.filters.BaseInFilter, django_filters.CharFilter):
     pass
 
 
 def to_datetime(datestr):
     """get a timestamp from a datestr like 2014-03-31"""
-    return datetime.strptime(
-        datestr,
-        "%Y-%m-%d")
+    return datetime.strptime(datestr, "%Y-%m-%d")
 
 
 def to_timestamp(datetime_obj):

--- a/treeherder/workers/task.py
+++ b/treeherder/workers/task.py
@@ -5,8 +5,7 @@ from functools import wraps
 import jsonschema
 import newrelic.agent
 from celery import task
-from django.db.utils import (IntegrityError,
-                             ProgrammingError)
+from django.db.utils import IntegrityError, ProgrammingError
 
 from treeherder.etl.exceptions import MissingPushException
 
@@ -29,9 +28,7 @@ class retryable_task:
     # For these exceptions, we expect a certain amount of retries
     # but to report each one is just noise.  So don't raise to
     # New Relic until the retries have been exceeded.
-    HIDE_DURING_RETRIES = (
-        MissingPushException,
-    )
+    HIDE_DURING_RETRIES = (MissingPushException,)
 
     def __init__(self, *args, **kwargs):
         self.task_args = args


### PR DESCRIPTION
A lot of PRs are being harder to read because there's a lot of black fixes.
Applying black formatting in one short will help make them easier to read again.
We also need to disable some flake8 rules that black violates.