### PR TITLE
Modify cycle_data for prototype2

### DIFF
--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -6,6 +6,7 @@ from django.db.utils import OperationalError
 
 from treeherder.model.models import Job, JobGroup, JobType, Machine
 from treeherder.perf.models import PerformanceDatum
+from django.conf import settings
 
 logging.basicConfig(format='%(levelname)s:%(message)s')
 
@@ -77,7 +78,10 @@ class PerfherderCycler(DataCycler):
 
     def __init__(self, days, chunk_size, sleep_time, is_debug=None, logger=None, **kwargs):
         super().__init__(days, chunk_size, sleep_time, is_debug, logger)
-        if days < MINIMUM_PERFHERDER_EXPIRE_INTERVAL:
+        if (
+            days < MINIMUM_PERFHERDER_EXPIRE_INTERVAL
+            and settings.SITE_HOSTNAME != 'treeherder-prototype2.herokuapp.com'
+        ):
             raise ValueError(
                 'Cannot remove performance data that is more recent than {} days'.format(
                     MINIMUM_PERFHERDER_EXPIRE_INTERVAL


### PR DESCRIPTION
Add an exception to the `days` restriction for prototype2. I thought about adding a `--force` option instead but it might be too dangerous since we only want to have less Perf data for this one deployment. (Prototype2 has a smaller database and Ionut said 30 days was probably sufficient).