### PR TITLE
Bug 2030719 - Include extra notification emails in CC list.

### DIFF
--- a/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_bug_manager.py
+++ b/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_bug_manager.py
@@ -100,6 +100,36 @@ class TestTelemetryBugManager:
             mock_build.assert_called_once_with(mock_probe, telemetry_alert_obj)
 
     @responses.activate
+    def test_file_bug_adds_cc_when_multiple_notification_emails(
+        self, bug_manager, mock_probe, telemetry_alert_obj
+    ):
+        """Test that file_bug adds CC emails when there are multiple notification emails."""
+        mock_probe.get_notification_emails.return_value = [
+            "owner@mozilla.com",
+            "cc1@mozilla.com",
+            "cc2@mozilla.com",
+        ]
+        responses.add(
+            responses.POST,
+            "https://bugzilla.mozilla.org/rest/bug",
+            json={"id": 123456},
+            status=200,
+        )
+
+        bug_manager.file_bug(mock_probe, telemetry_alert_obj)
+
+        import json
+
+        request_body = json.loads(responses.calls[0].request.body)
+
+        # First email gets needinfo, not CC
+        assert request_body["flags"][0]["requestee"] == "owner@mozilla.com"
+
+        # Remaining emails go into CC
+        assert "cc" in request_body
+        assert request_body["cc"] == ["cc1@mozilla.com", "cc2@mozilla.com"]
+
+    @responses.activate
     def test_modify_bug_success(self, bug_manager):
         """Test successfully modifying a bug."""
         expected_response = {"bugs": [{"id": 123456, "changes": {}}]}

--- a/treeherder/perf/auto_perf_sheriffing/base_bug_manager.py
+++ b/treeherder/perf/auto_perf_sheriffing/base_bug_manager.py
@@ -37,6 +37,9 @@ class BugManager:
             }
         )
 
+    def _add_cc(self, bugzilla_emails, bug_data):
+        bug_data.setdefault("cc", []).extend(bugzilla_emails)
+
     def _create(self, bug_data):
         """Create a new bug.
 

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/bug_manager.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/bug_manager.py
@@ -39,6 +39,8 @@ class TelemetryBugManager(BugManager):
         # Only set a needinfo on the first email in the notification list
         needinfo_emails = probe.get_notification_emails()
         self._add_needinfo(needinfo_emails[0], bug_data)
+        if len(needinfo_emails) > 1:
+            self._add_cc(needinfo_emails[1:], bug_data)
 
         bug_info = self._create(bug_data)
         logger.info(f"Filed bug {bug_info['id']}")


### PR DESCRIPTION
This patch incorporates the extra notification emails specified by the telemetry probe into the CC list in the bug that gets created.