### PR TITLE
Bug 1725459 - update taskcluster client ID map with GCP instances, drop obsolete prototype2

### DIFF
--- a/ui/taskcluster-auth-callback/constants.js
+++ b/ui/taskcluster-auth-callback/constants.js
@@ -3,11 +3,11 @@ import { tcAuthCallbackUrl } from '../helpers/url';
 export const tcClientIdMap = {
   'https://treeherder.mozilla.org': 'production',
   'https://treeherder.allizom.org': 'stage',
-  'https://treeherder-prototype.herokuapp.com': 'dev',
+  'https://prototype.treeherder.nonprod.cloudops.mozgcp.net/': 'dev',
   'http://localhost:5000': 'localhost-5000',
   'http://localhost:8000': 'localhost-8000',
-  'https://treeherder-taskcluster-staging.herokuapp.com': 'taskcluster-staging',
-  'https://treeherder-prototype2.herokuapp.com': 'dev2',
+  'https://tc-staging.treeherder.nonprod.cloudops.mozgcp.net':
+    'taskcluster-staging',
 };
 
 export const clientId = `treeherder-${


### PR DESCRIPTION
The deployment side is opaque to me, I cannot spot any traces of prototype2 in GCP and don't find a way to validate the values of this dict (only set in the deployment?).