### PR TITLE
Update untriaged item text color from green to yellow

### DIFF
--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -207,7 +207,7 @@ export default class AlertTableRow extends React.Component {
       statusColor = 'text-danger';
     }
     if (alertStatus === 'untriaged') {
-      statusColor = 'text-success';
+      statusColor = 'text-warning';
     }
     if (
       alertStatus === 'invalid' ||


### PR DESCRIPTION
The `untriaged` label was displayed in green with a checkmark before it, which doesn't really convey
the state of the alert (someone might think the work is done here).
This patch updates the element so it uses yellow instead (from the `text-warning` class).

Bug was filed in bugzilla: for https://bugzilla.mozilla.org/show_bug.cgi?id=1741449