### PR TITLE
add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.tox
+.git
+.venv
+.env
+.build
+.build-docs
+.pytest_cache
+.coverage
+.ruff_cache


### PR DESCRIPTION
Adding dockerignore helps reduce the size of docker images and speed up their build.
Locally, my images went from 3.87 GB to 1.78 GB.