### PR TITLE
Taskcluster utils module

### DIFF
--- a/treeherder/etl/job_loader.py
+++ b/treeherder/etl/job_loader.py
@@ -4,7 +4,6 @@ import uuid
 import jsonschema
 import newrelic.agent
 import slugid
-import taskcluster_urls
 
 from treeherder.etl.taskcluster_pulse.handler import ignore_task
 from treeherder.etl.common import to_timestamp
@@ -12,7 +11,7 @@ from treeherder.etl.exceptions import MissingPushException
 from treeherder.etl.jobs import store_job_data
 from treeherder.etl.schema import get_json_schema
 from treeherder.model.models import Push, Repository
-from treeherder.utils.http import fetch_json
+from treeherder.utils.taskcluster import get_task_definition
 
 logger = logging.getLogger(__name__)
 
@@ -104,10 +103,7 @@ class JobLoader:
             (real_task_id, _) = task_and_retry_ids(pulse_job["taskId"])
             project = pulse_job["origin"]["project"]
             repository = Repository.objects.get(name=project)
-            task_url = taskcluster_urls.api(
-                repository.tc_root_url, 'queue', 'v1', 'task/{}'.format(real_task_id)
-            )
-            task = fetch_json(task_url)
+            task = get_task_definition(repository.tc_root_url, real_task_id)
             # We do this to prevent raising an exception for a task that will never be ingested
             if not ignore_task(task, real_task_id, repository.tc_root_url, project):
                 raise MissingPushException(

--- a/treeherder/utils/taskcluster.py
+++ b/treeherder/utils/taskcluster.py
@@ -1,0 +1,8 @@
+import taskcluster_urls
+
+from treeherder.utils.http import fetch_json
+
+
+def get_task_definition(root_url, task_id):
+    task_url = taskcluster_urls.api(root_url, 'queue', 'v1', 'task/{}'.format(task_id))
+    return fetch_json(task_url)


### PR DESCRIPTION
There's various approaches in the repository on how to fetch information from Taskcluster
but there's no centralized module. This is the beginning of centralizing it.

This patch is used in following PRs.