### PR TITLE
Ignore focus-android pushes on non-main branches

### DIFF
--- a/treeherder/etl/taskcluster_pulse/handler.py
+++ b/treeherder/etl/taskcluster_pulse/handler.py
@@ -106,7 +106,13 @@ def ignore_task(task, taskId, rootUrl, project):
         logger.debug("Ignoring tasks not matching PROJECTS_TO_INGEST (Task id: %s)", taskId)
         return True
 
-    mobile_repos = ('android-components', 'fenix', 'reference-browser', 'mozilla-vpn-client')
+    mobile_repos = (
+        'android-components',
+        'fenix',
+        'focus-android',
+        'reference-browser',
+        'mozilla-vpn-client',
+    )
     if project in mobile_repos:
         envs = task["payload"].get("env", {})
         if envs.get("MOBILE_BASE_REPOSITORY"):


### PR DESCRIPTION
Add focus-android to the list of mobile repos where we ignore non-{main,master} pushes.