### PR TITLE
Show "Open in Firefox Profiler" link for artifacts ending in .json.gz

### DIFF
--- a/tests/ui/job-view/PerformanceTab_test.jsx
+++ b/tests/ui/job-view/PerformanceTab_test.jsx
@@ -151,6 +151,35 @@ describe('PerformanceTab', () => {
     );
   });
 
+  test('perf test job with json.gz profile should show retrigger button and open button', async () => {
+    const { getByTestId } = render(
+      testPerformanceTab({
+        selectedJobFull: {
+          job_type_name:
+            'test-macosx1015-64-shippable-qr/opt-browsertime-something',
+          job_type_symbol: 'some',
+          job_group_name: 'Browsertime performance tests on Firefox',
+          hasSideBySide: false,
+        },
+        jobDetails: [
+          {
+            url: 'profile_something.json.gz',
+            value: 'profile_something.json.gz',
+          },
+        ],
+        perfJobDetail: [],
+      }),
+    );
+
+    const generateProfile = getByTestId('generate-profile');
+    expect(generateProfile.textContent).toBe('Re-trigger performance profile');
+
+    const openProfiler = getByTestId('open-profiler');
+    expect(openProfiler.href).toBe(
+      'https://profiler.firefox.com/from-url/profile_something.json.gz',
+    );
+  });
+
   test('perf test should use most relevant profile', async () => {
     const { getByTestId } = render(
       testPerformanceTab({

--- a/ui/job-view/details/tabs/PerformanceTab.jsx
+++ b/ui/job-view/details/tabs/PerformanceTab.jsx
@@ -99,7 +99,7 @@ class PerformanceTab extends React.PureComponent {
       return PROFILE_ZIP_RELEVANCE;
     }
 
-    if (!value.endsWith('.json')) {
+    if (!value.endsWith('.json') && !value.endsWith('.json.gz')) {
       return NO_PROFILE_RELEVANCE;
     }
 


### PR DESCRIPTION
The Firefox Profiler supports gzip-compressed profile JSONs as inputs, and we'd like to start outputting them from various jobs because they're much smaller. We should keep showing the "Open in Firefox Profiler" link when we make that change.