### PR TITLE
Run codecov orb as a standalone job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,6 @@ jobs:
       - run:
           command: yarn test:coverage
           name: Run Jest tests
-      - codecov/upload
 
   builds:
     docker:
@@ -67,7 +66,6 @@ jobs:
             pip install --upgrade pip
             pip install tox
             tox -e docker
-      - codecov/upload
 
   test-docker-build:
     docker:
@@ -144,6 +142,7 @@ workflows:
       - builds
       - python-tests
       - test-docker-build
+      - codecov/upload
       - deploy:
           filters:
             tags:


### PR DESCRIPTION
Since we have two jobs that report test coverage, when there is a delay in the result from one of them, Codecov generates an inaccurate report (sometimes the report gets edited by Codecov afterward to include the results from the other job).