### PR TITLE
Optimize intermittent-failure classification query

### DIFF
--- a/tests/log_parser/test_intermittents.py
+++ b/tests/log_parser/test_intermittents.py
@@ -1,0 +1,101 @@
+import datetime
+
+from treeherder.log_parser.intermittents import check_and_mark_intermittent
+from treeherder.model.models import Group, GroupStatus, Job, JobLog, JobType, Push
+
+
+def _make_job(repository, push, job_type, refdata, result, fc_id, guid):
+    """Create a completed Job wired to the shared generic reference data."""
+    return Job.objects.create(
+        guid=guid,
+        repository=repository,
+        push=push,
+        signature=refdata.signature,
+        build_platform=refdata.build_platform,
+        machine_platform=refdata.machine_platform,
+        machine=refdata.machine,
+        option_collection_hash=refdata.option_collection_hash,
+        job_type=job_type,
+        job_group=refdata.job_group,
+        product=refdata.product,
+        failure_classification_id=fc_id,
+        who="test@example.com",
+        reason="",
+        result=result,
+        state="completed",
+        submit_time=push.time,
+        start_time=push.time,
+        end_time=push.time,
+        tier=1,
+    )
+
+
+def test_check_and_mark_intermittent_marks_prior_failure(
+    test_repository, generic_reference_data, failure_classifications
+):
+    """A group that ERROR'd on an earlier push but passes on the current push
+    causes the earlier job to be marked intermittent (failure_classification 8).
+
+    This characterizes the all_groups query in check_and_mark_intermittent so
+    the repository-filter rewrite (which drops the push join) stays equivalent.
+    """
+    now = datetime.datetime.now()
+    older_push = Push.objects.create(
+        repository=test_repository,
+        revision="a" * 40,
+        author="test@example.com",
+        time=now - datetime.timedelta(hours=1),
+    )
+    current_push = Push.objects.create(
+        repository=test_repository,
+        revision="b" * 40,
+        author="test@example.com",
+        time=now,
+    )
+
+    # A name with no trailing chunk number and no leading/trailing chars in
+    # {-, c, f} so check_and_mark_intermittent's jtname normalization is a no-op.
+    job_type = JobType.objects.create(name="test-linux1804-64/opt-mochitest-plain")
+
+    failed_job = _make_job(
+        test_repository,
+        older_push,
+        job_type,
+        generic_reference_data,
+        result="testfailed",
+        fc_id=1,  # "not classified"
+        guid="job-older",
+    )
+    passing_job = _make_job(
+        test_repository,
+        current_push,
+        job_type,
+        generic_reference_data,
+        result="success",
+        fc_id=1,
+        guid="job-current",
+    )
+
+    group = Group.objects.create(name="/some/manifest.ini")
+
+    failed_log = JobLog.objects.create(
+        job=failed_job, name="errorsummary_json", url="http://log/1", status=JobLog.PARSED
+    )
+    passing_log = JobLog.objects.create(
+        job=passing_job, name="errorsummary_json", url="http://log/2", status=JobLog.PARSED
+    )
+
+    GroupStatus.objects.create(
+        status=GroupStatus.ERROR, duration=1, job_log=failed_log, group=group
+    )
+    GroupStatus.objects.create(status=GroupStatus.OK, duration=1, job_log=passing_log, group=group)
+
+    check_and_mark_intermittent(passing_job.id)
+
+    failed_job.refresh_from_db()
+    passing_job.refresh_from_db()
+
+    # The earlier failure is reclassified as a known intermittent (8); the
+    # passing job (result=success) is left untouched by classify().
+    assert failed_job.failure_classification_id == 8
+    assert passing_job.failure_classification_id == 1

--- a/treeherder/log_parser/intermittents.py
+++ b/treeherder/log_parser/intermittents.py
@@ -142,7 +142,11 @@ def check_and_mark_intermittent(job_id):
     all_groups = (
         Group.objects.filter(
             job_logs__job__push__id__range=(ids[-1], ids[0]),
-            job_logs__job__push__repository__id=current_job.repository.id,
+            # Filter on job.repository_id directly rather than push.repository_id:
+            # a job's repository always matches its push's repository, so this is
+            # equivalent but lets PostgreSQL drop the join to the push table and
+            # use the (repository, job_type, push) index on job.
+            job_logs__job__repository__id=current_job.repository.id,
             job_logs__job__job_type__name__startswith=jtname,
             job_logs__job__failure_classification__id__in=[
                 1,

--- a/treeherder/model/migrations/0051_job_repo_jobtype_push_idx.py
+++ b/treeherder/model/migrations/0051_job_repo_jobtype_push_idx.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    # Use non-atomic so we can create the index CONCURRENTLY (the job table is
+    # large in production and a blocking build would lock out ingestion).
+    atomic = False
+
+    dependencies = [
+        ("model", "0050_repository_accepts_pull_requests"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql=(
+                        "CREATE INDEX CONCURRENTLY IF NOT EXISTS job_repo_jobtype_push_idx "
+                        "ON job (repository_id, job_type_id, push_id);"
+                    ),
+                    reverse_sql="DROP INDEX IF EXISTS job_repo_jobtype_push_idx;",
+                ),
+            ],
+            state_operations=[
+                migrations.AddIndex(
+                    model_name="job",
+                    index=models.Index(
+                        fields=["repository", "job_type", "push"],
+                        name="job_repo_jobtype_push_idx",
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -648,6 +648,14 @@ class Job(models.Model):
             models.Index(fields=["machine_platform", "option_collection_hash", "push"]),
             # speed up cycle data
             models.Index(fields=["repository", "submit_time"]),
+            # speed up intermittent-failure classification
+            # (treeherder/log_parser/intermittents.py): equality on repository
+            # and job_type, range on push. Matches both the group-history query
+            # and the infra-check query, which scan a repository's jobs of a
+            # given type within a recent push-id window.
+            models.Index(
+                fields=["repository", "job_type", "push"], name="job_repo_jobtype_push_idx"
+            ),
         ]
 
     @property


### PR DESCRIPTION
# Optimize intermittent-failure classification query

## Summary

Optimizes the heaviest query in `check_and_mark_intermittent`
(`treeherder/log_parser/intermittents.py`) — the `all_groups` query that runs
on every parsed log to decide whether a job's failures are intermittent. Two
complementary changes: drop a redundant table join, and add an index whose
column order matches the query's access pattern.

No behavior change — this is a pure performance optimization.

## Background

For each newly parsed job, `check_and_mark_intermittent` scans a repository's
recent push window for jobs of the same type and compares group (manifest)
pass/fail history. The driving query joined six tables:

```sql
FROM "group"
  JOIN "group_status" ... JOIN "job_log" ... JOIN "job"
  JOIN "job_type" ... JOIN "push"
WHERE group_status.status IN (...)
  AND job.failure_classification_id IN (...)
  AND job_type.name LIKE 'jobtype%'
  AND job.push_id BETWEEN ... AND ...
  AND push.repository_id = ...
  AND job.result IN (...)
ORDER BY job.push_id DESC
```

## Changes

### 1. Drop the redundant `push` join

The `push` table was joined **only** to filter `push.repository_id`. But a
job's repository always equals its push's repository, and `job` already carries
its own `repository_id` column. Filtering `job.repository_id` directly is
equivalent and lets Postgres drop the join entirely (6 joins → 5), turning the
repository filter into an indexable equality on the `job` table.

### 2. Add a `(repository, job_type, push)` index on `job`

The query filters **equality on repository + job_type** and a **range on push**.
The textbook btree ordering for that is equality columns first, range column
last.

An existing index from migration 0044, `idx_job_push_repo_composite`, is
`(push_id, repository_id)` — it leads with the *range* column, so Postgres can't
seek on `repository_id` after it. The new `(repository, job_type, push)` index
orders the equality columns first and also serves the sibling `extra_jobs` query
in `_check_and_mark_infra`, which filters repository + exact job_type + push
range.

The migration builds the index `CONCURRENTLY` via the `SeparateDatabaseAndState`
pattern (matching migration 0046) with `atomic = False`, so the large `job`
table is not locked during the build.

## Testing

- **New characterization test** (`tests/log_parser/test_intermittents.py`) —
  there were none for `check_and_mark_intermittent`. It sets up a group that
  errors on an earlier push but passes on the current push and asserts the
  earlier job is reclassified intermittent (`failure_classification_id == 8`)
  while the passing job is untouched. It passes on both the old and new query,
  pinning the rewrite as behavior-equivalent.
- Full `tests/log_parser/` suite: **147 passed**.
- `makemigrations --check`: no changes (model ↔ migration consistent); migration
  applies cleanly; index confirmed present on the `job` table.
- Verified via the generated SQL that the rewritten query no longer joins
  `push`.
