### PR TITLE
Revert 2 changes to the `push` API endpoint

### DIFF
--- a/tests/push_health/test_compare.py
+++ b/tests/push_health/test_compare.py
@@ -103,7 +103,6 @@ def test_get_commit_history(test_push, test_repository, mock_rev, mock_json_push
         author='foo@bar.baz',
         time=datetime.datetime.now(),
     )
-    test_push.revision_count = test_push.commits.count()
 
     history = get_commit_history(test_repository, test_revision, test_push)
     print('\n<><><>history')

--- a/treeherder/push_health/usage.py
+++ b/treeherder/push_health/usage.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.db.models import Count
 from treeherder.config import settings
 from treeherder.model.models import Push, Job
 from treeherder.push_health.classification import NEED_INVESTIGATION
@@ -56,9 +55,7 @@ def get_usage():
 
     results = [
         {
-            'push': PushSerializer(
-                pushes.annotate(revision_count=Count('commits')).get(revision=facet['name'])
-            ).data,
+            'push': PushSerializer(pushes.get(revision=facet['name'])).data,
             'peak': get_peak(facet),
             'latest': get_latest(facet),
             'retriggers': jobs_retriggered(pushes.get(revision=facet['name'])),

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -3,14 +3,13 @@ import logging
 
 import newrelic.agent
 from cache_memoize import cache_memoize
-from django.db.models import Count, Prefetch
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
 from treeherder.log_parser.failureline import get_group_results
-from treeherder.model.models import Commit, Job, JobType, Push, Repository
+from treeherder.model.models import Job, JobType, Push, Repository
 from treeherder.push_health.builds import get_build_failures
 from treeherder.push_health.compare import get_commit_history
 from treeherder.push_health.linting import get_lint_failures
@@ -177,11 +176,7 @@ class PushViewSet(viewsets.ViewSet):
         # false. however AFAIK no one ever used it (default was to fetch
         # everything), so let's just leave it out. it doesn't break
         # anything to send extra data when not required.
-        pushes = (
-            pushes.select_related('repository')
-            .annotate(revision_count=Count('commits'))
-            .prefetch_related(Prefetch('commits', queryset=Commit.objects.order_by('-id')))
-        )[:count]
+        pushes = pushes.select_related('repository').prefetch_related('commits')[:count]
         serializer = PushSerializer(pushes, many=True)
 
         meta['count'] = len(pushes)
@@ -197,9 +192,7 @@ class PushViewSet(viewsets.ViewSet):
         GET method implementation for detail view of ``push``
         """
         try:
-            push = Push.objects.annotate(revision_count=Count('commits')).get(
-                repository__name=project, id=pk
-            )
+            push = Push.objects.get(repository__name=project, id=pk)
             serializer = PushSerializer(push)
             return Response(serializer.data)
         except Push.DoesNotExist:
@@ -342,9 +335,7 @@ class PushViewSet(viewsets.ViewSet):
 
         try:
             repository = Repository.objects.get(name=project)
-            push = Push.objects.annotate(revision_count=Count('commits')).get(
-                revision=revision, repository=repository
-            )
+            push = Push.objects.get(revision=revision, repository=repository)
         except Push.DoesNotExist:
             return Response(
                 "No push with revision: {0}".format(revision), status=HTTP_404_NOT_FOUND

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -270,11 +270,18 @@ class CommitSerializer(serializers.ModelSerializer):
 
 
 class PushSerializer(serializers.ModelSerializer):
+    def get_revisions(self, push):
+        serializer = CommitSerializer(instance=push.commits.all().order_by('-id')[:20], many=True)
+        return serializer.data
+
+    def get_revision_count(self, push):
+        return push.commits.count()
+
     def get_push_timestamp(self, push):
         return to_timestamp(push.time)
 
-    revisions = CommitSerializer(many=True, source='commits')
-    revision_count = serializers.IntegerField()
+    revisions = serializers.SerializerMethodField()
+    revision_count = serializers.SerializerMethodField()
     push_timestamp = serializers.SerializerMethodField()
     repository_id = serializers.PrimaryKeyRelatedField(source="repository", read_only=True)
 


### PR DESCRIPTION
Revert "Update Serializer usages"

This reverts commit d27d0c333347e3d55b0cbdbf70a9f63b0263bde4.

Revert "Optimize push-list endpoint"

This reverts commit e7403314328add68fd43e213434edd288f507fd9.