### PR TITLE
Link to tests.firefox.dev/try.html in the push health summary of the jobs view

### DIFF
--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -707,6 +707,7 @@ function Push({
                         healthStatus={pushHealthStatus}
                         revision={revision}
                         repoName={currentRepo.name}
+                        jobList={jobListRef.current}
                       />
                     </div>
                   )}

--- a/ui/shared/PushHealthSummary.jsx
+++ b/ui/shared/PushHealthSummary.jsx
@@ -12,7 +12,7 @@ import StatusButton from './StatusButton';
 
 class PushHealthSummary extends PureComponent {
   render() {
-    const { healthStatus = {}, revision, repoName } = this.props;
+    const { healthStatus = {}, revision, repoName, jobList = [] } = this.props;
     const status = healthStatus || {};
     const {
       needInvestigation,
@@ -25,6 +25,13 @@ class PushHealthSummary extends PureComponent {
       metrics,
     } = status;
     const { linting, builds, tests } = metrics;
+    // tests.firefox.dev/try.html currently supports only mochitest and xpcshell tests
+    const failedMochitestXpcshellCount = jobList.filter(
+      (job) =>
+        job.result === 'testfailed' &&
+        (job.job_type_name.includes('xpcshell') ||
+          job.job_type_name.includes('mochitest')),
+    ).length;
     const heartSize = 20;
     const pushHealthUrl = getPushHealthUrl({ revision, repo: repoName });
     const noResultsFound =
@@ -103,6 +110,16 @@ class PushHealthSummary extends PureComponent {
                   title="Tests"
                   repo={repoName}
                   revision={revision}
+                  externalFailureUrl={
+                    failedMochitestXpcshellCount > 0
+                      ? `https://tests.firefox.dev/try.html?rev=${revision}`
+                      : null
+                  }
+                  externalFailureTooltip={
+                    failedMochitestXpcshellCount > 0
+                      ? `View aggregated failures from ${failedMochitestXpcshellCount} failed mochitest/xpcshell test jobs`
+                      : null
+                  }
                 />
               )}
             </Col>
@@ -124,6 +141,7 @@ PushHealthSummary.propTypes = {
     buildInProgressCount: PropTypes.number,
     lintingInProgressCount: PropTypes.number,
   }),
+  jobList: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default PushHealthSummary;

--- a/ui/shared/StatusButton.jsx
+++ b/ui/shared/StatusButton.jsx
@@ -13,6 +13,8 @@ const StatusButton = ({
   status,
   repo,
   revision,
+  externalFailureUrl,
+  externalFailureTooltip,
 }) => {
   let result = 'in progress';
   let text = `In Progress`;
@@ -30,6 +32,17 @@ const StatusButton = ({
     text = 'Passed';
     result = 'pass';
   }
+
+  const statusContent = (
+    <React.Fragment>
+      <FontAwesomeIcon
+        icon={getIcon(result)}
+        className={`me-2 text-${resultColorMap[result]}`}
+      />
+      <span className={`text-${resultColorMap[result]}`}>{text}</span>
+    </React.Fragment>
+  );
+
   return (
     <React.Fragment>
       <Link
@@ -40,11 +53,18 @@ const StatusButton = ({
       </Link>
       <br />
       <div className="pt-2">
-        <FontAwesomeIcon
-          icon={getIcon(result)}
-          className={`me-2 text-${resultColorMap[result]}`}
-        />
-        <span className={`text-${resultColorMap[result]}`}>{text}</span>
+        {externalFailureUrl && failureCount ? (
+          <a
+            href={externalFailureUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={externalFailureTooltip}
+          >
+            {statusContent}
+          </a>
+        ) : (
+          statusContent
+        )}
       </div>
     </React.Fragment>
   );
@@ -57,6 +77,8 @@ StatusButton.propTypes = {
   status: PropTypes.string.isRequired,
   revision: PropTypes.string.isRequired,
   repo: PropTypes.string.isRequired,
+  externalFailureUrl: PropTypes.string,
+  externalFailureTooltip: PropTypes.string,
 };
 
 export default StatusButton;


### PR DESCRIPTION
<img width="598" height="207" alt="image" src="https://github.com/user-attachments/assets/2da01725-6e5f-49a7-8381-1d91749c7f16" />

- In the push health summary on the jobs view, the "Failures (N)" text for the Tests category now links to tests.firefox.dev/try.html?rev=<revision> when any of the failed test jobs are mochitest or xpcshell.                                                                                                                                                                       
- The link has a tooltip indicating the number of failed mochitest/xpcshell jobs we'll be looking at.
- The detection is done purely on the frontend by checking the job list for jobs with result === 'testfailed' whose job_type_name contains "xpcshell" or "mochitest".