### PR TITLE
Add % percentage indicator to standard deviation

### DIFF
--- a/ui/perfherder/compare/TableAverage.jsx
+++ b/ui/perfherder/compare/TableAverage.jsx
@@ -64,7 +64,7 @@ const TableAverage = ({ value, stddev, stddevpct, replicates, app }) => {
                 ? formatNumber(displayNumber(value))
                 : `${formatNumber(
                     displayNumber(value),
-                  )} ${'\u00B1'} ${formatNumber(displayNumber(stddevpct))}`
+                  )} ${'\u00B1'} ${formatNumber(displayNumber(stddevpct))}%`
             }
             tooltipText={
               notZeroSum ? (


### PR DESCRIPTION
## This PR adds a % percentage indicator to the standard deviation in compare view.
It is a solution for https://bugzilla.mozilla.org/show_bug.cgi?id=1831319.   
![image](https://github.com/mozilla/treeherder/assets/60618877/b501d072-77d1-4d5e-b6b1-b7561799fcda)
