### PR TITLE
Fix select all test checkboxes not scrolling properly

### DIFF
--- a/ui/push-health/Test.jsx
+++ b/ui/push-health/Test.jsx
@@ -326,7 +326,7 @@ class Test extends PureComponent {
                 </NavItem>
               </Nav>
             </Navbar>
-            <div className="ml-5 pl-2">
+            <div className="ml-5 pl-2 position-relative">
               <FormGroup className="mb-1 pl-4">
                 <Input
                   aria-label="Select all platforms for this test"


### PR DESCRIPTION
Previously, select all checkboxes in the tests tab would always stay on the same position on screen due to a missing positive relative.