### PR TITLE
Bug 2042946 - Add mozilla-releng/staging-firefox and mozilla/firefox-dev to Treeherder

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -2031,5 +2031,18 @@
       "repository_group": 13,
       "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
+  },
+  {
+    "pk": 147,
+    "model": "model.repository",
+    "fields": {
+      "dvcs_type": "git",
+      "name": "staging-firefox",
+      "url": "https://github.com/mozilla-releng/staging-firefox",
+      "active_status": "active",
+      "codebase": "gecko",
+      "repository_group": 7,
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
+    }
   }
 ]

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -2044,5 +2044,18 @@
       "repository_group": 7,
       "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
     }
+  },
+  {
+    "pk": 148,
+    "model": "model.repository",
+    "fields": {
+      "dvcs_type": "git",
+      "name": "firefox-dev",
+      "url": "https://github.com/mozilla/firefox-dev",
+      "active_status": "active",
+      "codebase": "gecko",
+      "repository_group": 1,
+      "tc_root_url": "https://firefox-ci-tc.services.mozilla.com"
+    }
   }
 ]

--- a/treeherder/model/fixtures/repository_branch.json
+++ b/treeherder/model/fixtures/repository_branch.json
@@ -438,5 +438,13 @@
       "repository": 146,
       "branch": "*"
     }
+  },
+  {
+    "pk": 59,
+    "model": "model.repositorybranch",
+    "fields": {
+      "repository": 147,
+      "branch": "*"
+    }
   }
 ]

--- a/treeherder/model/fixtures/repository_branch.json
+++ b/treeherder/model/fixtures/repository_branch.json
@@ -446,5 +446,13 @@
       "repository": 147,
       "branch": "*"
     }
+  },
+  {
+    "pk": 60,
+    "model": "model.repositorybranch",
+    "fields": {
+      "repository": 148,
+      "branch": "user/*"
+    }
   }
 ]


### PR DESCRIPTION
Releng uses this repo to test infrastructure and CI related changes affecting the Firefox repo. It would be handy to see pushes here in Treeherder, espcially for the Github migration.