### PR TITLE
Remove joint Pulse consumer from Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -38,8 +38,6 @@ celery_scheduler: REMAP_SIGTERM=SIGQUIT newrelic-admin run-program celery beat -
 # TODO: Merge these two listeners into one since they use so little CPU each (bug 1530965).
 pulse_listener_pushes: newrelic-admin run-program ./manage.py pulse_listener_pushes
 pulse_listener_tasks: newrelic-admin run-program ./manage.py pulse_listener_tasks
-# Both Pulse listeners; for now, do not run at the same time as the othe ones. 
-pulse_listener: newrelic-admin run-program ./manage.py pulse_listener
 
 # Processes pushes/jobs from Pulse that were collected by `pulse_listener_{pushes,tasks}`.
 worker_store_pulse_data: REMAP_SIGTERM=SIGQUIT newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q store_pulse_pushes,store_pulse_tasks --concurrency=3


### PR DESCRIPTION
It sometimes confuses me. Once we decide to switch over we can add it back.

That ingestion command is only used for the Docker set up.