### PR TITLE
Bug 1840394 - Use signature_id instead of signature_hash for graphs link.

### DIFF
--- a/ui/perfherder/compare/CompareSubtestsView.jsx
+++ b/ui/perfherder/compare/CompareSubtestsView.jsx
@@ -96,8 +96,8 @@ class CompareSubtestsView extends React.PureComponent {
       });
     }
     const signatureHash = !oldResults
-      ? newResults.signature_hash
-      : oldResults.signature_hash;
+      ? newResults.signature_id
+      : oldResults.signature_id;
 
     links = createGraphsLinks(
       this.props.validated,
@@ -139,9 +139,13 @@ class CompareSubtestsView extends React.PureComponent {
       cmap.name = testName;
       if (oldResults !== undefined) {
         cmap.suite = oldResults.suite;
+        cmap.baseColumnMeasurementUnit = oldResults.measurement_unit;
+        cmap.app = oldResults.application;
       }
       if (newResults !== undefined) {
         cmap.suite = newResults.suite;
+        cmap.newColumnMeasurementUnit = newResults.measurement_unit;
+        cmap.app = newResults.application;
       }
 
       if (

--- a/ui/perfherder/compare/CompareView.jsx
+++ b/ui/perfherder/compare/CompareView.jsx
@@ -120,8 +120,8 @@ class CompareView extends React.PureComponent {
       });
     }
     const signatureHash = !oldResults
-      ? newResults.signature_hash
-      : oldResults.signature_hash;
+      ? newResults.signature_id
+      : oldResults.signature_id;
     links = createGraphsLinks(
       this.props.validated,
       links,


### PR DESCRIPTION
This patch modified the CompareView graphs link to use the `signature_id` instead of the `signature_hash`. This fixes an issue where the graphs link for `custom-car` results would redirect to `chrome` or `chromium` results instead.

Locally, you can test this by going to here (note you'll need to change the domain to the localhost): `https://treeherder.mozilla.org/perfherder/compare?originalProject=mozilla-central&newProject=mozilla-central&newRevision=a0f7b9f56d1f3dd6b66ba0417bab9acccddc3ad9&framework=13&originalRevision=b94f3d418f54f964368486a65cd5d15e828867db&page=25`

Next, find a test with `custom-car`, and click the `graph` link. This should bring you to an incorrect page (either chrome or chromium). With this patch applied, the link correctly redirects to a `custom-car` graph.