### PR TITLE
Bug 1923923 - Fix Bugscache and BugJobMap migrations

### DIFF
--- a/treeherder/model/migrations/0036_bugscache_init_autoincrement.py
+++ b/treeherder/model/migrations/0036_bugscache_init_autoincrement.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("model", "0035_bugscache_optional_bugzilla_ref"),
+    ]
+
+    operations = [
+        migrations.RunSQL("SELECT SETVAL('bugscache_id_seq', (SELECT MAX(id) FROM bugscache))")
+    ]

--- a/treeherder/model/migrations/0037_bugjobmap_internal_bug_refs.py
+++ b/treeherder/model/migrations/0037_bugjobmap_internal_bug_refs.py
@@ -31,7 +31,7 @@ def set_internal_fks(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("model", "0035_bugscache_optional_bugzilla_ref"),
+        ("model", "0036_bugscache_init_autoincrement"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 


### PR DESCRIPTION
Refs. https://github.com/mozilla/treeherder/pull/8512#issuecomment-2671449773

* Sets the auto increment Postgres sequence to the greatest current PK (max bugzilla ID) to avoid future conflicts.
* Use real reference to Bugscache in the BugJobMap migration (we cannot assume internal ID == bugzilla ID).