### PR TITLE
Taskcluster login fix on prototype and tc-staging

### DIFF
--- a/ui/taskcluster-auth-callback/constants.js
+++ b/ui/taskcluster-auth-callback/constants.js
@@ -3,10 +3,10 @@ import { tcAuthCallbackUrl } from '../helpers/url';
 export const tcClientIdMap = {
   'https://treeherder.mozilla.org': 'production',
   'https://treeherder.allizom.org': 'stage',
-  'https://prototype.treeherder.nonprod.cloudops.mozgcp.net/': 'dev',
+  'https://prototype.treeherder.nonprod.cloudops.mozgcp.net': 'dev',
   'http://localhost:5000': 'localhost-5000',
   'http://localhost:8000': 'localhost-8000',
-  'https://tc-staging.treeherder.nonprod.cloudops.mozgcp.net/':
+  'https://tc-staging.treeherder.nonprod.cloudops.mozgcp.net':
     'taskcluster-staging',
 };
 


### PR DESCRIPTION
* Remove forward slash in tcClientIdMap const

I discovered this while trying to test out something unrelated and it breaks the login callback.