### PR TITLE
Reduce over-fetching in Bugscache queries

### DIFF
--- a/tests/webapp/api/test_bugzilla.py
+++ b/tests/webapp/api/test_bugzilla.py
@@ -2,6 +2,9 @@ import json
 
 import responses
 from django.urls import reverse
+from django.utils import timezone
+
+from treeherder.model.models import Bugscache
 
 
 def test_create_bug(client, eleven_jobs_stored, activate_responses, test_user):
@@ -264,3 +267,86 @@ def test_create_bug_with_long_crash_signature(
     )
     assert resp.status_code == 400
     assert resp.json()["failure"] == "Crash signature can't be more than 2048 characters."
+
+
+def _make_bug_response(bug_id=323):
+    def request_callback(request):
+        return (200, {}, json.dumps({"id": bug_id}))
+
+    responses.add_callback(
+        responses.POST,
+        "https://thisisnotbugzilla.org/rest/bug",
+        callback=request_callback,
+        content_type="application/json",
+    )
+
+
+def test_create_bug_returns_existing_internal_id(
+    client, eleven_jobs_stored, activate_responses, test_user
+):
+    """When a Bugscache row already exists for the new bugzilla id, its pk is returned."""
+    _make_bug_response(bug_id=323)
+    existing = Bugscache.objects.create(
+        bugzilla_id=323,
+        status="NEW",
+        resolution="",
+        summary="some pre-existing summary",
+        crash_signature="",
+        keywords="",
+        modified=timezone.now(),
+    )
+
+    client.force_authenticate(user=test_user)
+    resp = client.post(
+        reverse("bugzilla-create-bug"),
+        {
+            "type": "defect",
+            "product": "Bugzilla",
+            "component": "Administration",
+            "summary": "Intermittent summary",
+            "version": "4.0.17",
+            "comment": "Intermittent Description",
+            "comment_tags": "treeherder",
+            "keywords": ["intermittent-failure"],
+            "is_security_issue": False,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["internal_id"] == existing.id
+
+
+def test_create_bug_links_internal_bug_by_summary(
+    client, eleven_jobs_stored, activate_responses, test_user
+):
+    """An internal bug matching by summary gets the new bugzilla id and its pk is returned."""
+    _make_bug_response(bug_id=323)
+    existing = Bugscache.objects.create(
+        bugzilla_id=None,
+        status="NEW",
+        resolution="",
+        summary="Intermittent summary",
+        crash_signature="",
+        keywords="",
+        modified=timezone.now(),
+    )
+
+    client.force_authenticate(user=test_user)
+    resp = client.post(
+        reverse("bugzilla-create-bug"),
+        {
+            "type": "defect",
+            "product": "Bugzilla",
+            "component": "Administration",
+            "summary": "Intermittent summary",
+            "version": "4.0.17",
+            "comment": "Intermittent Description",
+            "comment_tags": "treeherder",
+            "keywords": ["intermittent-failure"],
+            "is_security_issue": False,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["internal_id"] == existing.id
+
+    existing.refresh_from_db()
+    assert existing.bugzilla_id == 323

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -305,7 +305,7 @@ class Bugscache(models.Model):
         return f"{self.id}"
 
     def serialize(self):
-        exclude_fields = ["modified", "processed_update", "jobmap"]
+        exclude_fields = ["modified", "processed_update"]
 
         attrs = model_to_dict(self, exclude=exclude_fields)
         # Serialize bug ID as the bugzilla number for compatibility reasons
@@ -333,6 +333,19 @@ class Bugscache(models.Model):
         # Django already escapes special characters, so we do not need to handle that here
         recent_qs = (
             Bugscache.objects.filter(summary__icontains=search_term)
+            # Only fetch the fields that serialize() returns; modified and
+            # processed_update are excluded there, so there's no need to load them.
+            .only(
+                "id",
+                "bugzilla_id",
+                "status",
+                "resolution",
+                "summary",
+                "dupe_of",
+                "crash_signature",
+                "keywords",
+                "whiteboard",
+            )
             .annotate(similarity=TrigramSimilarity("summary", search_term))
             .order_by("-similarity")[0:max_size]
         )

--- a/treeherder/webapp/api/bugzilla.py
+++ b/treeherder/webapp/api/bugzilla.py
@@ -105,15 +105,21 @@ class BugzillaViewSet(viewsets.ViewSet):
         bug_id = response.json()["id"]
         summary = summary.decode("utf-8")
         # Creation API only returns the ID, but the bug will be updated later on by `treeherder.etl.bugzilla.BzApiBugProcess`
-        bug = Bugscache.objects.filter(bugzilla_id=bug_id).first()
-        if not bug:
-            bugs = list(Bugscache.objects.filter(summary=summary).order_by("modified"))
+        internal_id = (
+            Bugscache.objects.filter(bugzilla_id=bug_id).values_list("id", flat=True).first()
+        )
+        if internal_id is None:
+            bugs = list(
+                Bugscache.objects.filter(summary=summary)
+                .only("id", "bugzilla_id", "modified")
+                .order_by("modified")
+            )
             if bugs and not (bug := next((b.bugzilla_id == bug_id for b in bugs), None)):
                 bug = bugs[-1]
                 bug.modified = timezone.now()
                 bug.bugzilla_id = bug_id
-                bug.save()
-        internal_id = bug.id if bug else None
+                bug.save(update_fields=["bugzilla_id", "modified"])
+                internal_id = bug.id
         return Response(
             {
                 "id": bug_id,


### PR DESCRIPTION
## Summary

`Bugscache.search()` (backing the bug-suggestions endpoint) and the `create_bug` endpoint both loaded full `Bugscache` rows when only a subset of columns is actually used. This trims the fetched/written columns without changing behavior.

### Changes

- **`Bugscache.search()`** — add `.only(...)` to defer `modified` and `processed_update`, which `serialize()` excludes anyway. The `TrigramSimilarity` annotation and `serialize()` output are unaffected.
- **`Bugscache.serialize()`** — remove the dead `"jobmap"` entry from `exclude_fields`; it's a reverse relation that `model_to_dict` never iterates, so it had no effect.
- **`create_bug`** — resolve the existing internal id with `values_list("id", flat=True).first()` instead of fetching the whole row; restrict the summary-fallback query with `.only("id", "bugzilla_id", "modified")`; and limit the linking `save()` to the two changed columns via `update_fields`.

### Tests

Added coverage for the `create_bug` internal-id resolution paths (existing bug matched by `bugzilla_id`, and an internal bug linked by `summary`), which were previously untested.

### Notes

This is the over-fetch portion of a broader Bugscache query audit. A separate, layered PR adds a GIN trigram index on `bugscache.summary` (the substring/similarity search currently can't use the existing btree index) — kept separate so the index change can be measured and reviewed on its own.