### PR TITLE
Optimize push-list endpoint

### DIFF
--- a/tests/push_health/test_compare.py
+++ b/tests/push_health/test_compare.py
@@ -103,6 +103,7 @@ def test_get_commit_history(test_push, test_repository, mock_rev, mock_json_push
         author='foo@bar.baz',
         time=datetime.datetime.now(),
     )
+    test_push.revision_count = test_push.commits.count()
 
     history = get_commit_history(test_repository, test_revision, test_push)
     print('\n<><><>history')

--- a/treeherder/push_health/usage.py
+++ b/treeherder/push_health/usage.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.db.models import Count
 from treeherder.config import settings
 from treeherder.model.models import Push, Job
 from treeherder.push_health.classification import NEED_INVESTIGATION
@@ -55,7 +56,9 @@ def get_usage():
 
     results = [
         {
-            'push': PushSerializer(pushes.get(revision=facet['name'])).data,
+            'push': PushSerializer(
+                pushes.annotate(revision_count=Count('commits')).get(revision=facet['name'])
+            ).data,
             'peak': get_peak(facet),
             'latest': get_latest(facet),
             'retriggers': jobs_retriggered(pushes.get(revision=facet['name'])),

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -3,13 +3,14 @@ import logging
 
 import newrelic.agent
 from cache_memoize import cache_memoize
+from django.db.models import Count, Prefetch
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
 from treeherder.log_parser.failureline import get_group_results
-from treeherder.model.models import Job, JobType, Push, Repository
+from treeherder.model.models import Commit, Job, JobType, Push, Repository
 from treeherder.push_health.builds import get_build_failures
 from treeherder.push_health.compare import get_commit_history
 from treeherder.push_health.linting import get_lint_failures
@@ -176,7 +177,11 @@ class PushViewSet(viewsets.ViewSet):
         # false. however AFAIK no one ever used it (default was to fetch
         # everything), so let's just leave it out. it doesn't break
         # anything to send extra data when not required.
-        pushes = pushes.select_related('repository').prefetch_related('commits')[:count]
+        pushes = (
+            pushes.select_related('repository')
+            .annotate(revision_count=Count('commits'))
+            .prefetch_related(Prefetch('commits', queryset=Commit.objects.order_by('-id')))
+        )[:count]
         serializer = PushSerializer(pushes, many=True)
 
         meta['count'] = len(pushes)

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -197,7 +197,9 @@ class PushViewSet(viewsets.ViewSet):
         GET method implementation for detail view of ``push``
         """
         try:
-            push = Push.objects.get(repository__name=project, id=pk)
+            push = Push.objects.annotate(revision_count=Count('commits')).get(
+                repository__name=project, id=pk
+            )
             serializer = PushSerializer(push)
             return Response(serializer.data)
         except Push.DoesNotExist:
@@ -340,7 +342,9 @@ class PushViewSet(viewsets.ViewSet):
 
         try:
             repository = Repository.objects.get(name=project)
-            push = Push.objects.get(revision=revision, repository=repository)
+            push = Push.objects.annotate(revision_count=Count('commits')).get(
+                revision=revision, repository=repository
+            )
         except Push.DoesNotExist:
             return Response(
                 "No push with revision: {0}".format(revision), status=HTTP_404_NOT_FOUND

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -270,18 +270,11 @@ class CommitSerializer(serializers.ModelSerializer):
 
 
 class PushSerializer(serializers.ModelSerializer):
-    def get_revisions(self, push):
-        serializer = CommitSerializer(instance=push.commits.all().order_by('-id')[:20], many=True)
-        return serializer.data
-
-    def get_revision_count(self, push):
-        return push.commits.count()
-
     def get_push_timestamp(self, push):
         return to_timestamp(push.time)
 
-    revisions = serializers.SerializerMethodField()
-    revision_count = serializers.SerializerMethodField()
+    revisions = CommitSerializer(many=True, source='commits')
+    revision_count = serializers.IntegerField()
     push_timestamp = serializers.SerializerMethodField()
     repository_id = serializers.PrimaryKeyRelatedField(source="repository", read_only=True)
 


### PR DESCRIPTION
## Changes
* Related commits (revisions in the serializer) are now prefetched, but not limited to 20 results as before (django does not supports slicing a prefetch, but it is possible in SQL)
  * Avoids 1 SQL request per Push
  * 35516 / 1260041 Push entries are linked to more than 20 commits. 8 are linked to ~10k commits.

## Performance
* Small data (`/api/project/autoland/push/?full=true&count=100&fromchange=<rev_id>`)
  * `master` : 569 ms ± 5.12 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  * `e6109c95`: 520 ms ± 4.65 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  * Approx 9% time reduction

* Large data (`/api/project/autoland/push/?full=true&count=100`)
  * `master` : 5.69 s ± 63.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  * `e6109c95`: 1.87 s ± 69.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  * Approx 66% time reduction