### PR TITLE
Bug 1496319 - add build type to IFV bot comments

### DIFF
--- a/tests/intermittents_commenter/expected_comment.text
+++ b/tests/intermittents_commenter/expected_comment.text
@@ -5,8 +5,9 @@ This is the #1 most frequent failure this week.
 Repository breakdown:
 * test_treeherder_jobs: 1
 
-Platform breakdown:
+Platform and build breakdown:
 * b2g-emu-jb: 1
+  * debug: 1
 
 For more details, see:
 https://treeherder.mozilla.org/intermittent-failures/bugdetails?bug=1&startday=2012-05-09&endday=2018-05-10&tree=all

--- a/tests/intermittents_commenter/test_commenter.py
+++ b/tests/intermittents_commenter/test_commenter.py
@@ -41,5 +41,6 @@ def test_intermittents_commenter(bug_data):
 
     with open('tests/intermittents_commenter/expected_comment.text', 'r') as comment:
         expected_comment = comment.read()
-
+    print(len(expected_comment))
+    print(len(comment_params[0]['changes']['comment']['body']))
     assert comment_params[0]['changes']['comment']['body'] == expected_comment

--- a/treeherder/intermittents_commenter/comment.template
+++ b/treeherder/intermittents_commenter/comment.template
@@ -24,9 +24,12 @@ Repository breakdown:
 {% for repository, count in repositories.items() -%}
 * {{repository}}: {{count}}
 {% endfor %}
-Platform breakdown:
+Platform and build breakdown:
 {% for platform, count in platforms.items() -%}
 * {{platform}}: {{count}}
+  {%- for build, count in counts[platform].items() %}
+  * {{ build }}: {{ count }}
+  {%- endfor %}
 {% endfor %}
 For more details, see:
 https://treeherder.mozilla.org/intermittent-failures/bugdetails?bug={{bug_id}}&startday={{startday}}&endday={{endday}}&tree=all


### PR DESCRIPTION
The IFV bot comments will include the build type, grouped by platform, to look like this:

Repository breakdown:
* autoland: 16
* mozilla-central: 5
* try: 2

Platform and build breakdown:
* macosx1014-64-qr: 18
  * opt: 7
  * debug: 11
* macosx1014-64-shippable-qr: 3
  * opt: 3
* macosx1014-64-devedition-qr: 1
  * opt: 1
* macosx1014-64: 1
  * debug: 1

FYI @jmaher 