### PR TITLE
Bug 1630293 - Increase max connections for Docker set up

### DIFF
--- a/docker/mysql.cnf
+++ b/docker/mysql.cnf
@@ -7,6 +7,7 @@
 [mysqld]
 character_set_server="utf8"
 collation_server="utf8_bin"
+max_connections=300
 
 # Ensure operations involving astral characters fail loudly,
 # rather than mysql silently replacing each each byte of the


### PR DESCRIPTION
The recent addition of Celery workers consumption has increased the usage
of number of connections to the database.

In certain cases like loading a large number of pushes we can hit the maximum
limit of connections.

This change increases the default `max_connections` to 300 (about double).