### PR TITLE
Bug 1779588 - Add safari application for Safari browser on macOS

### DIFF
--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -12,7 +12,8 @@
             "fennec",
             "geckoview",
             "refbrow",
-            "fenix"
+            "fenix",
+            "safari"
           ],
           "maxLength": 10,
           "type": "string"


### PR DESCRIPTION
Required for [bug 1779588](https://bugzilla.mozilla.org/show_bug.cgi?id=1779588).