### PR TITLE
Bug 1778202 - show error message in failure even if it is supposed to be classified with a single tracking bug

### DIFF
--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -105,11 +105,6 @@ class FailureSummaryTab extends React.Component {
         if (simpleCase.length > 0 && !crashTimeoutLeak) {
           suggestion.bugs.open_recent = simpleCase;
 
-          // HACK: remove the error message from the error line to avoid confusion
-          suggestion.search =
-            suggestion.search.split(suggestion.path_end)[0] +
-            suggestion.path_end;
-
           // HACK: remove any other bugs, keep this simple.
           suggestion.bugs.all_others = [];
         }


### PR DESCRIPTION


Bug 1757222 removed the error message from failure lines if they are supposed to
get classified with bugs which track all failures for a test (single tracking
bug). The error message contains valuable information (e.g. it can indicate if
the issue is a permanent failure) and should be shown.