### PR TITLE
Add Safari Tech Preview to perf schema (Bug 1840660)

### DIFF
--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -14,6 +14,7 @@
             "refbrow",
             "fenix",
             "safari",
+            "safari-tp",
             "custom-car",
             "cstm-car-m"
           ],


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1840660