### PR TITLE
Bug 1627993 - Ignore 'test_groups' data from errorsummary.log.

### DIFF
--- a/treeherder/log_parser/crossreference.py
+++ b/treeherder/log_parser/crossreference.py
@@ -94,7 +94,7 @@ def failure_line_summary(formatter, failure_line):
     """
     if failure_line.action == "test_result":
         action = "test_status" if failure_line.subtest is not None else "test_end"
-    elif failure_line.action == "truncated":
+    elif failure_line.action in ["test_groups", "truncated"]:
         return
     else:
         action = failure_line.action


### PR DESCRIPTION
The 'test_groups' data got added in bug 1340551 to track which test manifests
contributed tests to the current task. It is not needed as part of the test
output and should be ignored.