### PR TITLE
Bug 1617835 - optimize time to switch to view showing single push

### DIFF
--- a/ui/job-view/redux/stores/pushes.js
+++ b/ui/job-view/redux/stores/pushes.js
@@ -388,11 +388,12 @@ export const updateRange = (range) => {
     window.dispatchEvent(new CustomEvent(thEvents.clearPinboard));
     if (revisionPushList.length) {
       const { id: pushId } = revisionPushList[0];
-      const revisionJobMap = Object.entries(jobMap).reduce(
-        (acc, [id, job]) =>
-          job.push_id === pushId ? { ...acc, [id]: job } : acc,
-        {},
-      );
+      const revisionJobMap = {};
+      for (const [id, job] of Object.entries(jobMap)) {
+        if (job.push_id === pushId) {
+          revisionJobMap[id] = job;
+        }
+      }
       if (getUrlParam('selectedJob') || getUrlParam('selectedTaskRun')) {
         dispatch(clearSelectedJob(0));
       }


### PR DESCRIPTION
The object holding the mapping of job IDs to the jobs themselves got iteratively
regenerated - the script walked over all jobs currently shown (with
Array.prototype.reduce) and for each job of the push which shall be shown, a new
object got generated based on the old one + the new job id and data. Based on
testing with mozilla-central and the default 10 pushes shown, this translates
into ~90k jobs and slow page warnings (execution up to 46s measured). The new
code takes one object and sets the id and data pairs iteratively in 100-200ms.