### PR TITLE
Cleanup bugdetails

### DIFF
--- a/ui/css/intermittent-failures.css
+++ b/ui/css/intermittent-failures.css
@@ -85,3 +85,42 @@ button.DateRangePickerInput_clearDates {
   padding: 5px 8px;
   margin: 1px 10px 0 5px;
 }
+
+.vm-container {
+  width: 100%;
+  height: 100%;
+  min-height: 20px;
+}
+
+.vm-text {
+  font-size: 0.9em;
+  font-style: italic;
+  visibility: hidden;
+}
+
+.rt-td:hover .vm-text {
+  visibility: visible !important;
+  color: #666;
+}
+
+.failure-header {
+  margin-bottom: 8px;
+}
+
+.failure-count {
+  font-size: 0.9em;
+  color: #666;
+}
+
+.failure-lines {
+  font-size: 0.85em;
+  line-height: 1.3;
+}
+
+.failure-line {
+  margin-bottom: 2px;
+  font-family: monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/ui/intermittent-failures/App.jsx
+++ b/ui/intermittent-failures/App.jsx
@@ -30,6 +30,14 @@ class IntermittentFailuresApp extends React.Component {
     this.setState(state);
   };
 
+  setUser = (user) => {
+    this.setState({ user });
+  };
+
+  notify = (message) => {
+    this.setState({ errorMessages: [message] });
+  };
+
   render() {
     const { user, graphData, tableData, errorMessages } = this.state;
     const { path } = this.props.match;
@@ -51,10 +59,8 @@ class IntermittentFailuresApp extends React.Component {
                 mainTableData={tableData}
                 updateAppState={this.updateAppState}
                 user={user}
-                setUser={(user) => this.setState({ user })}
-                notify={(message) =>
-                  this.setState({ errorMessages: [message] })
-                }
+                setUser={this.setUser}
+                notify={this.notify}
               />
             )}
           />
@@ -66,16 +72,33 @@ class IntermittentFailuresApp extends React.Component {
                 mainGraphData={graphData}
                 mainTableData={tableData}
                 updateAppState={this.updateAppState}
+                user={user}
+                setUser={this.setUser}
+                notify={this.notify}
               />
             )}
           />
           <Route
             path={`${path}/bugdetails`}
-            render={(props) => <BugDetailsView {...props} />}
+            render={(props) => (
+              <BugDetailsView
+                {...props}
+                user={user}
+                setUser={this.setUser}
+                notify={this.notify}
+              />
+            )}
           />
           <Route
             path={`${path}/bugdetails?startday=:startday&endday=:endday&tree=:tree&failurehash=:failurehash&bug=bug`}
-            render={(props) => <BugDetailsView {...props} />}
+            render={(props) => (
+              <BugDetailsView
+                {...props}
+                user={user}
+                setUser={this.setUser}
+                notify={this.notify}
+              />
+            )}
           />
           <Redirect from={`${path}/`} to={`${path}/main`} />
         </Switch>

--- a/ui/intermittent-failures/BugDetailsView.jsx
+++ b/ui/intermittent-failures/BugDetailsView.jsx
@@ -371,6 +371,9 @@ BugDetailsView.propTypes = {
       }),
     ),
   }),
+  user: PropTypes.shape({}),
+  setUser: PropTypes.func.isRequired,
+  notify: PropTypes.func.isRequired,
 };
 
 BugDetailsView.defaultProps = {

--- a/ui/intermittent-failures/Layout.jsx
+++ b/ui/intermittent-failures/Layout.jsx
@@ -28,7 +28,6 @@ const Layout = (props) => {
     table,
     datePicker,
     header,
-    location,
   } = props;
 
   let failureMessage = null;
@@ -38,14 +37,7 @@ const Layout = (props) => {
     failureMessage = graphData;
   }
   return (
-    <Container
-      fluid
-      className={`my-5 ${
-        location && location.pathname !== '/intermittent-failures/main'
-          ? 'max-width-default'
-          : ''
-      }`}
-    >
+    <Container fluid className="my-5">
       <Navigation
         updateState={updateState}
         updateHash={updateHash}

--- a/ui/intermittent-failures/MainView.jsx
+++ b/ui/intermittent-failures/MainView.jsx
@@ -405,6 +405,8 @@ MainView.propTypes = {
   tableData: PropTypes.arrayOf(PropTypes.shape({})),
   graphData: PropTypes.arrayOf(PropTypes.shape({})),
   initialParamsSet: PropTypes.bool.isRequired,
+  user: PropTypes.shape({}),
+  setUser: PropTypes.func.isRequired,
   notify: PropTypes.func.isRequired,
 };
 

--- a/ui/intermittent-failures/MainView.jsx
+++ b/ui/intermittent-failures/MainView.jsx
@@ -7,7 +7,6 @@ import Checkbox from '@mui/material/Checkbox';
 import TextField from '@mui/material/TextField';
 import Autocomplete from '@mui/material/Autocomplete';
 import Popper from '@mui/material/Popper';
-import IconButton from '@mui/material/IconButton';
 
 import { bugsEndpoint, getBugUrl } from '../helpers/url';
 import { setUrlParam, getUrlParam } from '../helpers/location';
@@ -17,6 +16,9 @@ import {
   prettyDate,
   ISODate,
   tableRowStyling,
+  regexpFilter,
+  tooltipCell,
+  textFilter,
 } from './helpers';
 import withView from './View';
 import Layout from './Layout';
@@ -49,16 +51,6 @@ const MainView = (props) => {
     product: [],
     component: [],
   });
-  const regexpFilter = (filter, row) => {
-    const text = row[filter.id];
-    const value = Array.isArray(filter.value)
-      ? filter.value.join('|')
-      : filter.value;
-    const regex = RegExp(value, 'i');
-    if (regex.test(text)) {
-      return row;
-    }
-  };
 
   const autoCompleteFilter = ({ column, onChange }) => {
     const options = [...new Set(tableData.map((d) => d[column.id]))];
@@ -100,56 +92,6 @@ const MainView = (props) => {
       />
     );
   };
-
-  const textFilter = ({ filter, onChange, placeholder, columnId }) => (
-    <TextField
-      size="small"
-      fullWidth
-      placeholder={placeholder}
-      value={filter ? filter.value : ''}
-      onChange={(event) => {
-        const { value } = event.target;
-        setUrlParam(columnId, value);
-        onChange(value);
-      }}
-      style={{
-        border: 'none',
-        padding: '0',
-      }}
-      slotProps={{
-        htmlInput: {
-          style: {
-            textAlign: 'left',
-          },
-        },
-        input: {
-          style: {
-            paddingRight: '0px',
-          },
-          endAdornment:
-            filter && filter.value ? (
-              <IconButton
-                onClick={() => {
-                  setUrlParam(columnId, '');
-                  onChange('');
-                }}
-                size="small"
-                style={{
-                  visibility: 'visible',
-                  margin: '4px',
-                  width: '24px',
-                  height: '24px',
-                }}
-              >
-                ✕
-              </IconButton>
-            ) : null,
-        },
-      }}
-    />
-  );
-
-  const tooltipCell = (props) => <span title={props.value}>{props.value}</span>;
 
   const columns = [
     {

--- a/ui/intermittent-failures/helpers.jsx
+++ b/ui/intermittent-failures/helpers.jsx
@@ -1,4 +1,9 @@
 import moment from 'moment';
+import React from 'react';
+import TextField from '@mui/material/TextField';
+import IconButton from '@mui/material/IconButton';
+
+import { setUrlParam } from '../helpers/location';
 
 // be sure to wrap date arg in a moment()
 export const ISODate = function formatISODate(date) {
@@ -141,4 +146,69 @@ export const tableRowStyling = function tableRowStyling(state, bug) {
   return {};
 };
 
+export const tooltipCell = (props) => (
+  <span title={props.value}>{props.value}</span>
+);
+
 export const removePath = (line = '') => line.replace(/\/?([\w\d-.]+\/)+/, '');
+
+export const regexpFilter = (filter, row) => {
+  if (filter.value) {
+    const text = row[filter.id];
+    const value = Array.isArray(filter.value)
+      ? filter.value.join('|')
+      : filter.value;
+    const regex = RegExp(value, 'i');
+    if (regex.test(text)) {
+      return row;
+    }
+  }
+};
+
+export const textFilter = ({ filter, onChange, placeholder, columnId }) => (
+  <TextField
+    size="small"
+    fullWidth
+    placeholder={placeholder}
+    value={filter ? filter.value : ''}
+    onChange={(event) => {
+      const { value } = event.target;
+      if (columnId) setUrlParam(columnId, value);
+      onChange(value);
+    }}
+    style={{
+      border: 'none',
+      padding: '0',
+    }}
+    slotProps={{
+      htmlInput: {
+        style: {
+          textAlign: 'left',
+        },
+      },
+      input: {
+        style: {
+          paddingRight: '0px',
+        },
+        endAdornment:
+          filter && filter.value ? (
+            <IconButton
+              onClick={() => {
+                if (columnId) setUrlParam(columnId, '');
+                onChange('');
+              }}
+              size="small"
+              style={{
+                visibility: 'visible',
+                margin: '4px',
+                width: '24px',
+                height: '24px',
+              }}
+            >
+              ✕
+            </IconButton>
+          ) : null,
+      },
+    }}
+  />
+);


### PR DESCRIPTION
Before:
<img width="1793" height="2043" alt="image" src="https://github.com/user-attachments/assets/805510a6-90de-4825-81f1-7d33aeb74272" />
After:
<img width="1793" height="2043" alt="image" src="https://github.com/user-attachments/assets/591d7408-2d4a-4f7a-98f2-feb5b0271301" />

Summary of the changes:
- Use the full available width;
- Adjust the width of columns to limit wasted space;
- Remove the "Revision" column and make the "Push Time" values link to the jobs;
- Merge the platform, build type and test suite columns into one "Job Name" column matching the job names we show in the log viewer;
- Hide the machine names for virtual machines. On hover show "virtual machine" in gray text to indicate why the cell was empty;
- Show the failure lines directly instead of hiding them in a tooltips;
- Fix the various filter boxes to have a placeholder text, a clear button, and filter by regexp rather than by prefix;
- Show the full cell content as a tooltip, so the values of cells cropped with an ellipsis can still be seen;
- Show 100 failures by default and hide the row count selector;
- Left-align the content of all table cells.