### PR TITLE
Add platform to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       # https://github.com/moby/moby/issues/32612#issuecomment-294055017
       # cache_from: TODO
     image: treeherder-backend
+    platform: linux/amd64
     environment:
       # Development/CI-specific environment variables only.
       # Those that do not vary across environments should go in `Dockerfile`.
@@ -64,11 +65,13 @@ services:
       - .:/app
     ports:
       - '5000:5000'
+    platform: linux/amd64
 
   mysql:
     container_name: mysql
     # https://hub.docker.com/r/library/mysql/
     image: mysql:5.7.41
+    platform: linux/amd64
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=true
       - MYSQL_DATABASE=treeherder
@@ -119,6 +122,7 @@ services:
     depends_on:
       - mysql
       - rabbitmq
+    platform: linux/amd64
 
   celery:
     build:
@@ -136,6 +140,7 @@ services:
       - mysql
       - redis
       - rabbitmq
+    platform: linux/amd64
 volumes:
   # TODO: Experiment with using tmpfs when testing, to speed up database-using Python tests.
   mysql_data: {}


### PR DESCRIPTION
Running `docker-compose up --build` on macbook M1 gives this error `no matching manifest for linux/arm64/v8 in the manifest list entries`

The solution was to add `platform: linux/amd64` to each container

To test this I use the following commands in the terminal:
1.  `docker system prune --all --volumes --force`
2. `docker-compose up --build`