### PR TITLE
Bug 2008333 - IrrelevantDataRemoval may stop early depending on repository order

### DIFF
--- a/tests/model/cycle_data/test_perfherder_cycling.py
+++ b/tests/model/cycle_data/test_perfherder_cycling.py
@@ -271,6 +271,61 @@ def test_irrelevant_repos_data_removal(
     ).exists()
 
 
+def test_irrelevant_data_removal_cycles_past_empty_repo(
+    monkeypatch,
+    test_repository,
+    try_repository,
+    push_stored,
+    test_perf_signature,
+    taskcluster_notify_mock,
+):
+    test_repository.name = f"{test_repository.name}-test"
+    test_repository.save()
+
+    expired = datetime.now() - timedelta(days=181)
+    push = Push.objects.first()
+
+    PerformanceDatum.objects.create(
+        repository=test_repository,
+        push=push,
+        job=None,
+        signature=test_perf_signature,
+        push_timestamp=datetime.now() - timedelta(days=1),
+        value=1.0,
+    )
+    PerformanceDatum.objects.create(
+        repository=try_repository,
+        push=push,
+        job=None,
+        signature=test_perf_signature,
+        push_timestamp=expired,
+        value=1.0,
+    )
+
+    def fake_irrelevant_repos(self):
+        # test_repository pops first but has no expired data
+        if self._IrrelevantDataRemoval__irrelevant_repos is None:
+            self._IrrelevantDataRemoval__irrelevant_repos = [
+                try_repository.id,
+                test_repository.id,
+            ]
+        return self._IrrelevantDataRemoval__irrelevant_repos
+
+    monkeypatch.setattr(
+        IrrelevantDataRemoval,
+        "irrelevant_repositories",
+        property(fake_irrelevant_repos),
+    )
+
+    call_command("cycle_data", "from:perfherder")
+    assert PerformanceDatum.objects.filter(repository=test_repository).exists()
+    assert not PerformanceDatum.objects.filter(
+        push_timestamp__lte=expired,
+        repository=try_repository,
+    ).exists()
+    assert PerformanceDatum.objects.count() == 1
+
+
 def test_signature_remover(
     test_perf_signature,
     test_perf_signature_2,

--- a/treeherder/model/data_cycling/removal_strategies.py
+++ b/treeherder/model/data_cycling/removal_strategies.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from itertools import cycle
 
 from django.db.backends.utils import CursorWrapper
 
@@ -291,7 +290,7 @@ class IrrelevantDataRemoval(RemovalStrategy):
 
         self._manager = PerformanceDatum.objects
         self.__irrelevant_repos = None
-        self.__circular_repos = None
+        self.__target_repository = None
 
     @property
     def max_timestamp(self):
@@ -308,23 +307,37 @@ class IrrelevantDataRemoval(RemovalStrategy):
         return self.__irrelevant_repos
 
     @property
-    def irrelevant_repo(self):
-        if self.__circular_repos is None:
-            self.__circular_repos = cycle(self.irrelevant_repositories)
-        return next(self.__circular_repos)
+    def target_repository(self):
+        if self.__target_repository is None:
+            _ = self.irrelevant_repositories
+            self.__lookup_new_repository()
+        return self.__target_repository
 
     @property
     def name(self) -> str:
         return "irrelevant data removal strategy"
 
     def remove(self, using: CursorWrapper):
+        while True:
+            try:
+                self.__attempt_remove(using)
+                deleted_rows = using.rowcount
+                if deleted_rows > 0:
+                    break  # deletion was successful
+                self.__lookup_new_repository()
+            except LookupError as ex:
+                logger.debug(
+                    f"Could not target any (new) irrelevant repository to delete data from. {ex}"
+                )
+                break
+
+    def __attempt_remove(self, using: CursorWrapper):
         """
         Raw SQL is used to avoid Django ORM cascade deletes on performance_datum_replicate.
         Although the WHERE clause in del_replicate looks redundant, it is intentionally kept to guide
         the PostgreSQL planner toward a more efficient execution plan.
         """
         chunk_size = self._find_ideal_chunk_size()
-        repository_id = self.irrelevant_repo
         using.execute(
             """
             WITH target_datum AS (
@@ -357,21 +370,35 @@ class IrrelevantDataRemoval(RemovalStrategy):
             USING target_datum td
             WHERE pd.id = td.id
             """,
-            [repository_id, self._max_timestamp, chunk_size, repository_id, self._max_timestamp],
+            [
+                self.target_repository,
+                self._max_timestamp,
+                chunk_size,
+                self.target_repository,
+                self._max_timestamp,
+            ],
         )
+
+    def __lookup_new_repository(self):
+        if not self.__irrelevant_repos:
+            raise LookupError("Exhausted all irrelevant repositories.")
+        self.__target_repository = self.__irrelevant_repos.pop()
 
     def _find_ideal_chunk_size(self) -> int:
         max_id_of_non_expired_row = (
             self._manager.filter(push_timestamp__gt=self._max_timestamp)
-            .filter(repository_id__in=self.irrelevant_repositories)
-            .order_by("-id")[0]
-            .id
+            .filter(repository_id=self.target_repository)
+            .order_by("-id")
+            .values_list("id", flat=True)
+            .first()
         )
+        if max_id_of_non_expired_row is None:
+            return self._chunk_size
         older_perf_data_rows = (
             self._manager.filter(
                 push_timestamp__lte=self._max_timestamp, id__lte=max_id_of_non_expired_row
             )
-            .filter(repository_id__in=self.irrelevant_repositories)
+            .filter(repository_id=self.target_repository)
             .order_by("id")[: self._chunk_size]
         )
         return len(older_perf_data_rows) or self._chunk_size


### PR DESCRIPTION
If the IrrelevantDataRemoval strategy encounters an empty repository during the process, the next repository is currently skipped (https://bugzilla.mozilla.org/show_bug.cgi?id=2008333).
In this PR, I updated the strategy so that it iterates through all candidate repositories without skipping any.

However, before landing this PR, we should first complete the work to improve the data cycling performance. Once this issue is fixed, the previously skipped repositories will start to be cleaned up. There are about 130 such repositories, and if each repository takes around 2~3 minutes, the total runtime could increase significantly.

Now, the data does not accumulate permanently. Any skipped data will eventually be removed by MainRemovalStrategy, and the target data size for this strategy is relatively small compared to the others.
It seems reasonable to delay landing this PR until the data cycling improvements are completed.