### PR TITLE
Limit log parser regex for unsuccessful task run to code 137

### DIFF
--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -57,7 +57,7 @@ class ErrorParser(ParserBase):
         "command timed out:",
         "wget: unable ",
         "bash.exe: *** ",
-        "Unsuccessful task run",
+        "Unsuccessful task run with exit code: 137",
     )
 
     RE_ERR_MATCH = re.compile(


### PR DESCRIPTION
Per the request by Aryx here: https://github.com/mozilla/treeherder/pull/6724#issuecomment-679384520