### PR TITLE
Hacky way to get rid of 'opt' from shippable platform labels

### DIFF
--- a/tests/sample_data/pulse_consumer/transformed_job_data.json
+++ b/tests/sample_data/pulse_consumer/transformed_job_data.json
@@ -137,7 +137,6 @@
       "start_timestamp": 1419039597.0,
       "name": "static-analysis-win32-st-an/debug",
       "option_collection": {
-        "opt": true
       },
       "machine_platform": {
         "platform": "linux64",
@@ -181,7 +180,6 @@
       "start_timestamp": 1419039597.0,
       "name": "test-windows10-64-vm/opt-jsreftest",
       "option_collection": {
-        "opt": true
       },
       "machine_platform": {
         "platform": "linux64",

--- a/treeherder/etl/job_loader.py
+++ b/treeherder/etl/job_loader.py
@@ -195,7 +195,7 @@ class JobLoader:
         return log_references
 
     def _get_option_collection(self, job):
-        option_collection = {"opt": True}
+        option_collection = {}
         if "labels" in job:
             option_collection = {}
             for option in job["labels"]:

--- a/ui/job-view/pushes/Platform.jsx
+++ b/ui/job-view/pushes/Platform.jsx
@@ -89,8 +89,9 @@ export default class Platform extends React.PureComponent {
     } = this.props;
     const { filteredPlatform } = this.state;
     const suffix =
-      thSimplePlatforms.includes(filteredPlatform.name) &&
-      filteredPlatform.option === 'opt'
+      (thSimplePlatforms.includes(filteredPlatform.name) &&
+        filteredPlatform.option === 'opt') ||
+      filteredPlatform.name.includes('Shippable')
         ? ''
         : ` ${filteredPlatform.option}`;
     const title = `${filteredPlatform.name}${suffix}`;


### PR DESCRIPTION
I'd be shocked if this is an acceptable way to solve it, but I think this is _a_ way of fixing #6467. (But mostly it's a way to get my feet wet with Treeherder development.)