### PR TITLE
Bug 2034150 - Provide direct link to exact alert in telemetry emails.

### DIFF
--- a/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_email_manager.py
+++ b/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_email_manager.py
@@ -373,6 +373,7 @@ class TestTelemetryEmailContent:
             detection_range,
             telemetry_alert_obj.telemetry_signature,
             telemetry_alert_obj.telemetry_alert_summary,
+            telemetry_alert_obj.telemetry_alert.id,
         )
 
         assert len(content._raw_content) > len(initial_content)
@@ -387,12 +388,13 @@ class TestTelemetryEmailContent:
             detection_range,
             telemetry_alert_obj.telemetry_signature,
             telemetry_alert_obj.telemetry_alert_summary,
+            telemetry_alert_obj.telemetry_alert.id,
         )
 
         # Should be a markdown table row with pipes
         assert row.startswith("|")
         assert row.endswith("|")
-        assert row.count("|") == 6  # 5 columns means 6 pipes
+        assert row.count("|") == 7  # 6 columns means 7 pipes
 
         # Should include key information
         assert "Nightly" in row  # channel
@@ -411,6 +413,7 @@ class TestTelemetryEmailContent:
             detection_range,
             telemetry_alert_obj.telemetry_signature,
             telemetry_alert_obj.telemetry_alert_summary,
+            telemetry_alert_obj.telemetry_alert.id,
         )
 
         # Should include dates in YYYY-MM-DD format
@@ -421,11 +424,13 @@ class TestTelemetryEmailContent:
         """Test _build_table_row includes proper links."""
         content = TelemetryEmailContent()
         detection_range = telemetry_alert_obj.get_detection_range()
+        alert_id = telemetry_alert_obj.telemetry_alert.id
 
         row = content._build_table_row(
             detection_range,
             telemetry_alert_obj.telemetry_signature,
             telemetry_alert_obj.telemetry_alert_summary,
+            alert_id,
         )
 
         # Should include Glean Dictionary link
@@ -434,8 +439,9 @@ class TestTelemetryEmailContent:
         # Should include Treeherder links
         assert "treeherder.mozilla.org" in row
 
-        # Should have markdown link format
-        assert "[Detection Push]" in row
+        # Should include alert details link
+        assert "gmierz.github.io/telemetry-alert-dashboard" in row
+        assert f"alertId={alert_id}" in row
 
     def test_str_returns_raw_content(self, telemetry_alert_obj, mock_probe):
         """Test __str__ returns the raw content."""
@@ -481,8 +487,14 @@ class TestTelemetryEmailContent:
     def test_table_headers_constant(self):
         """Test that TABLE_HEADERS constant is properly defined."""
         headers = TelemetryEmailContent.TABLE_HEADERS
-        assert "| Channel | Probe | Platform | Date Range | Detection Push |" in headers
+        assert "Channel" in headers
+        assert "Probe" in headers
+        assert "Platform" in headers
+        assert "Date" in headers
+        assert "Detection" in headers
+        assert "Alert" in headers
         assert ":---:" in headers  # Markdown center alignment
+        assert headers.count(":---:") == 6  # 6 columns
 
     def test_additional_probes_constant(self):
         """Test that ADDITIONAL_PROBES constant is properly defined."""

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/email_manager.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/email_manager.py
@@ -1,5 +1,7 @@
 from treeherder.perf.auto_perf_sheriffing.base_email_manager import EmailManager
 from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.utils import (
+    TELEMETRY_ALERT_DASHBOARD_ALERT,
+    TELEMETRY_ALERT_DASHBOARD_SUMMARY,
     get_glean_dictionary_link,
     get_treeherder_detection_link,
     get_treeherder_detection_range_link,
@@ -56,14 +58,27 @@ class TelemetryEmailWriter(EmailWriter):
         self._email.content = str(content)
 
 
+def format_header(header_name):
+    """Format email header names to improve column spacing.
+
+    The taskcluster email service condenses the columns far too much
+    so this method helps that situation by replacing spaces with "&nbsp;"
+    in the header names to prevent the headers from being split into multiple
+    rows. It also adds an additional 4 of these at the end of the header names
+    """
+    return header_name.replace(" ", "&nbsp;") + "&nbsp;" * 4
+
+
 class TelemetryEmailContent:
     DESCRIPTION = (
         "MozDetect has detected a telemetry change in a probe you are subscribed to:\n---\n"
     )
 
     TABLE_HEADERS = (
-        "| Channel | Probe | Platform | Date Range | Detection Push |\n"
-        "| :---: | :---: | :---: | :---: | :---: |\n"
+        f"| {format_header('Channel')} | {format_header('Probe')} | {format_header('Platform')} "
+        f"| {format_header('Date Range')} | {format_header('Detection Push')} "
+        f"| {format_header('Alert Details')} |\n"
+        f"| :---: | :---: | :---: | :---: | :---: | :---: |\n"
     )
 
     ADDITIONAL_PROBES = (
@@ -73,10 +88,7 @@ class TelemetryEmailContent:
     )
 
     DASHBOARD_SECTION = (
-        "\n---\n"
-        "**[View this alert on the Telemetry Alert Dashboard.]"
-        "(https://gmierz.github.io/telemetry-alert-dashboard/index.html"
-        "?view=without-bugs&alertSummaryId={summary_id})**\n"
+        "\n---\n**[View the alert summary on the Telemetry Alert Dashboard.]({url})**\n"
     )
 
     def __init__(self):
@@ -85,7 +97,10 @@ class TelemetryEmailContent:
     def write_email(self, probe, alert):
         self._initialize_report_intro()
         self._include_probe(
-            alert.get_detection_range(), alert.telemetry_signature, alert.telemetry_alert_summary
+            alert.get_detection_range(),
+            alert.telemetry_signature,
+            alert.telemetry_alert_summary,
+            alert.telemetry_alert.id,
         )
 
         if alert.get_related_alerts():
@@ -97,14 +112,18 @@ class TelemetryEmailContent:
         if self._raw_content is None:
             self._raw_content = self.DESCRIPTION + self.TABLE_HEADERS
 
-    def _include_probe(self, detection_range, telemetry_signature, telemetry_alert_summary):
+    def _include_probe(
+        self, detection_range, telemetry_signature, telemetry_alert_summary, alert_id
+    ):
         new_table_row = self._build_table_row(
-            detection_range, telemetry_signature, telemetry_alert_summary
+            detection_range, telemetry_signature, telemetry_alert_summary, alert_id
         )
         self._raw_content += f"{new_table_row}\n"
 
     def _include_dashboard_link(self, summary_id):
-        self._raw_content += self.DASHBOARD_SECTION.format(summary_id=summary_id)
+        self._raw_content += self.DASHBOARD_SECTION.format(
+            url=TELEMETRY_ALERT_DASHBOARD_SUMMARY.format(summary_id=summary_id)
+        )
 
     def _include_additional_probes(self, alert):
         self._raw_content += f"\n{self.ADDITIONAL_PROBES}{self.TABLE_HEADERS}"
@@ -113,18 +132,20 @@ class TelemetryEmailContent:
                 alert.get_detection_range(),
                 related_alert.series_signature,
                 alert.telemetry_alert_summary,
+                related_alert.id,
             )
 
     def _build_table_row(
-        self, detection_range, telemetry_signature, telemetry_alert_summary
+        self, detection_range, telemetry_signature, telemetry_alert_summary, alert_id
     ) -> str:
         # TODO: Have change-detection-technique/mozdetect provide a method for building
         # a row. That way we can decouple the information provided to bugzilla
         # users from the alerting system.
         return (
-            "| {channel} | [{probe}]({glean_dictionary_link}) | {platform} "
+            "| {channel} | [{probe}]({glean_dictionary_link})&nbsp;&nbsp;&nbsp;&nbsp; | {platform} "
             "| [{date_from} - {date_to}]({treeherder_date_link})"
-            "| [Detection Push]({treeherder_push_link}) |"
+            "| [{commit_hash}]({treeherder_push_link}) "
+            "| [{alert_id}]({alert_details_link}) |"
         ).format(
             channel=telemetry_signature.channel,
             probe=telemetry_signature.probe,
@@ -132,12 +153,15 @@ class TelemetryEmailContent:
             platform=telemetry_signature.platform,
             date_from=detection_range["from"].time.strftime("%Y-%m-%d"),
             date_to=detection_range["to"].time.strftime("%Y-%m-%d"),
+            commit_hash=detection_range["detection"].revision[:12],
             treeherder_date_link=get_treeherder_detection_range_link(
                 detection_range, telemetry_signature
             ),
             treeherder_push_link=get_treeherder_detection_link(
                 detection_range, telemetry_signature
             ),
+            alert_id=alert_id,
+            alert_details_link=TELEMETRY_ALERT_DASHBOARD_ALERT.format(alert_id=alert_id),
         )
 
     def __str__(self):

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/utils.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/utils.py
@@ -10,7 +10,14 @@ PUSH_LOG = (
     "https://hg-edge.mozilla.org/mozilla-central/pushloghtml?"
     "startdate={start_date}&enddate={end_date}"
 )
-TELEMETRY_ALERT_DASHBOARD = "https://gmierz.github.io/telemetry-alert-dashboard/?view=grouped&alertSummaryId={alert_summary_id}"
+BASE_TELEMETRY_DASHBOARD = "https://gmierz.github.io/telemetry-alert-dashboard/"
+TELEMETRY_ALERT_DASHBOARD = (
+    BASE_TELEMETRY_DASHBOARD + "?view=grouped&alertSummaryId={alert_summary_id}"
+)
+TELEMETRY_ALERT_DASHBOARD_SUMMARY = (
+    BASE_TELEMETRY_DASHBOARD + "?view=without-bugs&alertSummaryId={summary_id}"
+)
+TELEMETRY_ALERT_DASHBOARD_ALERT = BASE_TELEMETRY_DASHBOARD + "?view=without-bugs&alertId={alert_id}"
 BZ_TELEMETRY_ALERTS_CHANGED = (
     "https://bugzilla.mozilla.org/rest/bug?"
     "include_fields=id&include_fields=resolution"


### PR DESCRIPTION
This patch adds a new column to the alert emails to link directly to the alert details in the dashboard. The alert row is set to auto-expand when we go to it as well so that users can immediately see all the details including the CDF graphs.

At the same time, some changes were needed to improve the email formatting so the `format_header` function was added to help with this and enforce some better spacing between the columns in the email.