### PR TITLE
Bug 1649387 - Provide enhanced management script for Bugzilla formulas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ __pycache__
 .eslintcache
 # PyCharm
 *.iml
+# Perf sheriffing criteria
+perf-sheriffing-criteria.csv
 
 # emacs
 *~

--- a/tests/perf/test_sheriffing_criteria/test_criteria_tracker.py
+++ b/tests/perf/test_sheriffing_criteria/test_criteria_tracker.py
@@ -1,0 +1,288 @@
+import time
+from contextlib import contextmanager
+from datetime import timedelta
+from unittest.mock import MagicMock
+from dateutil.parser import parse as dateutil_parse
+from multiprocessing.pool import AsyncResult
+
+import pytest
+from freezegun import freeze_time
+
+from tests.perf.test_sheriffing_criteria.conftest import CASSETTES_RECORDING_DATE
+from treeherder.perf.exceptions import NoFiledBugs
+from treeherder.perf.sheriffing_criteria import (
+    CriteriaTracker,
+    EngineerTractionFormula,
+    FixRatioFormula,
+    RecordComputer,
+    CriteriaRecord,
+)
+from treeherder.perf.sheriffing_criteria.criteria_tracking import ResultsChecker
+from treeherder.utils import PROJECT_ROOT
+
+pytestmark = [pytest.mark.freeze_time(CASSETTES_RECORDING_DATE, tick=True)]
+
+RECORD_TEST_PATH = (PROJECT_ROOT / 'tests/sample_data/criteria-records.csv').resolve()
+EXPECTED_LAST_UPDATE = dateutil_parse(CASSETTES_RECORDING_DATE)
+EXPECTED_VALUE = 0.5
+TESTS_WITH_NO_DATA = [
+    ('awsy', 'Base Content Explicit'),
+    ('browsertime', 'allrecipes-cold'),
+    ('raptor', 'os-baseline-power'),
+    ('talos', 'a11yr'),
+]
+TESTS_WITH_EXPIRED_DATA = [
+    ('awsy', 'Base Content Heap Unclassified'),
+    ('browsertime', 'amazon'),
+    ('build_metrics', 'compiler warnings'),
+    ('raptor', 'raptor-ares6-firefox'),
+    ('talos', 'about_newtab_with_snippets'),
+]
+TESTS_WITH_UPDATED_DATA = [
+    ('awsy', 'Base Content JS'),
+    ('browsertime', 'amazon-cold'),
+    ('build_metrics', 'installer size'),
+    ('raptor', 'raptor-assorted-dom-firefox'),
+    ('talos', 'about_preferences_basic'),
+]
+recording_date = dateutil_parse(CASSETTES_RECORDING_DATE).isoformat()
+RECORDS_WITH_NO_DATA = [
+    CriteriaRecord(
+        Framework=test[0],
+        Suite=test[1],
+        EngineerTraction='',
+        FixRatio='',
+        LastUpdatedOn='',
+        ShouldSync='',
+    )
+    for test in TESTS_WITH_NO_DATA
+]
+RECORDS_WITH_EXPIRED_DATA = [
+    CriteriaRecord(
+        Framework=test[0],
+        Suite=test[1],
+        EngineerTraction=0.5,
+        FixRatio=0.3,
+        LastUpdatedOn='2020-05-02T00:00:00.000000',
+        ShouldSync='',
+    )
+    for test in TESTS_WITH_EXPIRED_DATA
+]
+RECORDS_WITH_UPDATED_DATA = [
+    CriteriaRecord(
+        Framework=test[0],
+        Suite=test[1],
+        EngineerTraction=0.5,
+        FixRatio=0.3,
+        LastUpdatedOn='2020-06-02T00:00:00.000000',
+        ShouldSync='',
+    )
+    for test in TESTS_WITH_UPDATED_DATA
+]
+NEVER_READY_RESULTS = [MagicMock(spec=AsyncResult) for _ in range(10)]
+PARTIALLY_READY_RESULTS = [MagicMock(spec=AsyncResult) for _ in range(10)]
+READY_RESULTS = [MagicMock(spec=AsyncResult) for _ in range(10)]
+EVENTUALLY_READY_RESULTS = [MagicMock(spec=AsyncResult) for _ in range(10)]
+
+for res in NEVER_READY_RESULTS:
+    res.ready = MagicMock(return_value=False)
+for res in PARTIALLY_READY_RESULTS:
+    res.ready = MagicMock(return_value=True)
+PARTIALLY_READY_RESULTS[-1].ready = MagicMock(return_value=False)
+
+for res in READY_RESULTS:
+    res.ready = MagicMock(return_value=True)
+
+
+class eventually_ready:
+    def __init__(self, start_time: float, ready_after: float):
+        print(f'start_time: {start_time}')
+        self.start_time = start_time
+        self.ready_after = ready_after
+
+    def __call__(self):
+        elapsed_time = time.time() - self.start_time
+        if elapsed_time > self.ready_after:
+            return True
+        return False
+
+
+with freeze_time(CASSETTES_RECORDING_DATE) as frozentime:
+    for res in EVENTUALLY_READY_RESULTS:
+        res.ready = MagicMock(
+            side_effect=eventually_ready(time.time(), 4 * 60 + 59)
+        )  # ready just before timeout
+
+
+class InvalidFormula:
+    pass
+
+
+@contextmanager
+def should_take_more_than(seconds: float):
+    start = time.time()
+    yield
+    it_took = time.time() - start
+
+    if it_took < seconds:
+        raise TimeoutError(
+            f"Should have taken more than {seconds}. But it took only {it_took} seconds."
+        )
+
+
+@pytest.fixture
+def updatable_criteria_csv(tmp_path):
+    updatable_csv = tmp_path / "updatable-criteria.csv"
+    with open(RECORD_TEST_PATH, 'r') as file_:
+        updatable_csv.write_text(file_.read())
+
+    return updatable_csv
+
+
+@pytest.fixture
+def mock_formula_map():
+    return {
+        'EngineerTraction': MagicMock(spec=EngineerTractionFormula, return_value=EXPECTED_VALUE),
+        'FixRatio': MagicMock(spec=FixRatioFormula, return_value=EXPECTED_VALUE),
+    }
+
+
+@pytest.mark.parametrize(
+    'invalid_formulas',
+    [
+        {'EngineerTraction': InvalidFormula(), 'FixRatio': InvalidFormula()},
+        {'EngineerTraction': None, 'FixRatio': None},
+        {'EngineerTraction': lambda f, s: None, 'FixRatio': lambda f, s: None},
+    ],
+)
+def test_tracker_throws_error_for_invalid_formulas(invalid_formulas):
+    with pytest.raises(TypeError):
+        CriteriaTracker(formula_map=invalid_formulas)
+
+
+def test_tracker_throws_error_if_no_record_file_found(tmp_path):
+    nonexistent_file = str(tmp_path / 'perf-sheriffing-criteria.csv')
+    tracker = CriteriaTracker(record_path=nonexistent_file)
+
+    with pytest.raises(FileNotFoundError):
+        tracker.load_records()
+
+
+def test_tracker_has_a_list_of_records():
+    tracker = CriteriaTracker(record_path=RECORD_TEST_PATH)
+    tracker.load_records()
+
+    record_list = list(iter(tracker))
+    assert len(record_list) == 5
+
+
+@pytest.mark.parametrize('criteria_record', RECORDS_WITH_NO_DATA)
+def test_record_computer_can_tell_missing_data(criteria_record):
+    computer = RecordComputer({}, timedelta(days=3), timedelta(seconds=0))
+
+    assert computer.should_update(criteria_record)
+
+
+@pytest.mark.parametrize('criteria_record', RECORDS_WITH_EXPIRED_DATA)
+def test_record_computer_can_tell_expired_data(criteria_record):
+    computer = RecordComputer({}, timedelta(days=3), timedelta(seconds=0))
+
+    assert computer.should_update(criteria_record)
+
+
+@pytest.mark.parametrize('criteria_record', RECORDS_WITH_UPDATED_DATA)
+def test_record_computer_can_tell_updated_data(criteria_record):
+    computer = RecordComputer({}, timedelta(days=3), timedelta(seconds=0))
+
+    assert not computer.should_update(criteria_record)
+
+
+@pytest.mark.freeze_time(CASSETTES_RECORDING_DATE)  # disable tick
+@pytest.mark.parametrize('exception', [NoFiledBugs(), Exception()])
+def test_record_computer_still_updates_if_one_of_the_formulas_fails(exception):
+    formula_map = {
+        'EngineerTraction': MagicMock(spec=EngineerTractionFormula, return_value=EXPECTED_VALUE),
+        'FixRatio': MagicMock(spec=FixRatioFormula, side_effect=exception),
+    }
+    record = CriteriaRecord(
+        Framework='talos',
+        Suite='tp5n',
+        EngineerTraction='',
+        FixRatio='',
+        LastUpdatedOn='',
+        ShouldSync='',
+    )
+
+    computer = RecordComputer(formula_map, timedelta(days=3), timedelta(seconds=0))
+    record = computer.apply_formulas(record)
+
+    assert record.Framework == 'talos'
+    assert record.Suite == 'tp5n'
+    assert record.EngineerTraction == EXPECTED_VALUE
+    assert record.FixRatio == 'N/A'
+    assert record.LastUpdatedOn == EXPECTED_LAST_UPDATE
+    assert record.ShouldSync is True
+
+
+def test_tracker_lets_web_service_rest(mock_formula_map, updatable_criteria_csv):
+    tracker = CriteriaTracker(
+        formula_map=mock_formula_map,
+        record_path=str(updatable_criteria_csv),
+        webservice_rest_time=timedelta(seconds=0.01),
+    )
+    tracker.load_records()
+
+    with should_take_more_than(0.01):
+        tracker.update_records()
+
+
+@pytest.mark.freeze_time(CASSETTES_RECORDING_DATE)  # disable tick
+def test_tracker_updates_records_with_missing_data(mock_formula_map, updatable_criteria_csv):
+    # all tests from the fixture don't have any kind of data
+    tracker = CriteriaTracker(
+        formula_map=mock_formula_map,
+        record_path=str(updatable_criteria_csv),
+        webservice_rest_time=timedelta(seconds=0.0),
+    )
+    tracker.load_records()
+
+    # CSV has no criteria data initially
+    for criteria_rec in tracker:
+        assert criteria_rec.EngineerTraction == ''
+        assert criteria_rec.FixRatio == ''
+        assert criteria_rec.LastUpdatedOn == ''
+        assert criteria_rec.ShouldSync is True
+
+    tracker.update_records()
+    del tracker
+
+    # let's re read with a separate tracker
+    # to ensure data was cached & correct
+    separate_tracker = CriteriaTracker(record_path=str(updatable_criteria_csv))
+    separate_tracker.load_records()
+
+    for criteria_rec in separate_tracker:
+        assert criteria_rec.EngineerTraction == EXPECTED_VALUE
+        assert criteria_rec.FixRatio == EXPECTED_VALUE
+        assert criteria_rec.LastUpdatedOn == EXPECTED_LAST_UPDATE
+        assert criteria_rec.ShouldSync is True
+
+
+@pytest.mark.freeze_time(CASSETTES_RECORDING_DATE, auto_tick_seconds=30)
+@pytest.mark.parametrize('async_results', [NEVER_READY_RESULTS, PARTIALLY_READY_RESULTS])
+def test_results_checker_timeouts_on_no_changes(async_results):
+    checker = ResultsChecker(check_interval=timedelta(0.0), timeout_after=timedelta(minutes=5))
+
+    with pytest.raises(TimeoutError):
+        checker.wait_for_results(async_results)
+
+
+@pytest.mark.freeze_time(CASSETTES_RECORDING_DATE, auto_tick_seconds=30)
+@pytest.mark.parametrize('async_results', [READY_RESULTS, EVENTUALLY_READY_RESULTS])
+def test_results_checker_doesnt_timeout_unexpectedly(async_results):
+    checker = ResultsChecker(check_interval=timedelta(0.0), timeout_after=timedelta(minutes=5))
+
+    try:
+        checker.wait_for_results(async_results)
+    except TimeoutError:
+        pytest.fail()

--- a/tests/sample_data/criteria-records.csv
+++ b/tests/sample_data/criteria-records.csv
@@ -1,4 +1,4 @@
-Framework,Suite,EngineerTraction,FixRatio,LastUpdatedOn,ShouldSync
+Framework,Suite,EngineerTraction,FixRatio,LastUpdatedOn,AllowSync
 awsy,JS,,,,
 build_metrics,build times,,,,
 build_metrics,installer size,,,,

--- a/tests/sample_data/criteria-records.csv
+++ b/tests/sample_data/criteria-records.csv
@@ -1,0 +1,6 @@
+Framework,Suite,EngineerTraction,FixRatio,LastUpdatedOn,ShouldSync
+awsy,JS,,,,
+build_metrics,build times,,,,
+build_metrics,installer size,,,,
+raptor,raptor-speedometer-firefox,,,,
+raptor,raptor-webaudio-firefox,,,,

--- a/treeherder/perf/management/commands/compute_criteria_formulas.py
+++ b/treeherder/perf/management/commands/compute_criteria_formulas.py
@@ -9,6 +9,7 @@ from treeherder.perf.sheriffing_criteria import (
     FixRatioFormula,
     CriteriaTracker,
 )
+from treeherder.perf.sheriffing_criteria import criteria_tracking
 from mo_times import Duration
 from django.core.management.base import BaseCommand
 
@@ -24,8 +25,8 @@ class Command(BaseCommand):
     FORMULAS = [ENGINEER_TRACTION, FIX_RATIO]  # register new formulas here
 
     help = f'''
-    Compute the {pretty_enumerated(FORMULAS)} for a particular framework/suite/test combo,
-     according to the Perf Sheriffing Criteria specification
+    Compute the {pretty_enumerated(FORMULAS)} for multiple framework/suite combinations,
+     according to the Perf Sheriffing Criteria specification.\nRequires "{criteria_tracking.CRITERIA_FILENAME}" to be provided for both program input & output.
     '''
 
     INITIAL_PROMPT_MSG = 'Computing Perf Sheriffing Criteria... (may take some time)'
@@ -65,7 +66,7 @@ class Command(BaseCommand):
         subparser = parser.add_subparsers(dest='individually')
         individual_parser = subparser.add_parser(
             'individually',
-            help='Compute perf sheriffing criteria for individual framework/suite combo',
+            help='Compute perf sheriffing criteria for individual framework/suite combo (no CSV file required)',
         )
         individual_parser.add_argument('framework', action='store')
         individual_parser.add_argument('suite', action='store')
@@ -100,7 +101,7 @@ class Command(BaseCommand):
     def _handle_individually(self, options):
         framework = options['framework']
         suite = options['suite']
-        test = options['suite']
+        test = options['test']
         quant_period = options['quantifying_period']
         bug_cooldown = options['bug_cooldown']
 

--- a/treeherder/perf/management/commands/compute_criteria_formulas.py
+++ b/treeherder/perf/management/commands/compute_criteria_formulas.py
@@ -4,7 +4,11 @@ from datetime import timedelta
 from typing import List
 
 from treeherder.config import settings
-from treeherder.perf.sheriffing_criteria import EngineerTractionFormula, FixRatioFormula
+from treeherder.perf.sheriffing_criteria import (
+    EngineerTractionFormula,
+    FixRatioFormula,
+    CriteriaTracker,
+)
 from mo_times import Duration
 from django.core.management.base import BaseCommand
 
@@ -28,12 +32,6 @@ class Command(BaseCommand):
     PRECISION = '.1f'
 
     def add_arguments(self, parser):
-        parser.add_argument('framework', action='store')
-
-        parser.add_argument('suite', action='store')
-
-        parser.add_argument('--test', default=None)
-
         parser.add_argument(
             '--quantifying-period',
             '-qp',
@@ -58,10 +56,51 @@ class Command(BaseCommand):
             metavar='BUG_COOLDOWN',
         )
 
+        parser.add_argument(
+            '--multiprocessing',
+            '-mp',
+            action='store_true',
+            help='''Experimental! Whether to use a process pool instead of a thread pool''',
+        )
+        subparser = parser.add_subparsers(dest='individually')
+        individual_parser = subparser.add_parser(
+            'individually',
+            help='Compute perf sheriffing criteria for individual framework/suite combo',
+        )
+        individual_parser.add_argument('framework', action='store')
+        individual_parser.add_argument('suite', action='store')
+        parser.add_argument('--test', default=None)
+
     def handle(self, *args, **options):
+        if options.get('individually'):
+            return self._handle_individually(options)
+
+        quant_period = options['quantifying_period']
+        bug_cooldown = options['bug_cooldown']
+        multiprocessed = options['multiprocessing']
+
+        init_params = (None, quant_period, bug_cooldown)
+        formula_map = {
+            'EngineerTraction': EngineerTractionFormula(*init_params),
+            'FixRatio': FixRatioFormula(*init_params),
+        }
+
+        tracker = CriteriaTracker(formula_map, multiprocessed=multiprocessed)
+        tracker.load_records()
+        start = time.time()
+        tracker.update_records()
+        duration = time.time() - start
+
+        print(f'{self.INITIAL_PROMPT_MSG}', end='')
+
+        for record in tracker:
+            print(record)
+        print(f"Took {duration:.1f} seconds")
+
+    def _handle_individually(self, options):
         framework = options['framework']
         suite = options['suite']
-        test = options['test']
+        test = options['suite']
         quant_period = options['quantifying_period']
         bug_cooldown = options['bug_cooldown']
 
@@ -82,17 +121,7 @@ class Command(BaseCommand):
         eng_traction_result *= 100
         fix_ratio_result *= 100
 
-        self._display_results(
-            eng_traction_result, fix_ratio_result, framework, suite, test, compute_duration
-        )
-
-    def _display_results(
-        self, eng_traction_result, fix_ratio_result, framework, suite, test, duration
-    ):
-        """
-        to console
-        """
-        # prepare some title
+        # display results (inline)
         test_moniker = ' '.join(filter(None, (suite, test)))
         title = f'Perf Sheriffing Criteria for {framework} - {test_moniker}'
         big_underline = '-' * len(title)
@@ -104,7 +133,9 @@ class Command(BaseCommand):
 
         # let's update 1st prompt line
         print(f"\r{' ' * len(self.INITIAL_PROMPT_MSG)}", end='')
-        print(f"\rComputing Perf Sheriffing Criteria... (took {duration:{self.PRECISION}} seconds)")
+        print(
+            f"\rComputing Perf Sheriffing Criteria... (took {compute_duration:{self.PRECISION}} seconds)"
+        )
 
         # display title
         print(big_underline)

--- a/treeherder/perf/sheriffing_criteria/__init__.py
+++ b/treeherder/perf/sheriffing_criteria/__init__.py
@@ -1,0 +1,7 @@
+from .bugzilla_formulas import (  # noqa
+    NonBlockableSession,
+    BugzillaFormula,
+    EngineerTractionFormula,
+    FixRatioFormula,
+)
+from .criteria_tracking import CriteriaTracker, RecordComputer, CriteriaRecord  # noqa

--- a/treeherder/perf/sheriffing_criteria/bugzilla_formulas.py
+++ b/treeherder/perf/sheriffing_criteria/bugzilla_formulas.py
@@ -1,16 +1,16 @@
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import List, Tuple
+from datetime import timedelta, datetime
+from typing import Tuple, List
 
 import requests
 from django.conf import settings
 from requests import Session
 
-from datetime import datetime, timedelta
-
 from treeherder.config.settings import BZ_DATETIME_FORMAT
 from treeherder.perf.exceptions import NoFiledBugs, BugzillaEndpointError
 
+# Google Doc specification
 PERF_SHERIFFING_CRITERIA = (
     'https://docs.google.com/document/d/11WPIPFeq-i1IAVOQhBR-SzIMOPSqBVjLepgOWCrz_S4'
 )

--- a/treeherder/perf/sheriffing_criteria/criteria_tracking.py
+++ b/treeherder/perf/sheriffing_criteria/criteria_tracking.py
@@ -24,7 +24,7 @@ class CriteriaRecord:
     EngineerTraction: Union[float, str]
     FixRatio: Union[float, str]
     LastUpdatedOn: datetime
-    ShouldSync: bool
+    AllowSync: bool
 
     def __post_init__(self):
         if self.EngineerTraction not in ('', 'N/A'):
@@ -36,10 +36,10 @@ class CriteriaRecord:
             if isinstance(self.LastUpdatedOn, str):
                 self.LastUpdatedOn = datetime.fromisoformat(self.LastUpdatedOn)
 
-        if self.ShouldSync in ('', 'True'):
-            self.ShouldSync = True
-        elif self.ShouldSync == 'False':
-            self.ShouldSync = False
+        if self.AllowSync in ('', 'True'):
+            self.AllowSync = True
+        elif self.AllowSync == 'False':
+            self.AllowSync = False
 
 
 class RecordComputer:
@@ -61,7 +61,7 @@ class RecordComputer:
         last_updated_on = record.LastUpdatedOn
 
         # consider explicit request above all else
-        if not record.ShouldSync:
+        if not record.AllowSync:
             return False
 
         # missing data

--- a/treeherder/perf/sheriffing_criteria/criteria_tracking.py
+++ b/treeherder/perf/sheriffing_criteria/criteria_tracking.py
@@ -1,0 +1,328 @@
+import csv
+from dataclasses import dataclass, asdict, replace, fields
+import logging
+from multiprocessing import cpu_count
+from multiprocessing.pool import Pool, ThreadPool, AsyncResult
+import time
+from typing import Tuple, Dict, Union, List
+
+from datetime import datetime, timedelta
+
+from treeherder.perf.exceptions import NoFiledBugs
+from .bugzilla_formulas import BugzillaFormula, EngineerTractionFormula, FixRatioFormula
+from treeherder.utils import PROJECT_ROOT
+
+CRITERIA_FILENAME = 'perf-sheriffing-criteria.csv'
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class CriteriaRecord:
+    Framework: str
+    Suite: str
+    EngineerTraction: Union[float, str]
+    FixRatio: Union[float, str]
+    LastUpdatedOn: datetime
+    ShouldSync: bool
+
+    def __post_init__(self):
+        if self.EngineerTraction not in ('', 'N/A'):
+            self.EngineerTraction = float(self.EngineerTraction)
+        if self.FixRatio not in ('', 'N/A'):
+            self.FixRatio = float(self.FixRatio)
+
+        if self.LastUpdatedOn != '':
+            if isinstance(self.LastUpdatedOn, str):
+                self.LastUpdatedOn = datetime.fromisoformat(self.LastUpdatedOn)
+
+        if self.ShouldSync in ('', 'True'):
+            self.ShouldSync = True
+        elif self.ShouldSync == 'False':
+            self.ShouldSync = False
+
+
+class RecordComputer:
+    def __init__(
+        self,
+        formula_map: Dict[str, BugzillaFormula],
+        time_until_expires: timedelta,
+        webservice_rest_time: timedelta,
+        logger=None,
+    ):
+        self._time_until_expires = time_until_expires
+        self._formula_map = formula_map
+        self._seconds_to_rest = webservice_rest_time.total_seconds()
+        self.log = logger or LOGGER
+
+    def should_update(self, record: CriteriaRecord) -> bool:
+        engineer_traction = record.EngineerTraction
+        fix_ratio = record.FixRatio
+        last_updated_on = record.LastUpdatedOn
+
+        # consider explicit request above all else
+        if not record.ShouldSync:
+            return False
+
+        # missing data
+        if '' in (engineer_traction, fix_ratio, last_updated_on):
+            return True
+
+        # expired data
+        since_last_update = datetime.utcnow() - last_updated_on
+        if since_last_update > self._time_until_expires:
+            return True
+
+        return False
+
+    def apply_formulas(self, record):
+        for form_name, formula in self._formula_map.items():
+            try:
+                result = formula(record.Framework, record.Suite)
+            except (NoFiledBugs, Exception) as ex:
+                result = 'N/A'
+                self.__log_unexpected(ex, form_name, record)
+
+            record = replace(
+                record, **{form_name: result, 'LastUpdatedOn': datetime.utcnow().isoformat()},
+            )
+            self.__let_web_service_rest_a_bit()
+        return record
+
+    def __log_unexpected(self, exception: Exception, formula_name: str, record: CriteriaRecord):
+        if type(Exception) is NoFiledBugs:
+            # maybe web service problem
+            self.log.info(exception)
+        elif type(exception) is Exception:
+            # maybe web service problem
+            self.log.warning(
+                f'Unexpected exception when applying {formula_name} formula over {record.Framework} - {record.Suite}: {exception}'
+            )
+
+    def __let_web_service_rest_a_bit(self):
+        # so we don't overload Bugzilla's endpoints
+        time.sleep(self._seconds_to_rest)
+
+
+class ConcurrencyStrategy:
+    def __init__(
+        self,
+        pool_class: Pool,
+        thread_wait: timedelta,
+        check_interval: timedelta,
+        cpu_allocation: float,
+        threads_per_cpu: int,
+        logger=None,
+    ):
+        self._pool_class = pool_class
+        self._thread_wait = thread_wait
+        self._check_interval = check_interval
+        self._cpu_alloc = cpu_allocation
+        self._threads_per_cpu = threads_per_cpu
+        self.log = logger or LOGGER
+
+        if not issubclass(self._pool_class, Pool):
+            raise TypeError(f'Expected Pool (sub)class parameter. Got {self._pool_class} instead')
+        if not type(thread_wait) is timedelta:
+            raise TypeError('Expected timedelta parameter.')
+        if not type(check_interval) is timedelta:
+            raise TypeError('Expected timedelta parameter.')
+
+    def pool(self):
+        size = self.figure_out_pool_size()
+        self.log.debug(f'Preparing a {self._pool_class.__name__} of size {size}...')
+        return self._pool_class(size)
+
+    def figure_out_pool_size(self) -> int:
+        cpus_to_allocate = int(cpu_count() * self._cpu_alloc)
+        threads_per_cpu = self._threads_per_cpu
+
+        return max(cpus_to_allocate * threads_per_cpu, threads_per_cpu)
+
+    @property
+    def thread_wait(self):
+        return self._thread_wait
+
+    @property
+    def check_interval(self):
+        return self._check_interval
+
+
+class ResultsChecker:
+    def __init__(self, check_interval, timeout_after: timedelta, logger=None):
+        self._check_interval = check_interval
+        self._timeout_after = timeout_after
+        self.log = logger or LOGGER
+
+        self.__last_change = 0
+        self.__since_last_change = timedelta(seconds=0)
+
+    def wait_for_results(self, results: List[AsyncResult]):
+        self.__reset_change_track()
+
+        while True:
+            last_check_on = time.time()
+            if all(r.ready() for r in results):
+                self.log.info('Finished computing updates for all records.')
+                break
+            time.sleep(self._check_interval.total_seconds())
+
+            if self.__updates_stagnated(results, last_check_on):
+                raise TimeoutError
+
+            ready = [r for r in results if r.ready()]
+            self.log.info(
+                f"Haven't computed updates for all records yet (only {len(ready)} out of {len(results)}). Still waiting..."
+            )
+
+    def __updates_stagnated(self, results: List[AsyncResult], last_check_on: float) -> bool:
+        ready_amount = len([r for r in results if r.ready()])
+        total_results = len(results)
+        new_change = total_results - ready_amount
+
+        if new_change != self.__last_change:
+            self.__reset_change_track(new_change)
+
+        if self.__since_last_change > self._timeout_after:
+            return True
+
+        self.__since_last_change = self.__since_last_change + timedelta(
+            seconds=(time.time() - last_check_on)
+        )
+        return False
+
+    def __reset_change_track(self, last_change=None):
+        self.__last_change = last_change or 0
+        self.__since_last_change = timedelta(seconds=0)
+
+
+class CriteriaTracker:
+    TIME_UNTIL_EXPIRES = timedelta(days=3)
+
+    ENGINEER_TRACTION = 'EngineerTraction'
+    FIX_RATIO = 'FixRatio'
+    FIELDNAMES = [field.name for field in fields(CriteriaRecord)]
+
+    # Instance defaults
+    RECORD_PATH = (PROJECT_ROOT / CRITERIA_FILENAME).resolve()
+
+    def __init__(
+        self,
+        formula_map: Dict[str, BugzillaFormula] = None,
+        record_path: str = None,
+        webservice_rest_time: timedelta = None,
+        multiprocessed: bool = False,
+        logger=None,
+    ):
+        self.log = logger or LOGGER
+        self._formula_map = formula_map or self.create_formula_map()
+        self._record_path = record_path or self.RECORD_PATH
+        self.fetch_strategy = self.create_fetch_strategy(multiprocessed)
+        self._explicit_rest_time = webservice_rest_time is not None
+        self._rest_time = (
+            webservice_rest_time
+            if webservice_rest_time is not None
+            else self.fetch_strategy.thread_wait
+        )  # wait time for Bugzilla web service, between individual formulas
+        self._computer = RecordComputer(self._formula_map, self.TIME_UNTIL_EXPIRES, self._rest_time)
+        self._records_map = {}
+
+        for formula in self._formula_map.values():
+            if not isinstance(formula, BugzillaFormula):
+                raise TypeError(
+                    f'Must provide formulas of type {BugzillaFormula.__class__.__name__}'
+                )
+
+    def get_test_moniker(self, record: CriteriaRecord) -> Tuple[str, str]:
+        return record.Framework, record.Suite
+
+    def __iter__(self):
+        # through criteria records
+        return iter(self._records_map.values())
+
+    def load_records(self):
+        self.log.info(f'Loading records from {self._record_path}...')
+        self._records_map = {}  # reset them
+
+        with open(self._record_path, 'r') as csv_file:
+            reader = csv.DictReader(csv_file)
+            for row in reader:
+                test_moniker = row.get('Framework'), row.get('Suite')
+                self._records_map[test_moniker] = CriteriaRecord(**row)
+        self.log.debug(f'Loaded {len(self._records_map)} records')
+
+    def update_records(self):
+        self.log.info('Updating records...')
+        result_checker = ResultsChecker(self.__check_interval(), timeout_after=timedelta(minutes=5))
+
+        with self.fetch_strategy.pool() as pool:
+            results = [
+                pool.apply_async(self.compute_record_update, (record,))
+                for record in self._records_map.values()
+            ]
+
+            result_checker.wait_for_results(results)  # to finish
+
+            for result in results:
+                if not result.successful():
+                    continue
+                record = result.get()
+                test_moniker = self.get_test_moniker(record)
+                self._records_map[test_moniker] = record
+            self.log.debug("Updated all records internally")
+
+            self.log.info(f'Updating CSV file at {self._record_path}...')
+            self.__dump_records()
+
+    def compute_record_update(self, record: CriteriaRecord) -> CriteriaRecord:
+        self.log.info(f'Computing update for record {record}...')
+        if self.__should_update(record):
+            record = self._computer.apply_formulas(record)
+        return record
+
+    def create_formula_map(self) -> Dict[str, BugzillaFormula]:
+        return {
+            self.ENGINEER_TRACTION: EngineerTractionFormula(),
+            self.FIX_RATIO: FixRatioFormula(),
+        }
+
+    def create_fetch_strategy(self, multiprocessed: bool) -> ConcurrencyStrategy:
+        options = {  # thread pool defaults
+            'pool_class': ThreadPool,
+            'thread_wait': timedelta(seconds=10),
+            'check_interval': timedelta(seconds=10),
+            'cpu_allocation': 0.75,
+            'threads_per_cpu': 12,
+            'logger': self.log,
+        }
+        if multiprocessed:
+            options = {  # process pool defaults (overrides upper ones)
+                'pool_class': Pool,
+                'thread_wait': timedelta(seconds=1.5),
+                'check_interval': timedelta(seconds=4),
+                'cpu_allocation': 0.8,
+                'threads_per_cpu': 12,
+                'logger': self.log,
+            }
+        return ConcurrencyStrategy(**options)
+
+    def __should_update(self, record: CriteriaRecord) -> bool:
+        """
+        convenience method for delegating
+        """
+        return self._computer.should_update(record)
+
+    def __check_interval(self):
+        wait_time = self.fetch_strategy.check_interval
+        if self._explicit_rest_time:
+            wait_time = self._rest_time
+
+        return wait_time
+
+    def __dump_records(self):
+        with open(self._record_path, 'w') as csv_file:
+            writer = csv.DictWriter(csv_file, self.FIELDNAMES)
+
+            writer.writeheader()
+            for record in self._records_map.values():
+                writer.writerow(asdict(record))

--- a/treeherder/utils/__init__.py
+++ b/treeherder/utils/__init__.py
@@ -1,4 +1,7 @@
 from datetime import datetime
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__) / '..' / '..' / '..'
 
 
 def default_serializer(val):


### PR DESCRIPTION
This PR extends `./manage.py compute_criteria_formulas` command to compute the perf sheriffing criteria formulas described [here](https://docs.google.com/document/d/11WPIPFeq-i1IAVOQhBR-SzIMOPSqBVjLepgOWCrz_S4/edit). Specifically, the engineer traction & fix ratio **for each** framework/suite combination.

Previously, it could compute these on the fly for a single combo. Nevertheless, the command kept that previous behavior also, in the form of a subcommand (`./manage.py compute_criteria_formulas individually <framework> <suite>`).

To be able to run the command locally, you'll need to copy/paste the [perf-sheriffing-criteria.csv](https://bugzilla.mozilla.org/attachment.cgi?id=9161800) file to your project's root. This CSV file mostly contains around 600 framework/suite rows (acting as input); it'll be populated by the command with the formula values.