### PR TITLE
Bug 2030720 - Use actual telemetry probe bugzilla component.

### DIFF
--- a/tests/perf/auto_perf_sheriffing/telemetry_alerting/conftest.py
+++ b/tests/perf/auto_perf_sheriffing/telemetry_alerting/conftest.py
@@ -84,6 +84,7 @@ def mock_probe():
     probe.name = "test_probe_metric"
     probe.time_unit = "nanosecond"
     probe.get_notification_emails.return_value = ["test@mozilla.com"]
+    probe.get_bugzilla_info.return_value = ("Testing", "Performance")
     probe.should_file_bug.return_value = True
     probe.should_email.return_value = False
     return probe

--- a/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_probe.py
+++ b/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_probe.py
@@ -7,6 +7,7 @@ from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.probe import (
     TelemetryProbeValidationError,
 )
 from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.utils import (
+    DEFAULT_BUGZILLA_INFO,
     DEFAULT_CHANGE_DETECTION,
 )
 
@@ -376,3 +377,72 @@ class TestTelemetryProbeInfo:
 
             # Should not raise, probe_info should be an empty dict
             assert probe._probe_info == {}
+
+
+class TestTelemetryProbeBugzillaInfo:
+    def test_get_bugzilla_info_returns_default_on_network_failure(self, metric_info_with_bool_true):
+        """Test get_bugzilla_info returns the default when probe info cannot be fetched."""
+        with patch(
+            "treeherder.perf.auto_perf_sheriffing.telemetry_alerting.probe.requests.get"
+        ) as mock_get:
+            mock_get.side_effect = Exception("Network error")
+
+            probe = TelemetryProbe(metric_info_with_bool_true)
+            result = probe.get_bugzilla_info()
+
+            assert result == DEFAULT_BUGZILLA_INFO
+
+    def test_get_bugzilla_info_returns_custom_default_on_network_failure(
+        self, metric_info_with_bool_true
+    ):
+        """Test get_bugzilla_info returns the custom default when provided."""
+        with patch(
+            "treeherder.perf.auto_perf_sheriffing.telemetry_alerting.probe.requests.get"
+        ) as mock_get:
+            mock_get.side_effect = Exception("Network error")
+
+            probe = TelemetryProbe(metric_info_with_bool_true)
+            custom_default = ("Firefox", "General")
+            result = probe.get_bugzilla_info(default=custom_default)
+
+            assert result == custom_default
+
+    def test_get_bugzilla_info_parsed_from_bugzilla_tag(self, metric_info_with_bool_true):
+        """Test get_bugzilla_info parses product and component from a matching tag."""
+        with patch(
+            "treeherder.perf.auto_perf_sheriffing.telemetry_alerting.probe.requests.get"
+        ) as mock_get:
+            mock_response = Mock()
+            mock_response.json.return_value = {
+                "tags": [
+                    {"name": "Core :: Networking", "description": "Bugzilla component"},
+                ]
+            }
+            mock_response.raise_for_status = Mock()
+            mock_get.return_value = mock_response
+
+            probe = TelemetryProbe(metric_info_with_bool_true)
+            result = probe.get_bugzilla_info()
+
+            assert result == ("Core", "Networking")
+
+    def test_get_bugzilla_info_returns_default_when_no_bugzilla_tag(
+        self, metric_info_with_bool_true
+    ):
+        """Test get_bugzilla_info returns default when no tag has 'bugzilla' in its description."""
+        with patch(
+            "treeherder.perf.auto_perf_sheriffing.telemetry_alerting.probe.requests.get"
+        ) as mock_get:
+            mock_response = Mock()
+            mock_response.json.return_value = {
+                "tags": [
+                    {"name": "Core :: Networking", "description": "Some other tag"},
+                ]
+            }
+            mock_response.raise_for_status = Mock()
+            mock_get.return_value = mock_response
+
+            probe = TelemetryProbe(metric_info_with_bool_true)
+            result = probe.get_bugzilla_info()
+
+            assert result == DEFAULT_BUGZILLA_INFO

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/bug_manager.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/bug_manager.py
@@ -27,10 +27,9 @@ class TelemetryBugManager(BugManager):
         bug_data["summary"] = bug_content["title"]
         bug_data["description"] = bug_content["description"]
 
-        # For testing use Testing :: Performance, later switch to
-        # using tags from metrics_info
-        bug_data["product"] = "Testing"
-        bug_data["component"] = "Performance"
+        bugzilla_info = probe.get_bugzilla_info()
+        bug_data["product"] = bugzilla_info[0]
+        bug_data["component"] = bugzilla_info[1]
 
         bug_data["severity"] = "S4"
         bug_data["priority"] = "P5"

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/probe.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/probe.py
@@ -5,6 +5,7 @@ import requests
 
 from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.utils import (
     DEFAULT_ALERT_EMAIL,
+    DEFAULT_BUGZILLA_INFO,
     DEFAULT_CHANGE_DETECTION,
     GLEAN_PROBE_INFO,
 )
@@ -88,6 +89,10 @@ class TelemetryProbe:
             "bugzilla_notification_emails", self.monitor_info.get("notification_emails", [default])
         )
 
+    def get_bugzilla_info(self, default=DEFAULT_BUGZILLA_INFO):
+        self.setup_bugzilla_info(default=default)
+        return self.monitor_info.get("bugzilla_info", default)
+
     def fetch_probe_info(self):
         if self._probe_info is not None:
             return
@@ -125,6 +130,25 @@ class TelemetryProbe:
             )
         else:
             self.monitor_info["notification_emails"] = [default]
+
+    def setup_bugzilla_info(self, default=DEFAULT_BUGZILLA_INFO):
+        if self.monitor_info.get("bugzilla_info"):
+            return
+
+        self.fetch_probe_info()
+        self.monitor_info["bugzilla_info"] = default
+        if self._probe_info:
+            raw_bugzilla_info = ""
+            for tag in self._probe_info["tags"]:
+                # Bug 2030837 - Best effort to find the bugzilla info
+                # reliably before that bug is looked at.
+                if "bugzilla" in tag.get("description", "").lower():
+                    raw_bugzilla_info = tag.get("name", "")
+                    break
+            if raw_bugzilla_info:
+                self.monitor_info["bugzilla_info"] = tuple(
+                    el.strip() for el in raw_bugzilla_info.split("::")
+                )
 
     def verify_probe_definition(self):
         if self.monitor_info.get("alert", False) and not self.monitor_info.get(

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/utils.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/utils.py
@@ -34,6 +34,7 @@ CHANNEL_TO_REPO_MAPPING = {
 
 MODIFIABLE_ALERT_FIELDS = ("status",)
 DEFAULT_ALERT_EMAIL = "gmierzwinski@mozilla.com"
+DEFAULT_BUGZILLA_INFO = ("Testing", "Performance")
 EMAIL_LIMIT = 50
 
 


### PR DESCRIPTION
This patch removes the hard coded product, and component being used for bugs filed. Instead, we will file them in the components that are specified by the probe.