### PR TITLE
Bug 1907897 Include documentation about mach try perf --alert in comment 0

### DIFF
--- a/treeherder/perf/fixtures/performance_bug_templates.yaml
+++ b/treeherder/perf/fixtures/performance_bug_templates.yaml
@@ -14,7 +14,9 @@
 
       If you need the profiling jobs you can trigger them yourself from treeherder job view or ask a sheriff to do that for you.
 
-      You can run these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+      You can run all of these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+
+      The following [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) provides more information about this command.
 
       For more information on performance sheriffing please see our [FAQ](https://wiki.mozilla.org/TestEngineering/Performance/FAQ).
 - model: perf.PerformanceBugTemplate
@@ -31,7 +33,9 @@
 
       Details of the alert can be found in the [alert summary]({{ alertHref }}), including links to graphs and comparisons for each of the affected tests. Please follow our [guide to handling regression bugs](https://wiki.mozilla.org/TestEngineering/Performance/Handling_regression_bugs) and **let us know your plans within 3 business days, or the patch(es) may be backed out** in accordance with our [regression policy](https://www.mozilla.org/en-US/about/governance/policies/regressions/).
 
-      You can run these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+      You can run all of these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+
+      The following [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) provides more information about this command.
 
       For more information on performance sheriffing please see our [FAQ](https://wiki.mozilla.org/TestEngineering/Performance/FAQ).
 - model: perf.PerformanceBugTemplate
@@ -50,7 +54,9 @@
 
       If you need the profiling jobs you can trigger them yourself from treeherder job view or ask a sheriff to do that for you.
 
-      You can run these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+      You can run all of these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+
+      The following [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) provides more information about this command.
 
       For more information on performance sheriffing please see our [FAQ](https://wiki.mozilla.org/TestEngineering/Performance/FAQ).
 - model: perf.PerformanceBugTemplate
@@ -69,7 +75,9 @@
 
       If you need the profiling jobs you can trigger them yourself from treeherder job view or ask a sheriff to do that for you.
 
-      You can run these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+      You can run all of these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+
+      The following [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) provides more information about this command.
 
       For more information on performance sheriffing please see our [FAQ](https://wiki.mozilla.org/TestEngineering/Performance/FAQ).
 - model: perf.PerformanceBugTemplate
@@ -88,7 +96,9 @@
 
       If you need the profiling jobs you can trigger them yourself from treeherder job view or ask a sheriff to do that for you.
 
-      You can run these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+      You can run all of these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+
+      The following [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) provides more information about this command.
 
       For more information on performance sheriffing please see our [FAQ](https://wiki.mozilla.org/TestEngineering/Performance/FAQ).
 - model: perf.PerformanceBugTemplate
@@ -107,7 +117,9 @@
 
       If you need the profiling jobs you can trigger them yourself from treeherder job view or ask a sheriff to do that for you.
 
-      You can run these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+      You can run all of these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+
+      The following [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) provides more information about this command.
 
       For more information on performance sheriffing please see our [FAQ](https://wiki.mozilla.org/TestEngineering/Performance/FAQ).
 - model: perf.PerformanceBugTemplate
@@ -126,7 +138,9 @@
 
       If you need the profiling jobs you can trigger them yourself from treeherder job view or ask a sheriff to do that for you.
 
-      You can run these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+      You can run all of these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+
+      The following [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) provides more information about this command.
 
       For more information on performance sheriffing please see our [FAQ](https://wiki.mozilla.org/TestEngineering/Performance/FAQ).
 - model: perf.PerformanceBugTemplate
@@ -145,7 +159,9 @@
 
       If you need the profiling jobs you can trigger them yourself from treeherder job view or ask a sheriff to do that for you.
 
-      You can run these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+      You can run all of these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+
+      The following [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) provides more information about this command.
 
       For more information on performance sheriffing please see our [FAQ](https://wiki.mozilla.org/TestEngineering/Performance/FAQ).
 - model: perf.PerformanceBugTemplate
@@ -164,7 +180,9 @@
 
       If you need the profiling jobs you can trigger them yourself from treeherder job view or ask a sheriff to do that for you.
 
-      You can run these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+      You can run all of these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+
+      The following [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) provides more information about this command.
 
       For more information on performance sheriffing please see our [FAQ](https://wiki.mozilla.org/TestEngineering/Performance/FAQ).
 - model: perf.PerformanceBugTemplate
@@ -183,6 +201,8 @@
 
       If you need the profiling jobs you can trigger them yourself from treeherder job view or ask a sheriff to do that for you.
 
-      You can run these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+      You can run all of these tests on try with `./mach try perf --alert {{ alertSummaryId }}`
+
+      The following [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) provides more information about this command.
 
       For more information on performance sheriffing please see our [FAQ](https://wiki.mozilla.org/TestEngineering/Performance/FAQ).


### PR DESCRIPTION
[FXP-3647](https://mozilla-hub.atlassian.net/browse/FXP-3647) - Adds a link to the Running Alert Tests section of the Mach Try Perf page from Perfdocs and clarifies that all of the tests in the mentioned alert summary id will be executed