### PR TITLE
Bug 1756488 - trigger update of react state for bug filer after log content got copied into it with button

### DIFF
--- a/ui/logviewer/App.jsx
+++ b/ui/logviewer/App.jsx
@@ -225,6 +225,10 @@ class App extends React.PureComponent {
       descriptionField.value.substring(endPos, descriptionField.value.length);
     descriptionField.selectionStart = startPos + selectedLogText.length;
     descriptionField.selectionEnd = startPos + selectedLogText.length;
+
+    const event = document.createEvent('HTMLEvents');
+    event.initEvent('change', true, true);
+    descriptionField.dispatchEvent(event);
   };
 
   collapseJobDetails = () => {


### PR DESCRIPTION


The button to transfer selected text from the log viewer into the bug filer in a
different tab got added in bug bug 1745936 but didn't trigger React's `onChange`
event.