### PR TITLE
small tweaks to handle edge cases in new failures

### DIFF
--- a/treeherder/model/error_summary.py
+++ b/treeherder/model/error_summary.py
@@ -135,14 +135,16 @@ def get_error_summary(job, queryset=None):
 
     date = str(job.submit_time.date())
     line_cache = lcache.get_cache()
-    if date not in line_cache.keys():
+    if date not in lcache.get_cache_keys():
         lcache.write_cache(date, {})
     else:
         dates = lcache.get_cache_keys()
         dates.sort()
         for d in dates:
             date_time = datetime.datetime.strptime(d, "%Y-%m-%d")
-            if date_time <= (job.submit_time - datetime.timedelta(days=LINE_CACHE_TIMEOUT_DAYS)):
+            if date_time <= (
+                datetime.datetime.today() - datetime.timedelta(days=LINE_CACHE_TIMEOUT_DAYS)
+            ):
                 lcache.remove_cache_key(d)
             else:
                 break


### PR DESCRIPTION
fix some edge cases.  I see that we continue to have keys up to 3 months old.  Looking in the database I don't see that we are retriggering old jobs- this patch really does 2 things:
1) fix bug to actually check for existing date
2) key 21 day cache off of "today", not job submit time.