### PR TITLE
Travis/jest - Disable printing to console on JS tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "start": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --mode development",
     "start:stage": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --mode development --env.BACKEND=https://treeherder.allizom.org",
     "start:local": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --mode development --env.BACKEND=http://localhost:8000",
-    "test:coverage": "node ./node_modules/jest/bin/jest --coverage",
+    "test:coverage": "node ./node_modules/jest/bin/jest --silent --coverage",
     "test": "node ./node_modules/jest/bin/jest",
     "test:watch": "node ./node_modules/jest/bin/jest --watch"
   }


### PR DESCRIPTION
Depending on how we write our tests I've noticed that it is not possible
to use `isRequired` as part of the `propTypes` without the tests calling
some unimportant component with all the required props.

In other words, this removes proptypes warnings in the output of our tests
while not preventing noticing test failures.

You can still test errors when they happen.