### PR TITLE
Bug 1646713 - Show subtests in Performance tab

### DIFF
--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -258,7 +258,6 @@ class DetailsPanel extends React.Component {
                     series: seriesList.find((s) => d.signature_id === s.id),
                     ...d,
                   }))
-                  .filter((d) => !d.series.parentSignature)
                   .map((d) => ({
                     url: `/perf.html#/graphs?series=${[
                       currentRepo.name,


### PR DESCRIPTION
Remove filter that only shows parent tests. Graph links for subtests work.