### PR TITLE
Reduce logging

### DIFF
--- a/treeherder/etl/perf.py
+++ b/treeherder/etl/perf.py
@@ -77,6 +77,8 @@ def _load_perf_datum(job, perf_datum):
     try:
         framework = PerformanceFramework.objects.get(name=perf_datum['framework']['name'])
     except PerformanceFramework.DoesNotExist:
+        if perf_datum['framework']['name'] == "job_resource_usage":
+            return
         logger.warning(
             "Performance framework %s does not exist, skipping " "load of performance artifacts",
             perf_datum['framework']['name'],

--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -57,7 +57,7 @@ class HgPushlogProcess:
 
         if not changeset and last_push_id:
             startid_url = "{}&startID={}".format(source_url, last_push_id)
-            logger.info(
+            logger.debug(
                 "Extracted last push for '%s', '%s', from cache, "
                 "attempting to get changes only from that point at: %s",
                 repository_name,

--- a/treeherder/etl/taskcluster_pulse/handler.py
+++ b/treeherder/etl/taskcluster_pulse/handler.py
@@ -132,7 +132,7 @@ async def handleMessage(message, taskDefinition=None):
         if envs["MOBILE_BASE_REPOSITORY"] == "https://github.com/mozilla-mobile/android-components":
             # Ignore tasks that are associated to a pull request
             if envs["MOBILE_BASE_REPOSITORY"] != envs["MOBILE_HEAD_REPOSITORY"]:
-                logger.info("Task: %s belong to a pull request which we ignore.", taskId)
+                logger.debug("Task: %s belong to a pull request which we ignore.", taskId)
                 return jobs
             # Bug 1587542 - Temporary change to ignore Github tasks not associated to 'master'
             if envs["MOBILE_HEAD_REF"] != "refs/heads/master":

--- a/treeherder/push_health/tests.py
+++ b/treeherder/push_health/tests.py
@@ -192,7 +192,7 @@ def has_line(failure_line, log_line_list):
 
 
 def get_test_failures(push, parent_push=None):
-    logger.info('Getting test failures for push: {}'.format(push.id))
+    logger.debug('Getting test failures for push: {}'.format(push.id))
     # query for jobs for the last two weeks excluding today
     # find tests that have failed in the last 14 days
     # this is very cache-able for reuse on other pushes.


### PR DESCRIPTION
These messages are producing too much noise in Papertrail.
These account for a big chunks of all of the logging.