### PR TITLE
Point shellcheck-py to new location

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@ repos:
     rev: 3.7.9
     hooks:
       - id: flake8
-  - repo: https://github.com/ryanrhee/shellcheck-py
-    rev: v0.7.0.1-1
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.7.1.1
     hooks:
       - id: shellcheck
   - repo: https://github.com/prettier/prettier


### PR DESCRIPTION
Travis started failling because it was pointing to the original location.