### PR TITLE
Bug 1741227 - List of suggested bugs should not sometimes remember if further bugs got shown for different task

### DIFF
--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -162,7 +162,7 @@ class FailureSummaryTab extends React.Component {
         >
           {suggestions.map((suggestion, index) => (
             <SuggestionsListItem
-              key={index} // eslint-disable-line react/no-array-index-key
+              key={`${selectedJob.id}-${index}`} // eslint-disable-line react/no-array-index-key
               index={index}
               suggestion={suggestion}
               toggleBugFiler={() => this.fileBug(suggestion)}


### PR DESCRIPTION
Switching between different failed tasks and clicking "Show more bug
suggestions" for a failure line shows the additional bugs and still "Hide more
bug suggestions" after one switched directly to another failed task with bug
suggestions for a failure line at the same index (e.g. the first one).

This doesn't apply if one e.g. selected a failed task with no suggestions at the
same failure line index or one selected a task without failure lines inbetween.

React didn't update the element because the key was static (onyl index used).