### PR TITLE
 Bug 1867837 - Remove chromium from performance-artifact.json

### DIFF
--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -8,7 +8,6 @@
             "firefox",
             "chrome",
             "chrome-m",
-            "chromium",
             "fennec",
             "geckoview",
             "refbrow",


### PR DESCRIPTION
As per 1867837 removing all mentions of chromium