### PR TITLE
Bug 1977456 - Enable Replicates on applink startup tests. r?#perftest

### DIFF
--- a/treeherder/etl/perf.py
+++ b/treeherder/etl/perf.py
@@ -133,7 +133,10 @@ def _test_should_gather_replicates_based_on(
         elif repository.name in ("mozilla-central",):
             if suite_name == "speedometer3":
                 return True
-            elif "applink-startup" in suite_name:
+            elif "applink-startup" in suite_name or "tab-restore" in suite_name:
+                return True
+        elif repository.name in ("autoland",):
+            if "applink-startup" in suite_name or "tab-restore" in suite_name:
                 return True
     return False
 


### PR DESCRIPTION
Perf team has requested to have:
- tab restore on central and autoland report replicates
- applink-startup report replicates on autoland