### PR TITLE
Bug 1980506 - Enable replicates on for homeview startup test as well. r?#perftest

### DIFF
--- a/treeherder/etl/perf.py
+++ b/treeherder/etl/perf.py
@@ -133,10 +133,18 @@ def _test_should_gather_replicates_based_on(
         elif repository.name in ("mozilla-central",):
             if suite_name == "speedometer3":
                 return True
-            elif "applink-startup" in suite_name or "tab-restore" in suite_name:
+            elif (
+                "applink-startup" in suite_name
+                or "tab-restore" in suite_name
+                or "homeview" in suite_name
+            ):
                 return True
         elif repository.name in ("autoland",):
-            if "applink-startup" in suite_name or "tab-restore" in suite_name:
+            if (
+                "applink-startup" in suite_name
+                or "tab-restore" in suite_name
+                or "homeview" in suite_name
+            ):
                 return True
     return False
 


### PR DESCRIPTION
Missed adding the homeview startup test in this bug where we intended to enable for all of the startup tests: https://bugzilla.mozilla.org/show_bug.cgi?id=1977456