### PR TITLE
fix(logviewer): normalize copy line endings and support off-screen Cmd+C

### DIFF
--- a/tests/ui/logviewer/useLogViewer_test.js
+++ b/tests/ui/logviewer/useLogViewer_test.js
@@ -331,4 +331,406 @@ describe('useLogViewer', () => {
 
     expect(mockWriteText).toHaveBeenCalledWith('line three');
   });
+
+  // --- handleCopy (browser native copy interception) ---
+
+  describe('handleCopy', () => {
+    let container;
+
+    // Build a fake rendered logviewer DOM matching the structure produced by
+    // LogRow.jsx: a `.classic-log-viewer` container holding `.classic-log-line`
+    // rows, each with an `<a class="classic-log-number">` and a
+    // `<span class="classic-log-text">`.
+    const buildContainer = () => {
+      const root = document.createElement('div');
+      root.className = 'classic-log-viewer';
+      const lineTexts = sampleLog.split('\n');
+      lineTexts.forEach((text, i) => {
+        const row = document.createElement('div');
+        row.className = 'classic-log-line';
+        row.dataset.line = String(i + 1);
+        const num = document.createElement('a');
+        num.className = 'classic-log-number';
+        num.textContent = String(i + 1);
+        const span = document.createElement('span');
+        span.className = 'classic-log-text';
+        span.textContent = text;
+        row.appendChild(num);
+        row.appendChild(span);
+        root.appendChild(row);
+      });
+      document.body.appendChild(root);
+      return root;
+    };
+
+    const buildEvent = () => ({
+      currentTarget: container,
+      preventDefault: jest.fn(),
+      clipboardData: { setData: jest.fn() },
+    });
+
+    const setSelection = ({ startEl, endEl, text, isCollapsed = false }) => {
+      const range = {
+        startContainer: startEl,
+        endContainer: endEl,
+        intersectsNode: (el) => {
+          // Naive intersection: between startEl and endEl by data-line ordering
+          const startRow =
+            startEl?.nodeType === Node.TEXT_NODE
+              ? startEl.parentElement?.closest?.('.classic-log-line')
+              : startEl?.closest?.('.classic-log-line');
+          const endRow =
+            endEl?.nodeType === Node.TEXT_NODE
+              ? endEl.parentElement?.closest?.('.classic-log-line')
+              : endEl?.closest?.('.classic-log-line');
+          if (!startRow || !endRow) return false;
+          const a = parseInt(startRow.dataset.line, 10);
+          const b = parseInt(endRow.dataset.line, 10);
+          const n = parseInt(el.dataset.line, 10);
+          return n >= Math.min(a, b) && n <= Math.max(a, b);
+        },
+      };
+      jest.spyOn(window, 'getSelection').mockReturnValue({
+        isCollapsed,
+        toString: () => text,
+        getRangeAt: () => range,
+        rangeCount: isCollapsed ? 0 : 1,
+      });
+    };
+
+    beforeEach(() => {
+      container = buildContainer();
+    });
+
+    afterEach(() => {
+      if (container?.parentNode) container.parentNode.removeChild(container);
+    });
+
+    test('overrides multi-row selection with normalized text from lines[]', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(sampleLog),
+      });
+      const { result } = renderHook(() =>
+        useLogViewer({ url: 'http://log.txt' }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      const rows = container.querySelectorAll('.classic-log-line');
+      // Selection from line 2 text → line 4 text
+      setSelection({
+        startEl: rows[1].querySelector('.classic-log-text').firstChild,
+        endEl: rows[3].querySelector('.classic-log-text').firstChild,
+        text: 'line two\nline three\nline four',
+      });
+
+      const event = buildEvent();
+      result.current.handleCopy(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(event.clipboardData.setData).toHaveBeenCalledWith(
+        'text/plain',
+        'line two\nline three\nline four',
+      );
+    });
+
+    test('does not override single-row partial selection (lets default fire)', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(sampleLog),
+      });
+      const { result } = renderHook(() =>
+        useLogViewer({ url: 'http://log.txt' }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      const rows = container.querySelectorAll('.classic-log-line');
+      const textNode = rows[2].querySelector('.classic-log-text').firstChild;
+      // Both ends inside line 3's text span
+      setSelection({ startEl: textNode, endEl: textNode, text: 'three' });
+
+      const event = buildEvent();
+      result.current.handleCopy(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(event.clipboardData.setData).not.toHaveBeenCalled();
+    });
+
+    test('does nothing on collapsed selection', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(sampleLog),
+      });
+      const { result } = renderHook(() =>
+        useLogViewer({ url: 'http://log.txt' }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      jest.spyOn(window, 'getSelection').mockReturnValue({
+        isCollapsed: true,
+        toString: () => '',
+        getRangeAt: () => null,
+        rangeCount: 0,
+      });
+
+      const event = buildEvent();
+      result.current.handleCopy(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(event.clipboardData.setData).not.toHaveBeenCalled();
+    });
+
+    test('does nothing when selection is outside log rows', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(sampleLog),
+      });
+      const { result } = renderHook(() =>
+        useLogViewer({ url: 'http://log.txt' }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      const outside = document.createElement('p');
+      outside.textContent = 'unrelated';
+      document.body.appendChild(outside);
+
+      setSelection({
+        startEl: outside.firstChild,
+        endEl: outside.firstChild,
+        text: 'unrelated',
+      });
+
+      const event = buildEvent();
+      result.current.handleCopy(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(event.clipboardData.setData).not.toHaveBeenCalled();
+
+      outside.parentNode.removeChild(outside);
+    });
+
+    test('reversed multi-row selection still produces in-order text', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(sampleLog),
+      });
+      const { result } = renderHook(() =>
+        useLogViewer({ url: 'http://log.txt' }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      const rows = container.querySelectorAll('.classic-log-line');
+      // querySelectorAll returns rows in DOM order regardless of selection
+      // direction, so the handler always derives [first row, last row].
+      // intersectsNode uses min/max so reversing endpoints is still in-range.
+      setSelection({
+        startEl: rows[3].querySelector('.classic-log-text').firstChild,
+        endEl: rows[1].querySelector('.classic-log-text').firstChild,
+        text: 'line two\nline three\nline four',
+      });
+
+      const event = buildEvent();
+      result.current.handleCopy(event);
+
+      expect(event.clipboardData.setData).toHaveBeenCalledWith(
+        'text/plain',
+        'line two\nline three\nline four',
+      );
+    });
+  });
+
+  // --- handleKeyDown (Cmd/Ctrl+C fallback for off-screen highlight ranges) ---
+
+  describe('handleKeyDown', () => {
+    const buildKeyEvent = (overrides = {}) => ({
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      key: 'c',
+      preventDefault: jest.fn(),
+      ...overrides,
+    });
+
+    const mockEmptySelection = () =>
+      jest.spyOn(window, 'getSelection').mockReturnValue({
+        isCollapsed: true,
+        toString: () => '',
+      });
+
+    test('Cmd+C copies highlight range when no native selection', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(sampleLog),
+      });
+      const { result } = renderHook(() =>
+        useLogViewer({ url: 'http://log.txt' }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.onLineClick(2, false);
+      });
+      act(() => {
+        result.current.onLineClick(4, true);
+      });
+      mockEmptySelection();
+
+      const event = buildKeyEvent({ metaKey: true });
+      await act(async () => {
+        result.current.handleKeyDown(event);
+        await Promise.resolve();
+      });
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(mockWriteText).toHaveBeenCalledWith(
+        'line two\nline three\nline four',
+      );
+    });
+
+    test('Ctrl+C also triggers copy', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(sampleLog),
+      });
+      const { result } = renderHook(() =>
+        useLogViewer({ url: 'http://log.txt' }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.onLineClick(1, false);
+      });
+      act(() => {
+        result.current.onLineClick(3, true);
+      });
+      mockEmptySelection();
+
+      const event = buildKeyEvent({ ctrlKey: true });
+      await act(async () => {
+        result.current.handleKeyDown(event);
+        await Promise.resolve();
+      });
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(mockWriteText).toHaveBeenCalledWith(
+        'line one\nline two\nline three',
+      );
+    });
+
+    test('does nothing when there is a non-empty native selection', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(sampleLog),
+      });
+      const { result } = renderHook(() =>
+        useLogViewer({ url: 'http://log.txt' }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.onLineClick(2, false);
+      });
+      act(() => {
+        result.current.onLineClick(4, true);
+      });
+
+      jest.spyOn(window, 'getSelection').mockReturnValue({
+        isCollapsed: false,
+        toString: () => 'a partial substring',
+      });
+
+      const event = buildKeyEvent({ metaKey: true });
+      result.current.handleKeyDown(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(mockWriteText).not.toHaveBeenCalled();
+    });
+
+    test('does nothing when no highlight is set', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(sampleLog),
+      });
+      const { result } = renderHook(() =>
+        useLogViewer({ url: 'http://log.txt' }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      mockEmptySelection();
+
+      const event = buildKeyEvent({ metaKey: true });
+      result.current.handleKeyDown(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(mockWriteText).not.toHaveBeenCalled();
+    });
+
+    test('ignores keys other than C', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(sampleLog),
+      });
+      const { result } = renderHook(() =>
+        useLogViewer({ url: 'http://log.txt' }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.onLineClick(2, false);
+      });
+      mockEmptySelection();
+
+      const event = buildKeyEvent({ metaKey: true, key: 'v' });
+      result.current.handleKeyDown(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(mockWriteText).not.toHaveBeenCalled();
+    });
+
+    test('ignores Cmd+C with shift modifier', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(sampleLog),
+      });
+      const { result } = renderHook(() =>
+        useLogViewer({ url: 'http://log.txt' }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.onLineClick(2, false);
+      });
+      mockEmptySelection();
+
+      const event = buildKeyEvent({ metaKey: true, shiftKey: true });
+      result.current.handleKeyDown(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(mockWriteText).not.toHaveBeenCalled();
+    });
+
+    test('handles single-line highlight with keyboard shortcut', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(sampleLog),
+      });
+      const { result } = renderHook(() =>
+        useLogViewer({ url: 'http://log.txt' }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.onLineClick(3, false);
+      });
+      mockEmptySelection();
+
+      const event = buildKeyEvent({ metaKey: true });
+      await act(async () => {
+        result.current.handleKeyDown(event);
+        await Promise.resolve();
+      });
+
+      expect(mockWriteText).toHaveBeenCalledWith('line three');
+    });
+  });
 });

--- a/ui/logviewer/ClassicLogViewer.jsx
+++ b/ui/logviewer/ClassicLogViewer.jsx
@@ -30,6 +30,8 @@ const ClassicLogViewer = ({
     setHighlight,
     onLineClick,
     copyHighlightedLines,
+    handleCopy,
+    handleKeyDown,
     virtuosoRef,
     scrollToLine,
   } = useLogViewer({ url, caseInsensitive });
@@ -145,7 +147,11 @@ const ClassicLogViewer = ({
   }
 
   return (
-    <div className="classic-log-viewer">
+    <div
+      className="classic-log-viewer"
+      onCopy={handleCopy}
+      onKeyDown={handleKeyDown}
+    >
       <SearchBar
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}

--- a/ui/logviewer/useLogViewer.js
+++ b/ui/logviewer/useLogViewer.js
@@ -177,6 +177,75 @@ export function useLogViewer({ url, caseInsensitive = true } = {}) {
     await navigator.clipboard.writeText(text);
   }, [highlight, lines]);
 
+  // Override the browser's native copy when the selection spans multiple log
+  // rows. Building the text from `lines[]` instead of from DOM serialization
+  // gives us clean LF-only line endings (no extra blank lines on Windows from
+  // CRLF + the `display:flex`/`white-space:pre` quirk in Chromium's clipboard
+  // writer) and works correctly for any rows still in the rendered DOM.
+  // Single-line partial selections fall through to default behavior so
+  // substring copy still works.
+  const handleCopy = useCallback(
+    (event) => {
+      const sel = window.getSelection();
+      if (!sel || sel.isCollapsed || sel.toString().length === 0) return;
+
+      const range = sel.getRangeAt(0);
+      const getLineEl = (node) => {
+        const el = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+        return el?.closest?.('.classic-log-line') ?? null;
+      };
+      const startLineEl = getLineEl(range.startContainer);
+      const endLineEl = getLineEl(range.endContainer);
+
+      // Selection doesn't touch any log row
+      if (!startLineEl && !endLineEl) return;
+      // Single-row partial selection — let default copy fire
+      if (startLineEl && startLineEl === endLineEl) return;
+
+      const container = event.currentTarget;
+      const lineEls = container.querySelectorAll('.classic-log-line');
+      const inSelection = Array.from(lineEls).filter((el) =>
+        range.intersectsNode(el),
+      );
+      if (inSelection.length === 0) return;
+
+      const startLine = parseInt(inSelection[0].dataset.line, 10);
+      const endLine = parseInt(
+        inSelection[inSelection.length - 1].dataset.line,
+        10,
+      );
+      if (!startLine || !endLine) return;
+
+      const text = lines.slice(startLine - 1, endLine).join('\n');
+      event.preventDefault();
+      event.clipboardData.setData('text/plain', text);
+    },
+    [lines],
+  );
+
+  // Cmd/Ctrl+C fallback for the off-screen case: shift-click sets
+  // `highlight = [start, end]` without creating a native browser selection,
+  // so the browser would otherwise fire no `copy` event at all. When there's
+  // no native selection but a highlight range exists, copy from `lines[]`.
+  const handleKeyDown = useCallback(
+    (event) => {
+      const isCopyKey =
+        (event.metaKey || event.ctrlKey) &&
+        event.key === 'c' &&
+        !event.shiftKey &&
+        !event.altKey;
+      if (!isCopyKey) return;
+      if (!highlight || highlight.length === 0) return;
+
+      const sel = window.getSelection();
+      if (sel && !sel.isCollapsed && sel.toString().length > 0) return;
+
+      event.preventDefault();
+      copyHighlightedLines();
+    },
+    [highlight, copyHighlightedLines],
+  );
+
   return useMemo(
     () => ({
       // Data
@@ -204,6 +273,8 @@ export function useLogViewer({ url, caseInsensitive = true } = {}) {
       scrollToLine,
       // Copy
       copyHighlightedLines,
+      handleCopy,
+      handleKeyDown,
     }),
     [
       lines,
@@ -222,6 +293,8 @@ export function useLogViewer({ url, caseInsensitive = true } = {}) {
       clearHighlight,
       scrollToLine,
       copyHighlightedLines,
+      handleCopy,
+      handleKeyDown,
     ],
   );
 }


### PR DESCRIPTION
The browser's DOM-to-text serialization on Windows uses CRLF and can produce extra blank lines when copying multi-row selections from the virtualized log viewer (depending on destination app). Mac/Linux use LF and don't show the symptom.

Adds two handlers wired onto the log viewer container:

- onCopy: when the user has a multi-row native selection, build the text from the lines[] data (joined with \n) and write it via clipboardData.setData, bypassing the browser's serialization. Single- row partial selections fall through to default behavior so substring copy still works.

- onKeyDown: Cmd/Ctrl+C with no native selection but an active highlight range now triggers copyHighlightedLines(). Previously the keyboard shortcut was a no-op for off-screen ranges (e.g. shift-click line 10 then scroll and shift-click line 500) because Virtuoso unmounts the rows in between, leaving no native selection for the browser to copy.