### PR TITLE
Change url() to re_path()

### DIFF
--- a/treeherder/config/urls.py
+++ b/treeherder/config/urls.py
@@ -1,17 +1,17 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from rest_framework.documentation import include_docs_urls
 
 from treeherder.webapp.api import urls as api_urls
 
 urlpatterns = [
-    url(r'^api/', include(api_urls)),
-    url(r'^docs/', include_docs_urls(title='REST API Docs')),
+    re_path(r'^api/', include(api_urls)),
+    re_path(r'^docs/', include_docs_urls(title='REST API Docs')),
 ]
 
 if settings.DEBUG:
     import debug_toolbar
 
     urlpatterns += [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
+        re_path(r'^__debug__/', include(debug_toolbar.urls)),
     ]

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from rest_framework import routers
 
 from treeherder.webapp.api import (
@@ -137,16 +137,16 @@ default_router.register(r'auth', auth.AuthViewSet, basename='auth')
 default_router.register(r'changelog', changelog.ChangelogViewSet, basename='changelog')
 
 urlpatterns = [
-    url(r'^project/(?P<project>[\w-]{0,50})/', include(project_bound_router.urls)),
-    url(r'^', include(default_router.urls)),
-    url(r'^failures/$', intermittents_view.Failures.as_view(), name='failures'),
-    url(r'^failuresbybug/$', intermittents_view.FailuresByBug.as_view(), name='failures-by-bug'),
-    url(r'^failurecount/$', intermittents_view.FailureCount.as_view(), name='failure-count'),
-    url(r'^infracompare/$', infra_compare.InfraCompareView.as_view(), name='infra-compare'),
-    url(
+    re_path(r'^project/(?P<project>[\w-]{0,50})/', include(project_bound_router.urls)),
+    re_path(r'^', include(default_router.urls)),
+    re_path(r'^failures/$', intermittents_view.Failures.as_view(), name='failures'),
+    re_path(r'^failuresbybug/$', intermittents_view.FailuresByBug.as_view(), name='failures-by-bug'),
+    re_path(r'^failurecount/$', intermittents_view.FailureCount.as_view(), name='failure-count'),
+    re_path(r'^infracompare/$', infra_compare.InfraCompareView.as_view(), name='infra-compare'),
+    re_path(
         r'^performance/summary/$',
         performance_data.PerformanceSummary.as_view(),
         name='performance-summary',
     ),
-    url(r'^csp-report/$', csp_report.csp_report_collector, name='csp-report'),
+    re_path(r'^csp-report/$', csp_report.csp_report_collector, name='csp-report'),
 ]


### PR DESCRIPTION
The old `django.conf.urls.url()` function is replaced with new `django.urls.re_path()` function for routing .
This would help : https://docs.djangoproject.com/en/3.1/ref/urls/#url

The `django.conf.urls.url()` function from previous versions is now available as `django.urls.re_path()`. The old location remains for backwards compatibility, without an imminent deprecation.

For `Django >= 3.x`, `django.conf.urls.url()` will be removed. (https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0)

### To Reproduce
Steps to reproduce the behavior:
1. Go to all the required `urls.py` files.
2. Change `django.conf.urls.url` to `django.urls.re_path`.
3. Change all the `url` to `re_path`