### PR TITLE
Bug 1967984 - show the Failure Summary faster when selecting a job

### DIFF
--- a/tests/ui/job-view/App_test.jsx
+++ b/tests/ui/job-view/App_test.jsx
@@ -82,15 +82,27 @@ describe('App', () => {
       ...fullJob,
       task_id: 'secondTaskId',
     });
+    fetchMock.get(
+      getProjectUrl('/jobs/259537372/bug_suggestions/', repoName),
+      [],
+    );
 
     fetchMock.get(getProjectUrl('/jobs/259539665/', repoName), {
       ...fullJob,
       task_id: 'MirsMc8UQPeSBC3yKMSlPw',
     });
+    fetchMock.get(
+      getProjectUrl('/jobs/259539665/bug_suggestions/', repoName),
+      [],
+    );
     fetchMock.get(getProjectUrl('/jobs/259539664/', repoName), {
       ...fullJob,
       task_id: 'Fe4GqwoZQSStNUbe4EeSPQ',
     });
+    fetchMock.get(
+      getProjectUrl('/jobs/259539664/bug_suggestions/', repoName),
+      [],
+    );
     fetchMock.get(
       `begin:${getProjectUrl('/performance/data/?job_id=', repoName)}`,
       [],

--- a/tests/ui/shared/FailureSummaryTab_test.jsx
+++ b/tests/ui/shared/FailureSummaryTab_test.jsx
@@ -58,6 +58,7 @@ describe('FailureSummaryTab', () => {
         />
         <FailureSummaryTab
           selectedJob={selectedJob}
+          selectedJobId={selectedJob.id}
           jobLogUrls={jobLogUrls}
           logParseStatus="parsed"
           reftestUrl="boo"

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -41,26 +41,26 @@ class TabsPanel extends React.Component {
   }
 
   static getDerivedStateFromProps(props, state) {
-    const { perfJobDetail, selectedJobFull } = props;
+    const { perfJobDetail, selectedJob } = props;
 
     // This fires every time the props change.  But we only want to figure out the new default
     // tab when we get a new job.  However, the job could change, then later, the perf details fetch
     // returns.  So we need to check for a change in the size of the perfJobDetail too.
     if (
-      state.jobId !== selectedJobFull.id ||
-      state.perfJobDetailSize !== perfJobDetail.length
+      !!selectedJob &&
+      (state.jobId !== selectedJob.id ||
+        state.perfJobDetailSize !== perfJobDetail.length)
     ) {
       const tabIndex = TabsPanel.getDefaultTabIndex(
-        selectedJobFull.resultStatus,
+        selectedJob.resultStatus,
         props,
       );
-
       return {
         tabIndex,
         // Every time we select a different job we need to let the component
         // let us know if we should enable the tab
         enableTestGroupsTab: false,
-        jobId: selectedJobFull.id,
+        jobId: selectedJob.id,
         perfJobDetailSize: perfJobDetail.length,
       };
     }
@@ -135,6 +135,7 @@ class TabsPanel extends React.Component {
       classificationMap,
       logViewerFullUrl,
       clearSelectedJob,
+      selectedJob,
       selectedJobFull,
       currentRepo,
       pinJob,
@@ -224,6 +225,7 @@ class TabsPanel extends React.Component {
           <TabPanel>
             <FailureSummaryTab
               selectedJob={selectedJobFull}
+              selectedJobId={selectedJob && selectedJob.id}
               jobLogUrls={jobLogUrls}
               jobDetails={jobDetails}
               logParseStatus={logParseStatus}
@@ -295,6 +297,7 @@ TabsPanel.propTypes = {
   pinnedJobs: PropTypes.shape({}).isRequired,
   bugs: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   clearSelectedJob: PropTypes.func.isRequired,
+  selectedJob: PropTypes.shape({}).isRequired,
   selectedJobFull: PropTypes.shape({}).isRequired,
   currentRepo: PropTypes.shape({}).isRequired,
   perfJobDetail: PropTypes.arrayOf(PropTypes.shape({})),

--- a/ui/push-health/details/DetailsPanel.jsx
+++ b/ui/push-health/details/DetailsPanel.jsx
@@ -193,6 +193,7 @@ class DetailsPanel extends React.Component {
                 <TabPanel>
                   <FailureSummaryTab
                     selectedJob={selectedTaskFull}
+                    selectedJobId={selectedTaskFull.id}
                     jobLogUrls={selectedTaskFull.logs}
                     logParseStatus="unknown"
                     logViewerFullUrl={getLogViewerUrl(

--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -41,12 +41,12 @@ class FailureSummaryTab extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { selectedJob } = this.props;
+    const { selectedJobId } = this.props;
 
     if (
-      !!selectedJob &&
+      !!selectedJobId &&
       !!prevProps.selectedJob &&
-      selectedJob.id !== prevProps.selectedJob.id
+      selectedJobId !== prevProps.selectedJobId
     ) {
       this.loadBugSuggestions();
     }
@@ -129,13 +129,13 @@ class FailureSummaryTab extends React.Component {
   };
 
   loadBugSuggestions = () => {
-    const { selectedJob } = this.props;
+    const { selectedJobId } = this.props;
 
-    if (!selectedJob) {
+    if (!selectedJobId) {
       return;
     }
     this.setState({ bugSuggestionsLoading: true });
-    BugSuggestionsModel.get(selectedJob.id).then(async (suggestions) => {
+    BugSuggestionsModel.get(selectedJobId).then(async (suggestions) => {
       suggestions.forEach((suggestion) => {
         suggestion.bugs.too_many_open_recent =
           suggestion.bugs.open_recent.length > thBugSuggestionLimit;
@@ -351,6 +351,7 @@ class FailureSummaryTab extends React.Component {
 
 FailureSummaryTab.propTypes = {
   selectedJob: PropTypes.shape({}).isRequired,
+  selectedJobId: PropTypes.number.isRequired,
   jobLogUrls: PropTypes.arrayOf({
     id: PropTypes.number.isRequired,
     job_id: PropTypes.number.isRequired,


### PR DESCRIPTION
This is done by ensuring network requests are done in parallel:
- if we are sure the failure summary tab will be selected, do not wait for the /api/project/try/performance/signatures/?id= request to finish before removing the loading throbber (setting jobDetailLoading to false)
- start fetching /api/project/try/performance/signatures/?id= immediately after the /api/project/try/performance/data/?job_id= request completes (instead of waiting for all the requests in jobPromise, jobLogUrlPromise and builtFromArtifactPromise promises to complete).
- do the /api/project/try/note/?job_id= and /api/project/try/bug-job-map/?job_id= requests in parallel with the other set of requests (ie call updateClassifications() in parallel rather than after the first set of promises has resolved).
- do the /api/project/try/jobs/<job-id>/bug_suggestions/ request in parallel. This was a lot more complicated, as the request is triggered from within the FailureSummaryTab component, which reads data from the selectedJobFull object that depends on the jobs request... except it didn't need it. So I'm now passing the selectedJob object to the TabsPanel component (in addition to the selectedJobFull object), so it can use the resultStatus and id fields without waiting for the jobs request to finish. Then the job id is passed as a new property to the FailureSummaryTab so it can also start fetching bug suggestions without waiting. This makes the code slightly messier, but I think the saved time is worth it.
- I think the additional requests to bug_suggestions urls in the test are because we now do this request earlier, and the test would have previously finished before the request got started.
 - no longer setting jobDetails to [] when selecting a job and starting to fetch data prevents the big grey "Open in Firefox Profiler" button of the performance tab from flickering. It's fine to leave it there while we are loading new data as the entire bottom panel is disabled anyway while the loading throbber is there.

One thing I haven't handled from bug 1967984 is starting the network request for the "Test Groups" panel immediately after the jobs request resolves, it's still blocked on all the other "phase 1" requests before it starts. I left it for a low priority follow-up as don't think it's important: the test groups tab is never selected by default, so it's not on the critical path to removing the loading throbber. It just causes some slight flicker as that tab header is disabled until its data is loaded.