### PR TITLE
Bug 1823654 - Switch to Ruff for linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,4 @@
 repos:
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        args: [--append-config=tox.ini]
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.9.0.5
     hooks:
@@ -16,6 +11,11 @@ repos:
     rev: v0.32.2
     hooks:
       - id: markdownlint
+        args: [--fix]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.14
+    hooks:
+      - id: ruff
         args: [--fix]
   - repo: https://github.com/psf/black
     rev: 23.3.0

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![Node dependencies Status](https://shields.io/librariesio/github/mozilla/treeherder)
 [![Documentation Status](https://readthedocs.org/projects/treeherder/badge/?version=latest)](https://treeherder.readthedocs.io/?badge=latest)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 ## Description
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,3 @@ ignore = [
 [tool.ruff.per-file-ignores]
 # Ignore `module-import-not-at-top-of-file` rule of `pycodestyle`
 "treeherder/model/models.py" = ["E402"]
-
-# Ignore `not-is-test` rule of `pycodestyle`
-"treeherder/perf/sheriffing_criteria/criteria_tracking.py" = ["E714"]
-
-# Ignore `not-in-test` rule of `pycodestyle`
-"treeherder/push_health/utils.py" = ["E713"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,40 @@ exclude = '''
   | treeherder/changelog/migrations
 )/
 '''
+
+[tool.ruff]
+# Same as Black.
+line-length = 100
+
+# Assume Python 3.9
+target-version = "py39"
+
+# In addition to the standard set of exclusions, omit all tests, plus a specific file.
+extend-exclude = ["*/.*/",".*/","__pycache__","node_modules"]
+
+select = [
+  # pycodestyle
+  "E",
+  "W",
+  # pyflakes
+  "F",
+]
+
+ignore = [
+  # E203 whitespace before ':'
+  "E203",
+  # E231: missing whitespace after ','
+  "E231",
+  # E501: line too long
+  "E501"
+]
+
+[tool.ruff.per-file-ignores]
+# Ignore `module-import-not-at-top-of-file` rule of `pycodestyle`
+"treeherder/model/models.py" = ["E402"]
+
+# Ignore `not-is-test` rule of `pycodestyle`
+"treeherder/perf/sheriffing_criteria/criteria_tracking.py" = ["E714"]
+
+# Ignore `not-in-test` rule of `pycodestyle`
+"treeherder/push_health/utils.py" = ["E713"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,6 @@ select = [
 ]
 
 ignore = [
-  # E203 whitespace before ':'
-  "E203",
-  # E231: missing whitespace after ','
-  "E231",
   # E501: line too long
   "E501"
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,3 @@
-[flake8]
-exclude = */.*/,.*/,__pycache__,node_modules
-# E129: visually indented line with same indent as next logical line
-# E203 whitespace before ':'
-# E231: missing whitespace after ','
-# E501: line too long
-extend_ignore = E129,E203,E231,E501
-max-line-length = 100
-
 [tool:pytest]
 testpaths = tests
 norecursedirs = __pycache__ ui

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,3 @@ whitelist_externals=
     docker-compose
 commands =
     docker-compose run -e TREEHERDER_DEBUG=False -e DATABASE_URL=psql://postgres:mozilla1234@postgres:5432/treeherder backend bash -c "pytest --cov --cov-report=xml tests/ --runslow -p no:unraisableexception"
-
-[flake8]
-per-file-ignores = treeherder/model/models.py:E402

--- a/treeherder/perf/sheriffing_criteria/criteria_tracking.py
+++ b/treeherder/perf/sheriffing_criteria/criteria_tracking.py
@@ -128,9 +128,9 @@ class ConcurrencyStrategy:
 
         if not issubclass(self._pool_class, Pool):
             raise TypeError(f'Expected Pool (sub)class parameter. Got {self._pool_class} instead')
-        if not type(thread_wait) is timedelta:
+        if type(thread_wait) is not timedelta:
             raise TypeError('Expected timedelta parameter.')
-        if not type(check_interval) is timedelta:
+        if type(check_interval) is not timedelta:
             raise TypeError('Expected timedelta parameter.')
 
     def pool(self):

--- a/treeherder/push_health/utils.py
+++ b/treeherder/push_health/utils.py
@@ -64,7 +64,7 @@ def clean_test(test, signature, message):
 
     if '|' in clean_name:
         parts = clean_name.split('|')
-        clean_parts = filter(lambda x: not x.strip() in trim_parts, parts)
+        clean_parts = filter(lambda x: x.strip() not in trim_parts, parts)
         clean_name = '|'.join(clean_parts)
 
     return clean_name


### PR DESCRIPTION
I replaced the flake8 pre-commit hook with ruff's and migrated the configuration found in:
- [setup.cfg](https://github.com/mozilla/treeherder/blob/e91eb1cd66c13ee592da45185c718276433e4976/setup.cfg#L1-L8)
- [tox.ini](https://github.com/mozilla/treeherder/blob/e91eb1cd66c13ee592da45185c718276433e4976/tox.ini#L58-L59)
To Ruff's configuration in `pyproject.toml`.

I kept the default Flake8 rules, `pyflakes` (`"F"` rule) and `pycodestyle` (`"E"` and `"W"` rules).