### PR TITLE
Make the parseAuthor function more i18n-friendly

### DIFF
--- a/ui/helpers/revision.js
+++ b/ui/helpers/revision.js
@@ -4,7 +4,10 @@ export const parseAuthor = function parseAuthor(author) {
   const userTokens = author.split(/[<>]+/);
   const name = userTokens[0]
     .trim()
-    .replace(/\p{General_Category=Letter}\S*/ug, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1));
+    .replace(
+      /\p{General_Category=Letter}\S*/ug,
+      (txt) => txt.charAt(0).toUpperCase() + txt.substr(1),
+    );
   const email = userTokens.length > 1 ? userTokens[1] : '';
   return { name, email };
 };

--- a/ui/helpers/revision.js
+++ b/ui/helpers/revision.js
@@ -5,7 +5,7 @@ export const parseAuthor = function parseAuthor(author) {
   const name = userTokens[0]
     .trim()
     .replace(
-      /\p{General_Category=Letter}\S*/ug,
+      /\p{General_Category=Letter}\S*/gu,
       (txt) => txt.charAt(0).toUpperCase() + txt.substr(1),
     );
   const email = userTokens.length > 1 ? userTokens[1] : '';

--- a/ui/helpers/revision.js
+++ b/ui/helpers/revision.js
@@ -4,7 +4,7 @@ export const parseAuthor = function parseAuthor(author) {
   const userTokens = author.split(/[<>]+/);
   const name = userTokens[0]
     .trim()
-    .replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1));
+    .replace(/\p{General_Category=Letter}\S*/ug, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1));
   const email = userTokens.length > 1 ? userTokens[1] : '';
   return { name, email };
 };


### PR DESCRIPTION
To fix bug 1865684: capitalize the first (Unicode) letter in each name component, not the first (ASCII) alphanumeric.