### PR TITLE
Upgrade urllib3 to 2.6.3

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -2671,9 +2671,9 @@ uritemplate==4.2.0 \
     # via
     #   -r requirements/common.in
     #   drf-spectacular
-urllib3==1.26.18 \
-    --hash=sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07 \
-    --hash=sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0
+urllib3==2.6.3 \
+    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4 \
+    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed
     # via
     #   botocore
     #   pygithub

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -33,4 +33,4 @@ vcrpy==8.1.1
 pip-tools==7.5.3
 
 requests==2.32.5
-urllib3==2.0.3
+urllib3==2.6.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -542,9 +542,9 @@ typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
     # via selenium
-urllib3[socks]==2.0.3 \
-    --hash=sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1 \
-    --hash=sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825
+urllib3[socks]==2.6.3 \
+    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4 \
+    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed
     # via
     #   -r requirements/dev.in
     #   requests

--- a/tests/sample_data/logs/asan_too_large.logview.json
+++ b/tests/sample_data/logs/asan_too_large.logview.json
@@ -2,11 +2,11 @@
   "logurl": "http://my-log.mozilla.org/asan_too_large.log.gz",
   "errors": [
     {
-      "linenumber": 5438,
+      "linenumber": 5444,
       "line": "22:10:07    ERROR - PID 16211 | ==16211==ERROR: AddressSanitizer: heap-use-after-free on address 0x512000dacef0 at pc 0x7f5f778257ff bp 0x7fff65bbc1b0 sp 0x7fff65bbc1a8"
     },
     {
-      "linenumber": 5542,
+      "linenumber": 5549,
       "line": "22:10:09     INFO - PID 16211 | SUMMARY: AddressSanitizer: heap-use-after-free /builds/worker/workspace/obj-build/dist/include/nsISupportsImpl.h:388:19 in operator++"
     }
   ]

--- a/tests/sample_data/logs/build-fail.logview.json
+++ b/tests/sample_data/logs/build-fail.logview.json
@@ -2,123 +2,123 @@
   "logurl": "http://my-log.mozilla.org/build-fail.log.gz",
   "errors": [
     {
-      "linenumber": 137717,
+      "linenumber": 137959,
       "line": "21:47:57    ERROR -  error: linking with `/builds/worker/checkouts/gecko/build/cargo-linker` failed: exit status: 1"
     },
     {
-      "linenumber": 137720,
+      "linenumber": 137962,
       "line": "21:47:57    ERROR -    = note: lld-link: error: undefined symbol: PropVariantCompareEx"
     },
     {
-      "linenumber": 137723,
+      "linenumber": 137965,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: VariantToPropVariant"
     },
     {
-      "linenumber": 137726,
+      "linenumber": 137968,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: PropVariantToVariant"
     },
     {
-      "linenumber": 137729,
+      "linenumber": 137971,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: PropVariantToBSTR"
     },
     {
-      "linenumber": 137732,
+      "linenumber": 137974,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: VariantToBoolean"
     },
     {
-      "linenumber": 137735,
+      "linenumber": 137977,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: PropVariantToBoolean"
     },
     {
-      "linenumber": 137738,
+      "linenumber": 137980,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: VariantToUInt16"
     },
     {
-      "linenumber": 137741,
+      "linenumber": 137983,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: PropVariantToUInt16"
     },
     {
-      "linenumber": 137744,
+      "linenumber": 137986,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: VariantToInt16"
     },
     {
-      "linenumber": 137747,
+      "linenumber": 137989,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: PropVariantToInt16"
     },
     {
-      "linenumber": 137750,
+      "linenumber": 137992,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: VariantToUInt32"
     },
     {
-      "linenumber": 137753,
+      "linenumber": 137995,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: PropVariantToUInt32"
     },
     {
-      "linenumber": 137756,
+      "linenumber": 137998,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: VariantToInt32"
     },
     {
-      "linenumber": 137759,
+      "linenumber": 138001,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: PropVariantToInt32"
     },
     {
-      "linenumber": 137762,
+      "linenumber": 138004,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: VariantToUInt64"
     },
     {
-      "linenumber": 137765,
+      "linenumber": 138007,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: PropVariantToUInt64"
     },
     {
-      "linenumber": 137768,
+      "linenumber": 138010,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: VariantToInt64"
     },
     {
-      "linenumber": 137771,
+      "linenumber": 138013,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: PropVariantToInt64"
     },
     {
-      "linenumber": 137774,
+      "linenumber": 138016,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: VariantToDouble"
     },
     {
-      "linenumber": 137777,
+      "linenumber": 138019,
       "line": "21:47:57    ERROR -            lld-link: error: undefined symbol: PropVariantToDouble"
     },
     {
-      "linenumber": 137780,
+      "linenumber": 138022,
       "line": "21:47:57    ERROR -  error: could not compile `crashreporter` (bin \"crashreporter\") due to 1 previous error"
     },
     {
-      "linenumber": 137783,
+      "linenumber": 138025,
       "line": "21:47:57    ERROR -  gmake[4]: *** [/builds/worker/checkouts/gecko/config/makefiles/rust.mk:600: force-cargo-program-build] Error 101"
     },
     {
-      "linenumber": 137787,
+      "linenumber": 138029,
       "line": "21:47:57    ERROR -  gmake[3]: *** [/builds/worker/checkouts/gecko/config/recurse.mk:72: toolkit/crashreporter/client/app/target] Error 2"
     },
     {
-      "linenumber": 137789,
+      "linenumber": 138031,
       "line": "21:47:57    ERROR -  gmake[2]: *** [/builds/worker/checkouts/gecko/config/recurse.mk:34: compile] Error 2"
     },
     {
-      "linenumber": 137790,
+      "linenumber": 138032,
       "line": "21:47:57    ERROR -  gmake[1]: *** [/builds/worker/checkouts/gecko/config/rules.mk:359: default] Error 2"
     },
     {
-      "linenumber": 137876,
+      "linenumber": 138118,
       "line": "21:47:57     INFO -  gmake: *** [client.mk:59: build] Error 2"
     },
     {
-      "linenumber": 137880,
+      "linenumber": 138122,
       "line": "21:47:58    FATAL - 'mach build -v' did not run successfully. Please check log for errors."
     },
     {
-      "linenumber": 137881,
+      "linenumber": 138123,
       "line": "21:47:58    FATAL - Running post_fatal callback..."
     },
     {
-      "linenumber": 137882,
+      "linenumber": 138124,
       "line": "21:47:58    FATAL - Exiting -1"
     }
   ]

--- a/tests/sample_data/logs/crashtest-timeout.logview.json
+++ b/tests/sample_data/logs/crashtest-timeout.logview.json
@@ -10,7 +10,7 @@
       "line": "[taskcluster:error] Error downloading \"public/image.tar.zst\" from task ID \"ACAekLExQ9ilBJ5DxWMSHA\". Error: Expected size is '1315403107' but received '331871776' Next Attempt in: 25473.50 ms."
     },
     {
-      "linenumber": 12933,
+      "linenumber": 12956,
       "line": "21:45:24  WARNING -  REFTEST TEST-UNEXPECTED-FAIL | dom/media/test/crashtests/1830206.html | load failed: timed out after 300000 ms waiting for 'load' event for http://10.0.2.2:8854/tests/dom/media/test/crashtests/1830206.html"
     }
   ]

--- a/tests/sample_data/logs/mochitest-crash.logview.json
+++ b/tests/sample_data/logs/mochitest-crash.logview.json
@@ -2,11 +2,11 @@
   "logurl": "http://my-log.mozilla.org/mochitest-crash.log.gz",
   "errors": [
     {
-      "linenumber": 8616,
+      "linenumber": 8637,
       "line": "21:24:26     INFO - GECKO(5432) | [5432] Hit MOZ_CRASH(Shutdown hanging at step XPCOMShutdownThreads. Something is blocking the main-thread.) at /builds/worker/checkouts/gecko/toolkit/components/terminator/nsTerminator.cpp:244"
     },
     {
-      "linenumber": 8640,
+      "linenumber": 8661,
       "line": "21:24:45     INFO - PROCESS-CRASH | Shutdown hanging at step XPCOMShutdownThreads. Something is blocking the main-thread. [@ mozilla::(anonymous namespace)::RunWatchdog] | dom/workers/test/test_sourcemap_header.html (finished)"
     }
   ]

--- a/tests/sample_data/logs/mochitest-end.logview.json
+++ b/tests/sample_data/logs/mochitest-end.logview.json
@@ -2,71 +2,71 @@
   "logurl": "http://my-log.mozilla.org/mochitest-end.log.gz",
   "errors": [
     {
-      "linenumber": 1744,
+      "linenumber": 1747,
       "line": "21:30:46  WARNING -  TEST-UNEXPECTED-FAIL | dom/canvas/test/crossorigin/test_webgl_crossorigin_textures.html | Test timed out. -"
     },
     {
-      "linenumber": 1745,
+      "linenumber": 1748,
       "line": "21:30:46  WARNING -  TEST-UNEXPECTED-FAIL | SimpleTest | this test already called finish!"
     },
     {
-      "linenumber": 1746,
+      "linenumber": 1749,
       "line": "21:30:46  WARNING -  TEST-UNEXPECTED-ERROR | dom/canvas/test/crossorigin/test_webgl_crossorigin_textures.html | called finish() multiple times"
     },
     {
-      "linenumber": 1748,
+      "linenumber": 1751,
       "line": "21:31:16  WARNING -  TEST-UNEXPECTED-FAIL | dom/canvas/test/crossorigin/test_webgl_crossorigin_textures.html | Test timed out. -"
     },
     {
-      "linenumber": 1749,
+      "linenumber": 1752,
       "line": "21:31:16  WARNING -  TEST-UNEXPECTED-FAIL | SimpleTest | this test already called finish!"
     },
     {
-      "linenumber": 1750,
+      "linenumber": 1753,
       "line": "21:31:16  WARNING -  TEST-UNEXPECTED-ERROR | dom/canvas/test/crossorigin/test_webgl_crossorigin_textures.html | called finish() multiple times"
     },
     {
-      "linenumber": 1752,
+      "linenumber": 1755,
       "line": "21:31:46  WARNING -  TEST-UNEXPECTED-FAIL | dom/canvas/test/crossorigin/test_webgl_crossorigin_textures.html | Test timed out. -"
     },
     {
-      "linenumber": 1753,
+      "linenumber": 1756,
       "line": "21:31:46  WARNING -  TEST-UNEXPECTED-FAIL | SimpleTest | this test already called finish!"
     },
     {
-      "linenumber": 1754,
+      "linenumber": 1757,
       "line": "21:31:46  WARNING -  TEST-UNEXPECTED-ERROR | dom/canvas/test/crossorigin/test_webgl_crossorigin_textures.html | called finish() multiple times"
     },
     {
-      "linenumber": 1756,
+      "linenumber": 1759,
       "line": "21:32:06  WARNING -  TEST-UNEXPECTED-FAIL | dom/canvas/test/crossorigin/test_webgl_crossorigin_textures.html | Test timed out. -"
     },
     {
-      "linenumber": 1757,
+      "linenumber": 1760,
       "line": "21:32:06  WARNING -  TEST-UNEXPECTED-FAIL | (SimpleTest/TestRunner.js) | 4 test timeouts, giving up. -"
     },
     {
-      "linenumber": 1758,
+      "linenumber": 1761,
       "line": "21:32:06  WARNING -  TEST-UNEXPECTED-FAIL | (SimpleTest/TestRunner.js) | Skipping 1 remaining tests. -"
     },
     {
-      "linenumber": 1759,
+      "linenumber": 1762,
       "line": "21:32:17  WARNING -  TEST-UNEXPECTED-FAIL | SimpleTest | this test already called finish!"
     },
     {
-      "linenumber": 1760,
+      "linenumber": 1763,
       "line": "21:32:17  WARNING -  TEST-UNEXPECTED-ERROR | (SimpleTest/TestRunner.js) | called finish() multiple times"
     },
     {
-      "linenumber": 1764,
+      "linenumber": 1768,
       "line": "21:38:54  WARNING -  TEST-UNEXPECTED-FAIL | (SimpleTest/TestRunner.js) (finished) | application timed out after 370 seconds with no output"
     },
     {
-      "linenumber": 1769,
+      "linenumber": 1773,
       "line": "21:38:58  WARNING -  PROCESS-CRASH | application crashed [@ libc.so + 0x000000000001ccb5] | dom/canvas/test/crossorigin/mochitest.toml"
     },
     {
-      "linenumber": 4964,
+      "linenumber": 4978,
       "line": "21:39:03  WARNING -  PROCESS-CRASH | application crashed [@ libc.so + 0x000000000008c66a] | dom/canvas/test/crossorigin/mochitest.toml"
     }
   ]

--- a/tests/sample_data/logs/mochitest-fail.logview.json
+++ b/tests/sample_data/logs/mochitest-fail.logview.json
@@ -2,7 +2,7 @@
   "logurl": "http://my-log.mozilla.org/mochitest-fail.log.gz",
   "errors": [
     {
-      "linenumber": 9093,
+      "linenumber": 9116,
       "line": "11:00:27     INFO - TEST-UNEXPECTED-FAIL | devtools/client/webconsole/test/browser/browser_console_enable_network_monitoring.js | A promise chain failed to handle a rejection: Protocol error (Error): Not listening for network events from: server18.conn0.networkParent25 (resource://devtools/server/actors/network-monitor/network-parent.js:99:13) - stack: onPacket/<@resource://devtools/shared/protocol/Front.js:382:31"
     }
   ]

--- a/tests/sample_data/logs/reftest-fail.logview.json
+++ b/tests/sample_data/logs/reftest-fail.logview.json
@@ -2,7 +2,7 @@
   "logurl": "http://my-log.mozilla.org/reftest-fail.log.gz",
   "errors": [
     {
-      "linenumber": 13566,
+      "linenumber": 13591,
       "line": "21:27:46     INFO - REFTEST TEST-UNEXPECTED-FAIL | layout/reftests/bugs/1804872-2.html == layout/reftests/bugs/1804872-2-ref.html | image comparison, max difference: 255, number of differing pixels: 22456"
     }
   ]

--- a/tests/sample_data/logs/reftest-timeout.logview.json
+++ b/tests/sample_data/logs/reftest-timeout.logview.json
@@ -2,7 +2,7 @@
   "logurl": "http://my-log.mozilla.org/reftest-timeout.log.gz",
   "errors": [
     {
-      "linenumber": 7470,
+      "linenumber": 7487,
       "line": "22:07:05     INFO - TEST-UNEXPECTED-TIMEOUT | /css/css-inline/initial-letter/Initial-letter-breaking-rtl.html | expected FAIL"
     }
   ]

--- a/tests/sample_data/logs/wpt-multiple.logview.json
+++ b/tests/sample_data/logs/wpt-multiple.logview.json
@@ -2,143 +2,143 @@
   "logurl": "http://my-log.mozilla.org/wpt-multiple.log.gz",
   "errors": [
     {
-      "linenumber": 6932,
+      "linenumber": 6944,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After a file has finished moving, that file can have an open access handle in readwrite-unsafe mode - promise_rejects_dom: function \"function() { throw e }\" threw object \"NotFoundError: Entry not found\" that is not a DOMException NoModificationAllowedError: property \"code\" is equal to 8, expected 7"
     },
     {
-      "linenumber": 6935,
+      "linenumber": 6947,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file cannot be moved to a location with an open access handle in readwrite-unsafe mode - expected NOTRUN"
     },
     {
-      "linenumber": 6938,
+      "linenumber": 6950,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open access handle in readwrite-unsafe mode cannot be moved - expected NOTRUN"
     },
     {
-      "linenumber": 6941,
+      "linenumber": 6953,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open access handle in readwrite-unsafe mode does not interfere with moving another file - expected NOTRUN"
     },
     {
-      "linenumber": 6944,
+      "linenumber": 6956,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After an open access handle in readwrite-unsafe mode on a file has been closed, that file can be moved - expected NOTRUN"
     },
     {
-      "linenumber": 6947,
+      "linenumber": 6959,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an ongoing remove operation does not interfere with the creation of an open access handle in readwrite-unsafe mode on another file - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 6950,
+      "linenumber": 6962,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After a file has finished being removed, that file can have an open access handle in readwrite-unsafe mode - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 6953,
+      "linenumber": 6965,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A directory cannot be removed if it contains a file that has an open access handle in readwrite-unsafe mode. - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 6956,
+      "linenumber": 6968,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open access handle in readwrite-unsafe mode cannot be removed - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 6959,
+      "linenumber": 6971,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open access handle in readwrite-unsafe mode does not interfere with removing another file - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 6962,
+      "linenumber": 6974,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After an open access handle in readwrite-unsafe mode on a file has been closed, that file can be removed - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 6965,
+      "linenumber": 6977,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | When there's an open writable stream in siloed mode on a file, cannot have an open access handle in readwrite-unsafe mode on that same file - expected NOTRUN"
     },
     {
-      "linenumber": 6968,
+      "linenumber": 6980,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open writable stream in siloed mode does not interfere with an open access handle in readwrite-unsafe mode on another file - expected NOTRUN"
     },
     {
-      "linenumber": 6971,
+      "linenumber": 6983,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After all writable streams in siloed mode have been closed for a file, that file can have an open access handle in readwrite-unsafe mode - expected NOTRUN"
     },
     {
-      "linenumber": 6974,
+      "linenumber": 6986,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | When there's an open access handle in readwrite-unsafe mode on a file, cannot open an open writable stream in siloed mode on that same file - expected NOTRUN"
     },
     {
-      "linenumber": 6977,
+      "linenumber": 6989,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open access handle in readwrite-unsafe mode does not interfere with the creation of an open writable stream in siloed mode on another file - expected NOTRUN"
     },
     {
-      "linenumber": 6980,
+      "linenumber": 6992,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | When there's an open writable stream in exclusive mode on a file, cannot have an open access handle in readwrite-unsafe mode on that same file - expected NOTRUN"
     },
     {
-      "linenumber": 6983,
+      "linenumber": 6995,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open writable stream in exclusive mode does not interfere with an open access handle in readwrite-unsafe mode on another file - expected NOTRUN"
     },
     {
-      "linenumber": 6986,
+      "linenumber": 6998,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After a writable stream in exclusive mode has been closed for a file, that file can have an open access handle in readwrite-unsafe mode - expected NOTRUN"
     },
     {
-      "linenumber": 6989,
+      "linenumber": 7001,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | When there's an open access handle in readwrite-unsafe mode on a file, cannot open an open writable stream in exclusive mode on that same file - expected NOTRUN"
     },
     {
-      "linenumber": 6992,
+      "linenumber": 7004,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open access handle in readwrite-unsafe mode does not interfere with the creation of an open writable stream in exclusive mode on another file - expected NOTRUN"
     },
     {
-      "linenumber": 6995,
+      "linenumber": 7007,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an ongoing move operation does not interfere with an open writable stream in siloed mode on another file - expected NOTRUN"
     },
     {
-      "linenumber": 6998,
+      "linenumber": 7010,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After a file has finished moving, that file can have an open writable stream in siloed mode - promise_rejects_dom: function \"function() { throw e }\" threw object \"NotFoundError: Entry not found\" that is not a DOMException NoModificationAllowedError: property \"code\" is equal to 8, expected 7"
     },
     {
-      "linenumber": 7001,
+      "linenumber": 7013,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file cannot be moved to a location with an open writable stream in siloed mode - expected NOTRUN"
     },
     {
-      "linenumber": 7004,
+      "linenumber": 7016,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | When there's an open writable stream in siloed mode on a file, cannot have an ongoing move operation on that same file - expected NOTRUN"
     },
     {
-      "linenumber": 7007,
+      "linenumber": 7019,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open writable stream in siloed mode does not interfere with an ongoing move operation on another file - expected NOTRUN"
     },
     {
-      "linenumber": 7010,
+      "linenumber": 7022,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After all writable streams in siloed mode have been closed for a file, that file can have an ongoing move operation - expected NOTRUN"
     },
     {
-      "linenumber": 7013,
+      "linenumber": 7025,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an ongoing remove operation does not interfere with the creation of an open writable stream in siloed mode on another file - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 7016,
+      "linenumber": 7028,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After a file has finished being removed, that file can have an open writable stream in siloed mode - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 15089,
+      "linenumber": 15111,
       "line": "00:01:58     INFO - KeyError: 261"
     },
     {
-      "linenumber": 15117,
+      "linenumber": 15139,
       "line": "00:01:58     INFO - KeyError: 275"
     },
     {
-      "linenumber": 17469,
+      "linenumber": 17497,
       "line": "00:05:10  WARNING - KeyError: 'bidi.bluetooth.simulate_adapter'"
     },
     {
-      "linenumber": 17482,
+      "linenumber": 17510,
       "line": "00:05:10  WARNING - ValueError: Unknown action bidi.bluetooth.simulate_adapter"
     },
     {
-      "linenumber": 17518,
+      "linenumber": 17546,
       "line": "00:05:15  WARNING - KeyError: 'bidi.permissions.set_permission'"
     },
     {
-      "linenumber": 17531,
+      "linenumber": 17559,
       "line": "00:05:15  WARNING - ValueError: Unknown action bidi.permissions.set_permission"
     }
   ]


### PR DESCRIPTION
## Summary

Upgrades `urllib3` to `2.6.3` (from `1.26.18` in production deps and `2.0.3` in dev deps), moving production onto the actively-maintained 2.x line.

## Log parser fixture regeneration

urllib3 2.x changes how gzip `Content-Encoding` is decompressed during streaming, which shifts line boundaries in the log parser's output. The **parsed error content is identical** — only the recorded `line_number` offsets change. Nine `.logview.json` fixtures are regenerated to match; the other sample logs were unaffected.

## Downstream impact

The stored `line_number` is used by the logviewer to position the error-line highlight and the "jump to first error" scroll. Other consumers (bug suggestions, failure classification, push-health matching) key off the error **text**, not the line number, and the `new_failure` tagging match is self-consistent under a uniform shift — so the user-visible effect is confined to where the logviewer highlight lands.

## Testing

- `pytest tests/log_parser/` → **146 passed** with urllib3 2.6.3 installed.
- Negative control: running the same fixtures against urllib3 1.26.18 fails on exactly the 9 regenerated fixtures (line-number mismatches), confirming the fixtures correctly track 2.x behavior.