### PR TITLE
Add field lower_is_better to the perfcompare endpoint

### DIFF
--- a/tests/webapp/api/test_perfcompare_api.py
+++ b/tests/webapp/api/test_perfcompare_api.py
@@ -138,6 +138,7 @@ def test_perfcompare_results_against_no_base(
             'delta_percentage': round(response['delta_pct'], 2),
             'magnitude': round(response['magnitude'], 2),
             'new_is_better': response['new_is_better'],
+            'lower_is_better': response['lower_is_better'],
             'is_confident': response['is_confident'],
             'more_runs_are_needed': response['more_runs_are_needed'],
             'noise_metric': False,
@@ -293,6 +294,7 @@ def test_perfcompare_results_with_only_one_run_and_diff_repo(
             'delta_percentage': round(response['delta_pct'], 2),
             'magnitude': round(response['magnitude'], 2),
             'new_is_better': response['new_is_better'],
+            'lower_is_better': response['lower_is_better'],
             'is_confident': response['is_confident'],
             'more_runs_are_needed': response['more_runs_are_needed'],
             'noise_metric': False,
@@ -451,6 +453,7 @@ def test_perfcompare_results_multiple_runs(
             'delta_percentage': round(first_row['delta_pct'], 2),
             'magnitude': round(first_row['magnitude'], 2),
             'new_is_better': first_row['new_is_better'],
+            'lower_is_better': first_row['lower_is_better'],
             'is_confident': first_row['is_confident'],
             'more_runs_are_needed': first_row['more_runs_are_needed'],
             'noise_metric': False,
@@ -497,6 +500,7 @@ def test_perfcompare_results_multiple_runs(
             'delta_percentage': round(second_row['delta_pct'], 2),
             'magnitude': round(second_row['magnitude'], 2),
             'new_is_better': second_row['new_is_better'],
+            'lower_is_better': second_row['lower_is_better'],
             'is_confident': second_row['is_confident'],
             'more_runs_are_needed': second_row['more_runs_are_needed'],
             'noise_metric': False,
@@ -620,6 +624,7 @@ def get_expected(
     response['new_is_better'] = perfcompare_utils.is_new_better(
         response['delta_value'], base_sig.lower_is_better
     )
+    response['lower_is_better'] = base_sig.lower_is_better
     response['confidence'] = perfcompare_utils.get_abs_ttest_value(
         base_perf_data_values, new_perf_data_values
     )

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -964,6 +964,7 @@ class PerfCompareResults(generics.ListAPIView):
                     'delta_percentage': delta_percentage,
                     'magnitude': magnitude,
                     'new_is_better': new_is_better,
+                    'lower_is_better': lower_is_better,
                     'is_confident': is_confident,
                     'more_runs_are_needed': more_runs_are_needed,
                     # highlighted revisions is the base_revision and the other highlighted revisions is new_revision

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -524,6 +524,7 @@ class PerfCompareResultsSerializer(serializers.ModelSerializer):
     delta_percentage = PerfCompareDecimalField()
     magnitude = PerfCompareDecimalField()
     new_is_better = OptionalBooleanField()
+    lower_is_better = OptionalBooleanField()
     is_confident = OptionalBooleanField()
     more_runs_are_needed = OptionalBooleanField()
     noise_metric = OptionalBooleanField(default=False)
@@ -571,6 +572,7 @@ class PerfCompareResultsSerializer(serializers.ModelSerializer):
             'delta_percentage',
             'magnitude',
             'new_is_better',
+            'lower_is_better',
             'is_confident',
             'more_runs_are_needed',
             'noise_metric',


### PR DESCRIPTION
For testing please use the staging credentials locally using docker.
Here's a [testing link](http://localhost:8000/api/perfcompare/results/?base_repository=mozilla-central&new_repository=mozilla-central&framework=1&interval=172800&no_subtests=true&base_revision=ffe93e4e0835b70448d485c82e3900bc4f47f205&new_revision=4124eee4f58ca46e13cb937c757a2fe1875120f0). You can edit this link to contain other repositories and revisions.