### PR TITLE
Bug 1525121 - use dynamic width for pinned tasks in pinboard to fit labels

### DIFF
--- a/ui/css/treeherder-pinboard.css
+++ b/ui/css/treeherder-pinboard.css
@@ -94,7 +94,7 @@
   font-size: 12px;
   margin-bottom: 2px;
   padding: 1px 2px;
-  width: 3.5em;
+  min-width: 2em;
 }
 
 .pinned-job-close-btn {


### PR DESCRIPTION
Before the width was fixed and long labels would wrap or get cut off.