### PR TITLE
Bug 1668511 - Remove empty alert summaries v2

### DIFF
--- a/tests/model/test_cycle_data.py
+++ b/tests/model/test_cycle_data.py
@@ -349,9 +349,9 @@ def empty_alert_summary(
 @pytest.mark.parametrize(
     'expired_time',
     [
-        datetime.now() - timedelta(days=1),
-        datetime.now() - timedelta(hours=2),
-        datetime.now() - timedelta(hours=1, seconds=1),
+        datetime.now() - timedelta(days=365),
+        datetime.now() - timedelta(days=181),
+        datetime.now() - timedelta(days=180, hours=1),
     ],
 )
 def test_summary_without_any_kind_of_alerts_is_deleted(expired_time, empty_alert_summary):
@@ -371,7 +371,8 @@ def test_summary_without_any_kind_of_alerts_is_deleted(expired_time, empty_alert
     [
         datetime.now(),
         datetime.now() - timedelta(minutes=30),
-        datetime.now() - timedelta(minutes=50),
+        datetime.now() - timedelta(weeks=4),
+        datetime.now() - timedelta(days=179, hours=23),
     ],
 )
 def test_summary_without_any_kind_of_alerts_isnt_deleted(recently, empty_alert_summary):
@@ -390,13 +391,14 @@ def test_summary_without_any_kind_of_alerts_isnt_deleted(recently, empty_alert_s
     'creation_time',
     [
         # expired
-        datetime.now() - timedelta(days=1),
-        datetime.now() - timedelta(hours=2),
-        datetime.now() - timedelta(hours=1, seconds=1),
+        datetime.now() - timedelta(days=365),
+        datetime.now() - timedelta(days=181),
+        datetime.now() - timedelta(days=180, hours=1),
         # not expired
         datetime.now(),
         datetime.now() - timedelta(minutes=30),
-        datetime.now() - timedelta(minutes=50),
+        datetime.now() - timedelta(weeks=4),
+        datetime.now() - timedelta(days=179, hours=23),
     ],
 )
 def test_summary_with_alerts_isnt_deleted(

--- a/tests/model/test_cycle_data.py
+++ b/tests/model/test_cycle_data.py
@@ -17,7 +17,12 @@ from treeherder.model.models import (
     Push,
 )
 from treeherder.perf.exceptions import MaxRuntimeExceeded
-from treeherder.perf.models import PerformanceDatum, PerformanceSignature
+from treeherder.perf.models import (
+    PerformanceDatum,
+    PerformanceSignature,
+    PerformanceAlertSummary,
+    PerformanceAlert,
+)
 
 
 def test_cycle_all_data(
@@ -326,3 +331,114 @@ def test_performance_cycler_quit_indicator():
         cycler._quit_on_timeout()
     except MaxRuntimeExceeded:
         pytest.fail('Performance cycling shouldn\'t have timed out')
+
+
+@pytest.fixture
+def empty_alert_summary(
+    test_repository, push_stored, test_perf_framework, test_issue_tracker
+) -> PerformanceAlertSummary:
+    return PerformanceAlertSummary.objects.create(
+        repository=test_repository,
+        framework=test_perf_framework,
+        prev_push_id=1,
+        push_id=3,
+        manually_created=True,
+    )
+
+
+@pytest.mark.parametrize(
+    'expired_time',
+    [
+        datetime.now() - timedelta(days=1),
+        datetime.now() - timedelta(hours=2),
+        datetime.now() - timedelta(hours=1, seconds=1),
+    ],
+)
+def test_summary_without_any_kind_of_alerts_is_deleted(expired_time, empty_alert_summary):
+    empty_alert_summary.created = expired_time
+    empty_alert_summary.save()
+
+    assert PerformanceAlertSummary.objects.count() == 1
+    assert empty_alert_summary.alerts.count() == 0
+    assert empty_alert_summary.related_alerts.count() == 0
+
+    call_command('cycle_data', 'from:perfherder')
+    assert not PerformanceAlertSummary.objects.exists()
+
+
+@pytest.mark.parametrize(
+    'recently',
+    [
+        datetime.now(),
+        datetime.now() - timedelta(minutes=30),
+        datetime.now() - timedelta(minutes=50),
+    ],
+)
+def test_summary_without_any_kind_of_alerts_isnt_deleted(recently, empty_alert_summary):
+    empty_alert_summary.created = recently
+    empty_alert_summary.save()
+
+    assert PerformanceAlertSummary.objects.count() == 1
+    assert empty_alert_summary.alerts.count() == 0
+    assert empty_alert_summary.related_alerts.count() == 0
+
+    call_command('cycle_data', 'from:perfherder')
+    assert PerformanceAlertSummary.objects.count() == 1
+
+
+@pytest.mark.parametrize(
+    'creation_time',
+    [
+        # expired
+        datetime.now() - timedelta(days=1),
+        datetime.now() - timedelta(hours=2),
+        datetime.now() - timedelta(hours=1, seconds=1),
+        # not expired
+        datetime.now(),
+        datetime.now() - timedelta(minutes=30),
+        datetime.now() - timedelta(minutes=50),
+    ],
+)
+def test_summary_with_alerts_isnt_deleted(
+    creation_time, empty_alert_summary, test_perf_alert, test_perf_alert_2, test_perf_data
+):
+    empty_alert_summary.created = creation_time
+    empty_alert_summary.save()
+
+    test_perf_data = list(test_perf_data)
+    for datum in test_perf_data[2:]:
+        datum.signature = test_perf_alert_2.series_signature
+        datum.repository = test_perf_alert_2.series_signature.repository
+        datum.save()
+
+    # with alerts only
+    test_perf_alert.summary = empty_alert_summary
+    test_perf_alert.save()
+
+    assert PerformanceAlertSummary.objects.filter(id=empty_alert_summary.id).exists()
+    assert empty_alert_summary.alerts.count() == 1
+    assert empty_alert_summary.related_alerts.count() == 0
+
+    call_command('cycle_data', 'from:perfherder')
+    assert PerformanceAlertSummary.objects.filter(id=empty_alert_summary.id).exists()
+
+    # with both
+    test_perf_alert_2.status = PerformanceAlert.REASSIGNED
+    empty_alert_summary.related_alerts.add(test_perf_alert_2, bulk=False)
+
+    assert PerformanceAlertSummary.objects.filter(id=empty_alert_summary.id).exists()
+    assert empty_alert_summary.alerts.count() == 1
+    assert empty_alert_summary.related_alerts.count() == 1
+
+    call_command('cycle_data', 'from:perfherder')
+    assert PerformanceAlertSummary.objects.filter(id=empty_alert_summary.id).exists()
+
+    # with related_alerts only
+    test_perf_alert.delete()
+
+    assert PerformanceAlertSummary.objects.filter(id=empty_alert_summary.id).exists()
+    assert empty_alert_summary.alerts.count() == 0
+    assert empty_alert_summary.related_alerts.count() == 1
+
+    call_command('cycle_data', 'from:perfherder')
+    assert PerformanceAlertSummary.objects.filter(id=empty_alert_summary.id).exists()

--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -7,12 +7,13 @@ from abc import ABC, abstractmethod
 from django.core.management.base import BaseCommand
 from django.db import connection
 from django.db.backends.utils import CursorWrapper
+from django.db.models import Count
 from django.db.utils import OperationalError
 from typing import List
 
 from treeherder.model.models import Job, JobGroup, JobType, Machine, Repository
 from treeherder.perf.exceptions import MaxRuntimeExceeded, NoDataCyclingAtAll
-from treeherder.perf.models import PerformanceDatum, PerformanceSignature
+from treeherder.perf.models import PerformanceDatum, PerformanceSignature, PerformanceAlertSummary
 
 logging.basicConfig(format='%(levelname)s:%(message)s')
 
@@ -60,9 +61,9 @@ class TreeherderCycler(DataCycler):
         except OperationalError as e:
             logger.error("Error running cycle_data: {}".format(e))
 
-        self.remove_leftovers()
+        self._remove_leftovers()
 
-    def remove_leftovers(self):
+    def _remove_leftovers(self):
         logger.warning('Pruning ancillary data: job types, groups and machines')
 
         def prune(id_name, model):
@@ -116,19 +117,42 @@ class PerfherderCycler(DataCycler):
                 except NoDataCyclingAtAll as ex:
                     logger.warning(str(ex))
 
-            # also remove any signatures which are (no longer) associated with
-            # a job
-            logger.warning('Removing performance signatures with missing jobs...')
-            for signature in PerformanceSignature.objects.all():
-                self._quit_on_timeout()
-
-                if not PerformanceDatum.objects.filter(
-                    repository_id=signature.repository_id,  # leverages (repository, signature) compound index
-                    signature_id=signature.id,
-                ).exists():
-                    signature.delete()
+            self._remove_leftovers()
         except MaxRuntimeExceeded as ex:
             logger.warning(ex)
+
+    def _remove_leftovers(self):
+        # remove any signatures which are
+        # no longer associated with a job
+        logger.warning('Removing performance signatures with missing jobs...')
+        for signature in PerformanceSignature.objects.all():
+            self._quit_on_timeout()
+
+            if not PerformanceDatum.objects.filter(
+                repository_id=signature.repository_id,  # leverages (repository, signature) compound index
+                signature_id=signature.id,
+            ).exists():
+                signature.delete()
+
+        # remove empty alert summaries
+        logger.warning('Removing alert summaries which no longer have any alerts...')
+        one_hour_ago = datetime.now() - timedelta(hours=1)
+        (
+            PerformanceAlertSummary.objects.prefetch_related('alerts', 'related_alerts')
+            .annotate(
+                total_alerts=Count('alerts'),
+                total_related_alerts=Count('related_alerts'),
+            )
+            .filter(
+                total_alerts=0,
+                total_related_alerts=0,
+                # mitigates race condition when the alert summary
+                # is manually created & for a moment doesn't yet have
+                # any alerts associated
+                created__lt=one_hour_ago,
+            )
+            .delete()
+        )
 
     def _quit_on_timeout(self):
         elapsed_runtime = datetime.now() - self.started_at

--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -136,7 +136,6 @@ class PerfherderCycler(DataCycler):
 
         # remove empty alert summaries
         logger.warning('Removing alert summaries which no longer have any alerts...')
-        one_hour_ago = datetime.now() - timedelta(hours=1)
         (
             PerformanceAlertSummary.objects.prefetch_related('alerts', 'related_alerts')
             .annotate(
@@ -146,10 +145,11 @@ class PerfherderCycler(DataCycler):
             .filter(
                 total_alerts=0,
                 total_related_alerts=0,
-                # mitigates race condition when the alert summary
-                # is manually created & for a moment doesn't yet have
-                # any alerts associated
-                created__lt=one_hour_ago,
+                # WARNING! Don't change this without proper approval!           #
+                # Otherwise we risk deleting data that's actively investigated  #
+                # and cripple the perf sheriffing process!                      #
+                created__lt=(datetime.now() - timedelta(days=180)),
+                #################################################################
             )
             .delete()
         )


### PR DESCRIPTION
This improves [PR 6786](https://github.com/mozilla/treeherder/pull/6786) (which was reverted) by explicitly increasing the expiring interval for empty alert summaries to a safer value.
That way, we further reduce the risk of unintentionally deleting data perf sheriffs still investigate.

**Bug link:** https://bugzilla.mozilla.org/show_bug.cgi?id=1668511