### PR TITLE
Show "Open in Firefox Profiler" link regardless of file extension

### DIFF
--- a/tests/ui/shared/JobArtifacts_test.jsx
+++ b/tests/ui/shared/JobArtifacts_test.jsx
@@ -1,0 +1,48 @@
+import { render, cleanup } from '@testing-library/react';
+
+import JobArtifacts from '../../../ui/shared/JobArtifacts';
+
+describe('JobArtifacts', () => {
+  const selectedJob = {
+    task_id: 'abc123',
+    result: 'success',
+    build_platform: 'windows10-64',
+  };
+
+  const renderArtifacts = (jobDetails) =>
+    render(
+      <JobArtifacts
+        jobDetails={jobDetails}
+        jobArtifactsLoading={false}
+        repoName="try"
+        selectedJob={selectedJob}
+      />,
+    );
+
+  afterEach(cleanup);
+
+  test('shows "open in Firefox Profiler" link for profile_*.json.gz artifact', () => {
+    const { getByText } = renderArtifacts([
+      {
+        url: 'https://example.com/profile_editor-tiptap-16.json.gz',
+        value: 'profile_editor-tiptap-16.json.gz',
+      },
+    ]);
+
+    const link = getByText('open in Firefox Profiler');
+    expect(link.href).toBe(
+      'https://profiler.firefox.com/from-url/https%3A%2F%2Fexample.com%2Fprofile_editor-tiptap-16.json.gz',
+    );
+  });
+
+  test('does not show profiler link for non-profile artifacts', () => {
+    const { queryByText } = renderArtifacts([
+      {
+        url: 'https://example.com/log.txt',
+        value: 'log.txt',
+      },
+    ]);
+
+    expect(queryByText('open in Firefox Profiler')).toBeNull();
+  });
+});

--- a/ui/job-view/details/tabs/PerformanceTab.jsx
+++ b/ui/job-view/details/tabs/PerformanceTab.jsx
@@ -98,10 +98,6 @@ class PerformanceTab extends React.PureComponent {
       return PROFILE_ZIP_RELEVANCE;
     }
 
-    if (!value.endsWith('.json') && !value.endsWith('.json.gz')) {
-      return NO_PROFILE_RELEVANCE;
-    }
-
     if (value === 'profile_resource-usage.json') {
       return PROFILE_RESOURCE_RELEVANCE;
     }

--- a/ui/shared/JobArtifacts.jsx
+++ b/ui/shared/JobArtifacts.jsx
@@ -261,9 +261,7 @@ export default class JobArtifacts extends React.PureComponent {
                 }
 
                 const isProfileArtifact =
-                  !!line.url &&
-                  line.value.startsWith('profile_') &&
-                  (line.value.endsWith('.zip') || line.value.endsWith('.json'));
+                  !!line.url && line.value.startsWith('profile_');
                 const primaryUrl = isProfileArtifact
                   ? getPerfAnalysisUrl(line.url, selectedJob)
                   : line.url;


### PR DESCRIPTION
Example job: https://treeherder.mozilla.org/jobs?repo=try&revision=f3b86f5e055f765193170b07af85b25fc56e2c7f&selectedTaskRun=dw9VQ3ihTLaz4JBhMLgjaQ.0

This PR makes it so that `test_info/profile_sp3_etw_compact.json.gz` will also have an "Open in Firefox Profiler" link behind it. I originally tried this in #9390 but changed the wrong code.

Rather than adding `.json.gz` to the allow-listed file extensions, this PR just removes any checks for file extensions and just fully relies on the `profile_` prefix. This is more flexible. I'm planning to add support for a binary profile format soon, and it might have yet another file extension, so this means that we won't have to worry about any other treeherder changes when that happens.