### PR TITLE
Bug 1681880 TypeError: e[0] is undefined when hiding all data series

### DIFF
--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -165,11 +165,14 @@ class GraphsContainer extends React.Component {
 
   updateGraphs = () => {
     const { testData, updateStateParams, visibilityChanged } = this.props;
+    let { zoomDomain } = this.state;
     const scatterPlotData = testData.flatMap((item) =>
       item.visible ? item.data : [],
     );
     this.addHighlights();
-    const zoomDomain = this.updateZoomDomain(scatterPlotData);
+    if (scatterPlotData.length) {
+      zoomDomain = this.updateZoomDomain(scatterPlotData);
+    }
     this.setState({
       scatterPlotData,
       zoomDomain,


### PR DESCRIPTION
This bug was introduced when the improvement of showing the graph timeline up to current date instead of up to the date of last datapoint.
![Screenshot from 2020-12-11 10-25-22](https://user-images.githubusercontent.com/47977085/101880503-b1916e80-3b9b-11eb-8868-e683a87c22b8.png)

### Before
- by clicking to hide the series in the graph is shown `TypeError: e[0] is undefined`
![Screenshot from 2020-12-11 10-25-56](https://user-images.githubusercontent.com/47977085/101880675-f87f6400-3b9b-11eb-93ec-3e6df4286133.png)

### After

- [x] by clicking to hide the series in the graph is shown an empty graph
![Screenshot from 2020-12-11 10-26-31](https://user-images.githubusercontent.com/47977085/101880718-0b923400-3b9c-11eb-8cb1-232f40e82460.png)
