### PR TITLE
Return replicates data in perfcompare if available.

### DIFF
--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -54,9 +54,7 @@ class PerformanceSignatureViewSet(viewsets.ViewSet):
     def list(self, request, project):
         repository = models.Repository.objects.get(name=project)
 
-        signature_data = PerformanceSignature.objects.filter(
-            repository=repository
-        ).select_related(
+        signature_data = PerformanceSignature.objects.filter(repository=repository).select_related(
             "parent_signature__signature_hash", "option_collection", "platform"
         )
 
@@ -65,9 +63,7 @@ class PerformanceSignatureViewSet(viewsets.ViewSet):
             parent_signatures = PerformanceSignature.objects.filter(
                 repository=repository, signature_hash__in=parent_signature_hashes
             )
-            signature_data = signature_data.filter(
-                parent_signature__in=parent_signatures
-            )
+            signature_data = signature_data.filter(parent_signature__in=parent_signatures)
 
         if not int(request.query_params.get("subtests", True)):
             signature_data = signature_data.filter(parent_signature__isnull=True)
@@ -207,9 +203,7 @@ class PerformancePlatformViewSet(viewsets.ViewSet):
         if frameworks:
             signature_data = signature_data.filter(framework__in=frameworks)
 
-        return Response(
-            signature_data.values_list("platform__platform", flat=True).distinct()
-        )
+        return Response(signature_data.values_list("platform__platform", flat=True).distinct())
 
 
 class PerformanceFrameworkViewSet(viewsets.ReadOnlyModelViewSet):
@@ -237,15 +231,12 @@ class PerformanceDatumViewSet(viewsets.ViewSet):
             job_ids = [int(job_id) for job_id in request.query_params.getlist("job_id")]
         except ValueError:
             return Response(
-                {"message": "Job id(s) must be specified as integers"},
-                status=HTTP_400_BAD_REQUEST,
+                {"message": "Job id(s) must be specified as integers"}, status=HTTP_400_BAD_REQUEST
             )
 
         if not (signature_ids or signature_hashes or push_ids or job_ids):
             raise exceptions.ValidationError(
-                "Need to specify either "
-                "signature_id, signatures, "
-                "push_id, or job_id"
+                "Need to specify either " "signature_id, signatures, " "push_id, or job_id"
             )
         if signature_ids and signature_hashes:
             raise exceptions.ValidationError(
@@ -350,14 +341,10 @@ class PerformanceAlertSummaryFilter(django_filters.FilterSet):
     status = django_filters.NumberFilter(field_name="status")
     framework = django_filters.NumberFilter(field_name="framework")
     repository = django_filters.NumberFilter(field_name="repository")
-    alerts__series_signature = django_filters.NumberFilter(
-        field_name="alerts__series_signature"
-    )
+    alerts__series_signature = django_filters.NumberFilter(field_name="alerts__series_signature")
     filter_text = django_filters.CharFilter(method="_filter_text")
     hide_improvements = django_filters.BooleanFilter(method="_hide_improvements")
-    hide_related_and_invalid = django_filters.BooleanFilter(
-        method="_hide_related_and_invalid"
-    )
+    hide_related_and_invalid = django_filters.BooleanFilter(method="_hide_related_and_invalid")
     with_assignee = django_filters.CharFilter(method="_with_assignee")
     timerange = django_filters.NumberFilter(method="_timerange")
 
@@ -366,8 +353,7 @@ class PerformanceAlertSummaryFilter(django_filters.FilterSet):
         words = value.split(" ")
 
         contains_all_words = [
-            Q(full_name__contains=word) | Q(related_full_name__contains=word)
-            for word in words
+            Q(full_name__contains=word) | Q(related_full_name__contains=word) for word in words
         ]
 
         # Django's distinct(*fields) isn't supported for MySQL
@@ -411,9 +397,9 @@ class PerformanceAlertSummaryFilter(django_filters.FilterSet):
         return queryset.filter(id__in=Subquery(filtered_summaries))
 
     def _hide_improvements(self, queryset, name, value):
-        return queryset.annotate(
-            total_regressions=Count("alerts__is_regression")
-        ).filter(alerts__is_regression=True, total_regressions__gte=1)
+        return queryset.annotate(total_regressions=Count("alerts__is_regression")).filter(
+            alerts__is_regression=True, total_regressions__gte=1
+        )
 
     def _hide_related_and_invalid(self, queryset, name, value):
         return queryset.exclude(
@@ -429,9 +415,7 @@ class PerformanceAlertSummaryFilter(django_filters.FilterSet):
 
     def _timerange(self, queryset, name, value):
         return queryset.filter(
-            push__time__gt=datetime.datetime.utcfromtimestamp(
-                int(time.time() - int(value))
-            )
+            push__time__gt=datetime.datetime.utcfromtimestamp(int(time.time() - int(value)))
         )
 
     class Meta:
@@ -482,10 +466,7 @@ class PerformanceAlertSummaryViewSet(viewsets.ModelViewSet):
     permission_classes = (IsStaffOrReadOnly,)
 
     serializer_class = PerformanceAlertSummarySerializer
-    filter_backends = (
-        django_filters.rest_framework.DjangoFilterBackend,
-        filters.OrderingFilter,
-    )
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend, filters.OrderingFilter)
     filterset_class = PerformanceAlertSummaryFilter
 
     ordering = ("-created", "-id")
@@ -503,9 +484,7 @@ class PerformanceAlertSummaryViewSet(viewsets.ModelViewSet):
                         for alert in summary["alerts"]:
                             if alert["is_regression"]:
                                 taskcluster_metadata = (
-                                    cache.get("task_metadata")
-                                    if cache.get("task_metadata")
-                                    else {}
+                                    cache.get("task_metadata") if cache.get("task_metadata") else {}
                                 )
                                 alert["profile_url"] = get_profile_artifact_url(
                                     alert, taskcluster_metadata
@@ -528,8 +507,7 @@ class PerformanceAlertSummaryViewSet(viewsets.ModelViewSet):
 
         if data["push_id"] == data["prev_push_id"]:
             return Response(
-                "IDs of push & previous push cannot be identical",
-                status=HTTP_400_BAD_REQUEST,
+                "IDs of push & previous push cannot be identical", status=HTTP_400_BAD_REQUEST
             )
 
         alert_summary, _ = PerformanceAlertSummary.objects.get_or_create(
@@ -556,10 +534,7 @@ class PerformanceAlertViewSet(viewsets.ModelViewSet):
     permission_classes = (IsStaffOrReadOnly,)
 
     serializer_class = PerformanceAlertSerializer
-    filter_backends = (
-        django_filters.rest_framework.DjangoFilterBackend,
-        filters.OrderingFilter,
-    )
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend, filters.OrderingFilter)
     filterset_fields = ["id"]
     ordering = "-id"
 
@@ -578,15 +553,10 @@ class PerformanceAlertViewSet(viewsets.ModelViewSet):
             return super().update(request, *args, **kwargs)
         else:
             alert = PerformanceAlert.objects.get(pk=kwargs["pk"])
-            if (
-                all([new_push_id, new_prev_push_id])
-                and alert.summary.push.id != new_push_id
-            ):
+            if all([new_push_id, new_prev_push_id]) and alert.summary.push.id != new_push_id:
                 return self.nudge(alert, new_push_id, new_prev_push_id)
 
-            return Response(
-                {"message": "Incorrect push was provided"}, status=HTTP_400_BAD_REQUEST
-            )
+            return Response({"message": "Incorrect push was provided"}, status=HTTP_400_BAD_REQUEST)
 
     def create(self, request, *args, **kwargs):
         data = request.data
@@ -642,9 +612,7 @@ class PerformanceAlertViewSet(viewsets.ModelViewSet):
         prev_value = sum(prev_values) / len(prev_values)
         new_value = sum(new_values) / len(new_values)
 
-        return get_alert_properties(
-            prev_value, new_value, series_signature.lower_is_better
-        )
+        return get_alert_properties(prev_value, new_value, series_signature.lower_is_better)
 
     @transaction.atomic
     def nudge(self, alert, new_push_id, new_prev_push_id):
@@ -656,10 +624,7 @@ class PerformanceAlertViewSet(viewsets.ModelViewSet):
 class PerformanceBugTemplateViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = PerformanceBugTemplate.objects.all()
     serializer_class = PerformanceBugTemplateSerializer
-    filter_backends = (
-        django_filters.rest_framework.DjangoFilterBackend,
-        filters.OrderingFilter,
-    )
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend, filters.OrderingFilter)
     filterset_fields = ["framework"]
 
 
@@ -785,9 +750,7 @@ class PerformanceSummary(generics.ListAPIView):
                         "push_timestamp",
                         "push__revision",
                         "performancedatumreplicate__value",
-                    ).order_by(
-                        "push_timestamp", "push_id", "job_id"
-                    ):
+                    ).order_by("push_timestamp", "push_id", "job_id"):
                         if replicate_value is not None:
                             item["data"].append(
                                 {
@@ -812,17 +775,10 @@ class PerformanceSummary(generics.ListAPIView):
                             )
                 else:
                     item["data"] = data.values(
-                        "value",
-                        "job_id",
-                        "id",
-                        "push_id",
-                        "push_timestamp",
-                        "push__revision",
+                        "value", "job_id", "id", "push_id", "push_timestamp", "push__revision"
                     ).order_by("push_timestamp", "push_id", "job_id")
 
-                item["option_name"] = option_collection_map[
-                    item["option_collection_id"]
-                ]
+                item["option_name"] = option_collection_map[item["option_collection_id"]]
                 item["repository_name"] = repository_name
 
         else:
@@ -830,10 +786,7 @@ class PerformanceSummary(generics.ListAPIView):
             grouped_job_ids = defaultdict(list)
             if replicates:
                 for signature_id, value, job_id, replicate_value in data.values_list(
-                    "signature_id",
-                    "value",
-                    "job_id",
-                    "performancedatumreplicate__value",
+                    "signature_id", "value", "job_id", "performancedatumreplicate__value"
                 ):
                     if replicate_value is not None:
                         grouped_values[signature_id].append(replicate_value)
@@ -853,9 +806,7 @@ class PerformanceSummary(generics.ListAPIView):
             for item in self.queryset:
                 item["values"] = grouped_values.get(item["id"], [])
                 item["job_ids"] = grouped_job_ids.get(item["id"], [])
-                item["option_name"] = option_collection_map[
-                    item["option_collection_id"]
-                ]
+                item["option_name"] = option_collection_map[item["option_collection_id"]]
                 item["repository_name"] = repository_name
 
         serializer = self.get_serializer(self.queryset, many=True)
@@ -895,16 +846,12 @@ class PerformanceAlertSummaryTasks(generics.ListAPIView):
     queryset = None
 
     def list(self, request):
-        query_params = PerfAlertSummaryTasksQueryParamSerializer(
-            data=request.query_params
-        )
+        query_params = PerfAlertSummaryTasksQueryParamSerializer(data=request.query_params)
         if not query_params.is_valid():
             return Response(data=query_params.errors, status=HTTP_400_BAD_REQUEST)
 
         alert_summary_id = query_params.validated_data["id"]
-        signature_ids = PerformanceAlertSummary.objects.filter(
-            id=alert_summary_id
-        ).values_list(
+        signature_ids = PerformanceAlertSummary.objects.filter(id=alert_summary_id).values_list(
             "alerts__series_signature__id", "related_alerts__series_signature__id"
         )
         signature_ids = [id for id_set in signature_ids for id in id_set]
@@ -925,9 +872,7 @@ class PerfCompareResults(generics.ListAPIView):
     queryset = None
 
     def list(self, request):
-        query_params = PerfCompareResultsQueryParamsSerializer(
-            data=request.query_params
-        )
+        query_params = PerfCompareResultsQueryParamsSerializer(data=request.query_params)
         if not query_params.is_valid():
             return Response(data=query_params.errors, status=HTTP_400_BAD_REQUEST)
 
@@ -942,9 +887,7 @@ class PerfCompareResults(generics.ListAPIView):
         new_parent_signature = query_params.validated_data["new_parent_signature"]
 
         try:
-            new_push = models.Push.objects.get(
-                revision=new_rev, repository__name=new_repo_name
-            )
+            new_push = models.Push.objects.get(revision=new_rev, repository__name=new_repo_name)
         except models.Push.DoesNotExist:
             return Response(
                 f"No new push with revision {new_rev} from repo {new_repo_name}.",
@@ -991,22 +934,10 @@ class PerfCompareResults(generics.ListAPIView):
 
         option_collection_map = perfcompare_utils.get_option_collection_map()
 
-        (
-            base_grouped_job_ids,
-            base_grouped_values,
-            base_grouped_replicates,
-        ) = self._get_grouped_perf_data(base_perf_data)
-        (
-            new_grouped_job_ids,
-            new_grouped_values,
-            new_grouped_replicates,
-        ) = self._get_grouped_perf_data(new_perf_data)
+        base_grouped_job_ids, base_grouped_values, base_grouped_replicates = self._get_grouped_perf_data(base_perf_data)
+        new_grouped_job_ids, new_grouped_values, new_grouped_replicates = self._get_grouped_perf_data(new_perf_data)
 
-        (
-            base_signatures_map,
-            base_header_names,
-            base_platforms,
-        ) = self._get_signatures_map(
+        base_signatures_map, base_header_names, base_platforms = self._get_signatures_map(
             base_signatures, base_grouped_values, option_collection_map
         )
         new_signatures_map, new_header_names, new_platforms = self._get_signatures_map(
@@ -1041,22 +972,14 @@ class PerfCompareResults(generics.ListAPIView):
                 no_results_to_show = not base_runs_count and not new_runs_count
                 if no_results_to_show:
                     continue
-                base_avg_value = perfcompare_utils.get_avg(
-                    base_perf_data_values, header
-                )
-                base_stddev = perfcompare_utils.get_stddev(
-                    base_perf_data_values, header
-                )
+                base_avg_value = perfcompare_utils.get_avg(base_perf_data_values, header)
+                base_stddev = perfcompare_utils.get_stddev(base_perf_data_values, header)
                 base_median_value = perfcompare_utils.get_median(base_perf_data_values)
                 new_avg_value = perfcompare_utils.get_avg(new_perf_data_values, header)
                 new_stddev = perfcompare_utils.get_stddev(new_perf_data_values, header)
                 new_median_value = perfcompare_utils.get_median(new_perf_data_values)
-                base_stddev_pct = perfcompare_utils.get_stddev_pct(
-                    base_avg_value, base_stddev
-                )
-                new_stddev_pct = perfcompare_utils.get_stddev_pct(
-                    new_avg_value, new_stddev
-                )
+                base_stddev_pct = perfcompare_utils.get_stddev_pct(base_avg_value, base_stddev)
+                new_stddev_pct = perfcompare_utils.get_stddev_pct(new_avg_value, new_stddev)
                 confidence = perfcompare_utils.get_abs_ttest_value(
                     base_perf_data_values, new_perf_data_values
                 )
@@ -1066,16 +989,12 @@ class PerfCompareResults(generics.ListAPIView):
                     if base_sig
                     else new_sig.get("signature_hash", "")
                 )
-                delta_value = perfcompare_utils.get_delta_value(
-                    new_avg_value, base_avg_value
-                )
+                delta_value = perfcompare_utils.get_delta_value(new_avg_value, base_avg_value)
                 delta_percentage = perfcompare_utils.get_delta_percentage(
                     delta_value, base_avg_value
                 )
                 magnitude = perfcompare_utils.get_magnitude(delta_percentage)
-                new_is_better = perfcompare_utils.is_new_better(
-                    delta_value, lower_is_better
-                )
+                new_is_better = perfcompare_utils.is_new_better(delta_value, lower_is_better)
                 is_confident = perfcompare_utils.is_confident(
                     base_runs_count, new_runs_count, confidence
                 )
@@ -1097,12 +1016,8 @@ class PerfCompareResults(generics.ListAPIView):
                     "platform": platform,
                     "base_app": base_sig.get("application", ""),
                     "new_app": new_sig.get("application", ""),
-                    "suite": base_sig.get(
-                        "suite", ""
-                    ),  # same suite for base_result and new_result
-                    "test": base_sig.get(
-                        "test", ""
-                    ),  # same test for base_result and new_result
+                    "suite": base_sig.get("suite", ""),  # same suite for base_result and new_result
+                    "test": base_sig.get("test", ""),  # same test for base_result and new_result
                     "is_complete": is_complete,
                     "framework_id": framework,
                     "is_empty": is_empty,
@@ -1126,12 +1041,8 @@ class PerfCompareResults(generics.ListAPIView):
                     "new_stddev": new_stddev,
                     "base_stddev_pct": base_stddev_pct,
                     "new_stddev_pct": new_stddev_pct,
-                    "base_retriggerable_job_ids": base_grouped_job_ids.get(
-                        base_sig_id, []
-                    ),
-                    "new_retriggerable_job_ids": new_grouped_job_ids.get(
-                        new_sig_id, []
-                    ),
+                    "base_retriggerable_job_ids": base_grouped_job_ids.get(base_sig_id, []),
+                    "new_retriggerable_job_ids": new_grouped_job_ids.get(new_sig_id, []),
                     "confidence": confidence,
                     "confidence_text": confidence_text,
                     "delta_value": delta_value,
@@ -1159,8 +1070,7 @@ class PerfCompareResults(generics.ListAPIView):
                     "base_signature_id": base_sig_id,
                     "new_signature_id": new_sig_id,
                     "has_subtests": (
-                        base_sig.get("has_subtests", None)
-                        or new_sig.get("has_subtests", None)
+                        base_sig.get("has_subtests", None) or new_sig.get("has_subtests", None)
                     ),
                 }
                 self.queryset.append(row_result)
@@ -1194,9 +1104,7 @@ class PerfCompareResults(generics.ListAPIView):
         return max(values)
 
     @staticmethod
-    def _get_perf_data(
-        repository_name, revision, signatures, interval, startday, endday
-    ):
+    def _get_perf_data(repository_name, revision, signatures, interval, startday, endday):
         signature_ids = [signature["id"] for signature in list(signatures)]
         perf_data = PerformanceDatum.objects.select_related(
             "push", "repository", "id"
@@ -1213,16 +1121,12 @@ class PerfCompareResults(generics.ListAPIView):
                 )
             )
         else:
-            perf_data = perf_data.filter(
-                push_timestamp__gt=startday, push_timestamp__lt=endday
-            )
+            perf_data = perf_data.filter(push_timestamp__gt=startday, push_timestamp__lt=endday)
 
         return perf_data
 
     @staticmethod
-    def _get_signatures(
-        repository_name, framework, parent_signature, interval, no_subtests
-    ):
+    def _get_signatures(repository_name, framework, parent_signature, interval, no_subtests):
         signatures = PerformanceSignature.objects.select_related(
             "framework", "repository", "platform", "push", "job"
         ).filter(repository__name=repository_name)
@@ -1271,12 +1175,8 @@ class PerfCompareResults(generics.ListAPIView):
 
         highlighted_revisions_params = []
         if base_revision:
-            highlighted_revisions_params.append(
-                (highlighted_revision_key, base_revision[:12])
-            )
-        highlighted_revisions_params.append(
-            (highlighted_revision_key, new_revision[:12])
-        )
+            highlighted_revisions_params.append((highlighted_revision_key, base_revision[:12]))
+        highlighted_revisions_params.append((highlighted_revision_key, new_revision[:12]))
 
         graph_link = "graphs?%s" % urlencode(highlighted_revisions_params)
 
@@ -1289,9 +1189,7 @@ class PerfCompareResults(generics.ListAPIView):
             # if repos selected are not the same
             base_repo_value = ",".join([base_repo_name, signature, "1", framework])
             new_repo_value = ",".join([new_repo_name, signature, "1", framework])
-            encoded = urlencode(
-                [(series_key, base_repo_value), (series_key, new_repo_value)]
-            )
+            encoded = urlencode([(series_key, base_repo_value), (series_key, new_repo_value)])
 
             graph_link = graph_link + "&%s" % encoded
 
@@ -1320,15 +1218,11 @@ class PerfCompareResults(generics.ListAPIView):
         grouped_replicate_values = defaultdict(list)
         grouped_values = defaultdict(list)
         grouped_job_ids = defaultdict(list)
-        for signature_id, value, job_id in perf_data.values_list(
-            "signature_id", "value", "job_id"
-        ):
+        for signature_id, value, job_id in perf_data.values_list("signature_id", "value", "job_id"):
             if value is not None:
                 grouped_values[signature_id].append(value)
                 grouped_job_ids[signature_id].append(job_id)
-        for signature_id, replicate_value in perf_data.values_list(
-            "signature_id", "performancedatumreplicate__value"
-        ):
+        for signature_id, replicate_value in perf_data.values_list("signature_id", "performancedatumreplicate__value"):
             if replicate_value is not None:
                 grouped_replicate_values[signature_id].append(replicate_value)
         return grouped_job_ids, grouped_values, grouped_replicate_values
@@ -1350,9 +1244,7 @@ class PerfCompareResults(generics.ListAPIView):
             option_name = option_collection_map[signature["option_collection_id"]]
             test_suite = perfcompare_utils.get_test_suite(suite, test)
             platform = signature["platform__platform"]
-            header = perfcompare_utils.get_header_name(
-                extra_options, option_name, test_suite
-            )
+            header = perfcompare_utils.get_header_name(extra_options, option_name, test_suite)
             sig_identifier = perfcompare_utils.get_sig_identifier(header, platform)
 
             if sig_identifier not in signatures_map or (
@@ -1387,12 +1279,7 @@ class TestSuiteHealthViewSet(viewsets.ViewSet):
             )
             .annotate(
                 total_untriaged=Count(
-                    Case(
-                        When(
-                            performancealert__status=PerformanceAlert.UNTRIAGED,
-                            then=Value(1),
-                        )
-                    )
+                    Case(When(performancealert__status=PerformanceAlert.UNTRIAGED, then=Value(1)))
                 )
             )
             .order_by("suite", "test")

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -153,10 +153,7 @@ class PerformanceAlertSerializer(serializers.ModelSerializer):
         queryset=PerformanceAlertSummary.objects.all(),
     )
     classifier = serializers.SlugRelatedField(
-        slug_field="username",
-        allow_null=True,
-        required=False,
-        queryset=User.objects.all(),
+        slug_field="username", allow_null=True, required=False, queryset=User.objects.all()
     )
     classifier_email = serializers.SerializerMethodField()
     backfill_record = BackfillRecordSerializer(read_only=True, allow_null=True)
@@ -181,8 +178,7 @@ class PerformanceAlertSerializer(serializers.ModelSerializer):
         related_summary = validated_data.get("related_summary")
         if related_summary:
             if (
-                validated_data.get("status", instance.status)
-                != PerformanceAlert.DOWNSTREAM
+                validated_data.get("status", instance.status) != PerformanceAlert.DOWNSTREAM
                 and instance.summary.repository_id != related_summary.repository_id
             ):
                 raise exceptions.ValidationError(
@@ -273,16 +269,11 @@ class PerformanceAlertSummarySerializer(serializers.ModelSerializer):
     alerts = PerformanceAlertSerializer(many=True, read_only=True)
     related_alerts = PerformanceAlertSerializer(many=True, read_only=True)
     performance_tags = serializers.SlugRelatedField(
-        many=True,
-        required=False,
-        slug_field="name",
-        queryset=PerformanceTag.objects.all(),
+        many=True, required=False, slug_field="name", queryset=PerformanceTag.objects.all()
     )
     repository = serializers.SlugRelatedField(read_only=True, slug_field="name")
     framework = serializers.SlugRelatedField(read_only=True, slug_field="id")
-    revision = serializers.SlugRelatedField(
-        read_only=True, slug_field="revision", source="push"
-    )
+    revision = serializers.SlugRelatedField(read_only=True, slug_field="revision", source="push")
     push_timestamp = TimestampField(source="push", read_only=True)
     prev_push_revision = serializers.SlugRelatedField(
         read_only=True, slug_field="revision", source="prev_push"
@@ -370,13 +361,9 @@ class PerformanceQueryParamsSerializer(serializers.Serializer):
     endday = serializers.DateTimeField(required=False, allow_null=True, default=None)
     revision = serializers.CharField(required=False, allow_null=True, default=None)
     repository = serializers.CharField()
-    framework = serializers.ListField(
-        required=False, child=serializers.IntegerField(), default=[]
-    )
+    framework = serializers.ListField(required=False, child=serializers.IntegerField(), default=[])
     interval = serializers.IntegerField(required=False, allow_null=True, default=None)
-    parent_signature = serializers.CharField(
-        required=False, allow_null=True, default=None
-    )
+    parent_signature = serializers.CharField(required=False, allow_null=True, default=None)
     signature = serializers.CharField(required=False, allow_null=True, default=None)
     no_subtests = serializers.BooleanField(required=False)
     all_data = OptionalBooleanField()
@@ -459,9 +446,7 @@ class PerformanceSummarySerializer(serializers.ModelSerializer):
         test = value["test"]
         suite = value["suite"]
         test_suite = suite if test == "" or test == suite else f"{suite} {test}"
-        return "{} {} {}".format(
-            test_suite, value["option_name"], value["extra_options"]
-        )
+        return "{} {} {}".format(test_suite, value["option_name"], value["extra_options"])
 
 
 class PerfAlertSummaryTasksQueryParamSerializer(serializers.Serializer):
@@ -491,12 +476,8 @@ class PerfCompareResultsQueryParamsSerializer(serializers.Serializer):
     framework = serializers.IntegerField(required=False, allow_null=True, default=None)
     interval = serializers.IntegerField(required=False, allow_null=True, default=None)
     no_subtests = serializers.BooleanField(required=False)
-    base_parent_signature = serializers.CharField(
-        required=False, allow_null=True, default=None
-    )
-    new_parent_signature = serializers.CharField(
-        required=False, allow_null=True, default=None
-    )
+    base_parent_signature = serializers.CharField(required=False, allow_null=True, default=None)
+    new_parent_signature = serializers.CharField(required=False, allow_null=True, default=None)
 
     def validate(self, data):
         if data["base_revision"] is None and data["interval"] is None:
@@ -507,9 +488,7 @@ class PerfCompareResultsQueryParamsSerializer(serializers.Serializer):
             Repository.objects.get(name=data["new_repository"])
         except ObjectDoesNotExist:
             raise serializers.ValidationError(
-                "{} or {} does not exist.".format(
-                    data["base_repository"], data["new_repository"]
-                )
+                "{} or {} does not exist.".format(data["base_repository"], data["new_repository"])
             )
 
         return data
@@ -534,12 +513,8 @@ class PerfCompareResultsSerializer(serializers.ModelSerializer):
     new_repository_name = serializers.CharField()
     base_measurement_unit = serializers.CharField(default="")
     new_measurement_unit = serializers.CharField(default="")
-    base_retriggerable_job_ids = serializers.ListField(
-        child=serializers.IntegerField(), default=[]
-    )
-    new_retriggerable_job_ids = serializers.ListField(
-        child=serializers.IntegerField(), default=[]
-    )
+    base_retriggerable_job_ids = serializers.ListField(child=serializers.IntegerField(), default=[])
+    new_retriggerable_job_ids = serializers.ListField(child=serializers.IntegerField(), default=[])
     option_name = serializers.CharField()
     base_runs = serializers.ListField(
         child=PerfCompareDecimalField(),

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -153,7 +153,10 @@ class PerformanceAlertSerializer(serializers.ModelSerializer):
         queryset=PerformanceAlertSummary.objects.all(),
     )
     classifier = serializers.SlugRelatedField(
-        slug_field="username", allow_null=True, required=False, queryset=User.objects.all()
+        slug_field="username",
+        allow_null=True,
+        required=False,
+        queryset=User.objects.all(),
     )
     classifier_email = serializers.SerializerMethodField()
     backfill_record = BackfillRecordSerializer(read_only=True, allow_null=True)
@@ -178,7 +181,8 @@ class PerformanceAlertSerializer(serializers.ModelSerializer):
         related_summary = validated_data.get("related_summary")
         if related_summary:
             if (
-                validated_data.get("status", instance.status) != PerformanceAlert.DOWNSTREAM
+                validated_data.get("status", instance.status)
+                != PerformanceAlert.DOWNSTREAM
                 and instance.summary.repository_id != related_summary.repository_id
             ):
                 raise exceptions.ValidationError(
@@ -269,11 +273,16 @@ class PerformanceAlertSummarySerializer(serializers.ModelSerializer):
     alerts = PerformanceAlertSerializer(many=True, read_only=True)
     related_alerts = PerformanceAlertSerializer(many=True, read_only=True)
     performance_tags = serializers.SlugRelatedField(
-        many=True, required=False, slug_field="name", queryset=PerformanceTag.objects.all()
+        many=True,
+        required=False,
+        slug_field="name",
+        queryset=PerformanceTag.objects.all(),
     )
     repository = serializers.SlugRelatedField(read_only=True, slug_field="name")
     framework = serializers.SlugRelatedField(read_only=True, slug_field="id")
-    revision = serializers.SlugRelatedField(read_only=True, slug_field="revision", source="push")
+    revision = serializers.SlugRelatedField(
+        read_only=True, slug_field="revision", source="push"
+    )
     push_timestamp = TimestampField(source="push", read_only=True)
     prev_push_revision = serializers.SlugRelatedField(
         read_only=True, slug_field="revision", source="prev_push"
@@ -361,9 +370,13 @@ class PerformanceQueryParamsSerializer(serializers.Serializer):
     endday = serializers.DateTimeField(required=False, allow_null=True, default=None)
     revision = serializers.CharField(required=False, allow_null=True, default=None)
     repository = serializers.CharField()
-    framework = serializers.ListField(required=False, child=serializers.IntegerField(), default=[])
+    framework = serializers.ListField(
+        required=False, child=serializers.IntegerField(), default=[]
+    )
     interval = serializers.IntegerField(required=False, allow_null=True, default=None)
-    parent_signature = serializers.CharField(required=False, allow_null=True, default=None)
+    parent_signature = serializers.CharField(
+        required=False, allow_null=True, default=None
+    )
     signature = serializers.CharField(required=False, allow_null=True, default=None)
     no_subtests = serializers.BooleanField(required=False)
     all_data = OptionalBooleanField()
@@ -446,7 +459,9 @@ class PerformanceSummarySerializer(serializers.ModelSerializer):
         test = value["test"]
         suite = value["suite"]
         test_suite = suite if test == "" or test == suite else f"{suite} {test}"
-        return "{} {} {}".format(test_suite, value["option_name"], value["extra_options"])
+        return "{} {} {}".format(
+            test_suite, value["option_name"], value["extra_options"]
+        )
 
 
 class PerfAlertSummaryTasksQueryParamSerializer(serializers.Serializer):
@@ -476,8 +491,12 @@ class PerfCompareResultsQueryParamsSerializer(serializers.Serializer):
     framework = serializers.IntegerField(required=False, allow_null=True, default=None)
     interval = serializers.IntegerField(required=False, allow_null=True, default=None)
     no_subtests = serializers.BooleanField(required=False)
-    base_parent_signature = serializers.CharField(required=False, allow_null=True, default=None)
-    new_parent_signature = serializers.CharField(required=False, allow_null=True, default=None)
+    base_parent_signature = serializers.CharField(
+        required=False, allow_null=True, default=None
+    )
+    new_parent_signature = serializers.CharField(
+        required=False, allow_null=True, default=None
+    )
 
     def validate(self, data):
         if data["base_revision"] is None and data["interval"] is None:
@@ -488,7 +507,9 @@ class PerfCompareResultsQueryParamsSerializer(serializers.Serializer):
             Repository.objects.get(name=data["new_repository"])
         except ObjectDoesNotExist:
             raise serializers.ValidationError(
-                "{} or {} does not exist.".format(data["base_repository"], data["new_repository"])
+                "{} or {} does not exist.".format(
+                    data["base_repository"], data["new_repository"]
+                )
             )
 
         return data
@@ -513,14 +534,26 @@ class PerfCompareResultsSerializer(serializers.ModelSerializer):
     new_repository_name = serializers.CharField()
     base_measurement_unit = serializers.CharField(default="")
     new_measurement_unit = serializers.CharField(default="")
-    base_retriggerable_job_ids = serializers.ListField(child=serializers.IntegerField(), default=[])
-    new_retriggerable_job_ids = serializers.ListField(child=serializers.IntegerField(), default=[])
+    base_retriggerable_job_ids = serializers.ListField(
+        child=serializers.IntegerField(), default=[]
+    )
+    new_retriggerable_job_ids = serializers.ListField(
+        child=serializers.IntegerField(), default=[]
+    )
     option_name = serializers.CharField()
     base_runs = serializers.ListField(
         child=PerfCompareDecimalField(),
         default=[],
     )
     new_runs = serializers.ListField(
+        child=PerfCompareDecimalField(),
+        default=[],
+    )
+    base_runs_replicates = serializers.ListField(
+        child=PerfCompareDecimalField(),
+        default=[],
+    )
+    new_runs_replicates = serializers.ListField(
         child=PerfCompareDecimalField(),
         default=[],
     )
@@ -573,6 +606,8 @@ class PerfCompareResultsSerializer(serializers.ModelSerializer):
             "new_retriggerable_job_ids",
             "base_runs",
             "new_runs",
+            "base_runs_replicates",
+            "new_runs_replicates",
             "base_avg_value",
             "new_avg_value",
             "base_median_value",


### PR DESCRIPTION
This patch enables replicates to be returned to PerfCompare. It will always return them if they are available alongside the summary values.