### PR TITLE
Bug 1712257 - Sherlock does not backfill if there are jobs

### DIFF
--- a/treeherder/perf/auto_perf_sheriffing/backfill_tool.py
+++ b/treeherder/perf/auto_perf_sheriffing/backfill_tool.py
@@ -30,7 +30,9 @@ class BackfillTool:
             action='backfill',
             task_id=task_id_to_backfill,
             decision_task_id=decision_task_id,
-            input={},
+            input={
+                "retrigger": False,
+            },
             root_url=job.repository.tc_root_url,
         )
         return task_id


### PR DESCRIPTION
Based on the newly added functionality from taskcluster (https://phabricator.services.mozilla.com/D115057), we can prevent Sherlock from retriggering jobs that already run