### PR TITLE
Add read-replica routing for expensive read-only endpoints

### DIFF
--- a/docs/accessing_data.md
+++ b/docs/accessing_data.md
@@ -170,23 +170,6 @@ Notes:
 - It may be required to add `extra_hosts: - "host.docker.internal:host-gateway"` to the backend container and to use 0.0.0.0 instead of 127.0.0.1 in the cloud-sql-proxy command
 - The check services calls may fail or hang, if you're having issues with this try removing those comments from the command block linked above
 
-## Exercising read-replica routing locally
-
-A subset of Perfherder GET endpoints is routed to a PostgreSQL read replica in
-production (configured via `READ_REPLICA_DATABASE_URL` and
-`READ_REPLICA_ENABLED`). To exercise the routing code path locally against your
-existing development DB, point both at the same DSN:
-
-```bash
-export READ_REPLICA_DATABASE_URL="$DATABASE_URL"
-export READ_REPLICA_ENABLED=true
-```
-
-The router and mixin are then active in dev. Routing is a no-op unless an
-endpoint opts in via `ReadReplicaMixin`; see
-`treeherder/config/db_routing.py` and the design at
-`.claude/plans/READ_REPLICA_DESIGN.md`.
-
 ## Import performance data from upstream
 
 If the use-cases above still aren't enough, you should ask for read-only access to one of

--- a/docs/accessing_data.md
+++ b/docs/accessing_data.md
@@ -170,6 +170,23 @@ Notes:
 - It may be required to add `extra_hosts: - "host.docker.internal:host-gateway"` to the backend container and to use 0.0.0.0 instead of 127.0.0.1 in the cloud-sql-proxy command
 - The check services calls may fail or hang, if you're having issues with this try removing those comments from the command block linked above
 
+## Exercising read-replica routing locally
+
+A subset of Perfherder GET endpoints is routed to a PostgreSQL read replica in
+production (configured via `READ_REPLICA_DATABASE_URL` and
+`READ_REPLICA_ENABLED`). To exercise the routing code path locally against your
+existing development DB, point both at the same DSN:
+
+```bash
+export READ_REPLICA_DATABASE_URL="$DATABASE_URL"
+export READ_REPLICA_ENABLED=true
+```
+
+The router and mixin are then active in dev. Routing is a no-op unless an
+endpoint opts in via `ReadReplicaMixin`; see
+`treeherder/config/db_routing.py` and the design at
+`.claude/plans/READ_REPLICA_DESIGN.md`.
+
 ## Import performance data from upstream
 
 If the use-cases above still aren't enough, you should ask for read-only access to one of

--- a/tests/config/test_db_routing.py
+++ b/tests/config/test_db_routing.py
@@ -1,9 +1,15 @@
+import logging
 from unittest.mock import MagicMock
 
 import pytest
+from django.db.utils import OperationalError
+from rest_framework.response import Response
+from rest_framework.test import APIRequestFactory
+from rest_framework.views import APIView
 
 from treeherder.config.db_routing import (
     READ_REPLICA_APP_ALLOW_LIST,
+    ReadReplicaMixin,
     ReadReplicaRouter,
     _state,
 )
@@ -73,3 +79,86 @@ def test_allow_migrate_blocks_replica():
 
 def test_allow_list_is_perf_and_model():
     assert READ_REPLICA_APP_ALLOW_LIST == {"perf", "model"}
+
+
+class _RecordingView(ReadReplicaMixin, APIView):
+    """Test view that records the thread-local state at the moment it ran."""
+
+    # Disable auth/permission so CSRF does not interfere with mixin tests.
+    authentication_classes = []
+    permission_classes = []
+
+    raise_on_call = None  # set per-test
+    call_count = 0
+    saw_use_replica = []
+
+    def get(self, request):
+        type(self).call_count += 1
+        type(self).saw_use_replica.append(getattr(_state, "use_replica", False))
+        if type(self).raise_on_call and type(self).call_count <= type(self).raise_on_call:
+            raise OperationalError("simulated replica failure")
+        return Response({"ok": True})
+
+    def post(self, request):
+        type(self).call_count += 1
+        type(self).saw_use_replica.append(getattr(_state, "use_replica", False))
+        return Response({"ok": True})
+
+
+@pytest.fixture
+def reset_view():
+    _RecordingView.raise_on_call = 0
+    _RecordingView.call_count = 0
+    _RecordingView.saw_use_replica = []
+    yield
+
+
+def test_mixin_flips_state_on_get(reset_view):
+    factory = APIRequestFactory()
+    view = _RecordingView.as_view()
+    response = view(factory.get("/x"))
+    assert response.status_code == 200
+    assert _RecordingView.saw_use_replica == [True]
+    assert not hasattr(_state, "use_replica")  # cleared after dispatch
+
+
+def test_mixin_does_not_flip_state_on_post(reset_view):
+    factory = APIRequestFactory()
+    view = _RecordingView.as_view()
+    response = view(factory.post("/x", data={}))
+    assert response.status_code == 200
+    assert _RecordingView.saw_use_replica == [False]
+
+
+def test_mixin_clears_state_when_view_raises(reset_view):
+    _RecordingView.raise_on_call = 99  # always raise
+    factory = APIRequestFactory()
+    view = _RecordingView.as_view()
+    # The second dispatch (retry) also raises, so the OperationalError
+    # propagates. The important thing is that _state is cleared.
+    with pytest.raises(OperationalError):
+        view(factory.get("/x"))
+    assert not hasattr(_state, "use_replica")
+
+
+def test_mixin_retries_once_on_operational_error(reset_view, caplog):
+    _RecordingView.raise_on_call = 1  # fail first call, succeed second
+    factory = APIRequestFactory()
+    view = _RecordingView.as_view()
+    with caplog.at_level(logging.WARNING):
+        response = view(factory.get("/x"))
+    assert response.status_code == 200
+    assert _RecordingView.call_count == 2
+    # First attempt had the flag, retry did not.
+    assert _RecordingView.saw_use_replica == [True, False]
+    # Fallback log emitted exactly once.
+    assert any("db_routing_fallback" in rec.message for rec in caplog.records)
+
+
+def test_mixin_retries_only_once(reset_view):
+    _RecordingView.raise_on_call = 2  # fail twice
+    factory = APIRequestFactory()
+    view = _RecordingView.as_view()
+    with pytest.raises(OperationalError):
+        view(factory.get("/x"))
+    assert _RecordingView.call_count == 2  # original + 1 retry

--- a/tests/config/test_db_routing.py
+++ b/tests/config/test_db_routing.py
@@ -1,0 +1,75 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from treeherder.config.db_routing import (
+    READ_REPLICA_APP_ALLOW_LIST,
+    ReadReplicaRouter,
+    _state,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_state():
+    """Ensure the thread-local is clean before and after every test."""
+    if hasattr(_state, "use_replica"):
+        del _state.use_replica
+    yield
+    if hasattr(_state, "use_replica"):
+        del _state.use_replica
+
+
+def _model(app_label):
+    m = MagicMock()
+    m._meta.app_label = app_label
+    return m
+
+
+def test_db_for_read_returns_replica_when_state_set_and_app_allowed():
+    _state.use_replica = True
+    router = ReadReplicaRouter()
+    assert router.db_for_read(_model("perf")) == "read_replica"
+    assert router.db_for_read(_model("model")) == "read_replica"
+
+
+def test_db_for_read_returns_none_when_state_unset():
+    router = ReadReplicaRouter()
+    assert router.db_for_read(_model("perf")) is None
+
+
+def test_db_for_read_returns_none_for_unlisted_app_even_when_state_set():
+    _state.use_replica = True
+    router = ReadReplicaRouter()
+    # Auth and sessions must always read from primary.
+    assert router.db_for_read(_model("auth")) is None
+    assert router.db_for_read(_model("sessions")) is None
+    assert router.db_for_read(_model("etl")) is None
+
+
+def test_db_for_write_always_returns_none():
+    _state.use_replica = True
+    router = ReadReplicaRouter()
+    assert router.db_for_write(_model("perf")) is None
+    assert router.db_for_write(_model("model")) is None
+
+
+def test_allow_relation_true_between_default_and_replica():
+    router = ReadReplicaRouter()
+    a, b = MagicMock(), MagicMock()
+    a._state.db = "default"
+    b._state.db = "read_replica"
+    assert router.allow_relation(a, b) is True
+    b._state.db = "default"
+    a._state.db = "read_replica"
+    assert router.allow_relation(a, b) is True
+
+
+def test_allow_migrate_blocks_replica():
+    router = ReadReplicaRouter()
+    assert router.allow_migrate("read_replica", "perf") is False
+    assert router.allow_migrate("default", "perf") is None
+    assert router.allow_migrate("default", "auth") is None
+
+
+def test_allow_list_is_perf_and_model():
+    assert READ_REPLICA_APP_ALLOW_LIST == {"perf", "model"}

--- a/tests/config/test_db_routing.py
+++ b/tests/config/test_db_routing.py
@@ -110,7 +110,6 @@ def reset_view():
     _RecordingView.raise_on_call = 0
     _RecordingView.call_count = 0
     _RecordingView.saw_use_replica = []
-    yield
 
 
 def test_mixin_flips_state_on_get(reset_view):

--- a/tests/config/test_db_routing.py
+++ b/tests/config/test_db_routing.py
@@ -162,3 +162,32 @@ def test_mixin_retries_only_once(reset_view):
     with pytest.raises(OperationalError):
         view(factory.get("/x"))
     assert _RecordingView.call_count == 2  # original + 1 retry
+
+
+def test_mixin_is_noop_when_replica_alias_not_configured(reset_view, caplog):
+    """When the kill switch is off (no replica alias), the mixin must not
+    flip the thread-local and must not emit fallback logs on primary errors.
+    """
+
+    from django.db import connections
+
+    _RecordingView.raise_on_call = 99  # always raise — simulates primary error
+    factory = APIRequestFactory()
+    view = _RecordingView.as_view()
+
+    # Temporarily drop the replica alias from the connection handler so the
+    # mixin sees the kill switch as off.
+    saved = connections.databases.pop("read_replica")
+    try:
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(OperationalError):
+                view(factory.get("/x"))
+    finally:
+        connections.databases["read_replica"] = saved
+
+    # Mixin did not flip the thread-local (no replica to route to).
+    assert _RecordingView.saw_use_replica == [False]
+    # Mixin did not retry — one call only, not two.
+    assert _RecordingView.call_count == 1
+    # No misleading fallback log.
+    assert not any("db_routing_fallback" in rec.message for rec in caplog.records)

--- a/tests/e2e/test_jobs_loaded.py
+++ b/tests/e2e/test_jobs_loaded.py
@@ -1,4 +1,11 @@
+import pytest
 from django.urls import reverse
+
+# The project jobs endpoint (JobsProjectViewSet) routes safe-method reads to the
+# read_replica alias (JOBS_POLLING_READ_REPLICA_DESIGN.md). transaction=True is
+# required because the routed viewset reads through the separate ``read_replica``
+# connection, which only sees committed data.
+pytestmark = pytest.mark.django_db(transaction=True, databases=["default", "read_replica"])
 
 
 def test_pending_job_available(test_repository, pending_jobs_stored, client):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,4 @@
+import copy
 import os
 
 from treeherder.config.settings import *  # noqa: F403
@@ -13,6 +14,13 @@ if TEST_DATABASE_URL:
     DATABASES["default"] = environ.Env.db_url_config(TEST_DATABASE_URL)  # noqa: F405
 
 DATABASES["default"]["TEST"] = {"NAME": "test_treeherder"}  # noqa: F405
+
+# Register a read_replica alias pointed at the same test DSN so integration
+# tests can capture per-alias queries via CaptureQueriesContext. The router
+# is installed unconditionally during tests so its behavior is exercised.
+DATABASES["read_replica"] = copy.deepcopy(DATABASES["default"])  # noqa: F405
+DATABASE_ROUTERS = ["treeherder.config.db_routing.ReadReplicaRouter"]
+
 KEY_PREFIX = "test"
 
 TREEHERDER_TEST_REPOSITORY_NAME = "mozilla-central"

--- a/tests/webapp/api/test_groupsummary_api.py
+++ b/tests/webapp/api/test_groupsummary_api.py
@@ -1,6 +1,13 @@
 import datetime
 
+import pytest
 from django.urls import reverse
+
+# SummaryByGroupName routes its safe-method reads to the read_replica alias
+# (JOBS_POLLING_READ_REPLICA_DESIGN.md). transaction=True is required because
+# the routed view reads through the separate ``read_replica`` connection, which
+# only sees committed data.
+pytestmark = pytest.mark.django_db(transaction=True, databases=["default", "read_replica"])
 
 
 # test date (future date, no data)

--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -7,6 +7,12 @@ from rest_framework.status import HTTP_400_BAD_REQUEST
 
 from treeherder.model.models import Job, TextLogError
 
+# JobsViewSet / JobsProjectViewSet route safe-method reads to the read_replica
+# alias (JOBS_POLLING_READ_REPLICA_DESIGN.md). transaction=True is required
+# because the routed viewset reads through the separate ``read_replica``
+# connection, which only sees committed data.
+pytestmark = pytest.mark.django_db(transaction=True, databases=["default", "read_replica"])
+
 
 @pytest.mark.parametrize(
     ("offset", "count", "expected_num"),

--- a/tests/webapp/api/test_perfcompare_api.py
+++ b/tests/webapp/api/test_perfcompare_api.py
@@ -8,7 +8,10 @@ from treeherder.model.models import Job
 from treeherder.perf.models import PerformanceDatum, PerformanceDatumReplicate
 from treeherder.webapp.api import perfcompare_utils
 
-pytestmark = pytest.mark.perf
+pytestmark = [
+    pytest.mark.perf,
+    pytest.mark.django_db(databases=["default", "read_replica"]),
+]
 
 NOW = datetime.datetime.now()
 ONE_DAY_AGO = NOW - datetime.timedelta(days=1)

--- a/tests/webapp/api/test_perfcompare_api.py
+++ b/tests/webapp/api/test_perfcompare_api.py
@@ -10,7 +10,9 @@ from treeherder.webapp.api import perfcompare_utils
 
 pytestmark = [
     pytest.mark.perf,
-    pytest.mark.django_db(databases=["default", "read_replica"]),
+    # transaction=True is required because the routed viewset reads through the
+    # separate ``read_replica`` connection, which only sees committed data.
+    pytest.mark.django_db(transaction=True, databases=["default", "read_replica"]),
 ]
 
 NOW = datetime.datetime.now()

--- a/tests/webapp/api/test_performance_bug_template_api.py
+++ b/tests/webapp/api/test_performance_bug_template_api.py
@@ -3,7 +3,10 @@ from django.urls import reverse
 
 from treeherder.perf.models import PerformanceBugTemplate, PerformanceFramework
 
-pytestmark = pytest.mark.perf
+pytestmark = [
+    pytest.mark.perf,
+    pytest.mark.django_db(databases=["default", "read_replica"]),
+]
 
 
 def test_perf_bug_template_api(client, test_perf_framework):

--- a/tests/webapp/api/test_performance_bug_template_api.py
+++ b/tests/webapp/api/test_performance_bug_template_api.py
@@ -5,7 +5,9 @@ from treeherder.perf.models import PerformanceBugTemplate, PerformanceFramework
 
 pytestmark = [
     pytest.mark.perf,
-    pytest.mark.django_db(databases=["default", "read_replica"]),
+    # transaction=True is required because the routed viewset reads through the
+    # separate ``read_replica`` connection, which only sees committed data.
+    pytest.mark.django_db(transaction=True, databases=["default", "read_replica"]),
 ]
 
 

--- a/tests/webapp/api/test_performance_data_api.py
+++ b/tests/webapp/api/test_performance_data_api.py
@@ -15,7 +15,10 @@ from treeherder.perf.models import (
 )
 from treeherder.webapp.api.performance_data import PerformanceSummary
 
-pytestmark = pytest.mark.perf
+pytestmark = [
+    pytest.mark.perf,
+    pytest.mark.django_db(databases=["default", "read_replica"]),
+]
 
 NOW = datetime.datetime.now()
 ONE_DAY_AGO = NOW - datetime.timedelta(days=1)

--- a/tests/webapp/api/test_performance_data_api.py
+++ b/tests/webapp/api/test_performance_data_api.py
@@ -17,7 +17,9 @@ from treeherder.webapp.api.performance_data import PerformanceSummary
 
 pytestmark = [
     pytest.mark.perf,
-    pytest.mark.django_db(databases=["default", "read_replica"]),
+    # transaction=True is required because the routed viewset reads through the
+    # separate ``read_replica`` connection, which only sees committed data.
+    pytest.mark.django_db(transaction=True, databases=["default", "read_replica"]),
 ]
 
 NOW = datetime.datetime.now()

--- a/tests/webapp/api/test_push_api.py
+++ b/tests/webapp/api/test_push_api.py
@@ -9,6 +9,12 @@ from treeherder.etl.push import store_push_data
 from treeherder.model.models import Commit, FailureClassification, JobNote, Push
 from treeherder.webapp.api import utils
 
+# PushViewSet routes safe-method reads to the read_replica alias
+# (JOBS_POLLING_READ_REPLICA_DESIGN.md). transaction=True is required because
+# the routed viewset reads through the separate ``read_replica`` connection,
+# which only sees committed data.
+pytestmark = pytest.mark.django_db(transaction=True, databases=["default", "read_replica"])
+
 
 def test_push_list_basic(client, eleven_jobs_stored, test_repository):
     """

--- a/tests/webapp/api/test_read_replica_routing.py
+++ b/tests/webapp/api/test_read_replica_routing.py
@@ -1,0 +1,41 @@
+"""End-to-end test that ReadReplicaMixin routes a real GET to the replica alias.
+
+Both DB aliases point at the same physical Postgres in test settings, but they
+are separate connections/sessions. We therefore use ``transaction=True`` so the
+``default`` connection commits its fixture writes and the ``read_replica``
+connection (separate session) can see them.
+"""
+
+import pytest
+from django.db import connections
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from treeherder.perf.models import PerformanceFramework
+
+pytestmark = pytest.mark.django_db(transaction=True, databases=["default", "read_replica"])
+
+
+def test_performance_framework_list_hits_replica(client):
+    PerformanceFramework.objects.create(name="talos", enabled=True)
+    PerformanceFramework.objects.create(name="awsy", enabled=True)
+
+    with CaptureQueriesContext(connections["read_replica"]) as replica_ctx:
+        response = client.get(reverse("performance-frameworks-list"))
+
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+    assert len(replica_ctx.captured_queries) > 0, (
+        "Expected PerformanceFramework reads to be routed to the replica alias"
+    )
+
+
+def test_performance_alert_summary_list_stays_on_default(client, test_perf_alert_summary):
+    """A viewset that is *not* opted in must not route to the replica."""
+    with CaptureQueriesContext(connections["read_replica"]) as replica_ctx:
+        response = client.get(reverse("performance-alert-summaries-list"))
+
+    assert response.status_code == 200
+    assert len(replica_ctx.captured_queries) == 0, (
+        "PerformanceAlertSummaryViewSet must remain on primary"
+    )

--- a/tests/webapp/api/test_read_replica_routing.py
+++ b/tests/webapp/api/test_read_replica_routing.py
@@ -11,6 +11,7 @@ from django.db import connections
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
+from treeherder.model.models import Job
 from treeherder.perf.models import PerformanceFramework
 
 pytestmark = pytest.mark.django_db(transaction=True, databases=["default", "read_replica"])
@@ -63,3 +64,50 @@ def test_performance_summary_hits_replica(client, test_perf_signature):
 
     assert response.status_code == 200
     assert len(replica_ctx.captured_queries) > 0
+
+
+# --- Jobs-view polling endpoints (JOBS_POLLING_READ_REPLICA_DESIGN.md) ---
+
+
+def test_jobs_list_hits_replica(client, eleven_jobs_stored, test_repository):
+    """The default /api/jobs/ polling endpoint (JobsViewSet) reads from the replica.
+
+    The default and project-bound jobs viewsets share the ``jobs-list`` URL
+    name, so we hit the default endpoint by its literal path to avoid the
+    ``reverse()`` ambiguity.
+    """
+    with CaptureQueriesContext(connections["read_replica"]) as replica_ctx:
+        response = client.get("/api/jobs/")
+
+    assert response.status_code == 200
+    assert response.json()["results"]
+    assert len(replica_ctx.captured_queries) > 0, (
+        "Expected JobsViewSet reads to be routed to the replica alias"
+    )
+
+
+def test_project_push_list_hits_replica(client, eleven_jobs_stored, test_repository):
+    """The push polling endpoint (PushViewSet.list) reads from the replica."""
+    with CaptureQueriesContext(connections["read_replica"]) as replica_ctx:
+        response = client.get(reverse("push-list", kwargs={"project": test_repository.name}))
+
+    assert response.status_code == 200
+    assert response.json()["results"]
+    assert len(replica_ctx.captured_queries) > 0, (
+        "Expected PushViewSet reads to be routed to the replica alias"
+    )
+
+
+def test_project_jobs_detail_hits_replica(client, eleven_jobs_stored, test_repository):
+    """Job detail (JobsProjectViewSet.retrieve) reads from the replica."""
+    job_id = Job.objects.values_list("id", flat=True).first()
+
+    with CaptureQueriesContext(connections["read_replica"]) as replica_ctx:
+        response = client.get(
+            reverse("jobs-detail", kwargs={"project": test_repository.name, "pk": job_id})
+        )
+
+    assert response.status_code == 200
+    assert len(replica_ctx.captured_queries) > 0, (
+        "Expected JobsProjectViewSet reads to be routed to the replica alias"
+    )

--- a/tests/webapp/api/test_read_replica_routing.py
+++ b/tests/webapp/api/test_read_replica_routing.py
@@ -111,3 +111,17 @@ def test_project_jobs_detail_hits_replica(client, eleven_jobs_stored, test_repos
     assert len(replica_ctx.captured_queries) > 0, (
         "Expected JobsProjectViewSet reads to be routed to the replica alias"
     )
+
+
+def test_groupsummary_hits_replica(client, group_data):
+    """The group summary aggregation (SummaryByGroupName) reads from the replica."""
+    startdate = str(group_data["query_string"]).split("=")[-1]
+
+    with CaptureQueriesContext(connections["read_replica"]) as replica_ctx:
+        response = client.get(reverse("groupsummary") + f"?startdate={startdate}")
+
+    assert response.status_code == 200
+    assert response.json() == group_data["expected"]
+    assert len(replica_ctx.captured_queries) > 0, (
+        "Expected SummaryByGroupName reads to be routed to the replica alias"
+    )

--- a/tests/webapp/api/test_read_replica_routing.py
+++ b/tests/webapp/api/test_read_replica_routing.py
@@ -39,3 +39,27 @@ def test_performance_alert_summary_list_stays_on_default(client, test_perf_alert
     assert len(replica_ctx.captured_queries) == 0, (
         "PerformanceAlertSummaryViewSet must remain on primary"
     )
+
+
+def test_performance_signatures_list_hits_replica(client, test_perf_signature):
+    with CaptureQueriesContext(connections["read_replica"]) as replica_ctx:
+        response = client.get(
+            reverse(
+                "performance-signatures-list",
+                kwargs={"project": test_perf_signature.repository.name},
+            )
+        )
+
+    assert response.status_code == 200
+    assert len(replica_ctx.captured_queries) > 0
+
+
+def test_performance_summary_hits_replica(client, test_perf_signature):
+    with CaptureQueriesContext(connections["read_replica"]) as replica_ctx:
+        response = client.get(
+            reverse("performance-summary")
+            + f"?repository={test_perf_signature.repository.name}&interval=86400"
+        )
+
+    assert response.status_code == 200
+    assert len(replica_ctx.captured_queries) > 0

--- a/treeherder/config/db_routing.py
+++ b/treeherder/config/db_routing.py
@@ -1,0 +1,45 @@
+"""Read-only replica routing.
+
+A thread-local flag, set by :class:`ReadReplicaMixin`, opts a single request
+into reading from the ``read_replica`` database alias. The router only routes
+models whose Django app label is in :data:`READ_REPLICA_APP_ALLOW_LIST`.
+
+Design: .claude/plans/READ_REPLICA_DESIGN.md
+"""
+
+from __future__ import annotations
+
+import threading
+
+# Apps whose models are eligible for replica reads when the thread-local is
+# set. Allow-list (not deny-list) so opting new code in is an explicit choice.
+READ_REPLICA_APP_ALLOW_LIST: frozenset[str] = frozenset({"perf", "model"})
+
+_state = threading.local()
+
+
+class ReadReplicaRouter:
+    """Route reads to ``read_replica`` when the thread-local flag is set."""
+
+    def db_for_read(self, model, **hints):
+        if not getattr(_state, "use_replica", False):
+            return None
+        if model._meta.app_label not in READ_REPLICA_APP_ALLOW_LIST:
+            return None
+        return "read_replica"
+
+    def db_for_write(self, model, **hints):
+        # Writes never go to the replica.
+        return None
+
+    def allow_relation(self, obj1, obj2, **hints):
+        dbs = {obj1._state.db, obj2._state.db}
+        if dbs <= {"default", "read_replica"}:
+            return True
+        return None
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        # Never run migrations against the replica.
+        if db == "read_replica":
+            return False
+        return None

--- a/treeherder/config/db_routing.py
+++ b/treeherder/config/db_routing.py
@@ -9,13 +9,21 @@ Design: .claude/plans/READ_REPLICA_DESIGN.md
 
 from __future__ import annotations
 
+import logging
 import threading
+
+from django.db import connections
+from django.db.utils import InterfaceError, OperationalError
 
 # Apps whose models are eligible for replica reads when the thread-local is
 # set. Allow-list (not deny-list) so opting new code in is an explicit choice.
 READ_REPLICA_APP_ALLOW_LIST: frozenset[str] = frozenset({"perf", "model"})
 
 _state = threading.local()
+
+logger = logging.getLogger(__name__)
+
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
 
 class ReadReplicaRouter:
@@ -43,3 +51,49 @@ class ReadReplicaRouter:
         if db == "read_replica":
             return False
         return None
+
+
+class ReadReplicaMixin:
+    """Opt a view's safe HTTP methods into reading from ``read_replica``.
+
+    For GET/HEAD/OPTIONS, the thread-local flag is set before ``dispatch``
+    runs and cleared in a ``finally``. On :class:`OperationalError` or
+    :class:`InterfaceError`, the request is retried once against the primary;
+    further failures propagate.
+    """
+
+    def handle_exception(self, exc):
+        # DRF's APIView.dispatch() wraps handler calls in a try/except that
+        # routes exceptions through handle_exception, which would swallow
+        # OperationalError/InterfaceError as a 500 response. Re-raise them
+        # here so the outer try/except in our dispatch() can trigger the
+        # fallback retry.
+        if isinstance(exc, OperationalError | InterfaceError):
+            raise exc
+        return super().handle_exception(exc)
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.method not in _SAFE_METHODS:
+            return super().dispatch(request, *args, **kwargs)
+
+        _state.use_replica = True
+        try:
+            try:
+                return super().dispatch(request, *args, **kwargs)
+            except (OperationalError, InterfaceError) as exc:
+                logger.warning(
+                    "db_routing_fallback path=%s method=%s exception_type=%s",
+                    request.path,
+                    request.method,
+                    type(exc).__name__,
+                )
+                # Drop the (likely bad) replica connection before retrying.
+                try:
+                    connections["read_replica"].close()
+                except Exception:
+                    pass
+                _state.use_replica = False
+                return super().dispatch(request, *args, **kwargs)
+        finally:
+            if hasattr(_state, "use_replica"):
+                del _state.use_replica

--- a/treeherder/config/db_routing.py
+++ b/treeherder/config/db_routing.py
@@ -76,6 +76,12 @@ class ReadReplicaMixin:
         if request.method not in _SAFE_METHODS:
             return super().dispatch(request, *args, **kwargs)
 
+        # No-op when the replica alias is not configured (kill switch off).
+        # Without this guard the fallback log line below would fire on any
+        # primary failure, misleading on-call into investigating the replica.
+        if "read_replica" not in connections.databases:
+            return super().dispatch(request, *args, **kwargs)
+
         _state.use_replica = True
         try:
             try:

--- a/treeherder/config/db_routing.py
+++ b/treeherder/config/db_routing.py
@@ -3,8 +3,6 @@
 A thread-local flag, set by :class:`ReadReplicaMixin`, opts a single request
 into reading from the ``read_replica`` database alias. The router only routes
 models whose Django app label is in :data:`READ_REPLICA_APP_ALLOW_LIST`.
-
-Design: .claude/plans/READ_REPLICA_DESIGN.md
 """
 
 from __future__ import annotations
@@ -83,6 +81,11 @@ class ReadReplicaMixin:
             return super().dispatch(request, *args, **kwargs)
 
         _state.use_replica = True
+        logger.debug(
+            "db_routing routed_to=read_replica path=%s method=%s",
+            request.path,
+            request.method,
+        )
         try:
             try:
                 return super().dispatch(request, *args, **kwargs)

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -143,6 +143,16 @@ UPSTREAM_DATABASE_URL = env("UPSTREAM_DATABASE_URL", default=None)
 if UPSTREAM_DATABASE_URL:
     DATABASES["upstream"] = env.db_url_config(UPSTREAM_DATABASE_URL)
 
+# Optional read-only replica for offloading specific GET endpoints from the
+# primary. Both env vars must be set for routing to activate. See
+# treeherder/config/db_routing.py and .claude/plans/READ_REPLICA_DESIGN.md.
+READ_REPLICA_DATABASE_URL = env("READ_REPLICA_DATABASE_URL", default=None)
+READ_REPLICA_ENABLED = env.bool("READ_REPLICA_ENABLED", default=False)
+
+if READ_REPLICA_DATABASE_URL and READ_REPLICA_ENABLED:
+    DATABASES["read_replica"] = env.db_url_config(READ_REPLICA_DATABASE_URL)
+    DATABASE_ROUTERS = ["treeherder.config.db_routing.ReadReplicaRouter"]
+
 # We're intentionally not using django-environ's query string options feature,
 # since it hides configuration outside of the repository, plus could lead to
 # drift between environments.

--- a/treeherder/webapp/api/groups.py
+++ b/treeherder/webapp/api/groups.py
@@ -6,13 +6,14 @@ from django.db.models import Count
 from rest_framework import generics
 from rest_framework.response import Response
 
+from treeherder.config.db_routing import ReadReplicaMixin
 from treeherder.model.models import Job
 from treeherder.webapp.api.serializers import GroupNameSerializer
 
 logger = logging.getLogger(__name__)
 
 
-class SummaryByGroupName(generics.ListAPIView):
+class SummaryByGroupName(ReadReplicaMixin, generics.ListAPIView):
     """
     This yields group names/status summary for the given group and day.
     """

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
+from treeherder.config.db_routing import ReadReplicaMixin
 from treeherder.model.error_summary import get_error_summary
 from treeherder.model.models import (
     Job,
@@ -82,7 +83,7 @@ class JobFilter(django_filters.FilterSet):
         }
 
 
-class JobsViewSet(viewsets.ReadOnlyModelViewSet):
+class JobsViewSet(ReadReplicaMixin, viewsets.ReadOnlyModelViewSet):
     """
     This viewset is the jobs endpoint.
     """
@@ -158,7 +159,7 @@ class JobsViewSet(viewsets.ReadOnlyModelViewSet):
         return Response(resp.data)
 
 
-class JobsProjectViewSet(viewsets.ViewSet):
+class JobsProjectViewSet(ReadReplicaMixin, viewsets.ViewSet):
     """
     This viewset is the project bound version of the jobs endpoint.
     """

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -71,7 +71,7 @@ from .utils import SHERIFFED_FRAMEWORKS, GroupConcat, get_profile_artifact_url
 logger = logging.getLogger(__name__)
 
 
-class PerformanceSignatureViewSet(viewsets.ViewSet):
+class PerformanceSignatureViewSet(ReadReplicaMixin, viewsets.ViewSet):
     def list(self, request, project):
         repository = models.Repository.objects.get(name=project)
 
@@ -205,7 +205,7 @@ class PerformanceSignatureViewSet(viewsets.ViewSet):
         return Response(signature_map)
 
 
-class PerformancePlatformViewSet(viewsets.ViewSet):
+class PerformancePlatformViewSet(ReadReplicaMixin, viewsets.ViewSet):
     """
     All platforms for a particular branch that have performance data
     """
@@ -234,7 +234,7 @@ class PerformanceFrameworkViewSet(ReadReplicaMixin, viewsets.ReadOnlyModelViewSe
     ordering = "id"
 
 
-class PerformanceJobViewSet(viewsets.ReadOnlyModelViewSet):
+class PerformanceJobViewSet(ReadReplicaMixin, viewsets.ReadOnlyModelViewSet):
     def list(self, request, project):
         repository = models.Repository.objects.get(name=project)
         # Expect exactly one job_id in query params
@@ -294,7 +294,7 @@ class PerformanceJobViewSet(viewsets.ReadOnlyModelViewSet):
         return Response(results)
 
 
-class PerformanceDatumViewSet(viewsets.ViewSet):
+class PerformanceDatumViewSet(ReadReplicaMixin, viewsets.ViewSet):
     """
     This view serves performance test result data
     """
@@ -895,21 +895,21 @@ class PerformanceAlertViewSet(viewsets.ModelViewSet):
         raise exceptions.APIException("Nudging has been disabled", 400)
 
 
-class PerformanceBugTemplateViewSet(viewsets.ReadOnlyModelViewSet):
+class PerformanceBugTemplateViewSet(ReadReplicaMixin, viewsets.ReadOnlyModelViewSet):
     queryset = PerformanceBugTemplate.objects.all()
     serializer_class = PerformanceBugTemplateSerializer
     filter_backends = (django_filters.rest_framework.DjangoFilterBackend, filters.OrderingFilter)
     filterset_fields = ["framework"]
 
 
-class PerformanceIssueTrackerViewSet(viewsets.ReadOnlyModelViewSet):
+class PerformanceIssueTrackerViewSet(ReadReplicaMixin, viewsets.ReadOnlyModelViewSet):
     queryset = IssueTracker.objects.all()
     serializer_class = IssueTrackerSerializer
     filter_backends = [filters.OrderingFilter]
     ordering = "id"
 
 
-class PerformanceSummary(generics.ListAPIView):
+class PerformanceSummary(ReadReplicaMixin, generics.ListAPIView):
     serializer_class = PerformanceSummarySerializer
     queryset = None
 
@@ -1157,7 +1157,7 @@ class PerformanceSummary(generics.ListAPIView):
         return serialized_data
 
 
-class PerformanceAlertSummaryTasks(generics.ListAPIView):
+class PerformanceAlertSummaryTasks(ReadReplicaMixin, generics.ListAPIView):
     serializer_class = PerformanceAlertSummaryTasksSerializer
     queryset = None
 
@@ -1183,7 +1183,7 @@ class PerformanceAlertSummaryTasks(generics.ListAPIView):
         return Response(data=serializer.data)
 
 
-class PerfCompareResults(generics.ListAPIView):
+class PerfCompareResults(ReadReplicaMixin, generics.ListAPIView):
     serializer_class = PerfCompareResultsSerializer
     queryset = None
 
@@ -2079,7 +2079,7 @@ class PerfCompareResults(generics.ListAPIView):
         return stats_data
 
 
-class TestSuiteHealthViewSet(viewsets.ViewSet):
+class TestSuiteHealthViewSet(ReadReplicaMixin, viewsets.ViewSet):
     def list(self, request):
         query_params = TestSuiteHealthParamsSerializer(data=request.query_params)
         if not query_params.is_valid():

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -28,6 +28,7 @@ from rest_framework import exceptions, filters, generics, pagination, viewsets
 from rest_framework.response import Response
 from rest_framework.status import HTTP_400_BAD_REQUEST
 
+from treeherder.config.db_routing import ReadReplicaMixin
 from treeherder.etl.common import to_timestamp
 from treeherder.model import models
 from treeherder.perf import stats
@@ -226,7 +227,7 @@ class PerformancePlatformViewSet(viewsets.ViewSet):
         return Response(signature_data.values_list("platform__platform", flat=True).distinct())
 
 
-class PerformanceFrameworkViewSet(viewsets.ReadOnlyModelViewSet):
+class PerformanceFrameworkViewSet(ReadReplicaMixin, viewsets.ReadOnlyModelViewSet):
     queryset = PerformanceFramework.objects.filter(enabled=True)
     serializer_class = PerformanceFrameworkSerializer
     filter_backends = [filters.OrderingFilter]

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -10,6 +10,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
+from treeherder.config.db_routing import ReadReplicaMixin
 from treeherder.log_parser.failureline import get_group_results
 from treeherder.model.models import Commit, Job, JobType, Push, Repository
 from treeherder.push_health.builds import get_build_failures
@@ -28,7 +29,7 @@ from treeherder.webapp.api.utils import to_datetime, to_timestamp
 logger = logging.getLogger(__name__)
 
 
-class PushViewSet(viewsets.ViewSet):
+class PushViewSet(ReadReplicaMixin, viewsets.ViewSet):
     """
     View for ``push`` records
     """


### PR DESCRIPTION
## Route read-only endpoints to a PostgreSQL read replica

### Summary
Adds an opt-in mechanism to serve a defined set of **read-only GET endpoints** from a PostgreSQL **read replica** instead of the primary, to relieve the primary of read load that competes with the data-ingestion write workload. Ships **off by default** and is controlled entirely by environment variables — no code change needed to turn it on or off.

### How it works
- **`ReadReplicaRouter`** (`treeherder/config/db_routing.py`) — a Django DB router that sends reads to a `read_replica` alias when a thread-local flag is set, but **only** for models whose app label is in an allow-list (`{"perf", "model"}`). Everything else stays on the primary.
- **`ReadReplicaMixin`** — a viewset/APIView mixin that flips the flag for **safe HTTP methods only** (GET/HEAD/OPTIONS). Unsafe methods (POST/PUT/PATCH/DELETE) always use the primary, so a viewset can mix routed reads and primary writes safely.
- **Auto-fallback** — on a replica `OperationalError`/`InterfaceError`, the request is retried **once against the primary** and a `db_routing_fallback` WARNING is logged. A degraded replica means "served from primary," not errors.
- **Kill switch** — gated on `READ_REPLICA_ENABLED`; when off (or the replica URL is unset), the alias isn't registered and the router isn't installed (complete no-op). Celery, ETL, and management commands are untouched and always use the primary.

### Endpoints routed
- **Jobs view polling** (the busiest read traffic): `/api/jobs/`, `/api/project/{repo}/push/`, `/api/project/{repo}/jobs/{id}/` (detail + similar/text-log actions).
- **Group summary**: `/api/groupsummary/` — a heavy day-wide multi-join aggregation, one of the most expensive reads in the app.
- **Perfherder reads**: (not as expensive, low hanging fruit): framework, signatures, platforms, job-data, data, bug-template, issue-tracker, validity-dashboard, summary, alertsummary-tasks, perfcompare results.

Perfherder **mutating** endpoints (alert summaries, alerts, tags) intentionally stay on the primary so a user's write is immediately visible on re-read.

### Consistency / safety
The routed jobs/push/group/Perfherder-read paths have no synchronous read-after-write: job actions go through Taskcluster + ingestion (not a direct DB write the user re-reads), and job classification updates `failure_classification_id` and `last_modified` in the same row, so a lagging replica returns either the whole old row or the whole new row — no torn reads. Polling tolerates replica lag via the existing cursor safety buffer; worst case a new job/push appears one poll cycle later.

### Enabling (for deploy/app-config owners)
Set **both** (both required to activate):
| Variable                    | Value                                      |
| --------------------------- | ------------------------------------------ |
| `READ_REPLICA_DATABASE_URL` | replica DSN, same format as `DATABASE_URL` |
| `READ_REPLICA_ENABLED`      | `true`                                     |

Verify from inside the app with `./manage.py dbshell --database=read_replica`. Recommended rollout: enable in **stage** → soak several days → enable in **prod**. Kill switch is `READ_REPLICA_ENABLED=false` (no deploy). During soak, watch: primary DB CPU/connections (should drop), replica CPU (should rise — currently near-zero, ample headroom), and `db_routing_fallback` log volume (should stay ~0).

### Testing
- Unit tests for the router and mixin (`tests/config/test_db_routing.py`) — allow-list routing, safe-vs-unsafe methods, state cleanup, one-shot fallback.
- End-to-end routing tests (`tests/webapp/api/test_read_replica_routing.py`) asserting per-alias query capture for the jobs, push, job-detail, group-summary, and Perfherder endpoints, plus a control proving a non-opted-in viewset stays on primary.
- Existing job/push/group/Perfherder API suites updated to run with both aliases (`transaction=True`, `databases=["default", "read_replica"]`) since routed reads use a separate connection that only sees committed data.

### Follow-ups (not in this PR)
Once proven in prod, the next routing candidates are the **Intermittent Failures views** (`/api/failures/`, `/api/failuresbybug/`, `/api/failurecount/`) — heavy date-range aggregations, GET-only, lag-tolerant, all in the already-allow-listed `model` app.

## Next candidates
- **Tier 1 (do next):** the **Intermittent Failures views** — `Failures`, `FailuresByBug`, `FailureCount` (`intermittents_view.py`). Heavy date-range `Count`/`TruncDate` aggregations, GET-only, highly lag-tolerant, all in the `model` app → no allow-list change. This is the standout.
- **Tier 2:** `InfraCompareView`, `NoteViewSet`, `BugJobMapViewSet`, `HashViewSet.tocommit`, `FilesBugzillaMapViewSet` — with a flagged **read-after-write nuance** on notes/bug-job-map (classify→view) to decide on first.
- **Tier 3:** small refdata endpoints — harmless but negligible.
- **Not routable** without an allow-list change: `ChangelogViewSet` (changelog app), `UserViewSet` (auth app).
- Key reassurance for the comment: **every routable candidate is in `{model, perf}`**, so they're all "add mixin + test," no router change.
