### PR TITLE
Fix: Ingest mobile nightly tasks

### DIFF
--- a/treeherder/etl/taskcluster_pulse/handler.py
+++ b/treeherder/etl/taskcluster_pulse/handler.py
@@ -140,6 +140,13 @@ def ignore_task(task, taskId, rootUrl, project):
                     ignore = False
                     break
 
+            # This handles nightly tasks
+            # e.g. index.mobile.v2.fenix.branch.master.latest.taskgraph.decision-nightly
+            for route in decision_task["routes"]:
+                if route.find('master') != -1:
+                    ignore = False
+                    break
+
     if ignore:
         logger.debug('Task to be ignored ({})'.format(taskId))
 


### PR DESCRIPTION
Fixes #6696

In my impetus to reduce the number of tasks that get stuck in the
celery queues, I made some nightly tasks not being ingested.

You can test this change with:

```shell
./manage.py ingest task --task-id Gcw1BJ1wTTu69A9Uud8NqA
```