### PR TITLE
Routing change fixes

### DIFF
--- a/ui/App.jsx
+++ b/ui/App.jsx
@@ -11,6 +11,11 @@ import LoginCallback from './login-callback/LoginCallback';
 import TaskclusterCallback from './taskcluster-auth-callback/TaskclusterCallback';
 import UserGuideApp from './userguide/App';
 
+import treeFavicon from './img/tree_open.png';
+import logFavicon from './img/logviewerIcon.png';
+import perfFavicon from './img/line_chart.png';
+import healthFavicon from './img/push-health-ok.png';
+
 const IntermittentFailuresApp = lazy(() =>
   import('./intermittent-failures/App'),
 );
@@ -61,23 +66,23 @@ const updateOldUrls = () => {
 };
 
 const faviconPaths = {
-  '/jobs': { title: 'Treeherder Jobs View', favicon: './ui/img/tree_open.png' },
+  '/jobs': { title: 'Treeherder Jobs View', favicon: treeFavicon },
   '/logviewer': {
     title: 'Treeherder Logviewer',
-    favicon: './ui/img/logviewerIcon.png',
+    favicon: logFavicon,
   },
-  '/perfherder': { title: 'Perfherder', favicon: './ui/img/line_chart.png' },
+  '/perfherder': { title: 'Perfherder', favicon: perfFavicon },
   '/userguide': {
     title: 'Treeherder User Guide',
-    favicon: './ui/img/tree_open.png',
+    favicon: treeFavicon,
   },
   '/intermittent-failures': {
     title: 'Intermittent Failures View',
-    favicon: './ui/img/tree_open.png',
+    favicon: treeFavicon,
   },
   '/push-health': {
     title: 'Push Health',
-    favicon: './ui/img/push-health-ok.png',
+    favicon: healthFavicon,
   },
 };
 

--- a/ui/App.jsx
+++ b/ui/App.jsx
@@ -10,7 +10,6 @@ import LoadingSpinner from './shared/LoadingSpinner';
 import LoginCallback from './login-callback/LoginCallback';
 import TaskclusterCallback from './taskcluster-auth-callback/TaskclusterCallback';
 import UserGuideApp from './userguide/App';
-
 import treeFavicon from './img/tree_open.png';
 import logFavicon from './img/logviewerIcon.png';
 import perfFavicon from './img/line_chart.png';

--- a/ui/perfherder/alerts/AlertsView.jsx
+++ b/ui/perfherder/alerts/AlertsView.jsx
@@ -72,6 +72,10 @@ class AlertsView extends React.Component {
         { id: params.id || null, filters: this.getFiltersFromParams(params) },
         this.fetchAlertSummaries,
       );
+      // all data updates due to page changes happens here so as
+      // to support back button navigation
+    } else if (params.page && params.page !== prevParams.page) {
+      this.fetchAlertSummaries(undefined, false, parseInt(params.page, 10));
     }
   }
 
@@ -80,21 +84,19 @@ class AlertsView extends React.Component {
     frameworkOptions = this.extendedOptions,
   ) => {
     return {
-      status: this.getDefaultStatus(),
+      status: this.getDefaultStatus(validated),
       framework: getFrameworkData({
         validated,
         frameworks: frameworkOptions,
       }),
-      filterText: this.getDefaultFilterText(),
+      filterText: this.getDefaultFilterText(validated),
       hideImprovements: convertParams(validated, 'hideImprovements'),
       hideDownstream: convertParams(validated, 'hideDwnToInv'),
       hideAssignedToOthers: convertParams(validated, 'hideAssignedToOthers'),
     };
   };
 
-  getDefaultStatus = () => {
-    const { validated } = this.props;
-
+  getDefaultStatus = (validated) => {
     const statusParam = convertParams(validated, 'status');
     if (!statusParam) {
       return Object.keys(summaryStatusMap)[1];
@@ -102,8 +104,8 @@ class AlertsView extends React.Component {
     return getStatus(parseInt(validated.status, 10));
   };
 
-  getDefaultFilterText = () => {
-    const { filterText } = this.props.validated;
+  getDefaultFilterText = (validated) => {
+    const { filterText } = validated;
     return filterText === undefined || filterText === null ? '' : filterText;
   };
 

--- a/ui/perfherder/alerts/AlertsViewControls.jsx
+++ b/ui/perfherder/alerts/AlertsViewControls.jsx
@@ -118,7 +118,6 @@ export default class AlertsViewControls extends React.Component {
                   updateParams={validated.updateParams}
                   currentPage={page}
                   count={count}
-                  fetchData={fetchAlertSummaries}
                 />
               </Row>
             )
@@ -147,7 +146,6 @@ export default class AlertsViewControls extends React.Component {
                   updateParams={validated.updateParams}
                   currentPage={page}
                   count={count}
-                  fetchData={fetchAlertSummaries}
                 />
               </Row>
             )

--- a/ui/perfherder/alerts/Pagination.jsx
+++ b/ui/perfherder/alerts/Pagination.jsx
@@ -4,8 +4,7 @@ import { Pagination, PaginationItem, PaginationLink } from 'reactstrap';
 
 class PaginationGroup extends React.Component {
   navigatePage = (page) => {
-    const { fetchData, updateParams } = this.props;
-    fetchData(undefined, false, parseInt(page, 10));
+    const { updateParams } = this.props;
     updateParams({ page });
   };
 
@@ -80,7 +79,6 @@ PaginationGroup.propTypes = {
   viewablePageNums: PropTypes.arrayOf(PropTypes.number).isRequired,
   currentPage: PropTypes.number,
   count: PropTypes.number,
-  fetchData: PropTypes.func.isRequired,
   updateParams: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
I thought I had fixed the favicon path but I forgot that our assets are handled differently for deployments vs local development.

Also includes some additional fixes for the Perfherder alerts page (back navigation for pagination) that was flagged in #6825.