### PR TITLE
Don't use OR with tables that contain many-to-many/one-to-many fields or associations.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -780,6 +780,40 @@ def test_perf_signature_2(test_perf_signature):
 
 
 @pytest.fixture
+def test_perf_signature_3(test_perf_signature):
+    return perf_models.PerformanceSignature.objects.create(
+        repository=test_perf_signature.repository,
+        signature_hash=(20 * "t3"),
+        framework=test_perf_signature.framework,
+        platform=test_perf_signature.platform,
+        option_collection=test_perf_signature.option_collection,
+        suite="mysuite2",
+        test="mytest3",
+        has_subtests=test_perf_signature.has_subtests,
+        extra_options=test_perf_signature.extra_options,
+        last_updated=datetime.datetime.now(),
+        tags="cold pageload",
+    )
+
+
+@pytest.fixture
+def test_perf_signature_4(test_perf_signature):
+    return perf_models.PerformanceSignature.objects.create(
+        repository=test_perf_signature.repository,
+        signature_hash=(20 * "t4"),
+        framework=test_perf_signature.framework,
+        platform=test_perf_signature.platform,
+        option_collection=test_perf_signature.option_collection,
+        suite="mysuite2",
+        test="mytest4",
+        has_subtests=test_perf_signature.has_subtests,
+        extra_options=test_perf_signature.extra_options,
+        last_updated=datetime.datetime.now(),
+        tags="cold pageload",
+    )
+
+
+@pytest.fixture
 def test_stalled_data_signature(test_perf_signature):
     stalled_data_timestamp = datetime.datetime.now() - datetime.timedelta(days=120)
     return perf_models.PerformanceSignature.objects.create(
@@ -1206,6 +1240,24 @@ def test_perf_alert_2(
 ) -> perf_models.PerformanceAlert:
     return create_perf_alert(
         summary=test_perf_alert_summary_2, series_signature=test_perf_signature_2
+    )
+
+
+@pytest.fixture
+def test_perf_alert_3(
+    test_perf_alert, test_perf_signature_3, test_perf_alert_summary_2
+) -> perf_models.PerformanceAlert:
+    return create_perf_alert(
+        summary=test_perf_alert_summary_2, series_signature=test_perf_signature_3
+    )
+
+
+@pytest.fixture
+def test_perf_alert_4(
+    test_perf_alert, test_perf_signature_4, test_perf_alert_summary_2
+) -> perf_models.PerformanceAlert:
+    return create_perf_alert(
+        summary=test_perf_alert_summary_2, series_signature=test_perf_signature_4
     )
 
 

--- a/tests/webapp/api/test_performance_alertsummary_api.py
+++ b/tests/webapp/api/test_performance_alertsummary_api.py
@@ -130,6 +130,27 @@ def test_alert_summaries_get(
     }
 
 
+def test_alert_summaries_get_multiple_alerts(
+    client,
+    test_perf_alert_summary,
+    test_perf_alert_summary_2,
+    test_perf_alert_2,
+    test_perf_alert_3,
+    test_perf_alert_4,
+):
+    # verify that we get the performance summary + alert on GET
+    resp = client.get(reverse("performance-alert-summaries-list"))
+    assert resp.status_code == 200
+
+    # make sure only 2 alert summaries are returned when one summary
+    # has multiple alerts associated with it
+    data = resp.json()
+    assert len(data["results"]) == 2
+
+    # make sure the 2 alert summaries are unique
+    assert len(set([result["id"] for result in data["results"]])) == 2
+
+
 def test_alert_summaries_get_onhold(
     client,
     test_perf_alert_summary,

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -474,18 +474,13 @@ class PerformanceAlertSummaryViewSet(viewsets.ModelViewSet):
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.queryset)
-        if request.query_params.get("monitored_alerts"):
-            queryset = queryset.filter(
-                alerts__series_signature__monitor=True,
-            )
-        else:
-            queryset = queryset.filter(
-                alerts__series_signature__monitor=None,
-            ) | queryset.filter(
-                alerts__series_signature__monitor=False,
-            )
-
         pk = request.query_params.get("id")
+        if not pk:
+            if request.query_params.get("monitored_alerts"):
+                queryset = queryset.filter(sheriffed=False)
+            else:
+                queryset = queryset.filter(sheriffed=True)
+
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)


### PR DESCRIPTION
This patch resolves an issue that causes duplicate alert summaries to be returned from the API because of the OR filter on a query that contains a ManyToOne field. Specifically, for each alert that an alert summary had, a duplicate alert summary would be created.