### PR TITLE
Bug 1539792 -- Tooltip for "bug xxxxxx" shows the commit message rather than the bug summary

### DIFF
--- a/tests/ui/job-view/App_test.jsx
+++ b/tests/ui/job-view/App_test.jsx
@@ -66,6 +66,12 @@ describe('App', () => {
       'begin:https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2',
       404,
     );
+    fetchMock.get(
+      'https://bugzilla.mozilla.org/rest/bug?id=1556854%2C1555861%2C1559418%2C1563766%2C1561537%2C1563692',
+      {
+        bugs: [],
+      },
+    );
 
     // Need to mock this function for the app switching tests.
     // Source: https://github.com/mui-org/material-ui/issues/15726#issuecomment-493124813

--- a/tests/ui/job-view/Filtering_test.jsx
+++ b/tests/ui/job-view/Filtering_test.jsx
@@ -10,7 +10,7 @@ import {
 import App from '../../../ui/job-view/App';
 import reposFixture from '../mock/repositories';
 import pushListFixture from '../mock/push_list';
-import { getApiUrl } from '../../../ui/helpers/url';
+import { getApiUrl, bzBaseUrl } from '../../../ui/helpers/url';
 import {
   getProjectUrl,
   replaceLocation,
@@ -31,6 +31,9 @@ const treeStatusResponse = {
 const emptyPushResponse = {
   results: [],
 };
+const emptyBzResponse = {
+  bugs: [{ id: '', summary: '' }],
+};
 
 describe('Filtering', () => {
   beforeAll(() => {
@@ -40,6 +43,7 @@ describe('Filtering', () => {
     fetchMock.get(getApiUrl('/repository/'), reposFixture);
     fetchMock.get(getApiUrl('/user/'), []);
     fetchMock.get(getApiUrl('/failureclassification/'), []);
+    fetchMock.get(`begin:${bzBaseUrl}rest/bug`, emptyBzResponse);
     fetchMock.get(
       'begin:https://treestatus.mozilla-releng.net/trees/',
       treeStatusResponse,

--- a/tests/ui/job-view/Filtering_test.jsx
+++ b/tests/ui/job-view/Filtering_test.jsx
@@ -32,7 +32,7 @@ const emptyPushResponse = {
   results: [],
 };
 const emptyBzResponse = {
-  bugs: [{ id: '', summary: '' }],
+  bugs: [],
 };
 
 describe('Filtering', () => {

--- a/tests/ui/job-view/PushList_test.jsx
+++ b/tests/ui/job-view/PushList_test.jsx
@@ -233,6 +233,9 @@ describe('PushList', () => {
       `begin:${getApiUrl('/jobs/?push_id=', repoName)}`,
       jobListFixtureOne,
     );
+    fetchMock.get(`begin:https://bugzilla.mozilla.org/rest/bug`, {
+      bugs: [],
+    });
 
     expect(await pushCount()).toHaveLength(2);
 
@@ -262,6 +265,14 @@ describe('PushList', () => {
     const jobEl = await waitFor(() => getByText('yaml'));
     const jobInstance = findJobInstance(jobEl.getAttribute('data-job-id'));
     const { job } = jobInstance.props;
+
+    fetchMock.get(
+      `begin:https://bugzilla.mozilla.org/rest/bug`,
+      {
+        bugs: [],
+      },
+      { overwriteRoutes: false },
+    );
 
     expect(job.signature).toBe('306fd1e8d922922cd171fa31f0d914300ff52228');
     expect(job.job_type_name).toBe('source-test-mozlint-yaml');

--- a/tests/ui/job-view/revisions_test.jsx
+++ b/tests/ui/job-view/revisions_test.jsx
@@ -31,6 +31,11 @@ const push = {
   author: 'ryanvm@gmail.com',
   push_timestamp: 1481326280,
   repository_id: 2,
+  bugSummaryMap: {
+    1319926: 'foo',
+    1322743: 'foo',
+    1506219: 'foo',
+  },
   revisions: [
     {
       result_set_id: 151371,
@@ -77,6 +82,7 @@ describe('Revision list component', () => {
         revision={push.revision}
         revisions={push.revisions}
         revisionCount={push.revision_count}
+        bugSummaryMap={push.bugSummaryMap}
       />,
     );
 
@@ -92,6 +98,7 @@ describe('Revision list component', () => {
         revision={push.revision}
         revisions={push.revisions}
         revisionCount={push.revision_count}
+        bugSummaryMap={push.bugSummaryMap}
       />,
     );
     expect(getByText('\u2026and more')).toBeInTheDocument();

--- a/tests/ui/job-view/revisions_test.jsx
+++ b/tests/ui/job-view/revisions_test.jsx
@@ -32,9 +32,8 @@ const push = {
   push_timestamp: 1481326280,
   repository_id: 2,
   bugSummaryMap: {
+    1322565: 'foo',
     1319926: 'foo',
-    1322743: 'foo',
-    1506219: 'foo',
   },
   revisions: [
     {
@@ -108,7 +107,11 @@ describe('Revision list component', () => {
 describe('Revision item component', () => {
   test('renders a linked revision', async () => {
     const { getByTitle, getByText } = render(
-      <Revision repo={repo} revision={revision} />,
+      <Revision
+        repo={repo}
+        revision={revision}
+        bugSummaryMap={push.bugSummaryMap}
+      />,
     );
     const revLink = await waitFor(() => getByText('5a110ad242ea'));
 
@@ -121,24 +124,38 @@ describe('Revision item component', () => {
   });
 
   test("renders the contributors' initials", () => {
-    const { getByText } = render(<Revision repo={repo} revision={revision} />);
+    const { getByText } = render(
+      <Revision
+        repo={repo}
+        revision={revision}
+        bugSummaryMap={push.bugSummaryMap}
+      />,
+    );
     expect(getByText('AB')).toBeInTheDocument();
   });
 
-  test('linkifies bug IDs in the comments', () => {
-    const { getByTitle } = render(<Revision repo={repo} revision={revision} />);
+  // test('linkifies bug IDs in the comments', () => {
+  //   const { getByTestId } = render(
+  //     <Revision
+  //       repo={repo}
+  //       revision={revision}
+  //       bugSummaryMap={push.bugSummaryMap}
+  //     />,
+  //   );
 
-    expect(
-      getByTitle(
-        'Bug 1319926 - Part 2: Collect telemetry about deprecated String generics methods. r=jandem',
-      ),
-    ).toBeInTheDocument();
-  });
+  //   expect(getByTestId('revision1319926')).toBeInTheDocument();
+  // });
 
   test('marks the revision as backed out if the words "Back out" appear in the comments', () => {
     revision.comments =
       'Back out changeset a6e2d96c1274 (bug 1322565) for eslint failure';
-    render(<Revision repo={repo} revision={revision} />);
+    render(
+      <Revision
+        repo={repo}
+        revision={revision}
+        bugSummaryMap={push.bugSummaryMap}
+      />,
+    );
 
     expect(document.querySelectorAll('.text-danger')).toHaveLength(1);
   });
@@ -146,7 +163,13 @@ describe('Revision item component', () => {
   test('marks the revision as backed out if the words "Backed out" appear in the comments', () => {
     revision.comments =
       'Backed out changeset a6e2d96c1274 (bug 1322565) for eslint failure';
-    render(<Revision repo={repo} revision={revision} />);
+    render(
+      <Revision
+        repo={repo}
+        revision={revision}
+        bugSummaryMap={push.bugSummaryMap}
+      />,
+    );
 
     expect(document.querySelectorAll('.text-danger')).toHaveLength(1);
   });

--- a/tests/ui/job-view/revisions_test.jsx
+++ b/tests/ui/job-view/revisions_test.jsx
@@ -134,17 +134,21 @@ describe('Revision item component', () => {
     expect(getByText('AB')).toBeInTheDocument();
   });
 
-  // test('linkifies bug IDs in the comments', () => {
-  //   const { getByTestId } = render(
-  //     <Revision
-  //       repo={repo}
-  //       revision={revision}
-  //       bugSummaryMap={push.bugSummaryMap}
-  //     />,
-  //   );
+  test('linkifies bug IDs in the comments', () => {
+    const { getByTestId } = render(
+      <Revision
+        repo={repo}
+        revision={revision}
+        bugSummaryMap={push.bugSummaryMap}
+      />,
+    );
 
-  //   expect(getByTestId('revision1319926')).toBeInTheDocument();
-  // });
+    expect(
+      getByTestId(
+        'Bug 1319926 - Part 2: Collect telemetry about deprecated String generics methods. r=jandem',
+      ),
+    ).toBeInTheDocument();
+  });
 
   test('marks the revision as backed out if the words "Back out" appear in the comments', () => {
     revision.comments =

--- a/tests/ui/job-view/stores/pushes_test.jsx
+++ b/tests/ui/job-view/stores/pushes_test.jsx
@@ -33,6 +33,9 @@ import { getApiUrl } from '../../../../ui/helpers/url';
 import JobModel from '../../../../ui/models/job';
 
 const mockStore = configureMockStore([thunk]);
+const emptyBugzillaResponse = {
+  bugs: [],
+};
 
 describe('Pushes Redux store', () => {
   const repoName = 'autoland';
@@ -52,6 +55,10 @@ describe('Pushes Redux store', () => {
     fetchMock.get(
       getProjectUrl('/push/?full=true&count=10', repoName),
       pushListFixture,
+    );
+    fetchMock.get(
+      `https://bugzilla.mozilla.org/rest/bug?id=1556854%2C1555861%2C1559418%2C1563766%2C1561537%2C1563692`,
+      emptyBugzillaResponse,
     );
     const store = mockStore({ pushes: initialState });
 
@@ -135,6 +142,11 @@ describe('Pushes Redux store', () => {
       pollPushListFixture,
     );
 
+    fetchMock.get(
+      `https://bugzilla.mozilla.org/rest/bug?id=1506219`,
+      emptyBugzillaResponse,
+    );
+
     const push = pushListFixture.results[0];
     const store = mockStore({
       pushes: {
@@ -184,6 +196,11 @@ describe('Pushes Redux store', () => {
         repoName,
       ),
       pushListFromChangeFixture,
+    );
+
+    fetchMock.get(
+      `https://bugzilla.mozilla.org/rest/bug?id=1556854`,
+      emptyBugzillaResponse,
     );
 
     const store = mockStore({

--- a/ui/css/treeherder-pushes.css
+++ b/ui/css/treeherder-pushes.css
@@ -135,6 +135,16 @@ fieldset[disabled] .btn-push:hover {
 }
 
 /*
+ * Revision
+ */
+
+.tooltip-content {
+  text-align: left;
+  min-width: 100%;
+  max-width: 100%;
+}
+
+/*
  * Job table
  */
 

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -558,6 +558,7 @@ class Push extends React.PureComponent {
       isOnlyRevision,
       pushHealthVisibility,
       decisionTaskMap,
+      bugSummaryMap,
     } = this.props;
     const {
       fuzzyJobList,
@@ -645,6 +646,7 @@ class Push extends React.PureComponent {
                   revisions={revisions}
                   revisionCount={revisionCount}
                   repo={currentRepo}
+                  bugSummaryMap={bugSummaryMap}
                   widthClass="ml-4"
                 >
                   {showPushHealthSummary && (
@@ -706,13 +708,15 @@ Push.propTypes = {
   isOnlyRevision: PropTypes.bool.isRequired,
   pushHealthVisibility: PropTypes.string.isRequired,
   decisionTaskMap: PropTypes.shape({}).isRequired,
+  bugSummaryMap: PropTypes.shape({}).isRequired,
 };
 
 const mapStateToProps = ({
-  pushes: { allUnclassifiedFailureCount, decisionTaskMap },
+  pushes: { allUnclassifiedFailureCount, decisionTaskMap, bugSummaryMap },
 }) => ({
   allUnclassifiedFailureCount,
   decisionTaskMap,
+  bugSummaryMap,
 });
 
 export default connect(mapStateToProps, {

--- a/ui/job-view/redux/stores/pushes.js
+++ b/ui/job-view/redux/stores/pushes.js
@@ -62,11 +62,16 @@ const getBugIds = (results) => {
 
 const getBugSummaryMap = async (bugIds, dispatch, oldBugSummaryMap) => {
   const bugNumbers = [...bugIds];
-  const { data } = await getData(bugzillaBugsApi('bug', { id: bugNumbers }));
-  const bugData = data.bugs.reduce((accumulator, curBug) => {
-    accumulator[curBug.id] = curBug.summary;
-    return accumulator;
-  }, {});
+  const { data } =
+    bugNumbers.length > 0
+      ? await getData(bugzillaBugsApi('bug', { id: bugNumbers }))
+      : {};
+  const bugData = data
+    ? data.bugs.reduce((accumulator, curBug) => {
+        accumulator[curBug.id] = curBug.summary;
+        return accumulator;
+      }, {})
+    : {};
   const result = { ...bugData, ...oldBugSummaryMap };
 
   dispatch({

--- a/ui/job-view/redux/stores/pushes.js
+++ b/ui/job-view/redux/stores/pushes.js
@@ -58,7 +58,7 @@ const getBugIds = (results) => {
   return bugIds;
 };
 
-const getBugSummaryMap = async (bugIds, newStuff, dispatch) => {
+const getBugSummaryMap = async (bugIds, dispatch) => {
   const bugNumbers = [...bugIds];
   const { data } = await getData(bugzillaBugsApi('bug', { id: bugNumbers }));
   const bugData = data.bugs.reduce((accumulator, curBug) => {
@@ -66,11 +66,9 @@ const getBugSummaryMap = async (bugIds, newStuff, dispatch) => {
     return accumulator;
   }, {});
 
-  newStuff.bugSummaryMap = bugData;
-
   dispatch({
     type: ADD_PUSHES,
-    pushResults: newStuff,
+    pushResults: { bugSummaryMap: bugData },
   });
 };
 
@@ -131,7 +129,7 @@ const addPushes = (data, pushList, jobMap, setFromchange, dispatch) => {
       ...getRevisionTips(newPushList),
     };
 
-    if (dispatch) getBugSummaryMap(bugIds, newStuff, dispatch);
+    if (dispatch) getBugSummaryMap(bugIds, dispatch);
 
     // since we fetched more pushes, we need to persist the push state in the URL.
     const updatedLastRevision = newPushList[newPushList.length - 1].revision;

--- a/ui/job-view/redux/stores/pushes.js
+++ b/ui/job-view/redux/stores/pushes.js
@@ -3,7 +3,6 @@ import keyBy from 'lodash/keyBy';
 import max from 'lodash/max';
 
 import { parseQueryParams, bugzillaBugsApi } from '../../../helpers/url';
-import { getData } from '../../../helpers/http';
 import {
   getAllUrlParams,
   getQueryString,
@@ -15,7 +14,7 @@ import { getTaskRunStr, isUnclassifiedFailure } from '../../../helpers/job';
 import FilterModel from '../../../models/filter';
 import JobModel from '../../../models/job';
 import { thEvents } from '../../../helpers/constants';
-import { processErrors } from '../../../helpers/http';
+import { processErrors, getData } from '../../../helpers/http';
 
 import { notify } from './notifications';
 import { setSelectedJob, clearSelectedJob } from './selectedJob';
@@ -46,8 +45,10 @@ const getRevisionTips = (pushList) => {
 
 const getBugIds = (results) => {
   const bugIds = new Set();
+
   results.forEach((result) => {
-    const revisions = result.revisions;
+    const { revisions } = result;
+
     revisions.forEach((revision) => {
       const comment = revision.comments.split('\n')[0];
       const bugMatches = comment.match(/-- ([0-9]+)|bug.([0-9]+)/gi);

--- a/ui/job-view/redux/stores/pushes.js
+++ b/ui/job-view/redux/stores/pushes.js
@@ -58,7 +58,7 @@ const getBugIds = (results) => {
   return bugIds;
 };
 
-const getBugSummaryMap = async (bugIds, newStuff) => {
+const getBugSummaryMap = async (bugIds, newStuff, dispatch) => {
   const bugNumbers = [...bugIds];
   const { data } = await getData(bugzillaBugsApi('bug', { id: bugNumbers }));
   const bugData = data.bugs.reduce((accumulator, curBug) => {
@@ -67,7 +67,11 @@ const getBugSummaryMap = async (bugIds, newStuff) => {
   }, {});
 
   newStuff.bugSummaryMap = bugData;
-  // console.log(newStuff);
+
+  dispatch({
+    type: ADD_PUSHES,
+    pushResults: newStuff,
+  });
 };
 
 const getLastModifiedJobTime = (jobMap) => {
@@ -106,7 +110,7 @@ const doRecalculateUnclassifiedCounts = (jobMap) => {
   };
 };
 
-const addPushes = (data, pushList, jobMap, setFromchange) => {
+const addPushes = (data, pushList, jobMap, setFromchange, dispatch) => {
   if (data.results.length > 0) {
     const pushIds = pushList.map((push) => push.id);
     const newPushList = [
@@ -127,8 +131,7 @@ const addPushes = (data, pushList, jobMap, setFromchange) => {
       ...getRevisionTips(newPushList),
     };
 
-    getBugSummaryMap(bugIds, newStuff);
-    // console.log(newStuff);
+    if (dispatch) getBugSummaryMap(bugIds, newStuff, dispatch);
 
     // since we fetched more pushes, we need to persist the push state in the URL.
     const updatedLastRevision = newPushList[newPushList.length - 1].revision;
@@ -267,6 +270,7 @@ export const fetchPushes = (
           pushList,
           jobMap,
           setFromchange,
+          dispatch,
         ),
       });
     }

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -96,14 +96,13 @@ export class Revision extends React.PureComponent {
       revisionComments,
     } = this.props;
     const comment = comments.split('\n')[0];
+    const bugMatches = comment.match(/-- ([0-9]+)|bug.([0-9]+)/gi);
     const { clipboardVisible, ready, tooltipOpen } = this.state;
     const { name, email } = parseAuthor(author);
     const commitRevision = revision;
     const commentColor = this.isBackout(comment)
       ? 'text-danger'
       : 'text-secondary';
-    // console.log(revisionComments);
-
     return (
       <Row
         className="revision flex-nowrap"
@@ -140,9 +139,17 @@ export class Revision extends React.PureComponent {
             isOpen={tooltipOpen}
             toggle={() => this.handleTooltip(comment)}
             target={`revision${revision}`}
+            innerClassName="tooltip-content"
           >
-            {/* {revisionComments} */}
-            asdf
+            {bugMatches.map((bug) => {
+              const bugId = bug.split(' ')[1];
+              return (
+                <div key={bugId}>
+                  Bug {bugId} - {revisionComments[bugId]}
+                </div>
+              );
+            })}
+            <br />
           </Tooltip>
         )}
       </Row>

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -102,6 +102,8 @@ export class Revision extends React.PureComponent {
     const commentColor = this.isBackout(comment)
       ? 'text-danger'
       : 'text-secondary';
+    // console.log(revisionComments);
+
     return (
       <Row
         className="revision flex-nowrap"
@@ -139,7 +141,8 @@ export class Revision extends React.PureComponent {
             toggle={() => this.handleTooltip(comment)}
             target={`revision${revision}`}
           >
-            {revisionComments}
+            {/* {revisionComments} */}
+            asdf
           </Tooltip>
         )}
       </Row>

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -137,18 +137,20 @@ export class Revision extends React.PureComponent {
         {ready && (
           <Tooltip
             isOpen={tooltipOpen}
-            toggle={() => this.handleTooltip(comment)}
+            toggle={() => this.handleTooltip()}
             target={`revision${revision}`}
             innerClassName="tooltip-content"
           >
-            {bugMatches.map((bug) => {
-              const bugId = bug.split(' ')[1];
-              return (
-                <div key={bugId}>
-                  Bug {bugId} - {revisionComments[bugId]}
-                </div>
-              );
-            })}
+            {!!bugMatches &&
+              bugMatches.map((bug) => {
+                const bugId = bug.split(' ')[1];
+                return (
+                  <div key={bugId}>
+                    Bug {bugId} - {revisionComments[bugId]}
+                  </div>
+                );
+              })}
+            {!bugMatches && comment}
             <br />
           </Tooltip>
         )}

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -74,13 +74,12 @@ export class Revision extends React.PureComponent {
       : 'text-secondary';
 
     return (
-      <Row
-        className="revision flex-nowrap"
-        onMouseEnter={() => this.showClipboard(true)}
-        onMouseLeave={() => this.showClipboard(false)}
-        data-testid="revision"
-      >
-        <span className="pr-1 text-nowrap">
+      <Row className="revision flex-nowrap" data-testid="revision">
+        <span
+          onMouseEnter={() => this.showClipboard(true)}
+          onMouseLeave={() => this.showClipboard(false)}
+          className="pr-1 text-nowrap"
+        >
           <Clipboard
             description="full hash"
             text={commitRevision}

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUser } from '@fortawesome/free-regular-svg-icons';
-import { Row, Tooltip } from 'reactstrap';
+import { Row, UncontrolledTooltip } from 'reactstrap';
 
 import { parseAuthor } from '../helpers/revision';
 
@@ -47,39 +47,8 @@ export class Revision extends React.PureComponent {
 
     this.state = {
       clipboardVisible: false,
-      ready: false,
-      tooltipOpen: false,
     };
-    this.spanRef = React.createRef();
   }
-
-  componentDidMount() {
-    this.setReady();
-  }
-
-  componentDidUpdate() {
-    this.setReady();
-  }
-
-  setReady() {
-    if (this.spanRef.current) {
-      this.setState({
-        ready: true,
-      });
-    }
-  }
-
-  handleTooltip = async () => {
-    this.handleTooltipOpen();
-  };
-
-  handleTooltipOpen = () => {
-    this.setState((prevState) => {
-      return {
-        tooltipOpen: !prevState.tooltipOpen,
-      };
-    });
-  };
 
   showClipboard = (show) => {
     this.setState({ clipboardVisible: show });
@@ -97,12 +66,13 @@ export class Revision extends React.PureComponent {
     } = this.props;
     const comment = comments.split('\n')[0];
     const bugMatches = comment.match(/-- ([0-9]+)|bug.([0-9]+)/gi);
-    const { clipboardVisible, ready, tooltipOpen } = this.state;
+    const { clipboardVisible } = this.state;
     const { name, email } = parseAuthor(author);
     const commitRevision = revision;
     const commentColor = this.isBackout(comment)
       ? 'text-danger'
       : 'text-secondary';
+
     return (
       <Row
         className="revision flex-nowrap"
@@ -134,26 +104,22 @@ export class Revision extends React.PureComponent {
             <BugLinkify id={revision}>{comment}</BugLinkify>
           </em>
         </span>
-        {ready && (
-          <Tooltip
-            isOpen={tooltipOpen}
-            toggle={() => this.handleTooltip()}
-            target={`revision${revision}`}
-            innerClassName="tooltip-content"
-          >
-            {!!bugMatches &&
-              bugMatches.map((bug) => {
-                const bugId = bug.split(' ')[1];
-                return (
-                  <div key={bugId}>
-                    Bug {bugId} - {bugSummaryMap[bugId]}
-                  </div>
-                );
-              })}
-            {!bugMatches && comment}
-            <br />
-          </Tooltip>
-        )}
+        <UncontrolledTooltip
+          placement="top-start"
+          innerClassName="tooltip-content"
+          target={`revision${revision}`}
+        >
+          {!!bugMatches &&
+            bugMatches.map((bug) => {
+              const bugId = bug.split(' ')[1];
+              return (
+                <div key={bugId}>
+                  Bug {bugId} - {bugSummaryMap[bugId]}
+                </div>
+              );
+            })}
+          {!bugMatches && comment}
+        </UncontrolledTooltip>
       </Row>
     );
   }

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -93,7 +93,7 @@ export class Revision extends React.PureComponent {
     const {
       revision: { comments, author, revision },
       repo,
-      revisionComments,
+      bugSummaryMap,
     } = this.props;
     const comment = comments.split('\n')[0];
     const bugMatches = comment.match(/-- ([0-9]+)|bug.([0-9]+)/gi);
@@ -146,7 +146,7 @@ export class Revision extends React.PureComponent {
                 const bugId = bug.split(' ')[1];
                 return (
                   <div key={bugId}>
-                    Bug {bugId} - {revisionComments[bugId]}
+                    Bug {bugId} - {bugSummaryMap[bugId]}
                   </div>
                 );
               })}

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -95,6 +95,7 @@ export class Revision extends React.PureComponent {
         </span>
         <AuthorInitials title={`${name}: ${email}`} author={name} />
         <span
+          data-testid={comment}
           className={`ml-2 revision-comment overflow-hidden text-nowrap ${commentColor}`}
           id={`revision${revision}`}
         >

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -96,7 +96,6 @@ export class Revision extends React.PureComponent {
         </span>
         <AuthorInitials title={`${name}: ${email}`} author={name} />
         <span
-          ref={this.spanRef}
           className={`ml-2 revision-comment overflow-hidden text-nowrap ${commentColor}`}
           id={`revision${revision}`}
         >

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -118,7 +118,7 @@ export class Revision extends React.PureComponent {
                 </div>
               );
             })}
-          {!bugSummaryMap && !bugMatches && comment}
+          {comment}
         </UncontrolledTooltip>
       </Row>
     );

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -107,7 +107,8 @@ export class Revision extends React.PureComponent {
           innerClassName="tooltip-content"
           target={`revision${revision}`}
         >
-          {!!bugMatches &&
+          {bugSummaryMap &&
+            !!bugMatches &&
             bugMatches.map((bug) => {
               const bugId = bug.split(' ')[1];
               return (
@@ -116,7 +117,7 @@ export class Revision extends React.PureComponent {
                 </div>
               );
             })}
-          {!bugMatches && comment}
+          {!bugSummaryMap && !bugMatches && comment}
         </UncontrolledTooltip>
       </Row>
     );

--- a/ui/shared/RevisionList.jsx
+++ b/ui/shared/RevisionList.jsx
@@ -20,15 +20,22 @@ export class RevisionList extends React.PureComponent {
 
   componentDidMount() {
     const { revisions } = this.props;
-    revisions.forEach((revision, i) => {
-      this.getRevisionComment(revision.comments, i);
-    });
+    const bugNumbers = revisions.map((revision) =>
+      this.getBugNumbers(revision.comments),
+    );
+    this.getRevisionComments(bugNumbers);
   }
 
-  getRevisionComment = async (comments) => {
+  getBugNumbers = (comments) => {
     const comment = comments.split('\n')[0];
     const bugMatches = comment.match(/-- ([0-9]+)|bug.([0-9]+)/gi);
-    const bugNumbers = bugMatches.map((bugMatch) => bugMatch.split(' ')[1]);
+    const bugNumbers = bugMatches
+      ? bugMatches.map((bugMatch) => bugMatch.split(' ')[1])
+      : [''];
+    return bugNumbers;
+  };
+
+  getRevisionComments = async (bugNumbers) => {
     const { data } = await getData(bugzillaBugsApi('bug', { id: bugNumbers }));
     const bugData = data.bugs.reduce((accumulator, curBug) => {
       accumulator[curBug.id] = curBug.summary;
@@ -49,6 +56,8 @@ export class RevisionList extends React.PureComponent {
       children,
     } = this.props;
 
+    const { revisionComments } = this.state;
+
     return (
       <Col className={`${widthClass} mb-3`}>
         {revisions.map((revision) => (
@@ -56,7 +65,7 @@ export class RevisionList extends React.PureComponent {
             revision={revision}
             repo={repo}
             key={revision.revision}
-            revisionComments={this.state.revisionComments}
+            revisionComments={revisionComments}
           />
         ))}
         {revisionCount > revisions.length && (

--- a/ui/shared/RevisionList.jsx
+++ b/ui/shared/RevisionList.jsx
@@ -20,26 +20,23 @@ export class RevisionList extends React.PureComponent {
 
   componentDidMount() {
     const { revisions } = this.props;
-
     revisions.forEach((revision, i) => {
       this.getRevisionComment(revision.comments, i);
     });
   }
 
-  getRevisionComment = async (comments, i) => {
+  getRevisionComment = async (comments) => {
     const comment = comments.split('\n')[0];
     const bugMatches = comment.match(/-- ([0-9]+)|bug.([0-9]+)/gi);
-    var bugNumbers = '';
-    var bugData = {};
-    bugMatches.forEach((bugMatch) => {
-      bugNumbers += `${bugMatch.split(' ')[1]},`;
-    });
+    const bugNumbers = bugMatches.map((bugMatch) => bugMatch.split(' ')[1]);
     const { data } = await getData(bugzillaBugsApi('bug', { id: bugNumbers }));
-    data.bugs.forEach((curBug) => {
-      bugData[curBug.id] = curBug.summary;
-    });
-    // console.log(bugData);
-    this.setState({ revisionComments: bugData });
+    const bugData = data.bugs.reduce((accumulator, curBug) => {
+      accumulator[curBug.id] = curBug.summary;
+      return accumulator;
+    }, {});
+    this.setState((prev) => ({
+      revisionComments: { ...prev.revisionComments, ...bugData },
+    }));
   };
 
   render() {

--- a/ui/shared/RevisionList.jsx
+++ b/ui/shared/RevisionList.jsx
@@ -29,18 +29,17 @@ export class RevisionList extends React.PureComponent {
   getRevisionComment = async (comments, i) => {
     const comment = comments.split('\n')[0];
     const bugMatches = comment.match(/-- ([0-9]+)|bug.([0-9]+)/gi);
-    console.log(bugMatches);
-    const bugNumber = bugMatches[0].split(' ')[1];
-    const { data } = await getData(bugzillaBugsApi('bug', { id: bugNumber }));
-
-    this.setState((prevState) => {
-      return {
-        revisionComments: {
-          ...prevState.revisionComments,
-          [i]: data.bugs[0].summary,
-        },
-      };
+    var bugNumbers = '';
+    var bugData = {};
+    bugMatches.forEach((bugMatch) => {
+      bugNumbers += `${bugMatch.split(' ')[1]},`;
     });
+    const { data } = await getData(bugzillaBugsApi('bug', { id: bugNumbers }));
+    data.bugs.forEach((curBug) => {
+      bugData[curBug.id] = curBug.summary;
+    });
+    // console.log(bugData);
+    this.setState({ revisionComments: bugData });
   };
 
   render() {
@@ -55,13 +54,12 @@ export class RevisionList extends React.PureComponent {
 
     return (
       <Col className={`${widthClass} mb-3`}>
-        {revisions.map((revision, i) => (
+        {revisions.map((revision) => (
           <Revision
             revision={revision}
             repo={repo}
             key={revision.revision}
-            // revisionComments={this.state.revisionComments[i]}
-            revisionComments={'asdf'}
+            revisionComments={this.state.revisionComments}
           />
         ))}
         {revisionCount > revisions.length && (

--- a/ui/shared/RevisionList.jsx
+++ b/ui/shared/RevisionList.jsx
@@ -4,48 +4,9 @@ import { Col, Row } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExternalLinkSquareAlt } from '@fortawesome/free-solid-svg-icons';
 
-import { getData } from '../helpers/http';
-import { bugzillaBugsApi } from '../helpers/url';
-
 import { Revision } from './Revision';
 
 export class RevisionList extends React.PureComponent {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      revisionComments: {},
-    };
-  }
-
-  componentDidMount() {
-    const { revisions } = this.props;
-    const bugNumbers = revisions.map((revision) =>
-      this.getBugNumbers(revision.comments),
-    );
-    this.getRevisionComments(bugNumbers);
-  }
-
-  getBugNumbers = (comments) => {
-    const comment = comments.split('\n')[0];
-    const bugMatches = comment.match(/-- ([0-9]+)|bug.([0-9]+)/gi);
-    const bugNumbers = bugMatches
-      ? bugMatches.map((bugMatch) => bugMatch.split(' ')[1])
-      : [''];
-    return bugNumbers;
-  };
-
-  getRevisionComments = async (bugNumbers) => {
-    const { data } = await getData(bugzillaBugsApi('bug', { id: bugNumbers }));
-    const bugData = data.bugs.reduce((accumulator, curBug) => {
-      accumulator[curBug.id] = curBug.summary;
-      return accumulator;
-    }, {});
-    this.setState((prev) => ({
-      revisionComments: { ...prev.revisionComments, ...bugData },
-    }));
-  };
-
   render() {
     const {
       revision,
@@ -54,9 +15,8 @@ export class RevisionList extends React.PureComponent {
       repo,
       widthClass,
       children,
+      bugSummaryMap,
     } = this.props;
-
-    const { revisionComments } = this.state;
 
     return (
       <Col className={`${widthClass} mb-3`}>
@@ -65,7 +25,7 @@ export class RevisionList extends React.PureComponent {
             revision={revision}
             repo={repo}
             key={revision.revision}
-            revisionComments={revisionComments}
+            bugSummaryMap={bugSummaryMap}
           />
         ))}
         {revisionCount > revisions.length && (


### PR DESCRIPTION
Hi! I need help understanding BugLinkify.js 
In the scenario where there are multiple bugs that are linkified, I am unsure how to attach a bug summary tooltip for each bug. I already have retrieved the bug summaries from RevisionList.js and passed it as a prop into Revision.js.

![image](https://user-images.githubusercontent.com/10367196/83983483-71071e80-a8f4-11ea-8c4a-5522a5b9868f.png)
In this image, there are different bugs that are linkified. The desired goal would be to hover over each hyperlinked bug and it would show the related bug summary. 
