### PR TITLE
Bug 1942904 - Perfcompare comparing incorrect applications (e.g. chrome-m vs fenix as opposed to fenix vs fenix)

### DIFF
--- a/tests/webapp/api/test_perfcompare_api.py
+++ b/tests/webapp/api/test_perfcompare_api.py
@@ -39,7 +39,7 @@ def test_perfcompare_results_against_no_base(
     extra_options = "e10s fission stylo webrender"
     measurement_unit = "ms"
     base_application = "firefox"
-    new_application = "geckoview"
+    new_application = "firefox"
 
     base_sig = create_signature(
         signature_hash=(20 * "t1"),
@@ -115,8 +115,8 @@ def test_perfcompare_results_against_no_base(
             "header_name": response["header_name"],
             "base_repository_name": base_sig.repository.name,
             "new_repository_name": new_sig.repository.name,
-            "base_app": "firefox",
-            "new_app": "geckoview",
+            "base_app": base_sig.application,
+            "new_app": new_sig.application,
             "is_complete": response["is_complete"],
             "base_measurement_unit": base_sig.measurement_unit,
             "new_measurement_unit": new_sig.measurement_unit,
@@ -208,7 +208,7 @@ def test_perfcompare_results_with_only_one_run_and_diff_repo(
     extra_options = "e10s fission stylo webrender"
     measurement_unit = "ms"
     base_application = "firefox"
-    new_application = "geckoview"
+    new_application = "firefox"
 
     base_sig = create_signature(
         signature_hash=(20 * "t1"),
@@ -284,8 +284,8 @@ def test_perfcompare_results_with_only_one_run_and_diff_repo(
             "header_name": response["header_name"],
             "base_repository_name": base_sig.repository.name,
             "new_repository_name": new_sig.repository.name,
-            "base_app": "firefox",
-            "new_app": "geckoview",
+            "base_app": base_sig.application,
+            "new_app": new_sig.application,
             "is_complete": response["is_complete"],
             "base_measurement_unit": base_sig.measurement_unit,
             "new_measurement_unit": new_sig.measurement_unit,
@@ -516,7 +516,7 @@ def test_perfcompare_results_subtests_support(
     extra_options = "e10s fission stylo webrender"
     measurement_unit = "ms"
     base_application = "firefox"
-    new_application = "geckoview"
+    new_application = "firefox"
 
     base_sig = create_signature(
         signature_hash=(20 * "t1"),
@@ -596,8 +596,8 @@ def test_perfcompare_results_subtests_support(
             "header_name": response["header_name"],
             "base_repository_name": base_sig.repository.name,
             "new_repository_name": new_sig.repository.name,
-            "base_app": "firefox",
-            "new_app": "geckoview",
+            "base_app": base_sig.application,
+            "new_app": new_sig.application,
             "is_complete": response["is_complete"],
             "base_measurement_unit": base_sig.measurement_unit,
             "new_measurement_unit": new_sig.measurement_unit,
@@ -940,7 +940,7 @@ def get_expected(
     response = {"option_name": test_option_collection.get(sig.option_collection_id, "")}
     test_suite = perfcompare_utils.get_test_suite(sig.suite, sig.test)
     response["header_name"] = perfcompare_utils.get_header_name(
-        extra_options, response["option_name"], test_suite
+        extra_options, response["option_name"], test_suite, sig.application
     )
     response["base_avg_value"] = perfcompare_utils.get_avg(
         base_perf_data_values, response["header_name"]

--- a/treeherder/webapp/api/perfcompare_utils.py
+++ b/treeherder/webapp/api/perfcompare_utils.py
@@ -32,8 +32,8 @@ def get_test_suite(suite, test):
     return suite if test == "" or test == suite else f"{suite} {test}"
 
 
-def get_header_name(extra_options, option_name, test_suite):
-    name = f"{test_suite} {option_name} {extra_options}"
+def get_header_name(extra_options, option_name, test_suite, application):
+    name = f"{test_suite} {option_name} {extra_options} {application}"
     return name
 
 

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -892,7 +892,7 @@ class PerfCompareResults(generics.ListAPIView):
                 base_push = models.Push.objects.get(
                     revision=base_rev, repository__name=base_repo_name
                 )
-                # Dynamically calculate an time interval based on the base and new push
+                # Dynamically calculate a time interval based on the base and new push
                 interval = self._get_interval(base_push, new_push)
             else:
                 # Comparing without a base needs a timerange from which to gather the data needed
@@ -1261,10 +1261,13 @@ class PerfCompareResults(generics.ListAPIView):
             suite = signature["suite"]
             test = signature["test"]
             extra_options = signature["extra_options"]
+            application = signature["application"]
             option_name = option_collection_map[signature["option_collection_id"]]
             test_suite = perfcompare_utils.get_test_suite(suite, test)
             platform = signature["platform__platform"]
-            header = perfcompare_utils.get_header_name(extra_options, option_name, test_suite)
+            header = perfcompare_utils.get_header_name(
+                extra_options, option_name, test_suite, application
+            )
             sig_identifier = perfcompare_utils.get_sig_identifier(header, platform)
 
             if sig_identifier not in signatures_map or (


### PR DESCRIPTION
I added a fix based on Julien's suggestion from [Bug 1947155 - Custom-car browser is being compared to chrome browser in this comparison](https://bugzilla.mozilla.org/show_bug.cgi?id=1947155)). 
See also: [Bug 1942904 - Perfcompare comparing incorrect applications (e.g. chrome-m vs fenix as opposed to fenix vs fenix)](https://bugzilla.mozilla.org/show_bug.cgi?id=1942904)