### PR TITLE
Bug 1867010 - Integrate replicates into the Graphs View.

### DIFF
--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -703,9 +703,54 @@ class PerformanceSummary(generics.ListAPIView):
 
         if signature and all_data:
             for item in self.queryset:
-                item['data'] = data.values(
-                    'value', 'job_id', 'id', 'push_id', 'push_timestamp', 'push__revision'
-                ).order_by('push_timestamp', 'push_id', 'job_id')
+                if replicates:
+                    item['data'] = list()
+                    for (
+                        value,
+                        job_id,
+                        datum_id,
+                        push_id,
+                        push_timestamp,
+                        push_revision,
+                        replicate_value,
+                    ) in data.values_list(
+                        'value',
+                        'job_id',
+                        'id',
+                        'push_id',
+                        'push_timestamp',
+                        'push__revision',
+                        'performancedatumreplicate__value',
+                    ).order_by(
+                        'push_timestamp', 'push_id', 'job_id'
+                    ):
+                        if replicate_value is not None:
+                            item['data'].append(
+                                {
+                                    "value": replicate_value,
+                                    "job_id": job_id,
+                                    "id": datum_id,
+                                    "push_id": push_id,
+                                    "push_timestamp": push_timestamp,
+                                    "push__revision": push_revision,
+                                }
+                            )
+                        elif value is not None:
+                            item['data'].append(
+                                {
+                                    "value": value,
+                                    "job_id": job_id,
+                                    "id": datum_id,
+                                    "push_id": push_id,
+                                    "push_timestamp": push_timestamp,
+                                    "push__revision": push_revision,
+                                }
+                            )
+                else:
+                    item['data'] = data.values(
+                        'value', 'job_id', 'id', 'push_id', 'push_timestamp', 'push__revision'
+                    ).order_by('push_timestamp', 'push_id', 'job_id')
+
                 item['option_name'] = option_collection_map[item['option_collection_id']]
                 item['repository_name'] = repository_name
 

--- a/ui/perfherder/graphs/GraphsView.jsx
+++ b/ui/perfherder/graphs/GraphsView.jsx
@@ -52,6 +52,7 @@ class GraphsView extends React.Component {
       showModal: false,
       showTable: false,
       visibilityChanged: false,
+      replicates: false,
     };
   }
 
@@ -62,6 +63,11 @@ class GraphsView extends React.Component {
   componentDidUpdate(prevProps) {
     const { location } = this.props;
     const { testData, loading } = this.state;
+    const { replicates } = queryString.parse(this.props.location.search);
+    const { replicates: prevReplicates } = queryString.parse(
+      prevProps.location.search,
+    );
+
     if (
       location.search === '' &&
       testData.length !== 0 &&
@@ -72,6 +78,10 @@ class GraphsView extends React.Component {
       this.setState({
         testData: [],
       });
+    }
+
+    if (replicates !== prevReplicates) {
+      window.location.reload(false);
     }
   }
 
@@ -94,13 +104,20 @@ class GraphsView extends React.Component {
       highlightCommonAlerts,
       highlightChangelogData,
       highlightedRevisions,
+      replicates,
     } = queryString.parse(this.props.location.search);
 
     const updates = {};
 
     if (series) {
+      // TODO: Move series/test data fetch to after the params are parsed, and
+      // the component is updated. Here, it's using default settings even if
+      // the parameters are different.
       const _series = typeof series === 'string' ? [series] : series;
-      const seriesParams = this.parseSeriesParam(_series);
+      const seriesParams = this.parseSeriesParam(
+        _series,
+        Boolean(parseInt(replicates, 10)),
+      );
       this.getTestData(seriesParams, true);
     }
 
@@ -118,6 +135,10 @@ class GraphsView extends React.Component {
       updates.highlightChangelogData = Boolean(
         parseInt(highlightChangelogData, 10),
       );
+    }
+
+    if (replicates) {
+      updates.replicates = Boolean(parseInt(replicates, 10));
     }
 
     if (highlightedRevisions) {
@@ -150,6 +171,7 @@ class GraphsView extends React.Component {
       repository_name: repositoryName,
       signature_id: signatureId,
       framework_id: frameworkId,
+      replicates,
     } = series;
     const { timeRange } = this.state;
 
@@ -159,6 +181,7 @@ class GraphsView extends React.Component {
       framework: frameworkId,
       interval: timeRange.value,
       all_data: true,
+      replicates,
     };
   };
 
@@ -287,7 +310,7 @@ class GraphsView extends React.Component {
     this.setState({ testData: newTestData });
   };
 
-  parseSeriesParam = (series) =>
+  parseSeriesParam = (series, replicates) =>
     series.map((encodedSeries) => {
       const partialSeriesArray = encodedSeries.split(',');
       const partialSeriesObject = {
@@ -301,6 +324,7 @@ class GraphsView extends React.Component {
         // for visibility of test legend cards but isn't actually being used
         // to control visibility so it should be removed at some point
         framework_id: parseInt(partialSeriesArray[3], 10),
+        replicates,
       };
 
       return partialSeriesObject;
@@ -330,6 +354,7 @@ class GraphsView extends React.Component {
       highlightChangelogData,
       highlightedRevisions,
       timeRange,
+      replicates,
     } = this.state;
 
     const newSeries = testData.map(
@@ -342,6 +367,7 @@ class GraphsView extends React.Component {
       highlightCommonAlerts: +highlightCommonAlerts,
       highlightChangelogData: +highlightChangelogData,
       timerange: timeRange.value,
+      replicates: +replicates,
       zoom,
     };
 
@@ -388,6 +414,7 @@ class GraphsView extends React.Component {
       showModal,
       showTable,
       visibilityChanged,
+      replicates,
     } = this.state;
 
     const { projects, frameworks, user } = this.props;
@@ -473,6 +500,7 @@ class GraphsView extends React.Component {
                 updateData={this.updateData}
                 toggle={() => this.setState({ showModal: !showModal })}
                 toggleTableView={() => this.setState({ showTable: !showTable })}
+                replicates={replicates}
                 updateTimeRange={(newTimeRange) =>
                   this.setState(
                     {

--- a/ui/perfherder/graphs/GraphsViewControls.jsx
+++ b/ui/perfherder/graphs/GraphsViewControls.jsx
@@ -78,6 +78,7 @@ export default class GraphsViewControls extends React.Component {
       hasNoData,
       toggle,
       toggleTableView,
+      replicates,
       showModal,
       showTable,
       testData,
@@ -199,6 +200,19 @@ export default class GraphsViewControls extends React.Component {
                     active={highlightCommonAlerts}
                   >
                     Highlight common alerts
+                  </Button>
+                  <Button
+                    className="ml-3"
+                    color="darker-info"
+                    outline
+                    onClick={() =>
+                      updateStateParams({
+                        replicates: !replicates,
+                      })
+                    }
+                    active={replicates}
+                  >
+                    Use replicates
                   </Button>
                 </Col>
               )}

--- a/ui/perfherder/graphs/TestDataModal.jsx
+++ b/ui/perfherder/graphs/TestDataModal.jsx
@@ -383,12 +383,14 @@ export default class TestDataModal extends React.Component {
       getTestData,
       timeRange: parentTimeRange,
       updateTestsAndTimeRange,
+      replicates,
     } = this.props;
 
     const displayedTestParams = selectedTests.map((series) => ({
       repository_name: series.projectName,
       signature_id: parseInt(series.id, 10),
       framework_id: parseInt(series.frameworkId, 10),
+      replicates,
     }));
 
     this.setState({


### PR DESCRIPTION
This patch adds a button to enable using replicates in the graphs view. The button is made available all the time as the cases for where replicates are available are not limited to a single branch anymore after PR #7886 lands. It also changes the API to return replicates for the specific case that the graphs view querys for (all_data).