### PR TITLE
Add platform to `statsd` in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,6 +146,7 @@ services:
       - ./docker/statsd_config.js:/usr/src/app/config.js
     ports:
       - '8125:8125'
+    platform: linux/amd64
 
 volumes:
   # TODO: Experiment with using tmpfs when testing, to speed up database-using Python tests.


### PR DESCRIPTION
`docker-compose up --build` was failing on machines with Apple Silicon with this error:
`no matching manifest for linux/arm64/v8 in the manifest list entries`

It looks like we fixed it a year ago in #7728, but "statsd" was added after that PR and broke the docker-compose builds with M1 chips again.

Similar to the previous PR, to test it you can run these commands in your terminal:
1. `docker system prune --all --volumes --force`
2. `docker-compose up --build`
