### PR TITLE
Update to 16.13.2 for latest security release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
   frontend:
     container_name: frontend
     # https://hub.docker.com/_/node
-    image: node:16.6.2-alpine
+    image: node:16.13.2-alpine
     environment:
       # Allows `.neutrinorc.js` to adjust filesystem watching and browser opening behaviour.
       - IN_DOCKER=1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ## Frontend stage
-FROM node:16.6.2 AS frontend
+FROM node:16.13.2 AS frontend
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "MPL-2.0",
   "engines": {
-    "node": "16",
+    "node": "16.13.2",
     "yarn": "1.22.5"
   },
   "dependencies": {


### PR DESCRIPTION
Per https://nodejs.org/en/blog/vulnerability/jan-2022-security-releases/

Will work on the node upgrade to v17 separately.