### PR TITLE
Bug 1674415 - selectedJob query param should show selected job

### DIFF
--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -105,7 +105,7 @@ export const getLogViewerUrl = function getLogViewerUrl(
   repoName,
   lineNumber,
 ) {
-  const rv = `/logviewer?job_id=${jobId}&repo=${repoName}`;
+  const rv = `logviewer?job_id=${jobId}&repo=${repoName}`;
   return lineNumber ? `${rv}&lineNumber=${lineNumber}` : rv;
 };
 

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -221,7 +221,13 @@ class PushHeader extends React.Component {
     const cancelJobsTitle = 'Cancel all jobs';
     const linkParams = this.getLinkParams();
     const revisionPushFilterUrl = getJobsUrl({ ...linkParams, revision });
-    const authorPushFilterUrl = getJobsUrl({ ...linkParams, author });
+
+    // we don't do this for revision because it is handled differently via updateRange.
+    const authorParams = this.getLinkParams();
+    if (authorParams.selectedTaskRun) {
+      delete authorParams.selectedTaskRun;
+    }
+    const authorPushFilterUrl = getJobsUrl({ ...authorParams, author });
     const showPushHealthStatus =
       pushHealthVisibility === 'All' ||
       currentRepo.name === pushHealthVisibility.toLowerCase();

--- a/ui/job-view/redux/stores/pushes.js
+++ b/ui/job-view/redux/stores/pushes.js
@@ -394,7 +394,6 @@ export const updateRange = (range) => {
         {},
       );
       if (getUrlParam('selectedJob') || getUrlParam('selectedTaskRun')) {
-        console.log('clearSelectedJob');
         dispatch(clearSelectedJob(0));
       }
       // We already have the one revision they're looking for,

--- a/ui/job-view/redux/stores/pushes.js
+++ b/ui/job-view/redux/stores/pushes.js
@@ -254,9 +254,6 @@ export const fetchPushes = (
 
     dispatch({ type: LOADING });
 
-    if (getUrlParam('selectedJob') || getUrlParam('selectedTaskRun')) {
-      dispatch(clearSelectedJob(0));
-    }
     // Only pass supported query string params to this endpoint.
     const options = {
       ...pick(parseQueryParams(window.location.search), PUSH_FETCH_KEYS),
@@ -397,6 +394,7 @@ export const updateRange = (range) => {
         {},
       );
       if (getUrlParam('selectedJob') || getUrlParam('selectedTaskRun')) {
+        console.log('clearSelectedJob');
         dispatch(clearSelectedJob(0));
       }
       // We already have the one revision they're looking for,


### PR DESCRIPTION
I had tried to fix a bug that was discovered [here](https://github.com/mozilla/treeherder/pull/6825#issuecomment-717601567) but went about it in the wrong way, and the result was that `selectedJob` and `selectedTaskRun` query params was stripped in all circumstances (so it affected urls from Perfherder and IFV). This fixes it and fixes the original bug by a different approach. 

FYI @camd merging and deploying this today since you're PTO and its affecting the code and perf sheriffs.