### PR TITLE
Bug 1707635 - update documentation how to ingest specific queues with new names

### DIFF
--- a/docs/pulseload.md
+++ b/docs/pulseload.md
@@ -56,10 +56,10 @@ docker-compose run backend celery -A treeherder worker --concurrency 1
 
 You will see a list of activated queues.  If you wanted to narrow that down, then note
 which queues you'd like to run and add them to a comma-separated list.  For instance, to
-only do Log Parsing:
+only do Log Parsing for sheriffed trees (autoland, mozilla-*):
 
 ```bash
-celery -A treeherder worker -Q log_parser,log_parser_fail --concurrency 1
+docker-compose run backend celery -A treeherder worker -Q log_parser,log_parser_fail_raw_sheriffed,log_parser_fail_json_sheriffed --concurrency 1
 ```
 
 ## Posting Data


### PR DESCRIPTION


Bug 1679162 had split the parsing of logs for failed tasks into multiple dimensions:
- monitored by code sheriffs or not
- raw or JSON data

This added 4 new queues:
- log_parser_fail_raw_sheriffed
- log_parser_fail_json_sheriffed
- log_parser_fail_raw_unsheriffed
- log_parser_fail_json_unsheriffed

The sheriffed ones handle the autoland and mozilla-* trees watched by code
sheriffs, the unsheriffed ones all other trees (e.g. 'try').