### PR TITLE
Do not await the /api/performance/framework/ request when loading treeherder

### DIFF
--- a/ui/job-view/App.jsx
+++ b/ui/job-view/App.jsx
@@ -107,8 +107,9 @@ class App extends React.Component {
 
   async componentDidMount() {
     const { repoName, landoCommitID } = this.state;
-    const { data } = await getData(getApiUrl(endpoints.frameworks));
-    this.setState({ frameworks: data });
+    getData(getApiUrl(endpoints.frameworks)).then((response) =>
+      this.setState({ frameworks: response.data }),
+    );
 
     RepositoryModel.getList().then((repos) => {
       const newRepo = repos.find((repo) => repo.name === repoName);


### PR DESCRIPTION
I profiled loading the treeherder homepage. We wait for 2 pairs of requests before loading the list of jobs: https://share.firefox.dev/4liIF28

This PR trivially reduces this to waiting for one group of 4 requests. Profile of loading the same page with the PR applied: https://share.firefox.dev/3HeQY0D