### PR TITLE
Add a "Show task group profile" item to the push action menu

### DIFF
--- a/ui/job-view/pushes/PushActionMenu.jsx
+++ b/ui/job-view/pushes/PushActionMenu.jsx
@@ -29,6 +29,12 @@ function PushActionMenu({
   const [customJobActionsShowing, setCustomJobActionsShowing] = useState(false);
 
   const decisionTaskMap = usePushesStore((state) => state.decisionTaskMap);
+  const decisionTask = decisionTaskMap[pushId];
+  const taskGroupProfileUrl = decisionTask
+    ? `https://profiler.firefox.com/from-url/${encodeURIComponent(
+        `https://firefox-ci-tc.services.mozilla.com/api/web-server/v1/task-group/${decisionTask.id}/profile`,
+      )}`
+    : null;
 
   const updateParamsAndRange = useCallback(
     (param) => {
@@ -172,6 +178,16 @@ function PushActionMenu({
             Set as bottom of range
           </Dropdown.Item>
           <Dropdown.Divider />
+          <Dropdown.Item
+            tag="a"
+            href={taskGroupProfileUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            disabled={!taskGroupProfileUrl}
+            title="Show a profile of all tasks in this push's task group"
+          >
+            Show task group profile
+          </Dropdown.Item>
           <Dropdown.Item
             tag="a"
             href={getPerfCompareChooserUrl({


### PR DESCRIPTION
Builds a profiler.firefox.com URL from the push's decision task ID (which is also the task group ID) and opens it in a new tab.

Taskcluster added support for showing profiles of a task group a little while ago. The way to access these profiles from treeherder is currently requires too many clicks: select the decision task, then click the "Task" link in the bottom left corner, from the page that opens click the "Task Group" link, from there hover the dot dot dot menu in the bottom right corner, then click "Open in Profiler" in the menu that appears.

I think we should simplify all of that by making it a single click from the push drop down menu on treeherder:
<img width="428" height="415" alt="image" src="https://github.com/user-attachments/assets/b100a050-8329-4e10-ba89-ab331c4cf48b" />
