### PR TITLE
Start telemetry earlier to fix a run time issue.

### DIFF
--- a/treeherder/perf/auto_perf_sheriffing/sherlock.py
+++ b/treeherder/perf/auto_perf_sheriffing/sherlock.py
@@ -308,7 +308,7 @@ class Sherlock:
                     logger.info(f"Failed: {traceback.format_exc()}")
 
     def _can_run_telemetry(self):
-        return time(23, 0) <= datetime.utcnow().time() < time(0, 0)
+        return time(22, 0) <= datetime.utcnow().time() < time(23, 0)
 
     def _create_detection_alert(
         self,


### PR DESCRIPTION
This patch fixes an issue where the telemetry start time was always returning False because the checks consider the 0 hour as being less than the 23rd hour. Starting an hour earlier fixes this. The start/run time is arbitrary, and changing it won't affect anything.