### PR TITLE
Bug 1819906 - search for 'non-fatal error' at any position in line to exclude it as failure

### DIFF
--- a/tests/log_parser/test_error_parser.py
+++ b/tests/log_parser/test_error_parser.py
@@ -101,7 +101,7 @@ NON_ERROR_TEST_CASES = (
     # "^ImportError: No module named pygtk$"
     "01:22:41     INFO -  ImportError: No module named pygtk\r\n",
     # "^non-fatal error"
-    "non-fatal error removing directory: Contents/_CodeSignature/, rv: 0, err: 39",
+    "2023-02-28 22:06:01+0000: non-fatal error removing directory: icons/, rv: 0, err: 39",
 )
 
 

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -94,7 +94,7 @@ class ErrorParser(ParserBase):
         r"|^TEST-UNEXPECTED-WARNING\b"
         r"|^TimeoutException: "
         r"|^ImportError: No module named pygtk$"
-        r"|^non-fatal error"
+        r"|non-fatal error"
     )
 
     RE_ERR_1_MATCH = re.compile(r"^\d+:\d+:\d+ +(?:ERROR|CRITICAL|FATAL) - ")


### PR DESCRIPTION


The text could be e.g. prefixed with a timestamp, see bug 1775522.