### PR TITLE
Add TaskclusterMetadata to the alert summary API endpoint

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -671,6 +671,7 @@ def create_perf_signature(
         last_updated=datetime.datetime.now(),
     )
 
+
 @pytest.fixture
 def test_taskcluster_metadata(test_job_2) -> th_models.TaskclusterMetadata:
     return create_taskcluster_metadata(test_job_2)
@@ -681,10 +682,7 @@ def test_taskcluster_metadata_2(test_job_3) -> th_models.TaskclusterMetadata:
     return create_taskcluster_metadata_2(test_job_3)
 
 
-def create_taskcluster_metadata(
-    test_job_2
-) -> th_models.TaskclusterMetadata:
-
+def create_taskcluster_metadata(test_job_2) -> th_models.TaskclusterMetadata:
     return th_models.TaskclusterMetadata.objects.create(
         job=test_job_2,
         task_id='V3SVuxO8TFy37En_6HcXLp',
@@ -692,10 +690,7 @@ def create_taskcluster_metadata(
     )
 
 
-def create_taskcluster_metadata_2(
-    test_job_3
-) -> th_models.TaskclusterMetadata:
-
+def create_taskcluster_metadata_2(test_job_3) -> th_models.TaskclusterMetadata:
     return th_models.TaskclusterMetadata.objects.create(
         job=test_job_3,
         task_id='V3SVuxO8TFy37En_6HcXLq',
@@ -988,12 +983,14 @@ def test_perf_alert(test_perf_signature, test_perf_alert_summary) -> perf_models
 
 
 @pytest.fixture
-def test_perf_alert_with_tcmetadata(test_perf_signature, test_perf_alert_summary) -> perf_models.PerformanceAlert:
-    perf_alert = create_perf_alert(summary=test_perf_alert_summary, series_signature=test_perf_signature)
-    perf_alert.taskcluster_metadata = {
-        "current_push": test_taskcluster_metadata_2,
-        "prev_push": test_taskcluster_metadata,
-    }
+def test_perf_alert_with_tcmetadata(
+    test_perf_signature, test_perf_alert_summary
+) -> perf_models.PerformanceAlert:
+    perf_alert = create_perf_alert(
+        summary=test_perf_alert_summary, series_signature=test_perf_signature
+    )
+    perf_alert.taskcluster_metadata = test_taskcluster_metadata_2
+    perf_alert.prev_taskcluster_metadata = test_taskcluster_metadata
     perf_alert.save()
     return perf_alert
 

--- a/tests/webapp/api/test_performance_alerts_api.py
+++ b/tests/webapp/api/test_performance_alerts_api.py
@@ -36,6 +36,7 @@ def test_alerts_get(
         'related_summary_id',
         'series_signature',
         'taskcluster_metadata',
+        'prev_taskcluster_metadata',
         'summary_id',
         'status',
         't_value',
@@ -46,18 +47,12 @@ def test_alerts_get(
     }
     assert resp.json()['results'][0]['related_summary_id'] is None
     assert set(resp.json()['results'][0]['taskcluster_metadata'].keys()) == {
-        'current_push',
-        'prev_push',
-    }
-    assert set(resp.json()['results'][0]['taskcluster_metadata']['current_push'].keys()) == {
         'task_id',
         'retry_id',
-        # 'result',
     }
-    assert set(resp.json()['results'][0]['taskcluster_metadata']['prev_push'].keys()) == {
+    assert set(resp.json()['results'][0]['prev_taskcluster_metadata'].keys()) == {
         'task_id',
         'retry_id',
-        # 'result',
     }
 
 

--- a/tests/webapp/api/test_performance_alerts_api.py
+++ b/tests/webapp/api/test_performance_alerts_api.py
@@ -8,7 +8,15 @@ from tests.conftest import create_perf_alert
 from treeherder.perf.models import PerformanceAlert, PerformanceAlertSummary, PerformanceFramework
 
 
-def test_alerts_get(client, test_repository, test_perf_alert):
+def test_alerts_get(
+    client,
+    test_repository,
+    test_perf_alert_with_tcmetadata,
+    test_perf_datum,
+    test_perf_datum_2,
+    test_taskcluster_metadata,
+    test_taskcluster_metadata_2,
+):
     resp = client.get(reverse('performance-alerts-list'))
     assert resp.status_code == 200
 
@@ -27,6 +35,7 @@ def test_alerts_get(client, test_repository, test_perf_alert):
         'prev_value',
         'related_summary_id',
         'series_signature',
+        'taskcluster_metadata',
         'summary_id',
         'status',
         't_value',
@@ -36,6 +45,20 @@ def test_alerts_get(client, test_repository, test_perf_alert):
         'noise_profile',
     }
     assert resp.json()['results'][0]['related_summary_id'] is None
+    assert set(resp.json()['results'][0]['taskcluster_metadata'].keys()) == {
+        'current_push',
+        'prev_push',
+    }
+    assert set(resp.json()['results'][0]['taskcluster_metadata']['current_push'].keys()) == {
+        'task_id',
+        'retry_id',
+        # 'result',
+    }
+    assert set(resp.json()['results'][0]['taskcluster_metadata']['prev_push'].keys()) == {
+        'task_id',
+        'retry_id',
+        # 'result',
+    }
 
 
 def test_alerts_put(

--- a/tests/webapp/api/test_performance_alertsummary_api.py
+++ b/tests/webapp/api/test_performance_alertsummary_api.py
@@ -53,7 +53,15 @@ def test_perf_alert_onhold(test_perf_signature, test_perf_alert_summary_onhold) 
     )
 
 
-def test_alert_summaries_get(client, test_perf_alert_summary, test_perf_alert):
+def test_alert_summaries_get(
+        client,
+        test_perf_alert_summary,
+        test_perf_alert_with_tcmetadata,
+        test_perf_datum,
+        test_perf_datum_2,
+        test_taskcluster_metadata,
+        test_taskcluster_metadata_2
+):
     # verify that we get the performance summary + alert on GET
     resp = client.get(reverse('performance-alert-summaries-list'))
     assert resp.status_code == 200
@@ -89,6 +97,7 @@ def test_alert_summaries_get(client, test_perf_alert_summary, test_perf_alert):
         'id',
         'status',
         'series_signature',
+        'taskcluster_metadata',
         'is_regression',
         'starred',
         'manually_created',
@@ -105,12 +114,30 @@ def test_alert_summaries_get(client, test_perf_alert_summary, test_perf_alert):
         'noise_profile',
     }
     assert resp.json()['results'][0]['related_alerts'] == []
+    assert set(resp.json()['results'][0]['alerts'][0]['taskcluster_metadata'].keys()) == {
+        'current_push',
+        'prev_push',
+    }
+    assert set(resp.json()['results'][0]['alerts'][0]['taskcluster_metadata']['current_push'].keys()) == {
+        'task_id',
+        'retry_id',
+        # 'result',
+    }
+    assert set(resp.json()['results'][0]['alerts'][0]['taskcluster_metadata']['prev_push'].keys()) == {
+        'task_id',
+        'retry_id',
+        # 'result',
+    }
 
 
 def test_alert_summaries_get_onhold(
     client,
     test_perf_alert_summary,
-    test_perf_alert,
+    test_perf_alert_with_tcmetadata,
+    test_perf_datum,
+    test_perf_datum_2,
+    test_taskcluster_metadata,
+    test_taskcluster_metadata_2,
     test_perf_alert_summary_onhold,
     test_perf_alert_onhold,
     test_repository_onhold,
@@ -150,6 +177,7 @@ def test_alert_summaries_get_onhold(
         'id',
         'status',
         'series_signature',
+        'taskcluster_metadata',
         'is_regression',
         'starred',
         'manually_created',
@@ -166,6 +194,20 @@ def test_alert_summaries_get_onhold(
         'noise_profile',
     }
     assert resp.json()['results'][0]['related_alerts'] == []
+    assert set(resp.json()['results'][0]['alerts'][0]['taskcluster_metadata'].keys()) == {
+        'current_push',
+        'prev_push',
+    }
+    assert set(resp.json()['results'][0]['alerts'][0]['taskcluster_metadata']['current_push'].keys()) == {
+        'task_id',
+        'retry_id',
+        # 'result',
+    }
+    assert set(resp.json()['results'][0]['alerts'][0]['taskcluster_metadata']['prev_push'].keys()) == {
+        'task_id',
+        'retry_id',
+        # 'result',
+    }
 
 
 def test_alert_summaries_put(

--- a/tests/webapp/api/test_performance_alertsummary_api.py
+++ b/tests/webapp/api/test_performance_alertsummary_api.py
@@ -54,13 +54,13 @@ def test_perf_alert_onhold(test_perf_signature, test_perf_alert_summary_onhold) 
 
 
 def test_alert_summaries_get(
-        client,
-        test_perf_alert_summary,
-        test_perf_alert_with_tcmetadata,
-        test_perf_datum,
-        test_perf_datum_2,
-        test_taskcluster_metadata,
-        test_taskcluster_metadata_2
+    client,
+    test_perf_alert_summary,
+    test_perf_alert_with_tcmetadata,
+    test_perf_datum,
+    test_perf_datum_2,
+    test_taskcluster_metadata,
+    test_taskcluster_metadata_2,
 ):
     # verify that we get the performance summary + alert on GET
     resp = client.get(reverse('performance-alert-summaries-list'))
@@ -98,6 +98,7 @@ def test_alert_summaries_get(
         'status',
         'series_signature',
         'taskcluster_metadata',
+        'prev_taskcluster_metadata',
         'is_regression',
         'starred',
         'manually_created',
@@ -115,18 +116,12 @@ def test_alert_summaries_get(
     }
     assert resp.json()['results'][0]['related_alerts'] == []
     assert set(resp.json()['results'][0]['alerts'][0]['taskcluster_metadata'].keys()) == {
-        'current_push',
-        'prev_push',
-    }
-    assert set(resp.json()['results'][0]['alerts'][0]['taskcluster_metadata']['current_push'].keys()) == {
         'task_id',
         'retry_id',
-        # 'result',
     }
-    assert set(resp.json()['results'][0]['alerts'][0]['taskcluster_metadata']['prev_push'].keys()) == {
+    assert set(resp.json()['results'][0]['alerts'][0]['prev_taskcluster_metadata'].keys()) == {
         'task_id',
         'retry_id',
-        # 'result',
     }
 
 
@@ -178,6 +173,7 @@ def test_alert_summaries_get_onhold(
         'status',
         'series_signature',
         'taskcluster_metadata',
+        'prev_taskcluster_metadata',
         'is_regression',
         'starred',
         'manually_created',
@@ -195,18 +191,12 @@ def test_alert_summaries_get_onhold(
     }
     assert resp.json()['results'][0]['related_alerts'] == []
     assert set(resp.json()['results'][0]['alerts'][0]['taskcluster_metadata'].keys()) == {
-        'current_push',
-        'prev_push',
-    }
-    assert set(resp.json()['results'][0]['alerts'][0]['taskcluster_metadata']['current_push'].keys()) == {
         'task_id',
         'retry_id',
-        # 'result',
     }
-    assert set(resp.json()['results'][0]['alerts'][0]['taskcluster_metadata']['prev_push'].keys()) == {
+    assert set(resp.json()['results'][0]['alerts'][0]['prev_taskcluster_metadata'].keys()) == {
         'task_id',
         'retry_id',
-        # 'result',
     }
 
 

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from rest_framework import exceptions, serializers
 
-from treeherder.model.models import Repository, TaskclusterMetadata, Job
+from treeherder.model.models import Repository, TaskclusterMetadata
 from treeherder.perf.models import (
     BackfillRecord,
     IssueTracker,
@@ -17,7 +17,6 @@ from treeherder.perf.models import (
     PerformanceSignature,
     PerformanceTag,
 )
-from treeherder.webapp.api.serializers import TaskclusterMetadataSerializer
 from treeherder.webapp.api.utils import to_timestamp
 
 
@@ -117,60 +116,10 @@ class PerformanceSignatureSerializer(serializers.ModelSerializer):
         ]
 
 
-class AlertTaskclusterMetadataSerializer(serializers.ModelSerializer):
-    current_push = serializers.SerializerMethodField()
-    prev_push = serializers.SerializerMethodField()
-
-    def get_current_push(self, alert):
-        datum = PerformanceDatum.objects.filter(
-            signature=alert.series_signature,
-            repository=alert.series_signature.repository,
-            push_id=alert.summary.push
-        ).first()
-        if datum:
-            try:
-                metadata = TaskclusterMetadata.objects.get(job=datum.job)
-                return {
-                    'task_id': metadata.task_id,
-                    'retry_id': metadata.retry_id,
-                }
-            except ObjectDoesNotExist:
-                return {}
-        else:
-            return {}
-
-    def get_prev_push(self, alert):
-        datum = PerformanceDatum.objects.filter(
-            signature=alert.series_signature,
-            repository=alert.series_signature.repository,
-            push_id=alert.summary.prev_push
-        ).first()
-        if datum:
-            try:
-                metadata = TaskclusterMetadata.objects.get(job=datum.job)
-                return {
-                    'task_id': metadata.task_id,
-                    'retry_id': metadata.retry_id,
-                }
-            except ObjectDoesNotExist:
-                return {}
-        else:
-            return {}
-
-
-    class Meta:
-        model = Job
-        fields = [
-            # 'task_id',
-            # 'retry_id',
-            'current_push',
-            'prev_push',
-        ]
-
-
 class PerformanceAlertSerializer(serializers.ModelSerializer):
     series_signature = PerformanceSignatureSerializer(read_only=True)
     taskcluster_metadata = serializers.SerializerMethodField()
+    prev_taskcluster_metadata = serializers.SerializerMethodField()
     summary_id = serializers.SlugRelatedField(
         slug_field="id",
         source="summary",
@@ -237,8 +186,40 @@ class PerformanceAlertSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
     def get_taskcluster_metadata(self, alert):
-        serializer = AlertTaskclusterMetadataSerializer(alert)
-        return serializer.data
+        datum = PerformanceDatum.objects.filter(
+            signature=alert.series_signature,
+            repository=alert.series_signature.repository,
+            push=alert.summary.push,
+        ).first()
+        if datum:
+            try:
+                metadata = TaskclusterMetadata.objects.get(job=datum.job)
+                return {
+                    'task_id': metadata.task_id,
+                    'retry_id': metadata.retry_id,
+                }
+            except ObjectDoesNotExist:
+                return {}
+        else:
+            return {}
+
+    def get_prev_taskcluster_metadata(self, alert):
+        datum = PerformanceDatum.objects.filter(
+            signature=alert.series_signature,
+            repository=alert.series_signature.repository,
+            push=alert.summary.prev_push,
+        ).first()
+        if datum:
+            try:
+                metadata = TaskclusterMetadata.objects.get(job=datum.job)
+                return {
+                    'task_id': metadata.task_id,
+                    'retry_id': metadata.retry_id,
+                }
+            except ObjectDoesNotExist:
+                return {}
+        else:
+            return {}
 
     def get_classifier_email(self, performance_alert):
         return getattr(performance_alert.classifier, 'email', None)
@@ -250,6 +231,7 @@ class PerformanceAlertSerializer(serializers.ModelSerializer):
             'status',
             'series_signature',
             'taskcluster_metadata',
+            'prev_taskcluster_metadata',
             'is_regression',
             'prev_value',
             'new_value',


### PR DESCRIPTION
Add TaskclusterMetadata information for current push and prev push (basically the ends of the push range of the alert summary):
- taskcluster `task_id` - the one that's visible in the treeherder job view, under `Job` link [example](https://prototype.treeherder.nonprod.cloudops.mozgcp.net/jobs?repo=autoland&group_state=expanded&selectedTaskRun=QTrvdpaJT0WyQMBQlr3Byw.0&searchStr=Linux%2C18.04%2Cx64%2CWebRender%2CShippable%2Copt%2CBrowsertime%2Cperformance%2Ctests%2Con%2CFirefox%2Ctest-linux1804-64-shippable-qr%2Fopt-browsertime-tp6-essential-firefox-bing-search%2Cbing&tochange=3338e8c3aaad554ffc57245d3897865695657a62&fromchange=3338e8c3aaad554ffc57245d3897865695657a62)
![image](https://github.com/mozilla/treeherder/assets/47977085/a6326cc6-9d0e-495e-86ac-055b0aa76a07)
- `retry_id` the index of the retrigger - zero is first run of the job, from 1 to higher is retrigger

https://prototype.treeherder.nonprod.cloudops.mozgcp.net/perfherder/alerts?id=246903&hideDwnToInv=0 >>>
![image](https://github.com/mozilla/treeherder/assets/47977085/09756498-d340-4f6c-9d00-1de3d405a6bc)

