### PR TITLE
Bug 1962486 Speedup tocommit API call

### DIFF
--- a/treeherder/webapp/api/hash.py
+++ b/treeherder/webapp/api/hash.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -10,6 +11,8 @@ from treeherder.webapp.api.serializers import HashQuerySerializer
 
 logger = logging.getLogger(__name__)
 
+TRY_REPOSITORY_NAME = "try"
+
 
 class HashViewSet(viewsets.ViewSet):
     @action(detail=False)
@@ -19,6 +22,21 @@ class HashViewSet(viewsets.ViewSet):
             return Response(data=query_params.errors, status=HTTP_400_BAD_REQUEST)
         newhash = query_params.validated_data["newhash"]
         basehash = query_params.validated_data["basehash"]
+        newhashdate = query_params.validated_data["newhashdate"]
+        basehashdate = query_params.validated_data["basehashdate"]
+        newpush = Commit.objects.filter(
+            comments__contains=newhash,
+            push__repository__name=TRY_REPOSITORY_NAME,
+            push__time__range=(newhashdate - timedelta(days=1), newhashdate + timedelta(days=1)),
+        ).first()
+        basepush = Commit.objects.filter(
+            comments__contains=basehash,
+            push__repository__name=TRY_REPOSITORY_NAME,
+            push__time__range=(basehashdate - timedelta(days=1), basehashdate + timedelta(days=1)),
+        ).first()
+        query_params.validate_pushes(
+            newpush, newhash, newhashdate, basepush, basehash, basehashdate
+        )
         newpush = Commit.objects.filter(comments__contains=newhash).first()
         basepush = Commit.objects.filter(comments__contains=basehash).first()
         query_params.validate_pushes(newpush, newhash, basepush, basehash)

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -403,12 +403,17 @@ class FailuresQueryParamsSerializer(serializers.Serializer):
 class HashQuerySerializer(serializers.Serializer):
     basehash = serializers.IntegerField()
     newhash = serializers.IntegerField()
+    newhashdate = serializers.DateField(format="%Y-%m-%d")
+    basehashdate = serializers.DateField(format="%Y-%m-%d")
 
-    def validate_pushes(self, newpush, newhash, basepush, basehash):
-        if newpush is None or basepush is None:
+    def validate_pushes(self, newpush, newhash, newhashdate, basepush, basehash, basehashdate):
+        if newpush is None:
             raise serializers.ValidationError(
-                f"{newhash} or {basehash} do not correspond to any existing hashes please double check both hashes you provided"
+                f"The date and hash combination you provided({newhashdate} and {newhash}) is invalid"
             )
+        if basepush is None:
+            raise serializers.ValidationError(
+                f"The date and hash combination you provided({basehashdate} and {basehash}) is invalid"
 
 
 class MachinePlatformSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
The tocommit API currently searches for substrings across all commits and all repositories, this patch limits the search to commits in try and commits in the past 2 months. The search times went from 14-15 seconds to under 1 second now We do this by passing a date parameter for each hash and searching for +1 and -2 around the date(I assumed timezones may cause some issues so to be safe I expanded the range a bit)