### PR TITLE
Bug 1704761 Remove inactive people from regression cc list

### DIFF
--- a/treeherder/perf/fixtures/performance_bug_templates.yaml
+++ b/treeherder/perf/fixtures/performance_bug_templates.yaml
@@ -20,7 +20,6 @@
     keywords: perf-alert, regression
     default_component: Performance
     default_product: Testing
-    cc_list: rstewart@mozilla.com
     text: |
       Perfherder has detected a {{ framework }} performance regression from push [{{ revision }}]({{ revisionHref }}). As author of one of the patches included in that push, we need your help to address this regression.
 
@@ -36,7 +35,6 @@
     keywords: perf, perf-alert, regression
     default_component: Performance
     default_product: Testing
-    cc_list: bob@bclary.com
     text: |
       Perfherder has detected a {{ framework }} performance regression from push [{{ revision }}]({{ revisionHref }}). As author of one of the patches included in that push, we need your help to address this regression.
 


### PR DESCRIPTION
Currently rstewart and bc no longer work at Mozilla and their emails appear on cc_list of the regression bug templates.