### PR TITLE
Update serialize-javascript to handle security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "yarn": "1.22.4"
   },
   "resolutions": {
-    "elliptic": "^6.5.3"
+    "elliptic": "^6.5.3",
+    "serialize-javascript": "^3.1.0"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "1.2.29",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9143,12 +9143,7 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
-  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
-
-serialize-javascript@^3.1.0:
+serialize-javascript@^2.1.2, serialize-javascript@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
   integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==


### PR DESCRIPTION
See details:
https://app.snyk.io/vuln/SNYK-JS-SERIALIZEJAVASCRIPT-570062
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7660