### PR TITLE
Revert djangorestframework from 3.15.1 to 3.14.0

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -12,7 +12,7 @@ mysqlclient==2.2.4   # Required by Django
 psycopg2-binary==2.9.9
 
 jsonschema==4.21.1  # import jsonschema
-djangorestframework==3.15.1  # Imported as rest_framework
+djangorestframework==3.14.0  # Imported as rest_framework
 django-cors-headers==4.3.1  # Listed as 3rd party app on settings.py
 mozlog==8.0.0
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -388,9 +388,9 @@ django-redis==5.4.0 \
     --hash=sha256:6a02abaa34b0fea8bf9b707d2c363ab6adc7409950b2db93602e6cb292818c42 \
     --hash=sha256:ebc88df7da810732e2af9987f7f426c96204bf89319df4c6da6ca9a2942edd5b
     # via -r requirements/common.in
-djangorestframework==3.15.1 \
-    --hash=sha256:3ccc0475bce968608cf30d07fb17d8e52d1d7fc8bfe779c905463200750cbca6 \
-    --hash=sha256:f88fad74183dfc7144b2756d0d2ac716ea5b4c7c9840995ac3bfd8ec034333c1
+djangorestframework==3.14.0 \
+    --hash=sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8 \
+    --hash=sha256:eb63f58c9f218e1a7d064d17a70751f528ed4e1d35547fdade9aaf4cd103fd08
     # via -r requirements/common.in
 dockerflow==2024.3.0 \
     --hash=sha256:96678b00636dfd61fccf08f5f4102d0444e43bec3f8850175a060d8e83559e4c \
@@ -1037,6 +1037,10 @@ python-jose[pycryptodome]==3.3.0 \
 python3-memcached==1.51 \
     --hash=sha256:7cbe5951d68eef69d948b7a7ed7decfbd101e15e7f5be007dcd1219ccc584859
     # via mozci
+pytz==2024.1 \
+    --hash=sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812 \
+    --hash=sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319
+    # via djangorestframework
 pyyaml==6.0.1 \
     --hash=sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5 \
     --hash=sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc \


### PR DESCRIPTION
The API documentation page was broken: https://github.com/encode/django-rest-framework/issues/9291

Revert "Bump djangorestframework from 3.15.0 to 3.15.1"

This reverts commit 995ce0322734bdec2c641b304a80b275549824f3.

Revert "Bump djangorestframework from 3.14.0 to 3.15.0"

This reverts commit 9b9a11f1e93bccdf7086f6fa6d6f07db9ed0643b.