### PR TITLE
Add GIN trigram index on bugscache.summary

### DIFF
--- a/treeherder/model/migrations/0052_bugscache_summary_gin_trgm_index.py
+++ b/treeherder/model/migrations/0052_bugscache_summary_gin_trgm_index.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    # Non-atomic so the index can be built CONCURRENTLY, avoiding a write lock
+    # on the bugscache table while the index is created.
+    atomic = False
+
+    dependencies = [
+        ("model", "0051_job_repo_jobtype_push_idx"),
+    ]
+
+    operations = [
+        # GIN trigram index backing Bugscache.search(), which filters with
+        # `summary ILIKE '%term%'` and orders by trigram similarity. The plain
+        # btree index on summary cannot serve substring/similarity matching, so
+        # this index is what lets those searches use an index scan instead of a
+        # sequential scan. Requires the pg_trgm extension (added in 0031).
+        migrations.RunSQL(
+            sql=(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS bugscache_summary_gin_trgm_idx "
+                "ON bugscache USING gin (summary gin_trgm_ops);"
+            ),
+            reverse_sql="DROP INDEX IF EXISTS bugscache_summary_gin_trgm_idx;",
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -278,7 +278,9 @@ class Bugscache(models.Model):
 
     status = models.CharField(max_length=64, db_index=True)
     resolution = models.CharField(max_length=64, blank=True, db_index=True)
-    # Is covered by a FULLTEXT index created via a migrations RunSQL operation.
+    # Backed by a GIN trigram index (bugscache_summary_gin_trgm_idx, created via
+    # a RunSQL migration) so the ILIKE + trigram similarity search in search()
+    # can use an index scan. The btree Index below only covers exact lookups.
     summary = models.CharField(max_length=255)
     dupe_of = models.PositiveIntegerField(null=True)
     crash_signature = models.TextField(blank=True)


### PR DESCRIPTION
Bugscache.search() and the create_bug endpoint loaded full Bugscache
rows when only a subset of columns is actually used:

- search(): defer `modified` and `processed_update` via .only(), since
  serialize() excludes them anyway. Remove the dead `jobmap` entry from
  the serialize() exclude list (a reverse relation model_to_dict never
  iterates).
- create_bug: resolve the existing bug id with values_list() instead of
  fetching the whole row, restrict the summary fallback query with
  .only(), and limit the linking save() to the two changed columns via
  update_fields.

Add tests covering the create_bug internal-id resolution paths.