### PR TITLE
Some CI & tox changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,11 @@ jobs:
           command: yarn markdownlint
           name: Check markdown linting
       - run:
-          command: yarn codecov
-          name: Check code coverage changes
-      - run:
           command: yarn test:coverage
           name: Run Jest tests
+      - run:
+          command: yarn codecov
+          name: Check code coverage changes
 
   builds:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,6 @@ jobs:
           name: Run Jest tests
 
   builds:
-    environment:
-      NODE_ENV: production
-      YARN_PRODUCTION: true
     docker:
       - image: 'circleci/python:3.7-node'
     steps:
@@ -41,6 +38,9 @@ jobs:
       - run:
           command: tox -e docs
           name: Build docs
+      - run:
+          command: tox -e linters
+          name: Run linters
 
   python-tests:
     machine: true
@@ -48,8 +48,9 @@ jobs:
       - checkout
       - docker/install-docker
       - docker/install-docker-compose
-      - run: docker-compose build
-      - run: docker-compose run backend bash -c "flake8 --show-source && black --check treeherder/ && pytest --cov --cov-report=xml tests/ --runslow"
+      - run: pip install tox codecov
+      - run: tox -e docker  # Run tests and coverage within Docker container
+      - run: codecov --required -f coverage.xml
 
 orbs:
   node: circleci/node@4.1.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
       - checkout
       - docker/install-docker
       - docker/install-docker-compose
+      - run: pip install --upgrade pip
       - run: pip install tox codecov
       - run: tox -e docker  # Run tests and coverage within Docker container
       - run: codecov --required -f coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -47,16 +47,18 @@ commands_post =
 # part of Heroku's build step when the code has already been merged to master.
 # The step ./bin/post_compile requires the output of `yarn build`, thus, we need
 # to build both the JS and Python builds
+# In Heroku, the JS dev dependencies are *not* installed because the env variable
+# YARN_PRODUCTION is detected by the buildpack, however, yarn does not care about
+# that and needs an explicit flag (`--prod`)
+# https://devcenter.heroku.com/articles/nodejs-support#only-installing-dependencies
+# NODE_ENV=production is implicit as part of the command `yarn build` with `--mode production`
 [testenv:heroku]
-setenv =
-    NODE_ENV = production
-    YARN_PRODUCTION = true
 whitelist_externals =
     yarn
     post_compile
 commands_pre =
     pip install -r requirements.txt
-    yarn install
+    yarn install --prod
 commands =
     yarn heroku-postbuild
     ./manage.py collectstatic --noinput

--- a/tox.ini
+++ b/tox.ini
@@ -14,12 +14,6 @@ commands_pre =
     pip install -r {toxinidir}/requirements/dev.txt
     pip install -r {toxinidir}/requirements/common.txt
 commands =
-    pip check
-    {toxinidir}/lints/queuelint.py
-    flake8 --show-source
-    black --check .
-    shellcheck initialize_data.sh
-    shellcheck docker/entrypoint.sh
     {toxinidir}/manage.py check
     sh -c "SITE_URL=https://treeherder.dev TREEHERDER_DEBUG=False ./manage.py check --deploy --fail-level WARNING"
     # Running slow tests (DB required)
@@ -27,6 +21,19 @@ commands =
 commands_post =
     # This is to deal with running the containers with --detached
     docker-compose down
+
+[testenv:linters]
+commands_pre =
+    pip install -r {toxinidir}/requirements/dev.txt
+    pip install -r {toxinidir}/requirements/common.txt
+commands =
+    pip check
+    {toxinidir}/lints/queuelint.py
+    flake8 --show-source
+    black --check .
+    shellcheck initialize_data.sh
+    shellcheck docker/entrypoint.sh
+commands_post =
 
 [testenv:docs]
 commands_pre =
@@ -41,6 +48,9 @@ commands_post =
 # The step ./bin/post_compile requires the output of `yarn build`, thus, we need
 # to build both the JS and Python builds
 [testenv:heroku]
+setenv =
+    NODE_ENV = production
+    YARN_PRODUCTION = true
 whitelist_externals =
     yarn
     post_compile


### PR DESCRIPTION
* Create new Tox environment for linting checks
  * This decouples the need for setting up Docker for it
* Move production environment variables into Heroku's tox environment
  * It makes it more atomic and less dependant on the CI being set up correctly
* Call `tox -e docker` instead of custom command
* Upload code coverage file