### PR TITLE
Bug 1620648 - Switch to github personal access token to avoid rate limiting

### DIFF
--- a/treeherder/changelog/collector.py
+++ b/treeherder/changelog/collector.py
@@ -41,11 +41,11 @@ class GitHub:
         if "since" in kw:
             gh_options["since"] = kw["since"]
 
-        for commit in github.commits_info(owner, repository, params=gh_options):
+        for commit in github.get_all_commits(owner, repository, params=gh_options):
             if filters:
                 for filter in filters:
                     if isinstance(filter, list) and filter[0] == "filter_by_path":
-                        commit_info = github.commit_info(owner, repository, commit["sha"])
+                        commit_info = github.get_commit(owner, repository, commit["sha"])
                         commit["files"] = commit_info["files"]
                         break
 

--- a/treeherder/etl/management/commands/ingest.py
+++ b/treeherder/etl/management/commands/ingest.py
@@ -370,12 +370,12 @@ def ingest_git_pushes(project, dry_run=False):
     logger.info("--> Converting Github commits to pushes")
     _repo = repo_meta(project)
     owner, repo = _repo["owner"], _repo["repo"]
-    github_commits = github.commits_info(owner, repo)
+    github_commits = github.get_all_commits(owner, repo)
     not_push_revision = []
     push_revision = []
     push_to_date = {}
     for _commit in github_commits:
-        info = github.commit_info(owner, repo, _commit["sha"])
+        info = github.get_commit(owner, repo, _commit["sha"])
         # Revisions that are marked as non-push should be ignored
         if _commit["sha"] in not_push_revision:
             logger.debug("Not a revision of a push: {}".format(_commit["sha"]))

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -22,9 +22,13 @@ def compare_shas(owner, repo, base, head):
     return fetch_api("repos/{}/{}/compare/{}...{}".format(owner, repo, base, head))
 
 
-def commits_info(owner, repo, params=None):
+def get_all_commits(owner, repo, params=None):
     return fetch_api("repos/{}/{}/commits".format(owner, repo), params)
 
 
-def commit_info(owner, repo, sha, params=None):
+def get_commit(owner, repo, sha, params=None):
     return fetch_api("repos/{}/{}/commits/{}".format(owner, repo, sha), params)
+
+
+def get_pull_request(owner, repo, sha, params=None):
+    return fetch_api("repos/{}/{}/pulls/{}/commits".format(owner, repo, sha), params)


### PR DESCRIPTION
* remove use of client id and secret for github app in push_loader.py
* rename helper functions in github.py

I need to set up 2FA for the bot account and then test this on prototype, so I'll do that Thursday.