### PR TITLE
Change push health visibility back to try

### DIFF
--- a/ui/job-view/App.jsx
+++ b/ui/job-view/App.jsx
@@ -88,7 +88,7 @@ class App extends React.Component {
       groupCountsExpanded: urlParams.get('group_state') === 'expanded',
       duplicateJobsVisible: urlParams.get('duplicate_jobs') === 'visible',
       showShortCuts: false,
-      pushHealthVisibility: 'All',
+      pushHealthVisibility: 'try',
     };
   }
 


### PR DESCRIPTION
The health summary query can be very slow sometimes and I'm concerned this is slowing page load, from some recent spikes in response time I'm seeing in New Relic.