### PR TITLE
Color commits which start with "Revert" red as backouts.

### DIFF
--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -55,7 +55,12 @@ export class Revision extends React.PureComponent {
   };
 
   isBackout = (comment) => {
-    return comment.search('Backed out') >= 0 || comment.search('Back out') >= 0;
+    // 'Revert' commits directly after migration to Git VCS when no `hg oops` equivalent available.
+    return (
+      comment.search('Backed out') >= 0 ||
+      comment.search('Back out') >= 0 ||
+      comment.startsWith('Revert')
+    );
   };
 
   render() {


### PR DESCRIPTION
The "Revert" commit messages are from the migration to Git VCS which has no `hg oops` equivalent as we speak.