### PR TITLE
Bug 1647447 - Refactor the push information UI

### DIFF
--- a/tests/ui/push-health/CommitHistory_test.jsx
+++ b/tests/ui/push-health/CommitHistory_test.jsx
@@ -30,6 +30,22 @@ describe('CommitHistory', () => {
     />
   );
 
+  test('should show the push header and the author', () => {
+    const { details: commitHistory } = pushHealth.metrics.commitHistory;
+    const { getByTestId } = render(testCommitHistory(commitHistory));
+    const headerText = getByTestId('headerText');
+    const authorTime = getByTestId('authorTime');
+
+    expect(headerText).toBeInTheDocument();
+    expect(headerText).toHaveTextContent(
+      'Backed out changeset f6ccc4ba38d9 (bug 1609356) for failures on browser_toolbox_dynamic_registration.js. CLOSED TREE',
+    );
+    expect(authorTime).toBeInTheDocument();
+    expect(authorTime).toHaveTextContent(
+      'Wed, May 6, 22:53:29-hiro@mozilla.com',
+    );
+  });
+
   test('should show a parent commit and health icon for that parent', async () => {
     const { details: commitHistory } = pushHealth.metrics.commitHistory;
     const { getByText, getByTestId, queryByTestId } = render(

--- a/tests/ui/push-health/CommitHistory_test.jsx
+++ b/tests/ui/push-health/CommitHistory_test.jsx
@@ -42,7 +42,7 @@ describe('CommitHistory', () => {
     );
     expect(authorTime).toBeInTheDocument();
     expect(authorTime).toHaveTextContent(
-      'Wed, May 6, 22:53:29-hiro@mozilla.com',
+      'Wed, May 6, 17:23:29-hiro@mozilla.com',
     );
   });
 

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -669,6 +669,7 @@ class Push extends React.PureComponent {
                   repo={currentRepo}
                   bugSummaryMap={bugSummaryMap}
                   widthClass="ml-4"
+                  commitShaClass="text-monospace"
                 >
                   {showPushHealthSummary && (
                     <div className="ml-3 mt-4">
@@ -703,6 +704,7 @@ class Push extends React.PureComponent {
                 revision={tipRevision}
                 repo={currentRepo}
                 key={tipRevision.revision}
+                commitShaClass="text-monospace"
               />
             </ul>
           </span>

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -668,7 +668,7 @@ class Push extends React.PureComponent {
                   revisionCount={revisionCount}
                   repo={currentRepo}
                   bugSummaryMap={bugSummaryMap}
-                  widthClass="ml-4"
+                  widthClass="ml-4 mb-3"
                   commitShaClass="text-monospace"
                 >
                   {showPushHealthSummary && (

--- a/ui/push-health/CommitHistory.jsx
+++ b/ui/push-health/CommitHistory.jsx
@@ -105,6 +105,7 @@ class CommitHistory extends React.PureComponent {
                 revision={revisions[1]}
                 repo={currentRepo}
                 key={revision.revision}
+                commitShaClass="font-weight-bold text-secondary"
               />
             </div>
           )}
@@ -114,6 +115,7 @@ class CommitHistory extends React.PureComponent {
               revisions={revisions.slice(2, 20)}
               revisionCount={revisionCount - 2}
               repo={currentRepo}
+              commitShaClass="font-weight-bold text-secondary"
             />
           )}
           <div className="ml-3">

--- a/ui/push-health/CommitHistory.jsx
+++ b/ui/push-health/CommitHistory.jsx
@@ -7,6 +7,7 @@ import { faCaretDown, faCaretRight } from '@fortawesome/free-solid-svg-icons';
 import Clipboard from '../shared/Clipboard';
 import PushHealthStatus from '../shared/PushHealthStatus';
 import { RevisionList } from '../shared/RevisionList';
+import { Revision } from '../shared/Revision';
 import { getJobsUrl } from '../helpers/url';
 import RepositoryModel from '../models/repository';
 import { toDateStr } from '../helpers/display';
@@ -17,7 +18,6 @@ class CommitHistory extends React.PureComponent {
 
     this.state = {
       clipboardVisible: false,
-      showAllRevisions: false,
       isExpanded: false,
     };
   }
@@ -48,7 +48,7 @@ class CommitHistory extends React.PureComponent {
       revision,
       currentRepo,
     } = this.props;
-    const { clipboardVisible, showAllRevisions, isExpanded } = this.state;
+    const { clipboardVisible, isExpanded } = this.state;
     const parentRepoModel = new RepositoryModel(parentRepository);
     const parentLinkUrl = exactMatch
       ? `${getJobsUrl({
@@ -66,7 +66,7 @@ class CommitHistory extends React.PureComponent {
     const authorEmail = authorMatch ? authorMatch[1] : author;
     const expandIcon = isExpanded ? faCaretDown : faCaretRight;
     const expandTitle = isExpanded ? 'Click to collapse' : 'Click to expand';
-    const expandText = isExpanded ? 'Hide all commits' : 'Show all commits';
+    const expandText = isExpanded ? 'Hide all commits' : 'Show more commits';
 
     return (
       <React.Fragment>
@@ -98,53 +98,47 @@ class CommitHistory extends React.PureComponent {
             </span>
           </div>
         </div>
-        <div className="commit-area mt-2 pl-2 text-secondary">
-          <span className="font-weight-bold">
-            <Button
-              onClick={this.toggleDetails}
-              outline
-              color="darker-secondary"
-              className="border-0 pl-0 shadow-none"
-              role="button"
-              aria-expanded={isExpanded}
-            >
-              <FontAwesomeIcon
-                icon={expandIcon}
-                title={expandTitle}
-                aria-label={expandTitle}
-                alt=""
-              />
-              <span className="ml-1 font-weight-bold">{expandText}</span>
-            </Button>
-          </span>
-          {isExpanded &&
-            (revisions.length <= 5 || showAllRevisions ? (
-              <RevisionList
-                revision={revision}
-                revisions={revisions.slice(0, 20)}
-                revisionCount={revisionCount}
+        <div className="commit-area mt-2 pl-3 text-secondary">
+          {revisions.length > 1 && (
+            <div>
+              <Revision
+                revision={revisions[1]}
                 repo={currentRepo}
+                key={revision.revision}
               />
-            ) : (
-              <span>
-                <RevisionList
-                  revision={revision}
-                  revisions={revisions.slice(0, 5)}
-                  revisionCount={revisionCount}
-                  repo={currentRepo}
-                />
+            </div>
+          )}
+          {revisions.length > 2 && (
+            <React.Fragment>
+              <span className="font-weight-bold">
                 <Button
+                  onClick={this.toggleDetails}
                   outline
                   color="darker-secondary"
-                  onClick={() =>
-                    this.setState({ showAllRevisions: !showAllRevisions })
-                  }
+                  className="border-0 pl-0 ml-2 shadow-none"
+                  role="button"
+                  aria-expanded={isExpanded}
                 >
-                  Show more...
+                  <FontAwesomeIcon
+                    icon={expandIcon}
+                    title={expandTitle}
+                    aria-label={expandTitle}
+                    alt=""
+                  />
+                  <span className="ml-1">{expandText}</span>
                 </Button>
               </span>
-            ))}
-          <div>
+              {isExpanded && (
+                <RevisionList
+                  revision={revision}
+                  revisions={revisions.slice(2, 20)}
+                  revisionCount={revisionCount - 2}
+                  repo={currentRepo}
+                />
+              )}
+            </React.Fragment>
+          )}
+          <div className="ml-1">
             Base commit:
             <span>
               {!exactMatch && (
@@ -161,18 +155,13 @@ class CommitHistory extends React.PureComponent {
                 onMouseEnter={() => this.showClipboard(true)}
                 onMouseLeave={() => this.showClipboard(false)}
               >
-                <Clipboard
-                  description="full hash"
-                  text={parentSha}
-                  visible={clipboardVisible}
-                />
                 <a
                   href={parentLinkUrl}
                   target="_blank"
                   rel="noopener noreferrer"
                   title="Open this push"
                   data-testid="parent-commit-sha"
-                  className="mr-1 text-monospace commit-sha font-weight-bold"
+                  className="mr-1 ml-1 text-monospace commit-sha font-weight-bold text-secondary"
                 >
                   {parentPushRevision || parentSha}
                 </a>
@@ -183,6 +172,11 @@ class CommitHistory extends React.PureComponent {
                     jobCounts={jobCounts}
                   />
                 )}
+                <Clipboard
+                  description="full hash"
+                  text={parentSha}
+                  visible={clipboardVisible}
+                />
               </span>
             </span>
           </div>

--- a/ui/push-health/CommitHistory.jsx
+++ b/ui/push-health/CommitHistory.jsx
@@ -66,7 +66,7 @@ class CommitHistory extends React.PureComponent {
     const authorEmail = authorMatch ? authorMatch[1] : author;
     const expandIcon = isExpanded ? faCaretUp : faCaretRight;
     const expandTitle = isExpanded ? 'Click to collapse' : 'Click to expand';
-    const expandText = isExpanded ? 'Hide all commits' : 'Show more commits';
+    const expandText = isExpanded ? 'Hide commits' : 'Show more commits';
 
     return (
       <React.Fragment>

--- a/ui/push-health/CommitHistory.jsx
+++ b/ui/push-health/CommitHistory.jsx
@@ -143,7 +143,7 @@ class CommitHistory extends React.PureComponent {
                   rel="noopener noreferrer"
                   title="Open this push"
                   data-testid="parent-commit-sha"
-                  className="mr-1 ml-1 text-monospace commit-sha font-weight-bold text-secondary"
+                  className="mr-1 ml-1 font-weight-bold text-secondary"
                 >
                   {parentPushRevision || parentSha}
                 </a>

--- a/ui/push-health/CommitHistory.jsx
+++ b/ui/push-health/CommitHistory.jsx
@@ -2,11 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Button } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
+import { faCaretDown, faCaretRight } from '@fortawesome/free-solid-svg-icons';
 
 import Clipboard from '../shared/Clipboard';
 import PushHealthStatus from '../shared/PushHealthStatus';
-import PushAuthor from '../shared/PushAuthor';
 import { RevisionList } from '../shared/RevisionList';
 import { getJobsUrl } from '../helpers/url';
 import RepositoryModel from '../models/repository';
@@ -19,11 +18,18 @@ class CommitHistory extends React.PureComponent {
     this.state = {
       clipboardVisible: false,
       showAllRevisions: false,
+      isExpanded: false,
     };
   }
 
   showClipboard = (show) => {
     this.setState({ clipboardVisible: show });
+  };
+
+  toggleDetails = () => {
+    this.setState((prevState) => ({
+      isExpanded: !prevState.isExpanded,
+    }));
   };
 
   render() {
@@ -42,7 +48,7 @@ class CommitHistory extends React.PureComponent {
       revision,
       currentRepo,
     } = this.props;
-    const { clipboardVisible, showAllRevisions } = this.state;
+    const { clipboardVisible, showAllRevisions, isExpanded } = this.state;
     const parentRepoModel = new RepositoryModel(parentRepository);
     const parentLinkUrl = exactMatch
       ? `${getJobsUrl({
@@ -55,93 +61,121 @@ class CommitHistory extends React.PureComponent {
       repo: currentRepo.name,
     });
     const { author, push_timestamp: pushTimestamp } = currentPush;
-    const authorPushFilterUrl = getJobsUrl({ author, repo: currentRepo.name });
+    const headerText = revisions[0].comments.split('\n')[0];
+    const authorMatch = author.match(/<(.*?)>+/);
+    const authorEmail = authorMatch ? authorMatch[1] : author;
+    const expandIcon = isExpanded ? faCaretDown : faCaretRight;
+    const expandTitle = isExpanded ? 'Click to collapse' : 'Click to expand';
+    const expandText = isExpanded ? 'Hide all commits' : 'Show all commits';
 
     return (
       <React.Fragment>
-        <div className="push-header border-bottom" data-testid="push-header">
+        <div className="push-header" data-testid="push-header">
           <div className="push-bar">
-            <a
-              href={revisionPushFilterUrl}
-              title="View this push in Treeherder"
-            >
+            <div className="h3 text-capitalize">{headerText}</div>
+            <div className="text-secondary">
               {toDateStr(pushTimestamp)}
-              <FontAwesomeIcon
-                icon={faExternalLinkAlt}
-                className="ml-1 icon-superscript"
-              />
-            </a>
-            <span className="mx-1">-</span>
-            <PushAuthor author={author} url={authorPushFilterUrl} />
+              <span className="mx-1">-</span>
+              <span>{authorEmail}</span>
+            </div>
           </div>
-        </div>
-        {revisions.length <= 5 || showAllRevisions ? (
-          <RevisionList
-            revision={revision}
-            revisions={revisions.slice(0, 20)}
-            revisionCount={revisionCount}
-            repo={currentRepo}
-          />
-        ) : (
-          <span>
-            <RevisionList
-              revision={revision}
-              revisions={revisions.slice(0, 5)}
-              revisionCount={revisionCount}
-              repo={currentRepo}
-            />
-            <Button
-              outline
-              color="darker-secondary"
-              onClick={() =>
-                this.setState({ showAllRevisions: !showAllRevisions })
-              }
-            >
-              Show more...
-            </Button>
-          </span>
-        )}
-        <div className="mt-4">
-          Parent Push:
-          <span className="ml-2">
-            {!exactMatch && (
-              <div>
-                <Alert color="warning" className="m-3 font-italics">
-                  Warning: Could not find an exact match parent Push in
-                  Treeherder.
-                </Alert>
-                {id && <div>Closest match: </div>}
-              </div>
-            )}
-            <span
-              className="mb-2"
-              onMouseEnter={() => this.showClipboard(true)}
-              onMouseLeave={() => this.showClipboard(false)}
-            >
-              <Clipboard
-                description="full hash"
-                text={parentSha}
-                visible={clipboardVisible}
-              />
+          <div className="text-secondary">
+            Push{' '}
+            <span className="font-weight-bold">
               <a
-                href={parentLinkUrl}
+                href={revisionPushFilterUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                title="Open this push"
-                data-testid="parent-commit-sha"
-                className="mr-1 text-monospace commit-sha"
               >
-                {parentPushRevision || parentSha}
+                {revision.substring(0, 17)}...
               </a>
-              {exactMatch && (
-                <PushHealthStatus
-                  revision={parentPushRevision}
-                  repoName={parentRepository.name}
-                  jobCounts={jobCounts}
-                />
-              )}
+            </span>{' '}
+            on{' '}
+            <span className="text-capitalize font-weight-bold">
+              {currentRepo.name}
             </span>
+          </div>
+        </div>
+        <div className="commit-area mt-2 pl-2 text-secondary">
+          <span className="font-weight-bold">
+            <FontAwesomeIcon
+              onClick={this.toggleDetails}
+              icon={expandIcon}
+              title={expandTitle}
+              aria-label={expandTitle}
+              alt=""
+            />{' '}
+            {expandText}
           </span>
+          {isExpanded &&
+            (revisions.length <= 5 || showAllRevisions ? (
+              <RevisionList
+                revision={revision}
+                revisions={revisions.slice(0, 20)}
+                revisionCount={revisionCount}
+                repo={currentRepo}
+              />
+            ) : (
+              <span>
+                <RevisionList
+                  revision={revision}
+                  revisions={revisions.slice(0, 5)}
+                  revisionCount={revisionCount}
+                  repo={currentRepo}
+                />
+                <Button
+                  outline
+                  color="darker-secondary"
+                  onClick={() =>
+                    this.setState({ showAllRevisions: !showAllRevisions })
+                  }
+                >
+                  Show more...
+                </Button>
+              </span>
+            ))}
+          <div>
+            Base commit:
+            <span>
+              {!exactMatch && (
+                <div>
+                  <Alert color="warning" className="m-3 font-italics">
+                    Warning: Could not find an exact match parent Push in
+                    Treeherder.
+                  </Alert>
+                  {id && <div>Closest match: </div>}
+                </div>
+              )}
+              <span
+                className="mb-2"
+                onMouseEnter={() => this.showClipboard(true)}
+                onMouseLeave={() => this.showClipboard(false)}
+              >
+                <Clipboard
+                  description="full hash"
+                  text={parentSha}
+                  visible={clipboardVisible}
+                />
+                <a
+                  href={parentLinkUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title="Open this push"
+                  data-testid="parent-commit-sha"
+                  className="mr-1 text-monospace commit-sha font-weight-bold"
+                >
+                  {parentPushRevision || parentSha}
+                </a>
+                {exactMatch && (
+                  <PushHealthStatus
+                    revision={parentPushRevision}
+                    repoName={parentRepository.name}
+                    jobCounts={jobCounts}
+                  />
+                )}
+              </span>
+            </span>
+          </div>
         </div>
       </React.Fragment>
     );

--- a/ui/push-health/CommitHistory.jsx
+++ b/ui/push-health/CommitHistory.jsx
@@ -105,7 +105,8 @@ class CommitHistory extends React.PureComponent {
                 revision={revisions[1]}
                 repo={currentRepo}
                 key={revision.revision}
-                commitShaClass="font-weight-bold text-secondary"
+                commitShaClass="font-weight-bold text-secondary h6"
+                commentFont="h6"
               />
             </div>
           )}
@@ -115,7 +116,8 @@ class CommitHistory extends React.PureComponent {
               revisions={revisions.slice(2, 20)}
               revisionCount={revisionCount - 2}
               repo={currentRepo}
-              commitShaClass="font-weight-bold text-secondary"
+              commitShaClass="font-weight-bold text-secondary h6"
+              commentFont="h6"
             />
           )}
           <div className="ml-3">

--- a/ui/push-health/CommitHistory.jsx
+++ b/ui/push-health/CommitHistory.jsx
@@ -72,16 +72,18 @@ class CommitHistory extends React.PureComponent {
       <React.Fragment>
         <div className="push-header" data-testid="push-header">
           <div className="push-bar">
-            <div className="h3 text-capitalize">{headerText}</div>
-            <div className="text-secondary">
+            <div className="h3 text-capitalize" data-testid="headerText">
+              {headerText}
+            </div>
+            <div className="text-secondary" data-testid="authorTime">
               {toDateStr(pushTimestamp)}
               <span className="mx-1">-</span>
               <span>{authorEmail}</span>
             </div>
           </div>
           <div className="text-secondary">
-            Push{' '}
-            <span className="font-weight-bold">
+            Push
+            <span className="font-weight-bold mr-1 ml-1">
               <a
                 href={revisionPushFilterUrl}
                 target="_blank"
@@ -89,23 +91,31 @@ class CommitHistory extends React.PureComponent {
               >
                 {revision.substring(0, 17)}...
               </a>
-            </span>{' '}
-            on{' '}
-            <span className="text-capitalize font-weight-bold">
+            </span>
+            on
+            <span className="d-inline-block text-capitalize font-weight-bold ml-1">
               {currentRepo.name}
             </span>
           </div>
         </div>
         <div className="commit-area mt-2 pl-2 text-secondary">
           <span className="font-weight-bold">
-            <FontAwesomeIcon
+            <Button
               onClick={this.toggleDetails}
-              icon={expandIcon}
-              title={expandTitle}
-              aria-label={expandTitle}
-              alt=""
-            />{' '}
-            {expandText}
+              outline
+              color="darker-secondary"
+              className="border-0 pl-0 shadow-none"
+              role="button"
+              aria-expanded={isExpanded}
+            >
+              <FontAwesomeIcon
+                icon={expandIcon}
+                title={expandTitle}
+                aria-label={expandTitle}
+                alt=""
+              />
+              <span className="ml-1 font-weight-bold">{expandText}</span>
+            </Button>
           </span>
           {isExpanded &&
             (revisions.length <= 5 || showAllRevisions ? (

--- a/ui/push-health/CommitHistory.jsx
+++ b/ui/push-health/CommitHistory.jsx
@@ -177,7 +177,7 @@ class CommitHistory extends React.PureComponent {
                 aria-label={expandTitle}
                 alt=""
               />
-              <span className="ml-1">{expandText}</span>
+              <span className="ml-1 font-weight-bold">{expandText}</span>
             </Button>
           </span>
         )}

--- a/ui/push-health/CommitHistory.jsx
+++ b/ui/push-health/CommitHistory.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Button } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCaretDown, faCaretRight } from '@fortawesome/free-solid-svg-icons';
+import { faCaretUp, faCaretRight } from '@fortawesome/free-solid-svg-icons';
 
 import Clipboard from '../shared/Clipboard';
 import PushHealthStatus from '../shared/PushHealthStatus';
@@ -64,7 +64,7 @@ class CommitHistory extends React.PureComponent {
     const headerText = revisions[0].comments.split('\n')[0];
     const authorMatch = author.match(/<(.*?)>+/);
     const authorEmail = authorMatch ? authorMatch[1] : author;
-    const expandIcon = isExpanded ? faCaretDown : faCaretRight;
+    const expandIcon = isExpanded ? faCaretUp : faCaretRight;
     const expandTitle = isExpanded ? 'Click to collapse' : 'Click to expand';
     const expandText = isExpanded ? 'Hide all commits' : 'Show more commits';
 
@@ -98,9 +98,9 @@ class CommitHistory extends React.PureComponent {
             </span>
           </div>
         </div>
-        <div className="commit-area mt-2 pl-3 text-secondary">
+        <div className="commit-area mt-2 text-secondary">
           {revisions.length > 1 && (
-            <div>
+            <div className="ml-3">
               <Revision
                 revision={revisions[1]}
                 repo={currentRepo}
@@ -108,37 +108,15 @@ class CommitHistory extends React.PureComponent {
               />
             </div>
           )}
-          {revisions.length > 2 && (
-            <React.Fragment>
-              <span className="font-weight-bold">
-                <Button
-                  onClick={this.toggleDetails}
-                  outline
-                  color="darker-secondary"
-                  className="border-0 pl-0 ml-2 shadow-none"
-                  role="button"
-                  aria-expanded={isExpanded}
-                >
-                  <FontAwesomeIcon
-                    icon={expandIcon}
-                    title={expandTitle}
-                    aria-label={expandTitle}
-                    alt=""
-                  />
-                  <span className="ml-1">{expandText}</span>
-                </Button>
-              </span>
-              {isExpanded && (
-                <RevisionList
-                  revision={revision}
-                  revisions={revisions.slice(2, 20)}
-                  revisionCount={revisionCount - 2}
-                  repo={currentRepo}
-                />
-              )}
-            </React.Fragment>
+          {revisions.length > 2 && isExpanded && (
+            <RevisionList
+              revision={revision}
+              revisions={revisions.slice(2, 20)}
+              revisionCount={revisionCount - 2}
+              repo={currentRepo}
+            />
           )}
-          <div className="ml-1">
+          <div className="ml-3">
             Base commit:
             <span>
               {!exactMatch && (
@@ -181,6 +159,26 @@ class CommitHistory extends React.PureComponent {
             </span>
           </div>
         </div>
+        {revisions.length > 2 && (
+          <span className="font-weight-bold">
+            <Button
+              onClick={this.toggleDetails}
+              outline
+              color="darker-secondary"
+              className="border-0 pl-0 shadow-none"
+              role="button"
+              aria-expanded={isExpanded}
+            >
+              <FontAwesomeIcon
+                icon={expandIcon}
+                title={expandTitle}
+                aria-label={expandTitle}
+                alt=""
+              />
+              <span className="ml-1">{expandText}</span>
+            </Button>
+          </span>
+        )}
       </React.Fragment>
     );
   }

--- a/ui/push-health/pushhealth.css
+++ b/ui/push-health/pushhealth.css
@@ -12,6 +12,10 @@
   min-width: 200px;
 }
 
+.commit-area {
+  border-left: 3px solid #6c757d;
+}
+
 .metric-name {
   font-size: 24px;
 }

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -64,6 +64,7 @@ export class Revision extends React.PureComponent {
       repo,
       bugSummaryMap,
       commitShaClass,
+      commentFont,
     } = this.props;
     const comment = comments.split('\n')[0];
     const bugMatches = comment.match(/-- ([0-9]+)|bug.([0-9]+)/gi);
@@ -97,7 +98,7 @@ export class Revision extends React.PureComponent {
         <AuthorInitials title={`${name}: ${email}`} author={name} />
         <span
           data-testid={comment}
-          className={`ml-2 revision-comment overflow-hidden text-nowrap ${commentColor}`}
+          className={`ml-2 revision-comment overflow-hidden text-nowrap ${commentColor} ${commentFont}`}
           id={`revision${revision}`}
         >
           <em>
@@ -137,8 +138,10 @@ Revision.propTypes = {
     revisionHrefPrefix: PropTypes.string,
   }).isRequired,
   commitShaClass: PropTypes.string,
+  commentFont: PropTypes.string,
 };
 
 Revision.defaultProps = {
   commitShaClass: '',
+  commentFont: '',
 };

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -63,6 +63,7 @@ export class Revision extends React.PureComponent {
       revision: { comments, author, revision },
       repo,
       bugSummaryMap,
+      commitShaClass,
     } = this.props;
     const comment = comments.split('\n')[0];
     const bugMatches = comment.match(/-- ([0-9]+)|bug.([0-9]+)/gi);
@@ -88,7 +89,7 @@ export class Revision extends React.PureComponent {
           <a
             title={`Open revision ${commitRevision} on ${repo.url}`}
             href={repo.getRevisionHref(commitRevision)}
-            className="text-monospace commit-sha"
+            className={`text-monospace commit-sha ${commitShaClass}`}
           >
             {commitRevision.substring(0, 12)}
           </a>
@@ -135,4 +136,9 @@ Revision.propTypes = {
     url: PropTypes.string,
     revisionHrefPrefix: PropTypes.string,
   }).isRequired,
+  commitShaClass: PropTypes.string,
+};
+
+Revision.defaultProps = {
+  commitShaClass: '',
 };

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -90,7 +90,7 @@ export class Revision extends React.PureComponent {
           <a
             title={`Open revision ${commitRevision} on ${repo.url}`}
             href={repo.getRevisionHref(commitRevision)}
-            className={`text-monospace commit-sha ${commitShaClass}`}
+            className={`commit-sha ${commitShaClass}`}
           >
             {commitRevision.substring(0, 12)}
           </a>

--- a/ui/shared/RevisionList.jsx
+++ b/ui/shared/RevisionList.jsx
@@ -21,7 +21,7 @@ export class RevisionList extends React.PureComponent {
     } = this.props;
 
     return (
-      <Col className={`${widthClass}`}>
+      <Col className={widthClass}>
         {revisions.map((revision) => (
           <Revision
             revision={revision}

--- a/ui/shared/RevisionList.jsx
+++ b/ui/shared/RevisionList.jsx
@@ -17,6 +17,7 @@ export class RevisionList extends React.PureComponent {
       children,
       bugSummaryMap,
       commitShaClass,
+      commentFont,
     } = this.props;
 
     return (
@@ -28,6 +29,7 @@ export class RevisionList extends React.PureComponent {
             key={revision.revision}
             bugSummaryMap={bugSummaryMap}
             commitShaClass={commitShaClass}
+            commentFont={commentFont}
           />
         ))}
         {revisionCount > revisions.length && (
@@ -48,11 +50,13 @@ RevisionList.propTypes = {
   }).isRequired,
   widthClass: PropTypes.string,
   commitShaClass: PropTypes.string,
+  commentFont: PropTypes.string,
 };
 
 RevisionList.defaultProps = {
   widthClass: '',
   commitShaClass: '',
+  commentFont: '',
 };
 
 export function MoreRevisionsLink(props) {

--- a/ui/shared/RevisionList.jsx
+++ b/ui/shared/RevisionList.jsx
@@ -19,7 +19,7 @@ export class RevisionList extends React.PureComponent {
     } = this.props;
 
     return (
-      <Col className={`${widthClass} mb-3`}>
+      <Col className={`${widthClass}`}>
         {revisions.map((revision) => (
           <Revision
             revision={revision}

--- a/ui/shared/RevisionList.jsx
+++ b/ui/shared/RevisionList.jsx
@@ -16,6 +16,7 @@ export class RevisionList extends React.PureComponent {
       widthClass,
       children,
       bugSummaryMap,
+      commitShaClass,
     } = this.props;
 
     return (
@@ -26,6 +27,7 @@ export class RevisionList extends React.PureComponent {
             repo={repo}
             key={revision.revision}
             bugSummaryMap={bugSummaryMap}
+            commitShaClass={commitShaClass}
           />
         ))}
         {revisionCount > revisions.length && (
@@ -45,10 +47,12 @@ RevisionList.propTypes = {
     pushLogUrl: PropTypes.string,
   }).isRequired,
   widthClass: PropTypes.string,
+  commitShaClass: PropTypes.string,
 };
 
 RevisionList.defaultProps = {
   widthClass: '',
+  commitShaClass: '',
 };
 
 export function MoreRevisionsLink(props) {

--- a/ui/shared/StatusProgress.jsx
+++ b/ui/shared/StatusProgress.jsx
@@ -19,7 +19,7 @@ const StatusProgress = (props) => {
           { x: 'running', y: running + pending },
           { x: 'failed', y: failed },
         ]}
-        colorScale={['#28a745', '#6c757d', '#dc3545']}
+        colorScale={['#28a745', 'lightgrey', '#dc3545']}
         labels={({ datum }) => (datum.y > 0 ? `${datum.x}: ${datum.y}` : '')}
         labelComponent={
           <VictoryTooltip pointerLength={0} flyoutComponent={<div />} />

--- a/ui/shared/StatusProgress.jsx
+++ b/ui/shared/StatusProgress.jsx
@@ -16,11 +16,10 @@ const StatusProgress = (props) => {
       <VictoryPie
         data={[
           { x: 'success', y: success },
-          { x: 'running', y: running },
-          { x: 'pending', y: pending },
+          { x: 'running', y: running + pending },
           { x: 'failed', y: failed },
         ]}
-        colorScale={['#28a745', '#17a2b8', '#6c757d', '#dc3545']}
+        colorScale={['#28a745', '#6c757d', '#dc3545']}
         labels={({ datum }) => (datum.y > 0 ? `${datum.x}: ${datum.y}` : '')}
         labelComponent={
           <VictoryTooltip pointerLength={0} flyoutComponent={<div />} />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44131389/87944325-e00f8f80-cabc-11ea-8fed-1c13b6233d53.png)

I could not find where to find the bug number to be written in the heading if it is not present already 
Also, I have not removed the links to the parent push although they were removed in the recent figma UI
Also, that button showing 6 items at the end of parent revision has not been removed since there were tests written for them already and could not removed without ammending the tests