### PR TITLE
[fixed] Push list optimization

### DIFF
--- a/tests/push_health/test_compare.py
+++ b/tests/push_health/test_compare.py
@@ -103,6 +103,7 @@ def test_get_commit_history(test_push, test_repository, mock_rev, mock_json_push
         author='foo@bar.baz',
         time=datetime.datetime.now(),
     )
+    test_push.revision_count = test_push.commits.count()
 
     history = get_commit_history(test_repository, test_revision, test_push)
     print('\n<><><>history')

--- a/tests/webapp/api/test_push_api.py
+++ b/tests/webapp/api/test_push_api.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest
 from django.urls import reverse
+from django.conf import settings
 
 from tests.conftest import IS_WINDOWS
 from treeherder.etl.push import store_push_data
@@ -9,6 +10,10 @@ from treeherder.model.models import Commit, FailureClassification, JobNote, Push
 from treeherder.webapp.api import utils
 
 
+@pytest.mark.skipif(
+    settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql',
+    reason="Version of MySQL doesn't yet support 'LIMIT'",
+)
 def test_push_list_basic(client, eleven_jobs_stored, test_repository):
     """
     test retrieving a list of ten json blobs from the jobs-list
@@ -51,6 +56,10 @@ def test_push_list_bad_project(client, transactional_db):
     assert resp.json() == {"detail": "No project with name foo"}
 
 
+@pytest.mark.skipif(
+    settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql',
+    reason="Version of MySQL doesn't yet support 'LIMIT'",
+)
 def test_push_list_empty_push_still_show(client, sample_push, test_repository):
     """
     test retrieving a push list, when the push has no jobs.
@@ -66,6 +75,10 @@ def test_push_list_empty_push_still_show(client, sample_push, test_repository):
     assert len(data['results']) == 10
 
 
+@pytest.mark.skipif(
+    settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql',
+    reason="Version of MySQL doesn't yet support 'LIMIT'",
+)
 def test_push_list_single_short_revision(client, eleven_jobs_stored, test_repository):
     """
     test retrieving a push list, filtered by single short revision
@@ -87,6 +100,10 @@ def test_push_list_single_short_revision(client, eleven_jobs_stored, test_reposi
     }
 
 
+@pytest.mark.skipif(
+    settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql',
+    reason="Version of MySQL doesn't yet support 'LIMIT'",
+)
 def test_push_list_single_long_revision(client, eleven_jobs_stored, test_repository):
     """
     test retrieving a push list, filtered by a single long revision
@@ -110,6 +127,10 @@ def test_push_list_single_long_revision(client, eleven_jobs_stored, test_reposit
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="timezone mixup happening somewhere")
+@pytest.mark.skipif(
+    settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql',
+    reason="Version of MySQL doesn't yet support 'LIMIT'",
+)
 def test_push_list_filter_by_revision(client, eleven_jobs_stored, test_repository):
     """
     test retrieving a push list, filtered by a revision range
@@ -139,6 +160,10 @@ def test_push_list_filter_by_revision(client, eleven_jobs_stored, test_repositor
     }
 
 
+@pytest.mark.skipif(
+    settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql',
+    reason="Version of MySQL doesn't yet support 'LIMIT'",
+)
 def test_push_list_many_related_commits(client, eleven_jobs_stored, test_repository):
     """
     Test prefetched commits are limited to the 20 last items
@@ -174,6 +199,10 @@ def test_push_list_many_related_commits(client, eleven_jobs_stored, test_reposit
     ]
 
 
+@pytest.mark.skipif(
+    settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql',
+    reason="Version of MySQL doesn't yet support 'LIMIT'",
+)
 @pytest.mark.skipif(IS_WINDOWS, reason="timezone mixup happening somewhere")
 def test_push_list_filter_by_date(client, test_repository, sample_push):
     """
@@ -213,6 +242,10 @@ def test_push_list_filter_by_date(client, test_repository, sample_push):
     }
 
 
+@pytest.mark.skipif(
+    settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql',
+    reason="Version of MySQL doesn't yet support 'LIMIT'",
+)
 @pytest.mark.parametrize(
     'filter_param, exp_ids',
     [
@@ -246,6 +279,10 @@ def test_push_list_filter_by_id(client, test_repository, filter_param, exp_ids):
     assert set([result['id'] for result in results]) == set(exp_ids)
 
 
+@pytest.mark.skipif(
+    settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql',
+    reason="Version of MySQL doesn't yet support 'LIMIT'",
+)
 def test_push_list_id_in(client, test_repository):
     """
     test the id__in parameter
@@ -291,6 +328,10 @@ def test_push_list_bad_count(client, test_repository):
     assert resp.json() == {'detail': 'Valid count value required'}
 
 
+@pytest.mark.skipif(
+    settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql',
+    reason="Version of MySQL doesn't yet support 'LIMIT'",
+)
 def test_push_author(client, test_repository):
     """
     test the author parameter
@@ -335,6 +376,10 @@ def test_push_author(client, test_repository):
     assert set([result['id'] for result in results]) == set([1, 2])
 
 
+@pytest.mark.skipif(
+    settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql',
+    reason="Version of MySQL doesn't yet support 'LIMIT'",
+)
 def test_push_reviewbot(client, test_repository):
     """
     test the reviewbot parameter
@@ -363,6 +408,10 @@ def test_push_reviewbot(client, test_repository):
     assert set([result['id'] for result in results]) == set([1, 2])
 
 
+@pytest.mark.skipif(
+    settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql',
+    reason="Version of MySQL doesn't yet support 'LIMIT'",
+)
 def test_push_list_without_jobs(client, test_repository, sample_push):
     """
     test retrieving a push list without jobs

--- a/treeherder/push_health/usage.py
+++ b/treeherder/push_health/usage.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.db.models import Count
 from treeherder.config import settings
 from treeherder.model.models import Push, Job
 from treeherder.push_health.classification import NEED_INVESTIGATION
@@ -55,7 +56,9 @@ def get_usage():
 
     results = [
         {
-            'push': PushSerializer(pushes.get(revision=facet['name'])).data,
+            'push': PushSerializer(
+                pushes.annotate(revision_count=Count('commits')).get(revision=facet['name'])
+            ).data,
             'peak': get_peak(facet),
             'latest': get_latest(facet),
             'retriggers': jobs_retriggered(pushes.get(revision=facet['name'])),

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -3,13 +3,14 @@ import logging
 
 import newrelic.agent
 from cache_memoize import cache_memoize
+from django.db.models import Count, Prefetch
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
 from treeherder.log_parser.failureline import get_group_results
-from treeherder.model.models import Job, JobType, Push, Repository
+from treeherder.model.models import Commit, Job, JobType, Push, Repository
 from treeherder.push_health.builds import get_build_failures
 from treeherder.push_health.compare import get_commit_history
 from treeherder.push_health.linting import get_lint_failures
@@ -176,7 +177,11 @@ class PushViewSet(viewsets.ViewSet):
         # false. however AFAIK no one ever used it (default was to fetch
         # everything), so let's just leave it out. it doesn't break
         # anything to send extra data when not required.
-        pushes = pushes.select_related('repository').prefetch_related('commits')[:count]
+        pushes = (
+            pushes.select_related('repository')
+            .annotate(revision_count=Count('commits'))
+            .prefetch_related(Prefetch('commits', queryset=Commit.objects.order_by('-id')))
+        )[:count]
         serializer = PushSerializer(pushes, many=True)
 
         meta['count'] = len(pushes)
@@ -192,7 +197,9 @@ class PushViewSet(viewsets.ViewSet):
         GET method implementation for detail view of ``push``
         """
         try:
-            push = Push.objects.get(repository__name=project, id=pk)
+            push = Push.objects.annotate(revision_count=Count('commits')).get(
+                repository__name=project, id=pk
+            )
             serializer = PushSerializer(push)
             return Response(serializer.data)
         except Push.DoesNotExist:
@@ -335,7 +342,9 @@ class PushViewSet(viewsets.ViewSet):
 
         try:
             repository = Repository.objects.get(name=project)
-            push = Push.objects.get(revision=revision, repository=repository)
+            push = Push.objects.annotate(revision_count=Count('commits')).get(
+                revision=revision, repository=repository
+            )
         except Push.DoesNotExist:
             return Response(
                 "No push with revision: {0}".format(revision), status=HTTP_404_NOT_FOUND

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -270,18 +270,11 @@ class CommitSerializer(serializers.ModelSerializer):
 
 
 class PushSerializer(serializers.ModelSerializer):
-    def get_revisions(self, push):
-        serializer = CommitSerializer(instance=push.commits.all().order_by('-id')[:20], many=True)
-        return serializer.data
-
-    def get_revision_count(self, push):
-        return push.commits.count()
-
     def get_push_timestamp(self, push):
         return to_timestamp(push.time)
 
-    revisions = serializers.SerializerMethodField()
-    revision_count = serializers.SerializerMethodField()
+    revisions = CommitSerializer(many=True, source='commits')
+    revision_count = serializers.IntegerField()
     push_timestamp = serializers.SerializerMethodField()
     repository_id = serializers.PrimaryKeyRelatedField(source="repository", read_only=True)
 


### PR DESCRIPTION
The [first patch](https://github.com/mozilla/treeherder/pull/7817) was reverted as it was breaking up ingestion (certainly due to timeout because some pushes could be linked to thousands of commits).

I restored the limit of prefetched commits to 20, using a subquery. This was relatively easy to implement with django's ORM, but is not supported by MySQL:
> This version of MySQL doesn't yet support 'LIMIT & IN/ALL/ANY/SOME subquery

The last alternative would be to perform the prefetch separately, then annotate the Push objects manually but this would be more of a hack.

Performances improvements still seems to be pretty good (if not even better):
* Small data (`/api/project/autoland/push/?full=true&count=100&fromchange=<rev_id>`)
  * `master` : 779 ms ± 63.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  * `7ad83d87`: 688 ms ± 6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  * Approx 12% time reduction

* Large data (`/api/project/autoland/push/?full=true&count=100`)
  * `master` : 7.64 s ± 97.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  * `7ad83d87`: 2.06 s ± 33 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  * Approx 73% time reduction