### PR TITLE
Bug 2039553 - Alerts View: some alert outer lines disappear when having a note attached

### DIFF
--- a/ui/perfherder/alerts/AlertTable.jsx
+++ b/ui/perfherder/alerts/AlertTable.jsx
@@ -465,7 +465,7 @@ export default class AlertTable extends React.Component {
                     <tr
                       className={`${
                         alertSummary.notes
-                          ? 'border-top border-left border-right'
+                          ? 'border-top border-start border-end'
                           : 'border'
                       }`}
                     >

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -425,7 +425,7 @@ export default class AlertTableRow extends React.Component {
     return (
       <tr
         className={`align-middle ${
-          alertSummary.notes ? 'border-top border-left border-right' : 'border'
+          alertSummary.notes ? 'border-top border-start border-end' : 'border'
         }`}
         aria-label="Alert table row"
         data-testid={alert.id}

--- a/ui/perfherder/alerts/CollapsableRows.jsx
+++ b/ui/perfherder/alerts/CollapsableRows.jsx
@@ -43,7 +43,7 @@ export default class CollapsableRows extends React.Component {
           <AlertTableRow key={alert.id} alert={alert} {...this.props} />
         ))}
         <tr
-          className="border-left border-right"
+          className="border-start border-end"
           role="button"
           onClick={() => this.toggleRows()}
           data-testid={isOpen ? 'show-less-alerts' : 'show-more-alerts'}


### PR DESCRIPTION
[Bug 2039553 - Alerts View: some alert outer lines disappear when having a note attached](https://bugzilla.mozilla.org/show_bug.cgi?id=2039553)

before:
<img width="1298" height="366" alt="Screenshot 2026-05-14 at 15 29 40" src="https://github.com/user-attachments/assets/41ebc45d-a884-432b-b3a2-8794262d7cf9" />

after:
<img width="1264" height="523" alt="Screenshot 2026-05-21 at 15 32 55" src="https://github.com/user-attachments/assets/5d660eac-8568-4d0b-a5e3-8cdd759a95b7" />

