### PR TITLE
PCF-509 Replace the target for comparison buttons to perfcompare

### DIFF
--- a/tests/ui/job-view/PerformanceTab_test.jsx
+++ b/tests/ui/job-view/PerformanceTab_test.jsx
@@ -8,6 +8,7 @@ import {
   history,
 } from '../../../ui/job-view/redux/configureStore';
 import PerformanceTab from '../../../ui/job-view/details/tabs/PerformanceTab.jsx';
+import { Perfdocs } from '../../../ui/perfherder/perf-helpers/perfdocs';
 
 describe('PerformanceTab', () => {
   const testPerformanceTab = ({
@@ -47,7 +48,17 @@ describe('PerformanceTab', () => {
           hasSideBySide: false,
         },
         jobDetails: [],
-        perfJobDetail: [],
+        perfJobDetail: [
+          {
+            frameworkName: 'browsertime',
+            perfdocs: new Perfdocs(
+              'browsertime',
+              'outlook',
+              'macosx1015-64-shippable-qr',
+              'outlook ContentfulSpeedIndex opt cold fission webrender',
+            ),
+          },
+        ],
       }),
     );
 
@@ -78,7 +89,17 @@ describe('PerformanceTab', () => {
             value: 'profile_build_resources.json',
           },
         ],
-        perfJobDetail: [],
+        perfJobDetail: [
+          {
+            frameworkName: 'browsertime',
+            perfdocs: new Perfdocs(
+              'browsertime',
+              'outlook',
+              'macosx1015-64-shippable-qr',
+              'outlook ContentfulSpeedIndex opt cold fission webrender',
+            ),
+          },
+        ],
       }),
     );
 
@@ -105,7 +126,17 @@ describe('PerformanceTab', () => {
             value: 'profile_something.zip',
           },
         ],
-        perfJobDetail: [],
+        perfJobDetail: [
+          {
+            frameworkName: 'browsertime',
+            perfdocs: new Perfdocs(
+              'browsertime',
+              'outlook',
+              'macosx1015-64-shippable-qr',
+              'outlook ContentfulSpeedIndex opt cold fission webrender',
+            ),
+          },
+        ],
       }),
     );
 
@@ -138,7 +169,17 @@ describe('PerformanceTab', () => {
             value: 'profile_something.json',
           },
         ],
-        perfJobDetail: [],
+        perfJobDetail: [
+          {
+            frameworkName: 'browsertime',
+            perfdocs: new Perfdocs(
+              'browsertime',
+              'outlook',
+              'macosx1015-64-shippable-qr',
+              'outlook ContentfulSpeedIndex opt cold fission webrender',
+            ),
+          },
+        ],
       }),
     );
 
@@ -171,7 +212,17 @@ describe('PerformanceTab', () => {
             value: 'profile_something.zip',
           },
         ],
-        perfJobDetail: [],
+        perfJobDetail: [
+          {
+            frameworkName: 'browsertime',
+            perfdocs: new Perfdocs(
+              'browsertime',
+              'outlook',
+              'macosx1015-64-shippable-qr',
+              'outlook ContentfulSpeedIndex opt cold fission webrender',
+            ),
+          },
+        ],
       }),
     );
 

--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -127,8 +127,10 @@ export const getPushHealthUrl = function getPushHealthUrl(params) {
   return `${uiPushHealthBase}/push${createQueryParams(params)}`;
 };
 
-export const getCompareChooserUrl = function getCompareChooserUrl(params) {
-  return `/perfherder/comparechooser${createQueryParams(params)}`;
+export const getPerfCompareChooserUrl = function getPerfCompareChooserUrl(
+  params,
+) {
+  return `https://perf.compare${createQueryParams(params)}`;
 };
 
 export const parseQueryParams = function parseQueryParams(search) {

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -287,6 +287,7 @@ class DetailsPanel extends React.Component {
                     title: d.series.name,
                     suite: d.series.suite,
                     options: d.series.options.join(' '),
+                    frameworkName: mappedFrameworks[d.series.frameworkId],
                     perfdocs: new Perfdocs(
                       mappedFrameworks[d.series.frameworkId],
                       d.series.suite,

--- a/ui/job-view/details/tabs/PerformanceTab.jsx
+++ b/ui/job-view/details/tabs/PerformanceTab.jsx
@@ -13,7 +13,7 @@ import {
 import { faYoutube } from '@fortawesome/free-brands-svg-icons';
 
 import {
-  getCompareChooserUrl,
+  getPerfCompareChooserUrl,
   getJobsUrl,
   getPerfAnalysisUrl,
 } from '../../../helpers/url';
@@ -236,9 +236,10 @@ class PerformanceTab extends React.PureComponent {
             </Button>
           )}
           <a
-            href={getCompareChooserUrl({
-              newProject: repoName,
-              newRevision: revision,
+            href={getPerfCompareChooserUrl({
+              newRepo: repoName,
+              newRev: revision,
+              frameworkName: perfJobDetail[0].frameworkName,
             })}
             target="_blank"
             rel="noopener noreferrer"

--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -12,7 +12,7 @@ import { push as pushRoute } from 'connected-react-router';
 import {
   createQueryParams,
   getPushHealthUrl,
-  getCompareChooserUrl,
+  getPerfCompareChooserUrl,
   parseQueryParams,
 } from '../../helpers/url';
 import { formatTaskclusterError } from '../../helpers/errorMessage';
@@ -172,9 +172,9 @@ class PushActionMenu extends React.PureComponent {
             </DropdownItem>
             <DropdownItem
               tag="a"
-              href={getCompareChooserUrl({
-                newProject: currentRepo.name,
-                newRevision: revision,
+              href={getPerfCompareChooserUrl({
+                newRepo: currentRepo.name,
+                newRev: revision,
               })}
               target="_blank"
               rel="noopener noreferrer"


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/PCF-509

The following links were modified to redirect to PerfCompare instead of  Perfherder's Compare View
<img width="1700" alt="Screenshot 2024-12-03 at 17 56 29" src="https://github.com/user-attachments/assets/38ce4e4e-853d-4298-a62b-44fae5f6d7c6">
