### PR TITLE
Graph View - Show 'create alert' button on datapoints with common alerts

### DIFF
--- a/ui/perfherder/graphs/GraphTooltip.jsx
+++ b/ui/perfherder/graphs/GraphTooltip.jsx
@@ -295,7 +295,7 @@ const GraphTooltip = ({
                 <p className="small text-danger">Common alert</p>
               </p>
             )}
-            {!isCommonAlert && !dataPointDetails.alertSummary && prevPushId && (
+            {!dataPointDetails.alertSummary && prevPushId && (
               <p className="pt-2">
                 {user.isStaff ? (
                   <Button


### PR DESCRIPTION
This was encountered when trying to create two alerts from Speedometer subtests. The first was successful, but the second only showed the common alert notice and no way for me to create another alert (or to associate it with the common one).