### PR TITLE
Bug 1879316 - Use the absolute value of the delta in the alert threshold check.

### DIFF
--- a/treeherder/perf/alerts.py
+++ b/treeherder/perf/alerts.py
@@ -129,7 +129,7 @@ def generate_new_alerts_in_series(signature):
                     and alert_properties.pct_change < alert_threshold
                 ) or (
                     signature.alert_change_type == PerformanceSignature.ALERT_ABS
-                    and alert_properties.delta < alert_threshold
+                    and abs(alert_properties.delta) < alert_threshold
                 ):
                     continue
 


### PR DESCRIPTION
This patch fixes an issue where the absolute alert threshold was negative on an improvement, and this was checked against the alert threshold. This meant that improvements would never have an alert generated for them since they were always negative. With this change, improvement alerts will now be produced for tests using the absolute threshold.