### PR TITLE
fix: Reduce re-authentication noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ docs.egg-info
 mcp-servers/
 .claude
 CLAUDE.md
+.superpowers/
 
 # Cloud SQL Auth Proxy
 cloud-sql-proxy

--- a/tests/ui/shared/AuthService.test.js
+++ b/tests/ui/shared/AuthService.test.js
@@ -31,6 +31,7 @@ jest.mock('../../../ui/helpers/auth', () => ({
   renew: (...args) => mockRenew(...args),
   loggedOutUser: { isLoggedIn: false },
   RENEW_INTERVAL: '15 minutes',
+  isAuthDebugEnabled: () => false,
 }));
 
 jest.mock('../../../ui/models/user');

--- a/ui/helpers/auth.js
+++ b/ui/helpers/auth.js
@@ -17,6 +17,16 @@ export const auth0Client = new Auth0Client({
 // per https://wiki.mozilla.org/Security/Guidelines/OpenID_connect#Session_handling
 export const RENEW_INTERVAL = '15 minutes';
 
+// Verbose auth breadcrumbs are hidden by default; opt in with
+// `localStorage.setItem('authDebug', '1')` in the browser console.
+export const isAuthDebugEnabled = () => {
+  try {
+    return localStorage.getItem('authDebug') === '1';
+  } catch {
+    return false;
+  }
+};
+
 // Normalize the auth0-spa-js token response into the same shape that
 // userSessionFromAuthResult expects (matching the old auth0-js authResult).
 const buildAuthResult = async () => {
@@ -49,9 +59,11 @@ export const userSessionFromAuthResult = (authResult) => {
     renewAfter: fromNow(renewInterval),
   };
 
-  console.debug(
-    `[Auth] Session created: renewAfter=${renewInterval}, accessTokenExpiresIn=${authResult.expiresIn}s, renewAt=${userSession.renewAfter}`,
-  );
+  if (isAuthDebugEnabled()) {
+    console.debug(
+      `[Auth] Session created: renewAfter=${renewInterval}, accessTokenExpiresIn=${authResult.expiresIn}s, renewAt=${userSession.renewAfter}`,
+    );
+  }
 
   return userSession;
 };

--- a/ui/shared/auth/AuthService.js
+++ b/ui/shared/auth/AuthService.js
@@ -5,11 +5,17 @@ import {
   renew,
   loggedOutUser,
   RENEW_INTERVAL,
+  isAuthDebugEnabled,
 } from '../../helpers/auth';
 import { getApiUrl } from '../../helpers/url';
 import UserModel from '../../models/user';
 
-const authLog = (msg, ...args) => console.debug(`[Auth]`, msg, ...args);
+// Verbose breadcrumbs (renewal cycle, lock contention, timer details) are
+// hidden by default. Enable with `localStorage.setItem('authDebug', '1')`.
+const authLog = (msg, ...args) => {
+  if (isAuthDebugEnabled()) console.debug(`[Auth]`, msg, ...args);
+};
+const authInfo = (msg, ...args) => console.log(`[Auth]`, msg, ...args);
 const authWarn = (msg, ...args) => console.warn(`[Auth]`, msg, ...args);
 const authError = (msg, ...args) => console.error(`[Auth]`, msg, ...args);
 
@@ -203,7 +209,7 @@ export default class AuthService {
   }
 
   logout() {
-    authLog('Logging out user');
+    authInfo('Logging out user');
     localStorage.removeItem('userSession');
     localStorage.removeItem('renewalLock');
     // Clear auth0-spa-js SDK token cache from localStorage

--- a/ui/shared/auth/Login.jsx
+++ b/ui/shared/auth/Login.jsx
@@ -27,6 +27,8 @@ const Login = ({ setUser, user = { isLoggedIn: false }, notify }) => {
         fullName: userSession.fullName,
       });
 
+      console.log('[Auth] Logged in as:', newUser.email); // eslint-disable-line no-console
+
       // start session renewal process
       if (userSession?.renewAfter) {
         authServiceRef.current.resetRenewalTimer();


### PR DESCRIPTION
## Summary

Reduces auth-related console output in the browser, which was firing 5+ debug lines every 15 minutes per tab and bothering customers (especially Firefox users, where debug-level logs are often visible).

## Behavior change

| Event | Before | After |
|---|---|---|
| Page load while signed in | several `[Auth] …` lines | `[Auth] Logged in as: <email>` |
| Background renewal (~15 min) | 5–6 `[Auth] …` debug lines | silent |
| Logout | `[Auth] Logging out user` | unchanged |
| Auth error / forced logout | warn/error | unchanged |

Verbose breadcrumbs (renewal triggers, lock contention, timer details, token refresh steps) are still available for debugging — opt in with `localStorage.setItem('authDebug', '1')` in the browser console and reload.

## Implementation

- `ui/helpers/auth.js`: exported `isAuthDebugEnabled()`; gated the per-session   "Session created" debug log behind it.
- `ui/shared/auth/AuthService.js`: `authLog` now only emits when the debug flag   is set; added `authInfo` (always-on `console.log`) for true state transitions.  "Backend login succeeded" demoted to gated debug since it fires on every renewal, not just on initial login. "Logging out user" stays visible.
- `ui/shared/auth/Login.jsx`: added `[Auth] Logged in as: <email>` in  `setLoggedIn` so the main window confirms login regardless of whether it  came from this tab's popup, a cross-tab storage event, or a page reload.
- `tests/ui/shared/AuthService.test.js`: added `isAuthDebugEnabled` to the  jest mock of `helpers/auth`.