### PR TITLE
Bug 1676186 - Fix scrolling in Push Health

### DIFF
--- a/ui/css/treeherder-base.css
+++ b/ui/css/treeherder-base.css
@@ -11,14 +11,6 @@
  * rather than here.
  */
 
-html,
-body {
-  height: 100%;
-  font-size: 14px;
-  line-height: 1.42;
-  overflow: hidden;
-}
-
 body {
   line-height: inherit;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;

--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -1,3 +1,11 @@
+html,
+body {
+  height: 100%;
+  font-size: 14px;
+  line-height: 1.42;
+  overflow: hidden;
+}
+
 #root {
   display: flex;
   flex-direction: column;

--- a/ui/index.jsx
+++ b/ui/index.jsx
@@ -5,6 +5,6 @@ import App from './App';
 
 import './css/treeherder-custom-styles.css';
 import './css/treeherder-navbar.css';
-import './css/treeherder.css';
+import './css/treeherder-base.css';
 
 render(<App />, document.getElementById('root'));

--- a/ui/job-view/App.jsx
+++ b/ui/job-view/App.jsx
@@ -32,7 +32,7 @@ import PushList from './pushes/PushList';
 import KeyboardShortcuts from './KeyboardShortcuts';
 import { clearExpiredNotifications } from './redux/stores/notifications';
 
-import '../css/treeherder-base.css';
+import '../css/treeherder.css';
 import '../css/treeherder-navbar-panels.css';
 import '../css/treeherder-notifications.css';
 import '../css/treeherder-details-panel.css';

--- a/ui/push-health/pushhealth.css
+++ b/ui/push-health/pushhealth.css
@@ -1,3 +1,8 @@
+body {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
 .absolute {
   position: absolute;
   width: 100%;


### PR DESCRIPTION
Seems like we might need a little audit on our `CSS` at some point.  Not sure all this stuff is necessary.  But due to the peculiarities of the navbars and the details panel in Treeherder itself, the snippet I moved to `treeherder.css` here **is** necessary.  I tried to get rid of it.  

But it shouldn't get applied to everything, so moved some of the `CSS` imports around.  

@sarah-clements : I tested this out a fair amount with TH, Push Health, Perfherder and IFV.  But would you give it a spin as well?  A second set of eyes on this would be great, since it changes such low-level elements.