### PR TITLE
Bug 2037502 - do not show content crashes as failure lines

### DIFF
--- a/treeherder/log_parser/parsers.py
+++ b/treeherder/log_parser/parsers.py
@@ -83,7 +83,10 @@ class ErrorParser(ParserBase):
         r"|mozmake\.(?:exe|EXE)(?:\[\d+\])?: \*\*\*"
     )
 
-    RE_EXCLUDE_1_SEARCH = re.compile(r"TEST-(?:INFO|PASS) ")
+    RE_EXCLUDE_1_SEARCH = re.compile(
+        r"TEST-(?:INFO|PASS) "
+        r"|A content process crashed and MOZ_CRASHREPORTER_SHUTDOWN is set, shutting down"
+    )
 
     RE_EXCLUDE_2_SEARCH = re.compile(
         r"I[ /](Gecko|TestRunner).*TEST-UNEXPECTED-"


### PR DESCRIPTION
Other failure lines for same task provide better information. Prevent classification with the generic content crash message.