### PR TITLE
Bug 1700763 - Add an isolated process option for Android treeherder platforms

### DIFF
--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -205,6 +205,7 @@ export const thOptionOrder = {
   cc: 6,
   addon: 7,
   all: 8,
+  'debug-isolated-process': 9,
 };
 
 export const thFavicons = {


### PR DESCRIPTION
This is needed for this bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1700763

We are working on implementing Fission and isolated process on Android, and want to start running tests in automation on builds with isolated process. So we need a Treeherder platform option for that.