### PR TITLE
Bug 1890349 - only check for crash signature to identify failure line as crash

### DIFF
--- a/ui/shared/BugFiler.jsx
+++ b/ui/shared/BugFiler.jsx
@@ -287,9 +287,9 @@ export class BugFilerClass extends React.Component {
   }
 
   getCrashSignatures(failureLine) {
-    const crashRegex = /application crashed \[@ (.+)\]/g;
-    const crash = failureLine.search.match(crashRegex);
-    return crash ? [crash[0].split('application crashed ')[1]] : [];
+    const crashRegex = /(\[@ .+\])/g;
+    const crashSignatures = failureLine.search.match(crashRegex);
+    return crashSignatures ? [crashSignatures[0]] : [];
   }
 
   getUnhelpfulSummaryReason(summary) {


### PR DESCRIPTION


Until now, 'application crashed' had been expected as prefix of the crash signature. Other text can be logged in its place, e.g. 'not thread-safe'.