### PR TITLE
Bug 2036342 - delete performance alerts with NULL created field in data cycling

### DIFF
--- a/treeherder/model/data_cycling/cyclers.py
+++ b/treeherder/model/data_cycling/cyclers.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 from django.db import OperationalError, connection
 from django.db.backends.utils import CursorWrapper
-from django.db.models import Count
+from django.db.models import Count, Q
 
 from treeherder.model.data_cycling.removal_strategies import RemovalStrategy
 from treeherder.model.models import (
@@ -172,7 +172,7 @@ class PerfherderCycler(DataCycler):
             # WARNING! Don't change this without proper approval!           #
             # Otherwise we risk deleting data that's actively investigated  #
             # and cripple the perf sheriffing process!                      #
-            created__lt=(datetime.now() - timedelta(days=365))
+            Q(created__lt=datetime.now() - timedelta(days=365)) | Q(created__isnull=True),
             #################################################################
         ).delete()
 


### PR DESCRIPTION
Alerts created before 2019-03-02 have `created = NULL` because the created field was added in migration 0013_add_alert_timestamps.py [0]. The data cycling deletion condition [1] only matches alerts older than 1 year based on the created field, so alerts with `created = NULL` are never matched and never deleted.

- `260 alerts` have not been processed (created is null)
```
select *
from performance_alert
where created is null
```
- `132 alert summaries` are pending removal (automatically deleted once alerts are processed). These alert summaries were created between 2016-12-14 23:57 and 2019-02-25 21:44.
```
select *
from performance_alert_summary
where id in (
    select related_summary_id
      from performance_alert
    where created is null
    union
    select summary_id
      from performance_alert
    where created is null
)
```
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2036342
[0] https://github.com/mozilla/treeherder/blob/4b1b136081764fe8a9cfb7df4e565dd2e180a6ce/treeherder/perf/migrations/0013_add_alert_timestamps.py#L19
[1] https://github.com/mozilla/treeherder/blob/4b1b136081764fe8a9cfb7df4e565dd2e180a6ce/treeherder/model/data_cycling/cyclers.py#L175