### PR TITLE
Move setup for enable_eager_celery so it's set for all ingestion types.

### DIFF
--- a/treeherder/etl/management/commands/ingest.py
+++ b/treeherder/etl/management/commands/ingest.py
@@ -67,12 +67,6 @@ def ingest_pr(pr_url, root_url):
 
 
 def ingest_hg_push(options):
-    if not options["enable_eager_celery"]:
-        logger.info("If you want all logs to be parsed use --enable-eager-celery")
-    else:
-        # Make sure all tasks are run synchronously / immediately
-        settings.CELERY_TASK_ALWAYS_EAGER = True
-
     # get reference to repo and ingest this particular revision for this project
     project = options["project"]
     commit = options["commit"]
@@ -463,6 +457,12 @@ class Command(BaseCommand):
         loop = asyncio.get_event_loop()
         typeOfIngestion = options["ingestion_type"][0]
         root_url = options["root_url"]
+
+        if not options["enable_eager_celery"]:
+            logger.info("If you want all logs to be parsed use --enable-eager-celery")
+        else:
+            # Make sure all tasks are run synchronously / immediately
+            settings.CELERY_TASK_ALWAYS_EAGER = True
 
         if typeOfIngestion == "task":
             assert options["taskId"]


### PR DESCRIPTION
This patch moves the setup for the `--enable-eager-celery` setting out of `ingest_hg_push`, and into the `handle` method for the ingest command. This enables us to use the flag with all the different `ingestion_type`s.

For example, this patch allows us to parse, and ingest logs for individual tasks (very useful for perf tasks), and the following command now parses and ingests the perf data for a single task, previously it would only ingest the task itself: `docker-compose exec backend ./manage.py ingest task -p autoland --task-id BKhBS3GbTKeIXvTMRI26vg --enable-eager-celery`