### PR TITLE
Bug 1720839 - Compare View Pagination links to pages are not shown when number of pages < 5

### DIFF
--- a/tests/ui/perfherder/compare-view/compare_table_test.jsx
+++ b/tests/ui/perfherder/compare-view/compare_table_test.jsx
@@ -333,6 +333,11 @@ test('page parameter updates with value 2 when clicking on the second page', asy
     findAllByLabelText('pagination-button-2'),
   );
   fireEvent.click(secondPage[0]);
+
+  const firstPage = await waitFor(() =>
+    findAllByLabelText('pagination-button-1'),
+  );
+  expect(firstPage[0]).toBeInTheDocument();
   expect(mockUpdateParams).toHaveBeenLastCalledWith({ page: 2 });
 });
 

--- a/ui/perfherder/compare/CompareTableControls.jsx
+++ b/ui/perfherder/compare/CompareTableControls.jsx
@@ -211,7 +211,7 @@ export default class CompareTableControls extends React.Component {
 
   getCurrentPages = () => {
     const { page, totalPagesList } = this.state;
-    if (totalPagesList.length === 5 || !totalPagesList.length) {
+    if (totalPagesList.length <= 5 || !totalPagesList.length) {
       return totalPagesList;
     }
     return totalPagesList.slice(page - 1, page + 4);


### PR DESCRIPTION
Reproduction link for this bug: https://treeherder.mozilla.org/perfherder/compare?originalProject=try&originalRevision=080aa96854f418e43bf7830723b4b8349f2d60b4&newProject=try&newRevision=a0bddba56926720593c4639f75ee0e7e68792bea&framework=13&filter=ContentfulSpeedIndex&pageTitle=strict+mode+vs+normal+mode+recorded+sites&page=1 