### PR TITLE
Fix Django Debug Toolbar

### DIFF
--- a/treeherder/config/urls.py
+++ b/treeherder/config/urls.py
@@ -5,11 +5,7 @@ from rest_framework.documentation import include_docs_urls
 from treeherder.webapp.api import urls as api_urls
 from django.views.generic.base import TemplateView
 
-urlpatterns = [
-    re_path(r'^api/', include(api_urls)),
-    re_path(r'^docs/', include_docs_urls(title='REST API Docs')),
-    re_path(r'', TemplateView.as_view(template_name='index.html')),
-]
+urlpatterns = []
 
 if settings.DEBUG:
     import debug_toolbar
@@ -17,3 +13,9 @@ if settings.DEBUG:
     urlpatterns += [
         re_path(r'^__debug__/', include(debug_toolbar.urls)),
     ]
+
+urlpatterns += [
+    re_path(r'^api/', include(api_urls)),
+    re_path(r'^docs/', include_docs_urls(title='REST API Docs')),
+    re_path(r'', TemplateView.as_view(template_name='index.html')),
+]

--- a/treeherder/config/urls.py
+++ b/treeherder/config/urls.py
@@ -6,6 +6,8 @@ from treeherder.webapp.api import urls as api_urls
 from django.views.generic.base import TemplateView
 
 urlpatterns = []
+# The order is important for the debug toolbar; it needs to be first
+# or the panels won't work
 
 if settings.DEBUG:
     import debug_toolbar


### PR DESCRIPTION
Move debug_toolbar path to first index in urlpatterns.