### PR TITLE
Bug 1637526 Show tooltip information properly when some of them are missing

### DIFF
--- a/ui/perfherder/graphs/GraphTooltip.jsx
+++ b/ui/perfherder/graphs/GraphTooltip.jsx
@@ -190,18 +190,18 @@ const GraphTooltip = ({
           </div>
 
           <div>
-            {prevRevision && (
-              <span>
-                <a href={pushUrl} target="_blank" rel="noopener noreferrer">
-                  {dataPointDetails.revision.slice(0, 13)}
-                </a>{' '}
-                (
-                {dataPointDetails.jobId && (
-                  <a href={jobsUrl} target="_blank" rel="noopener noreferrer">
-                    job
-                  </a>
-                )}
-                ,{' '}
+            <span>
+              <a href={pushUrl} target="_blank" rel="noopener noreferrer">
+                {dataPointDetails.revision.slice(0, 13)}
+              </a>{' '}
+              {(dataPointDetails.jobId || prevRevision) && '('}
+              {dataPointDetails.jobId && (
+                <a href={jobsUrl} target="_blank" rel="noopener noreferrer">
+                  job
+                </a>
+              )}
+              {dataPointDetails.jobId && prevRevision && ', '}
+              {prevRevision && (
                 <a
                   href={`#/comparesubtest${createQueryParams({
                     originalProject: testDetails.repository_name,
@@ -219,14 +219,14 @@ const GraphTooltip = ({
                 >
                   compare
                 </a>
-                ){' '}
-                <Clipboard
-                  text={dataPointDetails.revision}
-                  description="Revision"
-                  outline
-                />
-              </span>
-            )}
+              )}
+              {(dataPointDetails.jobId || prevRevision) && ') '}
+              <Clipboard
+                text={dataPointDetails.revision}
+                description="Revision"
+                outline
+              />
+            </span>
             {dataPointDetails.alertSummary && (
               <p>
                 <a


### PR DESCRIPTION
When there are no previous revisions or the jobs are older than 4 months, the job link is missing. This PR is showing the data properly when one of those links are [missing](https://treeherder.mozilla.org/perf.html#/graphs?highlightAlerts=1&series=autoland,1925871,1,1&timerange=31536000&zoom=1557598427458,1558233523623,14.807632501856,47.513514917235895).

- [x] When the data-point is the very first of the graph, the tool-tip doesn't show job nor comparison link. It can show the job link
- [x] When the data-point is older than 4 months, the tool-tip shows ` hash (, compare)`. The comma will be removed
- [x] When the data-point is older then 4 months and is the very first of the graph, the tool-tip doesn't show the hash link (pushlog) nor jobs and compare links. It will show the hash link.

Example:
**Datapoint is very first**
Before: [tool-tip showing hash, job nor compare links](https://treeherder.mozilla.org/perf.html#/graphs?highlightAlerts=1&selected=1925871,808954023&series=autoland,1925871,1,1&timerange=31536000&zoom=1557598427458,1558233523623,14.807632501856,47.513514917235895)
![Screenshot from 2020-05-13 12-40-22](https://user-images.githubusercontent.com/47977085/81797287-3e495080-9517-11ea-93a9-59bcb76fb7ff.png)
After: tool-tip showing hash and job links
![Screenshot from 2020-05-13 12-40-39](https://user-images.githubusercontent.com/47977085/81797353-53be7a80-9517-11ea-9a8f-c9c21aa6f099.png)
