### PR TITLE
Bug 1755460 - Exclude the results where should_alert is False

### DIFF
--- a/tests/webapp/api/test_performance_data_api.py
+++ b/tests/webapp/api/test_performance_data_api.py
@@ -362,6 +362,8 @@ def test_filter_signatures_by_field_should_alert(
     # set signature field should_alert to True
     test_perf_signature.should_alert = True
     test_perf_signature.save()
+    test_perf_signature_2.should_alert = False
+    test_perf_signature_2.save()
 
     resp = client.get(
         reverse(
@@ -386,6 +388,9 @@ def test_filter_data_by_should_alert(
     test_perf_signature.save()
 
     signature2 = test_perf_signature_same_hash_different_framework
+    signature2.should_alert = False
+    signature2.save()
+
     push = Push.objects.get(id=1)
     for signature in [test_perf_signature, signature2]:
         PerformanceDatum.objects.create(

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -107,7 +107,7 @@ class PerformanceSignatureViewSet(viewsets.ViewSet):
             signature_data = signature_data.filter(platform__in=platforms)
 
         if int(request.query_params.get('should_alert', False)):
-            signature_data = signature_data.filter(should_alert=True)
+            signature_data = signature_data.exclude(should_alert=False)
 
         signature_map = {}
         for (
@@ -282,7 +282,7 @@ class PerformanceDatumViewSet(viewsets.ViewSet):
             datums = datums.filter(push_timestamp__lt=end_date)
 
         if should_alert:
-            datums = datums.filter(signature__should_alert=True)
+            datums = datums.exclude(signature__should_alert=False)
 
         ret, seen_push_ids = defaultdict(list), defaultdict(set)
         values_list = datums.values_list(


### PR DESCRIPTION
Fix for the case where the [performance tab for AWSY tests is missing](https://treeherder.mozilla.org/jobs?repo=autoland&searchStr=Linux%2C18.04%2Cx64%2CWebRender%2CShippable%2Copt%2CAre%2Cwe%2Cslim%2Cyet%2Ctests%2Cby%2CTaskCluster%2C%2Cfission%2Cenabled%2Ctest-linux1804-64-shippable-qr%2Fopt-awsy-base-fis-e10s%2Cab&revision=7c9a7ccd7e0742a1b4994cb60b4c35394e1a2ec5&selectedTaskRun=cA7Neo9LQLe_Tahb4TWz7A.0) due to the fact that results being filtered after `should_alert = True`. An empty value for the field `should_alert` in `PerformanceSignature` table is stored as `null` and results with the `null` value will be excluded without this change. 