### PR TITLE
Use bold font-weight for collapsed retry job groups

### DIFF
--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -301,6 +301,7 @@ fieldset[disabled] .btn-red-classified.active {
 .btn-dkblue-count:hover,
 .btn-dkblue-classified-count:hover {
   color: #283aa2;
+  font-weight: bold;
 }
 .btn-dkblue:hover,
 .btn-dkblue-classified:hover,


### PR DESCRIPTION
The current font weight makes it almost indistinguishable from black