### PR TITLE
Bug 1901687 - Look up push ID in push table for faster query

### DIFF
--- a/tests/log_parser/test_store_failure_lines.py
+++ b/tests/log_parser/test_store_failure_lines.py
@@ -212,7 +212,7 @@ def test_get_group_results(activate_responses, test_repository, test_job):
     log_obj = JobLog.objects.create(job=test_job, name="errorsummary_json", url=log_url)
     store_failure_lines(log_obj)
 
-    groups = get_group_results(test_job.push)
+    groups = get_group_results(test_repository, test_job.push)
     task_groups = groups["V3SVuxO8TFy37En_6HcXLs"]
 
     assert task_groups["dom/base/test/browser.ini"]
@@ -228,7 +228,7 @@ def test_get_group_results_with_colon(activate_responses, test_repository, test_
     log_obj = JobLog.objects.create(job=test_job, name="errorsummary_json", url=log_url)
     store_failure_lines(log_obj)
 
-    groups = get_group_results(test_job.push)
+    groups = get_group_results(test_repository, test_job.push)
     task_groups = groups["V3SVuxO8TFy37En_6HcXLs"]
 
     assert task_groups[

--- a/treeherder/log_parser/failureline.py
+++ b/treeherder/log_parser/failureline.py
@@ -186,9 +186,11 @@ def replace_astral(log_list):
         yield item
 
 
-def get_group_results(push):
+def get_group_results(repository, push):
     groups = Group.objects.filter(
-        job_logs__job__push=push, group_result__status__in=[GroupStatus.OK, GroupStatus.ERROR]
+        job_logs__job__push__revision=push.revision,
+        job_logs__job__push__repository=repository,
+        group_result__status__in=[GroupStatus.OK, GroupStatus.ERROR],
     ).values(
         "group_result__status",
         "name",

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -468,6 +468,6 @@ class PushViewSet(viewsets.ViewSet):
             push = Push.objects.get(revision=revision, repository=repository)
         except Push.DoesNotExist:
             return Response(f"No push with revision: {revision}", status=HTTP_404_NOT_FOUND)
-        groups = get_group_results(push)
+        groups = get_group_results(repository, push)
 
         return Response(groups)


### PR DESCRIPTION
Django filters the group status data on the push ID in the `job` table where it is a foreign key. Moving the condition to the `push` table reduces query time (from 17-27s to 4-5s in a local development setup with production db queried).