### PR TITLE
Bug 1722731 - remove filtering by 'machine name'

### DIFF
--- a/ui/helpers/filter.js
+++ b/ui/helpers/filter.js
@@ -19,7 +19,6 @@ export const thFieldChoices = {
   job_type_symbol: { name: 'job symbol', matchType: thMatchType.exactstr },
   job_group_name: { name: 'group name', matchType: thMatchType.substr },
   job_group_symbol: { name: 'group symbol', matchType: thMatchType.exactstr },
-  machine_name: { name: 'machine name', matchType: thMatchType.substr },
   platform: { name: 'platform', matchType: thMatchType.substr },
   tier: { name: 'tier', matchType: thMatchType.exactstr },
   test_paths: { name: 'test path', matchType: thMatchType.substr },


### PR DESCRIPTION
Bug 1450045 removed the machine_name data from the frontend cache and the
ability to filter by 'machine name' has been broken since.

Checking the results of tasks which have been run a specific machine should be
done with Taskcluster. Treeherder would also only show the runs for the
currently shown tree, to which machines are not bound.