### PR TITLE
Implement revert button for revision (change culprit)

### DIFF
--- a/ui/perfherder/alerts/AlertHeader.jsx
+++ b/ui/perfherder/alerts/AlertHeader.jsx
@@ -82,15 +82,15 @@ const AlertHeader = ({
         {user.isStaff &&
           alertSummary.original_revision !== alertSummary.revision && (
             <Col className="p-0" xs="auto">
-              <Button className="ml-1" size="xs" onClick={handleRevertRevision}>
-                Reset hash
+              <Button className="ml-2" size="xs" onClick={handleRevertRevision}>
+                Reset Revision
               </Button>
             </Col>
           )}
         <Col className="p-0" xs="auto">
           <UncontrolledDropdown tag="span">
             <DropdownToggle
-              className="btn-xs ml-2"
+              className="btn-xs ml-1"
               color="secondary"
               caret
               data-testid="push-dropdown"

--- a/ui/perfherder/alerts/AlertHeader.jsx
+++ b/ui/perfherder/alerts/AlertHeader.jsx
@@ -83,7 +83,7 @@ const AlertHeader = ({
           alertSummary.original_revision !== alertSummary.revision && (
             <Col className="p-0" xs="auto">
               <Button className="ml-1" size="xs" onClick={handleRevertRevision}>
-                Revert
+                Reset hash
               </Button>
             </Col>
           )}

--- a/ui/perfherder/alerts/AlertHeader.jsx
+++ b/ui/perfherder/alerts/AlertHeader.jsx
@@ -79,6 +79,14 @@ const AlertHeader = ({
             </a>
           </Row>
         </Col>
+        {user.isStaff &&
+          alertSummary.original_revision !== alertSummary.revision && (
+            <Col className="p-0" xs="auto">
+              <Button className="ml-1" size="xs" onClick={handleRevertRevision}>
+                Revert
+              </Button>
+            </Col>
+          )}
         <Col className="p-0" xs="auto">
           <UncontrolledDropdown tag="span">
             <DropdownToggle
@@ -155,19 +163,6 @@ const AlertHeader = ({
             user={user}
           />
         </Col>
-        {user.isStaff &&
-          alertSummary.original_revision !== alertSummary.revision && (
-            <Col className="p-0" xs="auto">
-              <Button
-                className="ml-1"
-                size="xs"
-                color="warning"
-                onClick={handleRevertRevision}
-              >
-                Revert
-              </Button>
-            </Col>
-          )}
       </Row>
       <Row>
         {performanceTags.length > 0 && (

--- a/ui/perfherder/alerts/AlertHeader.jsx
+++ b/ui/perfherder/alerts/AlertHeader.jsx
@@ -8,6 +8,7 @@ import {
   Container,
   Row,
   Col,
+  Button,
 } from 'reactstrap';
 
 import { getJobsUrl, getPerfCompareBaseURL } from '../../helpers/url';
@@ -25,12 +26,16 @@ const AlertHeader = ({
   issueTrackers,
   user,
   updateAssignee,
+  changeRevision,
 }) => {
   const getIssueTrackerUrl = () => {
     const { issue_tracker_url: issueTrackerUrl } = issueTrackers.find(
       (tracker) => tracker.id === alertSummary.issue_tracker,
     );
     return issueTrackerUrl + alertSummary.bug_number;
+  };
+  const handleRevertRevision = async () => {
+    await changeRevision(alertSummary.original_revision);
   };
   const bugNumber = alertSummary.bug_number
     ? `Bug ${alertSummary.bug_number}`
@@ -150,6 +155,19 @@ const AlertHeader = ({
             user={user}
           />
         </Col>
+        {user.isStaff &&
+          alertSummary.original_revision !== alertSummary.revision && (
+            <Col className="p-0" xs="auto">
+              <Button
+                className="ml-1"
+                size="xs"
+                color="warning"
+                onClick={handleRevertRevision}
+              >
+                Revert
+              </Button>
+            </Col>
+          )}
       </Row>
       <Row>
         {performanceTags.length > 0 && (

--- a/ui/perfherder/alerts/AlertTable.jsx
+++ b/ui/perfherder/alerts/AlertTable.jsx
@@ -236,6 +236,30 @@ export default class AlertTable extends React.Component {
     return { failureStatus };
   };
 
+  changeRevision = async (newRevision) => {
+    const {
+      updateAlertSummary,
+      updateViewState,
+      fetchAlertSummaries,
+    } = this.props;
+    const { alertSummary } = this.state;
+
+    const { data, failureStatus } = await updateAlertSummary(alertSummary.id, {
+      revision: newRevision,
+    });
+
+    if (!failureStatus) {
+      // now refresh UI, by syncing with backend
+      fetchAlertSummaries(alertSummary.id);
+    } else {
+      updateViewState({
+        errorMessages: [`Failed to set revision "${newRevision}". (${data})`],
+      });
+    }
+
+    return { failureStatus };
+  };
+
   setSelectedAlerts = ({ selectedAlerts, allSelected }) =>
     this.setState({
       selectedAlerts,
@@ -324,6 +348,7 @@ export default class AlertTable extends React.Component {
                         issueTrackers={issueTrackers}
                         user={user}
                         updateAssignee={this.updateAssignee}
+                        changeRevision={this.changeRevision}
                       />
                     </FormGroup>
                   </Col>


### PR DESCRIPTION
How to Change the Revision of an Alert

Prerequisites:
You must be authenticated to perform this action.
The "Reset Revision" button is only visible if the alert's initial revision has been modified.

---

Steps

1. Open Browser Developer Tools
Open your browser's console (usually by pressing F12 or Ctrl+Shift+I).
Navigate to the Network tab.


2. Use the "Take" Button
Click the Take button to generate a request to the backend.


3. Copy the Request as cURL
Locate the request generated by the Take button in the Network tab.
Right-click the request and select Copy > Copy all as cURL.


4. Modify the cURL Request
Paste the copied cURL request into a text editor.
Find and remove the assignee_username key from the request.
Replace it with:
"revision": "hash_revision"

(Replace hash_revision with the desired revision hash.)


5. Execute the Modified Request
Open a terminal on your system.
Paste the modified cURL command into the terminal and press Enter.

---

Executing this command will update the alert's revision to the specified hash.
