### PR TITLE
Bug 1676499 - Add hyphen to possible perfherder-data tag entry characters.

### DIFF
--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -125,7 +125,7 @@
           "description": "Similar to extraOptions, except it does not break existing performance data series",
           "items": {
             "type": "string",
-            "pattern": "^[a-zA-Z0-9]{1,24}$"
+            "pattern": "^[a-zA-Z0-9-]{1,24}$"
           },
           "uniqueItems": true,
           "maxItems": 14


### PR DESCRIPTION
This patch adds a hyphen to the list of possible characters in the `tags` entries.

See this bug for more information: https://bugzilla.mozilla.org/show_bug.cgi?id=1676499

Try run for these changes: https://treeherder.mozilla.org/jobs?repo=try&tier=1%2C2%2C3&revision=40c831b4b9d0f1e2899d53dbe5bff8da229d6f35