### PR TITLE
Perform the /note/ and /bug-job-map/ network requests in parallel

### DIFF
--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -95,10 +95,10 @@ class DetailsPanel extends React.Component {
 
   updateClassifications = async () => {
     const { selectedJob } = this.props;
-    const classifications = await JobClassificationModel.getList({
-      job_id: selectedJob.id,
-    });
-    const bugs = await BugJobMapModel.getList({ job_id: selectedJob.id });
+    const [classifications, bugs] = await Promise.all([
+      JobClassificationModel.getList({ job_id: selectedJob.id }),
+      BugJobMapModel.getList({ job_id: selectedJob.id }),
+    ]);
 
     this.setState({ classifications, bugs });
   };


### PR DESCRIPTION
Low hanging fruit of https://bugzilla.mozilla.org/show_bug.cgi?id=1967984.

Because the /bug-job-map/ network request is the very last one, doing it in parallel with the /note/ request means we remove the loading throbber faster.