### PR TITLE
Merge autoclassify workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -47,8 +47,8 @@ worker_store_pulse_data: REMAP_SIGTERM=SIGQUIT newrelic-admin run-program celery
 # Handles the log parsing tasks scheduled by `worker_store_pulse_data` as part of job ingestion.
 worker_log_parser: REMAP_SIGTERM=SIGQUIT newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_parser --concurrency=7
 worker_log_parser_fail: REMAP_SIGTERM=SIGQUIT newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_parser_fail --concurrency=1
-worker_log_parser_autoclassify: REMAP_SIGTERM=SIGQUIT newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_autoclassify --concurrency=7
-worker_log_parser_autoclassify_fail: REMAP_SIGTERM=SIGQUIT newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_autoclassify_fail --concurrency=7
 
+# Autoclassify workers
+worker_autoclassify: REMAP_SIGTERM=SIGQUIT newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_autoclassify,log_autoclassify_fail --concurrency=3
 # Tasks that don't need a dedicated worker.
 worker_misc: REMAP_SIGTERM=SIGQUIT newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q default,generate_perf_alerts,pushlog,seta_analyze_failures --concurrency=3


### PR DESCRIPTION
Since they're not utilizing the worker enough.
I'm also lowering from concurrency of 7 to 3 since these are low memory workers.

We see barely some load.
<img width="963" alt="image" src="https://user-images.githubusercontent.com/44410/83270092-fe7c9d00-a195-11ea-97c0-6f147180a406.png">
