### PR TITLE
Ignore warning RemovedInDjango41Warning to let pytest run in local development environment

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,9 @@ filterwarnings =
     # however this is expected when running tests since Django collectstatic and yarn build
     # (which create those directories) typically aren't run apart from during deployments.
     ignore:No directory at.*:UserWarning:whitenoise.base
+    # The django-extensions package sets 'default_app_config' wrapped in a 'try'
+    # statement.
+    ignore::django.utils.deprecation.RemovedInDjango41Warning
 markers =
     slow: mark a test as slow.
 xfail_strict = true


### PR DESCRIPTION
The django-extensions package sets 'default_app_config' wrapped in a 'try'
statement.