### PR TITLE
Optimize jobs-list endpoint with push_id filter

### DIFF
--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -35,6 +35,8 @@ class JobFilter(django_filters.FilterSet):
     id = django_filters.NumberFilter(field_name='id')
     id__in = NumberInFilter(field_name='id', lookup_expr='in')
     tier__in = NumberInFilter(field_name='tier', lookup_expr='in')
+    # Perform a single lookup query when filtering with push_id=<int>
+    push_id = django_filters.NumberFilter(field_name='push_id')
     push_id__in = NumberInFilter(field_name='push_id', lookup_expr='in')
     job_guid = django_filters.CharFilter(field_name='guid')
     job_guid__in = CharInFilter(field_name='guid', lookup_expr='in')
@@ -57,8 +59,6 @@ class JobFilter(django_filters.FilterSet):
     signature = django_filters.CharFilter(field_name='signature__signature')
     task_id = django_filters.CharFilter(field_name='taskcluster_metadata__task_id')
     retry_id = django_filters.NumberFilter(field_name='taskcluster_metadata__retry_id')
-    # Perform a single lookup query when filtering with push_id=<int>
-    push_id = django_filters.NumberFilter(field_name='push_id')
 
     class Meta:
         model = Job


### PR DESCRIPTION
This endpoint cannot be simplified much, as built with a viewset + django-filters.

The majority of requests use the `push_id__in` filter, which performs a single lookup query (50+% of the requests compare with a single push ID using the `__in` clause).
However, 10% of the overall queries uses the `push_id` filter directly (you can see thoses request when loading the app main page), which cause an extra query to fetch the push entry before listing related jobs.

This implementation cuts off this extra query, improving perf by approx. 12% (389ms → 341ms).
On the other side, the API will return an empty jobs list when filtering with a wrong ID, instead of returning an explicit message (that was `"push_id": ["Select a valid choice. That choice is not one of the available choices."]`).