### PR TITLE
Bug 1766520 - Use the same font size for job button and group button.

### DIFF
--- a/ui/css/treeherder-job-buttons.css
+++ b/ui/css/treeherder-job-buttons.css
@@ -23,6 +23,7 @@
   vertical-align: 0;
   line-height: 1.32;
   cursor: pointer;
+  font-size: 12px;
 }
 
 .group-btn::before {


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1766520

This changes the text size of the group button (collapsed button) to the same size as regular job button,
in order to avoid making the line taller.

<img width="718" alt="button-size" src="https://github.com/mozilla/treeherder/assets/6299746/7496b930-c762-47f1-83ac-1fa6f9ef7805">
