### PR TITLE
Improve backfill logging and iteration tracking

### DIFF
--- a/tests/perf/auto_perf_sheriffing/conftest.py
+++ b/tests/perf/auto_perf_sheriffing/conftest.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -156,7 +156,7 @@ def report_maintainer_mock():
 
 @pytest.fixture
 def backfill_tool_mock():
-    def backfill_job(job_id):
+    def backfill_job(job_id, alert_id=None):
         if job_id is None:
             raise Job.DoesNotExist
         return "RANDOM_TASK_ID"
@@ -190,7 +190,7 @@ def empty_sheriff_settings(secretary):
 def performance_settings(db):
     settings = {
         "limits": 500,
-        "last_reset_date": datetime.utcnow(),
+        "last_reset_date": datetime.now(UTC),
     }
     return PerformanceSettings.objects.create(
         name="perf_sheriff_bot",
@@ -202,7 +202,7 @@ def performance_settings(db):
 def expired_performance_settings(db):
     settings = {
         "limits": 500,
-        "last_reset_date": datetime.utcnow() - timedelta(days=30),
+        "last_reset_date": datetime.now(UTC) - timedelta(days=30),
     }
     return PerformanceSettings.objects.create(
         name="perf_sheriff_bot",

--- a/tests/perf/auto_perf_sheriffing/test_secretary.py
+++ b/tests/perf/auto_perf_sheriffing/test_secretary.py
@@ -347,7 +347,9 @@ class TestVerifyAndIterate:
 
         with (
             patch.object(secretary, "re_run_detect_changes", return_value=(push_id, 2.5, [])),
-            patch.object(secretary, "_calculate_gap_size", return_value=0),
+            patch(
+                "treeherder.perf.auto_perf_sheriffing.secretary.calculate_gap_size", return_value=0
+            ),
         ):
             secretary.verify_and_iterate(record_successful)
 
@@ -362,7 +364,9 @@ class TestVerifyAndIterate:
 
         with (
             patch.object(secretary, "re_run_detect_changes", return_value=(push_id, 2.5, [])),
-            patch.object(secretary, "_calculate_gap_size", return_value=3),
+            patch(
+                "treeherder.perf.auto_perf_sheriffing.secretary.calculate_gap_size", return_value=3
+            ),
         ):
             secretary.verify_and_iterate(record_successful)
 
@@ -418,14 +422,17 @@ class TestVerifyAndIterate:
         push_id = record_successful.last_detected_push_id
 
         # Simulate a previous log entry with gap_size=3
+        record_successful.iteration_count = 1
         record_successful.append_to_backfill_logs(
-            {"iteration": 0, "detected_push_gap_size": 3, "status": "stabilized_with_gap"}
+            {"iteration": 0, "detected_push_gap_size": 3, "status": "initial"}
         )
         record_successful.save()
 
         with (
             patch.object(secretary, "re_run_detect_changes", return_value=(push_id, 2.5, [])),
-            patch.object(secretary, "_calculate_gap_size", return_value=3),
+            patch(
+                "treeherder.perf.auto_perf_sheriffing.secretary.calculate_gap_size", return_value=3
+            ),
         ):
             secretary.verify_and_iterate(record_successful)
 

--- a/treeherder/perf/auto_perf_sheriffing/backfill_reports.py
+++ b/treeherder/perf/auto_perf_sheriffing/backfill_reports.py
@@ -1,10 +1,11 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from itertools import groupby, zip_longest
 
 import simplejson as json
 from django.db.models import F, Q, QuerySet
 
+from treeherder.perf.auto_perf_sheriffing.secretary import calculate_gap_size
 from treeherder.perf.exceptions import MissingRecordsError
 from treeherder.perf.models import (
     BackfillRecord,
@@ -12,6 +13,7 @@ from treeherder.perf.models import (
     PerformanceAlert,
     PerformanceAlertSummary,
     PerformanceDatum,
+    Push,
 )
 from treeherder.utils import default_serializer
 
@@ -321,12 +323,31 @@ class BackfillReportMaintainer:
 
     def _provide_records(self, backfill_report: BackfillReport, alert_context_map: list[tuple]):
         for alert, retrigger_context in alert_context_map:
-            BackfillRecord.objects.create(
+            record = BackfillRecord.objects.create(
                 alert=alert,
                 report=backfill_report,
                 context=json.dumps(retrigger_context, default=default_serializer),
                 last_detected_push_id=alert.summary.push_id,
             )
+            try:
+                detected_push = Push.objects.get(id=record.last_detected_push_id)
+            except Push.DoesNotExist:
+                self.log.warning(
+                    f"Push {record.last_detected_push_id} not found for initial log: [alert_id={record.alert.id}]"
+                )
+                continue
+            record.append_to_backfill_logs(
+                {
+                    "iteration": record.iteration_count,
+                    "status": "initial",
+                    "detected_push_id": record.last_detected_push_id,
+                    "detected_push_revision": detected_push.revision,
+                    "detected_push_gap_size": calculate_gap_size(record, detected_push),
+                    "timestamp": datetime.now(UTC).isoformat(),
+                    "notes": "Initial detection from the alert.",
+                }
+            )
+            record.save()
 
     def __fetch_summaries_to_retrigger(
         self, since: datetime, frameworks: list[str], repositories: list[str]

--- a/treeherder/perf/auto_perf_sheriffing/backfill_tool.py
+++ b/treeherder/perf/auto_perf_sheriffing/backfill_tool.py
@@ -13,7 +13,7 @@ class BackfillTool:
     def __init__(self, taskcluster_model: TaskclusterModel):
         self.__taskcluster = taskcluster_model
 
-    def backfill_job(self, job: Job | str) -> str:
+    def backfill_job(self, job: Job | str, alert_id=None) -> str:
         if not isinstance(job, Job):
             job = self._fetch_job_by_id(job)
 
@@ -25,7 +25,9 @@ class BackfillTool:
         decision_task_id = decision_job.taskcluster_metadata.task_id
 
         if "browsertime" in job.job_group.name.lower():
-            logger.debug(f"Requesting side_by_side for task {task_id_to_backfill}...")
+            logger.info(
+                f"Requesting side_by_side for task {task_id_to_backfill} [alert_id={alert_id}, job_id={job.id}]"
+            )
             side_by_side_task_id = self.__taskcluster.trigger_action(
                 action="side-by-side",
                 task_id=task_id_to_backfill,
@@ -34,9 +36,11 @@ class BackfillTool:
                 root_url=job.repository.tc_root_url,
             )
             logger.info(
-                f"Task id {side_by_side_task_id} created when triggered side_by_side for job id {task_id_to_backfill}"
+                f"side_by_side triggered, result task_id={side_by_side_task_id} [alert_id={alert_id}, job_id={job.id}]"
             )
-        logger.debug(f"Requesting backfill for task {task_id_to_backfill}...")
+        logger.info(
+            f"Requesting backfill for task {task_id_to_backfill} [alert_id={alert_id}, job_id={job.id}]"
+        )
         task_id = self.__taskcluster.trigger_action(
             action="backfill",
             task_id=task_id_to_backfill,
@@ -46,6 +50,9 @@ class BackfillTool:
                 "slices": 3,
             },
             root_url=job.repository.tc_root_url,
+        )
+        logger.info(
+            f"Backfill triggered, result task_id={task_id} [alert_id={alert_id}, job_id={job.id}]"
         )
         return task_id
 

--- a/treeherder/perf/auto_perf_sheriffing/secretary.py
+++ b/treeherder/perf/auto_perf_sheriffing/secretary.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import simplejson as json
@@ -22,6 +22,37 @@ from treeherder.perfalert.perfalert import RevisionDatum, detect_changes
 from treeherder.utils import default_serializer
 
 logger = logging.getLogger(__name__)
+
+
+def calculate_gap_size(record: BackfillRecord, target_push: Push) -> int:
+    """
+    Count consecutive pushes without performance data immediately before `target_push`.
+    """
+    signature = record.alert.series_signature
+    repository = record.repository
+    pushes_before = list(
+        Push.objects.filter(repository=repository, time__lt=target_push.time).order_by("-time")[
+            :100
+        ]
+    )
+    if not pushes_before:
+        return 0
+
+    datum_push_ids = set(
+        PerformanceDatum.objects.filter(
+            repository=repository,
+            signature=signature,
+            push_id__in=[p.id for p in pushes_before],
+        ).values_list("push_id", flat=True)
+    )
+
+    gap_count = 0
+    for p in pushes_before:
+        if p.id not in datum_push_ids:
+            gap_count += 1
+        else:
+            break
+    return gap_count
 
 
 # TODO: update the backfill status using data (bug 1626548)
@@ -65,7 +96,7 @@ class Secretary:
     @classmethod
     def mark_reports_for_backfill(cls):
         # get the backfill reports that are mature, but not frozen
-        mature_date_limit = datetime.utcnow() - django_settings.TIME_TO_MATURE
+        mature_date_limit = datetime.now(UTC) - django_settings.TIME_TO_MATURE
         mature_reports = BackfillReport.objects.filter(
             frozen=False, last_updated__lte=mature_date_limit
         )
@@ -73,7 +104,7 @@ class Secretary:
         logger.info(f"Sherlock: {mature_reports.count()} mature reports found.")
 
         # Only for logging alternative strategy for choosing maturity limit
-        alternative_date_limit = datetime.utcnow() - timedelta(days=1)
+        alternative_date_limit = datetime.now(UTC) - timedelta(days=1)
         alternative_mature_reports = BackfillReport.objects.filter(
             frozen=False, created__lte=alternative_date_limit
         )
@@ -83,11 +114,13 @@ class Secretary:
 
         for report in mature_reports:
             should_freeze = False
-            logger.info(f"Sherlock: Marking report with id {report.summary.id} for backfill...")
+            logger.info(
+                f"Sherlock: Marking report [summary_id={report.summary.id}] for backfill..."
+            )
             for record in report.records.all():
                 if record.status == BackfillRecord.PRELIMINARY:
                     logger.info(
-                        f"Sherlock: Marking record with id {record.alert.id} READY_FOR_PROCESSING..."
+                        f"Sherlock: Marking record [alert_id={record.alert.id}] as READY_FOR_PROCESSING..."
                     )
                     record.status = BackfillRecord.READY_FOR_PROCESSING
                     record.save()
@@ -99,7 +132,9 @@ class Secretary:
     @classmethod
     def are_expired(cls, settings):
         last_reset_date = datetime.fromisoformat(settings["last_reset_date"])
-        return datetime.utcnow() > last_reset_date + django_settings.RESET_BACKFILL_LIMITS
+        if last_reset_date.tzinfo is None:
+            last_reset_date = last_reset_date.replace(tzinfo=UTC)
+        return datetime.now(UTC) > last_reset_date + django_settings.RESET_BACKFILL_LIMITS
 
     def backfills_left(self, on_platform: str) -> int:
         self.__assert_platform_is_supported(on_platform)
@@ -147,13 +182,13 @@ class Secretary:
     def verify_and_iterate(self, record: BackfillRecord, max_iterations: int = 5):
         if record.iteration_count >= max_iterations:
             logger.info(
-                f"Record {record.alert.id} reached max iterations ({max_iterations}), stopping verification."
+                f"Record [alert_id={record.alert.id}] reached max iterations ({max_iterations}), stopping verification."
             )
             return
 
         if record.last_detected_push_id is None:
             logger.warning(
-                f"Record {record.alert.id}: last_detected_push_id is None; "
+                f"Record [alert_id={record.alert.id}]: last_detected_push_id is None; "
                 f"skipping iteration (legacy record, no culprit push to compare)."
             )
             return
@@ -162,16 +197,33 @@ class Secretary:
             detected_push_id, detected_t_value, candidates = self.re_run_detect_changes(record)
 
             if detected_push_id is None:
-                logger.warning(
-                    f"Record {record.alert.id}: No change detected in verification, stopping iteration."
+                logger.info(
+                    f"Record [alert_id={record.alert.id}]: No change detected in verification, stopping iteration."
                 )
+                log_entry = {
+                    "status": "no_candidate_detected",
+                    "notes": "No candidate detected during verification, stopping iteration.",
+                    "timestamp": datetime.now(UTC).isoformat(),
+                }
+                record.update_backfill_log(record.iteration_count, log_entry)
+                record.save()
                 return
 
             try:
                 detected_push = Push.objects.get(id=detected_push_id)
             except Push.DoesNotExist as ex:
                 logger.warning(
-                    f"Record {record.alert.id}: Could not find push for comparison: {ex}"
+                    f"Record [alert_id={record.alert.id}]: Could not find push for comparison: {ex}"
+                )
+                record.status = BackfillRecord.VERIFICATION_FAILED
+                record.save()
+                return
+
+            try:
+                previous_push = Push.objects.get(id=record.last_detected_push_id)
+            except Push.DoesNotExist as ex:
+                logger.warning(
+                    f"Record [alert_id={record.alert.id}]: Could not find push for comparison: {ex}"
                 )
                 record.status = BackfillRecord.VERIFICATION_FAILED
                 record.save()
@@ -180,67 +232,65 @@ class Secretary:
             log_entry = {
                 "iteration": record.iteration_count,
                 "detected_push_id": detected_push_id,
+                "detected_push_revision": detected_push.revision,
                 "detected_t_value": detected_t_value,
                 "candidates": candidates,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(UTC).isoformat(),
                 "previous_push_id": record.last_detected_push_id,
-                "detected_push_gap_size": self._calculate_gap_size(record, detected_push),
+                "previous_push_revision": previous_push.revision,
+                "detected_push_gap_size": calculate_gap_size(record, detected_push),
             }
 
             if detected_push_id == record.last_detected_push_id:
                 if log_entry["detected_push_gap_size"] > 0:
                     previous_logs = record.get_backfill_logs()
+                    previous_iteration = record.iteration_count - 1
+                    previous_log = None
+                    for log in previous_logs:
+                        if log.get("iteration") == previous_iteration:
+                            previous_log = log
+                            break
                     previous_gap_size = (
-                        previous_logs[-1].get("detected_push_gap_size") if previous_logs else None
+                        previous_log.get("detected_push_gap_size") if previous_log else None
                     )
                     current_gap_size = log_entry["detected_push_gap_size"]
                     if previous_gap_size is not None and current_gap_size == previous_gap_size:
                         log_entry["status"] = "stabilized_gap_stuck"
                         log_entry["notes"] = (
-                            f"Gap before {detected_push_id} did not shrink "
+                            f"Gap before {detected_push.revision[:7]} did not shrink "
                             f"(was {previous_gap_size}, still {current_gap_size}); "
-                            f"pushes likely lack target job type, stopping."
+                            f"stopping iteration."
                         )
-                        record.append_to_backfill_logs(log_entry)
+                        record.update_backfill_log(record.iteration_count, log_entry)
                         record.save()
                         logger.info(
-                            f"Backfill Record {record.alert.id}: Gap stuck at size {current_gap_size} "
-                            f"(was {previous_gap_size}), pushes likely unsupported — stopping iteration."
+                            f"Backfill Record [alert_id={record.alert.id}]: Gap stuck at size {current_gap_size} "
+                            f"(was {previous_gap_size}), stopping iteration."
                         )
                         return
 
                     log_entry["status"] = "stabilized_with_gap"
                     log_entry["notes"] = (
-                        f"Detection stabilized at {detected_push_id} but gap remains before it, re-triggering"
+                        f"Detection stabilized at {detected_push.revision[:7]} but gap remains before it, re-triggering"
                     )
                     record.last_detected_push_id = detected_push_id
-                    record.append_to_backfill_logs(log_entry)
+                    record.update_backfill_log(record.iteration_count, log_entry)
                     record.status = BackfillRecord.READY_FOR_PROCESSING
                     record.save()
                     logger.info(
-                        f"Backfill Record {record.alert.id}: Detection stabilized at {detected_push_id} "
+                        f"Backfill Record [alert_id={record.alert.id}]: Detection stabilized at {detected_push.revision[:7]} "
                         f"but gap remains, iteration {record.iteration_count}/{max_iterations}, "
                         f"triggering next backfill."
                     )
                 else:
                     log_entry["status"] = "stabilized"
                     log_entry["notes"] = "Detected push same as previous, culprit stabilized"
-                    record.append_to_backfill_logs(log_entry)
+                    record.update_backfill_log(record.iteration_count, log_entry)
                     record.save()
                     logger.info(
-                        f"Backfill Record {record.alert.id}: Detected push {detected_push_id} stabilized, "
+                        f"Backfill Record [alert_id={record.alert.id}]: Detected push {detected_push.revision[:7]} stabilized, "
                         f"stopping iteration."
                     )
-                return
-
-            try:
-                previous_push = Push.objects.get(id=record.last_detected_push_id)
-            except Push.DoesNotExist as ex:
-                logger.warning(
-                    f"Record {record.alert.id}: Could not find push for comparison: {ex}"
-                )
-                record.status = BackfillRecord.VERIFICATION_FAILED
-                record.save()
                 return
 
             if detected_push.time < previous_push.time:
@@ -250,22 +300,22 @@ class Secretary:
 
             log_entry["status"] = direction
             log_entry["notes"] = (
-                f"Detected push moved {direction} (from {record.last_detected_push_id} to {detected_push_id})"
+                f"Detected push moved {direction} (from {previous_push.revision[:7]} to {detected_push.revision[:7]})"
             )
             logger.info(
-                f"Backfill Record {record.alert.id}: Detected push moved {direction} "
+                f"Backfill Record [alert_id={record.alert.id}]: Detected push moved {direction} "
                 f"from {record.last_detected_push_id} to {detected_push_id}, "
                 f"iteration {record.iteration_count}/{max_iterations}, triggering next backfill."
             )
 
             record.last_detected_push_id = detected_push_id
-            record.append_to_backfill_logs(log_entry)
+            record.update_backfill_log(record.iteration_count, log_entry)
             record.status = BackfillRecord.READY_FOR_PROCESSING
             record.save()
 
         except Exception as ex:
             logger.error(
-                f"Record {record.alert.id}: Error during verification/iteration: {ex}",
+                f"Record [alert_id={record.alert.id}]: Error during verification/iteration: {ex}",
                 exc_info=True,
             )
             record.status = BackfillRecord.VERIFICATION_FAILED
@@ -279,7 +329,7 @@ class Secretary:
     def _get_default_settings(cls, as_json=True):
         default_settings = {
             "limits": django_settings.MAX_BACKFILLS_PER_PLATFORM,
-            "last_reset_date": datetime.utcnow(),
+            "last_reset_date": datetime.now(UTC),
         }
 
         return (
@@ -375,9 +425,15 @@ class Secretary:
         candidates: list[dict[str, Any]] = []
         for prev, cur in zip(analyzed_series, analyzed_series[1:]):
             if cur.change_detected:
+                try:
+                    push = Push.objects.get(id=cur.push_id)
+                except Push.DoesNotExist as ex:
+                    logger.warning(f"Push {cur.push_id} not found for candidate: {ex}")
+                    continue
                 candidates.append(
                     {
-                        "push_id": int(cur.push_id),
+                        "push_id": int(push.id),
+                        "revision": push.revision,
                         "t_value": float(cur.t),
                         "push_timestamp": int(cur.push_timestamp),
                     }
@@ -388,33 +444,3 @@ class Secretary:
         # Pick the earliest push from the detected candidates
         culprit = min(candidates, key=lambda c: c["push_timestamp"])
         return culprit["push_id"], culprit["t_value"], candidates
-
-    def _calculate_gap_size(self, record: BackfillRecord, target_push: Push) -> int:
-        """
-        Count consecutive pushes without performance data immediately before `target_push`.
-        """
-        signature = record.alert.series_signature
-        repository = record.repository
-        pushes_before = list(
-            Push.objects.filter(repository=repository, time__lt=target_push.time).order_by("-time")[
-                :100
-            ]
-        )
-        if not pushes_before:
-            return 0
-
-        datum_push_ids = set(
-            PerformanceDatum.objects.filter(
-                repository=repository,
-                signature=signature,
-                push_id__in=[p.id for p in pushes_before],
-            ).values_list("push_id", flat=True)
-        )
-
-        gap_count = 0
-        for p in pushes_before:
-            if p.id not in datum_push_ids:
-                gap_count += 1
-            else:
-                break
-        return gap_count

--- a/treeherder/perf/auto_perf_sheriffing/sherlock.py
+++ b/treeherder/perf/auto_perf_sheriffing/sherlock.py
@@ -126,21 +126,25 @@ class Sherlock:
             platform, frameworks, repositories
         )
         logger.info(
-            f"Sherlock: {records_to_backfill.count()} records found to backfill on {platform.title()}."
+            f"Sherlock: {records_to_backfill.count()} records found to backfill on {platform.title()}, {left} backfills remaining."
         )
 
         for record in records_to_backfill:
             if left <= 0 or self.runtime_exceeded():
+                logger.info(
+                    f"Sherlock: Max runtime exceeded. Stopping backfill on {platform.title()}."
+                )
                 break
             left, consumed = self._backfill_record(record, left)
-            logger.info(f"Sherlock: Backfilled record with id {record.alert.id}.")
+            logger.info(f"Sherlock: Processed backfill record [alert_id={record.alert.id}].")
             # Model used for reporting backfill outcome
             BackfillNotificationRecord.objects.get_or_create(record=record)
             total_consumed += consumed
 
         self.secretary.consume_backfills(platform, total_consumed)
-        logger.info(f"Sherlock: Consumed {total_consumed} backfills for {platform.title()}.")
-        logger.debug(f"Sherlock: Having {left} backfills left on {platform.title()}.")
+        logger.info(
+            f"Sherlock: Consumed {total_consumed} backfills, {left} remaining on {platform.title()}."
+        )
 
     @staticmethod
     def __fetch_records_requiring_backfills_on(
@@ -169,7 +173,7 @@ class Sherlock:
                 context = record.get_context()
             except JSONDecodeError:
                 logger.warning(
-                    f"Failed to backfill record {record.alert.id}: invalid JSON context."
+                    f"Failed to backfill [alert_id={record.alert.id}]: invalid JSON context."
                 )
                 record.status = BackfillRecord.FAILED
                 record.save()
@@ -179,11 +183,12 @@ class Sherlock:
             data_points_to_backfill = self.__get_data_points_to_backfill(record)
 
         if not data_points_to_backfill:
-            logger.warning(f"No data points found to backfill for record {record.alert.id}.")
+            logger.warning(f"No data points found to backfill [alert_id={record.alert.id}].")
             record.status = BackfillRecord.FAILED
             record.save()
             return left, consumed
 
+        task_ids = {}
         for data_point in data_points_to_backfill:
             if left <= 0 or self.runtime_exceeded():
                 break
@@ -193,31 +198,43 @@ class Sherlock:
                 else:
                     using_job_id = data_point.job_id
                 if not using_job_id:
-                    logger.info(f"Failed to backfill record {record.alert.id}: invalid job id.")
+                    logger.warning(
+                        f"Failed to backfill [alert_id={record.alert.id}]: invalid job id."
+                    )
                     continue
-                self.backfill_tool.backfill_job(using_job_id)
+                task_id = self.backfill_tool.backfill_job(using_job_id, alert_id=record.alert.id)
+                task_ids[using_job_id] = task_id
                 left, consumed = left - 1, consumed + 1
             except (KeyError, CannotBackfillError, Exception) as ex:
-                logger.debug(f"Failed to backfill record {record.alert.id}: {ex}")
+                logger.warning(f"Failed to backfill [alert_id={record.alert.id}]: {ex}")
             else:
                 record.try_remembering_job_properties(using_job_id)
 
         success, outcome = self._note_backfill_outcome(
-            record, len(data_points_to_backfill), consumed
+            record, len(data_points_to_backfill), consumed, task_ids
         )
         log_level = INFO if success else WARNING
-        logger.log(log_level, f"{outcome} (for backfill record {record.alert.id})")
+        logger.log(log_level, f"{outcome} [alert_id={record.alert.id}]")
 
         return left, consumed
 
     @staticmethod
     def _note_backfill_outcome(
-        record: BackfillRecord, to_backfill: int, actually_backfilled: int
+        record: BackfillRecord, to_backfill: int, actually_backfilled: int, task_ids: dict[str, str]
     ) -> tuple[bool, str]:
         success = False
 
         record.total_actions_triggered = actually_backfilled
         record.iteration_count += 1
+        now = datetime.now(UTC).isoformat()
+        log_entry = {
+            "status": "backfill_requested",
+            "iteration": record.iteration_count,
+            "job_task_ids": task_ids,
+            "backfill_requested_at": now,
+            "timestamp": now,
+        }
+        record.append_to_backfill_logs(log_entry)
 
         if actually_backfilled == to_backfill:
             record.status = BackfillRecord.BACKFILLED

--- a/treeherder/perf/models.py
+++ b/treeherder/perf/models.py
@@ -1085,9 +1085,8 @@ class BackfillRecord(models.Model):
             job = Job.objects.get(id=job_id)
             self.__remember_job_properties(job)
         except Job.DoesNotExist as ex:
-            logger.warning(ex)
-            logger.debug(
-                f"Failed to set properties of job ID {job_id} to record ID {self.alert_id}."
+            logger.warning(
+                f"Failed to set properties of job ID [{job_id}] to record ID [{self.alert.id}]: {ex}"
             )
 
     def __remember_job_properties(self, job: Job):
@@ -1169,6 +1168,16 @@ class BackfillRecord(models.Model):
     def append_to_backfill_logs(self, entry: dict):
         log = self.get_backfill_logs()
         log.append(entry)
+        self.backfill_logs = json.dumps(log, default=str)
+
+    def update_backfill_log(self, iteration: int, updates: dict):
+        log = self.get_backfill_logs()
+        for entry in log:
+            if entry.get("iteration") == iteration:
+                entry.update(updates)
+                break
+        else:
+            log.append(updates)
         self.backfill_logs = json.dumps(log, default=str)
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
Related bug: https://bugzilla.mozilla.org/show_bug.cgi?id=2007002

This PR improves Sherlock logging and iteration tracking.
* Add the initial detected push ID and gap size to `backfill_logs` as iteration 0
* Add backfill history to `backfill_logs`, including the task ID returned by Taskcluster
  *  `job_task_ids` is a mapping of job IDs to task IDs
* Improve Sherlock logs overall

If you have any feedback or suggestions, please let me know.

Below is a sample `backfill_logs` entry. This data was created locally, so the final gap does not shrink because real backfills were not actually run.
```
[{
"iteration": 0, 
"status": "initial",
"detected_push_id": 14, 
"detected_push_revision": "086d14f4215495401f6eafe03c8a4951ad85d368", 
"detected_push_gap_size": 3, 
"timestamp": "2026-06-04T22:31:29.905854+00:00", 
"notes": "Initial detection from the alert."
}, {
"iteration": 1, 
"job_task_ids": {"20": "fake-backfill-task-id-for-SLR2k3gNSDKUFMj9qF59Og-79937318cc494ac68b2732103644de46"}, 
"backfill_requested_at": "2026-06-04T22:41:18.819020+00:00", 
"timestamp": "2026-06-04T22:45:24.705114+00:00", 
"detected_push_id": 10, 
"detected_push_revision": "0d9ff7aed208feb016077ea0b7389a07cbf4a207", 
"detected_t_value": 36.77446764831958, 
"candidates": [{"push_id": 10, "revision": "0d9ff7aed208feb016077ea0b7389a07cbf4a207", "t_value": 36.77446764831958, "push_timestamp": 1774781813}], 
"previous_push_id": 14, 
"previous_push_revision": "086d14f4215495401f6eafe03c8a4951ad85d368", 
"detected_push_gap_size": 3, 
"status": "left", 
"notes": "Detected push moved left (from 086d14f to 0d9ff7a)"
}, {
"iteration": 2, 
"job_task_ids": {"16": "fake-backfill-task-id-for-HtAsQApCTFC2-ZsvmJlDLg-196b999db427474dabc3f4778c52c881"}, 
"backfill_requested_at": "2026-06-04T22:49:35.810449+00:00", 
"timestamp": "2026-06-04T22:53:50.371647+00:00", 
"detected_push_id": 10, 
"detected_push_revision": "0d9ff7aed208feb016077ea0b7389a07cbf4a207", 
"detected_t_value": 36.77446764831958, 
"candidates": [{"push_id": 10, "revision": "0d9ff7aed208feb016077ea0b7389a07cbf4a207", "t_value": 36.77446764831958, "push_timestamp": 1774781813}], 
"previous_push_id": 10, 
"previous_push_revision": "0d9ff7aed208feb016077ea0b7389a07cbf4a207", 
"detected_push_gap_size": 3, 
"status": "stabilized_gap_stuck", 
"notes": "Gap before 0d9ff7a did not shrink (was 3, still 3); stopping iteration."
}]
```

