### PR TITLE
Add a table-based view for the performance data

### DIFF
--- a/ui/css/treeherder-custom-styles.css
+++ b/ui/css/treeherder-custom-styles.css
@@ -35,6 +35,10 @@
   font-size: 11px;
 }
 
+.font-size-16 {
+  font-size: 16px;
+}
+
 .font-size-18 {
   font-size: 18px;
 }

--- a/ui/css/treeherder-details-panel.css
+++ b/ui/css/treeherder-details-panel.css
@@ -423,20 +423,6 @@ div.performance-panel {
   margin: 0.25rem;
 }
 
-.performance-panel-data td, th {
-  white-space: nowrap;
-  /* The graph needs a little bit more padding compared to the defaults to be easily
-     readable.*/
-  padding-left: 0.6rem;
-  padding-right: 0.6rem;
-}
-
-.performance-panel-title {
-  font-size: 16px;
-  margin-top: 0.5rem;
-  line-height: 1.5;
-}
-
 /**
  * This rule is a bit ugly, but the button doesn't fit in the table row without
  * resizing the vertical contents. In addition, there isn't a button size that

--- a/ui/css/treeherder-details-panel.css
+++ b/ui/css/treeherder-details-panel.css
@@ -422,3 +422,32 @@ div.performance-panel {
   /* This is the same value as m-1 */
   margin: 0.25rem;
 }
+
+.performance-panel-data td, th {
+  white-space: nowrap;
+  /* The graph needs a little bit more padding compared to the defaults to be easily
+     readable.*/
+  padding-left: 0.6rem;
+  padding-right: 0.6rem;
+}
+
+.performance-panel-title {
+  font-size: 16px;
+  margin-top: 0.5rem;
+  line-height: 1.5;
+}
+
+/**
+ * This rule is a bit ugly, but the button doesn't fit in the table row without
+ * resizing the vertical contents. In addition, there isn't a button size that
+ * matches the font size of the row.
+ */
+.performance-panel-view-button {
+  padding: 0px 6px;
+  margin: -3px 0;
+  display: inline-block;
+  font-size: 12px;
+  position: relative;
+  top: -1px;
+  line-height: 17px;
+}

--- a/ui/css/treeherder-details-panel.css
+++ b/ui/css/treeherder-details-panel.css
@@ -134,7 +134,7 @@ div#details-panel-content .actionbar-nav > li > button:focus {
 
 .react-tabs__tab-panel--selected {
   height: 100%;
-  margin: 0.5em 1em;
+  padding: 0.5em 1em;
   overflow-y: auto;
 }
 

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -258,6 +258,8 @@ class DetailsPanel extends React.Component {
                       d.series.frameworkId,
                     ]}&selected=${[d.signature_id, d.id]}`,
                     value: d.value,
+                    measurementUnit: d.series.measurementUnit,
+                    lowerIsBetter: d.series.lowerIsBetter,
                     title: d.series.name,
                   }));
               }

--- a/ui/job-view/details/tabs/PerformanceTab.jsx
+++ b/ui/job-view/details/tabs/PerformanceTab.jsx
@@ -73,13 +73,64 @@ class PerformanceTab extends React.PureComponent {
     return null;
   }
 
+  maybeRenderPerfData() {
+    const { perfJobDetail, selectedJobFull } = this.props;
+    if (perfJobDetail.length === 0) {
+      return null;
+    }
+
+    const sortedDetails = perfJobDetail.slice();
+    sortedDetails.sort((a, b) => a.title.localeCompare(b.title));
+
+    return (
+      <>
+        <h3 className="performance-panel-title">
+          Results for: {selectedJobFull.job_type_name}
+        </h3>
+        <table className="table table-sm performance-panel-data">
+          <thead>
+            <tr>
+              <th scope="col" className="text-right">
+                Value
+              </th>
+              <th scope="col">Unit</th>
+              <th scope="col">Better</th>
+              <th scope="col">History</th>
+              <th scope="col">Name</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedDetails.map(
+              ({ value, url, measurementUnit, lowerIsBetter, title }, idx) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <tr key={idx}>
+                  {/* Ensure the value and measurement are visually next to each
+                  other in the chart, by aligning the value to the right. */}
+                  <td className="text-right">{value}</td>
+                  <td>{measurementUnit || '–'}</td>
+                  <td>{lowerIsBetter ? 'Lower' : 'Higher'}</td>
+                  <td>
+                    <a
+                      href={url}
+                      className="btn btn-outline-darker-secondary btn-sm performance-panel-view-button"
+                    >
+                      View
+                    </a>
+                  </td>
+                  <td className="w-100">{title}</td>
+                </tr>
+              ),
+            )}
+          </tbody>
+        </table>
+      </>
+    );
+  }
+
   render() {
-    const { repoName, revision, perfJobDetail, selectedJobFull } = this.props;
+    const { repoName, revision, selectedJobFull } = this.props;
     const { triggeredGeckoProfiles } = this.state;
     const profilerLink = this.maybeGetFirefoxProfilerLink();
-    const sortedDetails = perfJobDetail ? perfJobDetail.slice() : [];
-
-    sortedDetails.sort((a, b) => a.title.localeCompare(b.title));
 
     return (
       <div
@@ -145,22 +196,7 @@ class PerformanceTab extends React.PureComponent {
             </Alert>
           ) : null
         }
-        {!!sortedDetails.length && (
-          <ul>
-            <li>
-              Perfherder:
-              {sortedDetails.map((detail, idx) => (
-                <ul
-                  key={idx} // eslint-disable-line react/no-array-index-key
-                >
-                  <li>
-                    {detail.title}:<a href={detail.url}> {detail.value}</a>
-                  </li>
-                </ul>
-              ))}
-            </li>
-          </ul>
-        )}
+        {this.maybeRenderPerfData()}
       </div>
     );
   }

--- a/ui/job-view/details/tabs/PerformanceTab.jsx
+++ b/ui/job-view/details/tabs/PerformanceTab.jsx
@@ -82,21 +82,32 @@ class PerformanceTab extends React.PureComponent {
     const sortedDetails = perfJobDetail.slice();
     sortedDetails.sort((a, b) => a.title.localeCompare(b.title));
 
+    // These styles are shared across all of the table cells.
+    const cellClassName = 'nowrap pl-2 pr-2';
+
     return (
       <>
-        <h3 className="performance-panel-title">
+        <h3 className="font-size-16 mt-3 mb-2">
           Results for: {selectedJobFull.job_type_name}
         </h3>
         <table className="table table-sm performance-panel-data">
           <thead>
             <tr>
-              <th scope="col" className="text-right">
+              <th scope="col" className={`text-right ${cellClassName}`}>
                 Value
               </th>
-              <th scope="col">Unit</th>
-              <th scope="col">Better</th>
-              <th scope="col">History</th>
-              <th scope="col">Name</th>
+              <th scope="col" className={cellClassName}>
+                Unit
+              </th>
+              <th scope="col" className={cellClassName}>
+                Better
+              </th>
+              <th scope="col" className={cellClassName}>
+                History
+              </th>
+              <th scope="col" className={cellClassName}>
+                Name
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -106,10 +117,12 @@ class PerformanceTab extends React.PureComponent {
                 <tr key={idx}>
                   {/* Ensure the value and measurement are visually next to each
                   other in the chart, by aligning the value to the right. */}
-                  <td className="text-right">{value}</td>
-                  <td>{measurementUnit || '–'}</td>
-                  <td>{lowerIsBetter ? 'Lower' : 'Higher'}</td>
-                  <td>
+                  <td className={`text-right ${cellClassName}`}>{value}</td>
+                  <td className={cellClassName}>{measurementUnit || '–'}</td>
+                  <td className={cellClassName}>
+                    {lowerIsBetter ? 'Lower' : 'Higher'}
+                  </td>
+                  <td className={cellClassName}>
                     <a
                       href={url}
                       className="btn btn-outline-darker-secondary btn-sm performance-panel-view-button"


### PR DESCRIPTION
This includes the unit and whether lower or higher is better. I felt a
bit confused looking at the results, and not knowing what the individual
values meant. This change also presents everything in a table format
which should make it easier to scan and understand.

I ran these changes by some users of this view, and handled some of
their early feedback. This included removing a graph that wasn't very
helpful. There might be some opportunities in the future to add more
details to the columns to help in making navigating the data easier.
However, this is not a replacement for the comparison view, but instead
the motivation is for making the individual test runs easier to
understand.

Useful link for testing:
 * [Raptor](https://treeherder.mozilla.org/jobs?repo=autoland&revision=43e0f933ad51ba77e5528a7125a958cee7bf4612&searchStr=raptor&selectedTaskRun=bXfMyEIiSR69F0iI7tzILg.0)
 * [Talos](https://treeherder.mozilla.org/jobs?repo=autoland&revision=43e0f933ad51ba77e5528a7125a958cee7bf4612&searchStr=talos&selectedTaskRun=bXfMyEIiSR69F0iI7tzILg.0)
 * [Browsertime](https://treeherder.mozilla.org/jobs?repo=autoland&revision=43e0f933ad51ba77e5528a7125a958cee7bf4612&searchStr=browsertime&selectedTaskRun=bXfMyEIiSR69F0iI7tzILg.0)

## Screenshots

<img width="687" alt="image" src="https://user-images.githubusercontent.com/1588648/97905768-2ef9d180-1d08-11eb-9317-ccc37e9dc5f5.png">

<img width="753" alt="image" src="https://user-images.githubusercontent.com/1588648/97905860-581a6200-1d08-11eb-9eda-26fd5a352a59.png">

<img width="693" alt="image" src="https://user-images.githubusercontent.com/1588648/97905909-69fc0500-1d08-11eb-9a17-7e8688c32b45.png">

## Before view

<img width="661" alt="image" src="https://user-images.githubusercontent.com/1588648/97905992-86983d00-1d08-11eb-9739-1bdfcf85ed45.png">
