### PR TITLE
Bug 1743534 - Add [All] button next to the expanded group name, to select/deselect all jobs in this group, in "Add new jobs" view.

### DIFF
--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -630,3 +630,19 @@ fieldset[disabled] .btn-pink.active {
   background-color: #ff80e5;
   border-color: #ff80e5;
 }
+
+.group-select-all-runnable {
+  color: rgba(128, 128, 0, 0.5);
+  font-size: 12px;
+  background: transparent;
+  padding: 0 2px 0 2px;
+  border: 0;
+  vertical-align: 0;
+  line-height: 1.32;
+  cursor: pointer;
+  margin-right: -3px;
+}
+
+.group-select-all-runnable:hover {
+  cursor: pointer;
+}

--- a/ui/job-view/pushes/JobGroup.jsx
+++ b/ui/job-view/pushes/JobGroup.jsx
@@ -41,6 +41,11 @@ export class JobGroupComponent extends React.Component {
     this.state = {
       expanded: groupState === 'expanded' || pushGroupState === 'expanded',
     };
+
+    this.jobButtonRefs = {};
+    for (const job of this.props.group.jobs) {
+      this.jobButtonRefs[job.id] = React.createRef();
+    }
   }
 
   static getDerivedStateFromProps(nextProps, state) {
@@ -58,6 +63,14 @@ export class JobGroupComponent extends React.Component {
   toggleExpanded = () => {
     this.setState((prevState) => ({ expanded: !prevState.expanded }));
   };
+
+  toggleAll() {
+    const { toggleSelectedRunnableJob } = this.props;
+    for (const ref of Object.values(this.jobButtonRefs)) {
+      toggleSelectedRunnableJob(ref.current.props.job.signature);
+      ref.current.toggleRunnableSelected();
+    }
+  }
 
   groupButtonsAndCounts(jobs, expanded) {
     const { duplicateJobsVisible, groupCountsExpanded } = this.props;
@@ -125,6 +138,7 @@ export class JobGroupComponent extends React.Component {
         jobs: groupJobs,
         mapKey: groupMapKey,
       },
+      runnableVisible,
     } = this.props;
     const { expanded } = this.state;
     const { buttons, counts } = this.groupButtonsAndCounts(groupJobs, expanded);
@@ -137,6 +151,16 @@ export class JobGroupComponent extends React.Component {
             tier={groupTier}
             toggleExpanded={this.toggleExpanded}
           />
+          {runnableVisible && expanded && (
+            <button
+              className="btn group-select-all-runnable"
+              type="button"
+              title="Select or deselect all jobs in this group"
+              onClick={this.toggleAll.bind(this)}
+            >
+              [All]
+            </button>
+          )}
           <span className="group-content">
             <span className="group-job-list">
               {buttons.map((job) => (
@@ -149,6 +173,7 @@ export class JobGroupComponent extends React.Component {
                   repoName={repoName}
                   filterPlatformCb={filterPlatformCb}
                   key={job.id}
+                  ref={this.jobButtonRefs[job.id]}
                 />
               ))}
             </span>

--- a/ui/job-view/pushes/JobsAndGroups.jsx
+++ b/ui/job-view/pushes/JobsAndGroups.jsx
@@ -14,6 +14,8 @@ export default class JobsAndGroups extends React.Component {
       pushGroupState,
       duplicateJobsVisible,
       groupCountsExpanded,
+      runnableVisible,
+      toggleSelectedRunnableJob,
     } = this.props;
 
     return (
@@ -31,6 +33,8 @@ export default class JobsAndGroups extends React.Component {
                   pushGroupState={pushGroupState}
                   duplicateJobsVisible={duplicateJobsVisible}
                   groupCountsExpanded={groupCountsExpanded}
+                  runnableVisible={runnableVisible}
+                  toggleSelectedRunnableJob={toggleSelectedRunnableJob}
                 />
               )
             );

--- a/ui/job-view/pushes/Platform.jsx
+++ b/ui/job-view/pushes/Platform.jsx
@@ -86,6 +86,8 @@ export default class Platform extends React.PureComponent {
       pushGroupState,
       duplicateJobsVisible,
       groupCountsExpanded,
+      runnableVisible,
+      toggleSelectedRunnableJob,
     } = this.props;
     const { filteredPlatform } = this.state;
     const suffix =
@@ -107,6 +109,8 @@ export default class Platform extends React.PureComponent {
           pushGroupState={pushGroupState}
           duplicateJobsVisible={duplicateJobsVisible}
           groupCountsExpanded={groupCountsExpanded}
+          runnableVisible={runnableVisible}
+          toggleSelectedRunnableJob={toggleSelectedRunnableJob}
         />
       </tr>
     ) : (

--- a/ui/job-view/pushes/PushJobs.jsx
+++ b/ui/job-view/pushes/PushJobs.jsx
@@ -40,7 +40,7 @@ class PushJobs extends React.Component {
     const jobInstance = findInstance(ev.target);
     const selectedTaskRun = getUrlParam('selectedTaskRun');
 
-    if (jobInstance && jobInstance.props.job) {
+    if (jobInstance && jobInstance.props && jobInstance.props.job) {
       const { job } = jobInstance.props;
       if (ev.button === 1) {
         // Middle click

--- a/ui/job-view/pushes/PushJobs.jsx
+++ b/ui/job-view/pushes/PushJobs.jsx
@@ -105,6 +105,7 @@ class PushJobs extends React.Component {
       groupCountsExpanded,
       runnableVisible,
       platforms,
+      toggleSelectedRunnableJob,
     } = this.props;
 
     return (
@@ -123,6 +124,7 @@ class PushJobs extends React.Component {
                   duplicateJobsVisible={duplicateJobsVisible}
                   groupCountsExpanded={groupCountsExpanded}
                   runnableVisible={runnableVisible}
+                  toggleSelectedRunnableJob={toggleSelectedRunnableJob}
                 />
               ))
             ) : (


### PR DESCRIPTION
In "Add new jobs" mode, if a group is expanded,
Show "[All]" button is next to the group name, that flips selected state of all runnable jobs in the group