### PR TITLE
Potential fix for Bug 1827920

### DIFF
--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -142,6 +142,7 @@ class TabsPanel extends React.Component {
       taskId,
       rootUrl,
       initializeGlean,
+      updatePinnedJob
     } = this.props;
     const { enableTestGroupsTab, tabIndex } = this.state;
     const countPinnedJobs = Object.keys(pinnedJobs).length;

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -142,7 +142,7 @@ class TabsPanel extends React.Component {
       taskId,
       rootUrl,
       initializeGlean,
-      updatePinnedJob
+      updatePinnedJob,
     } = this.props;
     const { enableTestGroupsTab, tabIndex } = this.state;
     const countPinnedJobs = Object.keys(pinnedJobs).length;


### PR DESCRIPTION
Potential fix for [Bug 1827920](https://bugzilla.mozilla.org/show_bug.cgi?id=1827920), the rare error/crash with `TypeError: s is not a function` when trying to load a push health page.

The import was being used instead of the prop tied to the store resulting in the `updatePinnedJob` prop sometimes having the value of `null` when it is attempted to be called later inside FailureSummaryTab.

Not sure this is the fix but I am reasonably confident as it seems straight forward - I can't repro/test the issue locally with just the UI.