### PR TITLE
Bug 1748445 - remove unused attributes from text_log_errors API endpoint

### DIFF
--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -225,32 +225,12 @@ def test_text_log_errors(client, test_job):
             'job': 1,
             'line': 'failure 1',
             'line_number': 101,
-            'bug_suggestions': {
-                'search': 'failure 1',
-                'path_end': None,
-                'search_terms': ['failure 1'],
-                'bugs': {'open_recent': [], 'all_others': []},
-                'line_number': 101,
-            },
-            'metadata': None,
-            'matches': [],
-            'classified_failures': [],
         },
         {
             'id': 2,
             'job': 1,
             'line': 'failure 2',
             'line_number': 102,
-            'bug_suggestions': {
-                'search': 'failure 2',
-                'path_end': None,
-                'search_terms': ['failure 2'],
-                'bugs': {'open_recent': [], 'all_others': []},
-                'line_number': 102,
-            },
-            'metadata': None,
-            'matches': [],
-            'classified_failures': [],
         },
     ]
 

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -182,20 +182,7 @@ class FailureLineNoStackSerializer(serializers.ModelSerializer):
         return response
 
 
-class TextLogErrorMetadataSerializer(serializers.ModelSerializer):
-    failure_line = FailureLineNoStackSerializer(read_only=True)
-
-    class Meta:
-        model = models.TextLogErrorMetadata
-        fields = '__all__'
-
-
 class TextLogErrorSerializer(serializers.ModelSerializer):
-    matches = TextLogErrorMatchSerializer(many=True)
-    classified_failures = ClassifiedFailureSerializer(many=True)
-    bug_suggestions = NoOpSerializer(read_only=True)
-    metadata = TextLogErrorMetadataSerializer(read_only=True)
-
     class Meta:
         model = models.TextLogError
         exclude = ['step']

--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -5,16 +5,9 @@ import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 import { thBugSuggestionLimit, thEvents } from '../../../helpers/constants';
 import { getResultState, isReftest } from '../../../helpers/job';
-import {
-  getBugUrl,
-  getLogViewerUrl,
-  getReftestUrl,
-  textLogErrorsEndpoint,
-} from '../../../helpers/url';
+import { getBugUrl, getReftestUrl } from '../../../helpers/url';
 import BugFiler from '../../BugFiler';
 import BugSuggestionsModel from '../../../models/bugSuggestions';
-import { getData } from '../../../helpers/http';
-import { getProjectJobUrl } from '../../../helpers/location';
 
 import ErrorsList from './ErrorsList';
 import ListItem from './ListItem';
@@ -74,7 +67,7 @@ class FailureSummaryTab extends React.Component {
   };
 
   loadBugSuggestions = () => {
-    const { repoName, selectedJob } = this.props;
+    const { selectedJob } = this.props;
 
     if (!selectedJob) {
       return;
@@ -95,27 +88,6 @@ class FailureSummaryTab extends React.Component {
           // relevant all_others bugs, so don't show them either.
           !suggestion.bugs.too_many_open_recent;
       });
-
-      // if we have no bug suggestions, populate with the raw errors from
-      // the log (we can do this asynchronously, it should normally be
-      // fast)
-      if (!suggestions.length) {
-        const { data, failureStatus } = await getData(
-          getProjectJobUrl(textLogErrorsEndpoint, selectedJob.id),
-        );
-        if (!failureStatus && data.length) {
-          const errors = data.map((error) => ({
-            line: error.line,
-            line_number: error.line_number,
-            logViewerUrl: getLogViewerUrl(
-              selectedJob.id,
-              repoName,
-              error.line_number,
-            ),
-          }));
-          this.setState({ errors });
-        }
-      }
 
       this.setState({ bugSuggestionsLoading: false, suggestions }, () => {
         const scrollArea = document.querySelector(


### PR DESCRIPTION
This improves the response time for tasks with many failure lines locally by a
factor of 5. In production these requests often timed out because they were
too slow to get a response.