### PR TITLE
Bug 1831945 - Limit the length of the replicates tooltip to 250 chars.

### DIFF
--- a/ui/perfherder/compare/TableAverage.jsx
+++ b/ui/perfherder/compare/TableAverage.jsx
@@ -15,6 +15,15 @@ const TableAverage = ({ value, stddev, stddevpct, replicates, app }) => {
       .join(' ')} > ${formatNumber(displayNumber(stddev))} = ${formatNumber(
       displayNumber(stddevpct),
     )}% standard deviation)`;
+
+    const TOOLTIP_MAX_LENGTH = 250;
+    if (tooltipText.length > TOOLTIP_MAX_LENGTH) {
+      tooltipText = `${tooltipText.slice(0, Math.floor(TOOLTIP_MAX_LENGTH / 2))}
+        ...(use JSON download button to see more)...
+        ${tooltipText.slice(
+          tooltipText.length - Math.floor(TOOLTIP_MAX_LENGTH / 2),
+        )}`;
+    }
   } else if (replicates.length === 1) {
     tooltipText = 'Only one run (consider more for greater confidence)';
   }


### PR DESCRIPTION
This patch fixes an issue with the replicates tooltip where there are far too many data points being displayed. A max character limit of 250 chars is added, and we use it to replace the middle of the tooltip with `...(use JSON download button to see more)...`.