### PR TITLE
Bug 1717212 - Compare View query string parameters are not updated

### DIFF
--- a/tests/ui/perfherder/compare-view/compare_table_test.jsx
+++ b/tests/ui/perfherder/compare-view/compare_table_test.jsx
@@ -208,7 +208,7 @@ test('toggle buttons should filter results by selected filter', async () => {
   expect(result2).toBeInTheDocument();
 });
 
-test('toggle buttons should update the URL params', async () => {
+test('toggle all buttons should update the URL params', async () => {
   const { getByText } = compareTableControls();
 
   const showImportant = getByText(filterText.showImportant);
@@ -250,16 +250,24 @@ test('toggle buttons should update the URL params', async () => {
     },
     [],
   );
+});
 
-  fireEvent.click(hideUncertain);
-  expect(mockUpdateParams).toHaveBeenLastCalledWith(
-    {
-      showOnlyImportant: 1,
-      showOnlyNoise: 1,
-      showOnlyComparable: 1,
+test('filters that are not enabled are removed from URL params', async () => {
+  const { getByText } = compareTableControls();
+
+  global.window = Object.create(window);
+  const url = '?showOnlyConfident=1';
+  Object.defineProperty(window, 'location', {
+    value: {
+      search: url,
     },
-    [],
-  );
+  });
+
+  const showImportant = getByText(filterText.showImportant);
+  fireEvent.click(showImportant);
+  expect(mockUpdateParams).toHaveBeenLastCalledWith({ showOnlyImportant: 1 }, [
+    'showOnlyConfident',
+  ]);
 });
 
 test('text input filter results should differ when filter button(s) are selected', async () => {

--- a/tests/ui/perfherder/compare-view/compare_table_test.jsx
+++ b/tests/ui/perfherder/compare-view/compare_table_test.jsx
@@ -140,6 +140,9 @@ const compareTableControlsNode = (
       isBaseAggregate={isBaseAggregate}
       onPermalinkClick={mockHandlePermalinkClick}
       projects={projects}
+      validated={{
+        updateParams: () => {},
+      }}
     />
   );
 };

--- a/tests/ui/perfherder/compare-view/compare_table_test.jsx
+++ b/tests/ui/perfherder/compare-view/compare_table_test.jsx
@@ -118,6 +118,7 @@ const results = new Map([['a11yr pgo e10s stylo', result]]);
 jest.mock('../../../../ui/models/job');
 
 const mockHandlePermalinkClick = jest.fn();
+const mockUpdateParams = jest.fn();
 const regexComptableHeaderId = /table-header-\d+/;
 const regexComptableRowId = /table-row-\d+/;
 
@@ -141,7 +142,7 @@ const compareTableControlsNode = (
       onPermalinkClick={mockHandlePermalinkClick}
       projects={projects}
       validated={{
-        updateParams: () => {},
+        updateParams: mockUpdateParams,
       }}
     />
   );
@@ -205,6 +206,45 @@ test('toggle buttons should filter results by selected filter', async () => {
   expect(hideUncertain).toHaveClass('active');
   expect(result1).not.toBeInTheDocument();
   expect(result2).toBeInTheDocument();
+});
+
+test('toggle buttons should update the URL params', async () => {
+  const { getByText } = compareTableControls();
+
+  const showImportant = getByText(filterText.showImportant);
+  fireEvent.click(showImportant);
+  expect(mockUpdateParams).toHaveBeenLastCalledWith({ showOnlyImportant: 1 });
+
+  const hideUncertain = getByText(filterText.hideUncertain);
+  fireEvent.click(hideUncertain);
+  expect(mockUpdateParams).toHaveBeenLastCalledWith({
+    showOnlyImportant: 1,
+    showOnlyConfident: 1,
+  });
+
+  const showNoise = getByText(filterText.showNoise);
+  fireEvent.click(showNoise);
+  expect(mockUpdateParams).toHaveBeenLastCalledWith({
+    showOnlyImportant: 1,
+    showOnlyConfident: 1,
+    showOnlyNoise: 1,
+  });
+
+  const hideUncomparable = getByText(filterText.hideUncomparable);
+  fireEvent.click(hideUncomparable);
+  expect(mockUpdateParams).toHaveBeenLastCalledWith({
+    showOnlyImportant: 1,
+    showOnlyConfident: 1,
+    showOnlyNoise: 1,
+    showOnlyComparable: 1,
+  });
+
+  fireEvent.click(hideUncertain);
+  expect(mockUpdateParams).toHaveBeenLastCalledWith({
+    showOnlyImportant: 1,
+    showOnlyNoise: 1,
+    showOnlyComparable: 1,
+  });
 });
 
 test('text input filter results should differ when filter button(s) are selected', async () => {

--- a/tests/ui/perfherder/compare-view/compare_table_test.jsx
+++ b/tests/ui/perfherder/compare-view/compare_table_test.jsx
@@ -7,7 +7,7 @@ import {
   waitFor,
   waitForElementToBeRemoved,
 } from '@testing-library/react';
-import ReactTestUtils from 'react-dom/test-utils';
+
 import projects from '../../mock/repositories';
 import CompareTableControls from '../../../../ui/perfherder/compare/CompareTableControls';
 import CompareTable from '../../../../ui/perfherder/compare/CompareTable';
@@ -281,30 +281,6 @@ test('filters that are not enabled are removed from URL params', async () => {
   fireEvent.click(showImportant);
   expect(mockUpdateParams).toHaveBeenLastCalledWith({}, [
     'filter',
-    'showOnlyComparable',
-    'showOnlyImportant',
-    'showOnlyConfident',
-    'showOnlyNoise',
-  ]);
-});
-
-test('filterText is removed when empty from URL params', async () => {
-  const { getByPlaceholderText } = compareTableControls();
-
-  const filterInput = await waitFor(() =>
-    getByPlaceholderText(filterText.inputPlaceholder),
-  );
-
-  // fireEvent.change(filterInput, { target: { value: 'linux' } });
-  const node = filterInput;
-  node.value = 'linux';
-  ReactTestUtils.Simulate.change(filterInput, { target: { value: 'linux' } });
-  // ReactTestUtils.Simulate.keyDown(node, {
-  //   key: 'Enter',
-  //   keyCode: 13,
-  //   which: 13,
-  // });
-  expect(mockUpdateParams).toHaveBeenLastCalledWith({ filter: 'linux' }, [
     'showOnlyComparable',
     'showOnlyImportant',
     'showOnlyConfident',

--- a/tests/ui/perfherder/compare-view/compare_table_test.jsx
+++ b/tests/ui/perfherder/compare-view/compare_table_test.jsx
@@ -213,38 +213,53 @@ test('toggle buttons should update the URL params', async () => {
 
   const showImportant = getByText(filterText.showImportant);
   fireEvent.click(showImportant);
-  expect(mockUpdateParams).toHaveBeenLastCalledWith({ showOnlyImportant: 1 });
+  expect(mockUpdateParams).toHaveBeenLastCalledWith(
+    { showOnlyImportant: 1 },
+    [],
+  );
 
   const hideUncertain = getByText(filterText.hideUncertain);
   fireEvent.click(hideUncertain);
-  expect(mockUpdateParams).toHaveBeenLastCalledWith({
-    showOnlyImportant: 1,
-    showOnlyConfident: 1,
-  });
+  expect(mockUpdateParams).toHaveBeenLastCalledWith(
+    {
+      showOnlyImportant: 1,
+      showOnlyConfident: 1,
+    },
+    [],
+  );
 
   const showNoise = getByText(filterText.showNoise);
   fireEvent.click(showNoise);
-  expect(mockUpdateParams).toHaveBeenLastCalledWith({
-    showOnlyImportant: 1,
-    showOnlyConfident: 1,
-    showOnlyNoise: 1,
-  });
+  expect(mockUpdateParams).toHaveBeenLastCalledWith(
+    {
+      showOnlyImportant: 1,
+      showOnlyConfident: 1,
+      showOnlyNoise: 1,
+    },
+    [],
+  );
 
   const hideUncomparable = getByText(filterText.hideUncomparable);
   fireEvent.click(hideUncomparable);
-  expect(mockUpdateParams).toHaveBeenLastCalledWith({
-    showOnlyImportant: 1,
-    showOnlyConfident: 1,
-    showOnlyNoise: 1,
-    showOnlyComparable: 1,
-  });
+  expect(mockUpdateParams).toHaveBeenLastCalledWith(
+    {
+      showOnlyImportant: 1,
+      showOnlyConfident: 1,
+      showOnlyNoise: 1,
+      showOnlyComparable: 1,
+    },
+    [],
+  );
 
   fireEvent.click(hideUncertain);
-  expect(mockUpdateParams).toHaveBeenLastCalledWith({
-    showOnlyImportant: 1,
-    showOnlyNoise: 1,
-    showOnlyComparable: 1,
-  });
+  expect(mockUpdateParams).toHaveBeenLastCalledWith(
+    {
+      showOnlyImportant: 1,
+      showOnlyNoise: 1,
+      showOnlyComparable: 1,
+    },
+    [],
+  );
 });
 
 test('text input filter results should differ when filter button(s) are selected', async () => {

--- a/ui/perfherder/Validation.jsx
+++ b/ui/perfherder/Validation.jsx
@@ -47,28 +47,17 @@ const withValidation = ({ requiredParams }, verifyRevisions = true) => (
       }
     }
 
-    updateParams = (params) => {
+    updateParams = (params, paramsToBeRemoved = []) => {
       const { history, location } = this.props;
 
       const newParams = {
         ...parseQueryParams(location.search),
         ...params,
       };
-      const queryString = createQueryParams(newParams);
-      history.push({ search: queryString });
-    };
-
-    removeParams = (params) => {
-      const { history, location } = this.props;
-
-      const newParams = {
-        ...parseQueryParams(location.search),
-      };
-
-      params.forEach((param) => {
-        delete newParams[param];
-      });
-
+      if (paramsToBeRemoved.length !== 0)
+        paramsToBeRemoved.forEach((param) => {
+          delete newParams[param];
+        });
       const queryString = createQueryParams(newParams);
       history.push({ search: queryString });
     };

--- a/ui/perfherder/Validation.jsx
+++ b/ui/perfherder/Validation.jsx
@@ -58,6 +58,21 @@ const withValidation = ({ requiredParams }, verifyRevisions = true) => (
       history.push({ search: queryString });
     };
 
+    removeParams = (params) => {
+      const { history, location } = this.props;
+
+      const newParams = {
+        ...parseQueryParams(location.search),
+      };
+
+      params.forEach((param) => {
+        delete newParams[param];
+      });
+
+      const queryString = createQueryParams(newParams);
+      history.push({ search: queryString });
+    };
+
     errorMessage = (param, value) => `${param} ${value} is not valid`;
 
     findParam = (param, value, list, errors) => {
@@ -171,9 +186,11 @@ const withValidation = ({ requiredParams }, verifyRevisions = true) => (
 
     render() {
       const updateParams = { updateParams: this.updateParams };
+      const removeParams = { removeParams: this.removeParams };
       const validatedProps = {
         ...this.state,
         ...updateParams,
+        ...removeParams,
       };
       const { validationComplete, errorMessages } = this.state;
 

--- a/ui/perfherder/alerts/AlertsViewControls.jsx
+++ b/ui/perfherder/alerts/AlertsViewControls.jsx
@@ -192,6 +192,7 @@ export default class AlertsViewControls extends React.Component {
           </Container>
         )}
         <FilterControls
+          filteredTextValue={filterText}
           dropdownOptions={isListMode ? alertDropdowns : []}
           filterOptions={alertCheckboxes}
           updateFilter={this.updateFilter}

--- a/ui/perfherder/compare/CompareTableControls.jsx
+++ b/ui/perfherder/compare/CompareTableControls.jsx
@@ -151,30 +151,23 @@ export default class CompareTableControls extends React.Component {
       hideUncertain,
       showNoise,
     } = this.state;
-    const {
-      showOnlyComparable,
-      showOnlyImportant,
-      showOnlyConfident,
-      showOnlyNoise,
-      filter,
-    } = parseQueryParams(window.location.search);
     const compareURLParams = {};
     const paramsToRemove = [];
 
     if (filteredText !== '') compareURLParams.filter = filteredText;
-    else if (filter) paramsToRemove.push('filter');
+    else paramsToRemove.push('filter');
 
     if (hideUncomparable) compareURLParams.showOnlyComparable = 1;
-    else if (showOnlyComparable) paramsToRemove.push('showOnlyComparable');
+    else paramsToRemove.push('showOnlyComparable');
 
     if (showImportant) compareURLParams.showOnlyImportant = 1;
-    else if (showOnlyImportant) paramsToRemove.push('showOnlyImportant');
+    else paramsToRemove.push('showOnlyImportant');
 
     if (hideUncertain) compareURLParams.showOnlyConfident = 1;
-    else if (showOnlyConfident) paramsToRemove.push('showOnlyConfident');
+    else paramsToRemove.push('showOnlyConfident');
 
     if (showNoise) compareURLParams.showOnlyNoise = 1;
-    else if (showOnlyNoise) paramsToRemove.push('showOnlyNoise');
+    else paramsToRemove.push('showOnlyNoise');
 
     updateParams(compareURLParams, paramsToRemove);
   };

--- a/ui/perfherder/compare/CompareTableControls.jsx
+++ b/ui/perfherder/compare/CompareTableControls.jsx
@@ -10,7 +10,6 @@ import {
   retriggerMultipleJobs,
 } from '../perf-helpers/helpers';
 import FilterControls from '../../shared/FilterControls';
-import { parseQueryParams } from '../../helpers/url';
 
 import CompareTable from './CompareTable';
 import RetriggerModal from './RetriggerModal';

--- a/ui/perfherder/compare/CompareTableControls.jsx
+++ b/ui/perfherder/compare/CompareTableControls.jsx
@@ -143,7 +143,7 @@ export default class CompareTableControls extends React.Component {
   };
 
   updateUrlParams = () => {
-    const { updateParams, removeParams } = this.props.validated;
+    const { updateParams } = this.props.validated;
     const {
       filteredText,
       hideUncomparable,
@@ -176,8 +176,7 @@ export default class CompareTableControls extends React.Component {
     if (showNoise) compareURLParams.showOnlyNoise = 1;
     else if (showOnlyNoise) paramsToRemove.push('showOnlyNoise');
 
-    updateParams(compareURLParams);
-    if (paramsToRemove.length !== 0) removeParams(paramsToRemove);
+    updateParams(compareURLParams, paramsToRemove);
   };
 
   onModalOpen = (rowResults) => {

--- a/ui/perfherder/compare/CompareTableControls.jsx
+++ b/ui/perfherder/compare/CompareTableControls.jsx
@@ -25,7 +25,7 @@ export default class CompareTableControls extends React.Component {
       hideUncertain: convertParams(this.validated, 'showOnlyConfident'),
       showNoise: convertParams(this.validated, 'showOnlyNoise'),
       results: new Map(),
-      filterText: this.getDefaultFilterText(this.validated),
+      filteredText: this.getDefaultFilterText(this.validated),
       showRetriggerModal: false,
       currentRetriggerRow: {},
     };
@@ -43,12 +43,14 @@ export default class CompareTableControls extends React.Component {
   }
 
   getDefaultFilterText = (validated) => {
-    const { filterText } = validated;
-    return filterText === undefined || filterText === null ? '' : filterText;
+    const { filter } = validated;
+    return filter === undefined || filter === null ? '' : filter;
   };
 
   updateFilterText = (filterText) => {
-    this.setState({ filterText }, () => this.updateFilteredResults());
+    this.setState({ filteredText: filterText }, () =>
+      this.updateFilteredResults(),
+    );
   };
 
   updateFilter = (filter) => {
@@ -60,7 +62,7 @@ export default class CompareTableControls extends React.Component {
 
   filterResult = (testName, result) => {
     const {
-      filterText,
+      filteredText,
       showImportant,
       hideUncertain,
       showNoise,
@@ -73,18 +75,18 @@ export default class CompareTableControls extends React.Component {
       (!hideUncertain || result.isConfident) &&
       (!showNoise || result.isNoiseMetric);
 
-    if (!filterText) return matchesFilters;
+    if (!filteredText) return matchesFilters;
 
     const textToSearch = `${testName} ${result.name}`;
 
     // searching with filter input and one or more metricFilter buttons on
     // will produce different results compared to when all filters are off
-    return containsText(textToSearch, filterText) && matchesFilters;
+    return containsText(textToSearch, filteredText) && matchesFilters;
   };
 
   updateFilteredResults = () => {
     const {
-      filterText,
+      filteredText,
       hideUncomparable,
       showImportant,
       hideUncertain,
@@ -94,9 +96,8 @@ export default class CompareTableControls extends React.Component {
     const { compareResults } = this.props;
 
     this.updateUrlParams();
-
     if (
-      !filterText &&
+      !filteredText &&
       !hideUncomparable &&
       !showImportant &&
       !hideUncertain &&
@@ -142,9 +143,9 @@ export default class CompareTableControls extends React.Component {
   };
 
   updateUrlParams = () => {
-    const { updateParams } = this.props.validated;
+    const { updateParams, removeParams } = this.props.validated;
     const {
-      filterText,
+      filteredText,
       hideUncomparable,
       showImportant,
       hideUncertain,
@@ -157,11 +158,10 @@ export default class CompareTableControls extends React.Component {
       showOnlyNoise,
       filter,
     } = parseQueryParams(window.location.search);
-    const { removeParams } = this.props.validated;
     const compareURLParams = {};
     const paramsToRemove = [];
 
-    if (filterText !== '') compareURLParams.filter = filterText;
+    if (filteredText !== '') compareURLParams.filter = filteredText;
     else if (filter) paramsToRemove.push('filter');
 
     if (hideUncomparable) compareURLParams.showOnlyComparable = 1;
@@ -207,6 +207,7 @@ export default class CompareTableControls extends React.Component {
       results,
       showRetriggerModal,
       currentRetriggerRow,
+      filteredText,
     } = this.state;
 
     const compareFilters = [
@@ -247,6 +248,7 @@ export default class CompareTableControls extends React.Component {
           isBaseAggregate={isBaseAggregate}
         />
         <FilterControls
+          filteredTextValue={filteredText}
           filterOptions={compareFilters}
           updateFilter={this.updateFilter}
           updateFilterText={this.updateFilterText}

--- a/ui/shared/FilterControls.jsx
+++ b/ui/shared/FilterControls.jsx
@@ -49,6 +49,7 @@ const FilterControls = ({
   updateFilter,
   updateOnEnter,
   dropdownCol,
+  filteredTextValue,
 }) => {
   const createButton = (filter) => (
     <Button
@@ -75,6 +76,7 @@ const FilterControls = ({
 
         <Col className="col-2 py-2 pl-0 pr-2">
           <InputFilter
+            filteredTextValue={filteredTextValue}
             updateFilterText={updateFilterText}
             updateOnEnter={updateOnEnter}
           />

--- a/ui/shared/InputFilter.jsx
+++ b/ui/shared/InputFilter.jsx
@@ -10,7 +10,7 @@ export default class InputFilter extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      input: '',
+      input: props.filteredTextValue,
     };
   }
 


### PR DESCRIPTION
The filter buttons ('Hide uncomparable results', 'Show only important changes', 'Hide uncertain results', 'Show only noise' ) and the filter text from the Compare View Page are not reflected in the URL as they should.

This PR should fix this issue.