### PR TITLE
Bug 1647451 - Follow-up improvements to Push Health details panel

### DIFF
--- a/tests/ui/mock/push_health.json
+++ b/tests/ui/mock/push_health.json
@@ -839,6 +839,54 @@
             "tier": 1,
             "failedInParent": false,
             "passFailRatio": 0
+          },
+          {
+            "testName": "Crash: had a bad day",
+            "action": "test",
+            "jobName": "test-linux1804-64-shippable/opt-reftest-no-accel-e10s-1",
+            "jobSymbol": "Ru1",
+            "jobGroup": "Reftests",
+            "jobGroupSymbol": "R",
+            "platform": "linux1804-64-shippable",
+            "config": "opt",
+            "key": "tlayoutreftestshighcontrastbackplatebgimage009htmllayoutreftestshighcontrastbackplatebgimage009refhtmloptlinux180464shippabletestlinux180464shippableoptreftestnoaccele10s1Reftests",
+            "jobKey": "optlinux1804-64-shippabletest-linux1804-64-shippable/opt-reftest-no-accel-e10s-1Reftests",
+            "inProgressJobs": [],
+            "failJobs": [
+              {
+                "id": 285871252,
+                "machine_platform_id": 716,
+                "option_collection_hash": "102210fe594ee9b33d82058545b1ed14f4c8206e",
+                "job_type_id": 213425,
+                "job_group_id": 450,
+                "result": "testfailed",
+                "state": "completed",
+                "failure_classification_id": 2,
+                "push_id": 630337,
+                "job_type_name": "test-linux1804-64-shippable/opt-reftest-no-accel-e10s-1",
+                "job_type_symbol": "Ru1",
+                "platform": "linux1804-64-shippable",
+                "task_id": "cdBQUnuyT92m-48d6GTLEw",
+                "run_id": 0
+              }
+            ],
+            "passJobs": [],
+            "passInFailedJobs": [],
+            "logLines": [
+              {
+                "action": "test_result",
+                "line_number": 21176,
+                "test": "layout/reftests/high-contrast/backplate-bg-image-009.html == layout/reftests/high-contrast/backplate-bg-image-009-ref.html",
+                "subtest": "image comparison, max difference: 0, number of differing pixels: 0",
+                "status": "PASS",
+                "expected": "FAIL"
+              }
+            ],
+            "suggestedClassification": "New Failure",
+            "confidence": 0,
+            "tier": 1,
+            "failedInParent": false,
+            "passFailRatio": 0
           }
         ],
         "knownIssues": [

--- a/tests/ui/push-health/ClassificationGroup_test.jsx
+++ b/tests/ui/push-health/ClassificationGroup_test.jsx
@@ -25,7 +25,7 @@ describe('GroupedTests', () => {
     const { getAllByTestId } = render(testClassificationGroup(tests));
 
     expect(await waitFor(() => getAllByTestId('test-grouping'))).toHaveLength(
-      2,
+      3,
     );
   });
 

--- a/tests/ui/push-health/GroupedTests_test.jsx
+++ b/tests/ui/push-health/GroupedTests_test.jsx
@@ -13,7 +13,6 @@ describe('GroupedTests', () => {
       group={tests}
       repo={repoName}
       revision={pushHealth.revision}
-      user={{ email: 'foo' }}
       groupedBy={groupedBy}
       orderedBy={orderedBy}
       currentRepo={{ name: repoName }}
@@ -22,22 +21,31 @@ describe('GroupedTests', () => {
   );
 
   test('should group by test path', async () => {
-    const { getAllByTestId } = render(
-      testGroupedTests(tests, 'path', 'count', ''),
-    );
+    const { getAllByTestId } = render(testGroupedTests(tests, 'path', 'count'));
 
     expect(await waitFor(() => getAllByTestId('test-grouping'))).toHaveLength(
-      2,
+      3,
     );
   });
 
   test('should group by platform', async () => {
     const { getAllByTestId } = render(
-      testGroupedTests(tests, 'platform', 'count', ''),
+      testGroupedTests(tests, 'platform', 'count'),
     );
 
     expect(await waitFor(() => getAllByTestId('test-grouping'))).toHaveLength(
       12,
     );
+  });
+
+  test('should bold the test file', async () => {
+    const { getAllByTestId } = render(testGroupedTests(tests, 'path', 'count'));
+
+    expect(
+      await waitFor(() => getAllByTestId('group-slash-bolded')),
+    ).toHaveLength(2);
+    expect(
+      await waitFor(() => getAllByTestId('group-colon-bolded')),
+    ).toHaveLength(1);
   });
 });

--- a/tests/ui/push-health/Health_test.jsx
+++ b/tests/ui/push-health/Health_test.jsx
@@ -136,7 +136,7 @@ describe('Health', () => {
       'test-grouping',
     );
 
-    expect(needInvestigationGroups).toHaveLength(2);
+    expect(needInvestigationGroups).toHaveLength(3);
     expect(intermittentGroups).toHaveLength(39);
   });
 

--- a/tests/ui/push-health/TestFailure_test.jsx
+++ b/tests/ui/push-health/TestFailure_test.jsx
@@ -81,7 +81,7 @@ describe('TestFailure', () => {
 
   test('should show bug suggestions when expander clicked', async () => {
     const { getByText } = render(testTestFailure(testFailure));
-    const detailsButton = getByText('Task 1');
+    const detailsButton = getByText('task');
 
     fireEvent.click(detailsButton);
 
@@ -94,7 +94,7 @@ describe('TestFailure', () => {
 
   test('should show artifacts when tab clicked', async () => {
     const { getByText } = render(testTestFailure(testFailure));
-    const detailsButton = getByText('Task 1');
+    const detailsButton = getByText('task');
 
     fireEvent.click(detailsButton);
 

--- a/tests/ui/push-health/details/DetailsPanel_test.jsx
+++ b/tests/ui/push-health/details/DetailsPanel_test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+
+import pushHealth from '../../mock/push_health.json';
+import DetailsPanel from '../../../../ui/push-health/details/DetailsPanel';
+
+const tests = pushHealth.metrics.tests.details.needInvestigation;
+const repoName = 'autoland';
+
+describe('DetailsPanel', () => {
+  const testGroupedTests = (tests, groupedBy, orderedBy) => (
+    <DetailsPanel
+      group={tests}
+      repo={repoName}
+      revision={pushHealth.revision}
+      groupedBy={groupedBy}
+      orderedBy={orderedBy}
+      currentRepo={{ name: repoName }}
+      notify={() => {}}
+    />
+  );
+
+  test('should group by test path', async () => {
+    const { getAllByTestId } = render(testGroupedTests(tests, 'path', 'count'));
+
+    expect(await waitFor(() => getAllByTestId('test-grouping'))).toHaveLength(
+      3,
+    );
+  });
+});

--- a/tests/ui/push-health/details/DetailsPanel_test.jsx
+++ b/tests/ui/push-health/details/DetailsPanel_test.jsx
@@ -1,30 +1,114 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
 
 import pushHealth from '../../mock/push_health.json';
+import fullJob from '../../mock/full_job.json';
+import repositories from '../../mock/repositories.json';
+import bugSuggestions from '../../mock/bug_suggestions.json';
 import DetailsPanel from '../../../../ui/push-health/details/DetailsPanel';
+import { getProjectUrl, setUrlParam } from '../../../../ui/helpers/location';
 
-const tests = pushHealth.metrics.tests.details.needInvestigation;
-const repoName = 'autoland';
+const task = pushHealth.metrics.tests.details.needInvestigation[0].failJobs[0];
+const selectedTaskFull = {
+  ...fullJob,
+  task_id: 'CwGewDH7RjOIZV-b77hGUQ',
+  id: 285852125,
+};
 
 describe('DetailsPanel', () => {
-  const testGroupedTests = (tests, groupedBy, orderedBy) => (
+  beforeAll(() => {
+    setUrlParam('repo', 'try');
+    fetchMock.get(
+      'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/CwGewDH7RjOIZV-b77hGUQ/runs/0/artifacts',
+      {
+        artifacts: [
+          {
+            storageType: 's3',
+            name: 'public/logs/live_backing.log',
+            expires: '2020-06-10T21:59:30.726Z',
+            contentType: 'text/plain; charset=utf-8',
+          },
+          {
+            storageType: 'reference',
+            name: 'public/logs/live.log',
+            expires: '2020-06-10T21:59:30.726Z',
+            contentType: 'text/plain; charset=utf-8',
+          },
+        ],
+      },
+    );
+
+    fetchMock.get(getProjectUrl('/jobs/285852125/', 'try'), selectedTaskFull);
+    fetchMock.get(
+      getProjectUrl('/jobs/285852125/bug_suggestions/', 'try'),
+      bugSuggestions,
+    );
+    fetchMock.get(
+      'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/O5YBAWwxRfuZ_UlRJS5Rqg/runs/0/artifacts/public/logs/live_backing.log',
+      '[taskcluster 2020-05-27 22:09:41.219Z] Task ID: WhN846qNQPin_jnGyF3w-g\n' +
+        '[taskcluster 2020-05-27 22:09:41.219Z] Worker ID: i-04f0e9fbffe5a9186\n',
+    );
+    fetchMock.get(getProjectUrl('/jobs/285852125/text_log_steps/', 'try'), [
+      {
+        id: 639432541,
+        errors: [
+          {
+            bug_suggestions: {
+              search:
+                'TEST-UNEXPECTED-FAIL | devtools/client/debugger/test/mochitest/browser_dbg-sourcemaps.js | Uncaught exception - at chrome://mochitests/content/browser/devtools/client/debugger/test/mochitest/helpers.js:358 - TypeError: can\'t access property "wrapClass", lineInfo is null',
+              bugs: {
+                open_recent: [],
+                all_others: [],
+              },
+              line_number: 18841,
+            },
+            line:
+              '22:42:53     INFO - TEST-UNEXPECTED-FAIL | devtools/client/debugger/test/mochitest/browser_dbg-sourcemaps.js | Uncaught exception - at chrome://mochitests/content/browser/devtools/client/debugger/test/mochitest/helpers.js:358 - TypeError: can\'t access property "wrapClass", lineInfo is null',
+            line_number: 18841,
+          },
+        ],
+      },
+    ]);
+  });
+
+  const testDetailsPanel = (selectedTask) => (
     <DetailsPanel
-      group={tests}
-      repo={repoName}
-      revision={pushHealth.revision}
-      groupedBy={groupedBy}
-      orderedBy={orderedBy}
-      currentRepo={{ name: repoName }}
-      notify={() => {}}
+      selectedTask={selectedTask}
+      closeDetails={() => {}}
+      currentRepo={repositories[1]}
     />
   );
 
-  test('should group by test path', async () => {
-    const { getAllByTestId } = render(testGroupedTests(tests, 'path', 'count'));
+  test('should have artifacts', async () => {
+    const { getAllByTestId, findByText } = render(testDetailsPanel(task));
+    const artifactsTab = await findByText('Artifacts');
 
-    expect(await waitFor(() => getAllByTestId('test-grouping'))).toHaveLength(
-      3,
+    fireEvent.click(artifactsTab);
+
+    expect(await waitFor(() => getAllByTestId('task-artifact'))).toHaveLength(
+      2,
     );
+  });
+
+  test('should have bug suggestions', async () => {
+    const { getAllByTestId, findByText } = render(testDetailsPanel(task));
+    const failuresTab = await findByText('Failure Summary');
+
+    fireEvent.click(failuresTab);
+
+    expect(await waitFor(() => getAllByTestId('bug-list-item'))).toHaveLength(
+      1,
+    );
+  });
+
+  test('should have a log viewer with custom buttons', async () => {
+    const { findByText, getByText } = render(testDetailsPanel(task));
+    const LogViewerTab = await findByText('Log Viewer');
+
+    fireEvent.click(LogViewerTab);
+
+    expect(await waitFor(() => getByText('Text Log'))).toBeInTheDocument();
+    expect(await waitFor(() => getByText('Full Screen'))).toBeInTheDocument();
   });
 });

--- a/ui/css/failure-summary.css
+++ b/ui/css/failure-summary.css
@@ -2,29 +2,10 @@
  * Failure summary
  */
 
-ul.failure-summary-list {
-  width: 100%;
-  margin-bottom: 0;
-  height: 100%;
-}
-
-ul.failure-summary-list li {
-  font-size: 11px;
-  padding: 1px 0 0 2px;
-}
-
-ul.failure-summary-list li .btn-xs {
-  font-size: 8px;
-}
-
 .failure-summary-line-empty {
   padding: 2px 4px 0;
   font-size: 12px;
   background: #ffffff;
-}
-
-.failure-summary-bugs-title {
-  font-size: 12px;
 }
 
 .failure-summary-bugs-container {
@@ -34,15 +15,6 @@ ul.failure-summary-list li .btn-xs {
   margin: 0 11px;
   padding: 10px 15px;
   border-left: 2px solid #0004;
-}
-
-/* We override global anchor color to replicate TBPL here */
-.failure-summary-bugs a {
-  color: #0000ee;
-}
-
-.failure-summary-bugs a:visited {
-  color: purple;
 }
 
 .show-hide-more {

--- a/ui/css/treeherder-custom-styles.css
+++ b/ui/css/treeherder-custom-styles.css
@@ -31,6 +31,10 @@
   font-size: 12px;
 }
 
+.smaller-text {
+  font-size: 11px;
+}
+
 /* this is better for drop down menu items because
   display: none will change text alignment */
 .hide {

--- a/ui/css/treeherder-custom-styles.css
+++ b/ui/css/treeherder-custom-styles.css
@@ -35,6 +35,10 @@
   font-size: 11px;
 }
 
+.half-bold {
+  font-weight: 500;
+}
+
 /* this is better for drop down menu items because
   display: none will change text alignment */
 .hide {

--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -171,14 +171,18 @@ export const findJobInstance = function findJobInstance(jobId, scrollTo) {
   }
 };
 
+export const getResultState = function getResultState(job) {
+  const { result, state } = job;
+
+  return state === 'completed' ? result : state;
+};
+
 export const addAggregateFields = function addAggregateFields(job) {
   const {
     job_group_name: jobGroupName,
     job_group_symbol: jobGroupSymbol,
     job_type_name: jobTypeName,
     job_type_symbol: jobTypeSymbol,
-    state,
-    result,
     platform,
     platform_option: platformOption,
     submit_timestamp: submitTimestamp,
@@ -186,7 +190,7 @@ export const addAggregateFields = function addAggregateFields(job) {
     end_timestamp: endTimestamp,
   } = job;
 
-  job.resultStatus = state === 'completed' ? result : state;
+  job.resultStatus = getResultState(job);
   // we want to join the group and type information together
   // so we can search for it as one token (useful when
   // we want to do a search on something like `fxup-esr(`)

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -191,6 +191,7 @@ class TabsPanel extends React.Component {
               addBug={addBug}
               pinJob={pinJob}
               repoName={repoName}
+              fontSize="smaller-text"
             />
           </TabPanel>
           <TabPanel>

--- a/ui/push-health/GroupedTests.jsx
+++ b/ui/push-health/GroupedTests.jsx
@@ -38,6 +38,33 @@ class GroupedTests extends PureComponent {
     this.setState({ clipboardVisible: key });
   };
 
+  getGroupHtml = (text) => {
+    const splitter = text.includes('/') ? '/' : ':';
+    const parts = text.split(splitter);
+
+    if (splitter === '/') {
+      const bolded = parts.pop();
+
+      return (
+        <span>
+          {parts.join(splitter)}
+          {splitter}
+          <strong>{bolded}</strong>
+        </span>
+      );
+    }
+
+    const bolded = parts.shift();
+
+    return (
+      <span>
+        <strong>{bolded}</strong>
+        {splitter}
+        {parts.join(splitter)}
+      </span>
+    );
+  };
+
   render() {
     const {
       group,
@@ -68,32 +95,33 @@ class GroupedTests extends PureComponent {
           sortedGroups.map((group) => (
             <div key={group.id} data-testid="test-grouping">
               <span
-                className="d-flex border-top w-100 bg-light p-2 border-top-1 border-secondary justify-content-center rounded"
+                className="d-flex w-100 p-2"
                 onMouseEnter={() => this.setClipboardVisible(group.key)}
                 onMouseLeave={() => this.setClipboardVisible(null)}
               >
-                <Clipboard
-                  text={group.key}
-                  description="group text"
-                  visible={clipboardVisible === group.key}
-                />
                 <Button
                   id={`group-${group.id}`}
-                  className="text-center text-break text-wrap text-monospace border-0"
+                  className="text-break text-wrap border-0"
                   title="Click to expand for test detail"
                   outline
                 >
-                  {group.key === 'none' ? 'All' : group.key} -
-                  <span className="ml-2 font-italic">
-                    {group.tests.length} test{group.tests.length > 1 && 's'}
+                  <FontAwesomeIcon icon={faCaretDown} className="mr-2" />
+                  {group.key === 'none' ? 'All' : this.getGroupHtml(group.key)}
+                  <span className="ml-2">
+                    ({group.tests.length} failure{group.tests.length > 1 && 's'}
+                    )
                   </span>
                   {!!group.failedInParent && (
                     <Badge color="info" className="mx-1">
                       {group.failedInParent} from parent
                     </Badge>
                   )}
-                  <FontAwesomeIcon icon={faCaretDown} className="ml-1" />
                 </Button>
+                <Clipboard
+                  text={group.key}
+                  description="group text"
+                  visible={clipboardVisible === group.key}
+                />
               </span>
 
               <UncontrolledCollapse toggler={`group-${group.id}`}>

--- a/ui/push-health/GroupedTests.jsx
+++ b/ui/push-health/GroupedTests.jsx
@@ -49,7 +49,7 @@ class GroupedTests extends PureComponent {
         <span>
           {parts.join(splitter)}
           {splitter}
-          <strong>{bolded}</strong>
+          <strong data-testid="group-slash-bolded">{bolded}</strong>
         </span>
       );
     }
@@ -58,7 +58,7 @@ class GroupedTests extends PureComponent {
 
     return (
       <span>
-        <strong>{bolded}</strong>
+        <strong data-testid="group-colon-bolded">{bolded}</strong>
         {splitter}
         {parts.join(splitter)}
       </span>

--- a/ui/push-health/Health.jsx
+++ b/ui/push-health/Health.jsx
@@ -276,7 +276,7 @@ export default class Health extends React.PureComponent {
             )}
           </Navbar>
         </Navigation>
-        <Container fluid className="mt-2 mb-5">
+        <Container fluid className="mt-2 mb-5 max-width-default">
           <NotificationList
             notifications={notifications}
             clearNotification={this.clearNotification}

--- a/ui/push-health/Metric.jsx
+++ b/ui/push-health/Metric.jsx
@@ -33,7 +33,6 @@ export default class Metric extends React.PureComponent {
     return (
       <Collapse isOpen={expanded} className="w-100 mt-2">
         <Row className="flex-nowrap">
-          <Col className={`bg-${resultColor} pr-2 mr-2 flex-grow-0`} />
           <Col>
             <Row className="justify-content-between">
               <Button

--- a/ui/push-health/TestFailure.jsx
+++ b/ui/push-health/TestFailure.jsx
@@ -69,11 +69,7 @@ class TestFailure extends React.PureComponent {
         <Row className="ml-2 w-100 mb-2 justify-content-between">
           <Col>
             <Row>
-              <span
-                id={key}
-                className="px-2 text-darker-secondary"
-                style={{ fontWeight: 500 }}
-              >
+              <span id={key} className="px-2 text-darker-secondary half-bold">
                 <span>{groupedBy !== 'path' && `${testName} `}</span>
                 <span>{jobName}</span>
               </span>
@@ -91,7 +87,7 @@ class TestFailure extends React.PureComponent {
                   <Button
                     className="py-0"
                     color={`${taskResultColorMap[result]} ${
-                      !isSelected && 'bg-white'
+                      !isSelected && 'bg-white bg-hover-grey'
                     }`}
                     outline={!isSelected}
                     size="sm"

--- a/ui/push-health/TestFailure.jsx
+++ b/ui/push-health/TestFailure.jsx
@@ -47,8 +47,6 @@ class TestFailure extends React.PureComponent {
       failJobs,
       passJobs,
       passInFailedJobs,
-      platform,
-      config,
       key,
       tier,
       failedInParent,
@@ -63,17 +61,22 @@ class TestFailure extends React.PureComponent {
     taskList.forEach((task) => addAggregateFields(task));
 
     return (
-      <Row className="pt-2" key={key}>
-        <Row className="mx-5 w-100 mb-2 justify-content-between">
+      <Row
+        className="ml-5 pt-2 mr-1"
+        key={key}
+        style={{ background: '#f2f2f2' }}
+      >
+        <Row className="ml-2 w-100 mb-2 justify-content-between">
           <Col>
             <Row>
-              <strong id={key} className="w-5 px-2 mx-2 text-darker-secondary">
-                <span>
-                  {groupedBy !== 'path' && `${testName} `}
-                  {groupedBy !== 'platform' && `${platform} ${config}`}
-                </span>
-                <span className="ml-3">{jobName}</span>
-              </strong>
+              <span
+                id={key}
+                className="px-2 text-darker-secondary"
+                style={{ fontWeight: 500 }}
+              >
+                <span>{groupedBy !== 'path' && `${testName} `}</span>
+                <span>{jobName}</span>
+              </span>
             </Row>
           </Col>
           <Col className="ml-2">
@@ -84,9 +87,12 @@ class TestFailure extends React.PureComponent {
               const { id, result, state, start_time: startTime } = task;
               const isSelected = selectedTask && selectedTask.id === id;
               return (
-                <span key={id} className="mr-1">
+                <span key={id} className="mr-3">
                   <Button
-                    color={taskResultColorMap[result]}
+                    className="py-0"
+                    color={`${taskResultColorMap[result]} ${
+                      !isSelected && 'bg-white'
+                    }`}
                     outline={!isSelected}
                     size="sm"
                     onClick={() => this.setSelectedTask(task)}
@@ -96,7 +102,7 @@ class TestFailure extends React.PureComponent {
                       startTime,
                     ).toLocaleString('en-US', shortDateFormat)}`}
                   >
-                    Task {idx + 1}
+                    task {idx > 0 ? idx + 1 : ''}
                   </Button>
                 </span>
               );

--- a/ui/push-health/details/DetailsPanel.jsx
+++ b/ui/push-health/details/DetailsPanel.jsx
@@ -212,7 +212,7 @@ class DetailsPanel extends React.Component {
                 <TabPanel>
                   <Col className="ml-2">
                     {taskDetails.map((artifact) => (
-                      <Row key={artifact.value}>
+                      <Row key={artifact.value} data-testid="task-artifact">
                         <a href={artifact.url} className="link-style">
                           {artifact.value}
                         </a>
@@ -231,8 +231,8 @@ class DetailsPanel extends React.Component {
 
 DetailsPanel.propTypes = {
   currentRepo: PropTypes.shape({}).isRequired,
-  selectedTask: PropTypes.shape({}),
   closeDetails: PropTypes.func.isRequired,
+  selectedTask: PropTypes.shape({}),
 };
 
 DetailsPanel.defaultProps = {

--- a/ui/push-health/details/DetailsPanel.jsx
+++ b/ui/push-health/details/DetailsPanel.jsx
@@ -200,6 +200,7 @@ class DetailsPanel extends React.Component {
                       currentRepo.name,
                     )}
                     repoName={currentRepo.name}
+                    developerMode
                   />
                 </TabPanel>
                 <TabPanel>

--- a/ui/push-health/details/DetailsPanel.jsx
+++ b/ui/push-health/details/DetailsPanel.jsx
@@ -163,7 +163,7 @@ class DetailsPanel extends React.Component {
             <Tabs
               selectedIndex={tabIndex}
               onSelect={this.setTabIndex}
-              className="w-100 h-100 ml-1 mr-5 mb-2 border p-3"
+              className="w-100 h-100 ml-1 mr-5 mb-2 border p-3 bg-white"
               selectedTabClassName="selected-detail-tab"
             >
               <TabList className="pl-0 w-100 list-inline">

--- a/ui/push-health/pushhealth.css
+++ b/ui/push-health/pushhealth.css
@@ -26,6 +26,11 @@
   border-bottom: 20px;
 }
 
+.bg-hover-grey:hover {
+  background-color: grey !important;
+  color: white !important;
+}
+
 /*
   Need this instead of the Bootstrap h-100 class because the `!important` in that class
   throws off the layout when tabs are switched.

--- a/ui/shared/tabs/failureSummary/BugListItem.jsx
+++ b/ui/shared/tabs/failureSummary/BugListItem.jsx
@@ -13,7 +13,7 @@ function BugListItem(props) {
   const bugUrl = getBugUrl(bug.id);
 
   return (
-    <li>
+    <li data-testid="bug-list-item">
       {!!addBug && (
         <Button
           className="bg-light px-2 py-1"

--- a/ui/shared/tabs/failureSummary/BugListItem.jsx
+++ b/ui/shared/tabs/failureSummary/BugListItem.jsx
@@ -18,7 +18,7 @@ function BugListItem(props) {
         <Button
           className="bg-light px-2 py-1"
           outline
-          size="xs"
+          style={{ fontSize: '8px' }}
           type="button"
           onClick={() => addBug(bug, selectedJob)}
           title="add to list of bugs to associate with all pinned jobs"

--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 import { thBugSuggestionLimit, thEvents } from '../../../helpers/constants';
-import { isReftest } from '../../../helpers/job';
+import { getResultState, isReftest } from '../../../helpers/job';
 import {
   getBugUrl,
   getLogViewerUrl,
@@ -136,9 +136,8 @@ class FailureSummaryTab extends React.Component {
       errors,
     } = this.state;
     const logs = jobLogUrls;
-    const jobLogsAllParsed = logs.every(
-      (jlu) => jlu.parse_status !== 'pending',
-    );
+    const jobLogsAllParsed =
+      logs.length > 0 && logs.every((jlu) => jlu.parse_status !== 'pending');
 
     return (
       <div className="w-100 h-100" role="region" aria-label="Failure Summary">
@@ -162,6 +161,8 @@ class FailureSummaryTab extends React.Component {
           ))}
 
           {!!errors.length && <ErrorsList errors={errors} />}
+
+          {!jobLogsAllParsed && <ListItem text="Log parsing not complete" />}
 
           {!bugSuggestionsLoading &&
             jobLogsAllParsed &&
@@ -214,7 +215,11 @@ class FailureSummaryTab extends React.Component {
           )}
 
           {!bugSuggestionsLoading && !logs.length && (
-            <ListItem text="No logs available for this job." />
+            <ListItem
+              text={`No logs yet available for this ${getResultState(
+                selectedJob,
+              )} job.`}
+            />
           )}
 
           {bugSuggestionsLoading && (

--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -126,6 +126,7 @@ class FailureSummaryTab extends React.Component {
       selectedJob,
       addBug,
       repoName,
+      developerMode,
     } = this.props;
     const {
       isBugFilerOpen,
@@ -142,7 +143,9 @@ class FailureSummaryTab extends React.Component {
     return (
       <div className="w-100 h-100" role="region" aria-label="Failure Summary">
         <ul
-          className="list-unstyled failure-summary-list overflow-auto"
+          className={`${
+            !developerMode && 'smaller-text'
+          } list-unstyled w-100 h-100 mb-0 overflow-auto text-small`}
           ref={this.fsMount}
         >
           {suggestions.map((suggestion, index) => (
@@ -154,6 +157,7 @@ class FailureSummaryTab extends React.Component {
               selectedJob={selectedJob}
               addBug={addBug}
               repoName={repoName}
+              developerMode={developerMode}
             />
           ))}
 
@@ -254,6 +258,7 @@ FailureSummaryTab.propTypes = {
   repoName: PropTypes.string.isRequired,
   addBug: PropTypes.func,
   pinJob: PropTypes.func,
+  developerMode: PropTypes.bool,
 };
 
 FailureSummaryTab.defaultProps = {
@@ -262,6 +267,7 @@ FailureSummaryTab.defaultProps = {
   logViewerFullUrl: null,
   addBug: null,
   pinJob: null,
+  developerMode: false,
 };
 
 export default FailureSummaryTab;

--- a/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
@@ -129,11 +129,8 @@ export default class SuggestionsListItem extends React.Component {
               rel="noopener noreferrer"
               title="Go to this line in the log viewer"
             >
-              <span
-                className="align-middle link-style"
-                style={{ fontWeight: '500' }}
-              >
-                {suggestion.search}{' '}
+              <span className="align-middle link-style half-bold">
+                {suggestion.search}
               </span>
             </a>
           ) : (

--- a/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
@@ -52,6 +52,9 @@ export default class SuggestionsListItem extends React.Component {
               suggestion={suggestion}
               selectedJob={selectedJob}
               addBug={addBug}
+              bugClassName={
+                developerMode ? 'text-darker-secondary small-text' : ''
+              }
             />
           ))}
         </ul>,
@@ -65,7 +68,9 @@ export default class SuggestionsListItem extends React.Component {
             color="link"
             rel="noopener"
             onClick={this.clickShowMore}
-            className="bg-light px-2 py-1 btn btn-outline-secondary btn-xs my-2 show-hide-more"
+            className={`bg-light px-2 py-1 btn btn-outline-secondary btn-xs my-2 show-hide-more ${
+              developerMode && 'text-darker-secondary small-text'
+            }`}
           >
             {suggestionShowMore
               ? 'Hide bug suggestions'
@@ -86,7 +91,9 @@ export default class SuggestionsListItem extends React.Component {
               key={bug.id}
               bug={bug}
               suggestion={suggestion}
-              bugClassName={bug.resolution !== '' ? 'strike-through' : ''}
+              bugClassName={`${bug.resolution !== '' ? 'strike-through' : ''} ${
+                developerMode ? 'text-darker-secondary small-text' : ''
+              }`}
               title={bug.resolution !== '' ? bug.resolution : ''}
               selectedJob={selectedJob}
               addBug={addBug}
@@ -122,7 +129,12 @@ export default class SuggestionsListItem extends React.Component {
               rel="noopener noreferrer"
               title="Go to this line in the log viewer"
             >
-              <span className="align-middle">{suggestion.search} </span>
+              <span
+                className="align-middle link-style"
+                style={{ fontWeight: '500' }}
+              >
+                {suggestion.search}{' '}
+              </span>
             </a>
           ) : (
             <span>
@@ -160,14 +172,12 @@ export default class SuggestionsListItem extends React.Component {
           )}
         </div>
         {suggestions.length > 0 && (
-          <div className="failure-summary-bugs-container">
+          <React.Fragment>
             {developerMode && (
-              <strong>
-                <div className="mb-1">These bugs may be related:</div>
-              </strong>
+              <div className="mt-2 mb-1">These bugs may be related:</div>
             )}
-            {suggestions}
-          </div>
+            <div className="failure-summary-bugs-container">{suggestions}</div>
+          </React.Fragment>
         )}
       </li>
     );

--- a/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
@@ -32,6 +32,7 @@ export default class SuggestionsListItem extends React.Component {
       selectedJob,
       addBug,
       repoName,
+      developerMode,
     } = this.props;
     const { suggestionShowMore } = this.state;
 
@@ -110,42 +111,61 @@ export default class SuggestionsListItem extends React.Component {
     return (
       <li>
         <div>
-          <Button
-            className="bg-light py-1 px-2 mr-2"
-            outline
-            size="xs"
-            onClick={() => toggleBugFiler(suggestion)}
-            title="file a bug for this failure"
-          >
-            <FontAwesomeIcon icon={faBug} title="File bug" />
-          </Button>
-          <span className="align-middle">{suggestion.search} </span>
-          <Clipboard
-            description=" text of error line"
-            text={suggestion.search}
-          />
-          <a
-            href={getLogViewerUrl(
-              selectedJob.id,
-              repoName,
-              suggestion.line_number + 1,
-            )}
-            target="_blank"
-            rel="noopener noreferrer"
-            title="Go to this line in the log viewer"
-          >
-            <img
-              alt="Logviewer"
-              src={logviewerIcon}
-              className="logviewer-icon ml-1"
-            />
-          </a>
+          {developerMode ? (
+            <a
+              href={getLogViewerUrl(
+                selectedJob.id,
+                repoName,
+                suggestion.line_number + 1,
+              )}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Go to this line in the log viewer"
+            >
+              <span className="align-middle">{suggestion.search} </span>
+            </a>
+          ) : (
+            <span>
+              <Button
+                className="bg-light py-1 px-2 mr-2"
+                outline
+                style={{ fontSize: '8px' }}
+                onClick={() => toggleBugFiler(suggestion)}
+                title="file a bug for this failure"
+              >
+                <FontAwesomeIcon icon={faBug} title="File bug" />
+              </Button>
+              <span className="align-middle">{suggestion.search} </span>
+              <Clipboard
+                description=" text of error line"
+                text={suggestion.search}
+              />
+              <a
+                href={getLogViewerUrl(
+                  selectedJob.id,
+                  repoName,
+                  suggestion.line_number + 1,
+                )}
+                target="_blank"
+                rel="noopener noreferrer"
+                title="Go to this line in the log viewer"
+              >
+                <img
+                  alt="Logviewer"
+                  src={logviewerIcon}
+                  className="logviewer-icon ml-1"
+                />
+              </a>
+            </span>
+          )}
         </div>
         {suggestions.length > 0 && (
           <div className="failure-summary-bugs-container">
-            <h4 className="failure-summary-bugs-title">
-              These bugs may be related:
-            </h4>
+            {developerMode && (
+              <strong>
+                <div className="mb-1">These bugs may be related:</div>
+              </strong>
+            )}
             {suggestions}
           </div>
         )}
@@ -158,6 +178,7 @@ SuggestionsListItem.propTypes = {
   selectedJob: PropTypes.shape({}).isRequired,
   suggestion: PropTypes.shape({}).isRequired,
   toggleBugFiler: PropTypes.func.isRequired,
+  developerMode: PropTypes.bool.isRequired,
   addBug: PropTypes.func,
 };
 


### PR DESCRIPTION
This has a few of the tweaks we talked about in the last PR for this bug:

* I added the `max-width` overall
* Added a `developerMode` for the `DetailsPanel`/`FailureSummaryTab`.  
* I removed the red bar along the left side
* Eliminated some of the specific `CSS` classes we've brought over from the AngularJS days.
* Increased the font size in the `FailureSummaryTab` when in `developerMode`
* Removed the "file bug", "clipboard" and "log viewer" icon buttons and just made the error text a link, as we discussed.

