### PR TITLE
fix: preserve logviewer scroll position across search/filter toggle

### DIFF
--- a/tests/ui/logviewer/useLogViewer_test.js
+++ b/tests/ui/logviewer/useLogViewer_test.js
@@ -283,6 +283,102 @@ describe('useLogViewer', () => {
     });
   });
 
+  // --- Search scroll behavior ---
+
+  test('typing search does not scroll when a match is in the visible viewport', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('aaa\nbbb\naaa\nbbb\naaa'),
+    });
+
+    const { result } = renderHook(() => useLogViewer({ url: 'http://log.txt' }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const mockScrollToIndex = jest.fn();
+    result.current.virtuosoRef.current = {
+      scrollToIndex: mockScrollToIndex,
+    };
+
+    // Viewport currently shows lines 3-5 (0-indexed: 2-4). Match line 3 (idx 2) is visible.
+    act(() => {
+      result.current.setVisibleRange({ startIndex: 2, endIndex: 4 });
+    });
+
+    act(() => {
+      result.current.setSearchTerm('aaa');
+    });
+
+    expect(result.current.matchLineNumbers).toEqual([1, 3, 5]);
+    // currentMatchIndex should anchor to the in-viewport match (line 3 = index 1)
+    expect(result.current.currentMatchIndex).toBe(1);
+    expect(mockScrollToIndex).not.toHaveBeenCalled();
+  });
+
+  test('typing search scrolls to first match when no match is in viewport', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('aaa\nbbb\nccc\nddd\neee'),
+    });
+
+    const { result } = renderHook(() => useLogViewer({ url: 'http://log.txt' }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const mockScrollToIndex = jest.fn();
+    result.current.virtuosoRef.current = {
+      scrollToIndex: mockScrollToIndex,
+    };
+
+    // Viewport shows lines 3-5 (0-indexed: 2-4). Searching for 'aaa' (line 1) — not visible.
+    act(() => {
+      result.current.setVisibleRange({ startIndex: 2, endIndex: 4 });
+    });
+
+    act(() => {
+      result.current.setSearchTerm('aaa');
+    });
+
+    expect(result.current.matchLineNumbers).toEqual([1]);
+    expect(result.current.currentMatchIndex).toBe(0);
+    expect(mockScrollToIndex).toHaveBeenCalledWith({
+      index: 0,
+      align: 'start',
+    });
+  });
+
+  test('nextMatch scrolls to the new match line', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('aaa\nbbb\naaa\nbbb\naaa'),
+    });
+
+    const { result } = renderHook(() => useLogViewer({ url: 'http://log.txt' }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const mockScrollToIndex = jest.fn();
+    result.current.virtuosoRef.current = {
+      scrollToIndex: mockScrollToIndex,
+    };
+
+    // Anchor search on line 3 (in viewport) so setSearchTerm doesn't scroll on its own.
+    act(() => {
+      result.current.setVisibleRange({ startIndex: 2, endIndex: 4 });
+    });
+    act(() => {
+      result.current.setSearchTerm('aaa');
+    });
+    mockScrollToIndex.mockClear();
+
+    act(() => {
+      result.current.nextMatch();
+    });
+
+    // Anchored at index 1 (line 3) — next is index 2 (line 5)
+    expect(mockScrollToIndex).toHaveBeenCalledWith({
+      index: 4,
+      align: 'start',
+    });
+  });
+
   // --- Copy ---
 
   test('copyHighlightedLines extracts correct range and writes to clipboard', async () => {

--- a/ui/logviewer/ClassicLogViewer.jsx
+++ b/ui/logviewer/ClassicLogViewer.jsx
@@ -32,7 +32,13 @@ const ClassicLogViewer = ({
     copyHighlightedLines,
     virtuosoRef,
     scrollToLine,
+    visibleRangeRef,
+    setVisibleRange,
   } = useLogViewer({ url, caseInsensitive });
+
+  // Anchor line to scroll to after a filter toggle, captured from the
+  // pre-toggle viewport so a visible match stays in view across the change.
+  const pendingFilterAnchorRef = useRef(null);
 
   // Only skip the first programmatic scroll if initialLine was set at mount
   // (meaning initialTopMostItemIndex already handled positioning).
@@ -56,14 +62,57 @@ const ClassicLogViewer = ({
   }, []);
 
   const handleFilter = useCallback(() => {
-    if (matchLineNumbers.length > 0) {
-      setIsFiltered(true);
+    if (matchLineNumbers.length === 0) return;
+
+    // Capture the topmost visible match line (in unfiltered space) as anchor.
+    // After the filter applies, we'll scroll to that match's index in filteredData.
+    const range = visibleRangeRef.current;
+    let anchorIdx = 0;
+    if (range) {
+      const anchorMatch = matchLineNumbers.find(
+        (lineNum) => lineNum - 1 >= range.startIndex,
+      );
+      if (anchorMatch != null) {
+        anchorIdx = matchLineNumbers.indexOf(anchorMatch);
+      }
     }
-  }, [matchLineNumbers, setIsFiltered]);
+    pendingFilterAnchorRef.current = { type: 'filtered', value: anchorIdx };
+    setIsFiltered(true);
+  }, [matchLineNumbers, setIsFiltered, visibleRangeRef]);
 
   const handleClearFilter = useCallback(() => {
+    // Capture the topmost visible filtered row's actual line number as anchor.
+    // After the filter clears, we'll scroll to that line in the unfiltered view.
+    const range = visibleRangeRef.current;
+    let anchorLine = null;
+    if (range && matchLineNumbers.length > 0) {
+      const idx = Math.max(0, range.startIndex);
+      if (idx < matchLineNumbers.length) {
+        anchorLine = matchLineNumbers[idx];
+      }
+    }
+    pendingFilterAnchorRef.current =
+      anchorLine != null ? { type: 'unfiltered', value: anchorLine } : null;
     setIsFiltered(false);
-  }, [setIsFiltered]);
+  }, [matchLineNumbers, setIsFiltered, visibleRangeRef]);
+
+  // After the filter state flips, scroll to the captured anchor so the user's
+  // place is preserved across the toggle.
+  useEffect(() => {
+    const pending = pendingFilterAnchorRef.current;
+    if (!pending) return;
+    pendingFilterAnchorRef.current = null;
+    const targetIndex =
+      pending.type === 'filtered' ? pending.value : pending.value - 1;
+    requestAnimationFrame(() => {
+      if (virtuosoRef.current) {
+        virtuosoRef.current.scrollToIndex({
+          index: targetIndex,
+          align: 'start',
+        });
+      }
+    });
+  }, [isFiltered, virtuosoRef]);
 
   const filteredData = useMemo(() => {
     if (!isFiltered || matchLineNumbers.length === 0) return null;
@@ -169,6 +218,7 @@ const ClassicLogViewer = ({
         fixedItemHeight={13}
         style={{ flex: 1 }}
         overscan={200}
+        rangeChanged={setVisibleRange}
         initialTopMostItemIndex={
           !isFiltered && initialLine ? Math.max(0, initialLine - 1) : 0
         }

--- a/ui/logviewer/useLogViewer.js
+++ b/ui/logviewer/useLogViewer.js
@@ -24,6 +24,12 @@ export function useLogViewer({ url, caseInsensitive = true } = {}) {
   const virtuosoRef = useRef(null);
   // Track the anchor line for shift-click range selection
   const anchorLineRef = useRef(null);
+  // Track the currently visible range of Virtuoso indices (0-indexed)
+  const visibleRangeRef = useRef(null);
+
+  const setVisibleRange = useCallback((range) => {
+    visibleRangeRef.current = range;
+  }, []);
 
   // --- Fetch + Parse ---
 
@@ -72,6 +78,15 @@ export function useLogViewer({ url, caseInsensitive = true } = {}) {
 
   // --- Search ---
 
+  const scrollToLine = useCallback((lineNumber) => {
+    if (virtuosoRef.current) {
+      virtuosoRef.current.scrollToIndex({
+        index: lineNumber - 1,
+        align: 'start',
+      });
+    }
+  }, []);
+
   const setSearchTerm = useCallback(
     (term) => {
       setSearchTermState(term);
@@ -95,40 +110,47 @@ export function useLogViewer({ url, caseInsensitive = true } = {}) {
       }
 
       setMatchLineNumbers(matches);
-      setCurrentMatchIndex(matches.length > 0 ? 0 : -1);
+
+      if (matches.length === 0) {
+        setCurrentMatchIndex(-1);
+        return;
+      }
+
+      // If a match is already in the visible viewport, anchor to it instead of
+      // scrolling to the first match. Only scroll when nothing on screen matches.
+      const range = visibleRangeRef.current;
+      const visibleMatchIdx = range
+        ? matches.findIndex(
+            (lineNum) =>
+              lineNum - 1 >= range.startIndex && lineNum - 1 <= range.endIndex,
+          )
+        : -1;
+
+      if (visibleMatchIdx !== -1) {
+        setCurrentMatchIndex(visibleMatchIdx);
+      } else {
+        setCurrentMatchIndex(0);
+        scrollToLine(matches[0]);
+      }
     },
-    [lines, caseInsensitive],
+    [lines, caseInsensitive, scrollToLine],
   );
 
   const nextMatch = useCallback(() => {
     if (matchLineNumbers.length === 0) return;
-    setCurrentMatchIndex(
-      (prev) => (prev + 1) % matchLineNumbers.length,
-    );
-  }, [matchLineNumbers]);
+    const nextIdx = (currentMatchIndex + 1) % matchLineNumbers.length;
+    setCurrentMatchIndex(nextIdx);
+    scrollToLine(matchLineNumbers[nextIdx]);
+  }, [matchLineNumbers, currentMatchIndex, scrollToLine]);
 
   const prevMatch = useCallback(() => {
     if (matchLineNumbers.length === 0) return;
-    setCurrentMatchIndex(
-      (prev) =>
-        (prev - 1 + matchLineNumbers.length) % matchLineNumbers.length,
-    );
-  }, [matchLineNumbers]);
-
-  // Scroll to current search match when navigating matches
-  useEffect(() => {
-    if (
-      currentMatchIndex >= 0 &&
-      currentMatchIndex < matchLineNumbers.length &&
-      virtuosoRef.current
-    ) {
-      const lineNumber = matchLineNumbers[currentMatchIndex];
-      virtuosoRef.current.scrollToIndex({
-        index: lineNumber - 1,
-        align: 'start',
-      });
-    }
-  }, [currentMatchIndex, matchLineNumbers]);
+    const prevIdx =
+      (currentMatchIndex - 1 + matchLineNumbers.length) %
+      matchLineNumbers.length;
+    setCurrentMatchIndex(prevIdx);
+    scrollToLine(matchLineNumbers[prevIdx]);
+  }, [matchLineNumbers, currentMatchIndex, scrollToLine]);
 
   // --- Selection ---
 
@@ -149,17 +171,6 @@ export function useLogViewer({ url, caseInsensitive = true } = {}) {
   const clearHighlight = useCallback(() => {
     setHighlight(null);
     anchorLineRef.current = null;
-  }, []);
-
-  // --- Scroll ---
-
-  const scrollToLine = useCallback((lineNumber) => {
-    if (virtuosoRef.current) {
-      virtuosoRef.current.scrollToIndex({
-        index: lineNumber - 1,
-        align: 'start',
-      });
-    }
   }, []);
 
   // --- Copy ---
@@ -202,6 +213,8 @@ export function useLogViewer({ url, caseInsensitive = true } = {}) {
       // Scroll
       virtuosoRef,
       scrollToLine,
+      visibleRangeRef,
+      setVisibleRange,
       // Copy
       copyHighlightedLines,
     }),
@@ -221,6 +234,7 @@ export function useLogViewer({ url, caseInsensitive = true } = {}) {
       onLineClick,
       clearHighlight,
       scrollToLine,
+      setVisibleRange,
       copyHighlightedLines,
     ],
   );


### PR DESCRIPTION
Typing in the search box no longer jumps the viewport when a match is already visible: `setSearchTerm` anchors `currentMatchIndex` to the in-viewport match and only scrolls to the first match when nothing on screen matches. Toggling the filter on/off now keeps the topmost visible match in view by capturing the pre-toggle anchor and scrolling to its position in the new view.