### PR TITLE
Bug 1711031 - Undefined measurement unit in Compare View

### DIFF
--- a/ui/perfherder/compare/CompareView.jsx
+++ b/ui/perfherder/compare/CompareView.jsx
@@ -159,8 +159,10 @@ class CompareView extends React.PureComponent {
           return;
         }
 
-        cmap.baseColumnMeasurementUnit = oldResults.measurement_unit;
-        cmap.newColumnMeasurementUnit = newResults.measurement_unit;
+        if (oldResults !== undefined)
+          cmap.baseColumnMeasurementUnit = oldResults.measurement_unit;
+        if (newResults !== undefined)
+          cmap.newColumnMeasurementUnit = newResults.measurement_unit;
 
         cmap.name = value;
 


### PR DESCRIPTION
Reproduction of the bug: Go to http://localhost:5000/perfherder/compare?originalProject=mozilla-central&newProject=try&newRevision=570364e12beb104652bb1a7950064b25383522e1&framework=4&selectedTimeRange=172800
 and then choose 'mozperftest' from the frameworks dropdown.