### PR TITLE
Add more prominent buttons to the PerformanceTab

### DIFF
--- a/ui/css/treeherder-custom-styles.css
+++ b/ui/css/treeherder-custom-styles.css
@@ -364,6 +364,10 @@
   border-color: #545b62;
 }
 
+.btn-darker-secondary:visited {
+  color: #ffffff;
+}
+
 .btn-darker-secondary.disabled {
   color: #242424;
   background-color: white;

--- a/ui/css/treeherder-details-panel.css
+++ b/ui/css/treeherder-details-panel.css
@@ -417,3 +417,18 @@ div.similar-jobs .similar-job-list table tr {
 div.performance-panel {
   display: block !important;
 }
+
+.performance-panel-actions {
+  display: flex;
+  flex-direction: row;
+}
+
+.performance-panel-actions > * {
+  /* This is the same value as m-1 */
+  margin: .25rem;
+}
+
+.performance-panel-actions > a {
+  /* Override the base "a" styles. */
+  color: #fff;
+}

--- a/ui/css/treeherder-details-panel.css
+++ b/ui/css/treeherder-details-panel.css
@@ -418,17 +418,7 @@ div.performance-panel {
   display: block !important;
 }
 
-.performance-panel-actions {
-  display: flex;
-  flex-direction: row;
-}
-
 .performance-panel-actions > * {
   /* This is the same value as m-1 */
-  margin: .25rem;
-}
-
-.performance-panel-actions > a {
-  /* Override the base "a" styles. */
-  color: #fff;
+  margin: 0.25rem;
 }

--- a/ui/helpers/performance.js
+++ b/ui/helpers/performance.js
@@ -1,0 +1,66 @@
+// This file may export additional functions.
+/* eslint-disable import/prefer-default-export */
+
+import TaskclusterModel from '../models/taskcluster';
+
+import { formatTaskclusterError } from './errorMessage';
+import { getAction } from './taskcluster';
+
+/**
+ * This function will create a new task that will run the Gecko Profiler against
+ * an existing performance test.
+ *
+ * @param {Object} selectedJobFull - The full job details, required by the TaskclusterModel.
+ * @param {Function} notify - Notify the UI that something happened.
+ * @param {Object} decisionTaskMap - Object that maps a job push ID to a decision task.
+ * @param {string} currentRepo - The name of the current repo, e.g. "try"
+ */
+export async function triggerGeckoProfileTask(
+  selectedJobFull,
+  notify,
+  decisionTaskMap,
+  currentRepo,
+) {
+  const { id: decisionTaskId } = decisionTaskMap[selectedJobFull.push_id];
+
+  TaskclusterModel.load(decisionTaskId, selectedJobFull, currentRepo).then(
+    (results) => {
+      try {
+        const geckoprofile = getAction(results.actions, 'geckoprofile');
+
+        if (
+          geckoprofile === undefined ||
+          !Object.prototype.hasOwnProperty.call(geckoprofile, 'kind')
+        ) {
+          return notify(
+            'Job was scheduled without taskcluster support for GeckoProfiles',
+          );
+        }
+
+        TaskclusterModel.submit({
+          action: geckoprofile,
+          decisionTaskId,
+          taskId: results.originalTaskId,
+          task: results.originalTask,
+          input: {},
+          staticActionVariables: results.staticActionVariables,
+          currentRepo,
+        }).then(
+          () => {
+            notify(
+              'Request sent to collect gecko profile job via actions.json',
+              'success',
+            );
+          },
+          (e) => {
+            // The full message is too large to fit in a Treeherder
+            // notification box.
+            notify(formatTaskclusterError(e), 'danger', { sticky: true });
+          },
+        );
+      } catch (e) {
+        notify(formatTaskclusterError(e), 'danger', { sticky: true });
+      }
+    },
+  );
+}

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -348,6 +348,7 @@ class DetailsPanel extends React.Component {
             <span className="job-tabs-divider" />
             <TabsPanel
               selectedJobFull={selectedJobFull}
+              currentRepo={currentRepo}
               jobDetails={jobDetails}
               perfJobDetail={perfJobDetail}
               repoName={currentRepo.name}

--- a/ui/job-view/details/tabs/PerformanceTab.jsx
+++ b/ui/job-view/details/tabs/PerformanceTab.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Alert, Button } from 'reactstrap';
 import {
   faInfoCircle,
   faExternalLinkAlt,
@@ -59,7 +60,7 @@ class PerformanceTab extends React.PureComponent {
         <a
           title={jobDetail.value}
           href={getPerfAnalysisUrl(jobDetail.url)}
-          className="btn btn-primary btn-sm"
+          className="btn btn-darker-secondary btn-sm"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -86,7 +87,7 @@ class PerformanceTab extends React.PureComponent {
         role="region"
         aria-label="Performance"
       >
-        <div className="performance-panel-actions">
+        <div className="performance-panel-actions d-flex">
           {
             // If there is a profiler link, show this first. This is most likely
             // the primary action of the user here.
@@ -96,11 +97,12 @@ class PerformanceTab extends React.PureComponent {
             // Just to be safe, use the same isPerfTest check the other
             // "Create Gecko Profile" button uses in the action menu.
             isPerfTest(selectedJobFull) ? (
-              <button
-                type="button"
-                className={`btn btn-${
+              <Button
+                className={`btn ${
                   // Only make this primary if there is no profiler link.
-                  profilerLink ? 'secondary' : 'primary'
+                  profilerLink
+                    ? 'btn-outline-darker-secondary'
+                    : 'btn-darker-secondary'
                 } btn-sm`}
                 onClick={this.createGeckoProfile}
                 title={
@@ -112,7 +114,7 @@ class PerformanceTab extends React.PureComponent {
                 {profilerLink
                   ? 'Re-trigger performance profile'
                   : 'Generate performance profile'}
-              </button>
+              </Button>
             ) : null
           }
           <a
@@ -122,7 +124,7 @@ class PerformanceTab extends React.PureComponent {
             })}
             target="_blank"
             rel="noopener noreferrer"
-            className="btn btn-secondary btn-sm"
+            className="btn btn-outline-darker-secondary btn-sm"
           >
             <FontAwesomeIcon icon={faTable} className="mr-2" />
             Compare against another revision
@@ -133,14 +135,14 @@ class PerformanceTab extends React.PureComponent {
           // job list only gets populated later. This notification will help the
           // user know the next action.
           triggeredGeckoProfiles > 0 ? (
-            <div className="alert alert-info m-1" role="alert">
+            <Alert color="info" className="m-1">
               <FontAwesomeIcon icon={faInfoCircle} className="mr-1" />
               {triggeredGeckoProfiles === 1
                 ? `Triggered ${triggeredGeckoProfiles} profiler run. It will show up ` +
                   `as a new entry in the job list once the task has been scheduled.`
                 : `Triggered ${triggeredGeckoProfiles} profiler runs. They will show up ` +
                   `as new entries in the job list once the task has been scheduled.`}
-            </div>
+            </Alert>
           ) : null
         }
         {!!sortedDetails.length && (

--- a/ui/job-view/details/tabs/PerformanceTab.jsx
+++ b/ui/job-view/details/tabs/PerformanceTab.jsx
@@ -1,13 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTable } from '@fortawesome/free-solid-svg-icons';
+import { faExternalLinkAlt, faTable } from '@fortawesome/free-solid-svg-icons';
 
-import { getCompareChooserUrl } from '../../../helpers/url';
+import { getCompareChooserUrl, getPerfAnalysisUrl } from '../../../helpers/url';
 
 export default class PerformanceTab extends React.PureComponent {
+  maybeGetFirefoxProfilerLink() {
+    // Look for a profiler artifact.
+    const jobDetail = this.props.jobDetails.find(
+      ({ url, value }) =>
+        url &&
+        value.startsWith('profile_') &&
+        (value.endsWith('.zip') || value.endsWith('.json')),
+    );
+
+    if (jobDetail) {
+      return (
+        <a
+          title={jobDetail.value}
+          href={getPerfAnalysisUrl(jobDetail.url)}
+          className="btn btn-primary btn-sm"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <FontAwesomeIcon icon={faExternalLinkAlt} className="mr-2" />
+          Open in Firefox Profiler
+        </a>
+      );
+    }
+
+    return null;
+  }
+
   render() {
     const { repoName, revision, perfJobDetail } = this.props;
+    const profilerLink = this.maybeGetFirefoxProfilerLink();
     const sortedDetails = perfJobDetail ? perfJobDetail.slice() : [];
 
     sortedDetails.sort((a, b) => a.title.localeCompare(b.title));
@@ -19,6 +47,11 @@ export default class PerformanceTab extends React.PureComponent {
         aria-label="Performance"
       >
         <div className="performance-panel-actions">
+          {
+            // If there is a profiler link, show this first. This is most likely
+            // the primary action of the user here.
+            profilerLink
+          }
           <a
             href={getCompareChooserUrl({
               newProject: repoName,
@@ -55,11 +88,13 @@ export default class PerformanceTab extends React.PureComponent {
 
 PerformanceTab.propTypes = {
   repoName: PropTypes.string.isRequired,
+  jobDetails: PropTypes.arrayOf(PropTypes.object),
   perfJobDetail: PropTypes.arrayOf(PropTypes.object),
   revision: PropTypes.string,
 };
 
 PerformanceTab.defaultProps = {
+  jobDetails: [],
   perfJobDetail: [],
   revision: '',
 };

--- a/ui/job-view/details/tabs/PerformanceTab.jsx
+++ b/ui/job-view/details/tabs/PerformanceTab.jsx
@@ -1,11 +1,50 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faExternalLinkAlt, faTable } from '@fortawesome/free-solid-svg-icons';
+import {
+  faInfoCircle,
+  faExternalLinkAlt,
+  faRedo,
+  faTable,
+} from '@fortawesome/free-solid-svg-icons';
 
 import { getCompareChooserUrl, getPerfAnalysisUrl } from '../../../helpers/url';
+import { triggerGeckoProfileTask } from '../../../helpers/performance';
+import { notify } from '../../redux/stores/notifications';
+import { isPerfTest } from '../../../helpers/job';
 
-export default class PerformanceTab extends React.PureComponent {
+/**
+ * The performance tab shows performance-oriented information about a test run.
+ * It helps users interact with the Firefox Profiler, and summarizes test
+ * timing information.
+ */
+class PerformanceTab extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      triggeredGeckoProfiles: 0,
+    };
+  }
+
+  createGeckoProfile = async () => {
+    const {
+      selectedJobFull,
+      notify,
+      decisionTaskMap,
+      currentRepo,
+    } = this.props;
+    await triggerGeckoProfileTask(
+      selectedJobFull,
+      notify,
+      decisionTaskMap,
+      currentRepo,
+    );
+    this.setState((state) => ({
+      triggeredGeckoProfiles: state.triggeredGeckoProfiles + 1,
+    }));
+  };
+
   maybeGetFirefoxProfilerLink() {
     // Look for a profiler artifact.
     const jobDetail = this.props.jobDetails.find(
@@ -34,7 +73,8 @@ export default class PerformanceTab extends React.PureComponent {
   }
 
   render() {
-    const { repoName, revision, perfJobDetail } = this.props;
+    const { repoName, revision, perfJobDetail, selectedJobFull } = this.props;
+    const { triggeredGeckoProfiles } = this.state;
     const profilerLink = this.maybeGetFirefoxProfilerLink();
     const sortedDetails = perfJobDetail ? perfJobDetail.slice() : [];
 
@@ -52,6 +92,29 @@ export default class PerformanceTab extends React.PureComponent {
             // the primary action of the user here.
             profilerLink
           }
+          {
+            // Just to be safe, use the same isPerfTest check the other
+            // "Create Gecko Profile" button uses in the action menu.
+            isPerfTest(selectedJobFull) ? (
+              <button
+                type="button"
+                className={`btn btn-${
+                  // Only make this primary if there is no profiler link.
+                  profilerLink ? 'secondary' : 'primary'
+                } btn-sm`}
+                onClick={this.createGeckoProfile}
+                title={
+                  'Trigger another run of this test with the profiler enabled. The ' +
+                  'profile can then be viewed in the Firefox Profiler.'
+                }
+              >
+                <FontAwesomeIcon icon={faRedo} className="mr-2" />
+                {profilerLink
+                  ? 'Re-trigger performance profile'
+                  : 'Generate performance profile'}
+              </button>
+            ) : null
+          }
           <a
             href={getCompareChooserUrl({
               newProject: repoName,
@@ -65,6 +128,21 @@ export default class PerformanceTab extends React.PureComponent {
             Compare against another revision
           </a>
         </div>
+        {
+          // It can be confusing after triggering a profile what happens next. The
+          // job list only gets populated later. This notification will help the
+          // user know the next action.
+          triggeredGeckoProfiles > 0 ? (
+            <div className="alert alert-info m-1" role="alert">
+              <FontAwesomeIcon icon={faInfoCircle} className="mr-1" />
+              {triggeredGeckoProfiles === 1
+                ? `Triggered ${triggeredGeckoProfiles} profiler run. It will show up ` +
+                  `as a new entry in the job list once the task has been scheduled.`
+                : `Triggered ${triggeredGeckoProfiles} profiler runs. They will show up ` +
+                  `as new entries in the job list once the task has been scheduled.`}
+            </div>
+          ) : null
+        }
         {!!sortedDetails.length && (
           <ul>
             <li>
@@ -91,6 +169,7 @@ PerformanceTab.propTypes = {
   jobDetails: PropTypes.arrayOf(PropTypes.object),
   perfJobDetail: PropTypes.arrayOf(PropTypes.object),
   revision: PropTypes.string,
+  decisionTaskMap: PropTypes.shape({}).isRequired,
 };
 
 PerformanceTab.defaultProps = {
@@ -98,3 +177,10 @@ PerformanceTab.defaultProps = {
   perfJobDetail: [],
   revision: '',
 };
+
+const mapStateToProps = (state) => ({
+  decisionTaskMap: state.pushes.decisionTaskMap,
+});
+const mapDispatchToProps = { notify };
+
+export default connect(mapStateToProps, mapDispatchToProps)(PerformanceTab);

--- a/ui/job-view/details/tabs/PerformanceTab.jsx
+++ b/ui/job-view/details/tabs/PerformanceTab.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTable } from '@fortawesome/free-solid-svg-icons';
 
 import { getCompareChooserUrl } from '../../../helpers/url';
 
@@ -16,6 +18,20 @@ export default class PerformanceTab extends React.PureComponent {
         role="region"
         aria-label="Performance"
       >
+        <div className="performance-panel-actions">
+          <a
+            href={getCompareChooserUrl({
+              newProject: repoName,
+              newRevision: revision,
+            })}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn btn-secondary btn-sm"
+          >
+            <FontAwesomeIcon icon={faTable} className="mr-2" />
+            Compare against another revision
+          </a>
+        </div>
         {!!sortedDetails.length && (
           <ul>
             <li>
@@ -32,20 +48,6 @@ export default class PerformanceTab extends React.PureComponent {
             </li>
           </ul>
         )}
-        <ul>
-          <li>
-            <a
-              href={getCompareChooserUrl({
-                newProject: repoName,
-                newRevision: revision,
-              })}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Compare result against another revision
-            </a>
-          </li>
-        </ul>
       </div>
     );
   }

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -126,7 +126,6 @@ class TabsPanel extends React.Component {
       logParseStatus,
       bugs,
       perfJobDetail,
-      repoName,
       jobRevision,
       classifications,
       togglePinBoardVisibility,
@@ -136,6 +135,7 @@ class TabsPanel extends React.Component {
       logViewerFullUrl,
       clearSelectedJob,
       selectedJobFull,
+      currentRepo,
       pinJob,
       addBug,
       taskId,
@@ -223,7 +223,7 @@ class TabsPanel extends React.Component {
               logViewerFullUrl={logViewerFullUrl}
               addBug={addBug}
               pinJob={pinJob}
-              repoName={repoName}
+              repoName={currentRepo.name}
               fontSize="font-size-11"
             />
           </TabPanel>
@@ -237,7 +237,7 @@ class TabsPanel extends React.Component {
           </TabPanel>
           <TabPanel>
             <SimilarJobsTab
-              repoName={repoName}
+              repoName={currentRepo.name}
               classificationMap={classificationMap}
               selectedJobFull={selectedJobFull}
             />
@@ -245,6 +245,10 @@ class TabsPanel extends React.Component {
           {showPerf && (
             <TabPanel>
               <PerformanceTab
+                key={selectedJobFull.id}
+                selectedJobFull={selectedJobFull}
+                currentRepo={currentRepo}
+                repoName={currentRepo.name}
                 jobDetails={jobDetails}
                 perfJobDetail={perfJobDetail}
                 revision={jobRevision}
@@ -277,7 +281,6 @@ class TabsPanel extends React.Component {
 TabsPanel.propTypes = {
   classificationMap: PropTypes.shape({}).isRequired,
   jobDetails: PropTypes.arrayOf(PropTypes.object).isRequired,
-  repoName: PropTypes.string.isRequired,
   classifications: PropTypes.arrayOf(PropTypes.object).isRequired,
   togglePinBoardVisibility: PropTypes.func.isRequired,
   isPinBoardVisible: PropTypes.bool.isRequired,
@@ -285,6 +288,7 @@ TabsPanel.propTypes = {
   bugs: PropTypes.arrayOf(PropTypes.object).isRequired,
   clearSelectedJob: PropTypes.func.isRequired,
   selectedJobFull: PropTypes.shape({}).isRequired,
+  currentRepo: PropTypes.shape({}).isRequired,
   perfJobDetail: PropTypes.arrayOf(PropTypes.object),
   jobRevision: PropTypes.string,
   jobLogUrls: PropTypes.arrayOf(PropTypes.object),

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -245,7 +245,7 @@ class TabsPanel extends React.Component {
           {showPerf && (
             <TabPanel>
               <PerformanceTab
-                repoName={repoName}
+                jobDetails={jobDetails}
                 perfJobDetail={perfJobDetail}
                 revision={jobRevision}
               />


### PR DESCRIPTION
This patch is part of the work identified by cross-project [Performance workflow improvements 2020 project](https://bugzilla.mozilla.org/show_bug.cgi?id=1665457) which is about collecting and prioritizing a smaller set of issues to improve performance workflow issues.

This individual issue is also being tracked on [Bug 1667193](https://bugzilla.mozilla.org/show_bug.cgi?id=1667193).

This link is the one I've been primarily testing against: http://localhost:5000/#/jobs?repo=try&selectedTaskRun=YPFqUsNFRaySxJzP3-hpeA.0&revision=b9afd492797dbe5456fd7a46d359bb4f00be2417

Each commit in this PR is broken out logically, and should be viewable independently.

A Talos run with no profile:
<img width="577" alt="image" src="https://user-images.githubusercontent.com/1588648/94934169-fbb9ed80-0490-11eb-826d-527c3b0657f2.png">

A Talos run with a profile artifact.
<img width="657" alt="image" src="https://user-images.githubusercontent.com/1588648/94934254-1d1ad980-0491-11eb-8232-52ee8605942b.png">

Please let me know if you have any questions about this PR.