### PR TITLE
Issue 6563 - add button to copy task label

### DIFF
--- a/ui/shared/JobInfo.jsx
+++ b/ui/shared/JobInfo.jsx
@@ -95,6 +95,7 @@ export default class JobInfo extends React.PureComponent {
         <li className="small">
           <strong>Job name: </strong>
           <span>{jobTypeName}</span>
+          <Clipboard description="job Name" text={jobTypeName} />
         </li>
         {[...timeFields, ...extraFields].map((field) => (
           <li className="small" key={`${field.title}${field.value}`}>


### PR DESCRIPTION
Adds a `copy to clipboard` button beside the job label.