### PR TITLE
Add "Retrigger all failed test jobs" to push action menu.

### DIFF
--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -12,6 +12,7 @@ import {
 import { formatTaskclusterError } from '../../helpers/errorMessage';
 import CustomJobActions from '../CustomJobActions';
 import PushModel from '../../models/push';
+import JobModel from '../../models/job';
 import { notify } from '../stores/notificationStore';
 import {
   usePushesStore,
@@ -26,6 +27,7 @@ function PushActionMenu({
   showFuzzyJobs,
   pushId,
   currentRepo,
+  getAllShownJobs,
 }) {
   const navigate = useNavigate();
   const [customJobActionsShowing, setCustomJobActionsShowing] = useState(false);
@@ -66,6 +68,31 @@ function PushActionMenu({
     });
   }, [pushId, revision, decisionTaskMap, currentRepo]);
 
+  const retriggerAllFailedJobs = useCallback(() => {
+    const failedJobs = getAllShownJobs(pushId).filter(
+      (job) =>
+        job.resultStatus === 'testfailed' &&
+        job.platform !== 'lint' &&
+        job.job_type_symbol !== 'mozlint' &&
+        !job.job_type_name.includes('build'),
+    );
+
+    if (!failedJobs.length) {
+      notify('No failed test jobs to retrigger', 'warning');
+      return;
+    }
+
+    if (
+      !window.confirm(
+        `This will retrigger ${failedJobs.length} failed test job${failedJobs.length > 1 ? 's' : ''} for revision ${revision}!\n\nClick "OK" if you want to proceed.`,
+      )
+    ) {
+      return;
+    }
+
+    JobModel.retrigger(failedJobs, currentRepo, notify, 1, decisionTaskMap);
+  }, [pushId, revision, getAllShownJobs, currentRepo, decisionTaskMap]);
+
   const toggleCustomJobActions = useCallback(() => {
     setCustomJobActionsShowing((prev) => !prev);
   }, []);
@@ -103,6 +130,13 @@ function PushActionMenu({
             onClick={showFuzzyJobs}
           >
             Add new jobs (Search)
+          </Dropdown.Item>
+          <Dropdown.Item
+            tag="a"
+            title="Retrigger all jobs with failed test results in this push"
+            onClick={retriggerAllFailedJobs}
+          >
+            Retrigger all failed test jobs
           </Dropdown.Item>
           <Dropdown.Item
             tag="a"
@@ -187,6 +221,7 @@ PushActionMenu.propTypes = {
   hideRunnableJobs: PropTypes.func.isRequired,
   showRunnableJobs: PropTypes.func.isRequired,
   showFuzzyJobs: PropTypes.func.isRequired,
+  getAllShownJobs: PropTypes.func.isRequired,
 };
 
 export default PushActionMenu;

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -284,6 +284,7 @@ function PushHeader({
             showRunnableJobs={showRunnableJobs}
             hideRunnableJobs={hideRunnableJobs}
             showFuzzyJobs={showFuzzyJobs}
+            getAllShownJobs={getAllShownJobs}
           />
         </span>
       </div>


### PR DESCRIPTION
- Adds a "Retrigger all failed test jobs" option to the push action menu on the /jobs page, placed between the "Add new job" and "Trigger missing jobs" items:
<img width="258" height="452" alt="image" src="https://github.com/user-attachments/assets/d10f6eae-921e-4204-ae8f-3a651b11d0d4" />

- Filters for test failures only, excluding linting jobs (platform === "lint" or job_type_symbol === "mozlint") and build jobs (job_type_name contains "build"), matching the server-side [classification used in push health](https://github.com/mozilla/treeherder/blob/d40cceef805e7ef292a09079534f11fa64d7b9a9/treeherder/push_health/tests.py#L167-L178)
- Shows a confirmation dialog with the count of jobs to retrigger, or a warning if there are no failed test jobs

<img width="435" height="200" alt="image" src="https://github.com/user-attachments/assets/430d2d67-67a8-4f1a-9109-bbda41aa8d60" />
