### PR TITLE
Add "browsertime" as a possible performance test in `isPerfTest`.

### DIFF
--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -52,7 +52,8 @@ export const isPerfTest = function isPerfTest(job) {
   return [job.job_group_name, job.job_type_name].some(
     (name) =>
       name.toLowerCase().includes('talos') ||
-      name.toLowerCase().includes('raptor'),
+      name.toLowerCase().includes('raptor') ||
+      name.toLowerCase().includes('browsertime'),
   );
 };
 


### PR DESCRIPTION
We're missing the generate profile button in browsertime tests and it's because they aren't being taken into account in the `isPerfTest` function. This patch solves issue #6950.