### PR TITLE
Bug 1982521 - Avoid calling fetchPushes from both App and PushList.

### DIFF
--- a/tests/ui/job-view/PushList_test.jsx
+++ b/tests/ui/job-view/PushList_test.jsx
@@ -17,6 +17,7 @@ import jobListFixtureOne from '../mock/job_list/job_1';
 import jobListFixtureTwo from '../mock/job_list/job_2';
 import { configureStore } from '../../../ui/job-view/redux/configureStore';
 import PushList from '../../../ui/job-view/pushes/PushList';
+import { fetchPushes } from '../../../ui/job-view/redux/stores/pushes';
 import { getApiUrl } from '../../../ui/helpers/url';
 import { findJobInstance } from '../../../ui/helpers/job';
 
@@ -128,6 +129,10 @@ describe('PushList', () => {
 
   const testPushList = () => {
     const store = configureStore(history);
+
+    // Manually trigger fetchPushes since outside testing the App does it.
+    store.dispatch(fetchPushes());
+
     return (
       <Provider store={store} context={ReactReduxContext}>
         <ConnectedRouter history={history} context={ReactReduxContext}>

--- a/ui/job-view/pushes/PushList.jsx
+++ b/ui/job-view/pushes/PushList.jsx
@@ -29,11 +29,6 @@ class PushList extends React.Component {
   }
 
   componentDidMount() {
-    const { fetchPushes } = this.props;
-
-    // Fetch pushes regardless of whether App started the request,
-    // the Redux action will handle deduplication if needed.
-    fetchPushes();
     this.poll();
   }
 

--- a/ui/job-view/redux/stores/pushes.js
+++ b/ui/job-view/redux/stores/pushes.js
@@ -248,14 +248,9 @@ export const fetchPushes = (
 ) => {
   return async (dispatch, getState) => {
     const {
-      pushes: { pushList, jobMap, oldestPushTimestamp, loadingPushes },
+      pushes: { pushList, jobMap, oldestPushTimestamp },
       router,
     } = getState();
-
-    // Prevent duplicate requests when already loading initial data.
-    if (loadingPushes && !setFromchange) {
-      return;
-    }
 
     dispatch({ type: LOADING });
 


### PR DESCRIPTION
When loading the treeherder jobs view with the "fromchange" parameter specified in the url, sometimes the parameter is respected, sometimes it isn't. That's due to a race between the fetchPushes() call made by App.jsx (since https://github.com/mozilla/treeherder/pull/8895/commits/9375945f941e278bd458378886fa025647c8d79b) and the fetchPushes call from PushList.jsx.

In that commit I tried to add a pre-fetch without removing the fetch that was triggered from the PushList component, but now I wonder why I made it so complicated. Unless I'm missing something, the PushList component will only exist once, so it shouldn't need to fetch again.

My confidence level in this PR isn't very high. It fixes the bug locally, but I'm not convinced yet it doesn't cause other regressions (and there's at least the tests/ui/job-view/PushList_test.jsx test that fails, not sure if it needs to be adjusted or if it's catching regressions. That test might actually be the reason why I kept both fetchPushes calls in the previous PR.).