### PR TITLE
Bug 1673050 - Exempt Reftest jobs from test path filter button

### DIFF
--- a/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
@@ -8,6 +8,7 @@ import { faBug, faFilter } from '@fortawesome/free-solid-svg-icons';
 import Clipboard from '../../Clipboard';
 import logviewerIcon from '../../../img/logviewerIcon.png';
 import { thBugSuggestionLimit } from '../../../helpers/constants';
+import { isReftest } from '../../../helpers/job';
 import {
   createQueryParams,
   getLogViewerUrl,
@@ -167,7 +168,7 @@ export default class SuggestionsListItem extends React.Component {
                 description=" text of error line"
                 text={suggestion.search}
               />
-              {filterTestPath && !developerMode && (
+              {filterTestPath && !developerMode && !isReftest(selectedJob) && (
                 <Link
                   to={this.getPathFilter(filterTestPath)}
                   className="px-1 text-darker-secondary"


### PR DESCRIPTION
This fixes an edge case where this filter button for test paths should not show for Reftests.  Because Reftests don't have Test Groups to filter by.