### PR TITLE
Bug 1756406 - show loading indicator while bug suggestions load

### DIFF
--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -72,6 +72,7 @@ class FailureSummaryTab extends React.Component {
     if (!selectedJob) {
       return;
     }
+    this.setState({ bugSuggestionsLoading: true });
     BugSuggestionsModel.get(selectedJob.id).then(async (suggestions) => {
       suggestions.forEach((suggestion) => {
         let simpleCase = [];


### PR DESCRIPTION
`bugSuggestionsLoading` was never set to `true`. If other requests for the selected task finished loading before the bug suggestions one, the suggestions for the previously selected task were shown.