### PR TITLE
Include a profileName parameter with the job name and task id for profiler links to resource usage profiles

### DIFF
--- a/ui/helpers/url.js
+++ b/ui/helpers/url.js
@@ -121,8 +121,27 @@ export const getLogViewerUrl = function getLogViewerUrl(
   return lineNumber ? `${rv}&lineNumber=${lineNumber}` : rv;
 };
 
-export const getPerfAnalysisUrl = function getPerfAnalysisUrl(url) {
-  return `https://profiler.firefox.com/from-url/${encodeURIComponent(url)}`;
+export const isResourceUsageProfile = function isResourceUsageProfile(
+  fileName,
+) {
+  return [
+    'profile_build_resources.json',
+    'profile_resource-usage.json',
+  ].includes(fileName);
+};
+
+export const getPerfAnalysisUrl = function getPerfAnalysisUrl(url, job) {
+  let profilerUrl = `https://profiler.firefox.com/from-url/${encodeURIComponent(
+    url,
+  )}`;
+
+  // Add a profileName parameter with the job name and id for resource usage profiles.
+  if (job && isResourceUsageProfile(url.split('/').pop())) {
+    const profileName = `${job.job_type_name} (${job.task_id}.${job.retry_id})`;
+    profilerUrl += `?profileName=${encodeURIComponent(profileName)}`;
+  }
+
+  return profilerUrl;
 };
 
 // This takes a plain object, rather than a URLSearchParams object.

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -37,6 +37,7 @@ import {
   getInspectTaskUrl,
   getReftestUrl,
   getPerfAnalysisUrl,
+  isResourceUsageProfile,
 } from '../../../helpers/url';
 import JobModel from '../../../models/job';
 import TaskclusterModel from '../../../models/taskcluster';
@@ -112,11 +113,14 @@ class ActionBar extends React.PureComponent {
 
   // Open the gecko profile and provide notifications if it isn't available
   onOpenGeckoProfile = () => {
-    const { notify } = this.props;
+    const { notify, selectedJobFull } = this.props;
     const resourceUsageProfile = this.getResourceUsageProfile();
 
     if (resourceUsageProfile) {
-      window.open(getPerfAnalysisUrl(resourceUsageProfile.url), '_blank');
+      window.open(
+        getPerfAnalysisUrl(resourceUsageProfile.url, selectedJobFull),
+        '_blank',
+      );
     } else {
       notify('No resource usage profile available for this job');
     }
@@ -125,9 +129,7 @@ class ActionBar extends React.PureComponent {
   getResourceUsageProfile = () => {
     const { jobDetails } = this.props;
     return jobDetails.find((artifact) =>
-      ['profile_build_resources.json', 'profile_resource-usage.json'].includes(
-        artifact.value,
-      ),
+      isResourceUsageProfile(artifact.value),
     );
   };
 
@@ -395,7 +397,10 @@ class ActionBar extends React.PureComponent {
                     className="actionbar-nav-btn btn"
                     target="_blank"
                     rel="noopener noreferrer"
-                    href={getPerfAnalysisUrl(resourceUsageProfile.url)}
+                    href={getPerfAnalysisUrl(
+                      resourceUsageProfile.url,
+                      selectedJobFull,
+                    )}
                   >
                     <FontAwesomeIcon icon={faGaugeHigh} />
                   </a>

--- a/ui/job-view/details/tabs/PerformanceTab.jsx
+++ b/ui/job-view/details/tabs/PerformanceTab.jsx
@@ -142,11 +142,12 @@ class PerformanceTab extends React.PureComponent {
 
     // Use the most relevant profile.
     const { jobDetail } = profiles[0];
+    const { selectedJobFull } = this.props;
 
     return (
       <a
         title={jobDetail.value}
-        href={getPerfAnalysisUrl(jobDetail.url)}
+        href={getPerfAnalysisUrl(jobDetail.url, selectedJobFull)}
         className="btn btn-darker-secondary btn-sm"
         target="_blank"
         rel="noopener noreferrer"

--- a/ui/shared/JobArtifacts.jsx
+++ b/ui/shared/JobArtifacts.jsx
@@ -80,7 +80,7 @@ export default class JobArtifacts extends React.PureComponent {
                         -{' '}
                         <a
                           title={line.value}
-                          href={getPerfAnalysisUrl(line.url)}
+                          href={getPerfAnalysisUrl(line.url, selectedJob)}
                           target="_blank"
                           rel="noreferrer"
                         >


### PR DESCRIPTION
When opening many resource usage profiles from treeherder, it quickly becomes different to remember which tab was what.

Without providing a profile name in the url, the profiler front-end generates something based on the metadata it finds in the profile, which gives us information about the host machine:
<img width="343" height="55" alt="image" src="https://github.com/user-attachments/assets/38685aa1-77a9-4c9c-8ddd-46eb3f9c9835" />

With the PR applied:
<img width="430" height="54" alt="image" src="https://github.com/user-attachments/assets/6b5b82a3-35b4-4f26-a742-87b26bedde98" />

The profiler also puts the profile name in the page title, so this name is visible in the browser tab bar.
