### PR TITLE
Bug 1637022 - Convert crossreference logging to info

### DIFF
--- a/treeherder/autoclassify/autoclassify.py
+++ b/treeherder/autoclassify/autoclassify.py
@@ -39,11 +39,11 @@ def match_errors(job, matchers=None):
     # error lines even in jobs marked as passing.
 
     if job.autoclassify_status < Job.CROSSREFERENCED:
-        logger.error("Tried to autoclassify job %i without crossreferenced error lines", job.id)
+        logger.info("Tried to autoclassify job %i without crossreferenced error lines", job.id)
         return
 
     if job.autoclassify_status == Job.AUTOCLASSIFIED:
-        logger.error("Tried to autoclassify job %i which was already autoclassified", job.id)
+        logger.info("Tried to autoclassify job %i which was already autoclassified", job.id)
         return
 
     if job.result not in ["testfailed", "busted", "exception"]:
@@ -80,7 +80,7 @@ def match_errors(job, matchers=None):
 
         create_note(job, all_matched)
     except Exception:
-        logger.error("Autoclassification of job %s failed", job.id)
+        logger.info("Autoclassification of job %s failed", job.id)
         job.autoclassify_status = Job.FAILED
         raise
     else:

--- a/treeherder/log_parser/crossreference.py
+++ b/treeherder/log_parser/crossreference.py
@@ -28,7 +28,7 @@ def crossreference_job(job):
     except IntegrityError:
         job.autoclassify_status = Job.FAILED
         job.save(update_fields=['autoclassify_status'])
-        logger.warning("IntegrityError crossreferencing error lines for job %s", job.id)
+        logger.info("IntegrityError crossreferencing error lines for job %s", job.id)
         return False
 
     job.autoclassify_status = Job.CROSSREFERENCED
@@ -64,7 +64,7 @@ def _crossreference(job):
         # We can have a line without a pattern at the end if the log is truncated
         if failure_line is None:
             break
-        logger.warning(
+        logger.info(
             "Crossreference %s: Failed to match structured line '%s' to an unstructured line",
             job.id,
             repr_str,
@@ -102,7 +102,7 @@ def failure_line_summary(formatter, failure_line):
     try:
         mozlog_func = getattr(formatter, action)
     except AttributeError:
-        logger.warning('Unknown mozlog function "%s"', action)
+        logger.info('Unknown mozlog function "%s"', action)
         return
 
     formatted_log = mozlog_func(failure_line.to_mozlog_format())


### PR DESCRIPTION
This just changes the logging to info, which I believe we filter out on production.  So a short term logging cleanup until I finish removing the crossreferencing tasks and actions.