### PR TITLE
Bug 1758089 - use `data.id` instead of `data.success` for classification with created bug

### DIFF
--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -60,7 +60,7 @@ class FailureSummaryTab extends React.Component {
   bugFilerCallback = (data) => {
     const { addBug } = this.props;
 
-    addBug({ id: data.success });
+    addBug({ id: data.id });
     window.dispatchEvent(new CustomEvent(thEvents.saveClassification));
     // Open the newly filed bug in a new tab or window for further editing
     window.open(data.url);


### PR DESCRIPTION
Necessary change which hadn't been included in bug 1756842.