### PR TITLE
Bug 1861899 - Ignore non-perf-test profiles in perf test job performance tab.

### DIFF
--- a/tests/ui/job-view/PerformanceTab_test.jsx
+++ b/tests/ui/job-view/PerformanceTab_test.jsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider, ReactReduxContext } from 'react-redux';
+import { ConnectedRouter } from 'connected-react-router';
+
+import {
+  configureStore,
+  history,
+} from '../../../ui/job-view/redux/configureStore';
+import PerformanceTab from '../../../ui/job-view/details/tabs/PerformanceTab.jsx';
+
+describe('PerformanceTab', () => {
+  const testPerformanceTab = ({
+    selectedJobFull,
+    jobDetails,
+    perfJobDetail,
+  }) => {
+    const repoName = 'try';
+    const currentRepo = { name: repoName };
+
+    const store = configureStore();
+
+    return (
+      <Provider store={store} context={ReactReduxContext}>
+        <ConnectedRouter history={history} context={ReactReduxContext}>
+          <PerformanceTab
+            selectedJobFull={selectedJobFull}
+            currentRepo={currentRepo}
+            repoName={repoName}
+            jobDetails={jobDetails}
+            perfJobDetail={perfJobDetail}
+            revision="REV1"
+          />
+        </ConnectedRouter>
+      </Provider>
+    );
+  };
+
+  test('perf test job with no profile should show generate button', async () => {
+    const { getByTestId, queryByTestId } = render(
+      testPerformanceTab({
+        selectedJobFull: {
+          job_type_name:
+            'test-macosx1015-64-shippable-qr/opt-browsertime-something',
+          job_type_symbol: 'some',
+          job_group_name: 'Browsertime performance tests on Firefox',
+          hasSideBySide: false,
+        },
+        jobDetails: [],
+        perfJobDetail: [],
+      }),
+    );
+
+    const generateProfile = await getByTestId('generate-profile');
+    expect(generateProfile.textContent).toBe('Generate performance profile');
+
+    const openProfiler = queryByTestId('open-profiler');
+    expect(openProfiler).toBeNull();
+  });
+
+  test('perf test job with resource profile should show generate button', async () => {
+    const { getByTestId, queryByTestId } = render(
+      testPerformanceTab({
+        selectedJobFull: {
+          job_type_name:
+            'test-macosx1015-64-shippable-qr/opt-browsertime-something',
+          job_type_symbol: 'some',
+          job_group_name: 'Browsertime performance tests on Firefox',
+          hasSideBySide: false,
+        },
+        jobDetails: [
+          {
+            url: 'dummy',
+            value: 'profile_resource-usage.json',
+          },
+          {
+            url: 'dummy',
+            value: 'profile_build_resources.json',
+          },
+        ],
+        perfJobDetail: [],
+      }),
+    );
+
+    const generateProfile = getByTestId('generate-profile');
+    expect(generateProfile.textContent).toBe('Generate performance profile');
+
+    const openProfiler = queryByTestId('open-profiler');
+    expect(openProfiler).toBeNull();
+  });
+
+  test('perf test job with perf profile should show retrigger button and open button', async () => {
+    const { getByTestId } = render(
+      testPerformanceTab({
+        selectedJobFull: {
+          job_type_name:
+            'test-macosx1015-64-shippable-qr/opt-browsertime-something',
+          job_type_symbol: 'some',
+          job_group_name: 'Browsertime performance tests on Firefox',
+          hasSideBySide: false,
+        },
+        jobDetails: [
+          {
+            url: 'profile_something.zip',
+            value: 'profile_something.zip',
+          },
+        ],
+        perfJobDetail: [],
+      }),
+    );
+
+    const generateProfile = getByTestId('generate-profile');
+    expect(generateProfile.textContent).toBe('Re-trigger performance profile');
+
+    const openProfiler = getByTestId('open-profiler');
+    expect(openProfiler.href).toBe(
+      'https://profiler.firefox.com/from-url/profile_something.zip',
+    );
+  });
+
+  test('perf test job with both perf and resource profiles should use perf profile', async () => {
+    const { getByTestId } = render(
+      testPerformanceTab({
+        selectedJobFull: {
+          job_type_name:
+            'test-macosx1015-64-shippable-qr/opt-browsertime-something',
+          job_type_symbol: 'some',
+          job_group_name: 'Browsertime performance tests on Firefox',
+          hasSideBySide: false,
+        },
+        jobDetails: [
+          {
+            url: 'dummy',
+            value: 'profile_resource-usage.json',
+          },
+          {
+            url: 'profile_something.json',
+            value: 'profile_something.json',
+          },
+        ],
+        perfJobDetail: [],
+      }),
+    );
+
+    const generateProfile = getByTestId('generate-profile');
+    expect(generateProfile.textContent).toBe('Re-trigger performance profile');
+
+    const openProfiler = getByTestId('open-profiler');
+    expect(openProfiler.href).toBe(
+      'https://profiler.firefox.com/from-url/profile_something.json',
+    );
+  });
+
+  test('perf test should use most relevant profile', async () => {
+    const { getByTestId } = render(
+      testPerformanceTab({
+        selectedJobFull: {
+          job_type_name:
+            'test-macosx1015-64-shippable-qr/opt-browsertime-something',
+          job_type_symbol: 'some',
+          job_group_name: 'Browsertime performance tests on Firefox',
+          hasSideBySide: false,
+        },
+        jobDetails: [
+          {
+            url: 'profile_something.json',
+            value: 'profile_something.json',
+          },
+          {
+            url: 'profile_something.zip',
+            value: 'profile_something.zip',
+          },
+        ],
+        perfJobDetail: [],
+      }),
+    );
+
+    const generateProfile = getByTestId('generate-profile');
+    expect(generateProfile.textContent).toBe('Re-trigger performance profile');
+
+    const openProfiler = getByTestId('open-profiler');
+    expect(openProfiler.href).toBe(
+      'https://profiler.firefox.com/from-url/profile_something.zip',
+    );
+  });
+});


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1861899

This changes the following:
  * If the job is perf test, ignore `profile_resource-usage.json` and `profile_build_resources.json`
    * "Open in Firefox Profiler" is shown only when there's profile for perf test
    * "Generate performance profile" button is shown if there's no profile for perf test
  * If there are multiple profiles, use most relevant profile
    * the order is "*.zip would go first, then profile_resource-usage.json / profile_build_resources.json, then *.json", as mentioned in the bug
