### PR TITLE
show NEW flag on try

### DIFF
--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -170,9 +170,11 @@ class FailureSummaryTab extends React.Component {
       // this allows us to focus on the top line
       if (suggestionCounter < 2) {
         suggestion.showNewButton = false;
+        // small hack here to use counter==0 and try for display only
         if (
           suggestion.search.split(' | ').length === 3 &&
-          suggestion.failure_new_in_rev === true
+          (suggestion.failure_new_in_rev === true ||
+            (suggestion.counter === 0 && repoName === 'try'))
         ) {
           suggestion.showNewButton = true;
           selectedJob.newFailure = true;


### PR DESCRIPTION
Originally I used counter==1 to determine if this was the "First" instance of a failure.  It became obvious we needed to see the NEW flag on all failures on the same revision, so we switched to `failure_new_in_rev`.  This hack is a hack-
 * we only increment `counter` if on autoland || mozilla-central, so a new failure would be `counter == 0`
 * here I check for `try && counter == 0`.  This was less processing than computing in the python backend to adjust `failure_new_in_rev`.
 * this will have the same effect because the counter will always be 0, so the experience will be the same.

once this lands and we verify it, I will post on dev-platform to discuss how it is used and how to surface errors (including the mittens icon as well as common edge cases).  I will also include a survey to collect ideas so I could think about whats next and allow people to act as a "working group" if they opt in.

I would like the "working group" to help vet ideas around `test-verify` and maybe help with collecting stats.  Some future ideas would be:
 * turn non NEW jobs green
 * auto annotate NEW jobs so they are not background ORANGE
 * have a filter in the UI to toggle !NEW off/on
 * probably 3 or 4 other great ideas

All of these future ideas are and should be simple (1-2 days of engineering total to figure out and deploy)

This is a simple change with no impact on the data and minimal impact on the UI. 

