### PR TITLE
Bug 1818364 - Add custom chromium-as-release app

### DIFF
--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -13,7 +13,8 @@
             "geckoview",
             "refbrow",
             "fenix",
-            "safari"
+            "safari",
+            "custom-car"
           ],
           "maxLength": 10,
           "type": "string"


### PR DESCRIPTION
required for https://bugzilla.mozilla.org/show_bug.cgi?id=1818364