### PR TITLE
Display artifacts as a sortable table with path, size, and expiry

### DIFF
--- a/ui/css/treeherder-details-panel.css
+++ b/ui/css/treeherder-details-panel.css
@@ -575,3 +575,34 @@ div.performance-panel {
   top: -1px;
   line-height: 17px;
 }
+
+.artifacts-table td {
+  position: relative;
+}
+
+.artifacts-table td a:not(.overlay-link) {
+  position: relative;
+  z-index: 1;
+}
+
+.artifacts-table .overlay-link {
+  position: absolute;
+  inset: 0;
+  color: transparent;
+  text-decoration: none;
+}
+
+.artifacts-table td span {
+  pointer-events: none;
+}
+
+.artifacts-table th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+/* Leave room for the vertical scrollbar so it doesn't overlap the size text. */
+.artifacts-table th:last-child,
+.artifacts-table td:last-child {
+  padding-right: 12px;
+}

--- a/ui/helpers/display.js
+++ b/ui/helpers/display.js
@@ -69,12 +69,54 @@ export const getPercentComplete = function getPercentComplete(counts) {
 
 export const formatArtifacts = function formatArtifacts(data, artifactParams) {
   return data.map((item) => {
-    const value = item.name.replace(/.*\//, '');
+    const [path, value] = item.name
+      .replace(/^public\//, '')
+      .match(/^(?:(.*)\/)?(.*)$/)
+      .slice(1);
     artifactParams.artifactPath = item.name;
-    // for backwards compatibility with JobDetail API
-    const title = 'artifact uploaded';
-    return { url: getArtifactsUrl(artifactParams), value, title };
+    return {
+      url: getArtifactsUrl(artifactParams),
+      value,
+      path: path || '',
+      contentLength: item.contentLength,
+      expires: item.expires,
+      // for backwards compatibility with JobDetail API
+      title: 'artifact uploaded',
+    };
   });
+};
+
+export const formatByteSize = function formatByteSize(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) return '';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let size = bytes;
+  let i = 0;
+  while (size >= 1024 && i < units.length - 1) {
+    size /= 1024;
+    i += 1;
+  }
+  return `${size.toFixed(i === 0 || size >= 10 ? 0 : 1)} ${units[i]}`;
+};
+
+export const formatExpires = function formatExpires(expires) {
+  if (!expires) return '';
+  const days = Math.floor((new Date(expires).getTime() - Date.now()) / 86400000);
+  if (Number.isNaN(days)) return '';
+  if (days <= 0) return 'expired';
+  if (days < 60) return `${days}d`;
+  return `${Math.floor(days / 30)}mo`;
+};
+
+export const formatSizeTooltip = function formatSizeTooltip(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) return '';
+  return `${bytes.toLocaleString()} bytes`;
+};
+
+export const formatExpiresTooltip = function formatExpiresTooltip(expires) {
+  if (!expires) return '';
+  const date = new Date(expires);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString('en-US', longDateFormat);
 };
 
 export const errorLinesCss = function errorLinesCss(errors) {

--- a/ui/shared/JobArtifacts.jsx
+++ b/ui/shared/JobArtifacts.jsx
@@ -1,22 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
+import {
+  faExternalLinkAlt,
+  faSort,
+  faSortUp,
+  faSortDown,
+} from '@fortawesome/free-solid-svg-icons';
 
 import {
   getPerfAnalysisUrl,
   getCrashViewerUrl,
   getPernoscoURL,
 } from '../helpers/url';
+import {
+  formatByteSize,
+  formatExpires,
+  formatSizeTooltip,
+  formatExpiresTooltip,
+} from '../helpers/display';
 
-const UNTITLED = 'Untitled data';
 // Pattern to match crash dump files: UUID.{dmp,extra,json}
 const CRASH_DUMP_PATTERN = /^([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})\.(dmp|extra|json)$/i;
 
 const ArtifactLink = ({ artifact, children = null }) => (
   <a
     data-testid="task-artifact"
-    title={artifact.title || artifact.value}
+    title={artifact.value}
     href={artifact.url}
     target="_blank"
     rel="noopener noreferrer"
@@ -29,12 +39,55 @@ ArtifactLink.propTypes = {
   artifact: PropTypes.shape({
     url: PropTypes.string.isRequired,
     value: PropTypes.string.isRequired,
-    title: PropTypes.string,
   }).isRequired,
   children: PropTypes.node,
 };
 
+// Invisible <a> filling the cell, so hover shows the URL and clicks on
+// otherwise-inert text (path prefix, size, expires) navigate there.
+const CellLink = ({ href, label }) => (
+  <a
+    className="overlay-link"
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    tabIndex={-1}
+  >
+    <span className="sr-only">{label}</span>
+  </a>
+);
+
 export default class JobArtifacts extends React.PureComponent {
+  state = { sortKey: 'name', sortDir: 'asc' };
+
+  sort = (key) => {
+    this.setState((prev) => {
+      const toggle = { asc: 'desc', desc: 'asc' };
+      const sortDir =
+        prev.sortKey === key ? toggle[prev.sortDir] : key === 'size' ? 'desc' : 'asc';
+      return { sortKey: key, sortDir };
+    });
+  };
+
+  sortHeader(key, label, className = '') {
+    const { sortKey, sortDir } = this.state;
+    const active = sortKey === key;
+    const icon = !active ? faSort : sortDir === 'asc' ? faSortUp : faSortDown;
+    return (
+      <th
+        scope="col"
+        className={`sortable ${className}`}
+        aria-sort={
+          active ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'
+        }
+        onClick={() => this.sort(key)}
+      >
+        {label}{' '}
+        <FontAwesomeIcon icon={icon} className={active ? '' : 'text-muted'} />
+      </th>
+    );
+  }
+
   shouldShowPernoscoLink(repoName, selectedJob) {
     return (
       (repoName === 'try' || repoName === 'autoland' || repoName === 'enterprise-firefox-pr') &&
@@ -63,10 +116,21 @@ export default class JobArtifacts extends React.PureComponent {
       }
     });
 
-    // Identify complete crash dumps (all 3 files present)
+    // Identify complete crash dumps (all 3 files present) and compute
+    // aggregated size (sum) and expiry (earliest) across the 3 files.
     crashDumps.forEach((crash, crashId) => {
       if (crash.dmp && crash.extra && crash.json) {
         completeCrashIds.add(crashId);
+        const files = [crash.dmp, crash.extra, crash.json];
+        crash.contentLength = files.reduce(
+          (sum, f) =>
+            Number.isFinite(f.contentLength) ? sum + f.contentLength : sum,
+          0,
+        );
+        crash.expires = files
+          .map((f) => f.expires)
+          .filter(Boolean)
+          .sort()[0];
       }
     });
 
@@ -83,11 +147,43 @@ export default class JobArtifacts extends React.PureComponent {
 
     const { crashDumps, completeCrashIds } = this.groupCrashDumps(jobDetails);
 
-    const sortedDetails = jobDetails.slice();
-    sortedDetails.sort((a, b) => {
-      const compareA = a.title || UNTITLED;
-      const compareB = b.title || UNTITLED;
-      return compareA.localeCompare(compareB);
+    // Emit one row per artifact, collapsing complete crash dumps into a
+    // single aggregated row (anchored on the .json file).
+    const rows = jobDetails.flatMap((line) => {
+      const match = line.value.match(CRASH_DUMP_PATTERN);
+      if (match) {
+        const [, crashId, fileType] = match;
+        if (completeCrashIds.has(crashId)) {
+          if (fileType !== 'json') return [];
+          const crash = crashDumps.get(crashId);
+          return [
+            {
+              ...line,
+              contentLength: crash.contentLength,
+              expires: crash.expires,
+              crash,
+            },
+          ];
+        }
+      }
+      return [line];
+    });
+
+    const { sortKey, sortDir } = this.state;
+    const mul = sortDir === 'asc' ? 1 : -1;
+    const sortedDetails = rows.sort((a, b) => {
+      if (sortKey === 'size') {
+        const av = Number.isFinite(a.contentLength) ? a.contentLength : -Infinity;
+        const bv = Number.isFinite(b.contentLength) ? b.contentLength : -Infinity;
+        return (av - bv) * mul;
+      }
+      if (sortKey === 'expires') {
+        const av = a.expires ? new Date(a.expires).getTime() : Infinity;
+        const bv = b.expires ? new Date(b.expires).getTime() : Infinity;
+        return (av - bv) * mul;
+      }
+      const name = (x) => `${x.path ? `${x.path}/` : ''}${x.value || ''}`;
+      return name(a).localeCompare(name(b)) * mul;
     });
 
     return (
@@ -111,72 +207,112 @@ export default class JobArtifacts extends React.PureComponent {
           </div>
         )}
         {jobArtifactsLoading && <span>Loading job artifacts…</span>}
-        {!jobArtifactsLoading && (
-          <ul className="list-unstyled">
-            {sortedDetails.length > 0 &&
-              sortedDetails.map((line) => {
-                const match = line.value.match(CRASH_DUMP_PATTERN);
-
-                // Handle complete crash dumps
-                if (match) {
-                  const [, crashId, fileType] = match;
-
-                  if (completeCrashIds.has(crashId)) {
-                    // Only render once per complete crash (on .json file)
-                    if (fileType !== 'json') return null;
-
-                    const crash = crashDumps.get(crashId);
-                    return (
-                      <li className="link-style" key={line.url}>
+        {!jobArtifactsLoading && sortedDetails.length > 0 && (
+          <table className="table table-super-condensed table-hover artifacts-table">
+            <thead>
+              <tr>
+                {this.sortHeader('name', 'Name')}
+                {this.sortHeader('expires', 'Expires in', 'text-nowrap text-end')}
+                {this.sortHeader('size', 'Size', 'text-end')}
+              </tr>
+            </thead>
+            <tbody>
+              {sortedDetails.map((line) => {
+                if (line.crash) {
+                  const { crash } = line;
+                  const viewerUrl = getCrashViewerUrl(crash.json.url);
+                  return (
+                    <tr key={line.url}>
+                      <td>
+                        <CellLink href={viewerUrl} label="Open in crash viewer" />
                         <ArtifactLink artifact={crash.dmp} />
                         {', '}
                         <ArtifactLink artifact={crash.extra}>
                           .extra
                         </ArtifactLink>
                         {', '}
-                        <ArtifactLink artifact={crash.json}>.json</ArtifactLink>
-                        <span>
-                          {' '}
-                          -{' '}
-                          <a
-                            title="Open in crash viewer"
-                            href={getCrashViewerUrl(crash.json.url)}
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            open in crash viewer
-                          </a>
-                        </span>
-                      </li>
-                    );
-                  }
+                        <ArtifactLink artifact={crash.json}>.json</ArtifactLink>{' '}
+                        -{' '}
+                        <a
+                          title="Open in crash viewer"
+                          href={viewerUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          open in crash viewer
+                        </a>
+                      </td>
+                      <td
+                        className="text-end text-nowrap text-muted"
+                        title={formatExpiresTooltip(line.expires)}
+                      >
+                        <CellLink href={viewerUrl} label="Open in crash viewer" />
+                        <span>{formatExpires(line.expires)}</span>
+                      </td>
+                      <td
+                        className="text-end text-nowrap text-muted"
+                        title={formatSizeTooltip(line.contentLength)}
+                      >
+                        <CellLink href={viewerUrl} label="Open in crash viewer" />
+                        <span>{formatByteSize(line.contentLength)}</span>
+                      </td>
+                    </tr>
+                  );
                 }
 
-                // Render all other artifacts normally
+                const isProfileArtifact =
+                  !!line.url &&
+                  line.value.startsWith('profile_') &&
+                  (line.value.endsWith('.zip') || line.value.endsWith('.json'));
+                const primaryUrl = isProfileArtifact
+                  ? getPerfAnalysisUrl(line.url, selectedJob)
+                  : line.url;
+                const primaryTitle = isProfileArtifact
+                  ? `Open ${line.value} in the Firefox Profiler`
+                  : line.value;
+
                 return (
-                  <li className="link-style" key={line.url}>
-                    {!!line.url && <ArtifactLink artifact={line} />}
-                    {line.url &&
-                      line.value.startsWith('profile_') &&
-                      (line.value.endsWith('.zip') ||
-                        line.value.endsWith('.json')) && (
-                        <span>
+                  <tr key={line.url}>
+                    <td>
+                      {primaryUrl && <CellLink href={primaryUrl} label={primaryTitle} />}
+                      {line.path && (
+                        <span className="text-muted">{line.path}/</span>
+                      )}
+                      {!!line.url && <ArtifactLink artifact={line} />}
+                      {isProfileArtifact && (
+                        <>
                           {' '}
                           -{' '}
                           <a
                             title={line.value}
-                            href={getPerfAnalysisUrl(line.url, selectedJob)}
+                            href={primaryUrl}
                             target="_blank"
                             rel="noreferrer"
                           >
                             open in Firefox Profiler
                           </a>
-                        </span>
+                        </>
                       )}
-                  </li>
+                    </td>
+                    <td
+                      className="text-end text-nowrap text-muted"
+                      title={formatExpiresTooltip(line.expires)}
+                    >
+                      {primaryUrl && <CellLink href={primaryUrl} label={primaryTitle} />}
+                      <span>{formatExpires(line.expires)}</span>
+                    </td>
+                    <td
+                      className="text-end text-nowrap text-muted"
+                      title={formatSizeTooltip(line.contentLength)}
+                    >
+                      {primaryUrl && <CellLink href={primaryUrl} label={primaryTitle} />}
+                      <span>{formatByteSize(line.contentLength)}</span>
+                    </td>
+                  </tr>
                 );
               })}
-          </ul>
+            </tbody>
+          </table>
         )}
       </div>
     );
@@ -189,6 +325,9 @@ JobArtifacts.propTypes = {
       url: PropTypes.string.isRequired,
       value: PropTypes.string.isRequired,
       title: PropTypes.string,
+      path: PropTypes.string,
+      contentLength: PropTypes.number,
+      expires: PropTypes.string,
     }),
   ),
   jobArtifactsLoading: PropTypes.bool,


### PR DESCRIPTION
The Taskcluster artifacts API now returns a contentLength field on each artifact. Surface it in the Artifacts panel along with the expiry and the directory path, and make the panel sortable:

- Render artifacts as a three-column table (Name / Expires in / Size).
- Show the subpath (after "public/") before the filename so files in the same directory are grouped visually.
- Column headers are clickable to sort; clicking again toggles direction.
- Whole cells are clickable, with the browser showing the destination URL on hover. Profile artifacts navigate to the Firefox Profiler; complete crash dumps to the crash viewer; everything else to the raw artifact URL.
- Complete crash dumps collapse into a single row showing the summed size and the earliest expiry of the three files.

Before:
<img width="1916" height="730" alt="image" src="https://github.com/user-attachments/assets/e19c8481-8197-4b75-9496-f7ae9cfe46b5" />

After:
<img width="1916" height="700" alt="image" src="https://github.com/user-attachments/assets/1165c8f3-7c88-48a4-aa7c-174a62730326" />