### PR TITLE
Bug 1651673 - Bug tooltips could be clearer about what is bug summary and what is commit message.

### DIFF
--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -110,8 +110,6 @@ export class Revision extends React.PureComponent {
           innerClassName="tooltip-content"
           target={`revision${revision}`}
         >
-          {`Commit: ${comment}`}
-          {<div style={{ visibility: 'hidden' }}>invisible space</div>}
           {bugSummaryMap &&
             !!bugMatches &&
             bugMatches.map((bug) => {
@@ -122,6 +120,8 @@ export class Revision extends React.PureComponent {
                 </div>
               );
             })}
+          {<div style={{ visibility: 'hidden' }}>invisible space</div>}
+          {`Commit: ${comment}`}
         </UncontrolledTooltip>
       </Row>
     );

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -120,7 +120,6 @@ export class Revision extends React.PureComponent {
                 </div>
               );
             })}
-          {/* {<div style={{ visibility: 'hidden' }}>invisible space</div>} */}
           {<span className="mt-3">{`Commit: ${comment}`}</span>}
         </UncontrolledTooltip>
       </Row>

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -120,8 +120,8 @@ export class Revision extends React.PureComponent {
                 </div>
               );
             })}
-          {<div style={{ visibility: 'hidden' }}>invisible space</div>}
-          {`Commit: ${comment}`}
+          {/* {<div style={{ visibility: 'hidden' }}>invisible space</div>} */}
+          {<span className="mt-3">{`Commit: ${comment}`}</span>}
         </UncontrolledTooltip>
       </Row>
     );

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -115,12 +115,13 @@ export class Revision extends React.PureComponent {
             bugMatches.map((bug) => {
               const bugId = bug.split(' ')[1];
               return (
-                <div key={bugId}>
+                <div key={bugId} className="mb-3">
                   Bug {bugId} - {bugSummaryMap[bugId]}
                 </div>
               );
             })}
-          {<span className="mt-3">{`Commit: ${comment}`}</span>}
+          <div>Commit:</div>
+          {<span>{comment}</span>}
         </UncontrolledTooltip>
       </Row>
     );

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -110,6 +110,8 @@ export class Revision extends React.PureComponent {
           innerClassName="tooltip-content"
           target={`revision${revision}`}
         >
+          {`Commit: ${comment}`}
+          {<div style={{ visibility: 'hidden' }}>invisible space</div>}
           {bugSummaryMap &&
             !!bugMatches &&
             bugMatches.map((bug) => {
@@ -120,7 +122,6 @@ export class Revision extends React.PureComponent {
                 </div>
               );
             })}
-          {comment}
         </UncontrolledTooltip>
       </Row>
     );

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -121,7 +121,7 @@ export class Revision extends React.PureComponent {
               );
             })}
           <div>Commit:</div>
-          {<span>{comment}</span>}
+          <span>{comment}</span>
         </UncontrolledTooltip>
       </Row>
     );


### PR DESCRIPTION
This PR increases clarity between commit message and bug summaries. A space is added in between the two as well as 'Commit: ' added before the commit message. 

![image](https://user-images.githubusercontent.com/10367196/87202070-6fe75980-c2c5-11ea-96af-2a3198b09102.png)
