### PR TITLE
Bug 1753211 - switch yaml v4 call from `safeLoad` to `load` to fix Custom Actions

### DIFF
--- a/ui/job-view/CustomJobActions.jsx
+++ b/ui/job-view/CustomJobActions.jsx
@@ -131,7 +131,7 @@ class CustomJobActions extends React.PureComponent {
     let input = null;
     if (validate && payload) {
       try {
-        input = jsyaml.safeLoad(payload);
+        input = jsyaml.load(payload);
       } catch (e) {
         this.setState({ triggering: false });
         notify(`YAML Error: ${e.message}`, 'danger');


### PR DESCRIPTION
yaml v4 made the `load` function safe and dropped the `safeLoad` one. The update
to yaml v4 had landed in
https://github.com/mozilla/treeherder/commit/933d8dfb69b7156b19f486fe853e6efd868f8fb0