### PR TITLE
Bug 2044773 - Add command to run test locally in comment0. r?#perftest

### DIFF
--- a/ui/perfherder/alerts/StatusDropdown.jsx
+++ b/ui/perfherder/alerts/StatusDropdown.jsx
@@ -232,6 +232,8 @@ If you need the profiling jobs [you can trigger them yourself from treeherder jo
 
 You can run all of these tests on try with \`./mach try perf --alert {{ alertSummaryId }}\`
 
+You can run all of these tests locally with \`./mach try perftest {{ alertSummaryId }}\`
+
 The following [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) provides more information about this command.
     `;
 
@@ -247,6 +249,8 @@ Details of the alert can be found in the [alert summary]({{ alertHref }}), inclu
 If you need the profiling jobs [you can trigger them yourself from treeherder job view](https://firefox-source-docs.mozilla.org/testing/perfdocs/perftest-in-a-nutshell.html#using-the-firefox-profiler) or ask a performance sheriff to do that for you.
 
 You can run all of these tests on try with \`./mach try perf --alert {{ alertSummaryId }}\`
+
+You can run all of these tests locally with \`./mach try perftest {{ alertSummaryId }}\`
 
 The following [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) provides more information about this command.
     `;


### PR DESCRIPTION
[From our interviews on how to improve comment 0](https://bugzilla.mozilla.org/show_bug.cgi?id=2044755)

We noticed that all candidates were able to figure out how to run a try job.
They were able to by looking within comment 0 and copying the command from [comment0](https://bugzilla.mozilla.org/show_bug.cgi?id=2044773#c0).

No candidate knew how to run locally however.
While not a definitive solution having a section in [comment0](https://bugzilla.mozilla.org/show_bug.cgi?id=2044773#c0) for running locally we would be able to help many people out with running tests locally.