### PR TITLE
Change circle-ci default machine image for python-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,8 @@ jobs:
           name: Run linters
 
   python-tests:
-    machine: true
+    machine:
+      image: ubuntu-2004:202010-01
     steps:
       - checkout
       - docker/install-docker


### PR DESCRIPTION
* It looks like the default image was changed to a different(?), older version of ubuntu
that was causing an error and the python-tests job to fail