### PR TITLE
Bug 1647462 - Show passing test paths in Push Health

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,41 +96,41 @@ services:
     ports:
       - '5672:5672'
 
-  pulse-task-push:
-    build:
-      context: .
-      dockerfile: docker/dev.Dockerfile
-    environment:
-      - PULSE_URL=${PULSE_URL:-amqp://docker-shared-user:8r5VFxpJHtJahTVV5bYutykgDsXhGF@pulse.mozilla.org:5671/?ssl=1}
-      - LOGGING_LEVEL=INFO
-      - PULSE_AUTO_DELETE_QUEUES=True
-      - DATABASE_URL=mysql://root@mysql:3306/treeherder
-      - BROKER_URL=amqp://guest:guest@rabbitmq//
-      - SKIP_INGESTION=${SKIP_INGESTION:-False}
-    entrypoint: './docker/entrypoint.sh'
-    command: ./manage.py pulse_listener
-    volumes:
-      - .:/app
-    depends_on:
-      - mysql
-      - rabbitmq
-
-  celery:
-    build:
-      context: .
-      dockerfile: docker/dev.Dockerfile
-    environment:
-      - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672//
-      - DATABASE_URL=mysql://root@mysql:3306/treeherder
-      - PROJECTS_TO_INGEST=${PROJECTS_TO_INGEST:-autoland}
-    entrypoint: './docker/entrypoint.sh'
-    command: celery worker -A treeherder --uid=nobody --gid=nogroup --without-gossip --without-mingle --without-heartbeat -Q store_pulse_pushes,store_pulse_tasks --concurrency=1 --loglevel=WARNING
-    volumes:
-      - .:/app
-    depends_on:
-      - mysql
-      - redis
-      - rabbitmq
+#  pulse-task-push:
+#    build:
+#      context: .
+#      dockerfile: docker/dev.Dockerfile
+#    environment:
+#      - PULSE_URL=${PULSE_URL:-amqp://docker-shared-user:8r5VFxpJHtJahTVV5bYutykgDsXhGF@pulse.mozilla.org:5671/?ssl=1}
+#      - LOGGING_LEVEL=INFO
+#      - PULSE_AUTO_DELETE_QUEUES=True
+#      - DATABASE_URL=mysql://root@mysql:3306/treeherder
+#      - BROKER_URL=amqp://guest:guest@rabbitmq//
+#      - SKIP_INGESTION=${SKIP_INGESTION:-False}
+#    entrypoint: './docker/entrypoint.sh'
+#    command: ./manage.py pulse_listener
+#    volumes:
+#      - .:/app
+#    depends_on:
+#      - mysql
+#      - rabbitmq
+#
+#  celery:
+#    build:
+#      context: .
+#      dockerfile: docker/dev.Dockerfile
+#    environment:
+#      - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672//
+#      - DATABASE_URL=mysql://root@mysql:3306/treeherder
+#      - PROJECTS_TO_INGEST=${PROJECTS_TO_INGEST:-autoland}
+#    entrypoint: './docker/entrypoint.sh'
+#    command: celery worker -A treeherder --uid=nobody --gid=nogroup --without-gossip --without-mingle --without-heartbeat -Q store_pulse_pushes,store_pulse_tasks --concurrency=1 --loglevel=WARNING
+#    volumes:
+#      - .:/app
+#    depends_on:
+#      - mysql
+#      - redis
+#      - rabbitmq
 volumes:
   # TODO: Experiment with using tmpfs when testing, to speed up database-using Python tests.
   mysql_data: {}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-split-pane": "0.1.92",
     "react-table": "6.10.3",
     "react-tabs": "3.0.0",
+    "react-window": "1.8.5",
     "reactstrap": "8.3.2",
     "redux": "4.0.5",
     "redux-debounce": "1.0.1",

--- a/tests/ui/job-view/Push_test.jsx
+++ b/tests/ui/job-view/Push_test.jsx
@@ -12,7 +12,7 @@ import configureStore from '../../../ui/job-view/redux/configureStore';
 import Push, {
   transformTestPath,
   transformedPaths,
-} from '../../../ui/job-view/pushes/Push';
+} from '../../../ui/helpers/taskcluster';
 import { getApiUrl } from '../../../ui/helpers/url';
 import { findInstance } from '../../../ui/helpers/job';
 

--- a/tests/ui/mock/manifests-by-task.json
+++ b/tests/ui/mock/manifests-by-task.json
@@ -1,0 +1,21 @@
+{
+  "test-linux1804-64/debug-mochitest-devtools-chrome-e10s-1": [
+    "devtools/client/framework/browser-toolbox/test/browser.ini",
+    "devtools/client/framework/test/browser.ini",
+    "devtools/client/framework/test/metrics/browser_metrics_inspector.ini",
+    "devtools/client/inspector/changes/test/browser.ini",
+    "devtools/client/inspector/extensions/test/browser.ini",
+    "devtools/client/inspector/markup/test/browser.ini",
+    "devtools/client/jsonview/test/browser.ini",
+    "devtools/client/shared/test/browser.ini",
+    "devtools/client/styleeditor/test/browser.ini",
+    "devtools/client/webconsole/test/node/fixtures/stubs/stubs.ini"
+  ],
+  "test-linux1804-64-shippable-qr/opt-web-platform-tests-e10s-5": [
+    "/IndexedDB",
+    "/WebCryptoAPI/wrapKey_unwrapKey",
+    "/_mozilla/fetch/api/redirect",
+    "/mixed-content/gen/sharedworker-classic.http-rp",
+    "/upgrade-insecure-requests/gen/sharedworker-module-data.meta"
+  ]
+}

--- a/ui/helpers/gzip.js
+++ b/ui/helpers/gzip.js
@@ -1,6 +1,7 @@
 import { inflate } from 'pako';
 
 export const unGzip = async (binData) => {
+  console.log('binData', binData);
   const decompressed = await inflate(binData, { to: 'string' });
   return JSON.parse(decompressed);
 };

--- a/ui/helpers/taskcluster.js
+++ b/ui/helpers/taskcluster.js
@@ -175,15 +175,18 @@ export const fetchGeckoDecisionArtifact = async (
     rootUrl,
   )}/api/index/v1/task/gecko.v2.${project}.revision.${revision}.taskgraph.decision/artifacts/public/${filePath}`;
   const response = await fetch(url);
-  if (url.endsWith('.gz')) {
+  console.log(response.headers.get('Content-Type'));
+
+  if (response.headers.get('Content-Type') === 'application/json') {
+    if ([200, 303, 304].includes(response.status)) {
+      artifactContents = await response.json();
+      console.log('its json', artifactContents);
+    }
+  } else if (url.endsWith('.gz')) {
     if ([200, 303, 304].includes(response.status)) {
       const blob = await response.blob();
       const binData = await blob.arrayBuffer();
       artifactContents = await decompress(binData);
-    }
-  } else if (url.endsWith('.json')) {
-    if ([200, 303, 304].includes(response.status)) {
-      artifactContents = await response.json();
     }
   }
   return artifactContents;

--- a/ui/push-health/Health.jsx
+++ b/ui/push-health/Health.jsx
@@ -211,6 +211,7 @@ export default class Health extends React.PureComponent {
     const needInvestigationCount = tests
       ? tests.details.needInvestigation.length
       : 0;
+    console.log('searchStr', searchStr);
 
     return (
       <React.Fragment>
@@ -247,6 +248,7 @@ export default class Health extends React.PureComponent {
                   <InputFilter
                     updateFilterText={this.filter}
                     placeholder="filter path or platform"
+                    initialValue={searchStr}
                   />
                 </span>
               </Nav>

--- a/ui/push-health/Health.jsx
+++ b/ui/push-health/Health.jsx
@@ -211,7 +211,6 @@ export default class Health extends React.PureComponent {
     const needInvestigationCount = tests
       ? tests.details.needInvestigation.length
       : 0;
-    console.log('searchStr', searchStr);
 
     return (
       <React.Fragment>

--- a/ui/push-health/MainHeading.jsx
+++ b/ui/push-health/MainHeading.jsx
@@ -1,0 +1,86 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Button, Collapse, Row } from 'reactstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCaretDown, faCaretRight } from '@fortawesome/free-solid-svg-icons';
+
+class MainHeading extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      detailsShowing: props.expanded,
+    };
+  }
+
+  toggleDetails = () => {
+    const { updateParamsAndState, name } = this.props;
+
+    updateParamsAndState({
+      testGroup: name === 'Possible Regressions' ? 'pr' : 'ki',
+    });
+    this.setState((prevState) => ({
+      detailsShowing: !prevState.detailsShowing,
+    }));
+  };
+
+  render() {
+    const { detailsShowing } = this.state;
+    const { name, className, stateIcon, iconColor, groupLength } = this.props;
+    const expandIcon = detailsShowing ? faCaretDown : faCaretRight;
+    const expandTitle = detailsShowing
+      ? 'Click to collapse'
+      : 'Click to expand';
+
+    return (
+      <Row
+        className={`justify-content-between ${className}`}
+        data-testid="classification-group"
+      >
+        <span className="font-size-24">
+          <Button
+            onClick={this.toggleDetails}
+            outline
+            className="font-size-24 border-0"
+            role="button"
+            aria-expanded={detailsShowing}
+          >
+            <FontAwesomeIcon
+              icon={expandIcon}
+              className="mr-1 min-width-1"
+              title={expandTitle}
+              aria-label={expandTitle}
+              alt=""
+            />
+            <FontAwesomeIcon
+              icon={stateIcon}
+              className={`mx-2 text-${iconColor}`}
+            />
+            {name} {groupLength ? <span>({groupLength})</span> : ''}
+          </Button>
+        </span>
+        <Collapse isOpen={detailsShowing} className="w-100">
+          {this.props.children}
+        </Collapse>
+      </Row>
+    );
+  }
+}
+
+MainHeading.propTypes = {
+  name: PropTypes.string.isRequired,
+  stateIcon: PropTypes.shape({}).isRequired,
+  groupLength: PropTypes.number,
+  expanded: PropTypes.bool,
+  className: PropTypes.string,
+  iconColor: PropTypes.string,
+};
+
+MainHeading.defaultProps = {
+  expanded: true,
+  className: '',
+  iconColor: 'darker-info',
+  groupLength: 0,
+};
+
+export default MainHeading;

--- a/ui/push-health/PassingPaths.jsx
+++ b/ui/push-health/PassingPaths.jsx
@@ -1,0 +1,103 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Spinner from 'reactstrap/es/Spinner';
+import { FixedSizeList as List } from 'react-window';
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
+import trimStart from 'lodash/trimStart';
+
+import { fetchGeckoDecisionArtifact } from '../helpers/taskcluster';
+
+import { filterPaths } from './helpers';
+
+class PassingPaths extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      paths: null,
+      filteredPaths: [],
+    };
+  }
+
+  async componentDidMount() {
+    const { revision, currentRepo, searchStr } = this.props;
+    const manifestByTask = await fetchGeckoDecisionArtifact(
+      currentRepo.name,
+      revision,
+      'manifests-by-task.json.gz',
+    );
+    const uniquePaths = [
+      ...new Set(
+        Object.values(manifestByTask).reduce(
+          (manArr, acc) => [...acc, ...manArr],
+          [],
+        ),
+      ),
+    ];
+    const paths = uniquePaths.map((path) => trimStart(path, '/'));
+    const filteredPaths = searchStr ? filterPaths(paths, searchStr) : paths;
+
+    filteredPaths.sort();
+    this.setState({ paths, filteredPaths });
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    const { searchStr } = this.props;
+    const { paths } = this.state;
+
+    return nextProps.searchStr !== searchStr || nextState.paths !== paths;
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    const { paths } = state;
+    const pathsToFilter = paths || [];
+    const { searchStr } = props;
+    const filteredPaths = searchStr
+      ? filterPaths(pathsToFilter, searchStr)
+      : pathsToFilter;
+
+    filteredPaths.sort();
+    return { filteredPaths };
+  }
+
+  passingPath = ({ index, style }) => {
+    const { filteredPaths } = this.state;
+
+    return <div style={style}>{filteredPaths[index]}</div>;
+  };
+
+  render() {
+    const { paths, filteredPaths } = this.state;
+
+    return paths ? (
+      <List
+        height={500}
+        width="100%"
+        itemData={filteredPaths}
+        itemSize={25}
+        itemCount={filteredPaths.length}
+        name="Passing Paths"
+        icon={faCheck}
+        iconColor="success"
+        expanded={false}
+        className="ml-4 border-secondary border-bottom border-top"
+      >
+        {this.passingPath}
+      </List>
+    ) : (
+      <Spinner />
+    );
+  }
+}
+
+PassingPaths.propTypes = {
+  revision: PropTypes.string.isRequired,
+  currentRepo: PropTypes.shape({}).isRequired,
+  searchStr: PropTypes.string,
+};
+
+PassingPaths.defaultProps = {
+  searchStr: '',
+};
+
+export default PassingPaths;

--- a/ui/push-health/PassingPaths.jsx
+++ b/ui/push-health/PassingPaths.jsx
@@ -20,13 +20,26 @@ class PassingPaths extends Component {
   }
 
   async componentDidMount() {
-    const { revision, currentRepo, searchStr } = this.props;
+    const { revision, currentRepo, searchStr, failingTaskLabels } = this.props;
     try {
       const manifestByTask = await fetchGeckoDecisionArtifact(
         currentRepo.name,
         revision,
         'manifests-by-task.json.gz',
       );
+
+      console.log('failingLabels', failingTaskLabels);
+      const taskLabels = Object.keys(manifestByTask);
+
+      failingTaskLabels.forEach((label) => {
+        if (manifestByTask[label]) {
+          console.log('found this one', label);
+        }
+        delete manifestByTask[label];
+        console.log('checking for', label, manifestByTask[label]);
+      });
+      // failingTaskLabels.forEach((label) => delete manifestByTask[label]);
+
       const uniquePaths = [
         ...new Set(
           Object.values(manifestByTask).reduce(
@@ -35,15 +48,15 @@ class PassingPaths extends Component {
           ),
         ),
       ];
-      console.log(uniquePaths);
+      // console.log(uniquePaths);
       const paths = uniquePaths.map((path) => trimStart(path, '/'));
       const filteredPaths = searchStr ? filterPaths(paths, searchStr) : paths;
 
       filteredPaths.sort();
       this.setState({ paths, filteredPaths });
     } catch (e) {
-      console.log('error getting manifests');
-      console.log(e);
+      // console.log('error getting manifests');
+      // console.log(e);
     }
   }
 
@@ -100,10 +113,12 @@ PassingPaths.propTypes = {
   revision: PropTypes.string.isRequired,
   currentRepo: PropTypes.shape({}).isRequired,
   searchStr: PropTypes.string,
+  failingTaskLabels: PropTypes.arrayOf(PropTypes.string),
 };
 
 PassingPaths.defaultProps = {
   searchStr: '',
+  failingTaskLabels: [],
 };
 
 export default PassingPaths;

--- a/ui/push-health/PassingPaths.jsx
+++ b/ui/push-health/PassingPaths.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Spinner from 'reactstrap/es/Spinner';
+import { Spinner } from 'reactstrap';
 import { FixedSizeList as List } from 'react-window';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import trimStart from 'lodash/trimStart';
@@ -21,24 +21,30 @@ class PassingPaths extends Component {
 
   async componentDidMount() {
     const { revision, currentRepo, searchStr } = this.props;
-    const manifestByTask = await fetchGeckoDecisionArtifact(
-      currentRepo.name,
-      revision,
-      'manifests-by-task.json.gz',
-    );
-    const uniquePaths = [
-      ...new Set(
-        Object.values(manifestByTask).reduce(
-          (manArr, acc) => [...acc, ...manArr],
-          [],
+    try {
+      const manifestByTask = await fetchGeckoDecisionArtifact(
+        currentRepo.name,
+        revision,
+        'manifests-by-task.json.gz',
+      );
+      const uniquePaths = [
+        ...new Set(
+          Object.values(manifestByTask).reduce(
+            (manArr, acc) => [...acc, ...manArr],
+            [],
+          ),
         ),
-      ),
-    ];
-    const paths = uniquePaths.map((path) => trimStart(path, '/'));
-    const filteredPaths = searchStr ? filterPaths(paths, searchStr) : paths;
+      ];
+      console.log(uniquePaths);
+      const paths = uniquePaths.map((path) => trimStart(path, '/'));
+      const filteredPaths = searchStr ? filterPaths(paths, searchStr) : paths;
 
-    filteredPaths.sort();
-    this.setState({ paths, filteredPaths });
+      filteredPaths.sort();
+      this.setState({ paths, filteredPaths });
+    } catch (e) {
+      console.log('error getting manifests');
+      console.log(e);
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {

--- a/ui/push-health/TestMetric.jsx
+++ b/ui/push-health/TestMetric.jsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import {
+  faExclamationTriangle,
+  faCheck,
+} from '@fortawesome/free-solid-svg-icons';
 
 import ClassificationGroup from './ClassificationGroup';
 import { filterTests } from './helpers';
+import PassingPaths from './PassingPaths';
+import MainHeading from './MainHeading';
 
 export default class TestMetric extends React.PureComponent {
   render() {
@@ -45,71 +50,97 @@ export default class TestMetric extends React.PureComponent {
     }
 
     return (
-      <div className="border-bottom border-secondary">
-        <ClassificationGroup
-          jobs={jobs}
-          tests={filteredNeedInvestigation}
+      <div>
+        <MainHeading
           name="Possible Regressions"
-          repo={repo}
-          currentRepo={currentRepo}
-          revision={revision}
-          className="mb-5"
-          icon={faExclamationTriangle}
+          stateIcon={faExclamationTriangle}
           iconColor={
             filteredNeedInvestigation.length ? 'danger' : 'darker-secondary'
           }
-          expanded={testGroup === 'pr'}
-          testGroup={testGroup}
-          selectedTest={selectedTest}
-          hasRetriggerAll
-          notify={notify}
-          orderedBy={regressionsOrderBy}
-          groupedBy={regressionsGroupBy}
-          selectedJobName={selectedJobName}
-          selectedTaskId={selectedTaskId}
-          setOrderedBy={(regressionsOrderBy) =>
-            updateParamsAndState({ regressionsOrderBy, testGroup: 'pr' })
-          }
-          setGroupedBy={(regressionsGroupBy) =>
-            updateParamsAndState({ regressionsGroupBy, testGroup: 'pr' })
-          }
-          updateParamsAndState={(stateObj) => {
-            stateObj.testGroup = 'pr';
-            updateParamsAndState(stateObj);
-          }}
-        />
-        <ClassificationGroup
-          jobs={jobs}
-          tests={filteredKnownIssues}
-          name="Known Issues"
-          repo={repo}
-          currentRepo={currentRepo}
-          revision={revision}
           className="mb-5"
-          icon={faExclamationTriangle}
+          expanded={testGroup === 'pr'}
+          updateParamsAndState={updateParamsAndState}
+          groupLength={filteredNeedInvestigation.length}
+        >
+          <ClassificationGroup
+            jobs={jobs}
+            tests={filteredNeedInvestigation}
+            repo={repo}
+            currentRepo={currentRepo}
+            revision={revision}
+            testGroup={testGroup}
+            selectedTest={selectedTest}
+            hasRetriggerAll
+            notify={notify}
+            orderedBy={regressionsOrderBy}
+            groupedBy={regressionsGroupBy}
+            selectedJobName={selectedJobName}
+            selectedTaskId={selectedTaskId}
+            setOrderedBy={(regressionsOrderBy) =>
+              updateParamsAndState({ regressionsOrderBy, testGroup: 'pr' })
+            }
+            setGroupedBy={(regressionsGroupBy) =>
+              updateParamsAndState({ regressionsGroupBy, testGroup: 'pr' })
+            }
+            updateParamsAndState={(stateObj) => {
+              stateObj.testGroup = 'pr';
+              updateParamsAndState(stateObj);
+            }}
+          />
+        </MainHeading>
+        <MainHeading
+          name="Known Issues"
+          stateIcon={faExclamationTriangle}
           iconColor={
             filteredKnownIssues.length ? 'warning' : 'darker-secondary'
           }
           expanded={testGroup === 'ki'}
-          testGroup={testGroup}
-          selectedTest={selectedTest}
-          hasRetriggerAll
-          notify={notify}
-          selectedTaskId={selectedTaskId}
-          orderedBy={knownIssuesOrderBy}
-          groupedBy={knownIssuesGroupBy}
-          selectedJobName={selectedJobName}
-          setOrderedBy={(knownIssuesOrderBy) =>
-            updateParamsAndState({ knownIssuesOrderBy, testGroup: 'ki' })
-          }
-          setGroupedBy={(knownIssuesGroupBy) =>
-            updateParamsAndState({ knownIssuesGroupBy, testGroup: 'ki' })
-          }
+          updateParamsAndState={updateParamsAndState}
+          className="mb-5"
+          groupLength={filteredKnownIssues.length}
+        >
+          <ClassificationGroup
+            jobs={jobs}
+            tests={filteredKnownIssues}
+            repo={repo}
+            currentRepo={currentRepo}
+            revision={revision}
+            testGroup={testGroup}
+            selectedTest={selectedTest}
+            hasRetriggerAll
+            notify={notify}
+            selectedTaskId={selectedTaskId}
+            orderedBy={knownIssuesOrderBy}
+            groupedBy={knownIssuesGroupBy}
+            selectedJobName={selectedJobName}
+            setOrderedBy={(knownIssuesOrderBy) =>
+              updateParamsAndState({ knownIssuesOrderBy, testGroup: 'ki' })
+            }
+            setGroupedBy={(knownIssuesGroupBy) =>
+              updateParamsAndState({ knownIssuesGroupBy, testGroup: 'ki' })
+            }
+            updateParamsAndState={(stateObj) => {
+              stateObj.testGroup = 'ki';
+              updateParamsAndState(stateObj);
+            }}
+          />
+        </MainHeading>
+        <MainHeading
+          name="Passing Paths"
+          stateIcon={faCheck}
+          iconColor="success"
+          expanded={testGroup === 'pp'}
           updateParamsAndState={(stateObj) => {
-            stateObj.testGroup = 'ki';
+            stateObj.testGroup = 'pp';
             updateParamsAndState(stateObj);
           }}
-        />
+        >
+          <PassingPaths
+            revision={revision}
+            currentRepo={currentRepo}
+            searchStr={searchStr}
+          />
+        </MainHeading>
       </div>
     );
   }

--- a/ui/push-health/TestMetric.jsx
+++ b/ui/push-health/TestMetric.jsx
@@ -49,6 +49,9 @@ export default class TestMetric extends React.PureComponent {
       );
     }
 
+    console.log('ni', filteredNeedInvestigation);
+    console.log('jobs', jobs);
+
     return (
       <div>
         <MainHeading
@@ -139,6 +142,7 @@ export default class TestMetric extends React.PureComponent {
             revision={revision}
             currentRepo={currentRepo}
             searchStr={searchStr}
+            failingTaskLabels={Object.keys(jobs)}
           />
         </MainHeading>
       </div>

--- a/ui/push-health/helpers.js
+++ b/ui/push-health/helpers.js
@@ -28,6 +28,12 @@ export const filterTests = (tests, searchStr, showParentMatches) => {
   );
 };
 
+export const filterPaths = (paths, searchStr) => {
+  const filters = searchStr.split(' ').map((filter) => new RegExp(filter, 'i'));
+
+  return paths.filter((path) => filters.every((f) => f.test(path)));
+};
+
 export const filterJobs = (jobs, showParentMatches) => {
   return jobs.filter((job) => job.failedInParent === showParentMatches);
 };

--- a/ui/shared/InputFilter.jsx
+++ b/ui/shared/InputFilter.jsx
@@ -19,6 +19,12 @@ export default class InputFilter extends React.Component {
     800,
   );
 
+  componentDidMount() {
+    const { initialValue } = this.props;
+
+    this.setState({ input: initialValue });
+  }
+
   updateInput = (event) => {
     const { updateFilterText, updateOnEnter } = this.props;
     const input = event.target.value;
@@ -67,10 +73,12 @@ InputFilter.propTypes = {
   disabled: PropTypes.bool,
   placeholder: PropTypes.string,
   updateOnEnter: PropTypes.bool,
+  initialValue: PropTypes.string,
 };
 
 InputFilter.defaultProps = {
   disabled: false,
   placeholder: filterText.inputPlaceholder,
   updateOnEnter: false,
+  initialValue: '',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,7 +897,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -6938,6 +6938,11 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
+"memoize-one@>=3.1.1 <6":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
+
 memoize-one@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
@@ -8572,6 +8577,14 @@ react-virtualized@^9.21.0:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-lifecycles-compat "^3.0.4"
+
+react-window@1.8.5:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.5.tgz#a56b39307e79979721021f5d06a67742ecca52d1"
+  integrity sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
 
 react-with-direction@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
This just gets the paths, not every test that is run.  I used `react-window` which is the newer, lighter version of `react-virtualized`

I moved the logic for getting the paths from `Push.jsx` into a taskcluster helper to make it available to Push Health.

I created a `MainHeader.jsx` component which handles the collapsing that used to be in `ClassificationGroup` so that I could use the same logic in the new `PassingPaths` section.