### PR TITLE
Bug 1343328 - [DO NOT MERGE] PerfDatum bigint PK migration using pt-osc

### DIFF
--- a/treeherder/perf/migrations/0043_drop_multicommitdatum.py
+++ b/treeherder/perf/migrations/0043_drop_multicommitdatum.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
     """This migration drops the perf_multicommitdatum table in order to perform
     performance_datum PK migration from INT(11) to BIGINT(20) using an external
     tool, percona toolkit's online schema change (pt-osc).
-    Any access to MultiCommitDatum may create errors before migration perf.0044 passed.
+    Any access to MultiCommitDatum may create errors until migration perf.0046 has been applied.
     """
 
     dependencies = [

--- a/treeherder/perf/migrations/0043_drop_multicommitdatum.py
+++ b/treeherder/perf/migrations/0043_drop_multicommitdatum.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+
+def check_no_multicommitdatum(apps, schema_editor):
+    MultiCommitDatum = apps.get_model('perf', 'MultiCommitDatum')
+    assert (
+        not MultiCommitDatum.objects.exists()
+    ), "MultiCommitDatum table must be empty to migrate PerformanceDatum PK"
+
+
+class Migration(migrations.Migration):
+    """This migration drops the perf_multicommitdatum table in order to perform
+    performance_datum PK migration from INT(11) to BIGINT(20) using an external
+    tool, percona toolkit's online schema change (pt-osc).
+    Any access to MultiCommitDatum may create errors before migration perf.0044 passed.
+    """
+
+    dependencies = [
+        ('perf', '0042_backfillrecord_new_fields'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            check_no_multicommitdatum,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.DeleteModel(
+            name='MultiCommitDatum',
+        ),
+    ]

--- a/treeherder/perf/migrations/0044_perfdatum_bigint_fk.py
+++ b/treeherder/perf/migrations/0044_perfdatum_bigint_fk.py
@@ -1,4 +1,4 @@
-"""This migration automatically update performance_datum.id column to Bigint(20).
+"""This migration automatically updates performance_datum.id column to Bigint(20).
 On large tables or production environment, it is recommanded to use an external tool (e.g. pt-osc)
 to update the column and fake this migration. Migration perf.0045 will restore a valid django's schema.
 """

--- a/treeherder/perf/migrations/0044_perfdatum_bigint_fk.py
+++ b/treeherder/perf/migrations/0044_perfdatum_bigint_fk.py
@@ -16,7 +16,7 @@ def check_perfdatum_pk(apps, schema_editor):
         )
         column_type = cursor.fetchone()
 
-        if column_type == ("int(11)",) and not PerformanceDatum.objects.exist():
+        if column_type == ("int(11)",) and not PerformanceDatum.objects.exists():
             # Directly alter the PK column in case the migration runs on an empty table
             # This is useful for scenarios running initial migration like tests
             cursor.execute(

--- a/treeherder/perf/migrations/0044_perfdatum_bigint_fk.py
+++ b/treeherder/perf/migrations/0044_perfdatum_bigint_fk.py
@@ -1,0 +1,64 @@
+from django.db import migrations, models, connection
+import django.db.models.deletion
+
+
+def check_perfdatum_pk(apps, schema_editor):
+    """Ensure performance_datum FK has been updated to bigint type"""
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT COLUMN_TYPE from INFORMATION_SCHEMA.COLUMNS WHERE "
+            "table_schema = 'treeherder' and "
+            "table_name = 'performance_datum' "
+            "and COLUMN_NAME = 'id'"
+        )
+        (column_type,) = cursor.fetchone()
+        assert (
+            column_type == "bigint(20)"
+        ), f"PerformanceDatum PK column type is {column_type} but should be bigint(20)"
+
+
+class Migration(migrations.Migration):
+    """This migration updates the django_migrations table and restore perf_multicommitdatum FK
+    toward the performance_datum table, after its PK has manually been updated to bigint.
+    """
+
+    dependencies = [
+        ('perf', '0043_drop_multicommitdatum'),
+    ]
+
+    operations = [
+        # Ensure the PK has been updated
+        migrations.RunPython(
+            check_perfdatum_pk,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        # Empty SQL migration that update django state schema
+        migrations.RunSQL(
+            migrations.RunSQL.noop,
+            reverse_sql=migrations.RunSQL.noop,
+            state_operations=[
+                migrations.AlterField(
+                    model_name='performancedatum',
+                    name='id',
+                    field=models.BigAutoField(primary_key=True, serialize=False),
+                ),
+            ],
+        ),
+        # Restore MultiCommitDatum FK to PerformanceDatum
+        migrations.CreateModel(
+            name='MultiCommitDatum',
+            fields=[
+                (
+                    'perf_datum',
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        primary_key=True,
+                        related_name='multi_commit_datum',
+                        serialize=False,
+                        to='perf.performancedatum',
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/treeherder/perf/migrations/0044_perfdatum_bigint_fk.py
+++ b/treeherder/perf/migrations/0044_perfdatum_bigint_fk.py
@@ -10,20 +10,20 @@ def check_perfdatum_pk(apps, schema_editor):
         PerformanceDatum = apps.get_model('perf', 'PerformanceDatum')
         cursor.execute(
             "SELECT COLUMN_TYPE from INFORMATION_SCHEMA.COLUMNS WHERE "
-            "table_schema = 'treeherder' and "
-            "table_name = 'performance_datum' "
-            "and COLUMN_NAME = 'id'"
+            f"""table_schema = '{connection.settings_dict["NAME"]}' and """
+            "table_name = 'performance_datum' and "
+            "COLUMN_NAME = 'id'"
         )
-        (column_type,) = cursor.fetchone()
+        column_type = cursor.fetchone()
 
-        if column_type == "int(11)" and not PerformanceDatum.objects.exist():
+        if column_type == ("int(11)",) and not PerformanceDatum.objects.exist():
             # Directly alter the PK column in case the migration runs on an empty table
             # This is useful for scenarios running initial migration like tests
             cursor.execute(
                 "ALTER TABLE performance_datum MODIFY COLUMN id BIGINT(20) NOT NULL AUTO_INCREMENT"
             )
             return
-        elif column_type != "bigint(20)":
+        elif column_type != ("bigint(20)",):
             raise DatabaseError(
                 f"PerformanceDatum PK column type is {column_type} but should be bigint(20)"
             )

--- a/treeherder/perf/migrations/0044_perfdatum_bigint_fk.py
+++ b/treeherder/perf/migrations/0044_perfdatum_bigint_fk.py
@@ -42,12 +42,10 @@ class Migration(migrations.Migration):
         # Ensure the PK has been updated
         migrations.RunPython(
             check_perfdatum_pk,
-            reverse_code=migrations.RunPython.noop,
         ),
         # Empty SQL migration that update django state schema
         migrations.RunSQL(
             migrations.RunSQL.noop,
-            reverse_sql=migrations.RunSQL.noop,
             state_operations=[
                 migrations.AlterField(
                     model_name='performancedatum',

--- a/treeherder/perf/migrations/0045_restore_cascade_perf_datum_deletion.py
+++ b/treeherder/perf/migrations/0045_restore_cascade_perf_datum_deletion.py
@@ -1,0 +1,34 @@
+"""This migration is a copy of perf.0036_cascade_perf_datum_deletion
+It restores the DB side CASCADE deletion behavior for perf_multicommitdatum table toward performance_datum
+"""
+from django.db import migrations
+
+MULTICOMMIT_CONSTRAINT_SYMBOL = 'perf_multicommitdatu_perf_datum_id_c2d7eb14_fk_performan'
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('perf', '0044_perfdatum_bigint_fk'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            # add ON DELETE CASCADE at database level
+            [
+                f'ALTER TABLE perf_multicommitdatum '
+                f'DROP FOREIGN KEY {MULTICOMMIT_CONSTRAINT_SYMBOL};',
+                f'ALTER TABLE perf_multicommitdatum '
+                f'ADD CONSTRAINT {MULTICOMMIT_CONSTRAINT_SYMBOL} '
+                f'FOREIGN KEY (perf_datum_id) REFERENCES performance_datum (ID) ON DELETE CASCADE;',
+            ],
+            # put back the non-CASCADE foreign key constraint
+            reverse_sql=[
+                f'ALTER TABLE perf_multicommitdatum '
+                f'DROP FOREIGN KEY {MULTICOMMIT_CONSTRAINT_SYMBOL};',
+                f'ALTER TABLE perf_multicommitdatum '
+                f'ADD CONSTRAINT {MULTICOMMIT_CONSTRAINT_SYMBOL} '
+                f'FOREIGN KEY (perf_datum_id) REFERENCES performance_datum (ID);',
+            ],
+        )
+    ]

--- a/treeherder/perf/migrations/0045_restore_perf_multicommitdatum_and_schema.py
+++ b/treeherder/perf/migrations/0045_restore_perf_multicommitdatum_and_schema.py
@@ -22,8 +22,8 @@ def check_perfdatum_pk(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-    """This migration updates the django_migrations table and restore perf_multicommitdatum FK
-    toward the performance_datum table, after its PK has manually been updated to bigint.
+    """This migration updates the django_migrations table and restores
+    perf_multicommitdatum FK toward the performance_datum table
     """
 
     dependencies = [

--- a/treeherder/perf/migrations/0045_restore_perf_multicommitdatum_and_schema.py
+++ b/treeherder/perf/migrations/0045_restore_perf_multicommitdatum_and_schema.py
@@ -1,0 +1,65 @@
+from django.db import migrations, models, connection
+import django.db.models.deletion
+from django.db.utils import DatabaseError
+
+
+def check_perfdatum_pk(apps, schema_editor):
+    """Ensure performance_datum FK has been updated to bigint type"""
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT COLUMN_TYPE from INFORMATION_SCHEMA.COLUMNS WHERE "
+            f"""table_schema = '{connection.settings_dict["NAME"]}' and """
+            "table_name = 'performance_datum' and "
+            "COLUMN_NAME = 'id'"
+        )
+        column_type = cursor.fetchone()
+
+        if column_type != ("bigint(20)",):
+            raise DatabaseError(
+                f"PerformanceDatum PK column type is {column_type} but should be bigint(20)"
+            )
+
+
+class Migration(migrations.Migration):
+    """This migration updates the django_migrations table and restore perf_multicommitdatum FK
+    toward the performance_datum table, after its PK has manually been updated to bigint.
+    """
+
+    dependencies = [
+        ('perf', '0044_perfdatum_bigint_fk'),
+    ]
+
+    operations = [
+        # Ensure the PK has been updated
+        migrations.RunPython(
+            check_perfdatum_pk,
+        ),
+        # Empty SQL migration that update django state schema
+        migrations.RunSQL(
+            migrations.RunSQL.noop,
+            state_operations=[
+                migrations.AlterField(
+                    model_name='performancedatum',
+                    name='id',
+                    field=models.BigAutoField(primary_key=True, serialize=False),
+                ),
+            ],
+        ),
+        # Restore MultiCommitDatum FK to PerformanceDatum
+        migrations.CreateModel(
+            name='MultiCommitDatum',
+            fields=[
+                (
+                    'perf_datum',
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        primary_key=True,
+                        related_name='multi_commit_datum',
+                        serialize=False,
+                        to='perf.performancedatum',
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/treeherder/perf/migrations/0046_restore_cascade_perf_datum_deletion.py
+++ b/treeherder/perf/migrations/0046_restore_cascade_perf_datum_deletion.py
@@ -9,7 +9,7 @@ MULTICOMMIT_CONSTRAINT_SYMBOL = 'perf_multicommitdatu_perf_datum_id_c2d7eb14_fk_
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('perf', '0044_perfdatum_bigint_fk'),
+        ('perf', '0045_restore_perf_multicommitdatum_and_schema'),
     ]
 
     operations = [

--- a/treeherder/perf/models.py
+++ b/treeherder/perf/models.py
@@ -190,6 +190,7 @@ class PerformanceSignature(models.Model):
 
 
 class PerformanceDatum(models.Model):
+    id = models.BigAutoField(primary_key=True)
     repository = models.ForeignKey(Repository, on_delete=models.CASCADE)
     signature = models.ForeignKey(PerformanceSignature, on_delete=models.CASCADE)
     value = models.FloatField()


### PR DESCRIPTION
There are 3 migrations:
* perf.0043 drops the `perf_muulticommitdatum` table, allowing to do the `performance_datum` PK migration with an external tool. There is a check that requires the table to be empty for the migration to pass.
* perf.0044 update django's state schema. It requires `performance_datum` PK column to be of type `bigint(20)` to pass. This migration is not reversible and restore the `perf_multicommitdatum` table (handled by django, no error should occur there).
* perf.0045 restores a specific DB constraint. It is a copy of perf.0036 that updates  `perf_muulticommitdatum` FK constraint (to add a CASCADE behavior on delete).

There are checks to ensure migrations are not ran if the data is not ready on the tables at each step:
```sh
$ django-admin migrate perf 0043
$ #Perform the PK migration directly on the table
$ django-admin migrate perf
```