### PR TITLE
Bug 1644851 - Fix Failure Summary scroll and selection on job change

### DIFF
--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -114,7 +114,16 @@ class FailureSummaryTab extends React.Component {
         });
       }
 
-      this.setState({ bugSuggestionsLoading: false, suggestions });
+      this.setState({ bugSuggestionsLoading: false, suggestions }, () => {
+        const scrollArea = document.querySelector(
+          '#failure-summary-scroll-area',
+        );
+
+        if (scrollArea.scrollTo) {
+          scrollArea.scrollTo(0, 0);
+          window.getSelection().removeAllRanges();
+        }
+      });
     });
   };
 
@@ -146,6 +155,7 @@ class FailureSummaryTab extends React.Component {
             !developerMode && 'font-size-11'
           } list-unstyled w-100 h-100 mb-0 overflow-auto text-small`}
           ref={this.fsMount}
+          id="failure-summary-scroll-area"
         >
           {suggestions.map((suggestion, index) => (
             <SuggestionsListItem


### PR DESCRIPTION
This fixes the Failure Summary Panel issues in the bug.  If the job is changed, it will re-scroll to the top and remove any text selection from the last job.