### PR TITLE
Bug 1936640 - Add mozperftest harness as a valid harness to show profiling button on.

### DIFF
--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -54,7 +54,8 @@ export const isPerfTest = function isPerfTest(job) {
     (name) =>
       name.toLowerCase().includes('talos') ||
       name.toLowerCase().includes('raptor') ||
-      name.toLowerCase().includes('browsertime'),
+      name.toLowerCase().includes('browsertime') ||
+      name.toLowerCase().includes('perftest'),
   );
 };
 


### PR DESCRIPTION
This patch adds the perftest/mozperftest tasks as valid performance test tasks to show the generate profile button on.