### PR TITLE
Optimize performance_datum queries in alert generation

### DIFF
--- a/tests/perfalert/test_alerts.py
+++ b/tests/perfalert/test_alerts.py
@@ -5,11 +5,15 @@ from unittest import mock
 import pytest
 
 from treeherder.model.models import Push
-from treeherder.perf.alerts import generate_new_alerts_in_series
+from treeherder.perf.alerts import (
+    _collect_replicates_map,
+    generate_new_alerts_in_series,
+)
 from treeherder.perf.models import (
     PerformanceAlert,
     PerformanceAlertSummary,
     PerformanceDatum,
+    PerformanceDatumReplicate,
     PerformanceSignature,
 )
 from treeherder.perf.utils import BUG_DAYS, TRIAGE_DAYS, calculate_time_to
@@ -440,3 +444,50 @@ def test_alert_emails(
                 for call_arg in mocked_email_client.email.call_args_list
             ]
         )
+
+
+def test_collect_replicates_map_groups_values_for_in_window_datums(
+    test_repository,
+    test_perf_signature,
+    test_perf_signature_2,
+):
+    base_time = time.time()
+    alert_after_ts = datetime.datetime.utcfromtimestamp(base_time)
+
+    def _make_datum(signature, offset, value):
+        push, _ = Push.objects.get_or_create(
+            repository=test_repository,
+            revision=f"replicaterev{offset}",
+            defaults={
+                "author": "foo@bar.com",
+                "time": datetime.datetime.fromtimestamp(base_time + offset),
+            },
+        )
+        return PerformanceDatum.objects.create(
+            repository=signature.repository,
+            push=push,
+            signature=signature,
+            push_timestamp=datetime.datetime.utcfromtimestamp(base_time + offset),
+            value=value,
+        )
+
+    # in-window datum with two replicates -> grouped under its id
+    datum_with_replicates = _make_datum(test_perf_signature, 10, 1.0)
+    PerformanceDatumReplicate.objects.create(performance_datum=datum_with_replicates, value=1.1)
+    PerformanceDatumReplicate.objects.create(performance_datum=datum_with_replicates, value=1.2)
+
+    # in-window datum with no replicates -> absent from the map
+    _make_datum(test_perf_signature, 20, 2.0)
+
+    # datum before alert_after_ts with a replicate -> excluded by the window
+    old_datum = _make_datum(test_perf_signature, -100, 3.0)
+    PerformanceDatumReplicate.objects.create(performance_datum=old_datum, value=3.1)
+
+    # in-window datum for a different signature -> excluded by the signature filter
+    other_datum = _make_datum(test_perf_signature_2, 30, 4.0)
+    PerformanceDatumReplicate.objects.create(performance_datum=other_datum, value=4.1)
+
+    result = _collect_replicates_map(test_perf_signature, alert_after_ts)
+
+    assert set(result.keys()) == {datum_with_replicates.id}
+    assert sorted(result[datum_with_replicates.id]) == [1.1, 1.2]

--- a/treeherder/perf/alerts.py
+++ b/treeherder/perf/alerts.py
@@ -74,25 +74,21 @@ def get_alert_properties(prev_value, new_value, lower_is_better):
     return AlertProperties(pct_change, delta, is_regression, prev_value, new_value)
 
 
-def generate_new_alerts_in_series(signature):
-    # get series data starting from either:
-    # (1) the last alert, if there is one
-    # (2) the alerts max age
-    # (use whichever is newer)
-    max_alert_age = alert_after_ts = datetime.now() - settings.PERFHERDER_ALERTS_MAX_AGE
-    series = PerformanceDatum.objects.filter(signature=signature, push_timestamp__gte=max_alert_age)
-    latest_alert_timestamp = (
-        PerformanceAlert.objects.filter(series_signature=signature)
-        .select_related("summary__push__time")
-        .order_by("-summary__push__time")
-        .values_list("summary__push__time", flat=True)[:1]
-    )
-    if latest_alert_timestamp:
-        latest_ts = latest_alert_timestamp[0]
-        series = series.filter(push_timestamp__gt=latest_ts)
-        if latest_ts > alert_after_ts:
-            alert_after_ts = latest_ts
+def _collect_replicates_map(signature, alert_after_ts) -> dict[int, list[float]]:
+    """Map each performance datum id to the list of its replicate values.
 
+    Only datums for ``signature`` (and its repository) with a ``push_timestamp``
+    on or after ``alert_after_ts`` are considered.
+
+    The two-step ``IN (SELECT ... WHERE EXISTS (...))`` shape looks redundant --
+    a replicate row's parent datum is in the set by definition -- but it is
+    load-bearing for the query planner. It first resolves the small set of datum
+    ids via the ``(repository, signature, push_timestamp)`` composite index, then
+    probes ``performance_datum_replicate`` by its ``performance_datum_id`` index.
+    A plain join instead lets PostgreSQL seq-scan a multi-hundred-million-row
+    table (measured on staging: ~22s vs ~53ms warm / 5.4s cold for this shape;
+    dropping the EXISTS alone regressed to ~65s). See PR #9550 review discussion.
+    """
     datum_with_replicates = (
         PerformanceDatum.objects.filter(
             signature=signature,
@@ -112,15 +108,47 @@ def generate_new_alerts_in_series(signature):
     replicates_map: dict[int, list[float]] = {}
     for datum_id, value in replicates:
         replicates_map.setdefault(datum_id, []).append(value)
+    return replicates_map
+
+
+def _load_revision_data(signature, latest_alert_timestamp, revision_datum_cls):
+    # get series data starting from either:
+    # (1) the last alert, if there is one (latest_alert_timestamp)
+    # (2) the alerts max age
+    # (use whichever is newer)
+    max_alert_age = alert_after_ts = datetime.now() - settings.PERFHERDER_ALERTS_MAX_AGE
+    series = PerformanceDatum.objects.filter(
+        signature=signature,
+        repository=signature.repository,
+        push_timestamp__gte=max_alert_age,
+    ).only("id", "push_id", "push_timestamp", "value")
+    if latest_alert_timestamp:
+        latest_ts = latest_alert_timestamp[0]
+        series = series.filter(push_timestamp__gt=latest_ts)
+        if latest_ts > alert_after_ts:
+            alert_after_ts = latest_ts
+
+    replicates_map = _collect_replicates_map(signature, alert_after_ts)
 
     revision_data = {}
     for d in series:
         if not revision_data.get(d.push_id):
-            revision_data[d.push_id] = RevisionDatum(
+            revision_data[d.push_id] = revision_datum_cls(
                 int(time.mktime(d.push_timestamp.timetuple())), d.push_id, [], []
             )
         revision_data[d.push_id].values.append(d.value)
         revision_data[d.push_id].replicates.extend(replicates_map.get(d.id, []))
+
+    return revision_data
+
+
+def generate_new_alerts_in_series(signature):
+    latest_alert_timestamp = (
+        PerformanceAlert.objects.filter(series_signature=signature)
+        .order_by("-summary__push__time")
+        .values_list("summary__push__time", flat=True)[:1]
+    )
+    revision_data = _load_revision_data(signature, latest_alert_timestamp, RevisionDatum)
 
     min_back_window = signature.min_back_window
     if min_back_window is None:
@@ -658,57 +686,15 @@ def generate_new_test_alerts_in_series(
         detection_index_tolerance,
         replicates_enabled,
     )
-    # get series data starting from either:
-    # (1) the last alert, if there is one
-    # (2) the alerts max age
-    # use whichever is newer
     with transaction.atomic():
-        max_alert_age = alert_after_ts = datetime.now() - settings.PERFHERDER_ALERTS_MAX_AGE
-        series = PerformanceDatum.objects.filter(
-            signature=signature, push_timestamp__gte=max_alert_age
-        )
         latest_alert_timestamp = (
             PerformanceAlertTesting.objects.filter(
                 series_signature=signature, detection_method=detection_method_name
             )
-            .select_related("summary__push__time")
             .order_by("-summary__push__time")
             .values_list("summary__push__time", flat=True)[:1]
         )
-        if latest_alert_timestamp:
-            latest_ts = latest_alert_timestamp[0]
-            series = series.filter(push_timestamp__gt=latest_ts)
-            if latest_ts > alert_after_ts:
-                alert_after_ts = latest_ts
-
-        datum_with_replicates = (
-            PerformanceDatum.objects.filter(
-                signature=signature,
-                repository=signature.repository,
-                push_timestamp__gte=alert_after_ts,
-            )
-            .annotate(
-                has_replicate=Exists(
-                    PerformanceDatumReplicate.objects.filter(performance_datum_id=OuterRef("pk"))
-                )
-            )
-            .filter(has_replicate=True)
-        )
-        replicates = PerformanceDatumReplicate.objects.filter(
-            performance_datum_id__in=Subquery(datum_with_replicates.values("id"))
-        ).values_list("performance_datum_id", "value")
-        replicates_map: dict[int, list[float]] = {}
-        for datum_id, value in replicates:
-            replicates_map.setdefault(datum_id, []).append(value)
-
-        revision_data = {}
-        for d in series:
-            if not revision_data.get(d.push_id):
-                revision_data[d.push_id] = RevisionDatumTest(
-                    int(time.mktime(d.push_timestamp.timetuple())), d.push_id, [], []
-                )
-            revision_data[d.push_id].values.append(d.value)
-            revision_data[d.push_id].replicates.extend(replicates_map.get(d.id, []))
+        revision_data = _load_revision_data(signature, latest_alert_timestamp, RevisionDatumTest)
 
         data = list(revision_data.values())
         methods = build_cpd_methods()


### PR DESCRIPTION
[Bug 2041948](https://bugzilla.mozilla.org/show_bug.cgi?id=2041948)

`generate_new_alerts_in_series` and `generate_new_test_alerts_in_series` run on every signature during ingestion. This PR addresses their `PerformanceDatum` / `PerformanceDatumReplicate` reads:

- The `series` query filtered only on `signature` + `push_timestamp`, so Postgres could not seek the composite (`repository`, `signature`, `push_timestamp`) index (its leading column, `repository`, was unconstrained). Add `repository=signature.repository`; a signature has exactly one repository, so results are unchanged.

- Trimmed over-fetching on the `series` query with `.only("id", "push_id", "push_timestamp", "value")` -- the consuming loop only reads those 4 attributes, so this drops the SELECT from 10 columns to 4 (including three unused VARCHARs).

- Removed a dead `.select_related("summary__push__time")` on the latest-alert query. Django silently ignores `select_related` when `.values_list()` is chained, so it produced identical SQL -- misleading dead code.

- De-duplicated the two near-identical functions into a shared `_load_revision_data()` + `_collect_replicates_map()`.

### `series` query impact (the headline win)

This is currently the **#1 query by total load** in prod Cloud SQL Query Insights -- not because any single call is slow (~30 ms avg), but because it is called ~8,858×/hour (once per signature on ingestion). Total load ≈ avg_exec_time × times_called, so cutting per-call cost cuts the dominant load proportionally.

Without `repository=`, Postgres uses the `signature_id`-only index and reads the signature's **entire history**, discarding everything outside the 2-week window. Adding `repository=` switches it to the composite index, which range-seeks straight to the window. Measured on the staging replica (sig 5182079, repo 77: 9,462 rows all-time, 1,788 in the 2-week window):

| | before (10 cols, `signature_id` index) | after (4 cols, composite index) |
|---|---|---|
| index | `performance_datum_signature_id_a9af3d6b` | `performance_reposit_c9d328_idx` (repo, sig, push_timestamp) |
| rows discarded by filter | 7,674 (scans all history) | 0 (range-seek to window) |
| buffers | 9,490 | 1,755 (~5.4× fewer) |
| row width | 64 | 28 (`.only()`) |
| **exec time** | **15.4 ms** | **3.6 ms (~4.3× faster)** |

The gain scales with how much history a signature has beyond the alert window, so the worst offenders (which drive the prod average up) benefit most.

### Note on the replicate lookup shape

An earlier revision of this PR replaced the replicate lookup's `IN (SELECT ... WHERE EXISTS (...))` with a plain join, on the assumption the `EXISTS` was redundant. It is logically redundant but **load-bearing for the query planner**, as @junngo flagged in review. Measured on the staging replica (autoland, sig 5182079, ~2.4k datums, ~118k replicate rows over the 2-week window):

| shape | plan | time |
|---|---|---|
| plain `INNER JOIN` | Parallel Seq Scan on `performance_datum` | ~22.2 s |
| `IN(Subquery(datum_ids))`, no `EXISTS` | same seq-scan plan | ~65.2 s |
| materialized literal `IN (...)` | Parallel Seq Scan on `performance_datum_replicate` | >120 s |
| original `IN(Subquery(... EXISTS ...))` | full index path | ~5.4 s cold / ~53 ms warm |

The original shape resolves the small datum-id set via the composite index first, then probes `performance_datum_replicate` by its FK index, instead of letting the planner full-scan a giant table. It has been **kept as-is** (reverted to the original form); only the other optimizations above are new.

Includes a characterization test pinning the replicate-map behavior.
