### PR TITLE
Use GCLOUD_PROJECT for setting the BigQuery projcet to use.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - BUG_FILER_API_KEY=${BUG_FILER_API_KEY:-}
       - TLS_CERT_PATH=${TLS_CERT_PATH:-}
       - TELEMETRY_ENABLE_ALERTS=${TELEMETRY_ENABLE_ALERTS:-}
+      - GCLOUD_PROJECT=${GCLOUD_PROJECT:-}
     entrypoint: './docker/entrypoint.sh'
     # We *ONLY* initialize the data when we're running the backend
     command: './initialize_data.sh ./manage.py runserver 0.0.0.0:8000'


### PR DESCRIPTION
In prod, we can't use the mozdata project since our service account is defined in a separate one. This patch fixes the issue by using the setting from `GCLOUD_PROJECT` to specify which project we should be querying in.