### PR TITLE
fix: Use original group_results api with optimized indexes

### DIFF
--- a/treeherder/log_parser/failureline.py
+++ b/treeherder/log_parser/failureline.py
@@ -193,11 +193,7 @@ def replace_astral(log_list):
         yield item
 
 
-def get_group_results_legacy(repository, push):
-    """
-    Legacy implementation - preserved for testing and comparison.
-    Performance: ~3.3 seconds average.
-    """
+def get_group_results(repository, push):
     groups = Group.objects.filter(
         job_logs__job__push__revision=push.revision,
         job_logs__job__push__repository=repository,
@@ -213,65 +209,5 @@ def get_group_results_legacy(repository, push):
         by_task_id[group["job_logs__job__taskcluster_metadata__task_id"]][group["name"]] = bool(
             GroupStatus.STATUS_LOOKUP[group["group_result__status"]] == "OK"
         )
-
-    return by_task_id
-
-
-def get_group_results(repository, push):
-    """
-    OPTIMIZED IMPLEMENTATION - Best performing non-cached query.
-
-    Performance: ~0.129s (27% faster than legacy 0.176s)
-
-    This implementation uses an optimized SQL query starting from the job table
-    for the best join performance with the new database indexes.
-
-    RECOMMENDED DATABASE INDEXES (already applied):
-
-    -- Composite indexes for optimal query performance
-    CREATE INDEX CONCURRENTLY idx_group_status_composite
-        ON group_status(status, job_log_id, group_id);
-
-    CREATE INDEX CONCURRENTLY idx_job_push_id
-        ON job(push_id);
-
-    CREATE INDEX CONCURRENTLY idx_job_log_job_id
-        ON job_log(job_id);
-
-    CREATE INDEX CONCURRENTLY idx_taskcluster_metadata_job_id
-        ON taskcluster_metadata(job_id);
-
-    CREATE INDEX CONCURRENTLY idx_push_revision_repo
-        ON push(revision, repository_id);
-    """
-    from django.db import connection
-
-    ok_status = GroupStatus.OK
-
-    query = """
-        SELECT
-            tcm.task_id,
-            g.name,
-            gs.status
-        FROM job j
-        INNER JOIN taskcluster_metadata tcm ON j.id = tcm.job_id
-        INNER JOIN job_log jl ON j.id = jl.job_id
-        INNER JOIN group_status gs ON jl.id = gs.job_log_id
-        INNER JOIN "group" g ON gs.group_id = g.id
-        WHERE j.push_id = %s
-        AND gs.status IN (%s, %s)
-        ORDER BY tcm.task_id
-    """
-
-    by_task_id = {}
-
-    with connection.cursor() as cursor:
-        cursor.execute(query, [push.id, GroupStatus.OK, GroupStatus.ERROR])
-        rows = cursor.fetchall()
-
-        for task_id, group_name, status in rows:
-            if task_id not in by_task_id:
-                by_task_id[task_id] = {}
-            by_task_id[task_id][group_name] = status == ok_status
 
     return by_task_id


### PR DESCRIPTION
This reverts back to the legacy API, but takes advantage of the new DB indexes.  Testing on Staging environment showed this is the current fastest API.