### PR TITLE
Bug 1779188 - Mark failed jobs where other job with same name does not fail.

### DIFF
--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -157,7 +157,7 @@
 }
 
 .classified-icon,
-.possibly-intermittent-icon {
+.intermittent-icon {
   font-size: 0.62em;
   vertical-align: super;
 }

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -156,7 +156,8 @@
   margin: 0 -1px 1px 1px;
 }
 
-.classified-icon {
+.classified-icon,
+.possibly-intermittent-icon {
   font-size: 0.62em;
   vertical-align: super;
 }

--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -159,7 +159,14 @@
 .classified-icon,
 .intermittent-icon {
   font-size: 0.62em;
+}
+
+.classified-icon {
   vertical-align: super;
+}
+
+.intermittent-icon {
+  vertical-align: sub;
 }
 
 /* Bold buttons */

--- a/ui/job-view/pushes/JobButton.jsx
+++ b/ui/job-view/pushes/JobButton.jsx
@@ -83,7 +83,7 @@ export default class JobButtonComponent extends React.Component {
   }
 
   render() {
-    const { job, possiblyIntermittent } = this.props;
+    const { job, intermittent } = this.props;
     const { isSelected, isRunnableSelected } = this.state;
     const {
       state,
@@ -137,11 +137,11 @@ export default class JobButtonComponent extends React.Component {
             title="classified"
           />
         )}
-        {possiblyIntermittent && (
+        {intermittent && (
           <FontAwesomeIcon
             icon={faMitten}
-            className="possibly-intermittent-icon"
-            title="possibly intermittent"
+            className="intermittent-icon"
+            title="Intermittent failure - There is a successful run of this task for the same push."
           />
         )}
       </button>
@@ -157,10 +157,10 @@ JobButtonComponent.propTypes = {
   resultStatus: PropTypes.string.isRequired,
   filterPlatformCb: PropTypes.func.isRequired,
   failureClassificationId: PropTypes.number, // runnable jobs won't have this
-  possiblyIntermittent: PropTypes.bool,
+  intermittent: PropTypes.bool,
 };
 
 JobButtonComponent.defaultProps = {
   failureClassificationId: 1,
-  possiblyIntermittent: false,
+  intermittent: false,
 };

--- a/ui/job-view/pushes/JobButton.jsx
+++ b/ui/job-view/pushes/JobButton.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faStar as faStarRegular } from '@fortawesome/free-regular-svg-icons';
-import { faStar as faStarSolid } from '@fortawesome/free-solid-svg-icons';
+import {
+  faStar as faStarSolid,
+  faMitten,
+} from '@fortawesome/free-solid-svg-icons';
 
 import { getBtnClass, findJobInstance } from '../../helpers/job';
 import { getUrlParam } from '../../helpers/location';
@@ -80,7 +83,7 @@ export default class JobButtonComponent extends React.Component {
   }
 
   render() {
-    const { job } = this.props;
+    const { job, possiblyIntermittent } = this.props;
     const { isSelected, isRunnableSelected } = this.state;
     const {
       state,
@@ -134,6 +137,13 @@ export default class JobButtonComponent extends React.Component {
             title="classified"
           />
         )}
+        {possiblyIntermittent && (
+          <FontAwesomeIcon
+            icon={faMitten}
+            className="possibly-intermittent-icon"
+            title="possibly intermittent"
+          />
+        )}
       </button>
     );
   }
@@ -147,8 +157,10 @@ JobButtonComponent.propTypes = {
   resultStatus: PropTypes.string.isRequired,
   filterPlatformCb: PropTypes.func.isRequired,
   failureClassificationId: PropTypes.number, // runnable jobs won't have this
+  possiblyIntermittent: PropTypes.bool,
 };
 
 JobButtonComponent.defaultProps = {
   failureClassificationId: 1,
+  possiblyIntermittent: false,
 };

--- a/ui/job-view/pushes/JobGroup.jsx
+++ b/ui/job-view/pushes/JobGroup.jsx
@@ -152,7 +152,7 @@ export class JobGroupComponent extends React.Component {
         successfulJobTypeNames.add(job.job_type_name);
       }
     }
-    function isPossiblyIntermittent(job) {
+    function isIntermittent(job) {
       if (job.result !== 'testfailed') {
         return false;
       }
@@ -189,7 +189,7 @@ export class JobGroupComponent extends React.Component {
                   failureClassificationId={job.failure_classification_id}
                   repoName={repoName}
                   filterPlatformCb={filterPlatformCb}
-                  possiblyIntermittent={isPossiblyIntermittent(job)}
+                  intermittent={isIntermittent(job)}
                   key={job.id}
                   ref={this.jobButtonRefs[job.id]}
                 />

--- a/ui/job-view/pushes/JobGroup.jsx
+++ b/ui/job-view/pushes/JobGroup.jsx
@@ -146,6 +146,20 @@ export class JobGroupComponent extends React.Component {
     const { expanded } = this.state;
     const { buttons, counts } = this.groupButtonsAndCounts(groupJobs, expanded);
 
+    const successfulJobTypeNames = new Set();
+    for (const job of groupJobs) {
+      if (job.result === 'success') {
+        successfulJobTypeNames.add(job.job_type_name);
+      }
+    }
+    function isPossiblyIntermittent(job) {
+      if (job.result !== 'testfailed') {
+        return false;
+      }
+
+      return successfulJobTypeNames.has(job.job_type_name);
+    }
+
     return (
       <span className="platform-group" data-group-key={groupMapKey}>
         <span className="disabled job-group" title={groupName}>
@@ -175,6 +189,7 @@ export class JobGroupComponent extends React.Component {
                   failureClassificationId={job.failure_classification_id}
                   repoName={repoName}
                   filterPlatformCb={filterPlatformCb}
+                  possiblyIntermittent={isPossiblyIntermittent(job)}
                   key={job.id}
                   ref={this.jobButtonRefs[job.id]}
                 />

--- a/ui/job-view/pushes/JobGroup.jsx
+++ b/ui/job-view/pushes/JobGroup.jsx
@@ -60,6 +60,27 @@ export class JobGroupComponent extends React.Component {
     this.setState({ expanded: isExpanded });
   }
 
+  getIntermittentJobTypeNames(groupJobs) {
+    const failedJobTypeNames = new Set();
+    for (const job of groupJobs) {
+      if (job.result === 'testfailed') {
+        failedJobTypeNames.add(job.job_type_name);
+      }
+    }
+
+    const intermittentJobTypeNames = new Set();
+    for (const job of groupJobs) {
+      if (
+        job.result === 'success' &&
+        failedJobTypeNames.has(job.job_type_name)
+      ) {
+        intermittentJobTypeNames.add(job.job_type_name);
+      }
+    }
+
+    return intermittentJobTypeNames;
+  }
+
   toggleExpanded = () => {
     this.setState((prevState) => ({ expanded: !prevState.expanded }));
   };
@@ -145,19 +166,15 @@ export class JobGroupComponent extends React.Component {
     } = this.props;
     const { expanded } = this.state;
     const { buttons, counts } = this.groupButtonsAndCounts(groupJobs, expanded);
-
-    const successfulJobTypeNames = new Set();
-    for (const job of groupJobs) {
-      if (job.result === 'success') {
-        successfulJobTypeNames.add(job.job_type_name);
-      }
-    }
+    const intermittentJobTypeNames = this.getIntermittentJobTypeNames(
+      groupJobs,
+    );
     function isIntermittent(job) {
       if (job.result !== 'testfailed') {
         return false;
       }
 
-      return successfulJobTypeNames.has(job.job_type_name);
+      return intermittentJobTypeNames.has(job.job_type_name);
     }
 
     return (


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1779188

Here's the current output, that adds a mitten icon at the top-right, the same place as the "classified" icon:

<img width="805" alt="intermittent" src="https://user-images.githubusercontent.com/6299746/178864672-4ede023f-1b7a-42c3-9c17-c4b84c669e90.png">

Things to consider:
  * How to mark these jobs (the above is just an example)
     * Use different color or style for the job button?
     * Show symbol? If so, where?
       * it would be better avoid confusion with "classified" icon
  * Add separate filter for them?
