### PR TITLE
pre-commit: run urlchecker and json check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: check-json
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.0
+    rev: 3.8.4
     hooks:
       - id: flake8
   - repo: https://github.com/shellcheck-py/shellcheck-py
@@ -12,11 +12,11 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1
+    rev: v2.1.2
     hooks:
       - id: prettier
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.27.1
+    rev: v0.23.2
     hooks:
       - id: markdownlint
         args: [--fix]
@@ -24,7 +24,7 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
-        language_version: python3
+        language_version: python3.7
   - repo: https://github.com/aerickson/urlchecker-python
     rev: 9654184451d967d2f03d8cfe3b5333b6facbfa2e
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: check-json
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.0
     hooks:
       - id: flake8
   - repo: https://github.com/shellcheck-py/shellcheck-py
@@ -8,11 +12,11 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.1.2
+    rev: v2.2.1
     hooks:
       - id: prettier
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.2
+    rev: v0.27.1
     hooks:
       - id: markdownlint
         args: [--fix]
@@ -20,4 +24,18 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3
+  - repo: https://github.com/aerickson/urlchecker-python
+    rev: 9654184451d967d2f03d8cfe3b5333b6facbfa2e
+    hooks:
+      - id: urlchecker
+        entry: urlchecker check_ci --exclude-pattern "http://localhost"
+        types_or: [markdown, json]
+        exclude: |
+          (?x)^(
+              version.json|
+              package.json|
+              package-lock.json|
+              ^tests/.*|
+              ^node_modules/.*
+          )$


### PR DESCRIPTION
Split off from #7045, where we decided it would be a good idea to check JSON for validity and ensure that URLs aren't broken.

DONE:
- pre-commit
  - add urlchecker-python hook
  - add check for malformed JSON

TODO:
- fix failing URLs (see github action output)
- decide on where to run urlchecker-python from
  - aerickson fork, mozilla relops fork of aerickson's fork, or official version (not sure when will be merged)

Files on master with bad URLs:
```bash
docs/infrastructure/administration.md 
docs/submitting_data.md 
treeherder/model/fixtures/repository.json 
treeherder/perf/fixtures/issue_tracker.json 
```
