### PR TITLE
Revert "Update dependency react-hot-keys to v3" for breaking hotkeys

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-bootstrap": "2.10.10",
     "react-dom": "19.2.3",
     "react-highlight-words": "0.20.0",
-    "react-hot-keys": "3.0.0",
+    "react-hot-keys": "2.7.3",
     "react-linkify": "0.2.2",
     "react-resizable-panels": "3.0.6",
     "react-router": "7.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: 0.20.0
         version: 0.20.0(react@19.2.3)
       react-hot-keys:
-        specifier: 3.0.0
-        version: 3.0.0(@babel/runtime@7.29.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 2.7.3
+        version: 2.7.3(@babel/runtime@7.29.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-linkify:
         specifier: 0.2.2
         version: 0.2.2
@@ -3182,8 +3182,8 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hotkeys-js@4.0.4:
-    resolution: {integrity: sha512-hseNiqaskxSnujuGp8aRMLJfcjaFiTSS0I2GQhqru82N/sx6CGyUf6pvU5X1iycvw2EqmvILkFIb5OzYFXY+9A==}
+  hotkeys-js@3.13.15:
+    resolution: {integrity: sha512-gHh8a/cPTCpanraePpjRxyIlxDFrIhYqjuh01UHWEwDpglJKCnvLW8kqSx5gQtOuSsJogNZXLhOdbSExpgUiqg==}
 
   hpack.js@2.1.6:
     resolution: {integrity: sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==}
@@ -4439,8 +4439,8 @@ packages:
     peerDependencies:
       react: ^0.14.0 || ^15.0.0 || ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
 
-  react-hot-keys@3.0.0:
-    resolution: {integrity: sha512-lcP0imYdnd8kLj9YE4TpgIoJp+wfJ+5WBoSZHryNCGzhavKmf5zf1rQsQ+z1tsbckc1x4dZNkaZLu2v3N+pShQ==}
+  react-hot-keys@2.7.3:
+    resolution: {integrity: sha512-OoX1kTookqQx/OBXBgBLQCANpw3KGUcJNOl+MNv8xJYyH/Rojv+jTjQbksDGQMIOWVfvLqOZi/ZVcVdsWUAUWg==}
     peerDependencies:
       '@babel/runtime': '>=7.10.0'
       react: '>=16.9.0'
@@ -8917,7 +8917,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hotkeys-js@4.0.4: {}
+  hotkeys-js@3.13.15: {}
 
   hpack.js@2.1.6:
     dependencies:
@@ -10408,10 +10408,11 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.3
 
-  react-hot-keys@3.0.0(@babel/runtime@7.29.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-hot-keys@2.7.3(@babel/runtime@7.29.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@babel/runtime': 7.29.2
-      hotkeys-js: 4.0.4
+      hotkeys-js: 3.13.15
+      prop-types: 15.8.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 


### PR DESCRIPTION
Reverts mozilla/treeherder#9426

Hotkeys only worked once.