### PR TITLE
Bug 1634099 - Add push date and author to commits list

### DIFF
--- a/tests/push_health/test_compare.py
+++ b/tests/push_health/test_compare.py
@@ -7,7 +7,14 @@ from treeherder.push_health.compare import get_commit_history, get_response_obje
 
 
 def test_get_response_object(test_push, test_repository):
-    resp = get_response_object('1234', [1, 2], 2, test_push, test_repository)
+    test_revision = 'abcdef77949168d16c03a4cba167678b7ab65f76'
+    current_push = Push.objects.create(
+        revision=test_revision,
+        repository=test_repository,
+        author='foo@bar.baz',
+        time=datetime.datetime.now(),
+    )
+    resp = get_response_object('1234', [1, 2], 2, test_push, test_repository, current_push)
     assert resp['parentSha'] == '1234'
     assert resp['id'] == 1
     assert resp['exactMatch'] is False

--- a/tests/ui/mock/push_health.json
+++ b/tests/ui/mock/push_health.json
@@ -42,7 +42,24 @@
             "revision": "cd02b96bdce57d9ae53b632ca4740c871d3ecc32"
           }
         ],
-        "revisionCount": 1
+        "revisionCount": 1,
+        "currentPush": {
+          "id": 701892,
+          "revision": "00e6c3477d8d0c4cd1526768f985b7b26b07b783",
+          "author": "hiro@mozilla.com",
+          "revisions": [
+            {
+              "result_set_id": 701892,
+              "repository_id": 77,
+              "revision": "00e6c3477d8d0c4cd1526768f985b7b26b07b783",
+              "author": "Hiro Protagonist<hiro@mozilla.com>",
+              "comments": "Bug 1234 - Fixed a thing"
+            }
+          ],
+          "revision_count": 1,
+          "push_timestamp": 1588785809,
+          "repository_id": 77
+        }
       }
     },
     "linting": {

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import sortBy from 'lodash/sortBy';
+import { Col } from 'reactstrap';
 
 import {
   thEvents,
@@ -634,23 +635,25 @@ class Push extends React.PureComponent {
         {!collapsed ? (
           <div className="row push clearfix">
             {currentRepo && (
-              <RevisionList
-                revision={revision}
-                revisions={revisions}
-                revisionCount={revisionCount}
-                repo={currentRepo}
-                widthClass="col-5"
-              >
-                {filteredTryPush && (
-                  <div className="ml-3 mt-4">
-                    <PushHealthSummary
-                      healthStatus={pushHealthStatus}
-                      revision={revision}
-                      repoName={currentRepo.name}
-                    />
-                  </div>
-                )}
-              </RevisionList>
+              <Col className="col-5">
+                <RevisionList
+                  revision={revision}
+                  revisions={revisions}
+                  revisionCount={revisionCount}
+                  repo={currentRepo}
+                  widthClass="ml-4"
+                >
+                  {filteredTryPush && (
+                    <div className="ml-3 mt-4">
+                      <PushHealthSummary
+                        healthStatus={pushHealthStatus}
+                        revision={revision}
+                        repoName={currentRepo.name}
+                      />
+                    </div>
+                  )}
+                </RevisionList>
+              </Col>
             )}
             <span className="job-list job-list-pad col-7">
               <PushJobs

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -20,6 +20,7 @@ import { getJobsUrl } from '../../helpers/url';
 import PushModel from '../../models/push';
 import JobModel from '../../models/job';
 import PushHealthStatus from '../../shared/PushHealthStatus';
+import PushAuthor from '../../shared/PushAuthor';
 import { getUrlParam, setUrlParam } from '../../helpers/location';
 import { notify } from '../redux/stores/notifications';
 import { setSelectedJob } from '../redux/stores/selectedJob';
@@ -38,22 +39,6 @@ const SKIPPED_LINK_PARAMS = [
   'enddate',
   'author',
 ];
-
-function Author(props) {
-  const authorMatch = props.author.match(/<(.*?)>+/);
-  const authorEmail = authorMatch ? authorMatch[1] : props.author;
-
-  return (
-    <span title="View pushes by this user" className="push-author">
-      <a href={props.url}>{authorEmail}</a>
-    </span>
-  );
-}
-
-Author.propTypes = {
-  author: PropTypes.string.isRequired,
-  url: PropTypes.string.isRequired,
-};
 
 function PushCounts(props) {
   const { pending, running, completed, fixedByCommit } = props;
@@ -286,7 +271,7 @@ class PushHeader extends React.Component {
                 </a>{' '}
                 -{' '}
               </span>
-              <Author author={author} url={authorPushFilterUrl} />
+              <PushAuthor author={author} url={authorPushFilterUrl} />
             </span>
           </span>
           {showPushHealthStatus && (

--- a/ui/push-health/pushhealth.css
+++ b/ui/push-health/pushhealth.css
@@ -14,3 +14,7 @@
 .table-fixed {
   table-layout: fixed;
 }
+
+.revision {
+  font-size: 12px;
+}

--- a/ui/shared/PushAuthor.jsx
+++ b/ui/shared/PushAuthor.jsx
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default function Author(props) {
+  const authorMatch = props.author.match(/<(.*?)>+/);
+  const authorEmail = authorMatch ? authorMatch[1] : props.author;
+
+  return (
+    <span title="View pushes by this user" className="push-author">
+      <a href={props.url}>{authorEmail}</a>
+    </span>
+  );
+}
+
+Author.propTypes = {
+  author: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+};

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -73,12 +73,12 @@ export class Revision extends React.PureComponent {
 
     return (
       <Row
-        className="revision ml-1 flex-nowrap"
+        className="revision flex-nowrap"
         onMouseEnter={() => this.showClipboard(true)}
         onMouseLeave={() => this.showClipboard(false)}
         data-testid="revision"
       >
-        <span className="pl-4 pr-1 text-nowrap">
+        <span className="pr-1 text-nowrap">
           <Clipboard
             description="full hash"
             text={commitRevision}


### PR DESCRIPTION
This takes the commits area and borrows some prior art from Treeherder.  The intention is to make it a little more familiar to what folks are accustomed to seeing.

<img width="743" alt="Screenshot 2020-04-30 15 23 35" src="https://user-images.githubusercontent.com/419924/80764921-98e5b400-8af6-11ea-927b-9766e77f7eb3.png">
