### PR TITLE
Bug 1519784 - Drop seconds from datetime 'Push Time' column in list of classifications to prevent cropping

### DIFF
--- a/ui/intermittent-failures/BugDetailsView.jsx
+++ b/ui/intermittent-failures/BugDetailsView.jsx
@@ -42,6 +42,8 @@ const BugDetailsView = (props) => {
     {
       Header: 'Push Time',
       accessor: 'push_time',
+      minWidth: 105,
+      className: 'text-left',
     },
     {
       Header: 'Tree',


### PR DESCRIPTION
I have adjusted the `PushTime` column width as it autocrop the columns with default width without affecting the maxWidth of the specified columns and it would not have any impact on the text of the other columns (all are clearly visible).

