### PR TITLE
Bug 2029999 - Handle case when test is empty for perf-alert emails.

### DIFF
--- a/tests/perf/test_email.py
+++ b/tests/perf/test_email.py
@@ -1,6 +1,10 @@
 import pytest
 
-from treeherder.perf.email import DeletionNotificationWriter, DeletionReportContent
+from treeherder.perf.email import (
+    AlertNotificationWriter,
+    DeletionNotificationWriter,
+    DeletionReportContent,
+)
 
 
 class TestDeletionReportContent:
@@ -53,3 +57,35 @@ class TestDeletionNotificationWriter:
             )
         )
         return expected_content
+
+
+class TestAlertNotificationWriter:
+    def test_subject_and_content_use_suite_when_test_field_is_empty(
+        self, test_perf_alert, test_perf_alert_summary
+    ):
+        test_perf_alert.series_signature.test = ""
+        test_perf_alert.series_signature.save()
+
+        writer = AlertNotificationWriter()
+        email = writer.prepare_new_email(
+            "test@example.com", test_perf_alert, test_perf_alert_summary
+        )
+
+        suite = test_perf_alert.series_signature.suite
+        assert suite in email["subject"]
+        assert suite in email["content"]
+
+    def test_subject_and_content_use_suite_dot_test_when_test_field_is_set(
+        self, test_perf_alert, test_perf_alert_summary
+    ):
+        suite = test_perf_alert.series_signature.suite
+        test = test_perf_alert.series_signature.test
+        expected_test_name = f"{suite}.{test}"
+
+        writer = AlertNotificationWriter()
+        email = writer.prepare_new_email(
+            "test@example.com", test_perf_alert, test_perf_alert_summary
+        )
+
+        assert expected_test_name in email["subject"]
+        assert expected_test_name in email["content"]

--- a/treeherder/perf/email.py
+++ b/treeherder/perf/email.py
@@ -321,15 +321,21 @@ class AlertNotificationWriter(EmailWriter):
         self, email: str, alert: PerformanceAlert, alert_summary: PerformanceAlertSummary
     ) -> dict:
         self._write_address(email)
-        self._write_subject(alert.series_signature.test)
-        self._write_content(alert.series_signature.test, str(alert_summary.id))
+
+        if not alert.series_signature.test:
+            test_name = alert.series_signature.suite
+        else:
+            test_name = f"{alert.series_signature.suite}.{alert.series_signature.test}"
+
+        self._write_subject(test_name)
+        self._write_content(test_name, str(alert_summary.id))
         return self.email
 
     def _write_address(self, email: str):
         self._email.address = email
 
     def _write_subject(self, test: str):
-        self._email.subject = f"Alert: Test {test} detected a performance change"
+        self._email.subject = f"Alert: Detected a performance change to {test} "
 
     def _write_content(self, test: str, alert_summary_id: str):
         content = AlertNotificationContent()


### PR DESCRIPTION
This patch fixes an issue where if the test was empty, it would look like the test was censored. Now, we include the suite in the subject and content.