### PR TITLE
Bug 2012477 - Filter by regressions or improvements in the Perfherder Alerts view

### DIFF
--- a/tests/webapp/api/test_performance_alertsummary_api.py
+++ b/tests/webapp/api/test_performance_alertsummary_api.py
@@ -1004,3 +1004,246 @@ def test_alert_summaries_filter_with_assignee(
     summary_ids = [summary["id"] for summary in retrieved_summaries]
 
     assert summary_ids == [test_perf_alert_summary.id]
+
+
+def test_untriaged_regressions_filter(
+    client,
+    test_perf_alert_summary,
+    test_perf_alert_summary_2,
+    test_perf_signature,
+    test_perf_signature_2,
+):
+    # Summary 1: one untriaged regression alert should be returned
+    create_perf_alert(
+        summary=test_perf_alert_summary,
+        series_signature=test_perf_signature,
+        is_regression=True,
+        status=PerformanceAlert.UNTRIAGED,
+    )
+    # Summary 2: one untriaged improvement alert should NOT be returned
+    create_perf_alert(
+        summary=test_perf_alert_summary_2,
+        series_signature=test_perf_signature_2,
+        is_regression=False,
+        status=PerformanceAlert.UNTRIAGED,
+    )
+
+    resp = client.get(
+        reverse("performance-alert-summaries-list"),
+        data={"untriaged_regressions": "true"},
+    )
+    assert resp.status_code == 200
+    result_ids = [summary["id"] for summary in resp.json()["results"]]
+    assert test_perf_alert_summary.id in result_ids
+    assert test_perf_alert_summary_2.id not in result_ids
+
+
+def test_untriaged_regressions_excludes_acknowledged(
+    client,
+    test_perf_alert_summary,
+    test_perf_signature,
+):
+    # Acknowledged regression should NOT be returned by untriaged_regressions filter
+    create_perf_alert(
+        summary=test_perf_alert_summary,
+        series_signature=test_perf_signature,
+        is_regression=True,
+        status=PerformanceAlert.ACKNOWLEDGED,
+    )
+
+    resp = client.get(
+        reverse("performance-alert-summaries-list"),
+        data={"untriaged_regressions": "true"},
+    )
+    assert resp.status_code == 200
+    result_ids = [summary["id"] for summary in resp.json()["results"]]
+    assert test_perf_alert_summary.id not in result_ids
+
+
+def test_untriaged_improvements_filter(
+    client,
+    test_perf_alert_summary,
+    test_perf_alert_summary_2,
+    test_perf_signature,
+    test_perf_signature_2,
+):
+    # Summary 1: one untriaged improvement alert should be returned
+    create_perf_alert(
+        summary=test_perf_alert_summary,
+        series_signature=test_perf_signature,
+        is_regression=False,
+        status=PerformanceAlert.UNTRIAGED,
+    )
+    # Summary 2: one untriaged regression alert should NOT be returned
+    create_perf_alert(
+        summary=test_perf_alert_summary_2,
+        series_signature=test_perf_signature_2,
+        is_regression=True,
+        status=PerformanceAlert.UNTRIAGED,
+    )
+
+    resp = client.get(
+        reverse("performance-alert-summaries-list"),
+        data={"untriaged_improvements": "true"},
+    )
+    assert resp.status_code == 200
+    result_ids = [summary["id"] for summary in resp.json()["results"]]
+    assert test_perf_alert_summary.id in result_ids
+    assert test_perf_alert_summary_2.id not in result_ids
+
+
+def test_untriaged_improvements_excludes_acknowledged(
+    client,
+    test_perf_alert_summary,
+    test_perf_signature,
+):
+    # Acknowledged improvement should NOT be returned by untriaged_improvements filter
+    create_perf_alert(
+        summary=test_perf_alert_summary,
+        series_signature=test_perf_signature,
+        is_regression=False,
+        status=PerformanceAlert.ACKNOWLEDGED,
+    )
+
+    resp = client.get(
+        reverse("performance-alert-summaries-list"),
+        data={"untriaged_improvements": "true"},
+    )
+    assert resp.status_code == 200
+    result_ids = [summary["id"] for summary in resp.json()["results"]]
+    assert test_perf_alert_summary.id not in result_ids
+
+
+def test_untriaged_improvements_excludes_regressions(
+    client,
+    test_perf_alert_summary,
+    test_perf_signature,
+    test_perf_alert_summary_2,
+    test_perf_signature_2,
+    test_perf_signature_3,
+):
+    # Summary 1: one untriaged improvement alert should be returned
+    create_perf_alert(
+        summary=test_perf_alert_summary,
+        series_signature=test_perf_signature,
+        is_regression=False,
+        status=PerformanceAlert.UNTRIAGED,
+    )
+    # Summary 2: one untriaged improvement and one untriaged regression alert should NOT be returned
+    create_perf_alert(
+        summary=test_perf_alert_summary_2,
+        series_signature=test_perf_signature_2,
+        is_regression=False,
+        status=PerformanceAlert.UNTRIAGED,
+    )
+    create_perf_alert(
+        summary=test_perf_alert_summary_2,
+        series_signature=test_perf_signature_3,
+        is_regression=True,
+        status=PerformanceAlert.UNTRIAGED,
+    )
+
+    resp = client.get(
+        reverse("performance-alert-summaries-list"),
+        data={"untriaged_improvements": "true"},
+    )
+    assert resp.status_code == 200
+    result_ids = [summary["id"] for summary in resp.json()["results"]]
+    assert test_perf_alert_summary.id in result_ids
+    assert test_perf_alert_summary_2.id not in result_ids
+
+
+def test_untriaged_improvements_includes_regression_reassigned_to_other_summaries(
+    client,
+    test_perf_alert_summary,
+    test_perf_alert_summary_2,
+    test_perf_signature,
+    test_perf_signature_2,
+):
+    # One untriaged improvement and one reassigned regression should still be returned
+    # since the regression no longer applies to this summary.
+    create_perf_alert(
+        summary=test_perf_alert_summary,
+        series_signature=test_perf_signature,
+        is_regression=False,
+        status=PerformanceAlert.UNTRIAGED,
+    )
+    create_perf_alert(
+        summary=test_perf_alert_summary,
+        series_signature=test_perf_signature_2,
+        is_regression=True,
+        status=PerformanceAlert.REASSIGNED,
+        related_summary=test_perf_alert_summary_2,
+    )
+
+    resp = client.get(
+        reverse("performance-alert-summaries-list"),
+        data={"untriaged_improvements": "true"},
+    )
+    assert resp.status_code == 200
+    result_ids = [summary["id"] for summary in resp.json()["results"]]
+    assert test_perf_alert_summary.id in result_ids
+
+
+def test_untriaged_improvements_excludes_regression_reassigned_from_other_summaries(
+    client,
+    test_perf_alert_summary,
+    test_perf_alert_summary_2,
+    test_perf_signature,
+    test_perf_signature_2,
+):
+    # Summary 1: has only an untriaged improvement alert of its own
+    create_perf_alert(
+        summary=test_perf_alert_summary,
+        series_signature=test_perf_signature,
+        is_regression=False,
+        status=PerformanceAlert.UNTRIAGED,
+    )
+    # A regression from summary 2 is reassigned to summary 1
+    create_perf_alert(
+        summary=test_perf_alert_summary_2,
+        series_signature=test_perf_signature_2,
+        is_regression=True,
+        related_summary=test_perf_alert_summary,
+        status=PerformanceAlert.REASSIGNED,
+    )
+
+    resp = client.get(
+        reverse("performance-alert-summaries-list"),
+        data={"untriaged_improvements": "true"},
+    )
+    assert resp.status_code == 200
+    result_ids = [summary["id"] for summary in resp.json()["results"]]
+    assert test_perf_alert_summary.id not in result_ids
+
+
+def test_untriaged_regressions_include_reassignments(
+    client,
+    test_perf_alert_summary,
+    test_perf_alert_summary_2,
+    test_perf_signature,
+    test_perf_signature_2,
+):
+    # Summary 1: has only an untriaged improvement alert
+    create_perf_alert(
+        summary=test_perf_alert_summary,
+        series_signature=test_perf_signature,
+        is_regression=False,
+        status=PerformanceAlert.UNTRIAGED,
+    )
+    # A regression from summary 2 is reassigned to summary 1
+    create_perf_alert(
+        summary=test_perf_alert_summary_2,
+        series_signature=test_perf_signature_2,
+        is_regression=True,
+        related_summary=test_perf_alert_summary,
+        status=PerformanceAlert.REASSIGNED,
+    )
+
+    resp = client.get(
+        reverse("performance-alert-summaries-list"),
+        data={"untriaged_regressions": "true"},
+    )
+    assert resp.status_code == 200
+    result_ids = [summary["id"] for summary in resp.json()["results"]]
+    assert test_perf_alert_summary.id in result_ids

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -12,7 +12,17 @@ import numpy as np
 from cliffs_delta import cliffs_delta
 from django.conf import settings
 from django.db import transaction
-from django.db.models import Case, CharField, Count, Q, Subquery, Value, When
+from django.db.models import (
+    Case,
+    CharField,
+    Count,
+    Exists,
+    OuterRef,
+    Q,
+    Subquery,
+    Value,
+    When,
+)
 from django.db.models.functions import Concat
 from rest_framework import exceptions, filters, generics, pagination, viewsets
 from rest_framework.response import Response
@@ -415,6 +425,8 @@ class PerformanceAlertSummaryFilter(django_filters.FilterSet):
     filter_text = django_filters.CharFilter(method="_filter_text")
     hide_improvements = django_filters.BooleanFilter(method="_hide_improvements")
     hide_related_and_invalid = django_filters.BooleanFilter(method="_hide_related_and_invalid")
+    untriaged_regressions = django_filters.BooleanFilter(method="_untriaged_regressions")
+    untriaged_improvements = django_filters.BooleanFilter(method="_untriaged_improvements")
     with_assignee = django_filters.CharFilter(method="_with_assignee")
     timerange = django_filters.NumberFilter(method="_timerange")
     show_sheriffed_frameworks = django_filters.BooleanFilter(method="_show_sheriffed_frameworks")
@@ -481,6 +493,35 @@ class PerformanceAlertSummaryFilter(django_filters.FilterSet):
             ]
         )
 
+    def _untriaged_regressions(self, queryset, name, value):
+        return queryset.filter(
+            Q(alerts__is_regression=True, alerts__status=PerformanceAlert.UNTRIAGED)
+            | Q(related_alerts__is_regression=True)
+        ).distinct()
+
+    def _untriaged_improvements(self, queryset, name, value):
+        untriaged_regression_alerts = PerformanceAlert.objects.filter(
+            summary_id=OuterRef("pk"),
+            is_regression=True,
+            status=PerformanceAlert.UNTRIAGED,
+        )
+        related_regression_alerts = PerformanceAlert.objects.filter(
+            related_summary_id=OuterRef("pk"),
+            is_regression=True,
+        )
+        return (
+            queryset.filter(
+                alerts__is_regression=False,
+                alerts__status=PerformanceAlert.UNTRIAGED,
+            )
+            .annotate(
+                has_untriaged_regression=Exists(untriaged_regression_alerts),
+                has_related_regression=Exists(related_regression_alerts),
+            )
+            .filter(has_untriaged_regression=False, has_related_regression=False)
+            .distinct()
+        )
+
     def _with_assignee(self, queryset, name, value):
         return queryset.filter(assignee__username=value)
 
@@ -503,6 +544,8 @@ class PerformanceAlertSummaryFilter(django_filters.FilterSet):
             "filter_text",
             "hide_improvements",
             "hide_related_and_invalid",
+            "untriaged_regressions",
+            "untriaged_improvements",
             "with_assignee",
             "timerange",
         ]

--- a/ui/perfherder/alerts/AlertsView.jsx
+++ b/ui/perfherder/alerts/AlertsView.jsx
@@ -219,6 +219,12 @@ function AlertsView({
         if (status === 'all regressions') {
           delete params.status;
           params.hide_improvements = true;
+        } else if (status === 'untriaged regressions') {
+          delete params.status;
+          params.untriaged_regressions = true;
+        } else if (status === 'untriaged improvements') {
+          delete params.status;
+          params.untriaged_improvements = true;
         }
         if (hideDownstream) {
           params.hide_related_and_invalid = hideDownstream;

--- a/ui/perfherder/perf-helpers/constants.js
+++ b/ui/perfherder/perf-helpers/constants.js
@@ -74,6 +74,9 @@ export const summaryStatusMap = {
   'all statuses': -2,
   'all regressions': -1,
   untriaged: 0,
+  // Positioned here (instead of appending) so they show up in the dropdown under "untriaged"
+  'untriaged regressions': 10,
+  'untriaged improvements': 11,
   downstream: 1,
   // Reassigned is in the performance_alert_summary model but it isn't a valid status parameter
   // with get requests
@@ -166,7 +169,8 @@ export const tooltipMessages = {
   improvement: 'patch that generated an actual improvement',
   'regression-backedout': 'patch backed out due to causing regressions',
   'regression-fix': 'patch fixing a reported regression bug',
-  bisection: 'bisection identified the exact revision causing the performance shifts',
+  bisection:
+    'bisection identified the exact revision causing the performance shifts',
 };
 
 export const alertBackfillResultVisual = {


### PR DESCRIPTION
Adds options in the status dropdown menu to filter alert summaries by the following:

- untriaged regressions
- untriaged improvements

Each of the options returns a list of alert summaries that contains at least one alert matching the selected entry from the dropdown.

<img width="1244" height="514" alt="untriaged_regressions_improvements" src="https://github.com/user-attachments/assets/79ec70bb-e0c7-4fcb-80fc-7b1ae9ac3241" />
