### PR TITLE
Bug 17456842 - Use same host for opening new bugs like the one on which they got created

### DIFF
--- a/tests/webapp/api/test_bugzilla.py
+++ b/tests/webapp/api/test_bugzilla.py
@@ -54,7 +54,8 @@ def test_create_bug(client, eleven_jobs_stored, activate_responses, test_user):
         },
     )
     assert resp.status_code == 200
-    assert resp.json()['success'] == 323
+    assert resp.json()['id'] == 323
+    assert resp.json()['url'] == 'https://thisisnotbugzilla.org/show_bug.cgi?id=323'
 
 
 def test_create_bug_with_unicode(client, eleven_jobs_stored, activate_responses, test_user):
@@ -107,7 +108,7 @@ def test_create_bug_with_unicode(client, eleven_jobs_stored, activate_responses,
         },
     )
     assert resp.status_code == 200
-    assert resp.json()['success'] == 323
+    assert resp.json()['id'] == 323
 
 
 def test_create_crash_bug(client, eleven_jobs_stored, activate_responses, test_user):
@@ -162,7 +163,7 @@ def test_create_crash_bug(client, eleven_jobs_stored, activate_responses, test_u
         },
     )
     assert resp.status_code == 200
-    assert resp.json()['success'] == 323
+    assert resp.json()['id'] == 323
 
 
 def test_create_unauthenticated_bug(client, eleven_jobs_stored, activate_responses):

--- a/treeherder/utils/bugzilla.py
+++ b/treeherder/utils/bugzilla.py
@@ -1,0 +1,2 @@
+def get_bug_url(id, host="https://bugzilla.mozilla.org"):
+    return f"{host}/show_bug.cgi?id={id}"

--- a/treeherder/webapp/api/bugzilla.py
+++ b/treeherder/webapp/api/bugzilla.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from rest_framework.status import HTTP_400_BAD_REQUEST
 
 from treeherder.model.models import BugzillaSecurityGroup
+from treeherder.utils.bugzilla import get_bug_url
 from treeherder.utils.http import make_request
 
 
@@ -76,4 +77,5 @@ class BugzillaViewSet(viewsets.ViewSet):
                 message = e.response.text
             return Response({"failure": message}, status=HTTP_400_BAD_REQUEST)
 
-        return Response({"success": response.json()["id"]})
+        bug_id = response.json()["id"]
+        return Response({"id": bug_id, "url": get_bug_url(bug_id, settings.BUGFILER_API_URL)})

--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -5,7 +5,7 @@ import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 import { thBugSuggestionLimit, thEvents } from '../../../helpers/constants';
 import { getResultState, isReftest } from '../../../helpers/job';
-import { getBugUrl, getReftestUrl } from '../../../helpers/url';
+import { getReftestUrl } from '../../../helpers/url';
 import BugFiler from '../../BugFiler';
 import BugSuggestionsModel from '../../../models/bugSuggestions';
 
@@ -63,7 +63,7 @@ class FailureSummaryTab extends React.Component {
     addBug({ id: data.success });
     window.dispatchEvent(new CustomEvent(thEvents.saveClassification));
     // Open the newly filed bug in a new tab or window for further editing
-    window.open(getBugUrl(data.success));
+    window.open(data.url);
   };
 
   loadBugSuggestions = () => {


### PR DESCRIPTION
The bug page opened after a bug got created with treeherder's bugfiler should
use the host specified by the BUGZILLA_API_URL environment variable. Until now,
the bug got created on httpst://bugzilla-dev.allizom.org but an unrelated bug
with same id on https://bugzilla.mozilla.org/ got opened on success.