### PR TITLE
Add percentage to compare view standard deviation.

### DIFF
--- a/ui/perfherder/compare/TableAverage.jsx
+++ b/ui/perfherder/compare/TableAverage.jsx
@@ -64,7 +64,7 @@ const TableAverage = ({ value, stddev, stddevpct, replicates, app }) => {
                 ? formatNumber(displayNumber(value))
                 : `${formatNumber(
                     displayNumber(value),
-                  )} ${'\u00B1'} ${formatNumber(displayNumber(stddevpct))}`
+                  )} ${'\u00B1'} ${formatNumber(displayNumber(stddevpct))}%`
             }
             tooltipText={
               notZeroSum ? (

--- a/ui/perfherder/compare/TableAverage.jsx
+++ b/ui/perfherder/compare/TableAverage.jsx
@@ -39,7 +39,9 @@ const TableAverage = ({ value, stddev, stddevpct, replicates, app }) => {
         <>
           {`Runs: < ${replicatesStr} > ${formatNumber(
             displayNumber(stddev),
-          )} = ${formatNumber(displayNumber(stddevpct))}% for 1 standard deviation`}
+          )} = ${formatNumber(
+            displayNumber(stddevpct),
+          )}% for 1 standard deviation`}
         </>
       );
     }

--- a/ui/perfherder/compare/TableAverage.jsx
+++ b/ui/perfherder/compare/TableAverage.jsx
@@ -29,7 +29,7 @@ const TableAverage = ({ value, stddev, stddevpct, replicates, app }) => {
           {`${formatNumber(displayNumber(stddev))} = ${formatNumber(
             displayNumber(stddevpct),
           )}% `}
-          standard deviation
+          for 1 standard deviation
           <br />
           (use JSON download button to see more)
         </>
@@ -39,7 +39,7 @@ const TableAverage = ({ value, stddev, stddevpct, replicates, app }) => {
         <>
           {`Runs: < ${replicatesStr} > ${formatNumber(
             displayNumber(stddev),
-          )} = ${formatNumber(displayNumber(stddevpct))}% standard deviation`}
+          )} = ${formatNumber(displayNumber(stddevpct))}% for 1 standard deviation`}
         </>
       );
     }


### PR DESCRIPTION
This patch adds a `%` sign to the standard deviation shown in compare view. It also adds a bit of text to clarify what the percentage means.