### PR TITLE
Make profiler links available in alerts view

### DIFF
--- a/ui/perfherder/alerts/AlertTable.jsx
+++ b/ui/perfherder/alerts/AlertTable.jsx
@@ -23,6 +23,7 @@ import ErrorBoundary from '../../shared/ErrorBoundary';
 import TableColumnHeader from '../shared/TableColumnHeader';
 import SortButtonDisabled from '../shared/SortButtonDisabled';
 import { tableSort, getNextSort, sort, sortTables } from '../perf-helpers/sort';
+import BrowsertimeAlertsExtraData from '../../models/browsertimeAlertsExtraData';
 
 import AlertTableRow from './AlertTableRow';
 import AlertHeader from './AlertHeader';
@@ -97,6 +98,21 @@ export default class AlertTable extends React.Component {
     }
   }
 
+  async enrichAlertsWithLinks(alertSummary) {
+    const { frameworks } = this.props;
+
+    const browsertimeAlertsExtraData = new BrowsertimeAlertsExtraData(
+      alertSummary,
+      frameworks,
+    );
+    const [alerts] = await Promise.all([
+      browsertimeAlertsExtraData.enrichAndRetrieveAlerts(),
+    ]);
+    alertSummary.alerts = alerts;
+
+    this.setState({ alertSummary });
+  }
+
   processAlerts = () => {
     const { alertSummary, optionCollectionMap } = this.props;
 
@@ -108,6 +124,7 @@ export default class AlertTable extends React.Component {
     );
 
     this.setState({ alertSummary }, () => {
+      this.enrichAlertsWithLinks(alertSummary);
       this.getDownstreamList();
       this.updateFilteredAlerts();
     });

--- a/ui/perfherder/perf-helpers/helpers.js
+++ b/ui/perfherder/perf-helpers/helpers.js
@@ -466,7 +466,7 @@ export const getInitializedAlerts = (alertSummary, optionCollectionMap) =>
     .concat(alertSummary.related_alerts)
     .map((alertData) => Alert(alertData, optionCollectionMap));
 
-export const addResultsLink = (taskId) => {
+export const getResultsLink = (taskId) => {
   const taskLink =
     'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/';
   const resultsPath =


### PR DESCRIPTION
The previous PR [Add TaskclusterMetadata to the alert summary API endpoint](https://github.com/mozilla/treeherder/pull/7740) added the taskcluster task id for every alert item in the alerts view. This PR is removing the call for the `jobList` to an entire push (to filter out the taskcluster task ids) and takes the data from the `alertSummary` object. This avoids a performance bottleneck for the case where we had to make the call for the `jobList` faster to get the data available in the alerts view, reduces the time to wait for a bug to be filed or copy a summary, and contributes to preventing the `Copy summary` button to malfunction (not copying the summary every time it's called).

The call for the job list to an entire push was done before in the `Copy summary` button
![Screenshot from 2023-09-29 17-09-29](https://github.com/mozilla/treeherder/assets/47977085/34c6da75-0407-4619-be13-d4b6dc59adf9)

The call to `Copy summary` after:
![Screenshot from 2023-09-29 17-02-53](https://github.com/mozilla/treeherder/assets/47977085/0d243a6f-afbb-4f05-8505-5a9849bb4100)
