### PR TITLE
Bug 1678760 - Push Health status progress fixes

### DIFF
--- a/ui/helpers/display.js
+++ b/ui/helpers/display.js
@@ -44,10 +44,11 @@ export const getSearchWords = function getHighlighterArray(text) {
 
 export const getPercentComplete = function getPercentComplete(counts) {
   const { pending, running, completed } = counts;
-  const inProgress = pending + running;
-  const total = completed + inProgress;
+  const total = completed + pending + running;
 
-  return total > 0 ? Math.floor((completed / total) * 100) : 0;
+  // pushes older than our 4-month data cutoff we want to display as 100% complete
+  // in the status progress indicator even though the total counts will be 0
+  return total > 0 ? Math.floor((completed / total) * 100) : 100;
 };
 
 export const formatArtifacts = function formatArtifacts(data, artifactParams) {

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -681,7 +681,7 @@ class Push extends React.PureComponent {
                   widthClass="ml-4 mb-3"
                   commitShaClass="text-monospace"
                 >
-                  {showPushHealthSummary && (
+                  {showPushHealthSummary && pushHealthStatus && (
                     <div className="mt-4">
                       <PushHealthSummary
                         healthStatus={pushHealthStatus}

--- a/ui/push-health/Health.jsx
+++ b/ui/push-health/Health.jsx
@@ -165,9 +165,6 @@ export default class Health extends React.PureComponent {
       knownIssuesGroupBy,
     } = this.state;
     const { tests, commitHistory, linting, builds } = metrics;
-    const needInvestigationCount = tests
-      ? tests.details.needInvestigation.length
-      : 0;
 
     const { notify } = this.props;
     return (
@@ -190,7 +187,9 @@ export default class Health extends React.PureComponent {
             rel="shortcut icon"
             href={result === 'fail' ? faviconBroken : faviconOk}
           />
-          <title>{`[${needInvestigationCount} failures] Push Health`}</title>
+          <title>{`[${
+            (status && status.testfailed) || 0
+          } failures] Push Health`}</title>
         </Helmet>
         <Container fluid className="mt-2 mb-5 max-width-default">
           {!!tests && !!currentRepo && (

--- a/ui/push-health/MyPushes.jsx
+++ b/ui/push-health/MyPushes.jsx
@@ -120,7 +120,7 @@ class MyPushes extends React.Component {
 
     const totalNeedInvestigation = pushMetrics.length
       ? pushMetrics
-          .map((push) => push.needInvestigation)
+          .map((push) => push.status.testfailed)
           .reduce((total, count) => total + count)
       : 0;
 

--- a/ui/push-health/MyPushes.jsx
+++ b/ui/push-health/MyPushes.jsx
@@ -96,8 +96,12 @@ class MyPushes extends React.Component {
 
     if (!failureStatus && data.length) {
       stateChanges.pushMetrics = data;
-    } else {
+    } else if (failureStatus) {
       notify(`There was a problem retrieving push metrics: ${data}`, 'danger');
+    } else {
+      notify(
+        `Didn't find push data for you in ${selectedRepo}. Try selecting a different option.`,
+      );
     }
 
     this.setState(stateChanges);

--- a/ui/shared/PushHealthStatus.jsx
+++ b/ui/shared/PushHealthStatus.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Badge, Spinner } from 'reactstrap';
+import { Badge } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faCheck,
@@ -85,7 +85,7 @@ class PushHealthStatus extends Component {
 
     return (
       <span data-testid={`health-status-${revision}`}>
-        {needInvestigation !== null ? (
+        {needInvestigation !== null && (
           <a
             href={getPushHealthUrl({ repo: repoName, revision })}
             target="_blank"
@@ -99,8 +99,6 @@ class PushHealthStatus extends Component {
               {healthStatus}
             </Badge>
           </a>
-        ) : (
-          <Spinner size="sm" />
         )}
       </span>
     );


### PR DESCRIPTION
![Screen Shot 2021-01-25 at 6 02 23 PM](https://user-images.githubusercontent.com/19615783/105926491-01ff4700-5ff7-11eb-8fbb-c52c1d736381.png)

The status progress indicators percentage of failures (in the pie chart) now matches the possible regressions. I also addressed a few other things - comments in the second commit or see the bug for details.
