### PR TITLE
adjust readthedocs OS to be unbuntu 22.04 which will support python 3.10

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,11 @@
 # https://docs.readthedocs.io/en/latest/config-file/index.html
 version: 2
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    - python: '3.10'
 python:
-  version: 3.10
+  version: '3.10'
   install:
     - method: pip
       path: .


### PR DESCRIPTION
got stuck with cleaning up PR 7471, so I just created a new branch as the changes were simple