### PR TITLE
Bug 1961788 - correctly set repoName for log link in failure line

### DIFF
--- a/tests/ui/job-view/App_test.jsx
+++ b/tests/ui/job-view/App_test.jsx
@@ -147,7 +147,9 @@ describe('App', () => {
 
   test('should have links to Perfherder and Intermittent Failures View', async () => {
     const { getByText, getByAltText } = render(testApp());
-    const appMenu = await waitFor(() => getByAltText('Treeherder'));
+    const appMenu = await waitFor(() => getByAltText('Treeherder'), {
+      timeout: 2000,
+    });
 
     expect(appMenu).toBeInTheDocument();
     fireEvent.click(appMenu);

--- a/tests/ui/shared/FailureSummaryTab_test.jsx
+++ b/tests/ui/shared/FailureSummaryTab_test.jsx
@@ -29,6 +29,7 @@ const { dispatch, getState } = store;
 
 describe('FailureSummaryTab', () => {
   const repoName = 'autoland';
+  const currentRepo = { name: repoName };
 
   beforeEach(async () => {
     fetchMock.get(getApiUrl('/jobs/?push_id=511138', repoName), selectedJob);
@@ -65,7 +66,7 @@ describe('FailureSummaryTab', () => {
              correct bug got added. */
           addBug={(bug, job) => addBug(bug, job)(dispatch, getState)}
           pinJob={() => {}}
-          repoName={repoName}
+          currentRepo={currentRepo}
         />
       </ConnectedRouter>
     </Provider>

--- a/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
@@ -47,9 +47,10 @@ export default class SuggestionsListItem extends React.Component {
       toggleBugFiler,
       selectedJob,
       addBug,
-      repoName,
+      currentRepo,
       developerMode,
     } = this.props;
+    const repoName = currentRepo.name;
     const { suggestionShowMore } = this.state;
 
     const suggestions = [];


### PR DESCRIPTION
Regression from 74c6fdb9ca9307e66d0fd4896dd91920604d5c0f