### PR TITLE
Bug 1649229 - Filter backfilled manifest scheduled tasks

### DIFF
--- a/tests/ui/job-view/Filtering_test.jsx
+++ b/tests/ui/job-view/Filtering_test.jsx
@@ -212,7 +212,7 @@ describe('Filtering', () => {
         10000,
       );
       expect(keywordLink.getAttribute('href')).toBe(
-        '/#/jobs?repo=autoland&selectedTaskRun=JFVlnwufR7G9tZu_pKM0dQ.0&searchStr=Gecko%2CDecision%2CTask%2Copt%2CGecko%2CDecision%2CTask%2C%28D%29',
+        '/#/jobs?repo=autoland&selectedTaskRun=JFVlnwufR7G9tZu_pKM0dQ.0&searchStr=Gecko%2CDecision%2CTask%2Copt%2CGecko%2CDecision%2CTask%2CD',
       );
     });
 


### PR DESCRIPTION
You can see a link filtering the tasks [here](https://treeherder.mozilla.org/#/jobs?repo=try&group_state=expanded&author=armenzg%40mozilla.com&searchStr=Linux%2C18.04%2Cx64%2Cdebug%2CMochitests%2Ctest-linux1804-64%2Fdebug-mochitest-browser-chrome-e10s%2Cbc4).

Manifest scheduled tasks when backfilled have their symbol changes and
potentially their label.

A manifest scheduled backfilled task (e.g. bc2) ends up being named bc2-<revision>-bk.
The label can also be different than the original task selected to be backfilled.
For instance 'test-linux1804-64/debug-mochitest-browser-chrome-e10s-4' can be
'test-linux1804-64/debug-mochitest-browser-chrome-e10s-1' yet the symbol be bc4

This changes the `searchStr` that helps filtering tasks from:
`Linux 18.04 x64 debug Mochitests test-linux1804-64/debug-mochitest-browser-chrome-e10s-4 M-bk(bc4-6cdc56c676b-bk)`
to
`Linux 18.04 x64 debug Mochitests test-linux1804-64/debug-mochitest-browser-chrome-e10s bc4`

The chunk number is removed from the label and the original symbol (no group symbol and brackets).

This changes permits seeing the original task that was backfilled plus all backfilled tasks.


<img width="754" alt="image" src="https://user-images.githubusercontent.com/44410/86966374-105b4380-c137-11ea-8daa-6d1f08d87593.png">
