### PR TITLE
Do more requests in parallel.

### DIFF
--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -117,12 +117,17 @@ class Push extends React.PureComponent {
     // this allows someone to more quickly load ranges of revisions
     // when they don't care about the specific jobs and results.
     const allParams = getAllUrlParams();
+    const promises = [];
+
     if (!allParams.has('nojobs')) {
-      await this.fetchJobs();
+      promises.push(this.fetchJobs());
     }
     if (allParams.has('test_paths')) {
-      await this.fetchTestManifests();
+      promises.push(this.fetchTestManifests());
     }
+
+    // Execute jobs and test manifests in parallel
+    await Promise.all(promises);
 
     this.testForFilteredTry();
 

--- a/ui/shared/PushHealthStatus.jsx
+++ b/ui/shared/PushHealthStatus.jsx
@@ -22,18 +22,21 @@ class PushHealthStatus extends Component {
   }
 
   async componentDidMount() {
-    const {
-      jobCounts: { completed },
-    } = this.props;
-
-    if (completed > 0) {
-      await this.loadLatestStatus();
-    }
+    // Load health status immediately without waiting for job completion
+    await this.loadLatestStatus();
   }
 
   async componentDidUpdate(prevProps) {
     const { jobCounts } = this.props;
     const fields = ['completed', 'fixedByCommit', 'pending', 'running'];
+
+    // Skip if this is the initial load (all previous counts were zero)
+    const isInitialLoad = !fields.some(
+      (field) => prevProps.jobCounts[field] > 0,
+    );
+    if (isInitialLoad) {
+      return;
+    }
 
     if (didObjectsChange(jobCounts, prevProps.jobCounts, fields)) {
       await this.loadLatestStatus();


### PR DESCRIPTION
When loading a treeherder page:
- If a test_paths filter exists in the url, do the request to fetch test manifests in parallel to the request to fetch jobs
- Fetch the push health status in parallel to the jobs.

I tested using this url: http://localhost:5000/jobs?repo=try&revision=2dc43042a5783288dceac27f42be318755fe9e71&test_paths=toolkit%2Fcomponents%2Fantitracking%2Ftest%2Fbrowser

Profile of the current deployed version: https://share.firefox.dev/4fsAfUt (https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.try.revision.<commit id>.taskgraph.decision/artifacts/public/manifests-by-task.json.gz and https://treeherder.mozilla.org/api/project/try/push/health_summary/?revision=<commit id>&with_in_progress_tests=true are fetched after https://treeherder.mozilla.org/api/jobs/?push_id=<push id> finishes)
Profile with the patch: https://share.firefox.dev/4oxg2kC (the 3 requests mentioned for the previous profiles are done in parallel).

Notes:
- patch generated using claude code
- I have a local patch to start the http://localhost:5000/api/project/try/push/?full=true&count=10&revision=<commit id> request earlier (before http://localhost:5000/api/repository/ finishes). It seems to work, but doesn't pass tests yet, so I'll keep it for a future PR.