### PR TITLE
Bug 1253768 - bulk unclassification support including removal of association with bug

### DIFF
--- a/treeherder/webapp/api/classification.py
+++ b/treeherder/webapp/api/classification.py
@@ -1,0 +1,28 @@
+from rest_framework import mixins, viewsets
+
+from rest_framework.response import Response
+from rest_framework.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN, HTTP_404_NOT_FOUND
+
+from treeherder.model.models import BugJobMap, Job, JobNote
+
+
+class ClassificationViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
+    """
+    This viewset is responsible for the classification endpoint.
+    """
+
+    def delete(self, request, project, format=None):
+        """
+        Delete both the classification type and the bugs linked to the task
+        """
+        if not request.user:
+            return Response("Must be logged in", status=HTTP_401_UNAUTHORIZED)
+        if not request.user.is_staff:
+            return Response("Must be staff or in sheriffing group", status=HTTP_403_FORBIDDEN)
+        job_ids = [job['id'] for job in request.data]
+        if not job_ids:
+            return Response("Must provide job IDs", status=HTTP_404_NOT_FOUND)
+        Job.objects.filter(id__in=job_ids).update(failure_classification_id=1)
+        JobNote.objects.filter(job_id__in=job_ids).delete()
+        BugJobMap.objects.filter(job_id__in=job_ids).delete()
+        return Response({"message": "Notes and bug classifications deleted"})

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -7,6 +7,7 @@ from treeherder.webapp.api import (
     bug_creation,
     bugzilla,
     changelog,
+    classification,
     csp_report,
     infra_compare,
     intermittents_view,
@@ -56,6 +57,12 @@ project_bound_router.register(
     r'note',
     note.NoteViewSet,
     basename='note',
+)
+
+project_bound_router.register(
+    r'classification',
+    classification.ClassificationViewSet,
+    basename='classification',
 )
 
 project_bound_router.register(

--- a/ui/helpers/http.js
+++ b/ui/helpers/http.js
@@ -60,6 +60,14 @@ export const destroy = function deleteRecord(uri) {
   });
 };
 
+export const destroyMany = function deleteRecords(uri, data) {
+  return getData(uri, {
+    method: 'DELETE',
+    headers: generateHeaders(),
+    body: JSON.stringify(data),
+  });
+};
+
 export const processResponse = (response, state, errorMessages) => {
   const { data, failureStatus } = response;
   if (failureStatus) {

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -327,6 +327,7 @@ class DetailsPanel extends React.Component {
         <PinBoard
           currentRepo={currentRepo}
           isLoggedIn={user.isLoggedIn || false}
+          isStaff={user.isStaff || false}
           classificationTypes={classificationTypes}
           selectedJobFull={selectedJobFull}
         />

--- a/ui/models/classificationTypeAndBugs.js
+++ b/ui/models/classificationTypeAndBugs.js
@@ -1,0 +1,10 @@
+import { destroyMany } from '../helpers/http';
+import { getProjectUrl } from '../helpers/location';
+
+const uri = '/classification/';
+
+export default class JobClassificationTypeAndBugsModel {
+  static destroy(pinnedJobs) {
+    return destroyMany(`${getProjectUrl(uri)}`, pinnedJobs);
+  }
+}


### PR DESCRIPTION
* Removing the bug-job associations prevents wrong updates to bugs about the
  issue still being observed in CI or about its frequency.
* Deletion of the classification type instead of appending 'not classified'
  makes the data more robust for analysis.
* This feature is only enabled for employees and members of the 'sheriff' LDAP
  group to prevent broad undesired changes by random users.

The failure classification type ("intermittent", "infra", ...) is stored
independently from the bug used for classification (bug 1169720), hence no model
based view set gets used.