### PR TITLE
Bug 1673050 - Add filter by test path button to Failure Summary lines

### DIFF
--- a/tests/ui/shared/FailureSummaryTab_test.jsx
+++ b/tests/ui/shared/FailureSummaryTab_test.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import fetchMock from 'fetch-mock';
 import { render, cleanup } from '@testing-library/react';
+import { createBrowserHistory } from 'history';
+import { ConnectedRouter } from 'connected-react-router';
+import { Provider } from 'react-redux';
 
 import { getApiUrl } from '../../../ui/helpers/url';
 import { getProjectUrl } from '../../../ui/helpers/location';
@@ -8,8 +11,11 @@ import FailureSummaryTab from '../../../ui/shared/tabs/failureSummary/FailureSum
 import jobMap from '../mock/job_map';
 import bugSuggestions from '../mock/bug_suggestions.json';
 import jobLogUrls from '../mock/job_log_urls.json';
+import { configureStore } from '../../../ui/job-view/redux/configureStore';
 
 const selectedJob = Object.values(jobMap)[0];
+const history = createBrowserHistory();
+const store = configureStore(history);
 
 describe('FailureSummaryTab', () => {
   const repoName = 'autoland';
@@ -29,16 +35,20 @@ describe('FailureSummaryTab', () => {
   });
 
   const testFailureSummaryTab = () => (
-    <FailureSummaryTab
-      selectedJob={selectedJob}
-      jobLogUrls={jobLogUrls}
-      logParseStatus="parsed"
-      reftestUrl="boo"
-      logViewerFullUrl="ber/baz"
-      addBug={() => {}}
-      pinJob={() => {}}
-      repoName={repoName}
-    />
+    <Provider store={store}>
+      <ConnectedRouter history={history}>
+        <FailureSummaryTab
+          selectedJob={selectedJob}
+          jobLogUrls={jobLogUrls}
+          logParseStatus="parsed"
+          reftestUrl="boo"
+          logViewerFullUrl="ber/baz"
+          addBug={() => {}}
+          pinJob={() => {}}
+          repoName={repoName}
+        />
+      </ConnectedRouter>
+    </Provider>
   );
 
   test('failures should be visible', async () => {

--- a/ui/css/treeherder-custom-styles.css
+++ b/ui/css/treeherder-custom-styles.css
@@ -339,7 +339,7 @@
 
 /* Darker Secondary */
 .text-darker-secondary {
-  color: #53595f;
+  color: #53595f !important;
 }
 
 .alert-darker-secondary,

--- a/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'reactstrap';
+import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBug } from '@fortawesome/free-solid-svg-icons';
+import { faBug, faFilter } from '@fortawesome/free-solid-svg-icons';
 
 import Clipboard from '../../Clipboard';
 import logviewerIcon from '../../../img/logviewerIcon.png';
 import { thBugSuggestionLimit } from '../../../helpers/constants';
-import { getLogViewerUrl } from '../../../helpers/url';
+import {
+  createQueryParams,
+  getLogViewerUrl,
+  parseQueryParams,
+} from '../../../helpers/url';
 
 import BugListItem from './BugListItem';
 
@@ -23,6 +28,16 @@ export default class SuggestionsListItem extends React.Component {
     this.setState((prevState) => ({
       suggestionShowMore: !prevState.suggestionShowMore,
     }));
+  };
+
+  getPathFilter = (filterTestPath) => {
+    const path = filterTestPath[0].replace(/\/$/, '');
+    const filterParams = {
+      ...parseQueryParams(window.location.search),
+      test_paths: path,
+    };
+
+    return `${window.location.pathname}${createQueryParams(filterParams)}`;
   };
 
   render() {
@@ -114,6 +129,9 @@ export default class SuggestionsListItem extends React.Component {
         </mark>,
       );
     }
+    const filterTestPath = suggestion.search.match(
+      RegExp('([a-z_\\-s0-9.]+[/])+', 'gi'),
+    );
 
     return (
       <li>
@@ -149,6 +167,15 @@ export default class SuggestionsListItem extends React.Component {
                 description=" text of error line"
                 text={suggestion.search}
               />
+              {filterTestPath && !developerMode && (
+                <Link
+                  to={this.getPathFilter(filterTestPath)}
+                  className="px-1 text-darker-secondary"
+                  title={`Filter by test path: ${filterTestPath[0]}`}
+                >
+                  <FontAwesomeIcon icon={faFilter} />
+                </Link>
+              )}
               <a
                 href={getLogViewerUrl(
                   selectedJob.id,


### PR DESCRIPTION
This uses a `regexp` to find paths within the failure summary search string.  It omits the filename and the trailing slash.

I had to make `text-darker-secondary` have `!important` because it wasn't working when the link had been visited.