### PR TITLE
Remove Push Health link from Failure Summary tab.

### DIFF
--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Button } from 'reactstrap';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
@@ -154,14 +153,6 @@ class FailureSummaryTab extends React.Component {
 
     return (
       <div className="w-100 h-100" role="region" aria-label="Failure Summary">
-        {!!suggestions.length && (
-          <a href="/push-health">
-            <Button outline className="bg-light mb-2" type="button">
-              View In Push Health
-            </Button>
-          </a>
-        )}
-
         <ul
           className={`${
             !developerMode && 'font-size-11'


### PR DESCRIPTION
This was included with #6998 by mistake.