### PR TITLE
Revert "Local dev: Skip ingesting if pointing to an RDS DB"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,6 @@ services:
       context: .
       dockerfile: docker/dev.Dockerfile
     environment:
-      - IN_DOCKER=1
       - PULSE_URL=${PULSE_URL:-amqp://docker-shared-user:8r5VFxpJHtJahTVV5bYutykgDsXhGF@pulse.mozilla.org:5671/?ssl=1}
       - LOGGING_LEVEL=INFO
       - PULSE_AUTO_DELETE_QUEUES=True

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -17,7 +17,6 @@ SRC_DIR = dirname(dirname(dirname(abspath(__file__))))
 
 env = environ.Env()
 
-PRODUCTION = env("VIRTUAL_ENV", default=False) or env("IN_DOCKER", default=False)
 # Checking for OS type
 IS_WINDOWS = "windows" in platform.system().lower()
 
@@ -142,14 +141,6 @@ LOCALHOST_MYSQL_HOST = 'mysql://root@{}:3306/treeherder'.format(
 DATABASES = {
     'default': env.db_url('DATABASE_URL', default=LOCALHOST_MYSQL_HOST),
 }
-
-SKIP_INGESTION = env('SKIP_INGESTION', default=False)
-
-# Block for changes within the context of local development (venv & Docker)
-if not PRODUCTION:
-    # Do not permit ingesting if DATABASE_URL points to a database different than localhost
-    if DATABASES['default']['HOST'] not in ['mysql', '127.0.0.1', 'localhost']:
-        SKIP_INGESTION = True
 
 # Only used when syncing local database with production replicas
 UPSTREAM_DATABASE_URL = env('UPSTREAM_DATABASE_URL', default=None)

--- a/treeherder/etl/management/commands/pulse_listener_pushes.py
+++ b/treeherder/etl/management/commands/pulse_listener_pushes.py
@@ -2,7 +2,6 @@ import environ
 from django.core.management.base import BaseCommand
 
 from treeherder.services.pulse import PushConsumer, prepare_consumers
-from treeherder.config.settings import SKIP_INGESTION
 
 env = environ.Env()
 
@@ -18,7 +17,7 @@ class Command(BaseCommand):
     help = "Read pushes from a set of pulse exchanges and queue for ingestion"
 
     def handle(self, *args, **options):
-        if SKIP_INGESTION:
+        if env.bool('SKIP_INGESTION', default=False):
             self.stdout.write("Skipping ingestion of Pulse Pushes")
             return
         # Specifies the Pulse services from which Treeherder will ingest push

--- a/treeherder/etl/management/commands/pulse_listener_tasks.py
+++ b/treeherder/etl/management/commands/pulse_listener_tasks.py
@@ -2,7 +2,6 @@ import environ
 from django.core.management.base import BaseCommand
 
 from treeherder.services.pulse import TaskConsumer, prepare_consumers
-from treeherder.config.settings import SKIP_INGESTION
 
 env = environ.Env()
 
@@ -18,7 +17,7 @@ class Command(BaseCommand):
     help = "Read jobs from a set of pulse exchanges and queue for ingestion"
 
     def handle(self, *args, **options):
-        if SKIP_INGESTION:
+        if env.bool('SKIP_INGESTION', default=False):
             self.stdout.write("Skipping ingestion of Pulse Tasks")
             return
         # Specifies the Pulse services from which Treeherder will consume task


### PR DESCRIPTION
Reverts mozilla/treeherder#6476

I think this is out of sync with the TH pipeline since I merged this before realizing we needed to reconnect our repo to heroku (since Armen's no longer an admin).