### PR TITLE
Bug 1779242 - Fix the backend configuration for frontend through docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,9 @@ services:
     # the host copy stays in sync (for people that switch back and forth between UI-only
     # and full stack Treeherder development).
     working_dir: /app
-    command: sh -c "yarn && yarn start:local --host 0.0.0.0"
+    environment:
+      BACKEND: http://backend:8000
+    command: sh -c "yarn && yarn start --host 0.0.0.0"
     volumes:
       - .:/app
     ports:


### PR DESCRIPTION
This should fix the backend usage through docker-compose: the backend was not used at the correct address (using host `localhost` instead of goinf through the docker inner hostname).