### PR TITLE
Bug 2021009 - Add mach try for enterprise

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -2047,5 +2047,19 @@
       "repository_group": 13,
       "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
-  }
+  },
+  {
+    "pk": 145,
+    "model": "model.repository",
+    "fields": {
+      "dvcs_type": "git",
+      "name": "enterprise-firefox-try",
+      "url": "https://github.com/mozilla/enterprise-firefox-try",
+      "branch": "pull request",
+      "active_status": "active",
+      "codebase": "enterprise-firefox",
+      "repository_group": 13,
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
+    }
+  },
 ]


### PR DESCRIPTION
The matching changes on taskcluster are https://github.com/mozilla/enterprise-firefox/pull/581/files/b5c566488fc0911766e905f07fa7710f7f0cd9ba#diff-8d55b0b4fa50a5d12dc201130b1868dace2ed758cfe9fd3458be0ed3438d6489:

```
    "enterprise-firefox-try": {
        "enable_always_target": True,
        "release_product": "firefox-enterprise",
        "target_tasks_method": "try_tasks",
    },
```