### PR TITLE
Bug 1821054 - Enable performance alerting on the firefox-android branch.

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1795,6 +1795,8 @@
       "active_status": "active",
       "codebase": "firefox-android",
       "repository_group": 11,
+      "performance_alerts_enabled": true,
+      "expire_performance_data": false,
       "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },


### PR DESCRIPTION
This patch enables performance test alerting on the firefox-android branch.