### PR TITLE
Bug 1915992 - wait for job to be pinned (and therefore pinboard to beshown) before setting focus to bug number input

### DIFF
--- a/ui/job-view/KeyboardShortcuts.jsx
+++ b/ui/job-view/KeyboardShortcuts.jsx
@@ -113,11 +113,11 @@ class KeyboardShortcuts extends React.Component {
   };
 
   // pin selected job to pinboard and add a related bug
-  addRelatedBug = () => {
+  addRelatedBug = async () => {
     const { selectedJob, pinJob } = this.props;
 
     if (selectedJob) {
-      pinJob(selectedJob);
+      await pinJob(selectedJob);
       document.getElementById('add-related-bug-button').click();
     }
   };


### PR DESCRIPTION
Fixes a regression from the upgrade to React 18 (bug 1901015).