### PR TITLE
Bug 1844214 - detect crashes logged in the new format

### DIFF
--- a/tests/ui/job-view/bugfiler_test.jsx
+++ b/tests/ui/job-view/bugfiler_test.jsx
@@ -264,6 +264,38 @@ describe('BugFiler', () => {
     expect(displayed).toBeInTheDocument(expected);
   });
 
+  test('should extract crash signature', async () => {
+    const suggestions = [
+      {
+        bugs: {},
+        search_terms: [],
+        search:
+          'PROCESS-CRASH | application crashed [@ servo_arc::HeaderSlice<H,T>::slice] | dom/tests/mochitest/pointerlock/test_pointerlock-api.html',
+      },
+    ];
+
+    render(bugFilerComponentSuggestions(suggestions));
+    const signatureArea = await screen.getByDisplayValue(
+      '[@ servo_arc::HeaderSlice<H,T>::slice]',
+    );
+    expect(signatureArea).toBeInTheDocument();
+  });
+
+  test('crash signature field should be empty for non-crash issues', async () => {
+    const suggestions = [
+      {
+        bugs: {},
+        search_terms: [],
+        search:
+          'TEST-UNEXPECTED-FAIL | dom/tests/mochitest/webvr/test_webvr.html | this passed',
+      },
+    ];
+
+    render(bugFilerComponentSuggestions(suggestions));
+    const signatureArea = await screen.queryByDisplayValue('test_webvr.html');
+    expect(signatureArea).toBeNull();
+  });
+
   test('should set as security bug if summary contains initially a relevant search term', async () => {
     const suggestions = [
       {

--- a/ui/shared/BugFiler.jsx
+++ b/ui/shared/BugFiler.jsx
@@ -34,7 +34,6 @@ import { notify } from '../job-view/redux/stores/notifications';
 import { classified } from '../glean/generated/pings.js';
 import { newFailureNewBug, newBug } from '../glean/generated/classification.js';
 
-const crashRegex = /application crashed \[@ (.+)\]$/g;
 const omittedLeads = [
   'TEST-UNEXPECTED-FAIL',
   'PROCESS-CRASH',
@@ -139,10 +138,7 @@ export class BugFilerClass extends React.Component {
       summaryString = summaryString.replace(re, '');
     }
 
-    const crash = suggestion.search.match(crashRegex);
-    const crashSignatures = crash
-      ? [crash[0].split('application crashed ')[1]]
-      : [];
+    const crashSignatures = this.getCrashSignatures(suggestion);
 
     const newFailure = suggestion.showNewButton;
     const keywords = [];
@@ -272,6 +268,12 @@ export class BugFilerClass extends React.Component {
   componentDidMount() {
     this.checkForSecurityIssue();
     this.findProductByPath();
+  }
+
+  getCrashSignatures(failureLine) {
+    const crashRegex = /application crashed \[@ (.+)\]/g;
+    const crash = failureLine.search.match(crashRegex);
+    return crash ? [crash[0].split('application crashed ')[1]] : [];
   }
 
   getUnhelpfulSummaryReason(summary) {
@@ -653,10 +655,7 @@ export class BugFilerClass extends React.Component {
       selectedProduct,
     } = this.state;
     const searchTerms = suggestion.search_terms;
-    const crash = summary.match(crashRegex);
-    const crashSignatures = crash
-      ? [crash[0].split('application crashed ')[1]]
-      : [];
+    const crashSignatures = this.getCrashSignatures(suggestion);
     const unhelpfulSummaryReason = this.getUnhelpfulSummaryReason(summary);
 
     return (


### PR DESCRIPTION
The new format got added in bug 1631828 and puts the crash signature in front of the test during whose execution the crash got recorded.