### PR TITLE
Upgrade Celery to v5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
       context: .
       dockerfile: docker/dev.Dockerfile
     environment:
-      - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672//
+      - BROKER_URL=amqp://guest:guest@rabbitmq:5672//
       - DATABASE_URL=mysql://root@mysql:3306/treeherder
       - PROJECTS_TO_INGEST=${PROJECTS_TO_INGEST:-autoland,try}
     entrypoint: './docker/entrypoint.sh'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
       - DATABASE_URL=mysql://root@mysql:3306/treeherder
       - PROJECTS_TO_INGEST=${PROJECTS_TO_INGEST:-autoland,try}
     entrypoint: './docker/entrypoint.sh'
-    command: celery -A treeherder worker --uid=nobody --gid=nogroup --without-gossip --without-mingle --without-heartbeat -Q store_pulse_pushes,store_pulse_tasks,store_pulse_tasks_classification --concurrency=1 --loglevel=WARNING
+    command: celery -A treeherder worker --uid=nobody --gid=nogroup --without-gossip --without-mingle --without-heartbeat -Q store_pulse_pushes,store_pulse_tasks,store_pulse_tasks_classification --concurrency=1 --loglevel=INFO
     volumes:
       - .:/app
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
       - DATABASE_URL=mysql://root@mysql:3306/treeherder
       - PROJECTS_TO_INGEST=${PROJECTS_TO_INGEST:-autoland,try}
     entrypoint: './docker/entrypoint.sh'
-    command: celery worker -A treeherder --uid=nobody --gid=nogroup --without-gossip --without-mingle --without-heartbeat -Q store_pulse_pushes,store_pulse_tasks,store_pulse_tasks_classification --concurrency=1 --loglevel=WARNING
+    command: celery -A treeherder worker --uid=nobody --gid=nogroup --without-gossip --without-mingle --without-heartbeat -Q store_pulse_pushes,store_pulse_tasks,store_pulse_tasks_classification --concurrency=1 --loglevel=WARNING
     volumes:
       - .:/app
     depends_on:

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -28,3 +28,8 @@ WORKDIR /app
 # Common and dev deps installed separately to prove that common.txt works standalone
 RUN pip install --no-cache-dir --disable-pip-version-check --require-hashes -r requirements/common.txt
 RUN pip install --no-cache-dir --disable-pip-version-check --require-hashes -r requirements/dev.txt
+
+# Setup home so it's readable by nobody
+# mozci will try to read a configuration file there
+ENV HOME /home
+RUN mkdir -p $HOME && chown nobody:nogroup $HOME

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,7 +9,7 @@ function check_service () {
   name=$1
   host=$2
   port=$3
-  while ! nc -z $host $port &> /dev/null; do
+  while ! nc -z "$host" "$port" &> /dev/null; do
       echo "-----> Waiting for $name server to be ready"
       sleep 1;
   done

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,18 +1,25 @@
 #!/usr/bin/env bash
 # This file is the entrypoint for the backend container.
-# It takes care of making sure to wait for the mysql container to be ready
+# It takes care of making sure to wait for the mysql and rabbitmq containers to be ready
 
 # Make non-zero exit codes & other errors fatal.
 set -euo pipefail
 
-# Keep these in sync with DATABASE_URL.
-DATABASE_HOST='mysql'
-DATABASE_PORT='3306'
+function check_service () {
+  name=$1
+  host=$2
+  port=$3
+  while ! nc -z $host $port &> /dev/null; do
+      echo "-----> Waiting for $name server to be ready"
+      sleep 1;
+  done
+  echo "-----> $name service is available"
+}
 
-while ! nc -z "${DATABASE_HOST}" "${DATABASE_PORT}" &> /dev/null; do
-    echo '-----> Waiting for MySQL server to be ready'
-    sleep 1;
-done
-echo '-----> MySQL service is available'
+# Keep these in sync with DATABASE_URL.
+check_service "MySQL" "mysql" 3306
+
+# Keep these in sync with CELERY_BROKER_URL.
+check_service "RabbitMQ" "rabbitmq" 5672
 
 exec "$@"

--- a/docker/entrypoint_prod.sh
+++ b/docker/entrypoint_prod.sh
@@ -34,29 +34,29 @@ elif [ "$1" == "pulse_listener_tasks_classification" ]; then
 # Processes pushes/jobs from Pulse that were collected by `pulse_listener_{pushes,tasks,tasks_classification}`.
 elif [ "$1" == "worker_store_pulse_data" ]; then
     export REMAP_SIGTERM=SIGQUIT
-    exec newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q store_pulse_pushes,store_pulse_tasks,store_pulse_tasks_classification --concurrency=3
+    exec newrelic-admin run-program celery -A treeherder worker --without-gossip --without-mingle --without-heartbeat -Q store_pulse_pushes,store_pulse_tasks,store_pulse_tasks_classification --concurrency=3
 
 # Handles the log parsing tasks scheduled by `worker_store_pulse_data` as part of job ingestion.
 elif [ "$1" == "worker_log_parser" ]; then
     export REMAP_SIGTERM=SIGQUIT
-    exec newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_parser --concurrency=7
+    exec newrelic-admin run-program celery -A treeherder worker --without-gossip --without-mingle --without-heartbeat -Q log_parser --concurrency=7
 elif [ "$1" == "worker_log_parser_fail_raw_sheriffed" ]; then
     export REMAP_SIGTERM=SIGQUIT
-    exec newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_parser_fail_raw_sheriffed --concurrency=1
+    exec newrelic-admin run-program celery -A treeherder worker --without-gossip --without-mingle --without-heartbeat -Q log_parser_fail_raw_sheriffed --concurrency=1
 elif [ "$1" == "worker_log_parser_fail_raw_unsheriffed" ]; then
     export REMAP_SIGTERM=SIGQUIT
-    exec newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_parser_fail_raw_unsheriffed --concurrency=1
+    exec newrelic-admin run-program celery -A treeherder worker --without-gossip --without-mingle --without-heartbeat -Q log_parser_fail_raw_unsheriffed --concurrency=1
 elif [ "$1" == "worker_log_parser_fail_json_sheriffed" ]; then
     export REMAP_SIGTERM=SIGQUIT
-    exec newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_parser_fail_json_sheriffed --concurrency=7
+    exec newrelic-admin run-program celery -A treeherder worker --without-gossip --without-mingle --without-heartbeat -Q log_parser_fail_json_sheriffed --concurrency=7
 elif [ "$1" == "worker_log_parser_fail_json_unsheriffed" ]; then
     export REMAP_SIGTERM=SIGQUIT
-    newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q log_parser_fail_json_unsheriffed --concurrency=7
+    newrelic-admin run-program celery -A treeherder worker --without-gossip --without-mingle --without-heartbeat -Q log_parser_fail_json_unsheriffed --concurrency=7
 
 # Tasks that don't need a dedicated worker.
 elif [ "$1" == "worker_misc" ]; then
     export REMAP_SIGTERM=SIGQUIT
-    exec newrelic-admin run-program celery worker -A treeherder --without-gossip --without-mingle --without-heartbeat -Q default,generate_perf_alerts,pushlog --concurrency=3
+    exec newrelic-admin run-program celery -A treeherder worker --without-gossip --without-mingle --without-heartbeat -Q default,generate_perf_alerts,pushlog --concurrency=3
 
 # Cron jobs
 elif [ "$1" == "run_intermittents_commenter" ]; then

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -3,6 +3,7 @@ gunicorn==20.0.4
 whitenoise[brotli]  # Used by Whitenoise to provide Brotli-compressed versions of static files.
 Django==3.2.13
 celery==5.2.6  # celery needed for data ingestion
+cached-property==1.5.2 # needed for kombu with --require-hashes
 simplejson  # import simplejson
 newrelic==5.22.1.152
 

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -2,7 +2,7 @@
 gunicorn==20.0.4
 whitenoise[brotli]  # Used by Whitenoise to provide Brotli-compressed versions of static files.
 Django==3.2.13
-celery==4.4.2  # 4.4.2 required to pass test_retryable_task_throws_retry, celery needed for data ingestion
+celery==5.2.6  # celery needed for data ingestion
 simplejson  # import simplejson
 newrelic==5.22.1.152
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -43,9 +43,9 @@ aiohttp==3.7.4.post0 \
     --hash=sha256:f881853d2643a29e643609da57b96d5f9c9b93f62429dcc1cbb413c7d07f0e1a \
     --hash=sha256:fe60131d21b31fd1a14bd43e6bb88256f69dfc3188b3a89d736d6c71ed43ec95
     # via taskcluster
-amqp==2.6.1 \
-    --hash=sha256:70cdb10628468ff14e57ec2f751c7aa9e48e7e3651cfd62d431213c0c4e58f21 \
-    --hash=sha256:aa7f313fb887c91f15474c1229907a04dac0b8135822d6603437803424c0aa59
+amqp==5.1.1 \
+    --hash=sha256:2c1b13fecc0893e946c65cbd5f36427861cffa4ea2201d8f6fca22e2a373b5e2 \
+    --hash=sha256:6f0956d2c23d8fa6e7691934d8c3930eadb44972cbbd1a7ae3a520f735d43359
     # via kombu
 appdirs==1.4.4 \
     --hash=sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41 \
@@ -67,9 +67,9 @@ attrs==20.3.0 \
     # via
     #   aiohttp
     #   jsonschema
-billiard==3.6.3.0 \
-    --hash=sha256:bff575450859a6e0fbc2f9877d9b715b0bbc07c3565bb7ed2280526a0cdf5ede \
-    --hash=sha256:d91725ce6425f33a97dfa72fb6bfef0e47d4652acd98a032bd1a7fbf06d5fa6a
+billiard==3.6.4.0 \
+    --hash=sha256:299de5a8da28a783d51b197d496bef4f1595dd023a93a4f59dde1886ae905547 \
+    --hash=sha256:87103ea78fa6ab4d5c751c4909bcff74617d985de7fa8b672cf8618afd5a875b
     # via celery
 blessings==1.7 \
     --hash=sha256:98e5854d805f50a5b58ac2333411b0482516a8210f23f43308baeb58d77c157d \
@@ -154,9 +154,9 @@ cachy==0.3.0 \
     --hash=sha256:186581f4ceb42a0bbe040c407da73c14092379b1e4c0e327fdb72ae4a9b269b1 \
     --hash=sha256:338ca09c8860e76b275aff52374330efedc4d5a5e45dc1c5b539c1ead0786fe7
     # via mozci
-celery==4.4.2 \
-    --hash=sha256:108a0bf9018a871620936c33a3ee9f6336a89f8ef0a0f567a9001f4aa361415f \
-    --hash=sha256:5b4b37e276033fe47575107a2775469f0b721646a08c96ec2c61531e4fe45f2a
+celery==5.2.6 \
+    --hash=sha256:d1398cadf30f576266b34370e28e880306ec55f7a4b6307549b0ae9c15663481 \
+    --hash=sha256:da31f8eae7607b1582e5ee2d3f2d6f58450585afd23379491e3d9229d08102d0
     # via -r requirements/common.in
 certifi==2020.12.5 \
     --hash=sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c \
@@ -168,6 +168,26 @@ chardet==4.0.0 \
     # via
     #   aiohttp
     #   requests
+click==8.1.3 \
+    --hash=sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e \
+    --hash=sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+click-didyoumean==0.3.0 \
+    --hash=sha256:a0713dc7a1de3f06bc0df5a9567ad19ead2d3d5689b434768a6145bff77c0667 \
+    --hash=sha256:f184f0d851d96b6d29297354ed981b7dd71df7ff500d82fa6d11f0856bee8035
+    # via celery
+click-plugins==1.1.1 \
+    --hash=sha256:46ab999744a9d831159c3411bb0c79346d94a444df9a3a3742e9ed63645f264b \
+    --hash=sha256:5d262006d3222f5057fd81e1623d4443e41dcda5dc815c06b442aa3c02889fc8
+    # via celery
+click-repl==0.2.0 \
+    --hash=sha256:94b3fbbc9406a236f176e0506524b2937e4b23b6f4c0c0b2a0a83f8a64e9194b \
+    --hash=sha256:cd12f68d745bf6151210790540b4cb064c7b13e571bc64b6957d98d120dacfd8
+    # via celery
 coreapi==2.3.3 \
     --hash=sha256:46145fcc1f7017c076a2ef684969b641d18a2991051fddec9458ad3f78ffc1cb \
     --hash=sha256:bf39d118d6d3e171f10df9ede5666f63ad80bba9a29a8ec17726a66cf52ee6f3
@@ -264,9 +284,9 @@ jsonschema==3.2.0 \
     --hash=sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163 \
     --hash=sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a
     # via -r requirements/common.in
-kombu==4.6.11 \
-    --hash=sha256:be48cdffb54a2194d93ad6533d73f69408486483d189fe9f5990ee24255b0e0a \
-    --hash=sha256:ca1b45faac8c0b18493d02a8571792f3c40291cf2bcf1f55afed3d8f3aa7ba74
+kombu==5.2.4 \
+    --hash=sha256:37cee3ee725f94ea8bb173eaab7c1760203ea53bbebae226328600f9d2799610 \
+    --hash=sha256:8b213b24293d3417bcf0d2f5537b7f756079e3ea232a8386dcc89a59fd2361a4
     # via celery
 loguru==0.5.3 \
     --hash=sha256:b28e72ac7a98be3d28ad28570299a393dfcd32e5e3f6a353dec94675767b6319 \
@@ -450,6 +470,10 @@ orderedmultidict==1.0.1 \
     --hash=sha256:04070bbb5e87291cc9bfa51df413677faf2141c73c61d2a5f7b26bea3cd882ad \
     --hash=sha256:43c839a17ee3cdd62234c47deca1a8508a3f2ca1d0678a3bf791c87cf84adbf3
     # via furl
+prompt-toolkit==3.0.29 \
+    --hash=sha256:62291dad495e665fca0bda814e342c69952086afb0f4094d0893d357e5c78752 \
+    --hash=sha256:bd640f60e8cecd74f0dc249713d433ace2ddc62b65ee07f96d358e0b152b6ea7
+    # via click-repl
 pyasn1==0.4.8 \
     --hash=sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d \
     --hash=sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba
@@ -512,9 +536,9 @@ python-jose[pycryptodome]==3.2.0 \
 python3-memcached==1.51 \
     --hash=sha256:7cbe5951d68eef69d948b7a7ed7decfbd101e15e7f5be007dcd1219ccc584859
     # via mozci
-pytz==2021.1 \
-    --hash=sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da \
-    --hash=sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798
+pytz==2022.1 \
+    --hash=sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7 \
+    --hash=sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c
     # via
     #   celery
     #   django
@@ -645,6 +669,7 @@ six==1.15.0 \
     --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
     # via
     #   blessings
+    #   click-repl
     #   ecdsa
     #   furl
     #   jsonschema
@@ -722,16 +747,21 @@ urllib3==1.26.5 \
     # via
     #   botocore
     #   requests
-vine==1.3.0 \
-    --hash=sha256:133ee6d7a9016f177ddeaf191c1f58421a1dcc6ee9a42c58b34bed40e1d2cd87 \
-    --hash=sha256:ea4947cc56d1fd6f2095c8d543ee25dad966f78692528e68b4fada11ba3f98af
+vine==5.0.0 \
+    --hash=sha256:4c9dceab6f76ed92105027c49c823800dd33cacce13bdedc5b914e3514b7fb30 \
+    --hash=sha256:7d3b1624a953da82ef63462013bbd271d3eb75751489f9807598e8f340bd637e
     # via
     #   amqp
     #   celery
+    #   kombu
 voluptuous==0.12.1 \
     --hash=sha256:663572419281ddfaf4b4197fd4942d181630120fb39b333e3adad70aeb56444b \
     --hash=sha256:8ace33fcf9e6b1f59406bfaf6b8ec7bcc44266a9f29080b4deb4fe6ff2492386
     # via mozci
+wcwidth==0.2.5 \
+    --hash=sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784 \
+    --hash=sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83
+    # via prompt-toolkit
 whitenoise[brotli]==5.2.0 \
     --hash=sha256:05ce0be39ad85740a78750c86a93485c40f08ad8c62a6006de0233765996e5c7 \
     --hash=sha256:05d00198c777028d72d8b0bbd234db605ef6d60e9410125124002518a48e515d

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -150,6 +150,10 @@ brotli==1.0.9 \
     --hash=sha256:ec1947eabbaf8e0531e8e899fc1d9876c179fc518989461f5d24e2223395a9e3 \
     --hash=sha256:f909bbbc433048b499cb9db9e713b5d8d949e8c109a2a548502fb9aa8630f0b1
     # via whitenoise
+cached-property==1.5.2 \
+    --hash=sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130 \
+    --hash=sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0
+    # via -r requirements/common.in
 cachy==0.3.0 \
     --hash=sha256:186581f4ceb42a0bbe040c407da73c14092379b1e4c0e327fdb72ae4a9b269b1 \
     --hash=sha256:338ca09c8860e76b275aff52374330efedc4d5a5e45dc1c5b539c1ead0786fe7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,10 +276,10 @@ def test_job_2(eleven_job_blobs, create_jobs):
 
 @pytest.fixture
 def mock_log_parser(monkeypatch):
-    from celery import task
+    from celery import shared_task
     from treeherder.log_parser import tasks
 
-    @task
+    @shared_task
     def task_mock(*args, **kwargs):
         pass
 

--- a/treeherder/etl/tasks/pushlog_tasks.py
+++ b/treeherder/etl/tasks/pushlog_tasks.py
@@ -1,11 +1,11 @@
 import newrelic.agent
-from celery import task
+from celery import shared_task
 
 from treeherder.etl.pushlog import HgPushlogProcess
 from treeherder.model.models import Repository
 
 
-@task(name='fetch-push-logs')
+@shared_task(name='fetch-push-logs')
 def fetch_push_logs():
     """
     Run several fetch_hg_push_log subtasks, one per repository
@@ -14,7 +14,7 @@ def fetch_push_logs():
         fetch_hg_push_log.apply_async(args=(repo.name, repo.url), queue='pushlog')
 
 
-@task(name='fetch-hg-push-logs', soft_time_limit=10 * 60)
+@shared_task(name='fetch-hg-push-logs', soft_time_limit=10 * 60)
 def fetch_hg_push_log(repo_name, repo_url):
     """
     Run a HgPushlog etl process

--- a/treeherder/workers/task.py
+++ b/treeherder/workers/task.py
@@ -62,7 +62,7 @@ class retryable_task:
                 # thundering herd type problems. Constant factor chosen so we get
                 # reasonable pause between the fastest retries.
                 timeout = 10 * int(random.uniform(1.9, 2.1) ** number_of_prior_retries)
-                raise task_func.retry(exc=e, countdown=timeout)
+                raise task_func.retry(exc=e, countdown=timeout, throw=False)
 
         task_func = shared_task(*self.task_args, **self.task_kwargs)(inner)
         return task_func

--- a/treeherder/workers/task.py
+++ b/treeherder/workers/task.py
@@ -4,7 +4,7 @@ from functools import wraps
 
 import jsonschema
 import newrelic.agent
-from celery import task
+from celery import shared_task
 from django.db.utils import IntegrityError, ProgrammingError
 
 from treeherder.etl.exceptions import MissingPushException
@@ -64,5 +64,5 @@ class retryable_task:
                 timeout = 10 * int(random.uniform(1.9, 2.1) ** number_of_prior_retries)
                 raise task_func.retry(exc=e, countdown=timeout)
 
-        task_func = task(*self.task_args, **self.task_kwargs)(inner)
+        task_func = shared_task(*self.task_args, **self.task_kwargs)(inner)
         return task_func


### PR DESCRIPTION
- As mentionned in [release notes](https://docs.celeryq.dev/en/stable/history/whatsnew-5.0.html#step-1-adjust-your-command-line-invocation), the global CLI parameters (app name) must be placed before the subcommand
- Requirements update for celery 5.2.6 (current stable on pypi)
- `from celery import task` must be replaced by `from celery import shared_task`
- an environment variable for celery was misnamed
- added a check in dev entrypoint to wait for rabbitmq to be up (as we already wait for mysql to be up)
   - this removes error messages present on `master` too
- configured the `$HOME` env variable to a folder writable by `nobody:nogroup`
   - this prevents a crash from `mozci` imports that tries to read a configuration file
- setup the configuration level in dev docker-compose to `INFO` to get a bit more logging

The system is now usable in dev, nest step is to fix the failing unit test with retyable tasks