### PR TITLE
Revert "update reference to variants.yml"

### DIFF
--- a/treeherder/intermittents_commenter/fetch.py
+++ b/treeherder/intermittents_commenter/fetch.py
@@ -7,7 +7,7 @@ firefoxci_artefact_api_url = f"{firefoxci_service_api_url}/task/gecko.v2.mozilla
 
 def fetch_test_variants():
     mozilla_central_url = "https://hg.mozilla.org/mozilla-central"
-    variant_file_url = f"{mozilla_central_url}/raw-file/tip/taskcluster/test_configs/variants.yml"
+    variant_file_url = f"{mozilla_central_url}/raw-file/tip/taskcluster/kinds/test/variants.yml"
     response = requests.get(variant_file_url, headers={"User-agent": "mach-test-info/1.0"})
     return yaml.safe_load(response.text)
 


### PR DESCRIPTION
Reverts mozilla/treeherder#8907

The [Gecko-side of this change](https://bugzilla.mozilla.org/show_bug.cgi?id=1982404) hasn't landed yet.