### PR TITLE
Revert "Update precommit hook prettier/prettier to v2.1.2"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/prettier/prettier
-    rev: 2.1.2
+    rev: 2.1.1
     hooks:
       - id: prettier
   - repo: https://github.com/igorshubovych/markdownlint-cli


### PR DESCRIPTION
Reverts mozilla/treeherder#6886

Seems to be an issue with this new version that is breaking the dependency tree and throwing errors locally (when precommit is installed).