### PR TITLE
Bug 1831945 - Handle replicates parameter in CompareSubtestsView.

### DIFF
--- a/ui/perfherder/compare/CompareSubtestsView.jsx
+++ b/ui/perfherder/compare/CompareSubtestsView.jsx
@@ -18,6 +18,7 @@ class CompareSubtestsView extends React.PureComponent {
     parent_signature: parentSignature,
     framework,
     repository,
+    replicates: false,
   });
 
   getQueryParams = (timeRange, framework) => {
@@ -29,6 +30,7 @@ class CompareSubtestsView extends React.PureComponent {
       newResultSet,
       originalSignature,
       newSignature,
+      replicates,
     } = this.props.validated;
 
     const originalParams = this.createQueryParams(
@@ -55,6 +57,12 @@ class CompareSubtestsView extends React.PureComponent {
       framework.id,
     );
     newParams.revision = newRevision;
+
+    if (replicates) {
+      originalParams.replicates = true;
+      newParams.replicates = true;
+    }
+
     return [originalParams, newParams];
   };
 


### PR DESCRIPTION
This patch is a follow-up to PR #7703. It enables the ability to use replicates on the subtest Compare View table. Currently, the `Use replicates` button is displayed, but doesn't do anything since the parameter isn't handled properly.

Before:
![Screenshot 2023-06-07 at 12-40-01 linux1804-64-shippable-qr speedometer3 opt fission webrender](https://github.com/mozilla/treeherder/assets/10966989/70517ab1-d69e-418b-80f1-c8542e0f4368)

After:
![Screenshot 2023-06-07 at 12-39-14 linux1804-64-shippable-qr speedometer3 opt fission webrender](https://github.com/mozilla/treeherder/assets/10966989/c19c3d29-64a3-4b4f-a9a9-c44401ff6363)
