### PR TITLE
Bug 1852185 - Fix error viewing push health tasks

### DIFF
--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -181,7 +181,7 @@ class FailureSummaryTab extends React.Component {
     });
 
     if (selectedJob.newFailure > 0) {
-      updatePinnedJob(selectedJob);
+      updatePinnedJob?.(selectedJob);
     }
 
     return (


### PR DESCRIPTION
Currently, if you try to view failed task details on push health (e.g. [here](https://treeherder.mozilla.org/push-health/push?repo=try&revision=0ed64f3af4ed16738fdcb7881bb0e7199d4d1d94&testGroup=pr&selectedTest=browserbasecontenttestperformancebrowserstartupcontentjs&selectedTaskId=)), the error `TypeError: updatePinnedJob is not a function` appears. Since this function doesn't seem to consistently be defined, I've used optional chaining to avoid this error, and now I'm able to load the tasks in the development environment.