### PR TITLE
Bug 2045860 - Transform repo name for treestatus links

### DIFF
--- a/ui/job-view/headerbars/WatchedRepo.jsx
+++ b/ui/job-view/headerbars/WatchedRepo.jsx
@@ -13,7 +13,10 @@ import {
 import { Button, Dropdown } from 'react-bootstrap';
 import { Link } from 'react-router';
 
-import TreeStatusModel, { treeStatusUiUrl } from '../../models/treeStatus';
+import TreeStatusModel, {
+  treeStatusUiUrl,
+  treeStatusName,
+} from '../../models/treeStatus';
 import BugLinkify from '../../shared/BugLinkify';
 import { updateRepoParams } from '../../helpers/location';
 
@@ -171,7 +174,7 @@ function WatchedRepo({ repoName, unwatchRepo, repo, setCurrentRepoTreeStatus }) 
           )}
           <Dropdown.Item
             tag="a"
-            href={`${treeStatusUiUrl()}${watchedRepo}`}
+            href={`${treeStatusUiUrl()}${treeStatusName(watchedRepo)}`}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/ui/models/treeStatus.js
+++ b/ui/models/treeStatus.js
@@ -28,16 +28,21 @@ export function treeStatusUiUrl() {
   return _treeStatusUiUrl;
 }
 
+export function treeStatusName(repoName) {
+  if (repoMap.has(repoName)) {
+    return repoMap.get(repoName);
+  }
+  if (repoName.includes('-esr')) {
+    return `firefox-esr${repoName.split('-esr')[1]}`;
+  }
+  return repoName;
+}
+
 const apiUrl = `${_treeStatusApiUrl}trees/`;
 
 export default class TreeStatusModel {
   static get(repoName) {
-    let repoNameGit = repoName;
-    if (repoMap.has(repoName)) {
-      repoNameGit = repoMap.get(repoName);
-    } else if (repoName.includes('-esr')) {
-      repoNameGit = `firefox-esr${repoName.split('-esr')[1]}`;
-    }
+    const repoNameGit = treeStatusName(repoName);
     return fetch(`${apiUrl}${repoNameGit}`)
       .then(async (resp) => {
         if (resp.ok) {


### PR DESCRIPTION
We transform the name already for querying current status, but the UI links are missing that. Factor out and reuse the same logic.