### PR TITLE
Bug 1816432 - add firefox-android as mobile repository, drop android-components and focus-android

### DIFF
--- a/treeherder/etl/taskcluster_pulse/handler.py
+++ b/treeherder/etl/taskcluster_pulse/handler.py
@@ -107,9 +107,8 @@ def ignore_task(task, taskId, rootUrl, project):
         return True
 
     mobile_repos = (
-        'android-components',
         'fenix',
-        'focus-android',
+        'firefox-android',
         'reference-browser',
         'mozilla-vpn-client',
         'mozilla-vpn-client-release',


### PR DESCRIPTION
This way only commits to the main branch gets ingested by Treeherder. The latter ones got migrated to the monorepo.