### PR TITLE
Bug 1732359 - several improvements to Bugzilla products and components suggested by bug filer

### DIFF
--- a/ui/shared/BugFiler.jsx
+++ b/ui/shared/BugFiler.jsx
@@ -278,9 +278,16 @@ export class BugFilerClass extends React.Component {
    */
   findProductByPath = async () => {
     const { suggestion } = this.props;
+    const { crashSignatures } = this.state;
     const pathEnd = suggestion.path_end;
 
     if (!pathEnd) {
+      return;
+    }
+
+    /* Don't suggest a Bugzilla product and component because it should be based
+       on the crashing file which is not mentioned in the failure line. */
+    if (crashSignatures.length) {
       return;
     }
 


### PR DESCRIPTION


Bug 1429030 added automatic suggestions of the Bugzilla product and component
combination to use for new bugs created from the bug filer. Unrelated
product::component suggestions got suggested under certain conditions.

Examples:

* Android tests junit tests separate the path by . compared to / in the
  database. If the search term starts with org.mozilla., the string between the
  first potential # and the last . left of it should be used for the search
  (should match the file name of the test). Example: bug 1732081
* Test framework files in the failure will suggest the component for that one.
  The real failure might not be in the failure log. Set the Mochitest framework
  as opt-in and do not automatically suggest it. Example: bug 1732236
* Crashes should be reported into the component of the file which executed the
  code which crashed. No component should be suggested because the top frames of
  the pasted crashing thread can be code handling the crash. Example: bug 1731956