### PR TITLE
Bug 1654892 - Add log parsing support for unsuccessful task run

### DIFF
--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -57,6 +57,7 @@ class ErrorParser(ParserBase):
         "command timed out:",
         "wget: unable ",
         "bash.exe: *** ",
+        "Unsuccessful task run",
     )
 
     RE_ERR_MATCH = re.compile(


### PR DESCRIPTION
Tested it with the `test_log_parser` management command to confirm it worked.