### PR TITLE
fix(ui): excluded autoclassified intermittent from counts

### DIFF
--- a/ui/helpers/job.js
+++ b/ui/helpers/job.js
@@ -379,26 +379,17 @@ export const getJobCount = (jobs) => {
     if (job.result === 'testfailed') {
       if (job.platform === 'lint') {
         state['lint_failed'] = (memo['lint_failed'] || 0) + 1;
-        if (
-          job.failure_classification_id === 4 ||
-          job.failure_classification_id === 8
-        ) {
+        if (job.failure_classification_id === 4) {
           state['intermittentLint'] = (memo['intermittentLint'] || 0) + 1;
         }
       } else if (job.job_type_name.includes('build')) {
         state['build_failed'] = (memo['build_failed'] || 0) + 1;
-        if (
-          job.failure_classification_id === 4 ||
-          job.failure_classification_id === 8
-        ) {
+        if (job.failure_classification_id === 4) {
           state['intermittentBuild'] = (memo['intermittentBuild'] || 0) + 1;
         }
       } else {
         state['test_failed'] = (memo['test_failed'] || 0) + 1;
-        if (
-          job.failure_classification_id === 4 ||
-          job.failure_classification_id === 8
-        ) {
+        if (job.failure_classification_id === 4) {
           state['intermittentTests'] = (memo['intermittentTests'] || 0) + 1;
         }
       }

--- a/ui/helpers/job.test.js
+++ b/ui/helpers/job.test.js
@@ -54,7 +54,7 @@ describe('job helpers', () => {
           task_run: 'T2b-HDM2Rsa26AgbwcNdsA.0',
         },
         {
-          failure_classification_id: 8,
+          failure_classification_id: 4,
           id: 555848998,
           job_group_name: 'pedantic checks',
           job_group_symbol: 'pedantic',


### PR DESCRIPTION
Remove autoclassified intermittent jobs from the detail count:
<img width="968" height="405" alt="Screenshot 2026-05-04 at 09 20 54" src="https://github.com/user-attachments/assets/8e70c515-6aba-4c3a-b8a2-65f7fc528c70" />
