### PR TITLE
Show the 'Task Queue' in the Job Info, and avoid flicker of the 'Test Groups' tab

### DIFF
--- a/ui/job-view/details/JobTestGroups.jsx
+++ b/ui/job-view/details/JobTestGroups.jsx
@@ -1,50 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Queue } from 'taskcluster-client-web';
 
 export default class JobTestGroups extends React.PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {
-      testGroups: [],
-    };
-  }
-
-  componentDidMount() {
-    this.fetch();
-  }
-
-  // Because we use Tab with forceRender it does not call componentDidMount
-  // even though the props have changes
-  componentDidUpdate(prevProps) {
-    if (this.props.taskId !== prevProps.taskId) {
-      this.fetch();
-    }
-  }
-
-  async fetch() {
-    const { notifyTestGroupsAvailable, taskId, rootUrl } = this.props;
-    if (taskId) {
-      const queue = new Queue({ rootUrl });
-      const taskDefinition = await queue.task(taskId);
-      if (taskDefinition && taskDefinition.payload.env.MOZHARNESS_TEST_PATHS) {
-        const testGroups = Object.values(
-          JSON.parse(taskDefinition.payload.env.MOZHARNESS_TEST_PATHS),
-        );
-        if (testGroups.length) {
-          this.setState({
-            testGroups: testGroups[0],
-          });
-        }
-        notifyTestGroupsAvailable(true);
-      } else {
-        notifyTestGroupsAvailable(false);
-      }
-    }
-  }
-
   render() {
-    const { testGroups } = this.state;
+    const { testGroups } = this.props;
     const currentLocation = window.location.href;
 
     return (
@@ -73,7 +32,5 @@ export default class JobTestGroups extends React.PureComponent {
 }
 
 JobTestGroups.propTypes = {
-  notifyTestGroupsAvailable: PropTypes.func.isRequired,
-  taskId: PropTypes.string.isRequired,
-  rootUrl: PropTypes.string.isRequired,
+  testGroups: PropTypes.arrayOf(PropTypes.string),
 };

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -34,10 +34,7 @@ class TabsPanel extends React.Component {
 
     this.state = {
       tabIndex: 0,
-      enableTestGroupsTab: false,
     };
-
-    this.handleEnableTestGroupsTab = this.handleEnableTestGroupsTab.bind(this);
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -57,9 +54,6 @@ class TabsPanel extends React.Component {
       );
       return {
         tabIndex,
-        // Every time we select a different job we need to let the component
-        // let us know if we should enable the tab
-        enableTestGroupsTab: false,
         jobId: selectedJob.id,
         perfJobDetailSize: perfJobDetail.length,
       };
@@ -111,10 +105,6 @@ class TabsPanel extends React.Component {
     ].filter((name) => !(name === 'perf' && !showPerf));
   }
 
-  handleEnableTestGroupsTab = (stateOfTab) => {
-    this.setState({ enableTestGroupsTab: stateOfTab });
-  };
-
   setTabIndex = (tabIndex) => {
     this.setState({ tabIndex });
   };
@@ -140,12 +130,12 @@ class TabsPanel extends React.Component {
       currentRepo,
       pinJob,
       addBug,
-      taskId,
-      rootUrl,
+      testGroups,
     } = this.props;
-    const { enableTestGroupsTab, tabIndex } = this.state;
+    const { tabIndex } = this.state;
     const countPinnedJobs = Object.keys(pinnedJobs).length;
     const { showPerf } = showTabsFromProps(this.props);
+    const enableTestGroupsTab = testGroups && testGroups.length > 0;
 
     return (
       <div id="tabs-panel" role="region" aria-label="Job">
@@ -161,11 +151,7 @@ class TabsPanel extends React.Component {
               <Tab>Annotations</Tab>
               <Tab>Similar Jobs</Tab>
               {showPerf && <Tab>Performance</Tab>}
-              {enableTestGroupsTab ? (
-                <Tab>Test Groups</Tab>
-              ) : (
-                <Tab disabled>Test Groups</Tab>
-              )}
+              {enableTestGroupsTab && <Tab>Test Groups</Tab>}
             </span>
             <span
               id="tab-header-buttons"
@@ -264,21 +250,9 @@ class TabsPanel extends React.Component {
               />
             </TabPanel>
           )}
-          {enableTestGroupsTab ? (
+          {enableTestGroupsTab && (
             <TabPanel>
-              <JobTestGroups
-                taskId={taskId}
-                rootUrl={rootUrl}
-                notifyTestGroupsAvailable={this.handleEnableTestGroupsTab}
-              />
-            </TabPanel>
-          ) : (
-            <TabPanel disabled forceRender>
-              <JobTestGroups
-                taskId={taskId}
-                rootUrl={rootUrl}
-                notifyTestGroupsAvailable={this.handleEnableTestGroupsTab}
-              />
+              <JobTestGroups testGroups={testGroups} />
             </TabPanel>
           )}
         </Tabs>
@@ -305,8 +279,7 @@ TabsPanel.propTypes = {
   jobLogUrls: PropTypes.arrayOf(PropTypes.shape({})),
   logParseStatus: PropTypes.string,
   logViewerFullUrl: PropTypes.string,
-  taskId: PropTypes.string.isRequired,
-  rootUrl: PropTypes.string.isRequired,
+  testGroups: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
 TabsPanel.defaultProps = {
@@ -316,6 +289,7 @@ TabsPanel.defaultProps = {
   perfJobDetail: [],
   jobRevision: null,
   logViewerFullUrl: null,
+  testGroups: [],
 };
 
 const mapStateToProps = ({

--- a/ui/shared/JobInfo.jsx
+++ b/ui/shared/JobInfo.jsx
@@ -87,11 +87,19 @@ export default class JobInfo extends React.PureComponent {
             <Clipboard description="task ID" text={taskId} />
           </li>
         )}
+        {taskId && job.taskQueueId && (
+          <li className="small">
+            <strong>Task Queue: </strong>
+            <span>{job.taskQueueId}</span>
+          </li>
+        )}
         <li className="small">
           <strong>Build: </strong>
-          <span>{`${buildArchitecture} ${buildPlatform} ${
-            buildOs || ''
-          }`}</span>
+          <span>
+            {[buildArchitecture, buildPlatform, buildOs]
+              .filter((val) => val && val !== '-')
+              .join(' ')}
+          </span>
         </li>
         <li className="small">
           <strong>Job name: </strong>


### PR DESCRIPTION
I noticed that when I click the "Task" link in the Job Info in the bottom left corner of the Treeherder UI, it's mostly to see which task queue the job is in, so I figured we could as well show it directly on treeherder.
Then I noticed we already fetch this information, but that's buried in the JobTestGroups component.

<img width="310" height="103" alt="image" src="https://github.com/user-attachments/assets/6dac1c20-5634-4692-92d0-b50b5abb66d6" />

So the PR contains the following changes:
- move the code fetching the task data from the JobTestGroups component to the DetailsPanel component. This means that request is now done in parallel with the other requests, and the flicker of the 'Test Groups' tab that was getting temporarily disabled and re-enabled as soon as the request finished is gone.
- show the Task Queue in the Job Info component.

And as ride along fixes in the surrounding areas:
- The 'Test Groups' tab is now hidden rather than disabled when the selected job doesn't contain the information (typically because it's not a test job). This matches the behavior of the "Performance" tab. The inconsistency between the 2 tabs was a bit annoying.
- "Build: - osx-cross -" now shows "Build: osx-cross" (ie the empty buildArchitecture and buildOs values that used to be shown as '-' are now filtered out).