### PR TITLE
drop dependency on tsconfig-paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "taskcluster-client-web": "44.18.0",
     "taskcluster-lib-scopes": "11.0.0",
     "taskcluster-lib-urls": "13.0.1",
-    "tsconfig-paths": "4.1.2",
     "url": "0.11.4",
     "victory": "36.6.12"
   },


### PR DESCRIPTION
It had been added initially as dependency of JSON5 which is not used anymore.