### PR TITLE
Bug 1782215 - Properly close the tab opened by LoginCallback when needed

### DIFF
--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -53,6 +53,9 @@ WSGI_APPLICATION = 'treeherder.config.wsgi.application'
 # Send full URL within origin but only origin for cross-origin requests
 SECURE_REFERRER_POLICY = "origin-when-cross-origin"
 
+# Prevent window.opener from always being null while it's used in the frontend
+SECURE_CROSS_ORIGIN_OPENER_POLICY = None
+
 # We can't set X_FRAME_OPTIONS to DENY since renewal of an Auth0 token
 # requires opening the auth handler page in an invisible iframe with the
 # same origin.


### PR DESCRIPTION
Refs https://bugzilla.mozilla.org/show_bug.cgi?id=1782215

`window.opener` is always set to `null` when the **Cross-Origin-Opener-Policy** header is present and set to `same-origin` in a request (see https://developer.mozilla.org/en-US/docs/Web/API/Window/opener).

Now, `window.opener` is used to determine whether the **LoginCallback** window should be closed or not, so we don't want it to be constantly `null`.

Since [Django 4.0](https://docs.djangoproject.com/en/4.2/releases/4.0/#requests-and-responses), this header is automatically added by Django's `SecurityMiddleware` and set to `same-origin`, which is unwanted.