### PR TITLE
Add a keyboard shortcut to open resource usage profiles

### DIFF
--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -353,6 +353,7 @@ export const thEvents = {
   saveClassification: 'save-classification-EVT',
   deleteClassification: 'delete-classification-EVT',
   openLogviewer: 'open-logviewer-EVT',
+  openGeckoProfile: 'open-gecko-profile-EVT',
   applyNewJobs: 'apply-new-jobs-EVT',
   filtersUpdated: 'filters-updated-EVT',
   clearPinboard: 'clear-pinboard-EVT',

--- a/ui/job-view/KeyboardShortcuts.jsx
+++ b/ui/job-view/KeyboardShortcuts.jsx
@@ -17,7 +17,7 @@ import {
 import { pinJob, unPinAll } from './redux/stores/pinnedJobs';
 
 const handledKeys =
-  'b,c,f,ctrl+shift+f,f,i,j,k,l,n,p,q,r,t,u,v,ctrl+shift+u,left,right,space,shift+/,escape,ctrl+enter,ctrl+backspace';
+  'b,c,f,ctrl+shift+f,f,g,i,j,k,l,n,p,q,r,t,u,v,ctrl+shift+u,left,right,space,shift+/,escape,ctrl+enter,ctrl+backspace';
 
 class KeyboardShortcuts extends React.Component {
   onKeyDown = (key, e) => {
@@ -34,6 +34,8 @@ class KeyboardShortcuts extends React.Component {
         return this.quickFilter();
       case 'ctrl+shift+f':
         return this.clearFilter();
+      case 'g':
+        return this.openGeckoProfile();
       case 'i':
         return filterModel.toggleInProgress();
       case 'j':
@@ -153,6 +155,11 @@ class KeyboardShortcuts extends React.Component {
   // open the logviewer for the selected job
   openLogviewer = () => {
     window.dispatchEvent(new CustomEvent(thEvents.openLogviewer));
+  };
+
+  // open the resource usage profile in the Firefox Profiler
+  openGeckoProfile = () => {
+    window.dispatchEvent(new CustomEvent(thEvents.openGeckoProfile));
   };
 
   // retrigger selected job

--- a/ui/job-view/details/summary/LogItem.jsx
+++ b/ui/job-view/details/summary/LogItem.jsx
@@ -26,7 +26,7 @@ function getLogUrlProps(logKey, logUrl, logViewerUrl, logViewerFullUrl) {
         )}`,
         href: logViewerUrl,
         'copy-value': logViewerFullUrl,
-        title: 'Open the log viewer in a new window',
+        title: 'Open the log viewer in a new window (l)',
       };
     case 'failed':
       return {

--- a/ui/shared/ShortcutTable.jsx
+++ b/ui/shared/ShortcutTable.jsx
@@ -24,6 +24,12 @@ const ShortcutTable = function ShortcutTable() {
             </tr>
             <tr>
               <td>
+                <kbd>g</kbd>
+              </td>
+              <td>Open the resource usage profile in the Firefox Profiler</td>
+            </tr>
+            <tr>
+              <td>
                 <kbd>ctrl</kbd>
                 <kbd>shift</kbd>
                 <kbd>f</kbd>

--- a/ui/shared/ShortcutTable.jsx
+++ b/ui/shared/ShortcutTable.jsx
@@ -24,12 +24,6 @@ const ShortcutTable = function ShortcutTable() {
             </tr>
             <tr>
               <td>
-                <kbd>g</kbd>
-              </td>
-              <td>Open the resource usage profile in the Firefox Profiler</td>
-            </tr>
-            <tr>
-              <td>
                 <kbd>ctrl</kbd>
                 <kbd>shift</kbd>
                 <kbd>f</kbd>
@@ -59,6 +53,12 @@ const ShortcutTable = function ShortcutTable() {
                 <kbd>l</kbd>
               </td>
               <td>Open the logviewer for the selected job</td>
+            </tr>
+            <tr>
+              <td>
+                <kbd>g</kbd>
+              </td>
+              <td>Open the resource usage profile in the Firefox Profiler</td>
             </tr>
             <tr>
               <td>


### PR DESCRIPTION
Also, document existing ActionBar shortcuts in the button tooltips. Someone suggested doing that when I told them an 'r' shortcut exists to retrigger. And I discovered today while working on this patch that the 'l' shortcut to open the log exists. And it is super useful so I wish I had discovered it earlier.