### PR TITLE
Bug 1637596 - Improve performance of FuzzyJobFinder

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-split-pane": "0.1.92",
     "react-table": "6.10.3",
     "react-tabs": "3.0.0",
+    "react-virtualized": "9.22.2",
     "reactstrap": "8.3.2",
     "redux": "4.0.5",
     "redux-debounce": "1.0.1",

--- a/ui/job-view/pushes/FuzzyJobFinder.jsx
+++ b/ui/job-view/pushes/FuzzyJobFinder.jsx
@@ -10,6 +10,8 @@ import {
   ModalHeader,
   ModalBody,
   ModalFooter,
+  InputGroupAddon,
+  InputGroupText,
   InputGroup,
   Input,
 } from 'reactstrap';
@@ -198,19 +200,47 @@ class FuzzyJobFinder extends React.Component {
     });
   };
 
+  addToSelectedList = (evt) => {
+    const jobName = evt.target.textContent;
+    const { selectedList } = this.state;
+    const newSelectedList = [...new Set([].concat(selectedList, jobName))];
+    this.setState({ selectedList: newSelectedList });
+  };
+
+  removeFromSelectedList = (evt) => {
+    const jobName = evt.target.textContent;
+    const { selectedList } = this.state;
+    const newSelectedList = selectedList.filter((value) => value != jobName);
+    this.setState({ selectedList: newSelectedList }, () => {
+      this.setState({
+        removeDisabled: true,
+      });
+    });
+  };
+
   renderJob = ({ index, key, style }) => {
     const { fuzzyList } = this.state;
     const e = fuzzyList[index];
 
     return (
-      <div
-        data-testid="fuzzyList"
-        title={`${e.name} - ${e.groupsymbol}(${e.symbol})`}
-        key={key}
-        style={style}
-        className={this.state.selectedList.includes(e.name) ? 'selected' : ''}
-      >
-        {e.name}
+      <div>
+        <Button outline onClick={this.addToSelectedList}>
+          {e.name}
+        </Button>
+      </div>
+    );
+  };
+
+  renderSelectedJob = ({ index, key, style }) => {
+    const { selectedList } = this.state;
+    const e = selectedList[index];
+
+    console.log(selectedList);
+    return (
+      <div>
+        <Button outline onClick={this.removeFromSelectedList}>
+          {e.name}
+        </Button>
       </div>
     );
   };
@@ -262,16 +292,10 @@ class FuzzyJobFinder extends React.Component {
                 Add all
               </Button>
             </div>
-            {/* <List
-              width={500}
-              height={220}
-              rowHeight={20}
-              rowRenderer={this.renderJob}
-              rowCount={this.state.fuzzyList.length}
-            /> */}
 
-            <InputGroup id="addJobsGroup">
-              <Input type="select" multiple onChange={this.updateAddButton}>
+            {/* <InputGroup id="addJobsGroup"> */}
+            {/* Outer Input Group Might End Up as a div */}
+            {/* <Input type="select" multiple onChange={this.updateAddButton}>
                 <List
                   width={500}
                   height={220}
@@ -279,7 +303,7 @@ class FuzzyJobFinder extends React.Component {
                   rowRenderer={this.renderJob}
                   rowCount={this.state.fuzzyList.length}
                 />
-                {/* {this.state.fuzzyList.sort(sortAlphaNum).map((e) => (
+                {this.state.fuzzyList.sort(sortAlphaNum).map((e) => (
                   <option
                     data-testid="fuzzyList"
                     title={`${e.name} - ${e.groupsymbol}(${e.symbol})`}
@@ -290,9 +314,16 @@ class FuzzyJobFinder extends React.Component {
                   >
                     {e.name}
                   </option>
-                ))} */}
-              </Input>
-            </InputGroup>
+                ))}
+              </Input> */}
+            <List
+              width={500}
+              height={400}
+              rowHeight={20}
+              rowRenderer={this.renderJob}
+              rowCount={this.state.fuzzyList.length}
+            />
+            {/* </InputGroup> */}
             <hr />
             <h4> Selected Jobs [{this.state.selectedList.length}]</h4>
             <div className="fuzzybuttons">
@@ -312,7 +343,7 @@ class FuzzyJobFinder extends React.Component {
                 Remove all
               </Button>
             </div>
-            <InputGroup id="removeJobsGroup">
+            {/* <InputGroup id="removeJobsGroup">
               <Input type="select" multiple onChange={this.updateRemoveButton}>
                 {this.state.selectedList.sort(sortAlphaNum).map((e) => (
                   <option title={e} key={e}>
@@ -320,7 +351,14 @@ class FuzzyJobFinder extends React.Component {
                   </option>
                 ))}
               </Input>
-            </InputGroup>
+            </InputGroup> */}
+            <List
+              width={500}
+              height={400}
+              rowHeight={20}
+              rowRenderer={this.renderSelectedJob}
+              rowCount={this.state.selectedList.length}
+            />
           </ModalBody>
           <ModalFooter>
             <Button

--- a/ui/job-view/pushes/FuzzyJobFinder.jsx
+++ b/ui/job-view/pushes/FuzzyJobFinder.jsx
@@ -13,6 +13,7 @@ import {
   InputGroup,
   Input,
 } from 'reactstrap';
+import { List } from 'react-virtualized';
 import Fuse from 'fuse.js';
 
 import PushModel from '../../models/push';
@@ -197,6 +198,23 @@ class FuzzyJobFinder extends React.Component {
     });
   };
 
+  renderJob = ({ index, key, style }) => {
+    const { fuzzyList } = this.state;
+    const e = fuzzyList[index];
+
+    return (
+      <div
+        data-testid="fuzzyList"
+        title={`${e.name} - ${e.groupsymbol}(${e.symbol})`}
+        key={key}
+        style={style}
+        className={this.state.selectedList.includes(e.name) ? 'selected' : ''}
+      >
+        {e.name}
+      </div>
+    );
+  };
+
   render() {
     return (
       <div>
@@ -244,8 +262,23 @@ class FuzzyJobFinder extends React.Component {
                 Add all
               </Button>
             </div>
-            <InputGroup id="addJobsGroup">
+            <List
+              width={500}
+              height={220}
+              rowHeight={20}
+              rowRenderer={this.renderJob}
+              rowCount={this.state.fuzzyList.length}
+            />
+
+            {/* <InputGroup id="addJobsGroup">
               <Input type="select" multiple onChange={this.updateAddButton}>
+                <List
+                  width={500}
+                  height={220}
+                  rowHeight={20}
+                  rowRenderer={this.renderJob}
+                  rowCount={this.state.fuzzyList.length}
+                />
                 {this.state.fuzzyList.sort(sortAlphaNum).map((e) => (
                   <option
                     data-testid="fuzzyList"
@@ -259,7 +292,7 @@ class FuzzyJobFinder extends React.Component {
                   </option>
                 ))}
               </Input>
-            </InputGroup>
+            </InputGroup> */}
             <hr />
             <h4> Selected Jobs [{this.state.selectedList.length}]</h4>
             <div className="fuzzybuttons">

--- a/ui/job-view/pushes/FuzzyJobFinder.jsx
+++ b/ui/job-view/pushes/FuzzyJobFinder.jsx
@@ -262,15 +262,15 @@ class FuzzyJobFinder extends React.Component {
                 Add all
               </Button>
             </div>
-            <List
+            {/* <List
               width={500}
               height={220}
               rowHeight={20}
               rowRenderer={this.renderJob}
               rowCount={this.state.fuzzyList.length}
-            />
+            /> */}
 
-            {/* <InputGroup id="addJobsGroup">
+            <InputGroup id="addJobsGroup">
               <Input type="select" multiple onChange={this.updateAddButton}>
                 <List
                   width={500}
@@ -279,7 +279,7 @@ class FuzzyJobFinder extends React.Component {
                   rowRenderer={this.renderJob}
                   rowCount={this.state.fuzzyList.length}
                 />
-                {this.state.fuzzyList.sort(sortAlphaNum).map((e) => (
+                {/* {this.state.fuzzyList.sort(sortAlphaNum).map((e) => (
                   <option
                     data-testid="fuzzyList"
                     title={`${e.name} - ${e.groupsymbol}(${e.symbol})`}
@@ -290,9 +290,9 @@ class FuzzyJobFinder extends React.Component {
                   >
                     {e.name}
                   </option>
-                ))}
+                ))} */}
               </Input>
-            </InputGroup> */}
+            </InputGroup>
             <hr />
             <h4> Selected Jobs [{this.state.selectedList.length}]</h4>
             <div className="fuzzybuttons">

--- a/yarn.lock
+++ b/yarn.lock
@@ -8559,7 +8559,7 @@ react-transition-group@^2.3.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react-virtualized@^9.21.0:
+react-virtualized@9.22.2, react-virtualized@^9.21.0:
   version "9.22.2"
   resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.2.tgz#217a870bad91e5438f46f01a009e1d8ce1060a5a"
   integrity sha512-5j4h4FhxTdOpBKtePSs1yk6LDNT4oGtUwjT7Nkh61Z8vv3fTG/XeOf8J4li1AYaexOwTXnw0HFVxsV0GBUqwRw==


### PR DESCRIPTION
React-virtualized's `List` component is not compatible with reactstrap's `Input` component because there exists a `div`. As a result, we can't use `Input`'s `multiple` attribute and the jobs are no longer selectable. I could try and create my own select functionality, but wanted to see if there's a cleaner way of going about this. 

To recreate, navigate to "Add New Jobs (Search)" and the message should appear in console. 
