### PR TITLE
Make the perfherder graph width sized dynamically, and refine the tooltip

### DIFF
--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -476,14 +476,6 @@ li.pagination-active.active > button {
   border-left-color: #4c3146;
 }
 
-@media only screen and (min-width: 1700px) {
-  .custom-col-xxl-auto {
-    flex: 0 0 auto;
-    width: auto;
-    max-width: 100%;
-  }
-}
-
 .edit-icon {
   visibility: hidden;
   font-size: 14px;

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -80,10 +80,20 @@ h1 {
   width: 120px;
 }
 
+.graph-tooltip-foreign-object {
+  overflow: visible;
+}
+
+.graph-tooltip-positioner {
+  position: absolute;
+}
+
 .graph-tooltip {
   pointer-events: none;
   width: 280px;
   text-align: left;
+  position: absolute;
+  bottom: 16px;
 }
 .graph-tooltip.locked {
   pointer-events: auto;
@@ -121,8 +131,12 @@ h1 {
   color: #17a2b8;
 }
 .graph-tooltip .tip {
+  position: absolute;
   display: block;
+  width: 20px;
   height: 10px;
+  bottom: -10px;
+  margin-left: -10px;
   background: url('../img/tip.png') no-repeat center top;
 }
 .graph-tooltip.locked .tip {

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -42,7 +42,7 @@ class GraphsContainer extends React.Component {
       zoomDomain,
       lockTooltip: false,
       externalMutation: undefined,
-      width: window.innerWidth,
+      windowWidth: window.innerWidth,
     };
   }
 
@@ -54,7 +54,7 @@ class GraphsContainer extends React.Component {
     if (selectedDataPoint) this.verifySelectedDataPoint();
     window.addEventListener('resize', () =>
       this.setState({
-        width: window.innerWidth,
+        windowWidth: window.innerWidth,
         zoomDomain,
       }),
     );
@@ -322,14 +322,20 @@ class GraphsContainer extends React.Component {
   };
 
   render() {
-    const { testData, showTable, zoom, highlightedRevisions } = this.props;
+    const {
+      testData,
+      showTable,
+      zoom,
+      highlightedRevisions,
+      width,
+    } = this.props;
     const {
       highlights,
       scatterPlotData,
       zoomDomain,
       lockTooltip,
       externalMutation,
-      width,
+      windowWidth,
     } = this.state;
 
     const yAxisLabel = this.computeYAxisLabel();
@@ -356,16 +362,18 @@ class GraphsContainer extends React.Component {
     const today = moment.utc().toDate();
 
     return (
-      <span data-testid="graphContainer">
+      <div data-testid="graphContainer">
         {!showTable && (
           <React.Fragment>
             <Row>
-              <Col className="p-0 col-md-auto">
+              <Col className="p-0">
                 <VictoryChart
                   padding={chartPadding}
-                  width={1350}
+                  width={width}
                   height={150}
-                  style={{ parent: { maxHeight: '150px', maxWidth: '1350px' } }}
+                  style={{
+                    parent: { maxHeight: '150px' },
+                  }}
                   scale={{ x: 'time', y: 'linear' }}
                   domainPadding={{ y: 30 }}
                   maxDomain={{ x: today }}
@@ -404,12 +412,12 @@ class GraphsContainer extends React.Component {
             </Row>
 
             <Row>
-              <Col className="p-0 col-md-auto">
+              <Col className="p-0">
                 <VictoryChart
                   padding={chartPadding}
-                  width={1350}
+                  width={width}
                   height={400}
-                  style={{ parent: { maxHeight: '400px', maxWidth: '1350px' } }}
+                  style={{ parent: { maxHeight: '400px' } }}
                   scale={{ x: 'time', y: 'linear' }}
                   domainPadding={{ y: 40, x: [10, 10] }}
                   minDomain={{ x: zoomDomain.minX, y: zoomDomain.minY }}
@@ -517,10 +525,13 @@ class GraphsContainer extends React.Component {
                         renderInPortal={false}
                         flyoutComponent={
                           <VictoryPortal>
+                            {/* Note that the WithSize component will always trigger a
+                                re-render on a resize, so the window.innerWidth should
+                                incidentally be updated when a resize event occurs. */}
                             <GraphTooltip
                               lockTooltip={lockTooltip}
                               closeTooltip={this.closeTooltip}
-                              windowWidth={width}
+                              windowWidth={windowWidth}
                               {...this.props}
                             />
                           </VictoryPortal>
@@ -554,7 +565,7 @@ class GraphsContainer extends React.Component {
             <TableView testData={testData} {...this.props} />
           </Row>
         )}
-      </span>
+      </div>
     );
   }
 }
@@ -571,6 +582,8 @@ GraphsContainer.propTypes = {
     PropTypes.arrayOf(PropTypes.string),
   ]),
   timeRange: PropTypes.shape({}).isRequired,
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
 };
 
 GraphsContainer.defaultProps = {

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -42,7 +42,6 @@ class GraphsContainer extends React.Component {
       zoomDomain,
       lockTooltip: false,
       externalMutation: undefined,
-      windowWidth: window.innerWidth,
     };
   }
 
@@ -54,7 +53,6 @@ class GraphsContainer extends React.Component {
     if (selectedDataPoint) this.verifySelectedDataPoint();
     window.addEventListener('resize', () =>
       this.setState({
-        windowWidth: window.innerWidth,
         zoomDomain,
       }),
     );
@@ -335,7 +333,6 @@ class GraphsContainer extends React.Component {
       zoomDomain,
       lockTooltip,
       externalMutation,
-      windowWidth,
     } = this.state;
 
     const yAxisLabel = this.computeYAxisLabel();
@@ -525,13 +522,10 @@ class GraphsContainer extends React.Component {
                         renderInPortal={false}
                         flyoutComponent={
                           <VictoryPortal>
-                            {/* Note that the WithSize component will always trigger a
-                                re-render on a resize, so the window.innerWidth should
-                                incidentally be updated when a resize event occurs. */}
                             <GraphTooltip
                               lockTooltip={lockTooltip}
                               closeTooltip={this.closeTooltip}
-                              windowWidth={windowWidth}
+                              graphWidth={width}
                               {...this.props}
                             />
                           </VictoryPortal>

--- a/ui/perfherder/graphs/GraphsView.jsx
+++ b/ui/perfherder/graphs/GraphsView.jsx
@@ -384,43 +384,50 @@ class GraphsView extends React.Component {
                 testData.length ? 'custom-col-xxl-auto' : 'col-auto'
               } ${showTable && 'w-100'}`}
             >
-              <GraphsViewControls
-                colors={colors}
-                symbols={symbols}
-                timeRange={timeRange}
-                frameworks={frameworks}
-                user={user}
-                projects={projects}
-                options={options}
-                getTestData={this.getTestData}
-                testData={testData}
-                showModal={showModal}
-                showTable={showTable}
-                highlightAlerts={highlightAlerts}
-                highlightedRevisions={highlightedRevisions}
-                zoom={zoom}
-                selectedDataPoint={selectedDataPoint}
-                updateStateParams={(state) =>
-                  this.setState(state, this.changeParams)
-                }
-                visibilityChanged={visibilityChanged}
-                updateData={this.updateData}
-                toggle={() => this.setState({ showModal: !showModal })}
-                toggleTableView={() => this.setState({ showTable: !showTable })}
-                updateTimeRange={(timeRange) =>
-                  this.setState(
-                    {
-                      timeRange,
-                      zoom: {},
-                      selectedDataPoint: null,
-                      colors: [...graphColors],
-                      symbols: [...graphSymbols],
-                    },
-                    this.getTestData,
-                  )
-                }
-                hasNoData={!testData.length && !loading}
-              />
+              {/* Only render the view controls when we're not loading. Otherwise
+               the WithSize component provides the wrong sizing information. */}
+              {!loading && (
+                <GraphsViewControls
+                  key={loading ? 'loading' : 'done'}
+                  colors={colors}
+                  symbols={symbols}
+                  timeRange={timeRange}
+                  frameworks={frameworks}
+                  user={user}
+                  projects={projects}
+                  options={options}
+                  getTestData={this.getTestData}
+                  testData={testData}
+                  showModal={showModal}
+                  showTable={showTable}
+                  highlightAlerts={highlightAlerts}
+                  highlightedRevisions={highlightedRevisions}
+                  zoom={zoom}
+                  selectedDataPoint={selectedDataPoint}
+                  updateStateParams={(state) =>
+                    this.setState(state, this.changeParams)
+                  }
+                  visibilityChanged={visibilityChanged}
+                  updateData={this.updateData}
+                  toggle={() => this.setState({ showModal: !showModal })}
+                  toggleTableView={() =>
+                    this.setState({ showTable: !showTable })
+                  }
+                  updateTimeRange={(timeRange) =>
+                    this.setState(
+                      {
+                        timeRange,
+                        zoom: {},
+                        selectedDataPoint: null,
+                        colors: [...graphColors],
+                        symbols: [...graphSymbols],
+                      },
+                      this.getTestData,
+                    )
+                  }
+                  hasNoData={!testData.length && !loading}
+                />
+              )}
             </Col>
           </Row>
         </Container>

--- a/ui/perfherder/graphs/GraphsViewControls.jsx
+++ b/ui/perfherder/graphs/GraphsViewControls.jsx
@@ -14,11 +14,12 @@ import { faTable, faChartArea } from '@fortawesome/free-solid-svg-icons';
 
 import { phTimeRanges } from '../constants';
 import DropdownMenuItems from '../../shared/DropdownMenuItems';
+import withSize from '../../shared/WithSize';
 
 import TestDataModal from './TestDataModal';
 import GraphsContainer from './GraphsContainer';
 
-export default class GraphsViewControls extends React.Component {
+class GraphsViewControls extends React.Component {
   changeHighlightedRevision = (index, newValue) => {
     const { highlightedRevisions, updateStateParams } = this.props;
 
@@ -60,7 +61,7 @@ export default class GraphsViewControls extends React.Component {
           plottedUnits={measurementUnits}
           {...this.props}
         />
-        <Row className="pb-3 max-width-default mx-auto">
+        <Row className={`pb-3 mx-auto ${showTable ? 'max-width-default' : ''}`}>
           {!hasNoData && (
             <Col sm="auto" className="pl-0 py-2 pr-3">
               <Button color="darker-info" onClick={toggleTableView}>
@@ -113,7 +114,11 @@ export default class GraphsViewControls extends React.Component {
               />
             )}
 
-            <Row className="justify-content-start pt-2 pb-5 max-width-default mx-auto">
+            <Row
+              className={`justify-content-start pt-2 pb-5 mx-auto ${
+                showTable ? 'max-width-default' : ''
+              }`}
+            >
               {highlightedRevisions.length > 0 &&
                 highlightedRevisions.map((revision, index) => (
                   // eslint-disable-next-line react/no-array-index-key
@@ -172,6 +177,9 @@ GraphsViewControls.propTypes = {
   testData: PropTypes.arrayOf(PropTypes.shape({})),
   showModal: PropTypes.bool,
   toggle: PropTypes.func.isRequired,
+  // Injected by the WithSize component:
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
 };
 
 GraphsViewControls.defaultProps = {
@@ -179,3 +187,5 @@ GraphsViewControls.defaultProps = {
   testData: [],
   showModal: false,
 };
+
+export default withSize(GraphsViewControls);

--- a/ui/shared/WithSize.jsx
+++ b/ui/shared/WithSize.jsx
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import * as React from 'react';
+import { findDOMNode } from 'react-dom';
+
+/**
+ * Note: This component was taken from the Firefox Profiler. At the time of this writing
+ * it has been used in production for years, and has been peer reviewed. It was modified
+ * for the initial import by converting the type information into comments.
+ *
+ * https://github.com/firefox-devtools/profiler/blob/846ba69260e167a1a2a872a64ad1b7be0eba47bf/src/components/shared/WithSize.js
+ *
+ * Wraps a React component and makes 'width' and 'height' available in the
+ * wrapped component's props. These props start out at zero and are updated to
+ * the component's DOM node's getBoundingClientRect().width/.height after the
+ * component has been mounted. They also get updated when the window is
+ * resized.
+ *
+ * Note that the props are *not* updated if the size of the element changes
+ * for reasons other than a window resize.
+ */
+export default function withSize(Wrapped) {
+  return class WithSizeWrapper extends React.PureComponent {
+    _isSizeInfoDirty = false;
+
+    // The DOMNode of the container
+    _container;
+
+    constructor(props) {
+      super(props);
+
+      /**
+       * @prop {number} width
+       * @prop {number} height
+       */
+      this.state = { width: 0, height: 0 };
+    }
+
+    componentDidMount() {
+      const container = findDOMNode(this); // eslint-disable-line react/no-find-dom-node
+      if (!container) {
+        throw new Error('Unable to find the DOMNode');
+      }
+      this._container = container;
+      window.addEventListener('resize', this.resizeListener);
+      window.addEventListener(
+        'visibilitychange',
+        this.visibilityChangeListener,
+      );
+
+      // Wrapping the first update in a requestAnimationFrame to defer the
+      // calculation until the full render is done.
+      requestAnimationFrame(() => {
+        // This component could have already been unmounted, check for the existence
+        // of the container.
+        if (this._container) {
+          this.updateWidth(this._container);
+        }
+      });
+    }
+
+    componentWillUnmount() {
+      this._container = null;
+      window.removeEventListener('resize', this.resizeListener);
+      window.removeEventListener(
+        'visibilitychange',
+        this.visibilityChangeListener,
+      );
+    }
+
+    // The size is only updated when the document is visible.
+    // In other cases resizing is registered in _isSizeInfoDirty.
+    resizeListener = () => {
+      const container = this._container;
+      if (!container) {
+        return;
+      }
+      if (document.hidden) {
+        this._isSizeInfoDirty = true;
+      } else {
+        this.updateWidth(container);
+      }
+    };
+
+    // If resizing was registered when the document wasn't visible,
+    // the size will be updated when the document becomes visible
+    visibilityChangeListener = () => {
+      const container = this._container;
+      if (!container) {
+        return;
+      }
+      if (!document.hidden && this._isSizeInfoDirty) {
+        this.updateWidth(container);
+        this._isSizeInfoDirty = false;
+      }
+    };
+
+    /**
+     * @param {HTMLElement | Text} container
+     */
+    updateWidth(container) {
+      if (typeof container.getBoundingClientRect !== 'function') {
+        throw new Error('Cannot measure a Text node.');
+      }
+      const { width, height } = container.getBoundingClientRect();
+      this.setState({ width, height });
+    }
+
+    render() {
+      return <Wrapped {...this.props} {...this.state} />;
+    }
+  };
+}


### PR DESCRIPTION
This PR changes some of the visual layout behavior of the perfherder graph. This change was motivated with the inconsistent feeling of looking at the data on different monitor setups. I frequently move between smaller screens, larger ones, and split views. The graphs were frequently not visible.

#6861 needs to land first, and then this needs to rebase through it, as they are touching similar parts of the code.

Each commit contains a message explaining more in detail what the changes are doing, so I would recommend looking at each commit individually with the message. Here are some screenshots detailing the changes.

# Commit 1 - Chart width

### Large width:

Before, the view was maxed out at 1350px.
> <img width="2560" alt="image" src="https://user-images.githubusercontent.com/1588648/98862800-176bc880-242d-11eb-854e-0e8a553db944.png">

After, the graph will take all available width.
> <img width="2560" alt="image" src="https://user-images.githubusercontent.com/1588648/98862755-091dac80-242d-11eb-9c71-15f0266788e3.png">

### Small width:

Before, the view scaled the entire chart down, including labels. For me, the labels were frequently too small to read. The tooltip also scaled according to the size of the chart, moving outside of the range of legibility.
> <img width="1053" alt="image" src="https://user-images.githubusercontent.com/1588648/98863599-39197f80-242e-11eb-8e03-e09043dce4ee.png">

After, the labels are always consistently sized, and the font doesn't change size.
> <img width="1052" alt="image" src="https://user-images.githubusercontent.com/1588648/98863498-15eed000-242e-11eb-87e9-3c3abca766a7.png">

# Commit 2 - Tooltip

Normally, I would break something like this into a separate PR, but commit 1 regressed the tooltip behavior, so that it would render off the side of the screen. I needed to fix this issue, and as I did, I included some usability fixes as well to make the tooltips more consistent when mousing over the graph.

### Typical view:

<img width="707" alt="image" src="https://user-images.githubusercontent.com/1588648/98863834-901f5480-242e-11eb-9bf5-523cdaf53545.png">

### Left overflow:
<img width="427" alt="image" src="https://user-images.githubusercontent.com/1588648/98863776-7978fd80-242e-11eb-978c-a724ca971bbf.png">

### Right overflow:
<img width="726" alt="image" src="https://user-images.githubusercontent.com/1588648/98863798-839afc00-242e-11eb-9c79-ff0b2dd4b6df.png">

### Fixed vertical positioning

Before, it was done through constant values, which would be weird for certain content.
<img width="356" alt="image" src="https://user-images.githubusercontent.com/1588648/98863912-b1804080-242e-11eb-9689-0a1b7d232fe3.png">

After, the divs can dynamically grow up.
<img width="393" alt="image" src="https://user-images.githubusercontent.com/1588648/98863960-c2c94d00-242e-11eb-92ae-42cda7f684c6.png">
