### PR TITLE
Bug 1908442 - call close method for Custom Job Action/Custom Push Action modal in callback of setState

### DIFF
--- a/ui/job-view/CustomJobActions.jsx
+++ b/ui/job-view/CustomJobActions.jsx
@@ -151,7 +151,7 @@ class CustomJobActions extends React.PureComponent {
       currentRepo,
     }).then(
       (taskId) => {
-        this.setState({ triggering: false });
+        this.setState({ triggering: false }, this.close);
         let message = 'Custom action request sent successfully:';
         let url = tcLibUrls.ui(
           checkRootUrl(currentRepo.tc_root_url),
@@ -175,8 +175,7 @@ class CustomJobActions extends React.PureComponent {
       },
       (e) => {
         notify(formatTaskclusterError(e), 'danger', { sticky: true });
-        this.setState({ triggering: false });
-        this.close();
+        this.setState({ triggering: false }, this.close);
       },
     );
   };


### PR DESCRIPTION
This is a regression from the upgrade to React 18. 'setState' (to set it from triggering state to non-triggering state) is asynchronous and the method in which it gets set calls this.close() itself. Put that call as callback of these setState calls.