### PR TITLE
Bug 1848419 - Add custom chromium-as-release app for android

### DIFF
--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -14,7 +14,8 @@
             "refbrow",
             "fenix",
             "safari",
-            "custom-car"
+            "custom-car",
+            "cstm-car-m"
           ],
           "maxLength": 10,
           "type": "string"


### PR DESCRIPTION
required for https://bugzilla.mozilla.org/show_bug.cgi?id=1848419, (android follow up of #7669)