### PR TITLE
Change pre_deploy to remove django checks

### DIFF
--- a/bin/pre_deploy
+++ b/bin/pre_deploy
@@ -20,9 +20,6 @@ if [[ -v NEW_RELIC_CONFIG_FILE ]]; then
     PRE_COMMAND="newrelic-admin run-program"
 fi
 
-echo "-----> PRE-DEPLOY: Running Django system checks..."
-./manage.py check --deploy --fail-level WARNING
-
 echo "-----> PRE-DEPLOY: Running Django migration..."
 $PRE_COMMAND ./manage.py migrate --noinput
 


### PR DESCRIPTION
* For some reason the django check warning is causing a release to fail for a recent schema change
so removing the check since its implicitly called as part of the migrate command that follows