### PR TITLE
urllib3 upgrade from 2.0.3 to 2.3.0

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1512,9 +1512,9 @@ uritemplate==4.1.1 \
     --hash=sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0 \
     --hash=sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e
     # via -r requirements/common.in
-urllib3==1.26.18 \
-    --hash=sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07 \
-    --hash=sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0
+urllib3==2.3.0 \
+    --hash=sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df \
+    --hash=sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d
     # via
     #   botocore
     #   requests

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -37,4 +37,4 @@ betamax-serializers==0.2.1
 pip-tools==7.4.1
 
 requests==2.32.3
-urllib3==2.0.3
+urllib3==2.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -507,9 +507,9 @@ typing-extensions==4.9.0 \
     #   asgiref
     #   black
     #   selenium
-urllib3[socks]==2.0.3 \
-    --hash=sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1 \
-    --hash=sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825
+urllib3[socks]==2.3.0 \
+    --hash=sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df \
+    --hash=sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d
     # via
     #   -r requirements/dev.in
     #   requests

--- a/tests/sample_data/logs/crash-1.logview.json
+++ b/tests/sample_data/logs/crash-1.logview.json
@@ -2,19 +2,19 @@
   "logurl": "http://my-log.mozilla.org/crash-1.txt.gz",
   "errors": [
     {
-      "linenumber": 38366,
+      "linenumber": 38435,
       "line": "Assertion failure: !(addr & GC_CELL_MASK), at e:/builds/moz2_slave/mozilla-central-win32-debug/build/js/src/jsgc.cpp:425"
     },
     {
-      "linenumber": 38374,
+      "linenumber": 38443,
       "line": "NEXT ERROR <#err1> TEST-UNEXPECTED-FAIL | /tests/dom/tests/mochitest/ajax/jquery/test_jQuery.html | Exited with code -1073741819 during test run"
     },
     {
-      "linenumber": 38377,
+      "linenumber": 38446,
       "line": "PROCESS-CRASH | /tests/dom/tests/mochitest/ajax/jquery/test_jQuery.html | application crashed (minidump found)"
     },
     {
-      "linenumber": 39522,
+      "linenumber": 39592,
       "line": "TEST-UNEXPECTED-FAIL | automationutils.processLeakLog() | missing output line for total leaks!"
     }
   ]

--- a/tests/sample_data/logs/jsreftest-fail.logview.json
+++ b/tests/sample_data/logs/jsreftest-fail.logview.json
@@ -2,163 +2,163 @@
   "logurl": "http://my-log.mozilla.org/jsreftest-fail.txt.gz",
   "errors": [
     {
-      "linenumber": 26935,
+      "linenumber": 26994,
       "line": "TypeError: invalid XML name <x/>[0]"
     },
     {
-      "linenumber": 77428,
+      "linenumber": 77596,
       "line": "NEXT ERROR <#err1> REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 6 of test -"
     },
     {
-      "linenumber": 77435,
+      "linenumber": 77603,
       "line": "NEXT ERROR <#err2> REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 7 of test -"
     },
     {
-      "linenumber": 77442,
+      "linenumber": 77610,
       "line": "NEXT ERROR <#err3> REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 8 of test -"
     },
     {
-      "linenumber": 77449,
+      "linenumber": 77617,
       "line": "NEXT ERROR <#err4> REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 9 of test -"
     },
     {
-      "linenumber": 77456,
+      "linenumber": 77624,
       "line": "NEXT ERROR <#err5> REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 10 of test -"
     },
     {
-      "linenumber": 77463,
+      "linenumber": 77631,
       "line": "NEXT ERROR <#err6> REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 11 of test -"
     },
     {
-      "linenumber": 77470,
+      "linenumber": 77638,
       "line": "NEXT ERROR <#err7> REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 12 of test -"
     },
     {
-      "linenumber": 77477,
+      "linenumber": 77645,
       "line": "REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 13 of test -"
     },
     {
-      "linenumber": 77484,
+      "linenumber": 77653,
       "line": "REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 14 of test -"
     },
     {
-      "linenumber": 77491,
+      "linenumber": 77660,
       "line": "REFTEST TEST-UNEXPECTED-FAIL | file:///c:/talos-slave/mozilla-central_win7_test-jsreftest/build/jsreftest/tests/jsreftest.html?test=ecma_3/RegExp/15.10.6.2-2.js | Section 15 of test -"
     },
     {
-      "linenumber": 80717,
+      "linenumber": 80893,
       "line": "568786: \"Assertion failure: !(attrs & (JSPROP_GETTER | JSPROP_SETTER)),\" with Object.defineProperty"
     },
     {
-      "linenumber": 83923,
+      "linenumber": 84107,
       "line": "ReferenceError: foo is not defined"
     },
     {
-      "linenumber": 84365,
+      "linenumber": 84550,
       "line": "InternalError: script stack space quota is exhausted"
     },
     {
-      "linenumber": 85640,
+      "linenumber": 85826,
       "line": "SyntaxError: property name a appears more than once in object literal"
     },
     {
-      "linenumber": 85642,
+      "linenumber": 85828,
       "line": "SyntaxError: property name 1 appears more than once in object literal"
     },
     {
-      "linenumber": 85644,
+      "linenumber": 85830,
       "line": "TypeError: redeclaration of const 5"
     },
     {
-      "linenumber": 85742,
+      "linenumber": 85928,
       "line": "TypeError: variable v redeclares argument"
     },
     {
-      "linenumber": 85967,
+      "linenumber": 86154,
       "line": "TypeError: redeclaration of const document"
     },
     {
-      "linenumber": 86510,
+      "linenumber": 86697,
       "line": "InternalError: script stack space quota is exhausted"
     },
     {
-      "linenumber": 88174,
+      "linenumber": 88372,
       "line": "InternalError: too much recursion"
     },
     {
-      "linenumber": 88223,
+      "linenumber": 88421,
       "line": "TypeError: anonymous function does not always return a value"
     },
     {
-      "linenumber": 88485,
+      "linenumber": 88683,
       "line": "SyntaxError: return not in function"
     },
     {
-      "linenumber": 88879,
+      "linenumber": 89077,
       "line": "SyntaxError: syntax error"
     },
     {
-      "linenumber": 89487,
+      "linenumber": 89686,
       "line": "STATUS: Do not assert: Assertion failed: \"need a way to EOT now, since this is trace end\": 0"
     },
     {
-      "linenumber": 89792,
+      "linenumber": 89991,
       "line": "ReferenceError: a is not defined | undefined | 45"
     },
     {
-      "linenumber": 90061,
+      "linenumber": 90260,
       "line": "TypeError: z is not a function"
     },
     {
-      "linenumber": 90067,
+      "linenumber": 90266,
       "line": "SyntaxError: return not in function"
     },
     {
-      "linenumber": 90511,
+      "linenumber": 90710,
       "line": "TypeError: 6 is not a function"
     },
     {
-      "linenumber": 90571,
+      "linenumber": 90770,
       "line": "TypeError: p.z = [1].some(function (y) {return y > 0;}) ? 4 : [6] is not a function"
     },
     {
-      "linenumber": 91298,
+      "linenumber": 91497,
       "line": "TypeError: (void 0) is undefined"
     },
     {
-      "linenumber": 91435,
+      "linenumber": 91634,
       "line": "ReferenceError: d is not defined"
     },
     {
-      "linenumber": 91665,
+      "linenumber": 91866,
       "line": "TypeError: [15].some([].watch) is not a function"
     },
     {
-      "linenumber": 91726,
+      "linenumber": 91927,
       "line": "TypeError: null has no properties"
     },
     {
-      "linenumber": 91895,
+      "linenumber": 92096,
       "line": "TypeError: (void 0) is undefined"
     },
     {
-      "linenumber": 91912,
+      "linenumber": 92113,
       "line": "TypeError: already executing generator iter.send"
     },
     {
-      "linenumber": 91918,
+      "linenumber": 92119,
       "line": "TypeError: already executing generator iter.next"
     },
     {
-      "linenumber": 91924,
+      "linenumber": 92125,
       "line": "TypeError: already executing generator iter.close"
     },
     {
-      "linenumber": 92194,
+      "linenumber": 92395,
       "line": "SyntaxError: let declaration not directly within block"
     },
     {
-      "linenumber": 92322,
+      "linenumber": 92523,
       "line": "ReferenceError: d is not defined"
     }
   ]

--- a/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.logview.json
+++ b/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.logview.json
@@ -2,11 +2,11 @@
   "logurl": "http://my-log.mozilla.org/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.txt.gz",
   "errors": [
     {
-      "linenumber": 26698,
+      "linenumber": 26745,
       "line": "TEST-UNEXPECTED-FAIL | chrome://mochitests/content/browser/dom/tests/browser/browser_ConsoleAPITests.js | Exception thrown in CO_observe: TypeError: Components.utils.isXrayWrapper is not a function"
     },
     {
-      "linenumber": 26705,
+      "linenumber": 26752,
       "line": "TEST-UNEXPECTED-FAIL | chrome://mochitests/content/browser/dom/tests/browser/browser_ConsoleAPITests.js | Test timed out"
     }
   ]

--- a/tests/sample_data/logs/opt-objc-exception.logview.json
+++ b/tests/sample_data/logs/opt-objc-exception.logview.json
@@ -2,15 +2,15 @@
   "logurl": "http://my-log.mozilla.org/opt-objc-exception.txt.gz",
   "errors": [
     {
-      "linenumber": 24003,
+      "linenumber": 24056,
       "line": "        SimpleTest._logResult(test, \"TEST-PASS\", \"TEST-UNEXPECTED-FAIL\");"
     },
     {
-      "linenumber": 24031,
+      "linenumber": 24084,
       "line": "      SimpleTest._logResult(test, \"TEST-UNEXPECTED-PASS\", \"TEST-KNOWN-FAIL\");"
     },
     {
-      "linenumber": 48632,
+      "linenumber": 48743,
       "line": "2010-09-23 14:48:01.299 firefox-bin[319:10b] *** Assertion failure in -[NSNextStepFrame lockFocus], /SourceCache/AppKit/AppKit-949.54/AppKit.subproj/NSView.m:4755"
     }
   ]


### PR DESCRIPTION
The expected default encoding changed from latin1 to utf-8 which can cause changes to parsing and yield e.g. different line numbers: https://github.com/urllib3/urllib3/issues/3053

Andra @esanuandra , could you re-record the betamax cassettes which cause the [failures](https://github.com/urllib3/urllib3/issues/3053) of `test_common_behaviour.py` and `test_engineer_traction.py`?