### PR TITLE
Make the AuthorInitials function more i18n-friendly

### DIFF
--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -13,7 +13,7 @@ export function AuthorInitials(props) {
   const str = props.author || '';
   const words = str.split(' ');
   const firstLetters = words
-    .map((word) => word.replace(/[^A-Z]/gi, '')[0])
+    .map((word) => word.replace(/\P{General_Category=Letter}/gu, '')[0])
     .filter((firstLetter) => typeof firstLetter !== 'undefined');
   let initials = '';
 


### PR DESCRIPTION
I believe this should fix bug 1444986, where the initial "Á" of Emilio's last name is being ignored, so that treeherder displays the incorrect initials "EL" instead of "EÁ".