### PR TITLE
Bug 1855222 -  Enable alerting on firefox iOS

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -1856,6 +1856,8 @@
       "active_status": "active",
       "codebase": "firefox-ios",
       "repository_group": 11,
+      "performance_alerts_enabled": true,
+      "expire_performance_data": false,
       "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
   },


### PR DESCRIPTION
We are just enabling performance alerting on Firefox iOS
Let me know if there are any issues @gmierz 