### PR TITLE
Update python Docker tag to v3.9.18

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN yarn build
 
 
 ## Backend stage
-FROM python:3.9.16-slim
+FROM python:3.9.18-slim-bullseye
 
 # libmysqlclient-dev is required for the mysqlclient Python package.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.16
+FROM python:3.9.18-bullseye
 
 # Variables that are not specific to a particular environment.
 ENV NEW_RELIC_CONFIG_FILE newrelic.ini


### PR DESCRIPTION
Use Debian bullseye to be able to pull the packages, else error message 'NO_PUBKEY' shown for fetching from Debian Bookworm.