### PR TITLE
Bug 1864319 - Always show the scrollbar to avoid the layout change depending on the content.

### DIFF
--- a/ui/css/treeherder.css
+++ b/ui/css/treeherder.css
@@ -17,7 +17,9 @@ body {
 }
 
 .th-global-content {
-  overflow-y: auto;
+  /* Always show the scrollbar to avoid the layout change
+   * depending on the content */
+  overflow-y: scroll;
   overflow-x: hidden;
   height: 100%;
 }


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1864319