### PR TITLE
display new button for failure lines we haven't seen [in 21 days].

### DIFF
--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -155,6 +155,24 @@ class FailureSummaryTab extends React.Component {
     const jobLogsAllParsed =
       logs.length > 0 && logs.every((jlu) => jlu.parse_status !== 'pending');
 
+    let newButtonShown = false;
+    let suggestionCounter = 0;
+    suggestions.forEach((suggestion) => {
+      suggestionCounter++;
+      // this allows us to focus on the top line
+      if (suggestionCounter < 2) {
+        suggestion.showNewButton = false;
+        if (
+          !newButtonShown &&
+          suggestion.search.split(' | ').length === 3 &&
+          suggestion.counter === 1
+        ) {
+          newButtonShown = true;
+          suggestion.showNewButton = true;
+        }
+      }
+    });
+
     return (
       <div className="w-100 h-100" role="region" aria-label="Failure Summary">
         <ul

--- a/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
@@ -168,6 +168,17 @@ export default class SuggestionsListItem extends React.Component {
               >
                 <FontAwesomeIcon icon={faBug} title="File bug" />
               </Button>
+
+              {suggestion.showNewButton && (
+                <Button
+                  className="btn-orange"
+                  outline
+                  title="number of times this error message has been seen until now (including this run)"
+                >
+                  NEW
+                </Button>
+              )}
+
               <span className="align-middle">{suggestion.search} </span>
               <Clipboard
                 description=" text of error line"


### PR DESCRIPTION
this allows us to use the data that is in the backend:
 * original: https://github.com/mozilla/treeherder/commit/6b2e992aa2c8d1c6b7e221fb2a6115ee1ec468ff
 * small tweak: https://github.com/mozilla/treeherder/commit/94284fd2588ee8e167f62398ad88b1a9b992663e

this displays the new button- as a signal for user/sheriff to investigate or file a new bug/reopen a bug.

once this is r+, I want to work on collecting some metrics so we can monitor this over time and if numbers shift further we can adjust rules.