### PR TITLE
Bug 1634263 - Alerts view's text search doesn't filter related alerts

### DIFF
--- a/ui/perfherder/helpers.js
+++ b/ui/perfherder/helpers.js
@@ -560,11 +560,7 @@ export const getStatus = (statusNum, statusMap = summaryStatusMap) => {
 };
 
 export const containsText = (string, text) => {
-  const words = text
-    .split(' ')
-    .map((word) => `(?=.*${word})`)
-    .join('');
-  const regex = RegExp(words, 'gi');
+  const regex = RegExp(text, 'gi');
   return regex.test(string);
 };
 


### PR DESCRIPTION
Changed filter in Alerts view to find all matches for filter text, not just whole word matches