### PR TITLE
Optimize summarygroup endpoint

### DIFF
--- a/treeherder/webapp/api/groups.py
+++ b/treeherder/webapp/api/groups.py
@@ -57,6 +57,7 @@ class SummaryByGroupName(generics.ListAPIView):
             )
             .annotate(
                 job_count=Count('job_id'),
+                # Directly annotate the result value as we filtered entries with status ∈ {1, 2}
                 result=Case(
                     When(group_result__status=1, then=Value("passed")),
                     When(group_result__status=2, then=Value("testfailed")),

--- a/treeherder/webapp/api/groups.py
+++ b/treeherder/webapp/api/groups.py
@@ -8,7 +8,7 @@ from rest_framework import generics
 from rest_framework.response import Response
 
 from treeherder.model.models import JobLog
-from treeherder.webapp.api.serializers import GroupNameSerializer
+from collections import defaultdict
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +18,6 @@ class SummaryByGroupName(generics.ListAPIView):
     This yields group names/status summary for the given group and day.
     """
 
-    serializer_class = GroupNameSerializer
     queryset = None
 
     def list(self, request):
@@ -51,8 +50,10 @@ class SummaryByGroupName(generics.ListAPIView):
             .filter(
                 job__repository_id__in=(1, 77),
                 job__job_type__name__startswith='test-',
-                groups__name__isnull=False,
                 group_result__status__in=(1, 2),
+            )
+            .exclude(
+                groups__name='',
             )
             .annotate(
                 job_count=Count('job_id'),
@@ -61,46 +62,48 @@ class SummaryByGroupName(generics.ListAPIView):
                     When(group_result__status=2, then=Value("testfailed")),
                 ),
             )
-            .values(
-                'job_count',
-                'job__job_type__name',
-                'job__failure_classification_id',
+            .values_list(
                 'groups__name',
+                'job__job_type__name',
                 'result',
+                'job__failure_classification_id',
+                'job_count',
             )
             .order_by('groups__name')
         )
 
-        serializer = self.get_serializer(self.queryset, many=True)
+        # Reference job types in a separated list
+        job_type_names = set()
+        # Group items by group name, type name, result and classification
+        summary = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(int))))
+        for item in self.queryset.all():
+            group_name, type_name, result, classification, job_count = item
 
-        summary = {}
-        job_type_names = []
-        for item in serializer.data:
-            # TODO: consider stripping out some types; mostly care about FBC vs Intermittent
-            classification = item['failure_classification']
-            result = item["result"]
+            # Strip a possible number suffix
+            name, suffix = type_name.rsplit('-', maxsplit=1)
+            if suffix.isdigit():
+                type_name = name
 
-            if item['job_type_name'] not in job_type_names:
-                job_type_names.append(item['job_type_name'])
-            if item['group_name'] not in summary:
-                summary[item['group_name']] = {}
-            if item['job_type_name'] not in summary[item['group_name']]:
-                summary[item['group_name']][item['job_type_name']] = {}
-            if result not in summary[item['group_name']][item['job_type_name']]:
-                summary[item['group_name']][item['job_type_name']][result] = {}
-            if classification not in summary[item['group_name']][item['job_type_name']][result]:
-                summary[item['group_name']][item['job_type_name']][result][classification] = 0
-            summary[item['group_name']][item['job_type_name']][result][classification] += item[
-                'job_count'
-            ]
+            job_type_names.add(type_name)
+            summary[group_name][type_name][result][classification] += job_count
 
-        data = {'job_type_names': job_type_names, 'manifests': []}
-        for m in summary.keys():
+        # Cast job types as a list, to use their index as reference in manifests
+        job_type_names = sorted(job_type_names)
+
+        manifests = []
+        for group, types in summary.items():
             mdata = []
-            for d in summary[m]:
-                for r in summary[m][d]:
-                    for c in summary[m][d][r]:
-                        mdata.append([job_type_names.index(d), r, int(c), summary[m][d][r][c]])
-            data['manifests'].append({m: mdata})
+            for t_name, results in types.items():
+                for result, classifications in results.items():
+                    for classif, job_count in classifications.items():
+                        mdata.append(
+                            [job_type_names.index(t_name), result, int(classif), job_count]
+                        )
+            manifests.append({group: mdata})
 
-        return Response(data=data)
+        return Response(
+            data={
+                'job_type_names': job_type_names,
+                'manifests': manifests,
+            }
+        )

--- a/treeherder/webapp/api/groups.py
+++ b/treeherder/webapp/api/groups.py
@@ -69,7 +69,9 @@ class SummaryByGroupName(generics.ListAPIView):
                 'job__failure_classification_id',
                 'job_count',
             )
-            .order_by('groups__name')
+            .order_by(
+                'groups__name', 'job__job_type__name', 'result', 'job__failure_classification_id'
+            )
             .distinct()
         )
 

--- a/treeherder/webapp/api/groups.py
+++ b/treeherder/webapp/api/groups.py
@@ -70,6 +70,7 @@ class SummaryByGroupName(generics.ListAPIView):
                 'job_count',
             )
             .order_by('groups__name')
+            .distinct()
         )
 
         # Reference job types in a separated list

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -321,17 +321,16 @@ class JobTypeNameField(serializers.Field):
 class GroupNameSerializer(serializers.ModelSerializer):
     group_name = serializers.CharField(source="groups__name")
     job_type_name = JobTypeNameField(source="job__job_type__name")
-    group_status = serializers.CharField(source="group_result__status")
+    result = serializers.CharField()
     failure_classification = serializers.CharField(source="job__failure_classification_id")
     job_count = serializers.IntegerField()
-
 
     class Meta:
         model = models.JobLog
         fields = (
             'group_name',
             'job_type_name',
-            'group_status',
+            'result',
             'failure_classification',
             'job_count',
         )

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -319,11 +319,12 @@ class JobTypeNameField(serializers.Field):
 
 
 class GroupNameSerializer(serializers.ModelSerializer):
-    group_name = serializers.CharField(source="job_log__groups__name")
-    job_type_name = JobTypeNameField(source="job_type__name")
-    group_status = serializers.CharField(source="job_log__group_result__status")
-    failure_classification = serializers.CharField(source="failure_classification_id")
+    group_name = serializers.CharField(source="groups__name")
+    job_type_name = JobTypeNameField(source="job__job_type__name")
+    group_status = serializers.CharField(source="group_result__status")
+    failure_classification = serializers.CharField(source="job__failure_classification_id")
     job_count = serializers.IntegerField()
+
 
     class Meta:
         model = models.JobLog

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -306,36 +306,6 @@ class FailuresSerializer(serializers.ModelSerializer):
         fields = ('bug_id', 'bug_count')
 
 
-class JobTypeNameField(serializers.Field):
-    """Removes the ending chunk number"""
-
-    def to_representation(self, value):
-        parts = value.split("-")
-        try:
-            _ = int(parts[-1])
-            return '-'.join(parts[:-1])
-        except ValueError:
-            return value
-
-
-class GroupNameSerializer(serializers.ModelSerializer):
-    group_name = serializers.CharField(source="groups__name")
-    job_type_name = JobTypeNameField(source="job__job_type__name")
-    result = serializers.CharField()
-    failure_classification = serializers.CharField(source="job__failure_classification_id")
-    job_count = serializers.IntegerField()
-
-    class Meta:
-        model = models.JobLog
-        fields = (
-            'group_name',
-            'job_type_name',
-            'result',
-            'failure_classification',
-            'job_count',
-        )
-
-
 class TestSuiteField(serializers.Field):
     """Removes all characters from test_suite that's also found in platform"""
 


### PR DESCRIPTION
Work on `groupsummary` endpoint performance:
* Base the query on the JobLog table
* Apply filters/transformation within the query when possible
* Avoid using a serializer to handle query output
* Clean some Python code

I got interesting performance improvements with different data size:
* `master`
  * Small : 619 ms ± 12.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  * Medium : 1.88 s ± 99.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  * Large : 12.2 s ± 412 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
* `61e2076`
  * Small : 481 ms ± 38.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  * Medium : 536 ms ± 14.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  * Large : 4.32 s ± 396 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  
  The results were ordered differently, so I sorted the first index list of type names so the payload is a bit cleaner.
  The references in groups seems to match those types correctly.