### PR TITLE
Add a shift+l keyboard shortcut to show the raw log.

### DIFF
--- a/ui/helpers/constants.js
+++ b/ui/helpers/constants.js
@@ -358,6 +358,7 @@ export const thEvents = {
   saveClassification: 'save-classification-EVT',
   deleteClassification: 'delete-classification-EVT',
   openLogviewer: 'open-logviewer-EVT',
+  openRawLog: 'open-raw-log-EVT',
   openGeckoProfile: 'open-gecko-profile-EVT',
   applyNewJobs: 'apply-new-jobs-EVT',
   filtersUpdated: 'filters-updated-EVT',

--- a/ui/job-view/KeyboardShortcuts.jsx
+++ b/ui/job-view/KeyboardShortcuts.jsx
@@ -17,7 +17,7 @@ import {
 import { pinJob, unPinAll } from './redux/stores/pinnedJobs';
 
 const handledKeys =
-  'b,c,f,ctrl+shift+f,f,g,i,j,k,l,n,p,q,r,t,u,v,ctrl+shift+u,left,right,space,shift+/,escape,ctrl+enter,ctrl+backspace';
+  'b,c,f,ctrl+shift+f,f,g,i,j,k,l,shift+l,n,p,q,r,t,u,v,ctrl+shift+u,left,right,space,shift+/,escape,ctrl+enter,ctrl+backspace';
 
 class KeyboardShortcuts extends React.Component {
   onKeyDown = (key, e) => {
@@ -44,6 +44,8 @@ class KeyboardShortcuts extends React.Component {
         return this.changeSelectedJob('previous', true);
       case 'l':
         return this.openLogviewer();
+      case 'shift+l':
+        return this.openRawLog();
       case 'n':
         return this.changeSelectedJob('next', true);
       case 'p':
@@ -155,6 +157,11 @@ class KeyboardShortcuts extends React.Component {
   // open the logviewer for the selected job
   openLogviewer = () => {
     window.dispatchEvent(new CustomEvent(thEvents.openLogviewer));
+  };
+
+  // open the raw log for the selected job
+  openRawLog = () => {
+    window.dispatchEvent(new CustomEvent(thEvents.openRawLog));
   };
 
   // open the resource usage profile in the Firefox Profiler

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -59,12 +59,14 @@ class ActionBar extends React.PureComponent {
 
   componentDidMount() {
     window.addEventListener(thEvents.openLogviewer, this.onOpenLogviewer);
+    window.addEventListener(thEvents.openRawLog, this.onOpenRawLog);
     window.addEventListener(thEvents.openGeckoProfile, this.onOpenGeckoProfile);
     window.addEventListener(thEvents.jobRetrigger, this.onRetriggerJob);
   }
 
   componentWillUnmount() {
     window.removeEventListener(thEvents.openLogviewer, this.onOpenLogviewer);
+    window.removeEventListener(thEvents.openRawLog, this.onOpenRawLog);
     window.removeEventListener(
       thEvents.openGeckoProfile,
       this.onOpenGeckoProfile,
@@ -95,6 +97,16 @@ class ActionBar extends React.PureComponent {
         break;
       case 'parsed':
         document.querySelector('.logviewer-btn').click();
+    }
+  };
+
+  // Open the raw log and provide notifications if it isn't available
+  onOpenRawLog = () => {
+    const { jobLogUrls, notify } = this.props;
+    if (jobLogUrls && jobLogUrls.length > 0) {
+      window.open(jobLogUrls[0].url, '_blank');
+    } else {
+      notify('No logs available for this job');
     }
   };
 

--- a/ui/job-view/details/summary/LogItem.jsx
+++ b/ui/job-view/details/summary/LogItem.jsx
@@ -11,7 +11,7 @@ import {
 function getLogUrlProps(logKey, logUrl, logViewerUrl, logViewerFullUrl) {
   if (logKey === 'rawlog') {
     return {
-      title: 'Open the raw log in a new window',
+      title: 'Open the raw log in a new window (shift+l)',
       target: '_blank',
       rel: 'noopener noreferrer',
       href: logUrl.url,

--- a/ui/shared/ShortcutTable.jsx
+++ b/ui/shared/ShortcutTable.jsx
@@ -56,6 +56,12 @@ const ShortcutTable = function ShortcutTable() {
             </tr>
             <tr>
               <td>
+                <kbd>shift</kbd>+<kbd>l</kbd>
+              </td>
+              <td>Open the raw log for the selected job</td>
+            </tr>
+            <tr>
+              <td>
                 <kbd>g</kbd>
               </td>
               <td>Open the resource usage profile in the Firefox Profiler</td>


### PR DESCRIPTION
Now that I'm used to using the 'l' keyboard shortcut to open the logviewer and 'g' to open the resource usage profile, I find needing to find the button to open the raw log needlessly slow. I propose making shift+l open the raw log.