### PR TITLE
Improvements to ingesting data locally - doc and docker changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - SITE_URL=http://backend:8000/
       - TREEHERDER_DEBUG=True
       - NEW_RELIC_INSIGHTS_API_KEY=${NEW_RELIC_INSIGHTS_API_KEY:-}
+      - PROJECTS_TO_INGEST=${PROJECTS_TO_INGEST:-autoland,try}
     entrypoint: './docker/entrypoint.sh'
     # We *ONLY* initialize the data when we're running the backend
     command: './initialize_data.sh ./manage.py runserver 0.0.0.0:8000'
@@ -102,7 +103,7 @@ services:
       context: .
       dockerfile: docker/dev.Dockerfile
     environment:
-      - PULSE_URL=${PULSE_URL:-amqp://docker-shared-user:8r5VFxpJHtJahTVV5bYutykgDsXhGF@pulse.mozilla.org:5671/?ssl=1}
+      - PULSE_URL=${PULSE_URL:-amqp://docker-shared-user:oGv7P5%H94@pulse.mozilla.org:5671/?ssl=1}
       - LOGGING_LEVEL=INFO
       - PULSE_AUTO_DELETE_QUEUES=True
       - DATABASE_URL=mysql://root@mysql:3306/treeherder
@@ -123,7 +124,7 @@ services:
     environment:
       - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672//
       - DATABASE_URL=mysql://root@mysql:3306/treeherder
-      - PROJECTS_TO_INGEST=${PROJECTS_TO_INGEST:-autoland}
+      - PROJECTS_TO_INGEST=${PROJECTS_TO_INGEST:-autoland,try}
     entrypoint: './docker/entrypoint.sh'
     command: celery worker -A treeherder --uid=nobody --gid=nogroup --without-gossip --without-mingle --without-heartbeat -Q store_pulse_pushes,store_pulse_tasks --concurrency=1 --loglevel=WARNING
     volumes:

--- a/docs/pulseload.md
+++ b/docs/pulseload.md
@@ -1,7 +1,7 @@
-# Loading Pulse data
+# Pulse Ingestion Configuration
 
 By default, running the Docker container with `docker-compose up` will ingest data
-from the `autoland` repo using a shared [Pulse Guardian] user.  You can configure this the following ways:
+from the `autoland` and `try` repositories using a shared [Pulse Guardian] user.  You can configure this the following ways:
 
 1. Specify a custom set of repositories for which to ingest data
 2. Create a custom **Pulse User** on [Pulse Guardian]
@@ -42,26 +42,6 @@ See [Starting a local Treeherder instance] for more info.
 
 [starting a local treeherder instance]: installation.md#starting-a-local-treeherder-instance
 
-## Advanced Celery Configuration
-
-If you only want to ingest the Pushes and Tasks, then the default will do that for you.
-But if you want to do other processing like parsing logs, etc, then you can specify the other queues
-you would like to process.
-
-Open a new terminal window. To run all the queues do:
-
-```bash
-docker-compose run backend celery -A treeherder worker --concurrency 1
-```
-
-You will see a list of activated queues.  If you wanted to narrow that down, then note
-which queues you'd like to run and add them to a comma-separated list.  For instance, to
-only do Log Parsing for sheriffed trees (autoland, mozilla-*):
-
-```bash
-docker-compose run backend celery -A treeherder worker -Q log_parser,log_parser_fail_raw_sheriffed,log_parser_fail_json_sheriffed --concurrency 1
-```
-
 ## Posting Data
 
 To post data to your own **Pulse** exchange, you can use the `publish_to_pulse`
@@ -82,3 +62,4 @@ ex: <https://community-tc.services.mozilla.com/pulse-messages/>
 
 [pulse guardian]: https://pulseguardian.mozilla.org/whats_pulse
 [yml schema]: https://github.com/mozilla/treeherder/blob/master/schemas/pulse-job.yml
+[settings]: https://github.com/mozilla/treeherder/blob/master/treeherder/config/settings.py#L318

--- a/tests/etl/test_job_loader.py
+++ b/tests/etl/test_job_loader.py
@@ -5,10 +5,10 @@ import pytest
 import responses
 import slugid
 
-from treeherder.etl.exceptions import MissingPushException
 from treeherder.etl.job_loader import JobLoader
 from treeherder.etl.taskcluster_pulse.handler import handleMessage
 from treeherder.model.models import Job, JobLog, TaskclusterMetadata
+from django.core.exceptions import ObjectDoesNotExist
 
 
 @pytest.fixture
@@ -233,7 +233,7 @@ def test_ingest_pulse_jobs_with_missing_push(pulse_jobs):
         status=200,
     )
 
-    with pytest.raises(MissingPushException):
+    with pytest.raises(ObjectDoesNotExist):
         for pulse_job in pulse_jobs:
             jl.process_job(pulse_job, 'https://firefox-ci-tc.services.mozilla.com')
 


### PR DESCRIPTION
@Archaeopteryx and @gmierz have both had issues with our docs being a bit confusing for backend development (even I was confused!) and things not working quite right.

I took some time debug this and make changes:
1) The shared pulse user wasn't working and you needed to export the PULSE_URL in the shell before running `docker-compose up`. Turns out the password needed to be reset :) So there's no need to do that anymore.
2) It seems you need to have both PROJECTS_TO_INGEST in the docker backend container (with some defaults) or you need to export whatever projects you want to see before also running docker-compose **and** specify those projects in a second shell to run the celery workers. So I've updated the docs and added `PROJECTS_TO_INGEST=autoland,try` to the docker-compose file.

Please let me know if these docs need further edits or clarification. For easier reading, you can follow these instructions to render them locally: https://treeherder.readthedocs.io/common_tasks.html#serving-the-docs-locally