### PR TITLE
Move telemetry alert unit tests to their own task.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,21 @@ jobs:
             tox -e docker-frontend
       - codecov/upload
 
+  python-tests-telemetry:
+    machine:
+      image: default
+    steps:
+      - checkout
+      - docker/install-docker-compose:
+          version: 1.29.2
+      - run:
+          name: Run tests and coverage within Docker container
+          command: |
+            pip install --upgrade pip
+            pip install tox
+            tox -e docker-telemetry
+      - codecov/upload
+
   test-docker-build:
     docker:
       - image: cimg/base:current
@@ -212,6 +227,7 @@ workflows:
       - python-tests-frontend
       - python-tests-general
       - python-tests-perf
+      - python-tests-telemetry
       - test-docker-build
       - deploy:
           filters:

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ filterwarnings =
 markers =
     slow: mark a test as slow.
     perf: mark tests related to perfherder.
+    telemetry_alerting: mark tests related to telemetry alerting.
     frontend: mark test related to frontend (UI/API).
     freeze_time: freeze time to a specific date using freezegun.
 xfail_strict = true

--- a/tests/perf/auto_perf_sheriffing/telemetry_alerting/conftest.py
+++ b/tests/perf/auto_perf_sheriffing/telemetry_alerting/conftest.py
@@ -1,3 +1,4 @@
+import pathlib
 from datetime import datetime
 from unittest.mock import Mock
 
@@ -9,6 +10,15 @@ from treeherder.perf.models import (
     PerformanceTelemetryAlertSummary,
     PerformanceTelemetrySignature,
 )
+
+
+def pytest_collection_modifyitems(config, items):
+    telemetry_path = pathlib.Path(__file__).parent
+    for item in items:
+        if telemetry_path in pathlib.Path(item.fspath).parents or str(item.fspath).startswith(
+            str(telemetry_path)
+        ):
+            item.add_marker(pytest.mark.telemetry_alerting)
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,14 @@ commands_pre =
 allowlist_externals=
     docker-compose
 commands =
-    docker-compose run -e TREEHERDER_DEBUG=False backend bash -c "pytest --cov --cov-report=xml -m perf --runslow -p no:unraisableexception"
+    docker-compose run -e TREEHERDER_DEBUG=False backend bash -c "pytest --cov --cov-report=xml -m 'perf and not telemetry_alerting' --runslow -p no:unraisableexception"
+
+[testenv:docker-telemetry]
+commands_pre =
+allowlist_externals=
+    docker-compose
+commands =
+    docker-compose run -e TREEHERDER_DEBUG=False backend bash -c "pytest --cov --cov-report=xml -m telemetry_alerting --runslow -p no:unraisableexception"
 
 [testenv:docker-frontend]
 commands_pre =


### PR DESCRIPTION
This patch moves the telemetry alerting unit tests to their own CircleCI task. This is being done because there are already quite a few unit tests for this (>200), and it's likely to grow. This reduces the perf task by about 3 minutes as well.