### PR TITLE
Improve error message handling when fetching taskcluster credentials

### DIFF
--- a/ui/taskcluster-auth-callback/TaskclusterCallback.jsx
+++ b/ui/taskcluster-auth-callback/TaskclusterCallback.jsx
@@ -19,12 +19,15 @@ export default class TaskclusterCallback extends React.PureComponent {
     // We're not using react router's location prop because we can't provide
     // taskcluster with a redirect URI that contains a fragment (hash) per
     // oath2 protocol (which is used by the hash router for parsing query params)
-    const { code, state } = parseQueryParams(window.location.search);
+    const { code, state, error } = parseQueryParams(window.location.search);
     const requestState = localStorage.getItem('requestState');
 
     if (code && requestState && requestState === state) {
       this.getCredentials(code);
     } else {
+      if (error)
+        errorMessage += `We received error: ${error} from Taskcluster.`;
+
       this.setState({
         errorMessage,
       });
@@ -40,13 +43,13 @@ export default class TaskclusterCallback extends React.PureComponent {
     let response = await this.fetchToken(code, rootUrl);
 
     if (response.failureStatus) {
-      this.setState({ errorMessage });
+      this.setState({ errorMessage: `errorMessage ${response.data}` });
       return;
     }
     response = await this.fetchCredentials(response.data.access_token, rootUrl);
 
     if (response.failureStatus) {
-      this.setState({ errorMessage });
+      this.setState({ errorMessage: `errorMessage ${response.data}` });
       return;
     }
     localStorage.setItem(

--- a/ui/taskcluster-auth-callback/constants.js
+++ b/ui/taskcluster-auth-callback/constants.js
@@ -13,7 +13,7 @@ export const clientId = `treeherder-${tcClientIdMap[window.location.origin]}`;
 
 export const redirectURI = `${window.location.origin}${tcAuthCallbackUrl}`;
 
-export const errorMessage = `There was a problem verifying your Taskcluster credentials. Please try again later.`;
+export const errorMessage = 'Unable to retrieve your Taskcluster credentials.';
 
 export const prodFirefoxRootUrl = 'https://firefox-ci-tc.services.mozilla.com';
 


### PR DESCRIPTION
This will hopefully save time for when issues like what happened over a week ago occur again (see this [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1643141)). Taskcluster seems to give pretty vague error messages but it will at least help us determine if its an issue on our end or theirs (or if a users credentials aren't set up correctly).