### PR TITLE
Revert "Add port to allowed hosts for gcp staging"

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -43,7 +43,7 @@ SITE_URL = env("SITE_URL", default='http://localhost:8000')
 
 SITE_HOSTNAME = furl(SITE_URL).host
 # Including localhost allows using the backend locally
-ALLOWED_HOSTS = [SITE_HOSTNAME, 'localhost', '127.0.0.1', '10.4.0.3']
+ALLOWED_HOSTS = [SITE_HOSTNAME, 'localhost', '127.0.0.1']
 
 # URL handling
 APPEND_SLASH = False


### PR DESCRIPTION
Reverts mozilla/treeherder#7127

This wasn't actually needed; there was a change on the cloudOps side that caused the need for this change (but its been fixed).