### PR TITLE
Bug 1667866 - Add the GET API to get the tasks by the id of the alert summary

### DIFF
--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -397,6 +397,25 @@ class PerformanceSummarySerializer(serializers.ModelSerializer):
         return '{} {} {}'.format(test_suite, value['option_name'], value['extra_options'])
 
 
+class PerfAlertSummaryTasksQueryParamSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+
+    def validate(self, data):
+        try:
+            PerformanceAlertSummary.objects.get(id=data['id'])
+        except PerformanceAlertSummary.DoesNotExist:
+            raise serializers.ValidationError(
+                {'message': 'PerformanceAlertSummary does not exist.'}
+            )
+
+        return data
+
+
+class PerformanceAlertSummaryTasksSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    tasks = serializers.ListField(child=serializers.CharField(), default=[])
+
+
 class PerfCompareResultsQueryParamsSerializer(serializers.Serializer):
     base_revision = serializers.CharField(required=False, allow_null=True, default=None)
     new_revision = serializers.CharField()

--- a/treeherder/webapp/api/urls.py
+++ b/treeherder/webapp/api/urls.py
@@ -163,6 +163,11 @@ urlpatterns = [
         name='performance-summary',
     ),
     re_path(
+        r'^performance/alertsummary-tasks/$',
+        performance_data.PerformanceAlertSummaryTasks.as_view(),
+        name='performance-alertsummary-tasks',
+    ),
+    re_path(
         r'^perfcompare/results/$',
         performance_data.PerfCompareResults.as_view(),
         name='perfcompare-results',


### PR DESCRIPTION
Hi there :)
I created the API to get the task data.
Please let me know if there is anything that needs to be modified :)

URL: `GET: /api/performance/alertsummary-tasks/?id=1` (`1` is the id of the alert summary)
result sample:
```
{
    "id": 1,
    "tasks": [
        "test-windows10-64-shippable-qr/opt-talos-tp5o",
        "test-linux1804-64-shippable-qr/opt-talos-tp5o",
        "test-linux1804-64-shippable-qr/opt-talos-g5"
    ]
}
```
raw SQL: (I referred to the query in the bugzilla [0])
```
select distinct jt.name
  from performance_alert_summary pas
     , performance_alert pa
     , performance_signature ps
     , performance_datum pd
     , job j
     , job_type jt
 where pas.id = 1
   and (  pas.id = pa.summary_id 
	   or pas.id = pa.related_summary_id)
   and pa.series_signature_id = ps.id
   and ps.id 		 = pd.signature_id
   and pd.job_id 	 = j.id
   and j.job_type_id     = jt.id
```

[0]
https://bugzilla.mozilla.org/show_bug.cgi?id=1667866