### PR TITLE
Bug 1815345 - Generate profiler before/after links to open them directly in Firefox Profiler

### DIFF
--- a/ui/perfherder/perf-helpers/textualSummary.js
+++ b/ui/perfherder/perf-helpers/textualSummary.js
@@ -1,7 +1,11 @@
 import numeral from 'numeral';
 import sortBy from 'lodash/sortBy';
 
-import { thBaseUrl, uiPerfherderBase } from '../../helpers/url';
+import {
+  thBaseUrl,
+  uiPerfherderBase,
+  getPerfAnalysisUrl,
+} from '../../helpers/url';
 
 import { alertStatusMap } from './constants';
 import { getFrameworkName, getGraphsURL, getTimeRange } from './helpers';
@@ -119,7 +123,9 @@ export default class TextualSummary {
         updatedAlert &&
         updatedAlert.profile_url &&
         updatedAlert.prev_profile_url
-          ? `[Before](${updatedAlert.prev_profile_url})/[After](${updatedAlert.profile_url}) |`
+          ? `[Before](${getPerfAnalysisUrl(
+              updatedAlert.prev_profile_url,
+            )})/[After](${getPerfAnalysisUrl(updatedAlert.profile_url)}) |`
           : ' |';
     }
 


### PR DESCRIPTION
Fixes [Bug 1815345](https://bugzilla.mozilla.org/show_bug.cgi?id=1815345).

Previously we were putting the zip file links directly to alert summaries. This wasn't great because users had to download the files first, and then open them inside the Firefox Profiler by dragging and dropping that file. This is still adding some friction between seeing the bug and analyzing the issue.

Now we are directly generating Firefox Profiler links. This way, users can directly click on these links to open them in Firefox Profiler instead of downloading the profiles. This reduces the friction even more.

Before we had urls like:
https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/PKkTETY8S9aDfCuLhivdLw/runs/0/artifacts/public/test_info/profile_espn.zip

Now generating urls like:
https://profiler.firefox.com/from-url/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FPKkTETY8S9aDfCuLhivdLw%2Fruns%2F0%2Fartifacts%2Fpublic%2Ftest_info%2Fprofile_espn.zip