### PR TITLE
added the xpcshell framework

### DIFF
--- a/tests/ui/perfherder/alerts-view/alerts_test.jsx
+++ b/tests/ui/perfherder/alerts-view/alerts_test.jsx
@@ -45,7 +45,7 @@ const frameworks = [
   { id: 12, name: 'devtools' },
   { id: 13, name: 'browsertime' },
   { id: 14, name: 'vcs' },
-  { id: 15, name: 'xpcshell' },
+  { id: 15, name: 'mozperftest' },
 ];
 
 const dummyFrameworkName = 'someTestFramework';

--- a/tests/ui/perfherder/alerts-view/alerts_test.jsx
+++ b/tests/ui/perfherder/alerts-view/alerts_test.jsx
@@ -45,6 +45,7 @@ const frameworks = [
   { id: 12, name: 'devtools' },
   { id: 13, name: 'browsertime' },
   { id: 14, name: 'vcs' },
+  { id: 15, name: 'xpcshell' },
 ];
 
 const dummyFrameworkName = 'someTestFramework';

--- a/treeherder/perf/fixtures/performance_framework.json
+++ b/treeherder/perf/fixtures/performance_framework.json
@@ -83,7 +83,7 @@
     "pk": 15,
     "model": "perf.PerformanceFramework",
     "fields": {
-      "name": "xpcshell",
+      "name": "mozperftest",
       "enabled": true
     }
   }

--- a/treeherder/perf/fixtures/performance_framework.json
+++ b/treeherder/perf/fixtures/performance_framework.json
@@ -78,5 +78,13 @@
       "name": "vcs",
       "enabled": true
     }
+  },
+  {
+    "pk": 15,
+    "model": "perf.PerformanceFramework",
+    "fields": {
+      "name": "xpcshell",
+      "enabled": true
+    }
   }
 ]


### PR DESCRIPTION
This patch adds the "mozperftest" framework. We are going to produce metrics for xpcshell tests via `./mach perftest` and want them to be displayed in the Treeherder UI (performance tab) and also ingested by perherder