### PR TITLE
Bug 1893782 - Only create a single Intl.NumberFormat instance to form…

### DIFF
--- a/ui/perfherder/perf-helpers/helpers.js
+++ b/ui/perfherder/perf-helpers/helpers.js
@@ -27,8 +27,11 @@ import {
   permaLinkPrefix,
 } from './constants';
 
-export const formatNumber = (input) =>
-  new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(input);
+const numberFormat = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 2,
+});
+
+export const formatNumber = (input) => numberFormat.format(input);
 
 export const abbreviatedNumber = (num) =>
   num.toString().length <= 5 ? num : numeral(num).format('0.0a');


### PR DESCRIPTION
…at numbers

Currently the code creates a new instance of this class for every number that needs to be formatted. This results in 70% of the time spent when switching to 'use replicates' being spent under internationalization code.

Creating a single instance greatly improves matters.