### PR TITLE
Update localhost clients for taskcluster authentication

### DIFF
--- a/ui/taskcluster-auth-callback/constants.js
+++ b/ui/taskcluster-auth-callback/constants.js
@@ -4,7 +4,8 @@ export const tcClientIdMap = {
   'https://treeherder.mozilla.org': 'production',
   'https://treeherder.allizom.org': 'stage',
   'https://treeherder-prototype.herokuapp.com': 'dev',
-  'http://localhost:5000': 'localhost',
+  'http://localhost:5000': 'localhost-5000',
+  'http://localhost:8000': 'localhost-8000',
   'https://treeherder-taskcluster-staging.herokuapp.com': 'taskcluster-staging',
   'https://treeherder-prototype2.herokuapp.com': 'dev2',
 };


### PR DESCRIPTION
I requested new clients be added in preparation for the hash-less routing per this [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1654850) (the addition of the new clients will be included in the forthcoming routing pr). I also asked for both localhosts to be registered, so these need to be updated. 