### PR TITLE
Bug 1692544 - Clear taskcluster credentials on logout

### DIFF
--- a/ui/shared/auth/Login.jsx
+++ b/ui/shared/auth/Login.jsx
@@ -90,6 +90,10 @@ class Login extends React.Component {
   logout = () => {
     const { notify } = this.props;
 
+    // only clear taskcluster credentials when a user logs outs to make it easier
+    // to clear an old token and retrieve a new one
+    localStorage.removeItem('userCredentials');
+
     fetch(getApiUrl('/auth/logout/')).then(async (resp) => {
       if (resp.ok) {
         this.setLoggedOut();

--- a/ui/shared/auth/Login.jsx
+++ b/ui/shared/auth/Login.jsx
@@ -90,7 +90,7 @@ class Login extends React.Component {
   logout = () => {
     const { notify } = this.props;
 
-    // only clear taskcluster credentials when a user logs outs to make it easier
+    // only clear taskcluster credentials when a user logs out to make it easier
     // to clear an old token and retrieve a new one
     localStorage.removeItem('userCredentials');
 


### PR DESCRIPTION
* To help guard against situations when a token is faulty and needs to be easily cleared so the user can retrieve a fresh taskcluster token