### PR TITLE
Bug 2017561 - Use IN clauses instead of OR-chains in alert summary

### DIFF
--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -567,17 +567,19 @@ class PerformanceAlertSummaryViewSet(viewsets.ModelViewSet):
         keys = {(summary.push_id, summary.framework_id) for summary in page}
         if not keys:
             return {}
-        q = Q()
-        for push_id, framework_id in keys:
-            q |= Q(push_id=push_id, framework_id=framework_id)
-        rows = PerformanceAlertSummary.objects.filter(q).values(
-            "id", "status", "push_id", "framework_id"
-        )
+        push_ids = {push_id for push_id, _ in keys}
+        framework_ids = {framework_id for _, framework_id in keys}
+        rows = PerformanceAlertSummary.objects.filter(
+            push_id__in=push_ids,
+            framework_id__in=framework_ids,
+        ).values("id", "status", "push_id", "framework_id")
         result = defaultdict(list)
         for row in rows:
-            result[(row["push_id"], row["framework_id"])].append(
-                {"id": row["id"], "status": row["status"]}
-            )
+            key = (row["push_id"], row["framework_id"])
+            if key not in keys:
+                # Cartesian over-fetch from independent IN clauses; ignore.
+                continue
+            result[key].append({"id": row["id"], "status": row["status"]})
         return dict(result)
 
     def _build_tc_metadata_map(self, page):
@@ -585,43 +587,55 @@ class PerformanceAlertSummaryViewSet(viewsets.ModelViewSet):
         Returns a dict mapping (signature_id, push_id) -> {"task_id": ..., "retry_id": ...}
         for all alerts on this page, replacing per-alert TC metadata queries.
         """
-        datum_keys = set()
+        target_keys = set()
+        all_repo_ids = set()
+        all_sig_ids = set()
+        all_push_ids = set()
         for summary in page:
             push_id = summary.push_id
             prev_push_id = summary.prev_push_id
             for alert in summary.alerts.all():
                 sig = alert.series_signature
-                datum_keys.add((sig.repository_id, sig.id, push_id))
-                datum_keys.add((sig.repository_id, sig.id, prev_push_id))
+                target_keys.add((sig.id, push_id))
+                target_keys.add((sig.id, prev_push_id))
+                all_repo_ids.add(sig.repository_id)
+                all_sig_ids.add(sig.id)
+                all_push_ids.add(push_id)
+                all_push_ids.add(prev_push_id)
             for alert in summary.related_alerts.all():
                 sig = alert.series_signature
-                datum_keys.add((sig.repository_id, sig.id, alert.summary.push_id))
-                datum_keys.add((sig.repository_id, sig.id, alert.summary.prev_push_id))
-        if not datum_keys:
+                rs_push_id = alert.summary.push_id
+                rs_prev_push_id = alert.summary.prev_push_id
+                target_keys.add((sig.id, rs_push_id))
+                target_keys.add((sig.id, rs_prev_push_id))
+                all_repo_ids.add(sig.repository_id)
+                all_sig_ids.add(sig.id)
+                all_push_ids.add(rs_push_id)
+                all_push_ids.add(rs_prev_push_id)
+        all_push_ids.discard(None)
+        if not target_keys or not all_push_ids:
             return {}
+        rows = PerformanceDatum.objects.filter(
+            repository_id__in=all_repo_ids,
+            signature_id__in=all_sig_ids,
+            push_id__in=all_push_ids,
+        ).values(
+            "signature_id",
+            "push_id",
+            "job__taskcluster_metadata__task_id",
+            "job__taskcluster_metadata__retry_id",
+        )
         result = {}
-        datum_keys_list = list(datum_keys)
-        chunk_size = 500
-        for i in range(0, len(datum_keys_list), chunk_size):
-            chunk = datum_keys_list[i : i + chunk_size]
-            q = Q()
-            for repo_id, sig_id, push_id in chunk:
-                q |= Q(repository_id=repo_id, signature_id=sig_id, push_id=push_id)
-            rows = PerformanceDatum.objects.filter(q).values(
-                "repository_id",
-                "signature_id",
-                "push_id",
-                "job__taskcluster_metadata__task_id",
-                "job__taskcluster_metadata__retry_id",
-            )
-            for row in rows:
-                key = (row["signature_id"], row["push_id"])
-                if key in result:
-                    continue
-                task_id = row["job__taskcluster_metadata__task_id"]
-                retry_id = row["job__taskcluster_metadata__retry_id"]
-                if task_id is not None:
-                    result[key] = {"task_id": task_id, "retry_id": retry_id}
+        for row in rows:
+            key = (row["signature_id"], row["push_id"])
+            if key not in target_keys or key in result:
+                # Cartesian over-fetch (key wasn't requested) or duplicate datum
+                # for the same (signature, push) — keep the first one with a task_id.
+                continue
+            task_id = row["job__taskcluster_metadata__task_id"]
+            retry_id = row["job__taskcluster_metadata__retry_id"]
+            if task_id is not None:
+                result[key] = {"task_id": task_id, "retry_id": retry_id}
         return result
 
     def get_serializer_context(self):

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -594,14 +594,14 @@ class PerformanceAlertSummaryViewSet(viewsets.ModelViewSet):
         for summary in page:
             push_id = summary.push_id
             prev_push_id = summary.prev_push_id
+            all_push_ids.add(push_id)
+            all_push_ids.add(prev_push_id)
             for alert in summary.alerts.all():
                 sig = alert.series_signature
                 target_keys.add((sig.id, push_id))
                 target_keys.add((sig.id, prev_push_id))
                 all_repo_ids.add(sig.repository_id)
                 all_sig_ids.add(sig.id)
-                all_push_ids.add(push_id)
-                all_push_ids.add(prev_push_id)
             for alert in summary.related_alerts.all():
                 sig = alert.series_signature
                 rs_push_id = alert.summary.push_id


### PR DESCRIPTION
Summary
  
  Refactor _build_tc_metadata_map and _build_duplicated_summaries_map in PerformanceAlertSummaryViewSet to use SQL IN clauses instead of chunked OR-chains. No behavior change —
  payload is byte-for-byte identical (verified by JSON diff across 10 summary IDs of varying sizes).

  Problem
  
  For alert summaries with thousands of alerts, /api/performance/alertsummary/?id= was issuing up to 9 chunked queries against performance_datum, each with a 500-way OR over
  (repository_id, signature_id, push_id) tuples — ~69 KB of SQL per query. On a real summary with 2103 alerts (id 43868), this alone accounted for ~5s of DB time.

  Solution

  Collapse the lookup into a single query that filters via three IN clauses (repository_id__in, signature_id__in, push_id__in) and discard the small amount of cartesian
  over-fetch in Python. The same treatment is applied to _build_duplicated_summaries_map.

  Benchmarks — DB time

  Staging Postgres, 10 representative summary IDs, 7 runs each, mock-tc to isolate DB performance, median reported.

  ID     | alerts | Queries before->after | DB ms before->after | DB gain
  -------|--------|-----------------------|---------------------|--------
  43868  |  2103  | 21 -> 13              | 4515 -> 2234        | -50.5%
  44024  |  1430  | 18 -> 13              | 3678 -> 2217        | -39.7%
  43986  |   563  | 15 -> 13              | 2805 -> 2186        | -22.1%
  44920  |   470  | 14 -> 13              | 2584 -> 2176        | -15.8%
  45593  |   422  | 14 -> 13              | 2539 -> 2179        | -14.2%
  45169  |   303  | 14 -> 13              | 2537 -> 2188        | -13.8%
  45512  |   267  | 14 -> 13              | 2498 -> 2174        | -13.0%
  41781  |   211  | 13 -> 13              | 2284 -> 2162        |  -5.3%
  43290  |   193  | 13 -> 13              | 2270 -> 2166        |  -4.6%
  44042  |   133  | 13 -> 13              | 2254 -> 2165        |  -3.9%

  Query count is now constant (13) regardless of summary size; previously it scaled with alert count due to OR-chain chunking.

  Benchmarks — real endpoint
  
  GET /api/performance/alertsummary/?id=X. cold = first request with Redis cleared; warm = median of 3 subsequent requests.

  ID     | alerts | regressions  | Opt cold | Opt warm | Base cold | Base warm | Cold gain
  -------|--------|--------------|----------|----------|-----------|-----------|----------
  43868  |  2103  |   0 (  0%)   |   7.16s  |   7.48s  |   17.13s  |   10.53s  |  -58%
  41867  |   120  |  56 ( 47%)   |   4.21s  |   3.71s  |    4.56s  |    3.85s  |   -8%
  45158  |   401  | 289 ( 72%)   |  19.70s  |   9.21s  |   19.44s  |    9.68s  |   ~0%
  43986  |   563  | 563 (100%)   |  41.29s  |  40.84s  |   43.16s  |   42.00s  |   -4%
  44024  |  1430  | 1430(100%)   | 101.06s  |  96.92s  |  103.63s  |  105.57s  |   -2%

  The DB savings are present everywhere; their visibility at endpoint level depends on the alert mix:

  - Improvement-heavy summaries (low regression count) are DB-bound — the optimization shows up in full (e.g., id 43868: 17s -> 7s cold, the original problem case from the bug).
  - Regression-heavy summaries are bottlenecked by external Taskcluster HTTP calls inside _fetch_profile_urls, which the DB optimization cannot offset.

