### PR TITLE
Bug 1620160 - Relax login requirements for UI features

### DIFF
--- a/ui/job-view/CustomJobActions.jsx
+++ b/ui/job-view/CustomJobActions.jsx
@@ -196,7 +196,7 @@ class CustomJobActions extends React.PureComponent {
   };
 
   render() {
-    const { isLoggedIn, toggle } = this.props;
+    const { toggle } = this.props;
     const { triggering, selectedAction, schema, actions, payload } = this.state;
     const isOpen = true;
 
@@ -276,23 +276,19 @@ class CustomJobActions extends React.PureComponent {
           )}
         </ModalBody>
         <ModalFooter>
-          {isLoggedIn ? (
-            <Button
-              color="darker-info"
-              className={triggering ? 'disabled' : ''}
-              onClick={this.triggerAction}
-              title={isLoggedIn ? 'Trigger this action' : 'Not logged in'}
-            >
-              <FontAwesomeIcon
-                icon={faCheckSquare}
-                className="mr-1"
-                title="Check"
-              />
-              <span>{triggering ? 'Triggering' : 'Trigger'}</span>
-            </Button>
-          ) : (
-            <p className="help-block"> Custom actions require login </p>
-          )}
+          <Button
+            color="darker-info"
+            className={triggering ? 'disabled' : ''}
+            onClick={this.triggerAction}
+            title="Trigger this action"
+          >
+            <FontAwesomeIcon
+              icon={faCheckSquare}
+              className="mr-1"
+              title="Check"
+            />
+            <span>{triggering ? 'Triggering' : 'Trigger'}</span>
+          </Button>
           <Button color="secondary" onClick={toggle}>
             Cancel
           </Button>
@@ -304,7 +300,6 @@ class CustomJobActions extends React.PureComponent {
 
 CustomJobActions.propTypes = {
   pushId: PropTypes.number.isRequired,
-  isLoggedIn: PropTypes.bool.isRequired,
   notify: PropTypes.func.isRequired,
   toggle: PropTypes.func.isRequired,
   decisionTaskMap: PropTypes.shape({}).isRequired,

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -601,7 +601,6 @@ class ActionBar extends React.PureComponent {
             job={selectedJobFull}
             pushId={selectedJobFull.push_id}
             currentRepo={currentRepo}
-            isLoggedIn={user.isLoggedIn}
             toggle={this.toggleCustomJobActions}
           />
         )}

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -91,15 +91,11 @@ class ActionBar extends React.PureComponent {
 
   createGeckoProfile = async () => {
     const {
-      user,
       selectedJobFull,
       notify,
       decisionTaskMap,
       currentRepo,
     } = this.props;
-    if (!user.isLoggedIn) {
-      return notify('Must be logged in to create a gecko profile', 'danger');
-    }
 
     const { id: decisionTaskId } = decisionTaskMap[selectedJobFull.push_id];
 
@@ -146,11 +142,7 @@ class ActionBar extends React.PureComponent {
   };
 
   retriggerJob = async jobs => {
-    const { user, notify, decisionTaskMap, currentRepo } = this.props;
-
-    if (!user.isLoggedIn) {
-      return notify('Must be logged in to retrigger a job', 'danger');
-    }
+    const { notify, decisionTaskMap, currentRepo } = this.props;
 
     // Spin the retrigger button when retriggers happen
     document
@@ -169,7 +161,6 @@ class ActionBar extends React.PureComponent {
 
   backfillJob = async () => {
     const {
-      user,
       selectedJobFull,
       notify,
       decisionTaskMap,
@@ -177,12 +168,6 @@ class ActionBar extends React.PureComponent {
     } = this.props;
 
     if (!this.canBackfill()) {
-      return;
-    }
-
-    if (!user.isLoggedIn) {
-      notify('Must be logged in to backfill a job', 'danger');
-
       return;
     }
 
@@ -228,7 +213,6 @@ class ActionBar extends React.PureComponent {
 
   isolateJob = async () => {
     const {
-      user,
       selectedJobFull,
       notify,
       decisionTaskMap,
@@ -237,12 +221,6 @@ class ActionBar extends React.PureComponent {
     const { id: decisionTaskId } = decisionTaskMap[selectedJobFull.push_id];
 
     if (!isTestIsolatable(selectedJobFull)) {
-      return;
-    }
-
-    if (!user.isLoggedIn) {
-      notify('Must be logged in to isolate a job', 'danger');
-
       return;
     }
 
@@ -322,18 +300,14 @@ class ActionBar extends React.PureComponent {
 
   // Can we backfill? At the moment, this only ensures we're not in a 'try' repo.
   canBackfill = () => {
-    const { user, isTryRepo } = this.props;
+    const { isTryRepo } = this.props;
 
-    return user.isLoggedIn && !isTryRepo;
+    return !isTryRepo;
   };
 
   backfillButtonTitle = () => {
-    const { user, isTryRepo } = this.props;
+    const { isTryRepo } = this.props;
     let title = '';
-
-    if (!user.isLoggedIn) {
-      title = title.concat('must be logged in to backfill a job / ');
-    }
 
     if (isTryRepo) {
       title = title.concat('backfill not available in this repository');
@@ -359,13 +333,6 @@ class ActionBar extends React.PureComponent {
       decisionTaskMap,
       currentRepo,
     } = this.props;
-
-    if (!user.isLoggedIn) {
-      return notify(
-        'Must be logged in to create an interactive task',
-        'danger',
-      );
-    }
 
     const { id: decisionTaskId } = decisionTaskMap[selectedJobFull.push_id];
     const results = await TaskclusterModel.load(
@@ -401,11 +368,8 @@ class ActionBar extends React.PureComponent {
   };
 
   cancelJobs = jobs => {
-    const { user, notify, decisionTaskMap, currentRepo } = this.props;
+    const { notify, decisionTaskMap, currentRepo } = this.props;
 
-    if (!user.isLoggedIn) {
-      return notify('Must be logged in to cancel a job', 'danger');
-    }
     JobModel.cancel(
       jobs.filter(({ state }) => state === 'pending' || state === 'running'),
       currentRepo,
@@ -430,7 +394,6 @@ class ActionBar extends React.PureComponent {
       logViewerUrl,
       logViewerFullUrl,
       jobLogUrls,
-      user,
       pinJob,
       currentRepo,
     } = this.props;
@@ -458,15 +421,8 @@ class ActionBar extends React.PureComponent {
             <li>
               <Button
                 id="retrigger-btn"
-                title={
-                  user.isLoggedIn
-                    ? 'Repeat the selected job'
-                    : 'Must be logged in to retrigger a job'
-                }
-                className={`actionbar-nav-btn bg-transparent border-0 ${
-                  user.isLoggedIn ? 'icon-green' : 'disabled'
-                }`}
-                disabled={!user.isLoggedIn}
+                title="Repeat the selected job"
+                className="actionbar-nav-btn bg-transparent border-0 icon-green"
                 onClick={() => this.retriggerJob([selectedJobFull])}
               >
                 <FontAwesomeIcon icon={faRedo} title="Retrigger job" />
@@ -507,14 +463,8 @@ class ActionBar extends React.PureComponent {
             {this.canCancel() && (
               <li>
                 <Button
-                  title={
-                    user.isLoggedIn
-                      ? 'Cancel this job'
-                      : 'Must be logged in to cancel a job'
-                  }
-                  className={`bg-transparent border-0 actionbar-nav-btn ${
-                    user.isLoggedIn ? 'hover-warning' : 'disabled'
-                  }`}
+                  title="Must be logged in to cancel a job"
+                  className="bg-transparent border-0 actionbar-nav-btn hover-warning"
                   onClick={() => this.cancelJob()}
                 >
                   <FontAwesomeIcon icon={faTimesCircle} title="Cancel job" />
@@ -534,9 +484,7 @@ class ActionBar extends React.PureComponent {
                   <DropdownItem
                     tag="a"
                     id="backfill-btn"
-                    className={`${
-                      !user.isLoggedIn || !this.canBackfill() ? 'disabled' : ''
-                    }`}
+                    className={`${!this.canBackfill() ? 'disabled' : ''}`}
                     title={this.backfillButtonTitle()}
                     onClick={() => !this.canBackfill() || this.backfillJob()}
                   >

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -544,7 +544,6 @@ class Push extends React.PureComponent {
   render() {
     const {
       push,
-      isLoggedIn,
       currentRepo,
       duplicateJobsVisible,
       filterModel,
@@ -611,7 +610,6 @@ class Push extends React.PureComponent {
           revision={revision}
           jobCounts={jobCounts}
           watchState={watched}
-          isLoggedIn={isLoggedIn}
           currentRepo={currentRepo}
           filterModel={filterModel}
           runnableVisible={runnableVisible}
@@ -686,7 +684,6 @@ Push.propTypes = {
     name: PropTypes.string,
   }).isRequired,
   filterModel: PropTypes.shape({}).isRequired,
-  isLoggedIn: PropTypes.bool.isRequired,
   notificationSupported: PropTypes.bool.isRequired,
   getAllShownJobs: PropTypes.func.isRequired,
   updateJobMap: PropTypes.func.isRequired,

--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -94,7 +94,6 @@ class PushActionMenu extends React.PureComponent {
 
   render() {
     const {
-      isLoggedIn,
       revision,
       runnableVisible,
       hideRunnableJobs,
@@ -131,10 +130,7 @@ class PushActionMenu extends React.PureComponent {
             ) : (
               <DropdownItem
                 tag="a"
-                title={
-                  isLoggedIn ? 'Add new jobs to this push' : 'Must be logged in'
-                }
-                className={isLoggedIn ? '' : 'disabled'}
+                title="Add new jobs to this push"
                 onClick={showRunnableJobs}
               >
                 Add new jobs
@@ -142,12 +138,7 @@ class PushActionMenu extends React.PureComponent {
             )}
             <DropdownItem
               tag="a"
-              title={
-                isLoggedIn
-                  ? 'Add new jobs to this push via a fuzzy search'
-                  : 'Must be logged in'
-              }
-              className={isLoggedIn ? '' : 'disabled'}
+              title="Add new jobs to this push via a fuzzy search"
               onClick={showFuzzyJobs}
             >
               Add new jobs (Search)
@@ -155,12 +146,7 @@ class PushActionMenu extends React.PureComponent {
             {triggerMissingRepos.includes(currentRepo.name) && (
               <DropdownItem
                 tag="a"
-                title={
-                  isLoggedIn
-                    ? 'Trigger all jobs that were optimized away'
-                    : 'Must be logged in'
-                }
-                className={isLoggedIn ? '' : 'disabled'}
+                title="Trigger all jobs that were optimized away"
                 onClick={this.triggerMissingJobs}
               >
                 Trigger missing jobs
@@ -236,7 +222,6 @@ class PushActionMenu extends React.PureComponent {
 
 PushActionMenu.propTypes = {
   runnableVisible: PropTypes.bool.isRequired,
-  isLoggedIn: PropTypes.bool.isRequired,
   revision: PropTypes.string.isRequired,
   currentRepo: PropTypes.shape({
     name: PropTypes.string,

--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -210,7 +210,6 @@ class PushActionMenu extends React.PureComponent {
           <CustomJobActions
             job={null}
             pushId={pushId}
-            isLoggedIn={isLoggedIn}
             currentRepo={currentRepo}
             toggle={this.toggleCustomJobActions}
           />

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -106,7 +106,6 @@ class PushHeader extends React.Component {
     const {
       jobCounts: prevJobCounts,
       watchState: prevWatchState,
-      isLoggedIn: prevIsLoggedIn,
       selectedRunnableJobs: prevSelectedRunnableJobs,
       runnableVisible: prevRunnableVisible,
       collapsed: prevCollapsed,
@@ -117,7 +116,6 @@ class PushHeader extends React.Component {
     const {
       jobCounts,
       watchState,
-      isLoggedIn,
       selectedRunnableJobs,
       runnableVisible,
       collapsed,
@@ -129,7 +127,6 @@ class PushHeader extends React.Component {
     return (
       !isEqual(prevJobCounts, jobCounts) ||
       prevWatchState !== watchState ||
-      prevIsLoggedIn !== isLoggedIn ||
       prevSelectedRunnableJobs !== selectedRunnableJobs ||
       prevRunnableVisible !== runnableVisible ||
       prevCollapsed !== collapsed ||
@@ -151,7 +148,6 @@ class PushHeader extends React.Component {
 
   triggerNewJobs = async () => {
     const {
-      isLoggedIn,
       pushId,
       selectedRunnableJobs,
       hideRunnableJobs,
@@ -167,25 +163,17 @@ class PushHeader extends React.Component {
     ) {
       return;
     }
-    if (isLoggedIn) {
-      const { id: decisionTaskId } = decisionTaskMap[pushId];
+    const { id: decisionTaskId } = decisionTaskMap[pushId];
 
-      PushModel.triggerNewJobs(
-        selectedRunnableJobs,
-        decisionTaskId,
-        currentRepo,
-      )
-        .then(result => {
-          notify(result, 'success');
-          hideRunnableJobs(pushId);
-          this.props.hideRunnableJobs();
-        })
-        .catch(e => {
-          notify(formatTaskclusterError(e), 'danger', { sticky: true });
-        });
-    } else {
-      notify('Must be logged in to trigger a job', 'danger');
-    }
+    PushModel.triggerNewJobs(selectedRunnableJobs, decisionTaskId, currentRepo)
+      .then(result => {
+        notify(result, 'success');
+        hideRunnableJobs(pushId);
+        this.props.hideRunnableJobs();
+      })
+      .catch(e => {
+        notify(formatTaskclusterError(e), 'danger', { sticky: true });
+      });
   };
 
   cancelAllJobs = () => {
@@ -194,15 +182,7 @@ class PushHeader extends React.Component {
         'This will cancel all pending and running jobs for this push. It cannot be undone! Are you sure?',
       )
     ) {
-      const {
-        notify,
-        push,
-        isLoggedIn,
-        decisionTaskMap,
-        currentRepo,
-      } = this.props;
-
-      if (!isLoggedIn) return;
+      const { notify, push, decisionTaskMap, currentRepo } = this.props;
 
       JobModel.cancelAll(
         push.id,
@@ -258,7 +238,6 @@ class PushHeader extends React.Component {
 
   render() {
     const {
-      isLoggedIn,
       pushId,
       jobCounts,
       author,
@@ -276,9 +255,7 @@ class PushHeader extends React.Component {
       currentRepo,
       pushHealthStatusCallback,
     } = this.props;
-    const cancelJobsTitle = isLoggedIn
-      ? 'Cancel all jobs'
-      : 'Must be logged in to cancel jobs';
+    const cancelJobsTitle = 'Cancel all jobs';
     const linkParams = this.getLinkParams();
     const revisionPushFilterUrl = getJobsUrl({ ...linkParams, revision });
     const authorPushFilterUrl = getJobsUrl({ ...linkParams, author });
@@ -348,21 +325,19 @@ class PushHeader extends React.Component {
                 {watchStateLabel}
               </button>
             )}
-            {isLoggedIn && (
-              <button
-                type="button"
-                className="btn btn-sm btn-push cancel-all-jobs-btn"
-                title={cancelJobsTitle}
-                onClick={this.cancelAllJobs}
-                aria-label={cancelJobsTitle}
-              >
-                <FontAwesomeIcon
-                  icon={faTimesCircle}
-                  className="dim-quarter"
-                  title="Cancel jobs"
-                />
-              </button>
-            )}
+            <button
+              type="button"
+              className="btn btn-sm btn-push cancel-all-jobs-btn"
+              title={cancelJobsTitle}
+              onClick={this.cancelAllJobs}
+              aria-label={cancelJobsTitle}
+            >
+              <FontAwesomeIcon
+                icon={faTimesCircle}
+                className="dim-quarter"
+                title="Cancel jobs"
+              />
+            </button>
             <button
               type="button"
               className="btn btn-sm btn-push pin-all-jobs-btn"
@@ -386,7 +361,6 @@ class PushHeader extends React.Component {
               </Button>
             )}
             <PushActionMenu
-              isLoggedIn={isLoggedIn}
               runnableVisible={runnableVisible}
               revision={revision}
               currentRepo={currentRepo}
@@ -416,7 +390,6 @@ PushHeader.propTypes = {
   hideRunnableJobs: PropTypes.func.isRequired,
   showFuzzyJobs: PropTypes.func.isRequired,
   cycleWatchState: PropTypes.func.isRequired,
-  isLoggedIn: PropTypes.bool.isRequired,
   setSelectedJob: PropTypes.func.isRequired,
   pinJobs: PropTypes.func.isRequired,
   expandAllPushGroups: PropTypes.func.isRequired,

--- a/ui/job-view/pushes/PushList.jsx
+++ b/ui/job-view/pushes/PushList.jsx
@@ -117,7 +117,6 @@ class PushList extends React.Component {
 
   render() {
     const {
-      user,
       repoName,
       revision,
       currentRepo,
@@ -132,7 +131,6 @@ class PushList extends React.Component {
       pushHealthVisibility,
     } = this.props;
     const { notificationSupported } = this.state;
-    const { isLoggedIn } = user;
 
     if (!revision) {
       this.setWindowTitle();
@@ -156,7 +154,6 @@ class PushList extends React.Component {
               <Push
                 role="listitem"
                 push={push}
-                isLoggedIn={isLoggedIn || false}
                 currentRepo={currentRepo}
                 filterModel={filterModel}
                 notificationSupported={notificationSupported}
@@ -207,9 +204,6 @@ class PushList extends React.Component {
 
 PushList.propTypes = {
   repoName: PropTypes.string.isRequired,
-  user: PropTypes.shape({
-    isLoggedIn: PropTypes.bool,
-  }).isRequired,
   filterModel: PropTypes.shape({}).isRequired,
   pushList: PropTypes.arrayOf(PropTypes.object).isRequired,
   fetchNextPushes: PropTypes.func.isRequired,

--- a/ui/push-health/ClassificationGroup.jsx
+++ b/ui/push-health/ClassificationGroup.jsx
@@ -86,7 +86,6 @@ class ClassificationGroup extends React.PureComponent {
       revision,
       className,
       headerColor,
-      user,
       hasRetriggerAll,
       notify,
       currentRepo,
@@ -230,7 +229,6 @@ class ClassificationGroup extends React.PureComponent {
               group={group}
               repo={repo}
               revision={revision}
-              user={user}
               groupedBy={groupedBy}
               orderedBy={orderedBy}
               currentRepo={currentRepo}
@@ -249,7 +247,6 @@ ClassificationGroup.propTypes = {
   repo: PropTypes.string.isRequired,
   currentRepo: PropTypes.shape({}).isRequired,
   revision: PropTypes.string.isRequired,
-  user: PropTypes.shape({}).isRequired,
   notify: PropTypes.func.isRequired,
   unfilteredLength: PropTypes.number.isRequired,
   hasRetriggerAll: PropTypes.bool,

--- a/ui/push-health/GroupedTests.jsx
+++ b/ui/push-health/GroupedTests.jsx
@@ -43,7 +43,6 @@ class GroupedTests extends PureComponent {
       group,
       repo,
       revision,
-      user,
       notify,
       currentRepo,
       orderedBy,
@@ -105,7 +104,6 @@ class GroupedTests extends PureComponent {
                     repo={repo}
                     currentRepo={currentRepo}
                     revision={revision}
-                    user={user}
                     notify={notify}
                     groupedBy={groupedBy}
                     className="ml-3"
@@ -126,7 +124,6 @@ GroupedTests.propTypes = {
   revision: PropTypes.string.isRequired,
   repo: PropTypes.string.isRequired,
   currentRepo: PropTypes.shape({}).isRequired,
-  user: PropTypes.shape({}).isRequired,
   notify: PropTypes.func.isRequired,
 };
 

--- a/ui/push-health/Health.jsx
+++ b/ui/push-health/Health.jsx
@@ -339,7 +339,6 @@ export default class Health extends React.PureComponent {
                   repo={repo}
                   currentRepo={currentRepo}
                   revision={revision}
-                  user={user}
                   notify={this.notify}
                   expanded={testsExpanded}
                   setExpanded={this.setExpanded}

--- a/ui/push-health/TestFailure.jsx
+++ b/ui/push-health/TestFailure.jsx
@@ -36,14 +36,8 @@ class TestFailure extends React.PureComponent {
   };
 
   retriggerJob = async job => {
-    const { user, notify, currentRepo } = this.props;
+    const { notify, currentRepo } = this.props;
 
-    if (!user.isLoggedIn) {
-      notify('Must be logged in to retrigger a job', 'danger', {
-        sticky: true,
-      });
-      return;
-    }
     JobModel.retrigger([job], currentRepo, notify);
   };
 
@@ -249,9 +243,6 @@ TestFailure.propTypes = {
   }).isRequired,
   repo: PropTypes.string.isRequired,
   currentRepo: PropTypes.shape({}).isRequired,
-  user: PropTypes.shape({
-    isLoggedIn: PropTypes.bool,
-  }).isRequired,
   revision: PropTypes.string.isRequired,
   notify: PropTypes.func.isRequired,
   groupedBy: PropTypes.string.isRequired,

--- a/ui/push-health/TestMetric.jsx
+++ b/ui/push-health/TestMetric.jsx
@@ -12,7 +12,6 @@ export default class TestMetric extends React.PureComponent {
       data,
       repo,
       revision,
-      user,
       notify,
       currentRepo,
       expanded,
@@ -57,7 +56,6 @@ export default class TestMetric extends React.PureComponent {
               filteredNeedInvestigation.length ? 'danger' : 'darker-secondary'
             }
             unfilteredLength={needInvestigation.length}
-            user={user}
             hasRetriggerAll
             notify={notify}
           />
@@ -71,7 +69,6 @@ export default class TestMetric extends React.PureComponent {
             headerColor="darker-secondary"
             unfilteredLength={knownIssues.length}
             expanded={false}
-            user={user}
             hasRetriggerAll
             notify={notify}
           />
@@ -100,7 +97,6 @@ TestMetric.propTypes = {
       unsupported: PropTypes.array.isRequired,
     }).isRequired,
   }).isRequired,
-  user: PropTypes.shape({}).isRequired,
   repo: PropTypes.string.isRequired,
   currentRepo: PropTypes.shape({}).isRequired,
   revision: PropTypes.string.isRequired,


### PR DESCRIPTION
Per a chat in-channel, we probably don't really need to require a user to be logged in to retrigger jobs or to access other features (except for classifications, which I left as-is), since we retrieve taskcluster credentials separately and they are used/verified when calling any tc action.
