### PR TITLE
Security update for Django

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -3,7 +3,7 @@ gunicorn==20.0.4
 whitenoise[brotli]==5.0.1
 
 # Used by Whitenoise to provide Brotli-compressed versions of static files.
-Django==3.0.5
+Django>=3.0.7
 celery  # Needed for data ingestion
 simplejson==3.17.0
 newrelic==5.2.1.129

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -3,7 +3,7 @@ gunicorn==20.0.4
 whitenoise[brotli]==5.0.1
 
 # Used by Whitenoise to provide Brotli-compressed versions of static files.
-Django>=3.0.7
+Django==3.0.7
 celery  # Needed for data ingestion
 simplejson==3.17.0
 newrelic==5.2.1.129

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -172,9 +172,9 @@ django-redis==4.11.0 \
     --hash=sha256:a5b1e3ffd3198735e6c529d9bdf38ca3fcb3155515249b98dc4d966b8ddf9d2b \
     --hash=sha256:e1aad4cc5bd743d8d0b13d5cae0cef5410eaace33e83bff5fc3a139ad8db50b4 \
     # via -r requirements/common.in
-django==3.0.5 \
-    --hash=sha256:642d8eceab321ca743ae71e0f985ff8fdca59f07aab3a9fb362c617d23e33a76 \
-    --hash=sha256:d4666c2edefa38c5ede0ec1655424c56dc47ceb04b6d8d62a7eac09db89545c1 \
+django==3.0.7 \
+    --hash=sha256:5052b34b34b3425233c682e0e11d658fd6efd587d11335a0203d827224ada8f2 \
+    --hash=sha256:e1630333248c9b3d4e38f02093a26f1e07b271ca896d73097457996e0fae12e8 \
     # via -r requirements/common.in, django-cors-headers, django-filter, django-redis, djangorestframework
 djangorestframework==3.11.0 \
     --hash=sha256:05809fc66e1c997fd9a32ea5730d9f4ba28b109b9da71fccfa5ff241201fd0a4 \

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -32,3 +32,6 @@ betamax-serializers
 
 # make pinning versions easier
 pip-tools
+
+# Force updating to secure version
+Django>=3.0.7

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,10 +12,6 @@ asgiref==3.2.7 \
     --hash=sha256:8036f90603c54e93521e5777b2b9a39ba1bad05773fcf2d208f0299d1df58ce5 \
     --hash=sha256:9ca8b952a0a9afa61d30aa6d3d9b570bb3fd6bafcf7ec9e6bed43b936133db1c \
     # via django
-atomicwrites==1.3.0 \
-    --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
-    --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
-    # via pytest
 attrs==19.3.0 \
     --hash=sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c \
     --hash=sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72 \
@@ -51,7 +47,7 @@ click==7.1.1 \
 colorama==0.4.3 \
     --hash=sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff \
     --hash=sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1 \
-    # via pytest, pytest-watch
+    # via pytest-watch
 coverage==5.0.4 \
     --hash=sha256:03f630aba2b9b0d69871c2e8d23a69b7fe94a1e2f5f10df5049c0df99db639a0 \
     --hash=sha256:046a1a742e66d065d16fb564a26c2a15867f17695e7f3d358d7b1ad8a61bca30 \
@@ -96,10 +92,10 @@ django-extensions==2.2.9 \
     --hash=sha256:2f81b618ba4d1b0e58603e25012e5c74f88a4b706e0022a3b21f24f0322a6ce6 \
     --hash=sha256:b19182d101a441fe001c5753553a901e2ef3ff60e8fbbe38881eb4a61fdd17c4 \
     # via -r requirements/dev.in
-django==3.0.5 \
-    --hash=sha256:642d8eceab321ca743ae71e0f985ff8fdca59f07aab3a9fb362c617d23e33a76 \
-    --hash=sha256:d4666c2edefa38c5ede0ec1655424c56dc47ceb04b6d8d62a7eac09db89545c1 \
-    # via django-debug-toolbar
+django==3.0.7 \
+    --hash=sha256:5052b34b34b3425233c682e0e11d658fd6efd587d11335a0203d827224ada8f2 \
+    --hash=sha256:e1630333248c9b3d4e38f02093a26f1e07b271ca896d73097457996e0fae12e8 \
+    # via -r requirements/dev.in, django-debug-toolbar
 docopt==0.6.2 \
     --hash=sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491 \
     # via pytest-watch


### PR DESCRIPTION
CVE-2020-13596
https://github.com/advisories/GHSA-2m34-jcjv-45xf

CVE-2020-13254
https://github.com/advisories/GHSA-wpjr-j57x-wxfw

Dependabot was failing to open the PR without giving a proper error report.