### PR TITLE
Bug 1626623 - Faster test path filtering (drop filtering by test file)

### DIFF
--- a/tests/ui/job-view/Push_test.jsx
+++ b/tests/ui/job-view/Push_test.jsx
@@ -9,23 +9,10 @@ import FilterModel from '../../../ui/models/filter';
 import pushListFixture from '../mock/push_list';
 import jobListFixture from '../mock/job_list/job_2';
 import configureStore from '../../../ui/job-view/redux/configureStore';
-import Push, {
-  transformTestPath,
-  joinArtifacts,
-} from '../../../ui/job-view/pushes/Push';
+import Push, { transformTestPath } from '../../../ui/job-view/pushes/Push';
 import { getApiUrl } from '../../../ui/helpers/url';
 import { findInstance } from '../../../ui/helpers/job';
 
-const testsByManifest = {
-  'devtools/client/framework/browser-toolbox/test/browser.ini': [
-    'browser_browser_toolbox.js',
-    'browser_browser_toolbox_debugger.js',
-    'browser_browser_toolbox_fission_contentframe_inspector.js',
-    'browser_browser_toolbox_fission_inspector.js',
-    'browser_browser_toolbox_rtl.js',
-  ],
-  'devtools/client/framework/test/browser.ini': ['foo.js'],
-};
 const manifestsByTask = {
   'test-linux1804-64/debug-mochitest-devtools-chrome-e10s-1': [
     'devtools/client/framework/browser-toolbox/test/browser.ini',
@@ -45,32 +32,37 @@ describe('Transform WPT test paths', () => {
   test('Test path transformations', () => {
     const tests = [
       {
-        manifest: 'devtools/client/framework/browser-toolbox/test/browser.ini',
-        test: 'browser_browser_toolbox.js',
-        expected:
+        path: 'devtools/client/framework/browser-toolbox/test/browser.ini',
+        expected: 'devtools/client/framework/browser-toolbox/test',
+      },
+      {
+        path:
           'devtools/client/framework/browser-toolbox/test/browser_browser_toolbox.js',
+        expected: 'devtools/client/framework/browser-toolbox/test',
       },
       {
-        manifest: '/IndexedDB',
-        test: '/IndexedDB/abort-in-initial-upgradeneeded.html',
-        expected:
-          'testing/web-platform/tests/IndexedDB/abort-in-initial-upgradeneeded.html',
+        path: '/IndexedDB',
+        expected: 'testing/web-platform/tests/IndexedDB',
       },
       {
-        manifest: '/_mozilla/xml',
-        test: '/_mozilla/xml/parsedepth.html',
-        expected: 'testing/web-platform/mozilla/tests/xml/parsedepth.html',
+        path: '/IndexedDB/abort-in-initial-upgradeneeded.html',
+        expected: 'testing/web-platform/tests/IndexedDB',
       },
       {
-        manifest: '/IndexedDB/key-generators',
-        test:
-          '/IndexedDB/key-generators/reading-autoincrement-indexes-cursors.any.worker.html',
-        expected:
-          'testing/web-platform/tests/IndexedDB/key-generators/reading-autoincrement-indexes-cursors.any.worker.html',
+        path: '/_mozilla/xml',
+        expected: 'testing/web-platform/mozilla/tests/xml',
+      },
+      {
+        path: '/_mozilla/xml/parsedepth.html',
+        expected: 'testing/web-platform/mozilla/tests/xml',
+      },
+      {
+        path: '/IndexedDB/key-generators',
+        expected: 'testing/web-platform/tests/IndexedDB/key-generators',
       },
     ];
-    tests.forEach(({ manifest, test, expected }) => {
-      expect(transformTestPath(manifest, test)).toEqual(expected);
+    tests.forEach(({ path, expected }) => {
+      expect(transformTestPath(path)).toEqual(expected);
     });
   });
 });
@@ -116,12 +108,6 @@ describe('Push', () => {
       'https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.autoland.revision.d5b037941b0ebabcc9b843f24d926e9d65961087.taskgraph.decision/artifacts/public';
     // XXX: Fix this to re-enable test
     // I need to figure out the right options to get a gzip blob
-    fetchMock.get(`${tcUrl}/tests-by-manifest.json.gz`, {
-      body: new Blob(await gzip(JSON.stringify(testsByManifest)), {
-        type: 'application/gzip',
-      }),
-      sendAsJson: false,
-    });
     fetchMock.get(`${tcUrl}/manifests-by-task.json.gz`, {
       body: new Blob(await gzip(JSON.stringify(manifestsByTask)), {
         type: 'application/gzip',
@@ -166,31 +152,5 @@ describe('Push', () => {
       'devtools/client/styleeditor/test/browser.ini',
       'devtools/client/webconsole/test/node/fixtures/stubs/stubs.ini',
     ]);
-  });
-});
-
-describe('Artifact transformations', () => {
-  test('Merge artifacts', () => {
-    const taskNameToTestPaths = joinArtifacts(manifestsByTask, testsByManifest);
-    expect(taskNameToTestPaths).toMatchObject({
-      'test-linux1804-64/debug-mochitest-devtools-chrome-e10s-1': [
-        'devtools/client/framework/browser-toolbox/test/browser_browser_toolbox.js',
-        'devtools/client/framework/browser-toolbox/test/browser_browser_toolbox_debugger.js',
-        'devtools/client/framework/browser-toolbox/test/browser_browser_toolbox_fission_contentframe_inspector.js',
-        'devtools/client/framework/browser-toolbox/test/browser_browser_toolbox_fission_inspector.js',
-        'devtools/client/framework/browser-toolbox/test/browser_browser_toolbox_rtl.js',
-        'devtools/client/framework/browser-toolbox/test/browser.ini',
-        'devtools/client/framework/test/foo.js',
-        'devtools/client/framework/test/browser.ini',
-        'devtools/client/framework/test/metrics/browser_metrics_inspector.ini',
-        'devtools/client/inspector/changes/test/browser.ini',
-        'devtools/client/inspector/extensions/test/browser.ini',
-        'devtools/client/inspector/markup/test/browser.ini',
-        'devtools/client/jsonview/test/browser.ini',
-        'devtools/client/shared/test/browser.ini',
-        'devtools/client/styleeditor/test/browser.ini',
-        'devtools/client/webconsole/test/node/fixtures/stubs/stubs.ini',
-      ],
-    });
   });
 });

--- a/tests/ui/job-view/Push_test.jsx
+++ b/tests/ui/job-view/Push_test.jsx
@@ -9,7 +9,10 @@ import FilterModel from '../../../ui/models/filter';
 import pushListFixture from '../mock/push_list';
 import jobListFixture from '../mock/job_list/job_2';
 import configureStore from '../../../ui/job-view/redux/configureStore';
-import Push, { transformTestPath } from '../../../ui/job-view/pushes/Push';
+import Push, {
+  transformTestPath,
+  transformedPaths,
+} from '../../../ui/job-view/pushes/Push';
 import { getApiUrl } from '../../../ui/helpers/url';
 import { findInstance } from '../../../ui/helpers/job';
 
@@ -26,19 +29,52 @@ const manifestsByTask = {
     'devtools/client/styleeditor/test/browser.ini',
     'devtools/client/webconsole/test/node/fixtures/stubs/stubs.ini',
   ],
+  'test-linux1804-64-shippable-qr/opt-web-platform-tests-e10s-5': [
+    '/IndexedDB',
+    '/WebCryptoAPI/wrapKey_unwrapKey',
+    '/_mozilla/fetch/api/redirect',
+    '/mixed-content/gen/sharedworker-classic.http-rp',
+    '/upgrade-insecure-requests/gen/sharedworker-module-data.meta',
+  ],
 };
 
-describe('Transform WPT test paths', () => {
-  test('Test path transformations', () => {
+describe('Transformations', () => {
+  test('Manifest by task structure transformations', () => {
+    const transformed = transformedPaths(manifestsByTask);
+    expect(transformed).toEqual({
+      'test-linux1804-64/debug-mochitest-devtools-chrome-e10s-1': [
+        'devtools/client/framework/browser-toolbox/test/browser.ini',
+        'devtools/client/framework/test/browser.ini',
+        'devtools/client/framework/test/metrics/browser_metrics_inspector.ini',
+        'devtools/client/inspector/changes/test/browser.ini',
+        'devtools/client/inspector/extensions/test/browser.ini',
+        'devtools/client/inspector/markup/test/browser.ini',
+        'devtools/client/jsonview/test/browser.ini',
+        'devtools/client/shared/test/browser.ini',
+        'devtools/client/styleeditor/test/browser.ini',
+        'devtools/client/webconsole/test/node/fixtures/stubs/stubs.ini',
+      ],
+      'test-linux1804-64-shippable-qr/opt-web-platform-tests-e10s-5': [
+        'testing/web-platform/tests/IndexedDB',
+        'testing/web-platform/tests/WebCryptoAPI/wrapKey_unwrapKey',
+        'testing/web-platform/mozilla/tests/fetch/api/redirect',
+        'testing/web-platform/tests/mixed-content/gen/sharedworker-classic.http-rp',
+        'testing/web-platform/tests/upgrade-insecure-requests/gen/sharedworker-module-data.meta',
+      ],
+    });
+  });
+
+  test('Test path transformations (WPT)', () => {
     const tests = [
       {
         path: 'devtools/client/framework/browser-toolbox/test/browser.ini',
-        expected: 'devtools/client/framework/browser-toolbox/test',
+        expected: 'devtools/client/framework/browser-toolbox/test/browser.ini',
       },
       {
         path:
           'devtools/client/framework/browser-toolbox/test/browser_browser_toolbox.js',
-        expected: 'devtools/client/framework/browser-toolbox/test',
+        expected:
+          'devtools/client/framework/browser-toolbox/test/browser_browser_toolbox.js',
       },
       {
         path: '/IndexedDB',
@@ -46,7 +82,8 @@ describe('Transform WPT test paths', () => {
       },
       {
         path: '/IndexedDB/abort-in-initial-upgradeneeded.html',
-        expected: 'testing/web-platform/tests/IndexedDB',
+        expected:
+          'testing/web-platform/tests/IndexedDB/abort-in-initial-upgradeneeded.html',
       },
       {
         path: '/_mozilla/xml',
@@ -54,7 +91,7 @@ describe('Transform WPT test paths', () => {
       },
       {
         path: '/_mozilla/xml/parsedepth.html',
-        expected: 'testing/web-platform/mozilla/tests/xml',
+        expected: 'testing/web-platform/mozilla/tests/xml/parsedepth.html',
       },
       {
         path: '/IndexedDB/key-generators',

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -51,18 +51,15 @@ export const transformTestPath = (path) => {
     newPath = `testing/web-platform/tests${path}`;
   }
 
-  if (newPath.includes('.')) {
-    // If we have a test file in the path we can drop it since
-    const splitPath = newPath.split('/');
-    newPath = splitPath.splice(0, splitPath.length - 1).join('/');
-  }
   return newPath;
 };
 
-const transformedPaths = (manifestsByTask) => {
+export const transformedPaths = (manifestsByTask) => {
   const newManifestsByTask = {};
   Object.keys(manifestsByTask).forEach((taskName) => {
-    newManifestsByTask[taskName] = transformTestPath(manifestsByTask[taskName]);
+    newManifestsByTask[taskName] = manifestsByTask[taskName].map((testPath) =>
+      transformTestPath(testPath),
+    );
   });
   return newManifestsByTask;
 };

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -39,41 +39,32 @@ const platformArray = Object.values(thPlatformMap);
 
 // Bug 1638424 - Transform WPT test paths to look like paths
 // from a local checkout
-export const transformTestPath = (manifest, testPath) => {
-  let newTestPath = testPath;
-  let basePath;
+export const transformTestPath = (path) => {
+  let newPath = path;
   // WPT path transformations
-  if (testPath.startsWith('/_mozilla')) {
+  if (path.startsWith('/_mozilla')) {
     // /_mozilla/<path> => testing/web-platform/mozilla/tests/<path>
-    basePath = 'testing/web-platform/mozilla/tests';
-    newTestPath = testPath.replace('/_mozilla', '');
-  } else if (testPath.startsWith('/')) {
+    const modifiedPath = path.replace('/_mozilla', '');
+    newPath = `testing/web-platform/mozilla/tests${modifiedPath}`;
+  } else if (path.startsWith('/')) {
     // /<path> => testing/web-platform/tests/<path>
-    basePath = 'testing/web-platform/tests';
-  } else {
-    const splitPath = manifest.split('/');
-    basePath = splitPath.splice(0, splitPath.length - 1).join('/');
-    newTestPath = `/${newTestPath}`;
+    newPath = `testing/web-platform/tests${path}`;
   }
-  return `${basePath}${newTestPath}`;
+
+  if (newPath.includes('.')) {
+    // If we have a test file in the path we can drop it since
+    const splitPath = newPath.split('/');
+    newPath = splitPath.splice(0, splitPath.length - 1).join('/');
+  }
+  return newPath;
 };
 
-export const joinArtifacts = (manifestsByTask, testsByManifest) => {
-  // We need to create a map from taskName to testPaths:
-  // e.g. taskName: test-linux1804-64-shippable/opt-mochitest-devtools-chrome-e10s-1
-  // e.g. manifest: devtools/client/framework/browser-toolbox/test/browser.ini
-  // e.g. testPath: devtools/client/framework/browser-toolbox/test/browser_browser_toolbox_debugger.js
-  const taskNameToTestPaths = {};
-  Object.entries(manifestsByTask).forEach(([taskName, manifetsts]) => {
-    manifetsts.forEach((manifest) => {
-      taskNameToTestPaths[taskName] = taskNameToTestPaths[taskName] || [];
-      (testsByManifest[manifest] || []).forEach((test) => {
-        taskNameToTestPaths[taskName].push(transformTestPath(manifest, test));
-      });
-      taskNameToTestPaths[taskName].push(manifest);
-    });
+const transformedPaths = (manifestsByTask) => {
+  const newManifestsByTask = {};
+  Object.keys(manifestsByTask).forEach((taskName) => {
+    newManifestsByTask[taskName] = transformTestPath(manifestsByTask[taskName]);
   });
-  return taskNameToTestPaths;
+  return newManifestsByTask;
 };
 
 const fetchGeckoDecisionArtifact = async (project, revision, filePath) => {
@@ -215,7 +206,7 @@ class Push extends React.PureComponent {
     if (allParams.has('test_paths')) {
       await this.fetchTestManifests();
     } else {
-      this.setState({ taskNameToTestPaths: {} });
+      this.setState({ manifestsByTask: {} });
     }
     this.setState({ collapsed: collapsedPushes.includes(push.id) });
   };
@@ -246,28 +237,17 @@ class Push extends React.PureComponent {
   fetchTestManifests = async () => {
     const { currentRepo, push } = this.props;
 
-    const [manifestsByTask, testsByManifest] = await Promise.all([
-      fetchGeckoDecisionArtifact(
-        currentRepo.name,
-        push.revision,
-        'manifests-by-task.json.gz',
-      ),
-      fetchGeckoDecisionArtifact(
-        currentRepo.name,
-        push.revision,
-        'tests-by-manifest.json.gz',
-      ),
-    ]);
-    const taskNameToTestPaths = joinArtifacts(manifestsByTask, testsByManifest);
-    // Call setState with callback to guarantee the state of taskNameToTestPaths
+    const manifestsByTask = await fetchGeckoDecisionArtifact(
+      currentRepo.name,
+      push.revision,
+      'manifests-by-task.json.gz',
+    );
+    // Call setState with callback to guarantee the state of manifestsByTask
     // to be set since it is read within mapPushJobs and we might have a race
     // condition. We are also reading jobList now rather than before fetching
     // the artifact because it gives us an empty list
-    this.setState(
-      {
-        taskNameToTestPaths,
-      },
-      () => this.mapPushJobs(this.state.jobList),
+    this.setState({ manifestsByTask: transformedPaths(manifestsByTask) }, () =>
+      this.mapPushJobs(this.state.jobList),
     );
   };
 
@@ -289,7 +269,7 @@ class Push extends React.PureComponent {
 
   mapPushJobs = (jobs, skipJobMap) => {
     const { updateJobMap, recalculateUnclassifiedCounts, push } = this.props;
-    const { taskNameToTestPaths = {} } = this.state;
+    const { manifestsByTask = {} } = this.state;
 
     // whether or not we got any jobs for this push, the operation to fetch
     // them has completed.
@@ -301,8 +281,8 @@ class Push extends React.PureComponent {
       const existingJobs = jobList.filter((job) => !newIds.includes(job.id));
       // Join both lists and add test_paths and task_run property
       const newJobList = [...existingJobs, ...jobs].map((job) => {
-        if (Object.keys(taskNameToTestPaths).length > 0) {
-          job.test_paths = taskNameToTestPaths[job.job_type_name] || [];
+        if (Object.keys(manifestsByTask).length > 0) {
+          job.test_paths = manifestsByTask[job.job_type_name] || [];
         }
         job.task_run = getTaskRunStr(job);
         return job;


### PR DESCRIPTION
This removes fetching the tests-by-manifest.json.gz and merging it with the contents
of manifests-by-task.json.gz.

This speeds up filtering by tests path and reduces the memory footprint.

It is not perfect but it is a big improvement.

You can test this locally by loading this URL:
http://localhost:5000/#/jobs?repo=autoland&test_paths=toolkit%2Fcomponents%2Fpictureinpicture%2Ftests%2F
and comparing it with:
https://treeherder.mozilla.org//#/jobs?repo=autoland&test_paths=toolkit%2Fcomponents%2Fpictureinpicture%2Ftests%2F