### PR TITLE
Issue 6630 - Add Test Groups tab

### DIFF
--- a/tests/ui/job-view/Filtering_test.jsx
+++ b/tests/ui/job-view/Filtering_test.jsx
@@ -8,8 +8,9 @@ import {
 } from '@testing-library/react';
 
 import App from '../../../ui/job-view/App';
-import reposFixture from '../mock/repositories';
+import taskDefinition from '../mock/task_definition.json';
 import pushListFixture from '../mock/push_list';
+import reposFixture from '../mock/repositories';
 import { getApiUrl, bzBaseUrl } from '../../../ui/helpers/url';
 import {
   getProjectUrl,
@@ -63,6 +64,10 @@ describe('Filtering', () => {
     fetchMock.get(
       getProjectUrl('/push/?full=true&count=10', repoName),
       pushListFixture,
+    );
+    fetchMock.get(
+      'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/JFVlnwufR7G9tZu_pKM0dQ',
+      taskDefinition,
     );
   });
 

--- a/tests/ui/job-view/details/PinBoard_test.jsx
+++ b/tests/ui/job-view/details/PinBoard_test.jsx
@@ -7,6 +7,7 @@ import JobModel from '../../../../ui/models/job';
 import DetailsPanel from '../../../../ui/job-view/details/DetailsPanel';
 import jobListFixtureOne from '../../mock/job_list/job_1';
 import pushFixture from '../../mock/push_list.json';
+import taskDefinition from '../../mock/task_definition.json';
 import { getApiUrl } from '../../../../ui/helpers/url';
 import FilterModel from '../../../../ui/models/filter';
 import {
@@ -63,6 +64,10 @@ describe('DetailsPanel', () => {
     fetchMock.get(
       'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/JFVlnwufR7G9tZu_pKM0dQ/runs/0/artifacts',
       { artifacts: [] },
+    );
+    fetchMock.get(
+      'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/JFVlnwufR7G9tZu_pKM0dQ',
+      taskDefinition,
     );
     store = configureStore().store;
     store.dispatch(setPushes(pushFixture.results, {}));

--- a/tests/ui/mock/task_definition.json
+++ b/tests/ui/mock/task_definition.json
@@ -1,0 +1,181 @@
+{
+  "provisionerId": "gecko-3",
+  "workerType": "b-linux",
+  "schedulerId": "gecko-level-3",
+  "taskGroupId": "VaQoWKTbSdGSwBJn6UZV9g",
+  "dependencies": [
+    "IL3pXFgfRZuanbaL6qhngA",
+    "I_IyXrxGSMOAWRTfK6dK1w",
+    "Ll-6mwKuRw-fFddaRUGknA",
+    "O1fsyO1xTvqR9mpcvxzvmQ",
+    "Od-lJtOZQm2QUjbfyT915Q",
+    "Qn52CuwUT3el8G6Uz7qwlA",
+    "RGE0LJ_zQ3mOPIWxnovs1Q",
+    "SBZuExGLRVGdZnLaYSsaig",
+    "VHkQiobIQ8mKlUiRIyjNeA",
+    "WsgZ4ulrTXS8ROAs5mKZ4g",
+    "e0jCJNwDSEOf3ELSqsK-Qw",
+    "VaQoWKTbSdGSwBJn6UZV9g"
+  ],
+  "requires": "all-completed",
+  "routes": [
+    "index.gecko.v2.autoland.latest.mobile.android-api-16-debug",
+    "index.gecko.v2.autoland.pushdate.2020.04.02.20200402174015.mobile.android-api-16-debug",
+    "index.gecko.v2.autoland.pushdate.2020.04.02.latest.mobile.android-api-16-debug",
+    "index.gecko.v2.autoland.pushlog-id.111893.mobile.android-api-16-debug",
+    "index.gecko.v2.autoland.revision.7f9799e1d3d5c955518ecd1d0024921ac159b970.mobile.android-api-16-debug",
+    "index.gecko.v2.trunk.revision.7f9799e1d3d5c955518ecd1d0024921ac159b970.mobile.android-api-16-debug",
+    "tc-treeherder.v2.autoland.7f9799e1d3d5c955518ecd1d0024921ac159b970.111893"
+  ],
+  "priority": "low",
+  "retries": 5,
+  "created": "2020-04-02T17:42:14.265Z",
+  "deadline": "2020-04-03T17:42:14.265Z",
+  "expires": "2021-04-02T17:42:14.265Z",
+  "scopes": [
+    "queue:get-artifact:project/gecko/android-ndk/*",
+    "queue:get-artifact:project/gecko/android-sdk/*",
+    "secrets:get:project/releng/gecko/build/level-3/*",
+    "secrets:get:project/taskcluster/gecko/hgfingerprint",
+    "secrets:get:project/taskcluster/gecko/hgmointernal",
+    "project:releng:services/tooltool/api/download/public",
+    "project:releng:services/tooltool/api/download/internal",
+    "docker-worker:feature:allowPtrace",
+    "assume:project:taskcluster:gecko:level-3-sccache-buckets",
+    "docker-worker:cache:gecko-level-3-checkouts-v3-f730704b60167efec983",
+    "docker-worker:cache:gecko-level-3-tooltool-cache-v3-f730704b60167efec983"
+  ],
+  "payload": {
+    "onExitStatus": {
+      "retry": [4, 72],
+      "purgeCaches": [72]
+    },
+    "maxRunTime": 7200,
+    "image": {
+      "path": "public/image.tar.zst",
+      "type": "task-image",
+      "taskId": "I_IyXrxGSMOAWRTfK6dK1w"
+    },
+    "cache": {
+      "gecko-level-3-tooltool-cache-v3-f730704b60167efec983": "/builds/worker/tooltool-cache",
+      "gecko-level-3-checkouts-v3-f730704b60167efec983": "/builds/worker/checkouts"
+    },
+    "artifacts": [
+      {
+        "public/build/maven": {
+          "path": "/builds/worker/workspace/obj-build/gradle/build/mobile/android/geckoview/maven/",
+          "expires": "2021-04-02T17:42:14.265Z",
+          "type": "directory"
+        },
+        "public/build/geckoview_example.apk": {
+          "path": "/builds/worker/workspace/obj-build/gradle/build/mobile/android/geckoview_example/outputs/apk/withGeckoBinaries/debug/geckoview_example-withGeckoBinaries-debug.apk",
+          "expires": "2021-04-02T17:42:14.265Z",
+          "type": "file"
+        },
+        "public/build": {
+          "path": "/builds/worker/artifacts/",
+          "expires": "2021-04-02T17:42:14.265Z",
+          "type": "directory"
+        },
+        "public/logs": {
+          "path": "/builds/worker/logs/",
+          "expires": "2021-04-02T17:42:14.265Z",
+          "type": "directory"
+        },
+        "public/build/geckoview-androidTest.apk": {
+          "path": "/builds/worker/workspace/obj-build/gradle/build/mobile/android/geckoview/outputs/apk/androidTest/withGeckoBinaries/debug/geckoview-withGeckoBinaries-debug-androidTest.apk",
+          "expires": "2021-04-02T17:42:14.265Z",
+          "type": "file"
+        }
+      }
+    ],
+    "command": [
+      "/builds/worker/bin/run-task",
+      "--gecko-checkout=/builds/worker/checkouts/gecko",
+      "--fetch-hgfingerprint",
+      "--",
+      "bash",
+      "-cx",
+      "${GECKO_PATH}/taskcluster/scripts/builder/build-linux.sh"
+    ],
+    "env": {
+      "MOZ_AUTOMATION": "1",
+      "MOZ_SOURCE_CHANGESET": "7f9799e1d3d5c955518ecd1d0024921ac159b970",
+      "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+      "NEED_XVFB": "false",
+      "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+      "WORKSPACE": "/builds/worker/workspace",
+      "PYTHONUNBUFFERED": "1",
+      "MH_CUSTOM_BUILD_VARIANT_CFG": "api-16-debug",
+      "MOZHARNESS_SCRIPT": "mozharness/scripts/fx_desktop_build.py",
+      "MOZ_BUILD_DATE": "20200402174015",
+      "MH_BUILD_POOL": "taskcluster",
+      "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+      "MOZ_FETCHES_DIR": "fetches",
+      "MOZHARNESS_ACTIONS": "get-secrets build",
+      "GECKO_PATH": "/builds/worker/checkouts/gecko",
+      "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/integration/autoland",
+      "EXTRA_MOZHARNESS_CONFIG": "{\"objdir\": \"obj-build\"}",
+      "MOZ_SOURCE_REPO": "https://hg.mozilla.org/integration/autoland",
+      "GECKO_HEAD_REV": "7f9799e1d3d5c955518ecd1d0024921ac159b970",
+      "MH_BRANCH": "autoland",
+      "MOZ_SCM_LEVEL": "3",
+      "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+      "SCCACHE_GCS_PROJECT": "sccache-3",
+      "MOZ_FETCHES": "[{\"artifact\": \"public/build/android-gradle-dependencies.tar.xz\", \"extract\": true, \"task\": \"e0jCJNwDSEOf3ELSqsK-Qw\"}, {\"artifact\": \"project/gecko/android-ndk/android-ndk.tar.xz\", \"extract\": true, \"task\": \"WsgZ4ulrTXS8ROAs5mKZ4g\"}, {\"artifact\": \"project/gecko/android-sdk/android-sdk-linux.tar.xz\", \"extract\": true, \"task\": \"SBZuExGLRVGdZnLaYSsaig\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"Qn52CuwUT3el8G6Uz7qwlA\"}, {\"artifact\": \"public/build/rust-size.tar.xz\", \"extract\": true, \"task\": \"Od-lJtOZQm2QUjbfyT915Q\"}, {\"artifact\": \"public/build/cbindgen.tar.xz\", \"extract\": true, \"task\": \"IL3pXFgfRZuanbaL6qhngA\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"O1fsyO1xTvqR9mpcvxzvmQ\"}, {\"artifact\": \"public/build/node.tar.xz\", \"extract\": true, \"task\": \"RGE0LJ_zQ3mOPIWxnovs1Q\"}, {\"artifact\": \"public/build/clang.tar.xz\", \"extract\": true, \"task\": \"Ll-6mwKuRw-fFddaRUGknA\"}, {\"artifact\": \"public/build/sccache.tar.xz\", \"extract\": true, \"task\": \"VHkQiobIQ8mKlUiRIyjNeA\"}]",
+      "USE_SCCACHE": "1",
+      "MOZ_DISABLE_FULL_SYMBOLS": "1",
+      "UPLOAD_DIR": "/builds/worker/artifacts/",
+      "MOZ_AUTOMATION_PACKAGE_TESTS": "1",
+      "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+      "MAR_CHANNEL_ID": "firefox-mozilla-central",
+      "GRADLE_USER_HOME": "/builds/worker/checkouts/gecko/mobile/android/gradle/dotgradle-offline",
+      "SCCACHE_IDLE_TIMEOUT": "0",
+      "TASKCLUSTER_VOLUMES": "/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+      "TOOLTOOL_MANIFEST": "mobile/android/config/tooltool-manifests/android/releng.manifest",
+      "MOZHARNESS_CONFIG": "builds/releng_base_android_64_builds.py"
+    },
+    "features": {
+      "taskclusterProxy": true,
+      "allowPtrace": true,
+      "chainOfTrust": true
+    }
+  },
+  "metadata": {
+    "owner": "aklotz@mozilla.com",
+    "source": "https://hg.mozilla.org/integration/autoland/file/7f9799e1d3d5c955518ecd1d0024921ac159b970/taskcluster/ci/build",
+    "description": "Android 4.0 api-16+ Debug ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=7f9799e1d3d5c955518ecd1d0024921ac159b970))",
+    "name": "build-android-api-16/debug"
+  },
+  "tags": {
+    "kind": "build",
+    "worker-implementation": "docker-worker",
+    "createdForUser": "aklotz@mozilla.com",
+    "retrigger": "false",
+    "label": "build-android-api-16/debug",
+    "os": "linux"
+  },
+  "extra": {
+    "index": {
+      "rank": 1585849215
+    },
+    "chainOfTrust": {
+      "inputs": {
+        "docker-image": "I_IyXrxGSMOAWRTfK6dK1w"
+      }
+    },
+    "treeherder": {
+      "machine": {
+        "platform": "android-4-0-armv7-api16"
+      },
+      "tier": 1,
+      "symbol": "B",
+      "jobKind": "build",
+      "collection": {
+        "debug": true
+      }
+    },
+    "treeherder-platform": "android-4-0-armv7-api16/debug",
+    "parent": "VaQoWKTbSdGSwBJn6UZV9g"
+  }
+}

--- a/ui/css/treeherder-details-panel.css
+++ b/ui/css/treeherder-details-panel.css
@@ -72,7 +72,7 @@ div#details-panel-content .details-panel-navbar > ul.tab-headers > li {
 }
 
 .tab-header-tabs > li {
-  padding: 1px 15px;
+  padding: 1px 12px;
   line-height: 30px;
   cursor: pointer;
   color: #9fa3a5;
@@ -134,6 +134,7 @@ div#details-panel-content .actionbar-nav > li > button:focus {
 
 .react-tabs__tab-panel--selected {
   height: 100%;
+  margin: 0.5em 1em;
 }
 
 #tabs-panel {
@@ -142,7 +143,7 @@ div#details-panel-content .actionbar-nav > li > button:focus {
   width: 100%;
 }
 
-#details-panel-content #job-details-list,
+#details-panel-content #job-artifacts-list,
 #details-panel-content .similar-jobs > .similar-job-list tbody {
   overflow-y: auto;
   height: 100%;
@@ -156,7 +157,7 @@ div#details-panel-content .actionbar-nav > li > button:focus {
   flex-flow: row;
 }
 
-#job-details-actionbar {
+#actionbar {
   min-height: 33px;
 }
 
@@ -245,16 +246,6 @@ div#details-panel-content .actionbar-nav > li > button:focus {
   color: red;
 }
 
-#job-details-pane ul {
-  margin: 0;
-  padding: 0;
-  line-height: 12px;
-}
-
-#job-details-pane {
-  overflow: auto;
-}
-
 #result-status-pane {
   width: 100%;
   padding: 4px;
@@ -276,7 +267,7 @@ div#details-panel-content .actionbar-nav > li > button:focus {
   border-left: 1px solid lightgrey;
 }
 
-#job-details-list label {
+#job-artifacts-list label {
   margin-left: 2px;
 }
 

--- a/ui/css/treeherder-details-panel.css
+++ b/ui/css/treeherder-details-panel.css
@@ -135,6 +135,11 @@ div#details-panel-content .actionbar-nav > li > button:focus {
 .react-tabs__tab-panel--selected {
   height: 100%;
   margin: 0.5em 1em;
+  overflow-y: auto;
+}
+
+.react-tabs__tab--disabled {
+  font-style: italic !important;
 }
 
 #tabs-panel {

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import chunk from 'lodash/chunk';
 import { connect } from 'react-redux';
-import { Queue } from 'taskcluster-client-web';
 
 import { setPinBoardVisible } from '../redux/stores/pinnedJobs';
 import { thEvents } from '../../helpers/constants';
@@ -156,12 +155,6 @@ class DetailsPanel extends React.Component {
           );
         }
 
-        let taskDefinitionPromise;
-        if (selectedJob.task_id) {
-          const queue = new Queue({ rootUrl: currentRepo.tc_root_url });
-          taskDefinitionPromise = queue.task(selectedJob.task_id);
-        }
-
         const jobLogUrlPromise = JobLogUrlModel.getList(
           { job_id: selectedJob.id },
           this.selectJobController.signal,
@@ -180,7 +173,6 @@ class DetailsPanel extends React.Component {
           phSeriesPromise,
           jobArtifactsPromise,
           builtFromArtifactPromise,
-          taskDefinitionPromise,
         ])
           .then(
             async ([
@@ -189,7 +181,6 @@ class DetailsPanel extends React.Component {
               phSeriesResult,
               jobArtifactsResult,
               builtFromArtifactResult,
-              taskDefinition,
             ]) => {
               // This version of the job has more information than what we get in the main job list.  This
               // is what we'll pass to the rest of the details panel.
@@ -281,7 +272,6 @@ class DetailsPanel extends React.Component {
                   logViewerFullUrl,
                   perfJobDetail,
                   jobRevision,
-                  taskDefinition,
                 },
                 async () => {
                   await this.updateClassifications();
@@ -321,7 +311,6 @@ class DetailsPanel extends React.Component {
       logViewerUrl,
       logViewerFullUrl,
       bugs,
-      taskDefinition,
     } = this.state;
     const detailsPanelHeight = isPinBoardVisible
       ? resizedHeight - pinboardHeight
@@ -373,7 +362,8 @@ class DetailsPanel extends React.Component {
               bugs={bugs}
               togglePinBoardVisibility={() => this.togglePinBoardVisibility()}
               logViewerFullUrl={logViewerFullUrl}
-              taskDefinition={taskDefinition}
+              taskId={selectedJobFull.task_id}
+              rootUrl={currentRepo.tc_root_url}
             />
           </div>
         )}

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import chunk from 'lodash/chunk';
 import { connect } from 'react-redux';
+import { Queue } from 'taskcluster-client-web';
 
 import { setPinBoardVisible } from '../redux/stores/pinnedJobs';
 import { thEvents } from '../../helpers/constants';
@@ -155,6 +156,12 @@ class DetailsPanel extends React.Component {
           );
         }
 
+        let taskDefinitionPromise;
+        if (selectedJob.task_id) {
+          const queue = new Queue({ rootUrl: currentRepo.tc_root_url });
+          taskDefinitionPromise = queue.task(selectedJob.task_id);
+        }
+
         const jobLogUrlPromise = JobLogUrlModel.getList(
           { job_id: selectedJob.id },
           this.selectJobController.signal,
@@ -173,6 +180,7 @@ class DetailsPanel extends React.Component {
           phSeriesPromise,
           jobArtifactsPromise,
           builtFromArtifactPromise,
+          taskDefinitionPromise,
         ])
           .then(
             async ([
@@ -181,6 +189,7 @@ class DetailsPanel extends React.Component {
               phSeriesResult,
               jobArtifactsResult,
               builtFromArtifactResult,
+              taskDefinition,
             ]) => {
               // This version of the job has more information than what we get in the main job list.  This
               // is what we'll pass to the rest of the details panel.
@@ -272,6 +281,7 @@ class DetailsPanel extends React.Component {
                   logViewerFullUrl,
                   perfJobDetail,
                   jobRevision,
+                  taskDefinition,
                 },
                 async () => {
                   await this.updateClassifications();
@@ -311,6 +321,7 @@ class DetailsPanel extends React.Component {
       logViewerUrl,
       logViewerFullUrl,
       bugs,
+      taskDefinition,
     } = this.state;
     const detailsPanelHeight = isPinBoardVisible
       ? resizedHeight - pinboardHeight
@@ -362,6 +373,7 @@ class DetailsPanel extends React.Component {
               bugs={bugs}
               togglePinBoardVisibility={() => this.togglePinBoardVisibility()}
               logViewerFullUrl={logViewerFullUrl}
+              taskDefinition={taskDefinition}
             />
           </div>
         )}

--- a/ui/job-view/details/JobTestGroups.jsx
+++ b/ui/job-view/details/JobTestGroups.jsx
@@ -1,48 +1,76 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Queue } from 'taskcluster-client-web';
 
 export default class JobTestGroups extends React.PureComponent {
-  render() {
-    const { taskDefinition } = this.props;
-    let testGroups = [];
-    if (taskDefinition.payload.env.MOZHARNESS_TEST_PATHS) {
-      [testGroups] = Object.values(
-        JSON.parse(taskDefinition.payload.env.MOZHARNESS_TEST_PATHS),
-      );
+  constructor(props) {
+    super(props);
+    this.state = {
+      testGroups: [],
+    };
+  }
+
+  componentDidMount() {
+    this.fetch();
+  }
+
+  // Because we use Tab with forceRender it does not call componentDidMount
+  // even though the props have changes
+  componentDidUpdate(prevProps) {
+    if (this.props.taskId !== prevProps.taskId) {
+      this.fetch();
     }
+  }
+
+  async fetch() {
+    const { notifyTestGroupsAvailable, taskId, rootUrl } = this.props;
+    if (taskId) {
+      const queue = new Queue({ rootUrl });
+      const taskDefinition = await queue.task(taskId);
+      if (taskDefinition && taskDefinition.payload.env.MOZHARNESS_TEST_PATHS) {
+        this.setState({
+          testGroups: Object.values(
+            JSON.parse(taskDefinition.payload.env.MOZHARNESS_TEST_PATHS),
+          )[0],
+        });
+        notifyTestGroupsAvailable(true);
+      } else {
+        notifyTestGroupsAvailable(false);
+      }
+    }
+  }
+
+  render() {
+    const { testGroups } = this.state;
     const currentLocation = window.location.href;
 
     return (
       <div className="job-test-groups" role="region" aria-label="Test Groups">
-        <div className="job-test-groups-list">
-          <strong>Test Groups</strong>
-          <ul className="list-unstyled">
-            {testGroups.map((testGroup) => (
-              <li className="small" key={testGroup}>
-                <a
-                  href={`${currentLocation}&test_paths=${testGroup}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {testGroup}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
+        {testGroups.length > 0 && (
+          <div className="job-test-groups-list">
+            <strong>Test Groups</strong>
+            <ul className="list-unstyled">
+              {testGroups.map((testGroup) => (
+                <li className="small" key={testGroup}>
+                  <a
+                    href={`${currentLocation}&test_paths=${testGroup}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {testGroup}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
       </div>
     );
   }
 }
 
 JobTestGroups.propTypes = {
-  taskDefinition: PropTypes.shape({
-    payload: PropTypes.shape({
-      env: PropTypes.shape({}),
-    }),
-  }),
-};
-
-JobTestGroups.defaultProps = {
-  taskDefinition: {},
+  notifyTestGroupsAvailable: PropTypes.func.isRequired,
+  taskId: PropTypes.string.isRequired,
+  rootUrl: PropTypes.string.isRequired,
 };

--- a/ui/job-view/details/JobTestGroups.jsx
+++ b/ui/job-view/details/JobTestGroups.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class JobTestGroups extends React.PureComponent {
+  render() {
+    const { taskDefinition } = this.props;
+    let testGroups = [];
+    if (taskDefinition.payload.env.MOZHARNESS_TEST_PATHS) {
+      [testGroups] = Object.values(
+        JSON.parse(taskDefinition.payload.env.MOZHARNESS_TEST_PATHS),
+      );
+    }
+    const currentLocation = window.location.href;
+
+    return (
+      <div className="job-test-groups" role="region" aria-label="Test Groups">
+        <div className="job-test-groups-list">
+          <strong>Test Groups</strong>
+          <ul className="list-unstyled">
+            {testGroups.map((testGroup) => (
+              <li className="small" key={testGroup}>
+                <a
+                  href={`${currentLocation}&test_paths=${testGroup}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {testGroup}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    );
+  }
+}
+
+JobTestGroups.propTypes = {
+  taskDefinition: PropTypes.shape({
+    payload: PropTypes.shape({
+      env: PropTypes.shape({}),
+    }),
+  }),
+};
+
+JobTestGroups.defaultProps = {
+  taskDefinition: {},
+};

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -400,7 +400,7 @@ class ActionBar extends React.PureComponent {
     const { customJobActionsShowing } = this.state;
 
     return (
-      <div id="job-details-actionbar">
+      <div id="actionbar">
         <nav className="navbar navbar-dark details-panel-navbar">
           <ul className="nav actionbar-nav">
             <LogUrls

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -11,7 +11,8 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 import { thEvents } from '../../../helpers/constants';
-import JobDetails from '../../../shared/JobDetails';
+import JobArtifacts from '../../../shared/JobArtifacts';
+import JobTestGroups from '../JobTestGroups';
 import { clearSelectedJob } from '../../redux/stores/selectedJob';
 import { pinJob, addBug } from '../../redux/stores/pinnedJobs';
 import FailureSummaryTab from '../../../shared/tabs/failureSummary/FailureSummaryTab';
@@ -19,6 +20,14 @@ import FailureSummaryTab from '../../../shared/tabs/failureSummary/FailureSummar
 import PerformanceTab from './PerformanceTab';
 import AnnotationsTab from './AnnotationsTab';
 import SimilarJobsTab from './SimilarJobsTab';
+
+const showTabsFromProps = (props) => {
+  const { perfJobDetail, taskDefinition } = props;
+  return {
+    showPerf: !!perfJobDetail.length,
+    showTestGroups: !!taskDefinition.payload.env.MOZHARNESS_TEST_PATHS,
+  };
+};
 
 class TabsPanel extends React.Component {
   constructor(props) {
@@ -41,7 +50,7 @@ class TabsPanel extends React.Component {
     ) {
       const tabIndex = TabsPanel.getDefaultTabIndex(
         selectedJobFull.resultStatus,
-        !!perfJobDetail.length,
+        props,
       );
 
       return {
@@ -63,31 +72,40 @@ class TabsPanel extends React.Component {
 
   onSelectNextTab = () => {
     const { tabIndex } = this.state;
-    const { perfJobDetail } = this.props;
     const nextIndex = tabIndex + 1;
-    const tabCount = TabsPanel.getTabNames(!!perfJobDetail.length).length;
+    const tabCount = TabsPanel.getTabNames(showTabsFromProps(this.props))
+      .length;
     this.setState({ tabIndex: nextIndex < tabCount ? nextIndex : 0 });
   };
 
-  static getDefaultTabIndex(status, showPerf) {
+  static getDefaultTabIndex(status, props) {
+    const { showPerf, showTestGroups } = showTabsFromProps(props);
     let idx = 0;
-    const tabNames = TabsPanel.getTabNames(showPerf);
+    const tabNames = TabsPanel.getTabNames({ showPerf, showTestGroups });
     const tabIndexes = tabNames.reduce(
       (acc, name) => ({ ...acc, [name]: idx++ }),
       {},
     );
 
-    let tabIndex = showPerf ? tabIndexes.perf : tabIndexes.details;
+    let tabIndex = showPerf ? tabIndexes.perf : tabIndexes.artifacts;
     if (['busted', 'testfailed', 'exception'].includes(status)) {
       tabIndex = tabIndexes.failure;
     }
     return tabIndex;
   }
 
-  static getTabNames(showPerf) {
-    return ['details', 'failure', 'annotations', 'similar', 'perf'].filter(
-      (name) => !(name === 'perf' && !showPerf),
-    );
+  static getTabNames({ showPerf, showTestGroups }) {
+    // The order in here has to match the order within the render method
+    return [
+      'artifacts',
+      'failure',
+      'annotations',
+      'similar',
+      'perf',
+      'test-groups',
+    ]
+      .filter((name) => !(name === 'perf' && !showPerf))
+      .filter((name) => !(name === 'test-groups' && !showTestGroups));
   }
 
   setTabIndex = (tabIndex) => {
@@ -113,9 +131,11 @@ class TabsPanel extends React.Component {
       selectedJobFull,
       pinJob,
       addBug,
+      taskDefinition,
     } = this.props;
     const { tabIndex } = this.state;
     const countPinnedJobs = Object.keys(pinnedJobs).length;
+    const { showPerf, showTestGroups } = showTabsFromProps(this.props);
 
     return (
       <div id="tabs-panel" role="region" aria-label="Job">
@@ -126,11 +146,12 @@ class TabsPanel extends React.Component {
         >
           <TabList className="tab-headers">
             <span className="tab-header-tabs">
-              <Tab>Job Details</Tab>
+              <Tab>Artifacts</Tab>
               <Tab>Failure Summary</Tab>
               <Tab>Annotations</Tab>
               <Tab>Similar Jobs</Tab>
-              {!!perfJobDetail.length && <Tab>Performance</Tab>}
+              {showPerf && <Tab>Performance</Tab>}
+              {showTestGroups && <Tab>Test Groups</Tab>}
             </span>
             <span
               id="tab-header-buttons"
@@ -180,7 +201,7 @@ class TabsPanel extends React.Component {
             </span>
           </TabList>
           <TabPanel>
-            <JobDetails jobDetails={jobDetails} />
+            <JobArtifacts jobDetails={jobDetails} />
           </TabPanel>
           <TabPanel>
             <FailureSummaryTab
@@ -209,13 +230,18 @@ class TabsPanel extends React.Component {
               selectedJobFull={selectedJobFull}
             />
           </TabPanel>
-          {!!perfJobDetail.length && (
+          {showPerf && (
             <TabPanel>
               <PerformanceTab
                 repoName={repoName}
                 perfJobDetail={perfJobDetail}
                 revision={jobRevision}
               />
+            </TabPanel>
+          )}
+          {showTestGroups && (
+            <TabPanel>
+              <JobTestGroups taskDefinition={taskDefinition} />
             </TabPanel>
           )}
         </Tabs>

--- a/ui/logviewer/App.jsx
+++ b/ui/logviewer/App.jsx
@@ -21,7 +21,7 @@ import {
 import { getData } from '../helpers/http';
 import JobModel from '../models/job';
 import PushModel from '../models/push';
-import JobDetails from '../shared/JobDetails';
+import JobArtifacts from '../shared/JobArtifacts';
 import JobInfo from '../shared/JobInfo';
 import RepositoryModel from '../models/repository';
 import { formatArtifacts, errorLinesCss } from '../helpers/display';
@@ -300,7 +300,7 @@ class App extends React.PureComponent {
                     showJobFilters={false}
                     currentRepo={currentRepo}
                   />
-                  <JobDetails jobDetails={jobDetails} />
+                  <JobArtifacts jobDetails={jobDetails} />
                 </div>
                 <ErrorLines
                   errors={errors}

--- a/ui/shared/JobArtifacts.jsx
+++ b/ui/shared/JobArtifacts.jsx
@@ -17,7 +17,7 @@ export default class JobDetails extends React.PureComponent {
     });
 
     return (
-      <div id="job-details-list" role="region" aria-label="Job Details">
+      <div id="job-artifacts-list" role="region" aria-label="Artifacts">
         <ul className="list-unstyled">
           {sortedDetails.map((line, idx) => (
             <li


### PR DESCRIPTION
Fixes #6630

When selecting a job that has MOZHARNESS_TEST_PATH specified we can fetch
what test groups[1] were executed.

This change adds a new tab named "Test Groups" and renames "Job Details" to "Artifacts".

[1] Some test jobs use manifests to group tests while wpt jobs don't use manifests.