### PR TITLE
Fix running job tooltip showing stale duration

### DIFF
--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -259,6 +259,9 @@ export const getResultState = function getResultState(job) {
   return state === 'completed' ? result : state;
 };
 
+export const formatDuration = (minutes) =>
+  `${minutes} min${minutes > 1 ? 's' : ''}`;
+
 export const addAggregateFields = function addAggregateFields(job) {
   const {
     job_group_name: jobGroupName,
@@ -307,10 +310,11 @@ export const addAggregateFields = function addAggregateFields(job) {
 
     job.duration = Math.round(diff / 60, 0);
   }
+  if (job.state === 'running') {
+    job._durationFetchedAt = Date.now();
+  }
 
-  job.hoverText = `${jobTypeName} - ${job.resultStatus} - ${job.duration} min${
-    job.duration > 1 ? 's' : ''
-  }`;
+  job.hoverText = `${jobTypeName} - ${job.resultStatus} - ${formatDuration(job.duration)}`;
   return job;
 };
 

--- a/ui/job-view/pushes/JobButton.jsx
+++ b/ui/job-view/pushes/JobButton.jsx
@@ -1,4 +1,4 @@
-import { useImperativeHandle, forwardRef, memo } from 'react';
+import { useImperativeHandle, forwardRef, memo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faStar as faStarRegular } from '@fortawesome/free-regular-svg-icons';
@@ -7,7 +7,7 @@ import {
   faMitten,
 } from '@fortawesome/free-solid-svg-icons';
 
-import { getBtnClass } from '../../helpers/job';
+import { getBtnClass, formatDuration } from '../../helpers/job';
 import { useJobButtonRegistry } from '../../hooks/useJobButtonRegistry';
 
 const JobButtonComponent = forwardRef(function JobButtonComponent(
@@ -35,8 +35,6 @@ const JobButtonComponent = forwardRef(function JobButtonComponent(
     [job, visible, setSelected, toggleRunnableSelected, refilter],
   );
 
-  if (!visible) return null;
-
   const {
     state,
     failure_classification_id: jobFailureClassificationId,
@@ -44,6 +42,24 @@ const JobButtonComponent = forwardRef(function JobButtonComponent(
     job_type_symbol: jobTypeSymbol,
     resultStatus: jobResultStatus,
   } = job;
+
+  const onMouseEnter = useCallback(
+    (e) => {
+      if (state === 'running' && job._durationFetchedAt) {
+        const elapsed = Math.floor(
+          (Date.now() - job._durationFetchedAt) / 60000,
+        );
+        const currentDuration = job.duration + elapsed;
+        e.currentTarget.title = job.hoverText.replace(
+          /\d+ mins?$/,
+          formatDuration(currentDuration),
+        );
+      }
+    },
+    [state, job],
+  );
+
+  if (!visible) return null;
 
   const runnable = state === 'runnable';
   const { status, isClassified } = getBtnClass(
@@ -89,7 +105,7 @@ const JobButtonComponent = forwardRef(function JobButtonComponent(
 
   attributes.className = classes.join(' ');
   return (
-    <button type="button" ref={buttonRef} {...attributes} data-testid="job-btn">
+    <button type="button" ref={buttonRef} onMouseEnter={state === 'running' ? onMouseEnter : undefined} {...attributes} data-testid="job-btn">
       {jobTypeSymbol}
       {classifiedIcon && (
         <FontAwesomeIcon


### PR DESCRIPTION
Running jobs fetched via polling had their duration computed once on the server and never updated, causing tooltips to show "1 min" indefinitely. Stamp _durationFetchedAt on running jobs and recompute elapsed time on hover in JobButton so the tooltip always reflects current duration.

Without the PR:
<img width="645" height="119" alt="image" src="https://github.com/user-attachments/assets/7411f7e6-3eb0-4bfd-a9d2-dedcbc4f973f" />

With the PR:
<img width="645" height="119" alt="image" src="https://github.com/user-attachments/assets/2ed7193e-5f4c-4221-aaf1-32e273e0037a" />
