### PR TITLE
Bug 1970261 - adjust schema definition to new task name maxLength of 255 characters

### DIFF
--- a/schemas/task-treeherder-config.yml
+++ b/schemas/task-treeherder-config.yml
@@ -109,7 +109,7 @@ properties:
     title: 'group name'
     type: 'string'
     minLength: 1
-    maxLength: 100
+    maxLength: 255
   groupSymbol:
     title: 'group symbol'
     description: |


### PR DESCRIPTION
This is a follow-up to a6da8ba397c18a7125194334f50116bfcf3606d3.