### PR TITLE
Bug 1679163 - Adjust tooltip placement to avoid it obscuring the targ…

### DIFF
--- a/ui/intermittent-failures/BugDetailsView.jsx
+++ b/ui/intermittent-failures/BugDetailsView.jsx
@@ -114,7 +114,7 @@ const BugDetailsView = (props) => {
                 </a>
               </React.Fragment>
             }
-            placement="left"
+            placement="top"
             tooltipText={
               original.lines.length && (
                 <ul>


### PR DESCRIPTION
…et text

If the tooltip is long, it can obscure the target "view details" text,
which then triggers the mouseout event that hides the tooltip. This can
set up an oscilation between the tooltip showing and hidding in quick
succession, which manifests as the user's cursor rapidly flickering.

Moving the tooltip to be above the target text seems to solve this
problem as it reduces the chance that the target text will be obscured.