### PR TITLE
Bug 1902276 - sort failurecount data returned by API by date

### DIFF
--- a/treeherder/webapp/api/intermittents_view.py
+++ b/treeherder/webapp/api/intermittents_view.py
@@ -140,6 +140,7 @@ class FailureCount(generics.ListAPIView):
             .values("date")
             .annotate(test_runs=Count("author"))
             .values("date", "test_runs")
+            .order_by("date")
         )
 
         if bug_id:


### PR DESCRIPTION
Else bugzilla's intermittent graph shows failures for incorrect days.