### PR TITLE
Bug 1864376 - Perform glean-probe-scraper workflow only on master/main branch.

### DIFF
--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -1,6 +1,10 @@
 ---
 name: Glean probe-scraper
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - main
 jobs:
   glean-probe-scraper:
     uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1864376

I've included both `master` and `main`, to make sure this workflow keeps working even if the branch is renamed in future.