### PR TITLE
Bug 1709356 - Don't use 'Last test finished' as search term but fall back to checks for crash signature and whole failure line

### DIFF
--- a/treeherder/model/error_summary.py
+++ b/treeherder/model/error_summary.py
@@ -197,6 +197,7 @@ def is_helpful_search_term(search_term):
         'mozalloc_abort(char const*)',
         'mozalloc_abort',
         'CrashingThread(void *)',
+        'Last test finished',
         'leakcheck',
         '# TBPL FAILURE #',
     ]


### PR DESCRIPTION
Used [this task](https://treeherder.mozilla.org/jobs?repo=try&group_state=expanded&resultStatus=usercancel%2Ctestfailed%2Cbusted%2Cexception&revision=e411a85d1ee041a77718cbb0d785b92e105392e8&selectedTaskRun=GKyYLRj1QYSBHau-i8oc5g.0) to verify the fix.