### PR TITLE
Show the build flavor for MinGW tests

### DIFF
--- a/ui/job-view/pushes/Platform.jsx
+++ b/ui/job-view/pushes/Platform.jsx
@@ -123,7 +123,7 @@ function Platform({
       filteredPlatform.option === 'opt') ||
     filteredPlatform.name.includes('Shippable') ||
     filteredPlatform.name.includes('DevEdition') ||
-    ['asan', 'tsan', 'ccov', 'mingw', 'nightlyasrelease'].some((type) =>
+    ['asan', 'tsan', 'ccov', 'nightlyasrelease'].some((type) =>
       filteredPlatform.name.toLowerCase().includes(type),
     )
       ? ''


### PR DESCRIPTION
We run tests on opt and debug and right now they're not distinguishable on Treeherder.