### PR TITLE
Bug 1772135 - Restore support for BACKEND environment variable

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -102,7 +102,8 @@ const developmentConfig = {
         headers: {
           referer: 'https://treeherder.mozilla.org/webpack-dev-server',
         },
-        target: 'https://treeherder.mozilla.org',
+        // Support BACKEND environment variable provided by npm run scripts
+        target: process.env.BACKEND || 'https://treeherder.mozilla.org',
         onProxyRes: (proxyRes) => {
           // Strip the cookie `secure` attribute, otherwise production's cookies
           // will be rejected by the browser when using non-HTTPS localhost:


### PR DESCRIPTION
The support for the `BACKEND` environment variable was dropped in the neutrino removal: the `treeherder.mozilla.org` was generated by `neutrino inspect` and finally hardcoded.

This will restore the view of the local backend by default when running `docker-compose up --build`