### PR TITLE
Bug 1640024 - Make group_results endpoint match mozci format

### DIFF
--- a/tests/log_parser/test_store_failure_lines.py
+++ b/tests/log_parser/test_store_failure_lines.py
@@ -196,8 +196,4 @@ def test_get_group_results(activate_responses, test_repository, test_job):
     groups = get_group_results(test_job.push)
     task_groups = groups['V3SVuxO8TFy37En_6HcXLs']
 
-    assert task_groups[0] == {
-        'group': 'dom/base/test',
-        'status': 'OK',
-        'label': 'B2G Emulator Image Build',
-    }
+    assert task_groups['dom/base/test'] == True

--- a/tests/log_parser/test_store_failure_lines.py
+++ b/tests/log_parser/test_store_failure_lines.py
@@ -196,4 +196,4 @@ def test_get_group_results(activate_responses, test_repository, test_job):
     groups = get_group_results(test_job.push)
     task_groups = groups['V3SVuxO8TFy37En_6HcXLs']
 
-    assert task_groups['dom/base/test'] == True
+    assert task_groups['dom/base/test']

--- a/treeherder/log_parser/failureline.py
+++ b/treeherder/log_parser/failureline.py
@@ -182,17 +182,12 @@ def get_group_results(push):
         'group_result__status',
         'name',
         'job_logs__job__taskcluster_metadata__task_id',
-        'job_logs__job__job_type__name',
     )
 
-    by_task_id = defaultdict(list)
+    by_task_id = defaultdict(dict)
     for group in groups:
-        by_task_id[group['job_logs__job__taskcluster_metadata__task_id']].append(
-            {
-                'group': group['name'],
-                'status': GroupStatus.STATUS_LOOKUP[group['group_result__status']],
-                'label': group['job_logs__job__job_type__name'],
-            }
-        ),
+        by_task_id[group['job_logs__job__taskcluster_metadata__task_id']][
+            group['name']
+        ] = bool(GroupStatus.STATUS_LOOKUP[group['group_result__status']] == "OK")
 
     return by_task_id

--- a/treeherder/log_parser/failureline.py
+++ b/treeherder/log_parser/failureline.py
@@ -186,8 +186,8 @@ def get_group_results(push):
 
     by_task_id = defaultdict(dict)
     for group in groups:
-        by_task_id[group['job_logs__job__taskcluster_metadata__task_id']][
-            group['name']
-        ] = bool(GroupStatus.STATUS_LOOKUP[group['group_result__status']] == "OK")
+        by_task_id[group['job_logs__job__taskcluster_metadata__task_id']][group['name']] = bool(
+            GroupStatus.STATUS_LOOKUP[group['group_result__status']] == "OK"
+        )
 
     return by_task_id


### PR DESCRIPTION
Making a tweak to the return value of this function and endpoint so that it matches the schema needs of the `mozci` function that uses it.