### PR TITLE
Bug 1671209 -  Add text to "Help" dropdown in treeherder/perfherder

### DIFF
--- a/ui/shared/HelpMenu.jsx
+++ b/ui/shared/HelpMenu.jsx
@@ -67,11 +67,7 @@ const menuItems = [
 const HelpMenu = () => (
   <UncontrolledDropdown>
     <DropdownToggle className="btn-view-nav nav-menu-btn" caret>
-      <FontAwesomeIcon
-        icon={faQuestionCircle}
-        className="lightgray mr-1"
-        title="Treeherder help"
-      />
+      Help
     </DropdownToggle>
     <DropdownMenu right className="icon-menu">
       {menuItems.map((item) => (


### PR DESCRIPTION
To improve usability and accessibility, I have added  `"Help and Resources"` text in the dropdown menu.