### PR TITLE
fix(logviewer): preserve URL lineNumber range across mount

### DIFF
--- a/tests/ui/logviewer/LogviewerUrlPreservation_test.jsx
+++ b/tests/ui/logviewer/LogviewerUrlPreservation_test.jsx
@@ -1,0 +1,115 @@
+import fetchMock from 'fetch-mock';
+import { render, waitFor, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+import App from '../../../ui/logviewer/App';
+import reposFixture from '../mock/repositories';
+import pushListFixture from '../mock/push_list';
+import { getApiUrl } from '../../../ui/helpers/url';
+import { getProjectUrl } from '../../../ui/helpers/location';
+import fullJob from '../mock/full_job.json';
+
+describe('Logviewer URL highlight preservation', () => {
+  const repoName = 'autoland';
+  const jobId = '259537375';
+  const taskId = 'O5YBAWwxRfuZ_UlRJS5Rqg';
+  const logUrl = `https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${taskId}/runs/0/artifacts/public/logs/live_backing.log`;
+  const errorsUrl = getProjectUrl(
+    `/jobs/${jobId}/text_log_errors/`,
+    repoName,
+  );
+
+  beforeEach(() => {
+    // Pin the URL with a multi-line highlight range using jsdom's real history.
+    window.history.replaceState(
+      null,
+      '',
+      `/logviewer?job_id=${jobId}&repo=${repoName}&task=${taskId}.0&lineNumber=17657-19403`,
+    );
+
+    // A non-empty log so lineCount > 0 triggers the initialLine effect.
+    const logContent = Array.from({ length: 100 }, (_, i) => `line ${i + 1}`)
+      .join('\n');
+
+    fetchMock.get(getApiUrl('/repository/'), reposFixture);
+    fetchMock.get(logUrl, logContent);
+    fetchMock.get(getProjectUrl(`/jobs/${jobId}/`, repoName), fullJob);
+    fetchMock.get(`begin:${getProjectUrl('/push/717491/', repoName)}`, {
+      ...pushListFixture,
+      results: [pushListFixture.results[0]],
+    });
+    fetchMock.get(
+      `https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${taskId}`,
+      404,
+    );
+    fetchMock.get(
+      `https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${taskId}/runs/0/artifacts`,
+      {
+        body: { artifacts: [] },
+        headers: { 'Content-Type': ['application/json; charset=UTF-8'] },
+      },
+    );
+    // At least one error so firstErrorLine fires the App effect that re-reads
+    // the URL — that effect is the second clobber path.
+    fetchMock.get(errorsUrl, [
+      { line: 'TEST-UNEXPECTED-FAIL fake', line_number: 17546 },
+    ]);
+  });
+
+  afterEach(() => {
+    fetchMock.reset();
+  });
+
+  // Regression test for the bug where opening a shared URL like
+  //   /logviewer?...&lineNumber=17657-19403
+  // would replace the range with `17547` (the first error line) or `17657`
+  // (the range start) before the page finished loading.
+  test('preserves ?lineNumber=START-END across log and error loads', async () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
+
+    // Wait for both async fetches that drive the bug-prone effects to fire.
+    await waitFor(() => {
+      expect(fetchMock.called(logUrl)).toBe(true);
+      expect(fetchMock.called(errorsUrl)).toBe(true);
+    });
+
+    // Let the effect cascade triggered by firstErrorLine settle.
+    await act(() => new Promise((resolve) => setTimeout(resolve, 50)));
+
+    expect(window.location.search).toContain('lineNumber=17657-19403');
+  });
+
+  test('seeds useLogViewer highlight from URL so the first onHighlightChange does not clear it', async () => {
+    const pushStateSpy = jest.spyOn(window.history, 'pushState');
+
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchMock.called(logUrl)).toBe(true);
+      expect(fetchMock.called(errorsUrl)).toBe(true);
+    });
+    await act(() => new Promise((resolve) => setTimeout(resolve, 50)));
+
+    // The mount-time highlight effect, the post-fetch initialLine effect, and
+    // the post-errors App effect must each preserve the range when they write
+    // back to the URL. No pushState call should clobber it with a single line
+    // or remove it entirely.
+    const urlWrites = pushStateSpy.mock.calls
+      .map(([, , url]) => url)
+      .filter((url) => typeof url === 'string' && url.includes('lineNumber'));
+
+    for (const url of urlWrites) {
+      expect(url).toContain('lineNumber=17657-19403');
+    }
+
+    pushStateSpy.mockRestore();
+  });
+});

--- a/tests/ui/logviewer/useLogViewer_test.js
+++ b/tests/ui/logviewer/useLogViewer_test.js
@@ -176,6 +176,14 @@ describe('useLogViewer', () => {
 
   // --- Selection ---
 
+  test('seeds highlight from initialHighlight (preserves URL-pinned range)', () => {
+    const { result } = renderHook(() =>
+      useLogViewer({ initialHighlight: [17657, 19403] }),
+    );
+
+    expect(result.current.highlight).toEqual([17657, 19403]);
+  });
+
   test('single click sets highlight to [lineNumber]', async () => {
     global.fetch.mockResolvedValue({
       ok: true,

--- a/ui/logviewer/App.jsx
+++ b/ui/logviewer/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 import formatLogLineWithLinks, {
   getLogLineColor,
@@ -49,11 +49,13 @@ const App = () => {
     const stored = localStorage.getItem(JOB_DETAILS_COLLAPSED);
     return stored !== null ? JSON.parse(stored) : true;
   });
-  const [initialLine, setInitialLine] = useState(() => {
-    const urlLN = getUrlLineNumber();
-    return urlLN ? urlLN[0] : null;
-  });
-  const [highlight, setHighlightState] = useState(null);
+  // Snapshot the URL-pinned highlight at mount so the full range (e.g.
+  // ?lineNumber=100-200) survives the first child-effect round-trip.
+  const initialHighlightRef = useRef(getUrlLineNumber());
+  const [initialLine, setInitialLine] = useState(
+    () => initialHighlightRef.current?.[0] ?? null,
+  );
+  const [highlight, setHighlightState] = useState(initialHighlightRef.current);
 
   // When errors arrive, default to scrolling to the first one (unless URL pinned a line)
   useEffect(() => {
@@ -173,6 +175,7 @@ const App = () => {
               url={rawLogUrl}
               formatLine={logFormatter}
               initialLine={initialLine}
+              initialHighlight={initialHighlightRef.current}
               onHighlightChange={onHighlightChange}
               errorLineNumbers={errorLineNumbers}
             />

--- a/ui/logviewer/ClassicLogViewer.jsx
+++ b/ui/logviewer/ClassicLogViewer.jsx
@@ -11,10 +11,14 @@ const ClassicLogViewer = ({
   url,
   formatLine,
   initialLine,
+  initialHighlight,
   onHighlightChange,
   errorLineNumbers,
 }) => {
   const [caseInsensitive, setCaseInsensitive] = useState(true);
+
+  // Capture initialHighlight ONCE so later prop changes don't reseed state.
+  const initialHighlightRef = useRef(initialHighlight);
 
   const {
     lines,
@@ -36,7 +40,11 @@ const ClassicLogViewer = ({
     scrollToLine,
     visibleRangeRef,
     setVisibleRange,
-  } = useLogViewer({ url, caseInsensitive });
+  } = useLogViewer({
+    url,
+    caseInsensitive,
+    initialHighlight: initialHighlightRef.current,
+  });
 
   // Anchor line to scroll to after a filter toggle, captured from the
   // pre-toggle viewport so a visible match stays in view across the change.
@@ -51,11 +59,13 @@ const ClassicLogViewer = ({
   useEffect(() => {
     if (!initialLine || !lineCount) return;
     if (mountedWithInitialLine.current) {
-      // First run with a line that was in the URL at mount — Virtuoso handled it
+      // First run with a line that was in the URL at mount — Virtuoso already
+      // scrolled via initialTopMostItemIndex and useLogViewer was seeded with
+      // initialHighlight (which may be a range). Skip both to preserve the URL.
       mountedWithInitialLine.current = false;
-    } else {
-      scrollToLine(initialLine);
+      return;
     }
+    scrollToLine(initialLine);
     setHighlight([initialLine]);
   }, [initialLine, lineCount, scrollToLine, setHighlight]);
 
@@ -237,6 +247,7 @@ ClassicLogViewer.propTypes = {
   url: PropTypes.string.isRequired,
   formatLine: PropTypes.func,
   initialLine: PropTypes.number,
+  initialHighlight: PropTypes.arrayOf(PropTypes.number),
   onHighlightChange: PropTypes.func,
   errorLineNumbers: PropTypes.arrayOf(PropTypes.number),
 };
@@ -244,6 +255,7 @@ ClassicLogViewer.propTypes = {
 ClassicLogViewer.defaultProps = {
   formatLine: undefined,
   initialLine: undefined,
+  initialHighlight: null,
   onHighlightChange: undefined,
   errorLineNumbers: [],
 };

--- a/ui/logviewer/useLogViewer.js
+++ b/ui/logviewer/useLogViewer.js
@@ -7,9 +7,14 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
  * @param {Object} params
  * @param {string} [params.url] - URL of the log file to fetch
  * @param {boolean} [params.caseInsensitive=true] - Whether search is case-insensitive
+ * @param {number[]|null} [params.initialHighlight=null] - Initial highlight ([line] or [start, end])
  * @returns {Object} Log viewer state and actions
  */
-export function useLogViewer({ url, caseInsensitive = true } = {}) {
+export function useLogViewer({
+  url,
+  caseInsensitive = true,
+  initialHighlight = null,
+} = {}) {
   const [lines, setLines] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -19,7 +24,7 @@ export function useLogViewer({ url, caseInsensitive = true } = {}) {
   const [currentMatchIndex, setCurrentMatchIndex] = useState(-1);
   const [isFiltered, setIsFiltered] = useState(false);
 
-  const [highlight, setHighlight] = useState(null);
+  const [highlight, setHighlight] = useState(initialHighlight);
 
   const virtuosoRef = useRef(null);
   // Track the anchor line for shift-click range selection


### PR DESCRIPTION
## Summary

A shared logviewer URL like `?lineNumber=17657-19403` had its range stripped within milliseconds of page load, so the UI ended up selecting either the first error line (~`17547`) or just the range start (`17657`) — the range end was always lost.

Three interacting issues:

- **`ClassicLogViewer.jsx`** had a mount-time effect that fired `onHighlightChange(highlight)` while `highlight` was still its initial `null` from `useLogViewer` — so the parent's `writeLineNumberParam(null)` cleared the URL param before any of the URL-preservation logic could run.
- **`App.jsx`** only read `urlLN[0]` for `initialLine` and initialized `highlight` to `null`, dropping the range end on load.
- **`ClassicLogViewer.jsx`**'s `initialLine` effect always called `setHighlight([initialLine])` once the log finished fetching, which would clobber any restored range with a single line.

The fix snapshots the full URL range at mount, plumbs it through as `initialHighlight` (App → ClassicLogViewer → useLogViewer), and skips the mount run of the `initialLine` effect so it no longer overrides the range.

## Test plan

- [x] New regression test `LogviewerUrlPreservation_test.jsx` loads `?lineNumber=17657-19403`, mocks the log + an error, and asserts `window.location.search` still contains the range after both fetches settle. A second test scans every `history.pushState` call and verifies none of them clobber the range.
- [x] New unit test in `useLogViewer_test.js` covers the `initialHighlight` seed.
- [x] All 1007 frontend tests still pass; biome lint clean on changed files.
- [x] Manual: open `/logviewer?...&lineNumber=A-B` and confirm both the URL and the highlighted range survive the load.
- [x] Manual: click and shift-click in the log, confirm the URL still updates with the single/range selection.
- [x] Manual: open `/logviewer?...` (no lineNumber) and confirm the first error line is still auto-selected.
