### PR TITLE
fix: Web console errors that don't require package changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.*/
 node_modules/
 .DS_store
 *.pyc
@@ -6,6 +5,9 @@ yarn-error.log
 npm-error.log
 vagrant/env_local.sh
 __pycache__
+.ruff_cache/
+.build/
+.venv/
 
 # vi
 *.swp
@@ -40,3 +42,11 @@ coverage.xml
 
 # Docs generation
 docs.egg-info
+
+# AI config
+.roo
+.roomodes
+.vscode/mcp.json
+mcp-servers/
+.claude
+CLAUDE.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "chat.mcp.discovery.enabled": true,
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "eslint.useFlatConfig": true,
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+  "eslint.options": {
+    "overrideConfigFile": "eslint.config.mjs"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   backend:
     container_name: backend

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,6 +62,7 @@ export default [
       'react/no-unused-class-component-methods': 'off',
       'react/prefer-exact-props': 'off',
       'react/prop-types': 'off',
+      'react/require-default-props': 'off', // Allow default parameters instead of defaultProps
       'react/sort-comp': [0, {}],
 
       'import/order': [

--- a/tests/ui/infra-compare/InfraCompare.test.jsx
+++ b/tests/ui/infra-compare/InfraCompare.test.jsx
@@ -1,0 +1,317 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// Import the component under test
+import InfraCompareView from '../../../ui/infra-compare/InfraCompare';
+import { getCounterMap } from '../../../ui/infra-compare/helpers';
+
+// Mock dependencies
+jest.mock('../../../ui/perfherder/Validation', () => ({
+  __esModule: true,
+  default: () => (Component) => (props) => (
+    <Component {...props} validated={props.validated || {}} />
+  ),
+}));
+
+jest.mock('../../../ui/infra-compare/helpers', () => ({
+  getCounterMap: jest.fn((jobName, originalData, newData) => {
+    if (!originalData && !newData) {
+      return { isEmpty: true };
+    }
+
+    return {
+      isEmpty: false,
+      platform: 'mock-platform',
+      suite: 'mock-suite',
+      originalValue: 100,
+      newValue: 110,
+      delta: 10,
+      deltaPercentage: 10,
+      originalJobs: new Map(),
+      newJobs: new Map(),
+    };
+  }),
+}));
+
+jest.mock('../../../ui/infra-compare/constants', () => ({
+  phTimeRanges: [
+    { value: 86400, text: 'Last day' },
+    { value: 86400 * 2, text: 'Last 2 days' },
+    { value: 604800, text: 'Last 7 days' },
+    { value: 1209600, text: 'Last 14 days' },
+    { value: 2592000, text: 'Last 30 days' },
+  ],
+}));
+
+// Store props passed to the mock component for testing
+let mockTableViewProps = {};
+
+jest.mock('../../../ui/infra-compare/InfraCompareTableView', () => {
+  const MockTableView = (props) => {
+    // Store the props for testing
+    mockTableViewProps = props;
+    return <div data-testid="infra-compare-table-view" />;
+  };
+  return MockTableView;
+});
+
+describe('InfraCompareView', () => {
+  // Test fixtures
+  const defaultProps = {
+    projects: [{ name: 'mozilla-central' }, { name: 'try' }],
+    updateAppState: jest.fn(),
+  };
+
+  const mockValidated = {
+    originalProject: 'mozilla-central',
+    newProject: 'try',
+    originalRevision: 'abc123',
+    newRevision: 'def456',
+    originalResultSet: {
+      push_timestamp: 1596240000,
+    },
+    newResultSet: {
+      push_timestamp: 1596250000,
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset the mock props
+    mockTableViewProps = {};
+    // Mock Date.now() to return a fixed timestamp for consistent testing
+    jest
+      .spyOn(Date.prototype, 'getTime')
+      .mockImplementation(() => 1596340000000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders correctly', () => {
+    const { getByTestId } = render(
+      <MemoryRouter>
+        <InfraCompareView {...defaultProps} validated={mockValidated} />
+      </MemoryRouter>,
+    );
+
+    expect(getByTestId('infra-compare-table-view')).toBeInTheDocument();
+  });
+
+  it('passes the correct props to InfraCompareTableView', () => {
+    render(
+      <MemoryRouter>
+        <InfraCompareView {...defaultProps} validated={mockValidated} />
+      </MemoryRouter>,
+    );
+
+    // Check that the correct props were passed to the mock component
+    expect(mockTableViewProps).toHaveProperty('projects');
+    expect(mockTableViewProps).toHaveProperty('validated');
+    expect(mockTableViewProps).toHaveProperty('updateAppState');
+    expect(mockTableViewProps).toHaveProperty('jobsNotDisplayed');
+    expect(mockTableViewProps).toHaveProperty('getQueryParams');
+    expect(mockTableViewProps).toHaveProperty('getDisplayResults');
+  });
+
+  describe('getInterval function', () => {
+    it('calculates the correct interval based on timestamps', () => {
+      render(
+        <MemoryRouter>
+          <InfraCompareView {...defaultProps} validated={mockValidated} />
+        </MemoryRouter>,
+      );
+
+      // Since we can't directly access the component's methods,
+      // we'll test the getQueryParams function which uses getInterval
+      expect(mockTableViewProps).toHaveProperty('getQueryParams');
+
+      // We can test that getQueryParams returns the expected result
+      const timeRange = { value: 86400 };
+      const [originalParams, newParams] = mockTableViewProps.getQueryParams(
+        timeRange,
+      );
+
+      // Verify the params have the expected properties
+      expect(originalParams).toHaveProperty('project', 'mozilla-central');
+      expect(originalParams).toHaveProperty('interval');
+      expect(originalParams).toHaveProperty('revision', 'abc123');
+
+      expect(newParams).toHaveProperty('project', 'try');
+      expect(newParams).toHaveProperty('interval');
+      expect(newParams).toHaveProperty('revision', 'def456');
+    });
+  });
+
+  describe('getQueryParams function', () => {
+    it('returns correct params with originalRevision', () => {
+      render(
+        <MemoryRouter>
+          <InfraCompareView {...defaultProps} validated={mockValidated} />
+        </MemoryRouter>,
+      );
+
+      const timeRange = { value: 86400 };
+      const [originalParams, newParams] = mockTableViewProps.getQueryParams(
+        timeRange,
+      );
+
+      // Verify the params have the expected properties
+      expect(originalParams).toHaveProperty('project', 'mozilla-central');
+      expect(originalParams).toHaveProperty('interval');
+      expect(originalParams).toHaveProperty('revision', 'abc123');
+
+      expect(newParams).toHaveProperty('project', 'try');
+      expect(newParams).toHaveProperty('interval');
+      expect(newParams).toHaveProperty('revision', 'def456');
+    });
+
+    it('returns correct params without originalRevision', () => {
+      const validatedWithoutOriginalRevision = {
+        ...mockValidated,
+        originalRevision: null,
+      };
+
+      render(
+        <MemoryRouter>
+          <InfraCompareView
+            {...defaultProps}
+            validated={validatedWithoutOriginalRevision}
+          />
+        </MemoryRouter>,
+      );
+
+      const timeRange = { value: 86400, text: 'Last day' };
+      const [originalParams, newParams] = mockTableViewProps.getQueryParams(
+        timeRange,
+      );
+
+      // Verify the params have the expected properties
+      expect(originalParams).toHaveProperty(
+        'originalProject',
+        'mozilla-central',
+      );
+      expect(originalParams).toHaveProperty('interval', 86400);
+      expect(originalParams).toHaveProperty('startday');
+      expect(originalParams).toHaveProperty('endday');
+
+      expect(newParams).toHaveProperty('project', 'try');
+      expect(newParams).toHaveProperty('interval', 86400);
+      expect(newParams).toHaveProperty('revision', 'def456');
+    });
+  });
+
+  describe('getDisplayResults function', () => {
+    it('processes empty results correctly', () => {
+      render(
+        <MemoryRouter>
+          <InfraCompareView {...defaultProps} validated={mockValidated} />
+        </MemoryRouter>,
+      );
+
+      const origResultsMap = [];
+      const newResultsMap = [];
+      const tableNames = [];
+
+      const result = mockTableViewProps.getDisplayResults(
+        origResultsMap,
+        newResultsMap,
+        tableNames,
+      );
+
+      expect(result).toHaveProperty('compareResults');
+      expect(result).toHaveProperty('loading', false);
+      expect(defaultProps.updateAppState).toHaveBeenCalledWith({
+        compareData: expect.any(Map),
+      });
+    });
+
+    it('processes valid results correctly', () => {
+      render(
+        <MemoryRouter>
+          <InfraCompareView {...defaultProps} validated={mockValidated} />
+        </MemoryRouter>,
+      );
+
+      const origResultsMap = [
+        {
+          job_type__name: 'platform/suite-1',
+          duration: 100,
+          result: 'success',
+        },
+      ];
+      const newResultsMap = [
+        {
+          job_type__name: 'platform/suite-1',
+          duration: 110,
+          result: 'success',
+        },
+      ];
+      const tableNames = ['platform/suite'];
+
+      const result = mockTableViewProps.getDisplayResults(
+        origResultsMap,
+        newResultsMap,
+        tableNames,
+      );
+
+      expect(result).toHaveProperty('compareResults');
+      expect(result).toHaveProperty('loading', false);
+      expect(defaultProps.updateAppState).toHaveBeenCalledWith({
+        compareData: expect.any(Map),
+      });
+    });
+
+    it('updates jobsNotDisplayed state for empty results', async () => {
+      // Mock getCounterMap to return isEmpty: true for the specific test case
+      getCounterMap.mockImplementation((jobName) => {
+        if (jobName === 'platform/suite') {
+          return { isEmpty: true };
+        }
+        return {
+          isEmpty: false,
+          platform: 'mock-platform',
+          suite: 'mock-suite',
+          originalJobs: new Map(),
+          newJobs: new Map(),
+        };
+      });
+
+      // Render the component
+      const { rerender } = render(
+        <MemoryRouter>
+          <InfraCompareView {...defaultProps} validated={mockValidated} />
+        </MemoryRouter>,
+      );
+
+      // Initial jobsNotDisplayed should be an empty array
+      expect(mockTableViewProps.jobsNotDisplayed).toEqual([]);
+
+      // Call getDisplayResults with a table name that will result in isEmpty: true
+      const origResultsMap = [];
+      const newResultsMap = [];
+      const tableNames = ['platform/suite'];
+
+      // Use act to handle the state update
+      await act(async () => {
+        mockTableViewProps.getDisplayResults(
+          origResultsMap,
+          newResultsMap,
+          tableNames,
+        );
+      });
+
+      // Force a re-render to ensure the updated state is reflected in the props
+      rerender(
+        <MemoryRouter>
+          <InfraCompareView {...defaultProps} validated={mockValidated} />
+        </MemoryRouter>,
+      );
+
+      // Now jobsNotDisplayed should contain the table name
+      expect(mockTableViewProps.jobsNotDisplayed).toContain('platform/suite');
+    });
+  });
+});

--- a/tests/ui/job-view/headerbars/FiltersMenu.test.jsx
+++ b/tests/ui/job-view/headerbars/FiltersMenu.test.jsx
@@ -1,0 +1,441 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import FiltersMenu from '../../../../ui/job-view/headerbars/FiltersMenu';
+import { thAllResultStatuses } from '../../../../ui/helpers/constants';
+import * as filterHelpers from '../../../../ui/helpers/filter';
+import * as selectedJobActions from '../../../../ui/job-view/redux/stores/selectedJob';
+import * as pinnedJobsActions from '../../../../ui/job-view/redux/stores/pinnedJobs';
+
+// Mock the filter helpers
+jest.mock('../../../../ui/helpers/filter', () => ({
+  thDefaultFilterResultStatuses: [
+    'success',
+    'testfailed',
+    'busted',
+    'exception',
+  ],
+  arraysEqual: jest.fn((a, b) => JSON.stringify(a) === JSON.stringify(b)),
+}));
+
+// Create a mock store
+const mockStore = configureStore([thunk]);
+
+describe('FiltersMenu', () => {
+  const mockFilterModel = {
+    urlParams: {
+      resultStatus: ['success', 'testfailed', 'busted', 'exception'],
+      classifiedState: ['unclassified', 'classified'],
+    },
+    toggleResultStatuses: jest.fn(),
+    toggleClassifiedFailures: jest.fn(),
+    toggleUnclassifiedFailures: jest.fn(),
+    isClassifiedFailures: jest.fn(),
+    isUnclassifiedFailures: jest.fn(),
+    setOnlySuperseded: jest.fn(),
+    resetNonFieldFilters: jest.fn(),
+  };
+
+  const mockGetAllShownJobs = jest.fn().mockReturnValue([
+    { id: 1, jobType: 'test' },
+    { id: 2, jobType: 'build' },
+  ]);
+
+  const mockUser = {
+    email: 'test@example.com',
+  };
+
+  let store;
+
+  const renderWithRouter = (component) => {
+    return render(
+      <MemoryRouter>
+        <Provider store={store}>{component}</Provider>
+      </MemoryRouter>,
+    );
+  };
+  let originalWindowLocation;
+
+  beforeEach(() => {
+    // Save original window.location and mock it
+    originalWindowLocation = window.location;
+    delete window.location;
+    window.location = {
+      search: '?repo=mozilla-central',
+      toString: jest.fn(),
+    };
+
+    // Mock the Redux actions
+    jest
+      .spyOn(selectedJobActions, 'setSelectedJob')
+      .mockImplementation((job) => ({
+        type: 'SET_SELECTED_JOB',
+        job,
+      }));
+    jest
+      .spyOn(selectedJobActions, 'clearSelectedJob')
+      .mockImplementation(() => ({
+        type: 'CLEAR_SELECTED_JOB',
+      }));
+    jest.spyOn(pinnedJobsActions, 'pinJobs').mockImplementation((jobs) => ({
+      type: 'PIN_JOBS',
+      jobs,
+    }));
+
+    // Reset all mocks
+    jest.clearAllMocks();
+
+    // Create a fresh store for each test
+    store = mockStore({
+      selectedJob: {
+        selectedJob: null,
+      },
+      pinnedJobs: {
+        pinnedJobs: [],
+      },
+    });
+  });
+
+  afterEach(() => {
+    // Restore window.location
+    window.location = originalWindowLocation;
+  });
+
+  it('renders correctly', () => {
+    renderWithRouter(
+      <FiltersMenu
+        filterModel={mockFilterModel}
+        getAllShownJobs={mockGetAllShownJobs}
+        user={mockUser}
+      />,
+    );
+
+    // Check that the dropdown toggle is rendered
+    expect(screen.getByText('Filters')).toBeInTheDocument();
+  });
+
+  it('renders all result status menu items', () => {
+    renderWithRouter(
+      <FiltersMenu
+        filterModel={mockFilterModel}
+        getAllShownJobs={mockGetAllShownJobs}
+        user={mockUser}
+      />,
+    );
+
+    // Open the dropdown
+    fireEvent.click(screen.getByText('Filters'));
+
+    // Check that all result status menu items are rendered (except 'runnable')
+    const resultStatusMenuItems = thAllResultStatuses.filter(
+      (rs) => rs !== 'runnable',
+    );
+
+    resultStatusMenuItems.forEach((status) => {
+      expect(screen.getByText(status)).toBeInTheDocument();
+    });
+  });
+
+  it('calls toggleResultStatuses when a status filter is clicked', () => {
+    renderWithRouter(
+      <FiltersMenu
+        filterModel={mockFilterModel}
+        getAllShownJobs={mockGetAllShownJobs}
+        user={mockUser}
+      />,
+    );
+
+    // Open the dropdown
+    fireEvent.click(screen.getByText('Filters'));
+
+    // Click on a status filter
+    fireEvent.click(screen.getByText('success'));
+
+    // Check that toggleResultStatuses was called with the correct argument
+    expect(mockFilterModel.toggleResultStatuses).toHaveBeenCalledWith([
+      'success',
+    ]);
+  });
+
+  it('calls pinJobs when "Pin all showing" is clicked', () => {
+    renderWithRouter(
+      <FiltersMenu
+        filterModel={mockFilterModel}
+        getAllShownJobs={mockGetAllShownJobs}
+        user={mockUser}
+      />,
+    );
+
+    // Open the dropdown
+    fireEvent.click(screen.getByText('Filters'));
+
+    // Click on "Pin all showing"
+    fireEvent.click(screen.getByText('Pin all showing'));
+
+    // Check that getAllShownJobs and pinJobs were called
+    expect(mockGetAllShownJobs).toHaveBeenCalled();
+
+    // Check that the store received the SET_PINNED_JOBS action
+    const actions = store.getActions();
+    expect(actions).toContainEqual({
+      type: 'SET_PINNED_JOBS',
+      payload: {
+        pinnedJobs: {
+          1: { id: 1, jobType: 'test' },
+          2: { id: 2, jobType: 'build' },
+        },
+      },
+    });
+  });
+
+  it('calls setSelectedJob when pinning jobs and no job is selected', () => {
+    renderWithRouter(
+      <FiltersMenu
+        filterModel={mockFilterModel}
+        getAllShownJobs={mockGetAllShownJobs}
+        user={mockUser}
+      />,
+    );
+
+    // Open the dropdown
+    fireEvent.click(screen.getByText('Filters'));
+
+    // Click on "Pin all showing"
+    fireEvent.click(screen.getByText('Pin all showing'));
+
+    // Check that the store received the SELECT_JOB action
+    const actions = store.getActions();
+    expect(actions).toContainEqual({
+      type: 'SELECT_JOB',
+      job: {
+        id: 1,
+        jobType: 'test',
+      },
+    });
+  });
+
+  it('does not call setSelectedJob when pinning jobs and a job is already selected', () => {
+    // Create a store with a selected job
+    const storeWithSelectedJob = mockStore({
+      selectedJob: {
+        selectedJob: { id: 3, jobType: 'test' },
+      },
+      pinnedJobs: {
+        pinnedJobs: [],
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <Provider store={storeWithSelectedJob}>
+          <FiltersMenu
+            filterModel={mockFilterModel}
+            getAllShownJobs={mockGetAllShownJobs}
+            user={mockUser}
+          />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    // Open the dropdown
+    fireEvent.click(screen.getByText('Filters'));
+
+    // Click on "Pin all showing"
+    fireEvent.click(screen.getByText('Pin all showing'));
+
+    // Check that setSelectedJob was not called
+    expect(selectedJobActions.setSelectedJob).not.toHaveBeenCalled();
+  });
+
+  it('calls toggleClassifiedFailures(true) when "All failures" is clicked', () => {
+    renderWithRouter(
+      <FiltersMenu
+        filterModel={mockFilterModel}
+        getAllShownJobs={mockGetAllShownJobs}
+        user={mockUser}
+      />,
+    );
+
+    // Open the dropdown
+    fireEvent.click(screen.getByText('Filters'));
+
+    // Click on "All failures"
+    fireEvent.click(screen.getByText('All failures'));
+
+    // Check that toggleClassifiedFailures was called with true
+    expect(mockFilterModel.toggleClassifiedFailures).toHaveBeenCalledWith(true);
+  });
+
+  it('calls toggleUnclassifiedFailures when "Unclassified failures" is clicked', () => {
+    renderWithRouter(
+      <FiltersMenu
+        filterModel={mockFilterModel}
+        getAllShownJobs={mockGetAllShownJobs}
+        user={mockUser}
+      />,
+    );
+
+    // Open the dropdown
+    fireEvent.click(screen.getByText('Filters'));
+
+    // Click on "Unclassified failures"
+    fireEvent.click(screen.getByText('Unclassified failures'));
+
+    // Check that toggleUnclassifiedFailures was called
+    expect(mockFilterModel.toggleUnclassifiedFailures).toHaveBeenCalled();
+  });
+
+  it('calls toggleClassifiedFailures when "Classified failures" is clicked', () => {
+    renderWithRouter(
+      <FiltersMenu
+        filterModel={mockFilterModel}
+        getAllShownJobs={mockGetAllShownJobs}
+        user={mockUser}
+      />,
+    );
+
+    // Open the dropdown
+    fireEvent.click(screen.getByText('Filters'));
+
+    // Click on "Classified failures"
+    fireEvent.click(screen.getByText('Classified failures'));
+
+    // Check that toggleClassifiedFailures was called
+    expect(mockFilterModel.toggleClassifiedFailures).toHaveBeenCalled();
+  });
+
+  it('calls setOnlySuperseded when "Superseded only" is clicked', () => {
+    renderWithRouter(
+      <FiltersMenu
+        filterModel={mockFilterModel}
+        getAllShownJobs={mockGetAllShownJobs}
+        user={mockUser}
+      />,
+    );
+
+    // Open the dropdown
+    fireEvent.click(screen.getByText('Filters'));
+
+    // Click on "Superseded only"
+    fireEvent.click(screen.getByText('Superseded only'));
+
+    // Check that setOnlySuperseded was called
+    expect(mockFilterModel.setOnlySuperseded).toHaveBeenCalled();
+  });
+
+  it('calls resetNonFieldFilters when "Reset" is clicked', () => {
+    renderWithRouter(
+      <FiltersMenu
+        filterModel={mockFilterModel}
+        getAllShownJobs={mockGetAllShownJobs}
+        user={mockUser}
+      />,
+    );
+
+    // Open the dropdown
+    fireEvent.click(screen.getByText('Filters'));
+
+    // Click on "Reset"
+    fireEvent.click(screen.getByText('Reset'));
+
+    // Check that resetNonFieldFilters was called
+    expect(mockFilterModel.resetNonFieldFilters).toHaveBeenCalled();
+  });
+
+  it('creates correct URL for "My pushes only" link', () => {
+    renderWithRouter(
+      <FiltersMenu
+        filterModel={mockFilterModel}
+        getAllShownJobs={mockGetAllShownJobs}
+        user={mockUser}
+      />,
+    );
+
+    // Open the dropdown
+    fireEvent.click(screen.getByText('Filters'));
+
+    // Find the "My pushes only" link
+    const myPushesLink = screen.getByText('My pushes only').closest('a');
+
+    // Check that the link has the correct search parameter
+    expect(myPushesLink.search).toContain('author=test%40example.com');
+  });
+
+  it('creates correct URL for "Hide code review pushes" link', () => {
+    renderWithRouter(
+      <FiltersMenu
+        filterModel={mockFilterModel}
+        getAllShownJobs={mockGetAllShownJobs}
+        user={mockUser}
+      />,
+    );
+
+    // Open the dropdown
+    fireEvent.click(screen.getByText('Filters'));
+
+    // Find the "Hide code review pushes" link
+    const hideReviewbotLink = screen
+      .getByText('Hide code review pushes')
+      .closest('a');
+
+    // Check that the link has the correct search parameter
+    expect(hideReviewbotLink.search).toContain('author=-reviewbot');
+  });
+
+  it('handles "All jobs" filter correctly when default filters are active', () => {
+    // Mock arraysEqual to return true for the default filters
+    filterHelpers.arraysEqual.mockImplementation((a, b) => {
+      if (
+        JSON.stringify(a) ===
+          JSON.stringify(filterHelpers.thDefaultFilterResultStatuses) &&
+        JSON.stringify(b) === JSON.stringify(['unclassified', 'classified'])
+      ) {
+        return true;
+      }
+      return JSON.stringify(a) === JSON.stringify(b);
+    });
+
+    renderWithRouter(
+      <FiltersMenu
+        filterModel={mockFilterModel}
+        getAllShownJobs={mockGetAllShownJobs}
+        user={mockUser}
+      />,
+    );
+
+    // Open the dropdown
+    fireEvent.click(screen.getByText('Filters'));
+
+    // Click on "All jobs"
+    fireEvent.click(screen.getByText('All jobs'));
+
+    // Check that toggleClassifiedFailures was called with true
+    expect(mockFilterModel.toggleClassifiedFailures).toHaveBeenCalledWith(true);
+  });
+
+  it('handles "All jobs" filter correctly when non-default filters are active', () => {
+    // Mock arraysEqual to return false for the default filters
+    filterHelpers.arraysEqual.mockImplementation(() => false);
+
+    renderWithRouter(
+      <FiltersMenu
+        filterModel={mockFilterModel}
+        getAllShownJobs={mockGetAllShownJobs}
+        user={mockUser}
+      />,
+    );
+
+    // Open the dropdown
+    fireEvent.click(screen.getByText('Filters'));
+
+    // Click on "All jobs"
+    fireEvent.click(screen.getByText('All jobs'));
+
+    // Check that resetNonFieldFilters was called
+    expect(mockFilterModel.resetNonFieldFilters).toHaveBeenCalled();
+  });
+});

--- a/tests/ui/job-view/pushes/JobsAndGroups.test.jsx
+++ b/tests/ui/job-view/pushes/JobsAndGroups.test.jsx
@@ -1,0 +1,325 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import JobsAndGroups from '../../../../ui/job-view/pushes/JobsAndGroups';
+
+// Mock the child components
+jest.mock('../../../../ui/job-view/pushes/JobButton', () => {
+  const MockJobButton = ({ job, visible, intermittent }) => (
+    <div
+      data-testid={`job-button-${job.id}`}
+      data-visible={visible}
+      data-intermittent={intermittent}
+    >
+      Job Button: {job.job_type_name}
+    </div>
+  );
+  return MockJobButton;
+});
+
+jest.mock('../../../../ui/job-view/pushes/JobGroup', () => {
+  const MockJobGroup = ({ group, confirmGroup }) => (
+    <div
+      data-testid={`job-group-${group.mapKey}`}
+      data-confirm-group={!!Object.keys(confirmGroup).length}
+    >
+      Job Group: {group.symbol}
+    </div>
+  );
+  return MockJobGroup;
+});
+
+describe('JobsAndGroups', () => {
+  const defaultProps = {
+    groups: [],
+    repoName: 'mozilla-central',
+    filterModel: {},
+    filterPlatformCb: jest.fn(),
+    pushGroupState: 'collapsed',
+    duplicateJobsVisible: false,
+    groupCountsExpanded: false,
+    runnableVisible: false,
+    toggleSelectedRunnableJob: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly with no groups', () => {
+    render(<JobsAndGroups {...defaultProps} />);
+
+    const jobRow = screen.getByRole('cell');
+    expect(jobRow).toHaveClass('job-row');
+    expect(jobRow).toBeEmptyDOMElement();
+  });
+
+  it('renders job groups correctly', () => {
+    const groups = [
+      {
+        mapKey: 'group1',
+        symbol: 'G1',
+        tier: 2,
+        visible: true,
+        jobs: [],
+      },
+      {
+        mapKey: 'group2',
+        symbol: 'G2',
+        tier: 3,
+        visible: true,
+        jobs: [],
+      },
+    ];
+
+    render(<JobsAndGroups {...defaultProps} groups={groups} />);
+
+    expect(screen.getByTestId('job-group-group1')).toBeInTheDocument();
+    expect(screen.getByTestId('job-group-group2')).toBeInTheDocument();
+  });
+
+  it('does not render invisible job groups', () => {
+    const groups = [
+      {
+        mapKey: 'group1',
+        symbol: 'G1',
+        tier: 2,
+        visible: true,
+        jobs: [],
+      },
+      {
+        mapKey: 'group2',
+        symbol: 'G2',
+        tier: 3,
+        visible: false,
+        jobs: [],
+      },
+    ];
+
+    render(<JobsAndGroups {...defaultProps} groups={groups} />);
+
+    expect(screen.getByTestId('job-group-group1')).toBeInTheDocument();
+    expect(screen.queryByTestId('job-group-group2')).not.toBeInTheDocument();
+  });
+
+  it('renders individual job buttons for tier 1 groups with empty symbol', () => {
+    const groups = [
+      {
+        mapKey: 'group1',
+        symbol: '',
+        tier: 1,
+        visible: true,
+        jobs: [
+          {
+            id: 1,
+            job_type_name: 'test-job-1',
+            visible: true,
+            resultStatus: 'success',
+            failure_classification_id: 0,
+            result: 'success',
+          },
+          {
+            id: 2,
+            job_type_name: 'test-job-2',
+            visible: true,
+            resultStatus: 'testfailed',
+            failure_classification_id: 0,
+            result: 'testfailed',
+          },
+        ],
+      },
+    ];
+
+    render(<JobsAndGroups {...defaultProps} groups={groups} />);
+
+    expect(screen.queryByTestId('job-group-group1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('job-button-1')).toBeInTheDocument();
+    expect(screen.getByTestId('job-button-2')).toBeInTheDocument();
+  });
+
+  it('identifies intermittent jobs correctly', () => {
+    const groups = [
+      {
+        mapKey: 'group1',
+        symbol: '',
+        tier: 1,
+        visible: true,
+        jobs: [
+          {
+            id: 1,
+            job_type_name: 'test-job-1',
+            visible: true,
+            resultStatus: 'success',
+            failure_classification_id: 0,
+            result: 'success',
+          },
+          {
+            id: 2,
+            job_type_name: 'test-job-1',
+            visible: true,
+            resultStatus: 'testfailed',
+            failure_classification_id: 0,
+            result: 'testfailed',
+          },
+        ],
+      },
+    ];
+
+    render(<JobsAndGroups {...defaultProps} groups={groups} />);
+
+    // The second job should be marked as intermittent because there's a passing job with the same name
+    expect(screen.getByTestId('job-button-2')).toHaveAttribute(
+      'data-intermittent',
+      'true',
+    );
+  });
+
+  it('handles confirm groups correctly', () => {
+    const groups = [
+      {
+        mapKey: 'push1 G1 2 linux debug2',
+        symbol: 'G1',
+        tier: 2,
+        visible: true,
+        jobs: [],
+      },
+      {
+        mapKey: 'push1 G1 2 linux debug-cf3',
+        symbol: 'G1-cf',
+        tier: 3,
+        visible: true,
+        jobs: [
+          {
+            job_type_name: 'test-job-1-cf',
+            result: 'testfailed',
+          },
+        ],
+      },
+    ];
+
+    render(<JobsAndGroups {...defaultProps} groups={groups} />);
+
+    // The first group should have a confirm group
+    expect(
+      screen.getByTestId('job-group-push1 G1 2 linux debug2'),
+    ).toHaveAttribute('data-confirm-group', 'true');
+  });
+
+  describe('getIntermittentJobTypeNames', () => {
+    it('identifies intermittent jobs based on failure ratio', () => {
+      const component = new JobsAndGroups(defaultProps);
+
+      const groupJobs = [
+        {
+          id: 1,
+          job_type_name: 'test-job-1',
+          result: 'testfailed',
+        },
+        {
+          id: 2,
+          job_type_name: 'test-job-1',
+          result: 'success',
+        },
+        {
+          id: 3,
+          job_type_name: 'test-job-1',
+          result: 'success',
+        },
+      ];
+
+      const intermittentJobTypeNames = component.getIntermittentJobTypeNames(
+        groupJobs,
+      );
+
+      // test-job-1 should be identified as intermittent because 1/3 of the jobs failed (below the 0.5 threshold)
+      expect(intermittentJobTypeNames.has('test-job-1')).toBe(true);
+    });
+
+    it('does not identify jobs as intermittent if failure ratio is too high', () => {
+      const component = new JobsAndGroups(defaultProps);
+
+      const groupJobs = [
+        {
+          id: 1,
+          job_type_name: 'test-job-1',
+          result: 'testfailed',
+        },
+        {
+          id: 2,
+          job_type_name: 'test-job-1',
+          result: 'testfailed',
+        },
+        {
+          id: 3,
+          job_type_name: 'test-job-1',
+          result: 'success',
+        },
+      ];
+
+      const intermittentJobTypeNames = component.getIntermittentJobTypeNames(
+        groupJobs,
+      );
+
+      // test-job-1 should not be identified as intermittent because 2/3 of the jobs failed (above the 0.5 threshold)
+      expect(intermittentJobTypeNames.has('test-job-1')).toBe(false);
+    });
+
+    it('identifies jobs as intermittent if they have a confirm job', () => {
+      const component = new JobsAndGroups(defaultProps);
+
+      const groupJobs = [
+        {
+          id: 1,
+          job_type_name: 'test-job-1',
+          result: 'testfailed',
+        },
+      ];
+
+      const confirmGroup = {
+        jobs: [
+          {
+            job_type_name: 'test-job-1-cf',
+            result: 'success',
+          },
+        ],
+      };
+
+      const intermittentJobTypeNames = component.getIntermittentJobTypeNames(
+        groupJobs,
+        confirmGroup,
+      );
+
+      // test-job-1 should be identified as intermittent because it has a green confirm job
+      expect(intermittentJobTypeNames.has('test-job-1')).toBe(true);
+    });
+
+    it('does not identify jobs as intermittent if they have a failing confirm job', () => {
+      const component = new JobsAndGroups(defaultProps);
+
+      const groupJobs = [
+        {
+          id: 1,
+          job_type_name: 'test-job-1',
+          result: 'testfailed',
+        },
+      ];
+
+      const confirmGroup = {
+        jobs: [
+          {
+            job_type_name: 'test-job-1-cf',
+            result: 'testfailed',
+          },
+        ],
+      };
+
+      const intermittentJobTypeNames = component.getIntermittentJobTypeNames(
+        groupJobs,
+        confirmGroup,
+      );
+
+      // test-job-1 should not be identified as intermittent because it has a failing confirm job
+      expect(intermittentJobTypeNames.has('test-job-1')).toBe(false);
+    });
+  });
+});

--- a/tests/ui/shared/BugFiler.test.jsx
+++ b/tests/ui/shared/BugFiler.test.jsx
@@ -1,0 +1,569 @@
+import React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+
+import { BugFilerClass } from '../../../ui/shared/BugFiler';
+import * as httpHelpers from '../../../ui/helpers/http';
+import * as jobHelpers from '../../../ui/helpers/job';
+import * as bugHelpers from '../../../ui/helpers/bug';
+
+// Mock the helpers
+jest.mock('../../../ui/helpers/http', () => ({
+  create: jest.fn(),
+}));
+
+jest.mock('../../../ui/helpers/job', () => ({
+  confirmFailure: jest.fn(),
+}));
+
+jest.mock('../../../ui/helpers/bug', () => ({
+  omittedLeads: ['TEST-UNEXPECTED-FAIL', 'TEST-UNEXPECTED-ERROR'],
+  parseSummary: jest.fn().mockReturnValue([['Test failure | test_file.js']]),
+  getCrashSignatures: jest.fn(),
+}));
+
+jest.mock('../../../ui/helpers/url', () => ({
+  bugzillaBugsApi: jest
+    .fn()
+    .mockReturnValue('https://bugzilla-api.mozilla.org/rest/bug'),
+  bzBaseUrl: 'https://bugzilla.mozilla.org/',
+  bzComponentEndpoint: '/component_search',
+  getApiUrl: jest.fn().mockReturnValue('/api/bugzilla/create_bug/'),
+}));
+
+describe('BugFiler', () => {
+  const defaultProps = {
+    isOpen: true,
+    toggle: jest.fn(),
+    suggestion: {
+      search: 'TEST-UNEXPECTED-FAIL | test_file.js | Test failure',
+      search_terms: ['test_file.js', 'Test failure'],
+      path_end: 'dom/tests/test_file.js',
+      bugs: {
+        open_recent: [],
+        all_others: [],
+      },
+    },
+    suggestions: [
+      {
+        search: 'TEST-UNEXPECTED-FAIL | test_file.js | Test failure',
+        search_terms: ['test_file.js', 'Test failure'],
+        path_end: 'dom/tests/test_file.js',
+        bugs: {
+          open_recent: [],
+          all_others: [],
+        },
+      },
+    ],
+    fullLog: 'https://example.com/full-log',
+    parsedLog: 'https://example.com/parsed-log',
+    reftestUrl: 'https://example.com/reftest',
+    successCallback: jest.fn(),
+    platform: 'linux',
+    notify: jest.fn(),
+    selectedJob: {
+      job_group_name: 'test-group',
+      job_type_name: 'test-job',
+    },
+    currentRepo: { name: 'mozilla-central' },
+    decisionTaskMap: {},
+  };
+
+  beforeEach(() => {
+    // Reset all mocks
+    jest.clearAllMocks();
+
+    // Set default return value for getCrashSignatures
+    bugHelpers.getCrashSignatures.mockReturnValue([]);
+
+    // Mock fetch for API calls
+    fetchMock.reset();
+    fetchMock.get('https://bugzilla-api.mozilla.org/rest/bug', {
+      products: [
+        {
+          versions: [
+            { name: '1.0', is_active: true },
+            { name: '2.0', is_active: true },
+          ],
+        },
+      ],
+    });
+    fetchMock.get(
+      'https://bugzilla.mozilla.org/rest/prod_comp_search/find/Firefox?limit=5',
+      {
+        products: [
+          { product: 'Firefox', component: 'General' },
+          { product: 'Firefox', component: 'Menus' },
+        ],
+      },
+    );
+    fetchMock.get('/api/component_search?path=dom%2Ftests%2Ftest_file.js', [
+      { product: 'Core', component: 'DOM' },
+      { product: 'Core', component: 'DOM: Core & HTML' },
+    ]);
+
+    // Mock http.create
+    httpHelpers.create.mockResolvedValue({
+      data: { id: 123456, internal_id: 'internal-123' },
+      failureStatus: false,
+    });
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('renders correctly when open', () => {
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Check that the modal is rendered
+    expect(screen.getByText('Intermittent Bug Filer')).toBeInTheDocument();
+
+    // Check that the form elements are rendered
+    expect(
+      screen.getByPlaceholderText('e.g. Firefox, Toolkit, Testing'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Summary:')).toBeInTheDocument();
+    expect(screen.getByText('Comment:')).toBeInTheDocument();
+    expect(
+      screen.getByText('This is an intermittent failure'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Submit Bug')).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  });
+
+  it('initializes state correctly', () => {
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Check that the summary field is initialized correctly
+    const summaryInput = screen.getByPlaceholderText('Intermittent...');
+    expect(summaryInput).toHaveValue(
+      'Intermittent Test failure | test_file.js',
+    );
+
+    // Check that the log links are checked by default
+    const parsedLogCheckbox = screen
+      .getByText('Include Parsed Log Link')
+      .closest('label')
+      .querySelector('input');
+    const fullLogCheckbox = screen
+      .getByText('Include Full Log Link')
+      .closest('label')
+      .querySelector('input');
+    const reftestCheckbox = screen
+      .getByText('Include Reftest Viewer Link')
+      .closest('label')
+      .querySelector('input');
+
+    expect(parsedLogCheckbox).toBeChecked();
+    expect(fullLogCheckbox).toBeChecked();
+    expect(reftestCheckbox).toBeChecked();
+
+    // Check that "This is an intermittent failure" is checked by default
+    const intermittentCheckbox = screen
+      .getByText('This is an intermittent failure')
+      .closest('label')
+      .querySelector('input');
+    expect(intermittentCheckbox).toBeChecked();
+  });
+
+  it('calls toggle when Cancel is clicked', () => {
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Click the Cancel button
+    fireEvent.click(screen.getByText('Cancel'));
+
+    // Check that toggle was called
+    expect(defaultProps.toggle).toHaveBeenCalled();
+  });
+
+  it('toggles log link checkboxes when clicked', () => {
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Get the checkboxes
+    const parsedLogCheckbox = screen
+      .getByText('Include Parsed Log Link')
+      .closest('label')
+      .querySelector('input');
+    const fullLogCheckbox = screen
+      .getByText('Include Full Log Link')
+      .closest('label')
+      .querySelector('input');
+
+    // Initially, they should be checked
+    expect(parsedLogCheckbox).toBeChecked();
+    expect(fullLogCheckbox).toBeChecked();
+
+    // Click the parsed log checkbox
+    fireEvent.click(parsedLogCheckbox);
+
+    // Now it should be unchecked
+    expect(parsedLogCheckbox).not.toBeChecked();
+
+    // The full log checkbox should still be checked
+    expect(fullLogCheckbox).toBeChecked();
+  });
+
+  it('toggles "This is an intermittent failure" checkbox when clicked', () => {
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Get the checkbox
+    const intermittentCheckbox = screen
+      .getByText('This is an intermittent failure')
+      .closest('label')
+      .querySelector('input');
+
+    // Initially, it should be checked
+    expect(intermittentCheckbox).toBeChecked();
+
+    // Click the checkbox
+    fireEvent.click(intermittentCheckbox);
+
+    // Now it should be unchecked
+    expect(intermittentCheckbox).not.toBeChecked();
+  });
+
+  it('updates summary when input changes', () => {
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Get the summary input
+    const summaryInput = screen.getByPlaceholderText('Intermittent...');
+
+    // Initially, it should have the default value
+    expect(summaryInput).toHaveValue(
+      'Intermittent Test failure | test_file.js',
+    );
+
+    // Change the input value
+    fireEvent.change(summaryInput, { target: { value: 'New summary' } });
+
+    // Now it should have the new value
+    expect(summaryInput).toHaveValue('New summary');
+  });
+
+  it('updates comment when input changes', () => {
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Get the comment textarea
+    const commentTextarea = screen.getByLabelText('Comment:');
+
+    // Initially, it should be empty
+    expect(commentTextarea).toHaveValue('');
+
+    // Change the input value
+    fireEvent.change(commentTextarea, { target: { value: 'New comment' } });
+
+    // Now it should have the new value
+    expect(commentTextarea).toHaveValue('New comment');
+  });
+
+  it('searches for products when Find Product button is clicked', async () => {
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Get the product search input and button
+    const productSearchInput = screen.getByPlaceholderText(
+      'e.g. Firefox, Toolkit, Testing',
+    );
+    const findProductButton = screen.getByText('Find Product');
+
+    // Enter a search term
+    fireEvent.change(productSearchInput, { target: { value: 'Firefox' } });
+
+    // Click the Find Product button
+    fireEvent.click(findProductButton);
+
+    // Wait for the search to complete
+    await waitFor(() => {
+      // Check that the fetch was called with the correct URL
+      expect(
+        fetchMock.called(
+          'https://bugzilla.mozilla.org/rest/prod_comp_search/find/Firefox?limit=5',
+        ),
+      ).toBe(true);
+
+      // Check that the suggested products are rendered
+      expect(screen.getByText('Firefox :: General')).toBeInTheDocument();
+      expect(screen.getByText('Firefox :: Menus')).toBeInTheDocument();
+    });
+  });
+
+  it('finds product by path on component mount', async () => {
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Wait for the search to complete
+    await waitFor(() => {
+      // Check that the fetch was called with the correct URL
+      expect(
+        fetchMock.called(
+          '/api/component_search?path=dom%2Ftests%2Ftest_file.js',
+        ),
+      ).toBe(true);
+
+      // Check that the suggested products are rendered
+      expect(screen.getByText('Core :: DOM')).toBeInTheDocument();
+      expect(screen.getByText('Core :: DOM: Core & HTML')).toBeInTheDocument();
+    });
+  });
+
+  it('submits the bug when Submit Bug button is clicked', async () => {
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Wait for the product search to complete
+    await waitFor(() => {
+      expect(screen.getByText('Core :: DOM')).toBeInTheDocument();
+    });
+
+    // Select a product
+    const productRadio = screen.getByLabelText('Core :: DOM');
+    fireEvent.click(productRadio);
+
+    // Click the Submit Bug button
+    fireEvent.click(screen.getByText('Submit Bug'));
+
+    // Wait for the submission to complete
+    await waitFor(() => {
+      // Check that create was called with the correct parameters
+      expect(httpHelpers.create).toHaveBeenCalledWith(
+        '/api/bugzilla/create_bug/',
+        expect.objectContaining({
+          product: 'Core',
+          component: 'DOM',
+          summary: 'Intermittent Test failure | test_file.js',
+          keywords: ['intermittent-failure'],
+        }),
+      );
+
+      // Check that toggle and successCallback were called
+      expect(defaultProps.toggle).toHaveBeenCalled();
+      expect(defaultProps.successCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 123456,
+          internal_id: 'internal-123',
+        }),
+      );
+    });
+  });
+
+  it('shows an error notification if product is not selected', async () => {
+    // Render with no suggested products
+    bugHelpers.getCrashSignatures.mockReturnValue(['SIGNATURE']);
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Click the Submit Bug button
+    fireEvent.click(screen.getByText('Submit Bug'));
+
+    // Check that notify was called with an error message
+    expect(defaultProps.notify).toHaveBeenCalledWith(
+      'Please select (or search and select) a product/component pair to continue',
+      'danger',
+    );
+  });
+
+  it('shows an error notification if summary is too long', async () => {
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Wait for the product search to complete
+    await waitFor(() => {
+      expect(screen.getByText('Core :: DOM')).toBeInTheDocument();
+    });
+
+    // Select a product
+    const productRadio = screen.getByLabelText('Core :: DOM');
+    fireEvent.click(productRadio);
+
+    // Set a very long summary
+    const summaryInput = screen.getByPlaceholderText('Intermittent...');
+    fireEvent.change(summaryInput, {
+      target: {
+        value: 'A'.repeat(256),
+      },
+    });
+
+    // Click the Submit Bug button
+    fireEvent.click(screen.getByText('Submit Bug'));
+
+    // Check that notify was called with an error message
+    expect(defaultProps.notify).toHaveBeenCalledWith(
+      'Please ensure the summary is no more than 255 characters',
+      'danger',
+    );
+  });
+
+  it('handles crash signatures correctly', async () => {
+    // Mock getCrashSignatures to return a signature
+    bugHelpers.getCrashSignatures.mockReturnValue(['SIGNATURE']);
+
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Check that the signature field is rendered
+    expect(screen.getByText('Signature:')).toBeInTheDocument();
+
+    // Check that the signature is displayed
+    const signatureTextarea = screen.getByLabelText('Signature:');
+    expect(signatureTextarea).toHaveValue('SIGNATURE');
+
+    // For crash signatures, we need to manually search for a product since automatic search is skipped
+    const productSearchInput = screen.getByPlaceholderText(
+      'e.g. Firefox, Toolkit, Testing',
+    );
+    fireEvent.change(productSearchInput, { target: { value: 'Firefox' } });
+
+    const findProductButton = screen.getByText('Find Product');
+    fireEvent.click(findProductButton);
+
+    // Wait for the manual search to complete
+    await waitFor(() => {
+      expect(screen.getByText('Firefox :: General')).toBeInTheDocument();
+    });
+
+    // Select a product
+    const productRadio = screen.getByLabelText('Firefox :: General');
+    fireEvent.click(productRadio);
+
+    // Click the Submit Bug button
+    fireEvent.click(screen.getByText('Submit Bug'));
+
+    // Wait for the submission to complete
+    await waitFor(() => {
+      // Check that create was called with the correct parameters
+      expect(httpHelpers.create).toHaveBeenCalledWith(
+        '/api/bugzilla/create_bug/',
+        expect.objectContaining({
+          product: 'Firefox',
+          component: 'General',
+          crash_signature: 'SIGNATURE',
+          keywords: expect.arrayContaining(['intermittent-failure', 'crash']),
+          priority: '--',
+          severity: '--',
+        }),
+      );
+    });
+  });
+
+  it('handles security issues correctly', async () => {
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Wait for the product search to complete
+    await waitFor(() => {
+      expect(screen.getByText('Core :: DOM')).toBeInTheDocument();
+    });
+
+    // Select a product
+    const productRadio = screen.getByLabelText('Core :: DOM');
+    fireEvent.click(productRadio);
+
+    // Check the security issue checkbox
+    const securityCheckbox = screen
+      .getByText('Report this as a security issue')
+      .closest('label')
+      .querySelector('input');
+    fireEvent.click(securityCheckbox);
+
+    // Click the Submit Bug button
+    fireEvent.click(screen.getByText('Submit Bug'));
+
+    // Wait for the submission to complete
+    await waitFor(() => {
+      // Check that create was called with the correct parameters
+      expect(httpHelpers.create).toHaveBeenCalledWith(
+        '/api/bugzilla/create_bug/',
+        expect.objectContaining({
+          is_security_issue: true,
+          priority: '--',
+          severity: '--',
+        }),
+      );
+    });
+  });
+
+  it('does not launch confirm failure task for regular intermittent failures', async () => {
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Wait for the product search to complete
+    await waitFor(() => {
+      expect(screen.getByText('Core :: DOM')).toBeInTheDocument();
+    });
+
+    // Select a product
+    const productRadio = screen.getByLabelText('Core :: DOM');
+    fireEvent.click(productRadio);
+
+    // Check that the confirm failure checkbox is rendered and checked by default
+    const confirmFailureCheckbox = screen
+      .getByText('Launch the Confirm Failures task at bug submission')
+      .closest('label')
+      .querySelector('input');
+    expect(confirmFailureCheckbox).toBeChecked();
+
+    // Click the Submit Bug button
+    fireEvent.click(screen.getByText('Submit Bug'));
+
+    // Wait for the submission to complete
+    await waitFor(() => {
+      // Check that confirmFailure was NOT called for regular intermittent failures
+      // (only single tracking bugs with 'intermittent-testcase' keyword should trigger confirm failure)
+      expect(jobHelpers.confirmFailure).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does not launch confirm failure task when checkbox is unchecked', async () => {
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Wait for the product search to complete
+    await waitFor(() => {
+      expect(screen.getByText('Core :: DOM')).toBeInTheDocument();
+    });
+
+    // Select a product
+    const productRadio = screen.getByLabelText('Core :: DOM');
+    fireEvent.click(productRadio);
+
+    // Uncheck the confirm failure checkbox
+    const confirmFailureCheckbox = screen
+      .getByText('Launch the Confirm Failures task at bug submission')
+      .closest('label')
+      .querySelector('input');
+    fireEvent.click(confirmFailureCheckbox);
+
+    // Click the Submit Bug button
+    fireEvent.click(screen.getByText('Submit Bug'));
+
+    // Wait for the submission to complete
+    await waitFor(() => {
+      // Check that confirmFailure was not called
+      expect(jobHelpers.confirmFailure).not.toHaveBeenCalled();
+    });
+  });
+
+  it('handles API errors correctly', async () => {
+    // Mock create to return an error
+    httpHelpers.create.mockResolvedValueOnce({
+      data: { failure: 'API error' },
+      failureStatus: 403,
+    });
+
+    render(<BugFilerClass {...defaultProps} />);
+
+    // Wait for the product search to complete
+    await waitFor(() => {
+      expect(screen.getByText('Core :: DOM')).toBeInTheDocument();
+    });
+
+    // Select a product
+    const productRadio = screen.getByLabelText('Core :: DOM');
+    fireEvent.click(productRadio);
+
+    // Click the Submit Bug button
+    fireEvent.click(screen.getByText('Submit Bug'));
+
+    // Wait for the submission to complete
+    await waitFor(() => {
+      // Check that notify was called with an error message
+      expect(defaultProps.notify).toHaveBeenCalledWith(
+        expect.stringContaining('Treeherder Bug Filer API returned status 403'),
+        'danger',
+        { sticky: true },
+      );
+    });
+  });
+});

--- a/tests/ui/shared/RevisionList.test.jsx
+++ b/tests/ui/shared/RevisionList.test.jsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import {
+  RevisionList,
+  MoreRevisionsLink,
+} from '../../../ui/shared/RevisionList';
+
+// Mock the Revision component
+jest.mock('../../../ui/shared/Revision', () => ({
+  Revision: ({ revision, repo }) => (
+    <div data-testid={`revision-${revision.revision}`} data-repo={repo.name}>
+      {revision.author}: {revision.comments}
+    </div>
+  ),
+}));
+
+describe('RevisionList', () => {
+  const defaultProps = {
+    revision: 'abc123',
+    revisions: [
+      {
+        author: 'developer1',
+        comments: 'Fix bug 123',
+        repository_id: 1,
+        result_set_id: 100,
+        revision: 'abc123',
+      },
+      {
+        author: 'developer2',
+        comments: 'Update tests',
+        repository_id: 1,
+        result_set_id: 101,
+        revision: 'def456',
+      },
+    ],
+    revisionCount: 2,
+    repo: {
+      name: 'mozilla-central',
+      getPushLogHref: jest
+        .fn()
+        .mockReturnValue(
+          'https://hg.mozilla.org/mozilla-central/pushloghtml?changeset=abc123',
+        ),
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly with revisions', () => {
+    render(<RevisionList {...defaultProps} />);
+
+    expect(screen.getByTestId('revision-abc123')).toBeInTheDocument();
+    expect(screen.getByTestId('revision-def456')).toBeInTheDocument();
+  });
+
+  it('applies the widthClass prop to the column', () => {
+    const { container } = render(
+      <RevisionList {...defaultProps} widthClass="custom-width" />,
+    );
+
+    // The Col component renders as a div with the widthClass
+    const column = container.querySelector('.custom-width.col');
+    expect(column).toBeInTheDocument();
+    expect(column).toHaveClass('custom-width', 'col');
+  });
+
+  it('passes commitShaClass prop to Revision components', () => {
+    render(<RevisionList {...defaultProps} commitShaClass="custom-sha" />);
+
+    // The mock implementation doesn't actually use commitShaClass,
+    // but we can verify it's passed through by checking the props
+    expect(screen.getByTestId('revision-abc123')).toBeInTheDocument();
+    expect(screen.getByTestId('revision-def456')).toBeInTheDocument();
+  });
+
+  it('passes commentFont prop to Revision components', () => {
+    render(<RevisionList {...defaultProps} commentFont="custom-font" />);
+
+    // The mock implementation doesn't actually use commentFont,
+    // but we can verify it's passed through by checking the props
+    expect(screen.getByTestId('revision-abc123')).toBeInTheDocument();
+    expect(screen.getByTestId('revision-def456')).toBeInTheDocument();
+  });
+
+  it('renders children when provided', () => {
+    render(
+      <RevisionList {...defaultProps}>
+        <div data-testid="child-element">Child content</div>
+      </RevisionList>,
+    );
+
+    expect(screen.getByTestId('child-element')).toBeInTheDocument();
+    expect(screen.getByText('Child content')).toBeInTheDocument();
+  });
+
+  it('renders MoreRevisionsLink when revisionCount > revisions.length', () => {
+    const props = {
+      ...defaultProps,
+      revisionCount: 5, // More than the 2 revisions we have
+    };
+
+    render(<RevisionList {...props} />);
+
+    // The MoreRevisionsLink should be rendered
+    expect(screen.getByText('…and more')).toBeInTheDocument();
+
+    // The link should have the correct href
+    const link = screen.getByText('…and more').closest('a');
+    expect(link).toHaveAttribute(
+      'href',
+      'https://hg.mozilla.org/mozilla-central/pushloghtml?changeset=abc123',
+    );
+  });
+
+  it('does not render MoreRevisionsLink when revisionCount <= revisions.length', () => {
+    render(<RevisionList {...defaultProps} />);
+
+    // The MoreRevisionsLink should not be rendered
+    expect(screen.queryByText('…and more')).not.toBeInTheDocument();
+  });
+});
+
+describe('MoreRevisionsLink', () => {
+  it('renders correctly with href', () => {
+    render(<MoreRevisionsLink href="https://example.com/revisions" />);
+
+    const link = screen.getByText('…and more');
+    expect(link).toBeInTheDocument();
+    expect(link.closest('a')).toHaveAttribute(
+      'href',
+      'https://example.com/revisions',
+    );
+    expect(link.closest('a')).toHaveAttribute('target', '_blank');
+    expect(link.closest('a')).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('includes an external link icon', () => {
+    const { container } = render(
+      <MoreRevisionsLink href="https://example.com/revisions" />,
+    );
+
+    // Check for the FontAwesome icon by looking for the svg element with the ml-1 class
+    const icon = container.querySelector('svg.ml-1');
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass('ml-1');
+  });
+});

--- a/ui/job-view/headerbars/FiltersMenu.jsx
+++ b/ui/job-view/headerbars/FiltersMenu.jsx
@@ -23,15 +23,14 @@ const resultStatusMenuItems = thAllResultStatuses.filter(
   (rs) => rs !== 'runnable',
 );
 
-function FiltersMenu(props) {
-  const {
-    filterModel,
-    pinJobs,
-    getAllShownJobs,
-    selectedJob,
-    setSelectedJob,
-    user,
-  } = props;
+function FiltersMenu({
+  filterModel,
+  pinJobs,
+  getAllShownJobs,
+  selectedJob = null,
+  setSelectedJob,
+  user,
+}) {
   const {
     urlParams: { resultStatus, classifiedState },
   } = filterModel;
@@ -194,10 +193,6 @@ FiltersMenu.propTypes = {
   getAllShownJobs: PropTypes.func.isRequired,
   selectedJob: PropTypes.shape({}),
   user: PropTypes.shape({}).isRequired,
-};
-
-FiltersMenu.defaultProps = {
-  selectedJob: null,
 };
 
 const mapStateToProps = ({ selectedJob: { selectedJob } }) => ({ selectedJob });

--- a/ui/job-view/pushes/JobsAndGroups.jsx
+++ b/ui/job-view/pushes/JobsAndGroups.jsx
@@ -156,6 +156,7 @@ export default class JobsAndGroups extends React.Component {
               group.visible && (
                 <JobGroup
                   group={group}
+                  confirmGroup={confirmGroups[group.mapKey] || {}}
                   repoName={repoName}
                   filterModel={filterModel}
                   filterPlatformCb={filterPlatformCb}

--- a/ui/shared/BugFiler.jsx
+++ b/ui/shared/BugFiler.jsx
@@ -978,7 +978,10 @@ BugFilerClass.propTypes = {
     bugs: PropTypes.shape({
       open_recent: PropTypes.arrayOf({
         crash_signature: PropTypes.string.isRequired,
-        dupe_of: PropTypes.oneOfType(null, PropTypes.number).isRequired,
+        dupe_of: PropTypes.oneOfType([
+          PropTypes.oneOf([null]),
+          PropTypes.number,
+        ]).isRequired,
         id: PropTypes.number.isRequired,
         keywords: PropTypes.string.isRequired,
         status: PropTypes.string.isRequired,
@@ -988,7 +991,10 @@ BugFilerClass.propTypes = {
       }),
       all_others: PropTypes.arrayOf({
         crash_signature: PropTypes.string.isRequired,
-        dupe_of: PropTypes.oneOfType(null, PropTypes.number).isRequired,
+        dupe_of: PropTypes.oneOfType([
+          PropTypes.oneOf([null]),
+          PropTypes.number,
+        ]).isRequired,
         id: PropTypes.number.isRequired,
         keywords: PropTypes.string.isRequired,
         status: PropTypes.string.isRequired,
@@ -1000,7 +1006,8 @@ BugFilerClass.propTypes = {
     counter: PropTypes.number.isRequired,
     failure_in_new_rev: PropTypes.bool.isRequired,
     line_number: PropTypes.number.isRequired,
-    path_end: PropTypes.oneOfType(null, PropTypes.string).isRequired,
+    path_end: PropTypes.oneOfType([PropTypes.oneOf([null]), PropTypes.string])
+      .isRequired,
     search: PropTypes.string.isRequired,
     search_terms: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,

--- a/ui/shared/RevisionList.jsx
+++ b/ui/shared/RevisionList.jsx
@@ -43,13 +43,15 @@ export class RevisionList extends React.PureComponent {
 
 RevisionList.propTypes = {
   revision: PropTypes.string.isRequired,
-  revisions: PropTypes.arrayOf({
-    author: PropTypes.string.isRequired,
-    comments: PropTypes.string.isRequired,
-    repository_id: PropTypes.number.isRequired,
-    result_set_id: PropTypes.number.isRequired,
-    revision: PropTypes.string.isRequired,
-  }).isRequired,
+  revisions: PropTypes.arrayOf(
+    PropTypes.shape({
+      author: PropTypes.string.isRequired,
+      comments: PropTypes.string.isRequired,
+      repository_id: PropTypes.number.isRequired,
+      result_set_id: PropTypes.number.isRequired,
+      revision: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
   revisionCount: PropTypes.number.isRequired,
   repo: PropTypes.shape({
     pushLogUrl: PropTypes.string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3383,9 +3383,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001688:
-  version "1.0.30001707"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz#c5e104d199e6f4355a898fcd995a066c7eb9bf41"
-  integrity sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==
+  version "1.0.30001731"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz"
+  integrity sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==
 
 chalk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
This fixes several web console errors that don't require large package changes.  Also added several new unit tests to cover the changed files.

This also includes a few config changes:
* VS Code settings to use the .eslint.config.mjs` and `.prettierrc`
* `.gitignore` Roo Code Plugin specific files

`reactstrap` is the culprit of several web console errors.  This will be handled in an upcoming PR.