### PR TITLE
feat(ui): hide push details counts while decision jobs is running

### DIFF
--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -678,7 +678,7 @@ function Push({
                   widthClass="mb-3 ms-4"
                   commitShaClass="font-monospace"
                 >
-                  {filteredTryPush && (
+                  {filteredTryPush && decisionTask && (
                     <PushCountsDetails
                       {...jobCounts}
                       externalFailureUrl={externalFailureUrl}


### PR DESCRIPTION
Hide the push details counts while the decision task is still running:
<img width="1191" height="335" alt="Screenshot 2026-05-05 at 15 20 14" src="https://github.com/user-attachments/assets/e51098f8-bf2c-49db-88a6-6b3c654a70de" />
