### PR TITLE
Bug 1674604 - Logviewer Url fixes

### DIFF
--- a/tests/ui/job-view/App_test.jsx
+++ b/tests/ui/job-view/App_test.jsx
@@ -360,4 +360,19 @@ describe('Test for backwards-compatible routes for other apps', () => {
       }),
     );
   });
+
+  test('old logviewer route should redirect to correct url', () => {
+    history.push(
+      '/logviewer.html#/jobs?job_id=319893964&repo=autoland&lineNumber=2728',
+    );
+    render(testApp());
+
+    expect(history.location).toEqual(
+      expect.objectContaining({
+        pathname: '/logviewer',
+        search: '?job_id=319893964&repo=autoland&lineNumber=2728',
+        hash: '',
+      }),
+    );
+  });
 });

--- a/ui/App.jsx
+++ b/ui/App.jsx
@@ -50,7 +50,9 @@ const updateOldUrls = () => {
     updates.search = hash.substring(index);
     const subRoute = hash.substring(1, index);
 
-    if (index >= 2 && updates.pathname !== subRoute) {
+    // there are old subroutes such as with the logviewer we want to ignore, i.e.:
+    // https://treeherder.mozilla.org/logviewer.html#/jobs?job_id=319893964&repo=autoland&lineNumber=2728
+    if (index >= 2 && updates.pathname !== subRoute && subRoute !== '/jobs') {
       updates.pathname += subRoute;
     }
   } else if (search.length) {

--- a/ui/intermittent-failures/BugDetailsView.jsx
+++ b/ui/intermittent-failures/BugDetailsView.jsx
@@ -101,7 +101,10 @@ const BugDetailsView = (props) => {
                 <br />
                 <a
                   className="small-text"
-                  href={getLogViewerUrl(value, original.tree)}
+                  href={`${window.location.origin}/${getLogViewerUrl(
+                    value,
+                    original.tree,
+                  )}`}
                   target="_blank"
                   rel="noopener noreferrer"
                 >


### PR DESCRIPTION
I missed a few things with the backwards-compatibility of the logviewer urls and needed to add the location origin to external logviewer links since the behavior has changed with the nested browser routing.