### PR TITLE
Bug 1676140 - Perfherder alerts Assignee button fix

### DIFF
--- a/ui/perfherder/App.jsx
+++ b/ui/perfherder/App.jsx
@@ -89,20 +89,7 @@ class App extends React.Component {
               )}
               <Switch>
                 <Route
-                  exact
                   path={`${path}/alerts`}
-                  render={(props) => (
-                    <AlertsView
-                      {...props}
-                      user={user}
-                      projects={projects}
-                      frameworks={frameworks}
-                      performanceTags={performanceTags}
-                    />
-                  )}
-                />
-                <Route
-                  path={`${path}/alerts?id=:id&status=:status&framework=:framework&filter=:filter&hideImprovements=:hideImprovements&hideDwnToInv=:hideDwnToInv&hideAssignedToOthers=:hideAssignedToOthers&filterText=:filterText&page=:page`}
                   render={(props) => (
                     <AlertsView
                       {...props}
@@ -125,17 +112,6 @@ class App extends React.Component {
                   )}
                 />
                 <Route
-                  path={`${path}/graphs?timerange=:timerange&series=:series&highlightedRevisions=:highlightedRevisions&highlightAlerts=:highlightAlerts&zoom=:zoom&selected=:selected`}
-                  render={(props) => (
-                    <GraphsView
-                      {...props}
-                      user={user}
-                      projects={projects}
-                      frameworks={frameworks}
-                    />
-                  )}
-                />
-                <Route
                   path={`${path}/comparechooser`}
                   render={(props) => (
                     <CompareSelectorView
@@ -147,31 +123,7 @@ class App extends React.Component {
                   )}
                 />
                 <Route
-                  path={`${path}/comparechooser?originalProject=:originalProject&originalRevision=:originalRevision&newProject=:newProject&newRevision=:newRevision`}
-                  render={(props) => (
-                    <CompareSelectorView
-                      {...props}
-                      user={user}
-                      projects={projects}
-                      frameworks={frameworks}
-                    />
-                  )}
-                />
-                <Route
                   path={`${path}/compare`}
-                  render={(props) => (
-                    <CompareView
-                      {...props}
-                      user={user}
-                      projects={projects}
-                      frameworks={frameworks}
-                      compareData={compareData}
-                      updateAppState={this.updateAppState}
-                    />
-                  )}
-                />
-                <Route
-                  path={`${path}/compare?originalProject=:originalProject&originalRevision=:originalRevison&newProject=:newProject&newRevision=:newRevision&framework=:framework&showOnlyComparable=:showOnlyComparable&showOnlyImportant=:showOnlyImportant&showOnlyConfident=:showOnlyConfident&selectedTimeRange=:selectedTimeRange&showOnlyNoise=:showOnlyNoise`}
                   render={(props) => (
                     <CompareView
                       {...props}
@@ -208,29 +160,7 @@ class App extends React.Component {
                   )}
                 />
                 <Route
-                  path={`${path}/comparesubtest?originalProject=:originalProject&originalRevision=:originalRevision&newProject=:newProject&newRevision=:newRevision&originalSignature=:originalSignature&newSignature=:newSignature&framework=:framework&showOnlyComparable=:showOnlyComparable&showOnlyImportant=:showOnlyImportant&showOnlyConfident=:showOnlyConfident&selectedTimeRange=:selectedTimeRange&showOnlyNoise=:showOnlyNoise`}
-                  render={(props) => (
-                    <CompareSubtestsView
-                      {...props}
-                      user={user}
-                      projects={projects}
-                      frameworks={frameworks}
-                    />
-                  )}
-                />
-                <Route
                   path={`${path}/comparesubtestdistribution`}
-                  render={(props) => (
-                    <CompareSubtestDistributionView
-                      {...props}
-                      user={user}
-                      projects={projects}
-                      frameworks={frameworks}
-                    />
-                  )}
-                />
-                <Route
-                  path={`${path}/comparesubtestdistribution?originalProject=:originalProject&newProject=:newProject&originalRevision=:originalRevision&newRevision=:newRevision&originalSubtestSignature=:originalSubtestSignature&newSubtestSignature=:newSubtestSignature`}
                   render={(props) => (
                     <CompareSubtestDistributionView
                       {...props}
@@ -252,21 +182,9 @@ class App extends React.Component {
                     />
                   )}
                 />
-                <Route
-                  path={`${path}/tests?framework=:framework"`}
-                  render={(props) => (
-                    <TestsView
-                      {...props}
-                      projects={projects}
-                      frameworks={frameworks}
-                      platforms={platforms}
-                      updateAppState={this.updateAppState}
-                    />
-                  )}
-                />
                 <Redirect
                   from={`${path}/`}
-                  to={`${path}/alerts?hideDwnToInv=1`}
+                  to={`${path}/alerts?hideDwnToInv=1&page=1`}
                 />
               </Switch>
             </main>

--- a/ui/perfherder/Navigation.jsx
+++ b/ui/perfherder/Navigation.jsx
@@ -22,7 +22,10 @@ const Navigation = ({ user, setUser, notify }) => (
         </Link>
       </NavItem>
       <NavItem>
-        <Link to="./alerts?hideDwnToInv=1" className="nav-link btn-view-nav">
+        <Link
+          to="./alerts?hideDwnToInv=1&page=1"
+          className="nav-link btn-view-nav"
+        >
           Alerts
         </Link>
       </NavItem>

--- a/ui/perfherder/alerts/Assignee.jsx
+++ b/ui/perfherder/alerts/Assignee.jsx
@@ -43,6 +43,7 @@ export default class Assignee extends React.Component {
   };
 
   pressedEnter = async (event) => {
+    event.preventDefault();
     if (event.key === 'Enter') {
       const { updateAssignee } = this.props;
       const newAssigneeUsername = event.target.value;


### PR DESCRIPTION
An interesting quirk of the routing changes is that hitting enter on an input element was causing a full page reload in Perfherder alerts view, whereas it wasn't before. Also found some Perfherder routes that didn't need to be there (and a added a default page value to prevent an unnecessary lifecyle update when filters are changed), so batched that cleanup in this pr.