### PR TITLE
Bug 1742479 - Ingest application version for tests that have a suite value.

### DIFF
--- a/treeherder/etl/perf.py
+++ b/treeherder/etl/perf.py
@@ -269,7 +269,7 @@ def _load_perf_datum(job: Job, perf_datum: dict):
                 push=job.push,
                 signature=signature,
                 push_timestamp=deduced_timestamp,
-                defaults={'value': value[0]},
+                defaults={'value': value[0], 'application_version': application_version},
             )
             if subtest_datum.should_mark_as_multi_commit(is_multi_commit, datum_created):
                 # keep a register with all multi commit perf data


### PR DESCRIPTION
This patch fixes an issue where the tests with a suite-level summary value don't have an application version set. See this query to see how the application version is not set in the tp6 tests: https://sql.telemetry.mozilla.org/queries/91180/source

If you change it to search for benchmark tests, they'll show an application version since they have no suite level value.