### PR TITLE
Show hours in artifact expiry instead of "expired" for sub-day expiries

### DIFF
--- a/ui/helpers/display.js
+++ b/ui/helpers/display.js
@@ -100,9 +100,12 @@ export const formatByteSize = function formatByteSize(bytes) {
 
 export const formatExpires = function formatExpires(expires) {
   if (!expires) return '';
-  const days = Math.floor((new Date(expires).getTime() - Date.now()) / 86400000);
-  if (Number.isNaN(days)) return '';
-  if (days <= 0) return 'expired';
+  const ms = new Date(expires).getTime() - Date.now();
+  if (Number.isNaN(ms)) return '';
+  if (ms <= 0) return 'expired';
+  const hours = Math.floor(ms / 3600000);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
   if (days < 60) return `${days}d`;
   return `${Math.floor(days / 30)}mo`;
 };


### PR DESCRIPTION
The live.log artifact of in-progress jobs has a short expiry (typically a bit more than 2h) and was being rendered as "expired" while the job was still running, which was misleading. The previous formatter floored the time-to-expiry to whole days, so anything under 24h became 0 and reported as expired.