### PR TITLE
Bug 2027671 - Alerts View: Display the <alert id> for duplicated summaries with the status reassigned and add a copy id feature

### DIFF
--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -571,14 +571,23 @@ class PerformanceAlertSummaryViewSet(viewsets.ModelViewSet):
         for push_id, framework_id in keys:
             q |= Q(push_id=push_id, framework_id=framework_id)
         rows = PerformanceAlertSummary.objects.filter(q).values(
-            "id", "status", "push_id", "framework_id"
+            "id", "status", "push_id", "framework_id", "alerts__related_summary_id"
         )
-        result = defaultdict(list)
+        result_map = defaultdict(dict)
         for row in rows:
-            result[(row["push_id"], row["framework_id"])].append(
-                {"id": row["id"], "status": row["status"]}
-            )
-        return dict(result)
+            key = (row["push_id"], row["framework_id"])
+            summary_id = row["id"]
+
+            if summary_id not in result_map[key]:
+                result_map[key][summary_id] = {
+                    "id": summary_id,
+                    "status": row["status"],
+                    "reassigned_to": row["alerts__related_summary_id"],
+                }
+            elif row["alerts__related_summary_id"]:
+                result_map[key][summary_id]["reassigned_to"] = row["alerts__related_summary_id"]
+
+        return {k: list(v.values()) for k, v in result_map.items()}
 
     def _build_tc_metadata_map(self, page):
         """

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -342,13 +342,28 @@ class PerformanceAlertSummarySerializer(serializers.ModelSerializer):
                 for summary in duplicated_summaries_map.get(key, [])
                 if summary["id"] != performance_alert_summary.id
             ]
-        return list(
+
+        rows = (
             PerformanceAlertSummary.objects.filter(
                 push=performance_alert_summary.push, framework=performance_alert_summary.framework
             )
             .exclude(id=performance_alert_summary.id)
-            .values("id", "status")
+            .values("id", "status", "alerts__related_summary_id")
         )
+
+        result_map = {}
+        for row in rows:
+            summary_id = row["id"]
+            if summary_id not in result_map:
+                result_map[summary_id] = {
+                    "id": summary_id,
+                    "status": row["status"],
+                    "reassigned_to": row["alerts__related_summary_id"],
+                }
+            elif row["alerts__related_summary_id"]:
+                result_map[summary_id]["reassigned_to"] = row["alerts__related_summary_id"]
+
+        return list(result_map.values())
 
     class Meta:
         model = PerformanceAlertSummary

--- a/ui/perfherder/alerts/AlertHeader.jsx
+++ b/ui/perfherder/alerts/AlertHeader.jsx
@@ -14,6 +14,7 @@ import {
 import { getJobsUrl, getPerfCompareBaseURL } from '../../helpers/url';
 import { toMercurialShortDateStr } from '../../helpers/display';
 import SimpleTooltip from '../../shared/SimpleTooltip';
+import Clipboard from '../../shared/Clipboard';
 
 import Assignee from './Assignee';
 import TagsList from './TagsList';
@@ -230,19 +231,34 @@ const AlertHeader = ({
       {alertSummary.duplicated_summaries.length > 0 && (
         <Row>
           Duplicated summaries:
-          {alertSummary.duplicated_summaries.map((summary, index) => (
-            <Link
-              key={summary.id}
-              className="text-dark me-1"
-              target="_blank"
-              to={`/perfherder/alerts?id=${summary.id}&hideDwnToInv=0`}
-              id={`duplicated alert summary ${summary.id.toString()} `}
-              style={{ marginLeft: '5px' }}
-            >
-              Alert #{summary.id} - {getStatus(summary.status)}
-              {alertSummary.duplicated_summaries.length - 1 !== index && ', '}
-            </Link>
-          ))}
+          {alertSummary.duplicated_summaries.map((summary, index) => {
+            const isReassigned = getStatus(summary.status) === 'reassigned';
+            return (
+              <span 
+                key={summary.id} 
+                className="d-inline-flex align-items-center" 
+                style={{ marginLeft: '5px' }}
+              >
+                <Link
+                  className="text-dark me-1"
+                  target="_blank"
+                  to={`/perfherder/alerts?id=${summary.id}&hideDwnToInv=0`}
+                  id={`duplicated alert summary ${summary.id.toString()} `}
+                >
+                  Alert #{summary.id} - {getStatus(summary.status)}
+                  {isReassigned && summary.reassigned_to && ` to #${summary.reassigned_to}`}
+                </Link>
+                {isReassigned && summary.reassigned_to && (
+                  <Clipboard
+                    text={`${summary.reassigned_to}`}
+                    description="Alert ID"
+                    variant="transparent"
+                  />
+                )}
+                {alertSummary.duplicated_summaries.length - 1 !== index && ', '}
+              </span>
+            );
+          })}
         </Row>
       )}
       <Row>

--- a/ui/perfherder/alerts/AlertHeader.jsx
+++ b/ui/perfherder/alerts/AlertHeader.jsx
@@ -96,6 +96,13 @@ const AlertHeader = ({
   const bugNumber = alertSummary.bug_number
     ? `Bug ${alertSummary.bug_number}`
     : '';
+  const getDuplicatedAlertTitle = (summary, status) => {
+    if (status === 'reassigned' && summary.reassigned_to) {
+      return `Alert #${summary.id} - ${status} to #${summary.reassigned_to}`;
+    }
+
+    return `Alert #${summary.id} - ${status}`;
+  };
 
   const performanceTags = alertSummary.performance_tags || [];
   const alertSummaryDatetime = new Date(alertSummary.push_timestamp * 1000);
@@ -232,11 +239,13 @@ const AlertHeader = ({
         <Row>
           Duplicated summaries:
           {alertSummary.duplicated_summaries.map((summary, index) => {
-            const isReassigned = getStatus(summary.status) === 'reassigned';
+            const status = getStatus(summary.status);
+            const isReassigned = status === 'reassigned';
+
             return (
-              <span 
-                key={summary.id} 
-                className="d-inline-flex align-items-center" 
+              <span
+                key={summary.id}
+                className="d-inline-flex align-items-center"
                 style={{ marginLeft: '5px' }}
               >
                 <Link
@@ -245,8 +254,7 @@ const AlertHeader = ({
                   to={`/perfherder/alerts?id=${summary.id}&hideDwnToInv=0`}
                   id={`duplicated alert summary ${summary.id.toString()} `}
                 >
-                  Alert #{summary.id} - {getStatus(summary.status)}
-                  {isReassigned && summary.reassigned_to && ` to #${summary.reassigned_to}`}
+                  {getDuplicatedAlertTitle(summary, status)}
                 </Link>
                 {isReassigned && summary.reassigned_to && (
                   <Clipboard


### PR DESCRIPTION
[Bug 2027671 - Alerts View: Display the <alert id> for duplicated summaries with the status reassigned and add a copy id feature](https://bugzilla.mozilla.org/show_bug.cgi?id=2027671)