### PR TITLE
Show the source branch on pushes matched by a wildcard rule

### DIFF
--- a/tests/etl/test_push_loader.py
+++ b/tests/etl/test_push_loader.py
@@ -324,6 +324,28 @@ def test_ingest_github_push_wildcard_repo(github_push, test_repository, mock_git
         "https://firefox-ci-tc.services.mozilla.com",
     )
     assert Push.objects.count() == 1
+    # The catch-all wildcard match records the branch the push came from
+    assert Push.objects.first().branch == "my-feature-branch"
+
+
+@pytest.mark.django_db
+def test_ingest_github_push_exact_branch_records_no_branch(
+    github_push, test_repository, mock_github_push_compare
+):
+    """An exact branch match leaves push.branch null (it's implied by the repository)"""
+    test_repository.url = github_push[0]["payload"]["details"]["event.head.repo.url"].replace(
+        ".git", ""
+    )
+    test_repository.save()
+    RepositoryBranch.objects.create(repository=test_repository, branch="master")
+    github_push[0]["payload"]["details"]["event.base.repo.branch"] = "master"
+    PushLoader().process(
+        github_push[0]["payload"],
+        github_push[0]["exchange"],
+        "https://firefox-ci-tc.services.mozilla.com",
+    )
+    assert Push.objects.count() == 1
+    assert Push.objects.first().branch is None
 
 
 @pytest.mark.django_db
@@ -403,6 +425,9 @@ def test_ingest_github_push_prefix_wildcard(
         "https://firefox-ci-tc.services.mozilla.com",
     )
     assert Push.objects.count() == expected_pushes
+    if expected_pushes:
+        # A prefix-wildcard match records the specific branch that matched
+        assert Push.objects.first().branch == branch
 
 
 @pytest.mark.django_db

--- a/tests/ui/job-view/pushes/PushHeader.test.jsx
+++ b/tests/ui/job-view/pushes/PushHeader.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+import PushHeader from '../../../../ui/job-view/pushes/PushHeader';
+
+const jobCounts = {
+  completed: 0,
+  fixedByCommit: 0,
+  pending: 0,
+  running: 0,
+  test_failed: 0,
+  build_failed: 0,
+  lint_failed: 0,
+};
+
+const renderHeader = (props = {}) =>
+  render(
+    <MemoryRouter initialEntries={['/jobs?repo=try']}>
+      <PushHeader
+        push={{ id: 1 }}
+        pushId={1}
+        pushTimestamp={1378293517}
+        author="someone@mozilla.com"
+        revision="abc123"
+        filterModel={{ getUrlParamsWithoutDefaults: () => ({}) }}
+        runnableVisible={false}
+        showRunnableJobs={() => {}}
+        hideRunnableJobs={() => {}}
+        showFuzzyJobs={() => {}}
+        cycleWatchState={() => {}}
+        expandAllPushGroups={() => {}}
+        notificationSupported={false}
+        getAllShownJobs={() => {}}
+        selectedRunnableJobs={[]}
+        collapsed={false}
+        jobCounts={jobCounts}
+        pushHealthVisibility="None"
+        decisionTaskMap={{}}
+        currentRepo={{ name: 'try' }}
+        togglePushCollapsed={() => {}}
+        {...props}
+      />
+    </MemoryRouter>,
+  );
+
+afterEach(cleanup);
+
+describe('PushHeader branch badge', () => {
+  test('shows the branch a push came from when set', () => {
+    const { getByTestId } = renderHeader({ branch: 'releases/v1.2' });
+
+    expect(getByTestId('push-branch-badge')).toHaveTextContent('releases/v1.2');
+  });
+
+  test('is hidden when the push has no branch', () => {
+    const { queryByTestId } = renderHeader({ branch: null });
+
+    expect(queryByTestId('push-branch-badge')).toBeNull();
+  });
+});

--- a/tests/webapp/api/test_push_api.py
+++ b/tests/webapp/api/test_push_api.py
@@ -29,6 +29,7 @@ def test_push_list_basic(client, eleven_jobs_stored, test_repository):
             "id",
             "repository_id",
             "author",
+            "branch",
             "revision",
             "revisions",
             "revision_count",

--- a/treeherder/etl/push.py
+++ b/treeherder/etl/push.py
@@ -19,6 +19,7 @@ def store_push(repository, push_dict):
             defaults={
                 "author": push_dict["author"],
                 "time": datetime.utcfromtimestamp(push_dict["push_timestamp"]),
+                "branch": push_dict.get("branch"),
             },
         )
         for revision in push_dict["revisions"]:

--- a/treeherder/etl/push_loader.py
+++ b/treeherder/etl/push_loader.py
@@ -46,6 +46,7 @@ class PushLoader:
             return
 
         transformed_data = transformer.transform(repo.name)
+        transformed_data["branch"] = transformer.get_push_branch(repo)
 
         logger.info(
             f"Storing push for repository '{repo.name}' revision '{transformed_data['revision']}' branch '{transformer.branch}' url {transformer.repo_url}",
@@ -75,6 +76,20 @@ class GithubTransformer:
 
     def resolve_repo(self):
         return Repository.resolve_branch(self.repo_url, self.branch)
+
+    def get_push_branch(self, repo):
+        """Return the branch to record on the push, or None.
+
+        Only recorded when the push matched a wildcard branch rule (e.g.
+        ``releases/*`` or the catch-all ``*``). For an exact branch rule the
+        branch is implied by the repository, so there is nothing to surface.
+        """
+        if not self.branch:
+            return None
+        if repo.branches.filter(branch=self.branch).exists():
+            # Exact branch match: redundant with the repository itself.
+            return None
+        return self.branch
 
     def get_info(self):
         # flatten the data a bit so it will show in new relic as fields
@@ -268,6 +283,10 @@ class HgPushTransformer:
 
     def resolve_repo(self):
         return self.repos.exclude(branches__branch__endswith="*").get()
+
+    def get_push_branch(self, repo):
+        # Hg pushes never resolve through wildcard branches (see resolve_repo).
+        return None
 
     def get_info(self):
         return self.message_body["payload"]

--- a/treeherder/model/migrations/0053_push_branch.py
+++ b/treeherder/model/migrations/0053_push_branch.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("model", "0052_bugscache_summary_gin_trgm_index"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="push",
+            name="branch",
+            field=models.CharField(blank=True, default=None, max_length=255, null=True),
+        ),
+    ]

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -191,6 +191,10 @@ class Push(models.Model):
     revision = models.CharField(max_length=40, db_index=True)
     author = models.CharField(max_length=150)
     time = models.DateTimeField(db_index=True)
+    # The specific branch this push came from, recorded only when it matched a
+    # wildcard branch rule (e.g. 'releases/*' or the catch-all '*'). For exact
+    # branch rules the branch is implied by the repository, so this stays null.
+    branch = models.CharField(max_length=255, null=True, blank=True, default=None)
 
     failures = FailuresQuerySet.as_manager()
     objects = models.Manager()

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -283,6 +283,7 @@ class PushSerializer(serializers.ModelSerializer):
             "id",
             "revision",
             "author",
+            "branch",
             "revisions",
             "revision_count",
             "push_timestamp",

--- a/ui/job-view/pushes/Push.jsx
+++ b/ui/job-view/pushes/Push.jsx
@@ -607,6 +607,7 @@ function Push({
     revisions,
     revision_count: revisionCount,
     author,
+    branch,
   } = push;
   const tipRevision = push.revisions[0];
   const decisionTask = decisionTaskMap[push.id];
@@ -643,6 +644,7 @@ function Push({
         pushId={id}
         pushTimestamp={pushTimestamp}
         author={author}
+        branch={branch}
         revision={revision}
         jobCounts={jobCounts}
         watchState={watched}

--- a/ui/job-view/pushes/PushHeader.jsx
+++ b/ui/job-view/pushes/PushHeader.jsx
@@ -6,6 +6,7 @@ import {
   faPlusSquare,
 } from '@fortawesome/free-regular-svg-icons';
 import {
+  faCodeBranch,
   faExternalLinkAlt,
   faThumbtack,
   faTimesCircle,
@@ -43,6 +44,7 @@ function PushHeader({
   pushId,
   pushTimestamp,
   author,
+  branch = null,
   revision = null,
   filterModel,
   runnableVisible,
@@ -169,6 +171,17 @@ function PushHeader({
               -{' '}
             </span>
             <Link to={authorPushFilterUrl}>{author}</Link>
+            {branch && (
+              <Badge
+                bg="secondary"
+                className="ms-2 push-branch-badge"
+                title={`This push came from the "${branch}" branch`}
+                data-testid="push-branch-badge"
+              >
+                <FontAwesomeIcon icon={faCodeBranch} className="me-1" />
+                {branch}
+              </Badge>
+            )}
           </span>
         </span>
         <PushCounts
@@ -258,6 +271,7 @@ PushHeader.propTypes = {
   pushId: PropTypes.number.isRequired,
   pushTimestamp: PropTypes.number.isRequired,
   author: PropTypes.string.isRequired,
+  branch: PropTypes.string,
   revision: PropTypes.string,
   filterModel: PropTypes.shape({}).isRequired,
   runnableVisible: PropTypes.bool.isRequired,


### PR DESCRIPTION
Repositories can match pushes through wildcard branch rules — the catch-all "*" or a prefix like "release/*". The specific branch that matched was previously discarded, so the UI had no way to show whether a push came from, say, release/v151.0 or release/v150.0.

Record that branch on the Push when (and only when) it matches a wildcard rule; exact branch rules are implied by the repository and stay null. The branch is exposed through the push API and rendered as a badge next to the author in the push header.

- model:  add nullable Push.branch (migration 0053)
- ingest: capture the matched branch for wildcard rules only
- api:    add branch to PushSerializer
- ui:     render a branch badge in PushHeader when present

Example:
<img width="991" height="287" alt="Screenshot 2026-06-01 at 3 43 23 PM" src="https://github.com/user-attachments/assets/72019006-9c27-48f4-bbd4-43243243454a" />

Note: badge should not appear on repos without wilcard branch configs