### PR TITLE
Add GhA task to run the probe-scraper workflow

### DIFF
--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -1,0 +1,6 @@
+---
+name: Glean probe-scraper
+on: [push, pull_request]
+jobs:
+  glean-probe-scraper:
+    uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main


### PR DESCRIPTION
This ensures:

* On pull-requests probe-scraper can verify that Glean metrics are declared correctly.
* On pushes to the default branch probe-scraper is informed to generate metrics data in the pipeline, to fill the Glean Dictionary and populate the table schemas.

---

This is part of [Step 4 of adding Glean to your product](https://mozilla.github.io/glean/book/user/adding-glean-to-your-project/index.html). See also https://github.com/mozilla/probe-scraper/pull/538 for enabling it in probe-scraper to begin with.