### PR TITLE
Bug 1840660 - Add Safari Technology Preview to perf schema

### DIFF
--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -14,7 +14,8 @@
             "refbrow",
             "fenix",
             "safari",
-            "custom-car"
+            "custom-car",
+            "cstm-car-m"
           ],
           "maxLength": 10,
           "type": "string"

--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -14,6 +14,7 @@
             "refbrow",
             "fenix",
             "safari",
+            "safari-tp",
             "custom-car",
             "cstm-car-m"
           ],


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1840660