### PR TITLE
bug 1691676: Fix log viewer links not to have double forward slash

### DIFF
--- a/ui/intermittent-failures/BugDetailsView.jsx
+++ b/ui/intermittent-failures/BugDetailsView.jsx
@@ -103,7 +103,7 @@ const BugDetailsView = (props) => {
                 <br />
                 <a
                   className="small-text"
-                  href={`${window.location.origin}/${getLogViewerUrl(
+                  href={`${window.location.origin}${getLogViewerUrl(
                     value,
                     original.tree,
                   )}`}

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -222,7 +222,7 @@ class DetailsPanel extends React.Component {
                 selectedJob.id,
                 currentRepo.name,
               );
-              const logViewerFullUrl = `${window.location.origin}/${logViewerUrl}`;
+              const logViewerFullUrl = `${window.location.origin}${logViewerUrl}`;
               const performanceData = Object.values(phSeriesResult).reduce(
                 (a, b) => [...a, ...b],
                 [],

--- a/ui/job-view/pushes/PushJobs.jsx
+++ b/ui/job-view/pushes/PushJobs.jsx
@@ -83,7 +83,7 @@ class PushJobs extends React.Component {
     JobModel.get(repoName, jobId).then((data) => {
       if (data.logs.length > 0) {
         window.open(
-          `${window.location.origin}/${getLogViewerUrl(jobId, repoName)}`,
+          `${window.location.origin}${getLogViewerUrl(jobId, repoName)}`,
         );
       }
     });


### PR DESCRIPTION
#6998 changed the log viewer helper function to include the leading forward slash, but didn't remove it from other consumers who add their own. I went through and audited usage of this to make sure everything is updated, and made sure the specific case that bug 1691676 mentions worked again.