### PR TITLE
FXP-4047 Implement functionality to filter by all sheriffed frameworks in Alerts View

### DIFF
--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -47,7 +47,7 @@ from .performance_serializers import (
     TestSuiteHealthParamsSerializer,
     TestSuiteHealthSerializer,
 )
-from .utils import GroupConcat, get_profile_artifact_url
+from .utils import SHERIFFED_FRAMEWORKS, GroupConcat, get_profile_artifact_url
 
 
 class PerformanceSignatureViewSet(viewsets.ViewSet):
@@ -347,6 +347,7 @@ class PerformanceAlertSummaryFilter(django_filters.FilterSet):
     hide_related_and_invalid = django_filters.BooleanFilter(method="_hide_related_and_invalid")
     with_assignee = django_filters.CharFilter(method="_with_assignee")
     timerange = django_filters.NumberFilter(method="_timerange")
+    show_sheriffed_frameworks = django_filters.BooleanFilter(method="_show_sheriffed_frameworks")
 
     def _filter_text(self, queryset, name, value):
         sep = Value(" ")
@@ -417,6 +418,9 @@ class PerformanceAlertSummaryFilter(django_filters.FilterSet):
         return queryset.filter(
             push__time__gt=datetime.datetime.utcfromtimestamp(int(time.time() - int(value)))
         )
+
+    def _show_sheriffed_frameworks(self, queryset, name, value):
+        return queryset.filter(framework__name__in=SHERIFFED_FRAMEWORKS)
 
     class Meta:
         model = PerformanceAlertSummary

--- a/treeherder/webapp/api/utils.py
+++ b/treeherder/webapp/api/utils.py
@@ -20,6 +20,17 @@ REPO_GROUPS = {
 
 FIVE_DAYS = 432000
 
+# Constant used to check for sheriffed frameworks
+SHERIFFED_FRAMEWORKS = [
+    "awsy",
+    "browsertime",
+    "build_metrics",
+    "devtools",
+    "js-bench",
+    "mozperftest",
+    "talos",
+]
+
 
 class GroupConcat(Aggregate):
     function = "GROUP_CONCAT"

--- a/ui/perfherder/alerts/AlertsView.jsx
+++ b/ui/perfherder/alerts/AlertsView.jsx
@@ -150,6 +150,11 @@ class AlertsView extends React.Component {
     const frameworkOptions = cloneDeep(frameworks);
     const ignoreFrameworks = { id: -1, name: 'all frameworks' };
     frameworkOptions.unshift(ignoreFrameworks);
+    const allSheriffedFrameworks = {
+      id: -2,
+      name: 'all sheriffed frameworks',
+    };
+    frameworkOptions.unshift(allSheriffedFrameworks);
     return frameworkOptions;
   };
 
@@ -201,13 +206,21 @@ class AlertsView extends React.Component {
 
     // -1 ('all') is created for UI purposes but is not a valid API parameter
     const doNotFilter = -1;
+    // -2 ('all sheriffed') Constant created for UI purposes but is not a valid API parameter
+    const allSheriffedFrameworksID = -2;
     const listMode = !id;
 
     if (listMode && params.status === doNotFilter) {
       delete params.status;
     }
-    if (listMode && params.framework === doNotFilter) {
-      delete params.framework;
+
+    if (listMode) {
+      if (params.framework === allSheriffedFrameworksID) {
+        params.show_sheriffed_frameworks = true;
+      }
+      if ([doNotFilter, allSheriffedFrameworksID].includes(params.framework)) {
+        delete params.framework;
+      }
     }
 
     return params;

--- a/ui/perfherder/alerts/AlertsViewControls.jsx
+++ b/ui/perfherder/alerts/AlertsViewControls.jsx
@@ -138,14 +138,16 @@ export default class AlertsViewControls extends React.Component {
 
     let sortedFrameworks = sortData(frameworkOptions, 'name', false);
     const allFrameworks = 'all frameworks';
-    const mozperftest = 'mozperftest';
+    const allSheriffedFrameworks = 'all sheriffed frameworks';
     const platformMicrobench = 'platform_microbench';
+    const telemetry = 'telemetry';
 
     sortedFrameworks = sortedFrameworks.filter(
       (framework) =>
-        framework.name !== mozperftest &&
         framework.name !== platformMicrobench &&
-        framework.name !== allFrameworks,
+        framework.name !== telemetry &&
+        framework.name !== allFrameworks &&
+        framework.name !== allSheriffedFrameworks,
     );
 
     const frameworkNames =
@@ -165,8 +167,8 @@ export default class AlertsViewControls extends React.Component {
         selectedItem: framework.name,
         updateData: this.updateFramework,
         namespace: 'framework',
-        pinned: [allFrameworks],
-        otherPinned: [mozperftest, platformMicrobench],
+        pinned: [allFrameworks, allSheriffedFrameworks],
+        otherPinned: [platformMicrobench, telemetry],
       },
     ];
 


### PR DESCRIPTION
This PR adds functionality for filtering the list of available alert summaries to only show the sheriffed framework alerts and exclude the non-sheriffed ones (for example, the platform_microbench alerts). 

Selecting the "all sheriffed frameworks" option in the dropdown will only display the sheriffed framework alerts.

<img width="1485" alt="all_sheriffed_dropdown" src="https://github.com/user-attachments/assets/fd4e024e-4c3b-4597-a4d9-0640668cc60d" />
