### PR TITLE
Bug 1675835 - add condition for JobTestGroups

### DIFF
--- a/ui/job-view/details/JobTestGroups.jsx
+++ b/ui/job-view/details/JobTestGroups.jsx
@@ -28,11 +28,14 @@ export default class JobTestGroups extends React.PureComponent {
       const queue = new Queue({ rootUrl });
       const taskDefinition = await queue.task(taskId);
       if (taskDefinition && taskDefinition.payload.env.MOZHARNESS_TEST_PATHS) {
-        this.setState({
-          testGroups: Object.values(
-            JSON.parse(taskDefinition.payload.env.MOZHARNESS_TEST_PATHS),
-          )[0],
-        });
+        const testGroups = Object.values(
+          JSON.parse(taskDefinition.payload.env.MOZHARNESS_TEST_PATHS),
+        );
+        if (testGroups.length) {
+          this.setState({
+            testGroups: testGroups[0],
+          });
+        }
         notifyTestGroupsAvailable(true);
       } else {
         notifyTestGroupsAvailable(false);


### PR DESCRIPTION
Fixes a quirk where if `{ MOZHARNESS_TEST_PATHS: "{}" }`, the value is parsed as an empty object and the uncaught error breaks the UI. I think technically we don't need to actually parse this payload, but it's easier to catch this type of bug if we do otherwise we'll end up with `["{", "}"]`. Ahal is also fixing it on his end.