### PR TITLE
Bug 1910864/1887138 - Fix how we handle profiler urls on the perfherder backend

### DIFF
--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -5,7 +5,6 @@ from urllib.parse import urlencode
 
 import django_filters
 from django.conf import settings
-from django.core.cache import cache
 from django.db import transaction
 from django.db.models import CharField, Count, Q, Subquery, Value, Case, When
 from django.db.models.functions import Concat
@@ -483,19 +482,11 @@ class PerformanceAlertSummaryViewSet(viewsets.ModelViewSet):
                     if summary["id"] == int(pk):
                         for alert in summary["alerts"]:
                             if alert["is_regression"]:
-                                taskcluster_metadata = (
-                                    cache.get("task_metadata") if cache.get("task_metadata") else {}
-                                )
                                 alert["profile_url"] = get_profile_artifact_url(
-                                    alert, taskcluster_metadata
-                                )
-                                prev_taskcluster_metadata = (
-                                    cache.get("prev_task_metadata")
-                                    if cache.get("prev_task_metadata")
-                                    else {}
+                                    alert, metadata_key="taskcluster_metadata"
                                 )
                                 alert["prev_profile_url"] = get_profile_artifact_url(
-                                    alert, prev_taskcluster_metadata
+                                    alert, metadata_key="prev_taskcluster_metadata"
                                 )
             return self.get_paginated_response(serializer.data)
 

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -208,7 +208,6 @@ class PerformanceAlertSerializer(serializers.ModelSerializer):
         try:
             taskcluster_metadata = get_tc_metadata(alert, alert.summary.push)
             cache.set("tc_root_url", alert.summary.repository.tc_root_url, FIVE_DAYS)
-            cache.set("task_metadata", taskcluster_metadata, FIVE_DAYS)
             return taskcluster_metadata
         except ObjectDoesNotExist:
             return {}

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -222,10 +222,10 @@ class PerformanceAlertSerializer(serializers.ModelSerializer):
             return {}
 
     def get_profile_url(self, alert):
-        return "N/A"
+        return None
 
     def get_prev_profile_url(self, alert):
-        return "N/A"
+        return None
 
     def get_classifier_email(self, performance_alert):
         return getattr(performance_alert.classifier, "email", None)

--- a/treeherder/webapp/api/utils.py
+++ b/treeherder/webapp/api/utils.py
@@ -68,14 +68,19 @@ def get_artifact_list(root_url, task_id):
         return artifacts.get("artifacts", [])
 
 
-def get_profile_artifact_url(alert, task_metadata):
+def get_profile_artifact_url(alert, metadata_key):
     tc_root_url = cache.get("tc_root_url", "")
-    # Return a string to tell that task_id wasn't found
+    # Get the taskcluster metadata we'll use. It's determined by the caller.
+    task_metadata = alert[metadata_key]
+
+    # Return None if task_id wasn't found
     if not task_metadata.get("task_id") or not tc_root_url:
-        return "task_id not found"
+        return None
+
     # If the url was already cached, don't calculate again, just return it
     if cache.get(task_metadata.get("task_id")):
         return cache.get(task_metadata.get("task_id"))
+
     artifacts_json = get_artifact_list(tc_root_url, task_metadata.get("task_id"))
     profile_artifact = [
         artifact
@@ -86,7 +91,8 @@ def get_profile_artifact_url(alert, task_metadata):
     ]
 
     if not profile_artifact:
-        return "Artifact not available"
+        return None
+
     task_url = f"{tc_root_url}/api/queue/v1/task/{task_metadata['task_id']}"
     # There's only one profile relevant for performance per task
     artifact_url = (


### PR DESCRIPTION
This PR fixes both [Bug 1910864](https://bugzilla.mozilla.org/show_bug.cgi?id=1910864) and [Bug 1887138](https://bugzilla.mozilla.org/show_bug.cgi?id=1887138).

First commit fixes Bug 1910864 and second commit fixes Bug 1887138. Please look at their commit messages to get more information about what they are doing. But to give you a quick overview about them:
1. First commit fixes how we send `"N/A"` for profile urls. Changed it to `None` there so we can see null properly on the frontend and omit them/
2. Second commit fixes various issues in the function where we generate the profile urls. But the most important issue was how we return incorrect profile urls sometimes because the caching mechanism only caches the last alert metadata inside a single push, and uses that for all the alerts.