### PR TITLE
Fix the 'setUser is not a function' error when loading /intermittent-failures/bugdetails

### DIFF
--- a/ui/intermittent-failures/App.jsx
+++ b/ui/intermittent-failures/App.jsx
@@ -30,6 +30,14 @@ class IntermittentFailuresApp extends React.Component {
     this.setState(state);
   };
 
+  setUser = (user) => {
+    this.setState({ user });
+  };
+
+  notify = (message) => {
+    this.setState({ errorMessages: [message] });
+  };
+
   render() {
     const { user, graphData, tableData, errorMessages } = this.state;
     const { path } = this.props.match;
@@ -51,10 +59,8 @@ class IntermittentFailuresApp extends React.Component {
                 mainTableData={tableData}
                 updateAppState={this.updateAppState}
                 user={user}
-                setUser={(user) => this.setState({ user })}
-                notify={(message) =>
-                  this.setState({ errorMessages: [message] })
-                }
+                setUser={this.setUser}
+                notify={this.notify}
               />
             )}
           />
@@ -66,16 +72,33 @@ class IntermittentFailuresApp extends React.Component {
                 mainGraphData={graphData}
                 mainTableData={tableData}
                 updateAppState={this.updateAppState}
+                user={user}
+                setUser={this.setUser}
+                notify={this.notify}
               />
             )}
           />
           <Route
             path={`${path}/bugdetails`}
-            render={(props) => <BugDetailsView {...props} />}
+            render={(props) => (
+              <BugDetailsView
+                {...props}
+                user={user}
+                setUser={this.setUser}
+                notify={this.notify}
+              />
+            )}
           />
           <Route
             path={`${path}/bugdetails?startday=:startday&endday=:endday&tree=:tree&failurehash=:failurehash&bug=bug`}
-            render={(props) => <BugDetailsView {...props} />}
+            render={(props) => (
+              <BugDetailsView
+                {...props}
+                user={user}
+                setUser={this.setUser}
+                notify={this.notify}
+              />
+            )}
           />
           <Redirect from={`${path}/`} to={`${path}/main`} />
         </Switch>

--- a/ui/intermittent-failures/BugDetailsView.jsx
+++ b/ui/intermittent-failures/BugDetailsView.jsx
@@ -371,6 +371,9 @@ BugDetailsView.propTypes = {
       }),
     ),
   }),
+  user: PropTypes.shape({}),
+  setUser: PropTypes.func.isRequired,
+  notify: PropTypes.func.isRequired,
 };
 
 BugDetailsView.defaultProps = {

--- a/ui/intermittent-failures/MainView.jsx
+++ b/ui/intermittent-failures/MainView.jsx
@@ -405,6 +405,8 @@ MainView.propTypes = {
   tableData: PropTypes.arrayOf(PropTypes.shape({})),
   graphData: PropTypes.arrayOf(PropTypes.shape({})),
   initialParamsSet: PropTypes.bool.isRequired,
+  user: PropTypes.shape({}),
+  setUser: PropTypes.func.isRequired,
   notify: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
In development mode I see this annoying popup whenever I load a /intermittent-failures/bugdetails page:
<img width="881" height="472" alt="Screenshot 2025-08-28 at 18-14-22 Intermittent Failures View" src="https://github.com/user-attachments/assets/932c7f40-4a02-47c2-bcd3-eb31547d482b" />

Navigation component expects user, setUser, and notify props (line 29, 51 in Navigation.jsx). BugDetailsView uses the Layout component which passes all props to Navigation using {...props} (line 53 in Layout.jsx).

The JS error also occurs in production, but is only visible in the devtools console. Of course it also means the name of the logged in user isn't shown in the top right corner, but it's not really needed in this view where the user can't trigger any action.