### PR TITLE
Remove the unnecessary OR operation while getting the content type in `getData`

### DIFF
--- a/ui/helpers/http.js
+++ b/ui/helpers/http.js
@@ -18,8 +18,7 @@ export const getData = async function getData(url, options = {}) {
     failureStatus = response.status;
   }
 
-  const contentType =
-    response.headers.get('content-type') || ''.startsWith('text/html');
+  const contentType = response.headers.get('content-type');
 
   if (contentType && contentType !== 'application/json' && failureStatus) {
     const errorMessage = processErrorMessage(


### PR DESCRIPTION
It looks like inside the `getData` function we are getting the `contentType` from the header. But while doing it, we have a weird `''.startsWith('text/html');` after an OR operator. I think this might be a forgotten artifact while refactoring that code. `''.startsWith('text/html');` always returns false, which was confusing to me while I was looking at this function. And below that line, we have a check for `contentType` to see if it's "application/json".

See:
https://github.com/mozilla/treeherder/blob/eccd74e32ea098bd5b57a1695bc1ff142ca49606/ui/helpers/http.js#L24