### PR TITLE
Bug 1991905 - do not use log line which contains 'Assertion failure' without further context as failure line

### DIFF
--- a/tests/log_parser/test_error_parser.py
+++ b/tests/log_parser/test_error_parser.py
@@ -102,6 +102,8 @@ NON_ERROR_TEST_CASES = (
     "01:22:41     INFO -  ImportError: No module named pygtk\r\n",
     # "^non-fatal error"
     "2023-02-28 22:06:01+0000: non-fatal error removing directory: icons/, rv: 0, err: 39",
+    # "Assertion failure$"
+    "PROCESS(1234) | Assertion failure",
 )
 
 

--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -87,6 +87,7 @@ class ErrorParser(ParserBase):
 
     RE_EXCLUDE_2_SEARCH = re.compile(
         r"I[ /](Gecko|TestRunner).*TEST-UNEXPECTED-"
+        r"|Assertion failure$"
         r"|^TEST-UNEXPECTED-WARNING\b"
         r"|^TimeoutException: "
         r"|^ImportError: No module named pygtk$"


### PR DESCRIPTION
`Assertion failure` without further context in the same log line is sometimes logged for marionette, mochitest and web platform tests. The ones checked were not fatal but e.g. failures related to asynchronous tab switching.