### PR TITLE
Do network requests in parallel and avoid flicker when loading the log viewer

### DIFF
--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -112,8 +112,12 @@ export const getLogViewerUrl = function getLogViewerUrl(
   jobId,
   repoName,
   lineNumber,
+  task,
 ) {
-  const rv = `/logviewer?job_id=${jobId}&repo=${repoName}`;
+  let rv = `/logviewer?job_id=${jobId}&repo=${repoName}`;
+  if (task && task.task_id && task.retry_id !== undefined) {
+    rv += `&task=${task.task_id}.${task.retry_id}`;
+  }
   return lineNumber ? `${rv}&lineNumber=${lineNumber}` : rv;
 };
 

--- a/ui/job-view/details/DetailsPanel.jsx
+++ b/ui/job-view/details/DetailsPanel.jsx
@@ -309,6 +309,8 @@ class DetailsPanel extends React.Component {
               const logViewerUrl = getLogViewerUrl(
                 selectedJob.id,
                 currentRepo.name,
+                null,
+                selectedJobFull,
               );
               const logViewerFullUrl = `${window.location.origin}${logViewerUrl}`;
 

--- a/ui/job-view/pushes/PushJobs.jsx
+++ b/ui/job-view/pushes/PushJobs.jsx
@@ -83,7 +83,12 @@ class PushJobs extends React.Component {
     JobModel.get(repoName, jobId).then((data) => {
       if (data.logs.length > 0) {
         window.open(
-          `${window.location.origin}${getLogViewerUrl(jobId, repoName)}`,
+          `${window.location.origin}${getLogViewerUrl(
+            jobId,
+            repoName,
+            null,
+            data,
+          )}`,
         );
       }
     });

--- a/ui/logviewer/Navigation.jsx
+++ b/ui/logviewer/Navigation.jsx
@@ -35,6 +35,7 @@ export default class Navigation extends React.PureComponent {
             {jobExists ? (
               <span
                 className={`lightgray ${resultStatusShading} pt-2 pl-2 pr-2`}
+                style={{ minWidth: '150px' }}
               >
                 <strong>Result: </strong>
                 {result}
@@ -46,23 +47,24 @@ export default class Navigation extends React.PureComponent {
                 </span>
               </span>
             )}
-            {!!jobUrl && (
-              <span>
-                <a
-                  title="Open the Job in Treeherder"
-                  className="nav-link btn-view-nav"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href={jobUrl}
-                >
-                  <FontAwesomeIcon
-                    icon={faTree}
-                    className="actionbtn-icon mr-1"
-                  />
-                  <span>open Job</span>
-                </a>
-              </span>
-            )}
+            <span>
+              <a
+                title={
+                  jobUrl ? 'Open the Job in Treeherder' : 'Loading job data...'
+                }
+                className={`nav-link btn-view-nav ${!jobUrl ? 'disabled' : ''}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                href={jobUrl || '#'}
+                {...(!jobUrl && { onClick: (e) => e.preventDefault() })}
+              >
+                <FontAwesomeIcon
+                  icon={faTree}
+                  className="actionbtn-icon mr-1"
+                />
+                <span>open Job</span>
+              </a>
+            </span>
             <span>
               <a
                 title="Open the raw log in a new window"

--- a/ui/logviewer/logviewer.css
+++ b/ui/logviewer/logviewer.css
@@ -31,5 +31,5 @@ body,
 }
 
 .run-data {
-  max-height: 250px;
+  height: 250px;
 }

--- a/ui/shared/Clipboard.jsx
+++ b/ui/shared/Clipboard.jsx
@@ -28,10 +28,6 @@ export default class Clipboard extends React.Component {
     const { description, text, outline, color } = this.props;
     const { copied } = this.state;
 
-    if (!text) {
-      return null;
-    }
-
     return (
       <Button
         type="button"
@@ -42,6 +38,7 @@ export default class Clipboard extends React.Component {
         className="py-0 px-1"
         color={`${color || 'light'}`}
         outline={outline}
+        {...(!text && { style: { visibility: 'hidden' } })}
       >
         {copied ? (
           <FontAwesomeIcon icon={faCheckCircle} color="#2da745" />

--- a/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
+++ b/ui/shared/tabs/failureSummary/SuggestionsListItem.jsx
@@ -182,6 +182,7 @@ export default class SuggestionsListItem extends React.Component {
                   selectedJob.id,
                   repoName,
                   suggestion.line_number + 1,
+                  selectedJob,
                 )}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -234,6 +235,7 @@ export default class SuggestionsListItem extends React.Component {
                   selectedJob.id,
                   repoName,
                   suggestion.line_number + 1,
+                  selectedJob,
                 )}
                 target="_blank"
                 rel="noopener noreferrer"


### PR DESCRIPTION
My initial idea was to make the log viewer load faster by doing all network requests in parallel, like I have already done for other areas of treeherder.

For most important requests for the log viewer is the one that fetches the log, but unfortunately we can't fetch it without the task id, that is currently obtained with a /jobs/ request.

The way around this is to add another url parameter to the log viewer urls, containing the full task id (task id + retry id), similar to the selectedTaskRun parameter that exists on the main view. The new task parameter is optional, to preserve backward compatibility with existing urls.

After making all requests happen in parallel, the experience still didn't feel great. While the wall clock load time was actually shorter, the loading still felt messy because the UI was updated multiple times, with things being resized when they were done loading. I added multiple simple changes to avoid flicker, which significantly improves the perceived performance.