### PR TITLE
Bug 1642933 - Perfherder's graph doesn't show properly the interrupted jobs

### DIFF
--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -297,6 +297,8 @@ class GraphsContainer extends React.Component {
       bottom: 50,
     };
 
+    const today = moment.utc().toDate();
+
     return (
       <span data-testid="graphContainer">
         {!showTable && (
@@ -310,6 +312,7 @@ class GraphsContainer extends React.Component {
                   style={{ parent: { maxHeight: '150px', maxWidth: '1350px' } }}
                   scale={{ x: 'time', y: 'linear' }}
                   domainPadding={{ y: 30 }}
+                  maxDomain={{ x: today }}
                   containerComponent={
                     <VictoryBrushContainer
                       brushDomain={zoom}
@@ -353,6 +356,7 @@ class GraphsContainer extends React.Component {
                   style={{ parent: { maxHeight: '400px', maxWidth: '1350px' } }}
                   scale={{ x: 'time', y: 'linear' }}
                   domainPadding={{ y: 40, x: [10, 10] }}
+                  maxDomain={{ x: today }}
                   externalEventMutations={externalMutation}
                   containerComponent={
                     <VictoryZoomSelectionContainer


### PR DESCRIPTION
This PR is setting explicitly the right limit of x axis to today.
**Before**
![Screenshot from 2020-06-16 12-07-27](https://user-images.githubusercontent.com/47977085/84756061-fe203680-afca-11ea-8bc7-a9ba6e8a3154.png)

**After**
![Screenshot from 2020-06-16 12-03-54](https://user-images.githubusercontent.com/47977085/84756040-f95b8280-afca-11ea-94f8-f4d3e7f87e63.png)