### PR TITLE
Bug 1765877 - Use outline for selected jobs and remove negative margins

### DIFF
--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -72,7 +72,7 @@
 .runnable-job-btn {
   display: none;
   color: rgba(128, 128, 0, 0.5);
-  margin: 0 -2px 0 -1px;
+  margin: 0;
   background: transparent;
   padding: 0 2px;
   vertical-align: 0;
@@ -84,15 +84,13 @@
 }
 
 .runnable-job-btn-selected {
-  border: 1px solid;
-  padding: 0 -1px;
-  border-radius: 3px;
-  margin: 0 -2px 1px 0;
+  outline: 1px solid;
+  outline-radius: 3px;
   overflow: visible;
 }
 
 .selected-job {
-  border: 4px solid;
+  outline: 4px solid;
   background-color: #fff;
 }
 
@@ -101,9 +99,8 @@
 }
 
 .btn-lg-xform {
-  margin: -2px 0px !important;
-  border: 2px solid;
-  border-radius: 3px;
+  outline: 2px solid;
+  outline-radius: 3px;
   font-size: 12px;
   z-index: 1;
   transition: 0.1s;


### PR DESCRIPTION
Use `outline` instead of `border` to show rounded rectangles around the buttons.
This achieves almost same effect, and this doesn't require the negative `margin`.

With this patch the following actions don't change the layout:
  * select jobs
  * select runnable jobs
  * pin jobs

especially the second one was troublesome because it changes the position of the button while selecting multiple jobs.