### PR TITLE
Bug 1962486 - Improve Performance of tocommit API

### DIFF
--- a/tests/webapp/api/test_hash_api.py
+++ b/tests/webapp/api/test_hash_api.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest import mock
 
 from django.urls import reverse
@@ -10,12 +11,11 @@ class MockedCommitObject:
 
 
 class MockedCommitSet:
-    def __init__(self, basehash, newhash):
-        self.newhash = newhash
-        self.basehash = basehash
+    def __init__(self, hash):
+        self.hash = hash
 
     def first(self):
-        if self.basehash == "492424224" or self.newhash == "492424224":
+        if self.hash == "492424224":
             return None
         else:
             return MockedCommitObject()
@@ -27,13 +27,20 @@ def test_all_good(client):
     """
     basehash = "494224"
     newhash = "4124814"
+    newhashdate = datetime.now().strftime("%Y-%m-%d")
+    basehashdate = datetime.now().strftime("%Y-%m-%d")
     with mock.patch(
         "treeherder.webapp.api.hash.Commit.objects.filter",
-        return_value=MockedCommitSet(basehash, newhash),
-    ):
+    ) as hash_filter:
+        hash_filter.side_effect = [MockedCommitSet(newhash), MockedCommitSet(basehash)]
         resp = client.get(
             reverse("hash-tocommit", kwargs={"project": "try"}),
-            {"basehash": basehash, "newhash": newhash},
+            {
+                "basehash": basehash,
+                "newhash": newhash,
+                "newhashdate": newhashdate,
+                "basehashdate": basehashdate,
+            },
         )
     assert resp.status_code == HTTP_200_OK
     assert resp.json() == {"baseRevision": "1ebfd5", "newRevision": "1ebfd5"}
@@ -43,19 +50,26 @@ def test_no_newhash_commit_returned(client):
     """
     test when no newhash is not found as a string in any commit we get the expected failure
     """
-    basehash = "492424224"
-    newhash = "412894814"
+    basehash = "412894814"
+    newhash = "492424224"
+    newhashdate = datetime.now().strftime("%Y-%m-%d")
+    basehashdate = datetime.now().strftime("%Y-%m-%d")
     with mock.patch(
         "treeherder.webapp.api.hash.Commit.objects.filter",
-        return_value=MockedCommitSet(basehash, newhash),
-    ):
+    ) as hash_filter:
+        hash_filter.side_effect = [MockedCommitSet(newhash), MockedCommitSet(basehash)]
         resp = client.get(
             reverse("hash-tocommit", kwargs={"project": "try"}),
-            {"basehash": basehash, "newhash": newhash},
+            {
+                "basehash": basehash,
+                "newhash": newhash,
+                "basehashdate": basehashdate,
+                "newhashdate": newhashdate,
+            },
         )
     assert resp.status_code == HTTP_400_BAD_REQUEST
     assert resp.json() == [
-        f"{newhash} or {basehash} do not correspond to any existing hashes please double check both hashes you provided"
+        f"The date and hash combination you provided({newhashdate} and {newhash}) is invalid"
     ]
 
 
@@ -63,20 +77,73 @@ def test_no_basehash_commit_returned(client):
     """
     test when no basehash is not found as a string in any commit we get the expected failure
     """
-    basehash = "412894814"
-    newhash = "492424224"
+    basehash = "492424224"
+    newhash = "412894814"
+    newhashdate = datetime.now().strftime("%Y-%m-%d")
+    basehashdate = datetime.now().strftime("%Y-%m-%d")
     with mock.patch(
         "treeherder.webapp.api.hash.Commit.objects.filter",
-        return_value=MockedCommitSet(basehash, newhash),
-    ):
+    ) as hash_filter:
+        hash_filter.side_effect = [MockedCommitSet(newhash), MockedCommitSet(basehash)]
         resp = client.get(
             reverse("hash-tocommit", kwargs={"project": "try"}),
-            {"basehash": basehash, "newhash": newhash},
+            {
+                "basehash": basehash,
+                "newhash": newhash,
+                "basehashdate": basehashdate,
+                "newhashdate": newhashdate,
+            },
         )
     assert resp.status_code == HTTP_400_BAD_REQUEST
     assert resp.json() == [
-        f"{newhash} or {basehash} do not correspond to any existing hashes please double check both hashes you provided"
+        f"The date and hash combination you provided({basehashdate} and {basehash}) is invalid"
     ]
+
+
+def test_invalid_newhashdate_parameter(client):
+    """
+    test when no basehash is not found as a string in any commit we get the expected failure
+    """
+    basehash = "412894814"
+    newhash = "492424224"
+    newhashdate = "Bad date - Sallah"
+    basehashdate = datetime.now().strftime("%Y-%m-%d")
+    resp = client.get(
+        reverse("hash-tocommit", kwargs={"project": "try"}),
+        {
+            "basehash": basehash,
+            "newhash": newhash,
+            "basehashdate": basehashdate,
+            "newhashdate": newhashdate,
+        },
+    )
+    assert resp.status_code == HTTP_400_BAD_REQUEST
+    assert resp.json() == {
+        "newhashdate": ["Date has wrong format. Use one of these formats instead: YYYY-MM-DD."]
+    }
+
+
+def test_invalid_basehashdate_parameter(client):
+    """
+    test when no basehash is not found as a string in any commit we get the expected failure
+    """
+    basehash = "412894814"
+    newhash = "492424224"
+    newhashdate = datetime.now().strftime("%Y-%m-%d")
+    basehashdate = "Bad date - Sallah"
+    resp = client.get(
+        reverse("hash-tocommit", kwargs={"project": "try"}),
+        {
+            "basehash": basehash,
+            "newhash": newhash,
+            "basehashdate": basehashdate,
+            "newhashdate": newhashdate,
+        },
+    )
+    assert resp.status_code == HTTP_400_BAD_REQUEST
+    assert resp.json() == {
+        "basehashdate": ["Date has wrong format. Use one of these formats instead: YYYY-MM-DD."]
+    }
 
 
 def test_invalid_newhash_parameter(client):
@@ -85,9 +152,16 @@ def test_invalid_newhash_parameter(client):
     """
     basehash = "124898925481"
     newhash = "Invalid"
+    newhashdate = datetime.now().strftime("%Y-%m-%d")
+    basehashdate = datetime.now().strftime("%Y-%m-%d")
     resp = client.get(
         reverse("hash-tocommit", kwargs={"project": "try"}),
-        {"basehash": basehash, "newhash": newhash},
+        {
+            "basehash": basehash,
+            "newhash": newhash,
+            "basehashdate": basehashdate,
+            "newhashdate": newhashdate,
+        },
     )
     assert resp.status_code == HTTP_400_BAD_REQUEST
     assert resp.json() == {"newhash": ["A valid integer is required."]}
@@ -99,9 +173,16 @@ def test_invalid_basehash_parameter(client):
     """
     basehash = "Invalid"
     newhash = "124898925481"
+    newhashdate = datetime.now().strftime("%Y-%m-%d")
+    basehashdate = datetime.now().strftime("%Y-%m-%d")
     resp = client.get(
         reverse("hash-tocommit", kwargs={"project": "try"}),
-        {"basehash": basehash, "newhash": newhash},
+        {
+            "basehash": basehash,
+            "newhash": newhash,
+            "basehashdate": basehashdate,
+            "newhashdate": newhashdate,
+        },
     )
     assert resp.status_code == 400
     assert resp.json() == {"basehash": ["A valid integer is required."]}

--- a/treeherder/webapp/api/hash.py
+++ b/treeherder/webapp/api/hash.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -9,6 +10,7 @@ from treeherder.model.models import Commit
 from treeherder.webapp.api.serializers import HashQuerySerializer
 
 logger = logging.getLogger(__name__)
+TRY_REPOSITORY_NAME = "try"
 
 
 class HashViewSet(viewsets.ViewSet):
@@ -19,7 +21,19 @@ class HashViewSet(viewsets.ViewSet):
             return Response(data=query_params.errors, status=HTTP_400_BAD_REQUEST)
         newhash = query_params.validated_data["newhash"]
         basehash = query_params.validated_data["basehash"]
-        newpush = Commit.objects.filter(comments__contains=newhash).first()
-        basepush = Commit.objects.filter(comments__contains=basehash).first()
-        query_params.validate_pushes(newpush, newhash, basepush, basehash)
+        newhashdate = query_params.validated_data["newhashdate"]
+        basehashdate = query_params.validated_data["basehashdate"]
+        newpush = Commit.objects.filter(
+            comments__contains=newhash,
+            push__repository__name=TRY_REPOSITORY_NAME,
+            push__time__range=(newhashdate - timedelta(days=1), newhashdate + timedelta(days=1)),
+        ).first()
+        basepush = Commit.objects.filter(
+            comments__contains=basehash,
+            push__repository__name=TRY_REPOSITORY_NAME,
+            push__time__range=(basehashdate - timedelta(days=1), basehashdate + timedelta(days=1)),
+        ).first()
+        query_params.validate_pushes(
+            newpush, newhash, newhashdate, basepush, basehash, basehashdate
+        )
         return Response({"baseRevision": basepush.revision, "newRevision": newpush.revision})

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -403,11 +403,17 @@ class FailuresQueryParamsSerializer(serializers.Serializer):
 class HashQuerySerializer(serializers.Serializer):
     basehash = serializers.IntegerField()
     newhash = serializers.IntegerField()
+    newhashdate = serializers.DateField(format="%Y-%m-%d")
+    basehashdate = serializers.DateField(format="%Y-%m-%d")
 
-    def validate_pushes(self, newpush, newhash, basepush, basehash):
-        if newpush is None or basepush is None:
+    def validate_pushes(self, newpush, newhash, newhashdate, basepush, basehash, basehashdate):
+        if newpush is None:
             raise serializers.ValidationError(
-                f"{newhash} or {basehash} do not correspond to any existing hashes please double check both hashes you provided"
+                f"The date and hash combination you provided({newhashdate} and {newhash}) is invalid"
+            )
+        if basepush is None:
+            raise serializers.ValidationError(
+                f"The date and hash combination you provided({basehashdate} and {basehash}) is invalid"
             )
 
 


### PR DESCRIPTION
The tocommit API currently searches for substrings across all commits and all repositories, this patch limits the search to commits in try and commits in the past 2 months. The search times went from 14-15 seconds to under 1 second now We do this by passing a date parameter for each hash and searching for +1 and -2 around the date(I assumed timezones may cause some issues so to be safe I expanded the range a bit)