### PR TITLE
Bug 1638424 - Translate WPT paths in the test path filter

### DIFF
--- a/tests/ui/job-view/Push_test.jsx
+++ b/tests/ui/job-view/Push_test.jsx
@@ -9,7 +9,10 @@ import FilterModel from '../../../ui/models/filter';
 import pushListFixture from '../mock/push_list';
 import jobListFixture from '../mock/job_list/job_2';
 import configureStore from '../../../ui/job-view/redux/configureStore';
-import Push, { joinArtifacts } from '../../../ui/job-view/pushes/Push';
+import Push, {
+  transformTestPath,
+  joinArtifacts,
+} from '../../../ui/job-view/pushes/Push';
 import { getApiUrl } from '../../../ui/helpers/url';
 import { findInstance } from '../../../ui/helpers/job';
 
@@ -37,6 +40,40 @@ const manifestsByTask = {
     'devtools/client/webconsole/test/node/fixtures/stubs/stubs.ini',
   ],
 };
+
+describe('Transform WPT test paths', () => {
+  test('Test path transformations', () => {
+    const tests = [
+      {
+        manifest: 'devtools/client/framework/browser-toolbox/test/browser.ini',
+        test: 'browser_browser_toolbox.js',
+        expected:
+          'devtools/client/framework/browser-toolbox/test/browser_browser_toolbox.js',
+      },
+      {
+        manifest: '/IndexedDB',
+        test: '/IndexedDB/abort-in-initial-upgradeneeded.html',
+        expected:
+          'testing/web-platform/tests/IndexedDB/abort-in-initial-upgradeneeded.html',
+      },
+      {
+        manifest: '/_mozilla/xml',
+        test: '/_mozilla/xml/parsedepth.html',
+        expected: 'testing/web-platform/mozilla/tests/xml/parsedepth.html',
+      },
+      {
+        manifest: '/IndexedDB/key-generators',
+        test:
+          '/IndexedDB/key-generators/reading-autoincrement-indexes-cursors.any.worker.html',
+        expected:
+          'testing/web-platform/tests/IndexedDB/key-generators/reading-autoincrement-indexes-cursors.any.worker.html',
+      },
+    ];
+    tests.forEach(({ manifest, test, expected }) => {
+      expect(transformTestPath(manifest, test)).toEqual(expected);
+    });
+  });
+});
 
 describe('Push', () => {
   const repoName = 'autoland';


### PR DESCRIPTION
Both paths work.
@ahal The paths are lower-cased in the UI.
@camd if you check out the branch you can use the links below

- [/indexeddb/key-generators/reading-autoincrement-indexes-cursors.any.worker.html](http://localhost:5000/#/jobs?repo=autoland&group_state=expanded&revision=5e566996d34e4d424750bf184a13e751a7e3b95f&test_paths=%2Findexeddb%2Fkey-generators%2Freading-autoincrement-indexes-cursors.any.worker.html)
- [testing/web-platform/tests/indexeddb/key-generators/reading-autoincrement-indexes-cursors.any.worker.html](http://localhost:5000/#/jobs?repo=autoland&group_state=expanded&revision=5e566996d34e4d424750bf184a13e751a7e3b95f&test_paths=testing%2Fweb-platform%2Ftests%2Findexeddb%2Fkey-generators%2Freading-autoincrement-indexes-cursors.any.worker.html)
- [xml/parsedepth.html](http://localhost:5000/#/jobs?repo=autoland&group_state=expanded&revision=5e566996d34e4d424750bf184a13e751a7e3b95f&test_paths=xml/parsedepth.html)
- [testing/web-platform/mozilla/tests/xml/parsedepth.html](http://localhost:5000/#/jobs?repo=autoland&group_state=expanded&revision=5e566996d34e4d424750bf184a13e751a7e3b95f&test_paths=testing%2Fweb-platform%2Fmozilla%2Ftests%2Fxml%2Fparsedepth.html)


<img width="995" alt="image" src="https://user-images.githubusercontent.com/44410/88334279-88149b00-ccff-11ea-8821-d044075ded39.png">
