### PR TITLE
Configure webpack dev server on all interfaces

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,11 +86,11 @@ const developmentConfig = {
   devtool: 'cheap-module-eval-source-map',
 
   devServer: {
-    host: 'local-ip',
+    host: '0.0.0.0',
     port: 5000,
     hot: true,
     historyApiFallback: true,
-    open: false,
+    open: true,
     proxy: {
       '/api': {
         changeOrigin: true,


### PR DESCRIPTION
I also set the `open` configuration to open Firefox immediately on the right page.