### PR TITLE
Bug 1125248 - Fix pinboard synchronization when bulk pinning jobs

### DIFF
--- a/tests/ui/job-view/stores/pinnedJobsStore_test.jsx
+++ b/tests/ui/job-view/stores/pinnedJobsStore_test.jsx
@@ -1,0 +1,60 @@
+import { usePinnedJobsStore } from '../../../../ui/job-view/stores/pinnedJobsStore';
+import { notify } from '../../../../ui/job-view/stores/notificationStore';
+
+jest.mock('../../../../ui/job-view/stores/notificationStore', () => ({
+  notify: jest.fn(),
+}));
+
+describe('pinnedJobsStore', () => {
+  beforeEach(() => {
+    usePinnedJobsStore.getState().unPinAll();
+    jest.clearAllMocks();
+  });
+
+  it('should correctly synchronize when re-pinning jobs after some were removed (Bug 1390211)', () => {
+    const store = usePinnedJobsStore.getState();
+
+    // 1. Setup: Pin 500 jobs
+    const initialJobs = Array.from({ length: 500 }, (_, i) => ({ id: i }));
+    store.pinJobs(initialJobs);
+    expect(Object.keys(usePinnedJobsStore.getState().pinnedJobs).length).toBe(500);
+
+    // 2. Manually remove 10 jobs
+    const jobsToRemove = initialJobs.slice(0, 10);
+    jobsToRemove.forEach(job => store.unPinJob(job));
+    expect(Object.keys(usePinnedJobsStore.getState().pinnedJobs).length).toBe(490);
+
+    // 3. Pin All again (using the original 500 jobs)
+    store.pinJobs(initialJobs);
+
+    // Expected: The 10 removed jobs should be re-added, bringing total back to 500.
+    // The 490 already there should have been filtered out and not counted against the limit.
+    expect(Object.keys(usePinnedJobsStore.getState().pinnedJobs).length).toBe(500);
+
+    // We shouldn't see a "Max size reached" error because we didn't actually exceed the limit
+    // with the *new* jobs being added.
+    expect(notify).not.toHaveBeenCalledWith(expect.stringContaining('Max pinboard size'), 'danger', expect.anything());
+  });
+
+  it('should partially fill the pinboard and notify if the batch exceeds remaining space', () => {
+    const store = usePinnedJobsStore.getState();
+
+    // Fill to 495
+    const initialJobs = Array.from({ length: 495 }, (_, i) => ({ id: i }));
+    store.pinJobs(initialJobs);
+
+    // Try to add 10 more (total would be 505)
+    const extraJobs = Array.from({ length: 10 }, (_, i) => ({ id: i + 500 }));
+    store.pinJobs(extraJobs);
+
+    // Should have filled up to 500
+    expect(Object.keys(usePinnedJobsStore.getState().pinnedJobs).length).toBe(500);
+
+    // Should have notified about the limit
+    expect(notify).toHaveBeenCalledWith(
+      'Max pinboard size of 500 reached.',
+      'danger',
+      { sticky: true }
+    );
+  });
+});

--- a/ui/job-view/stores/pinnedJobsStore.js
+++ b/ui/job-view/stores/pinnedJobsStore.js
@@ -66,22 +66,31 @@ export const usePinnedJobsStore = create(
 
       pinJobs: (jobsToPin) => {
         const { pinnedJobs } = get();
+        const newJobs = jobsToPin.filter((job) => !pinnedJobs[job.id]);
 
-        const spaceRemaining = MAX_SIZE - Object.keys(pinnedJobs).length;
-        const showError = jobsToPin.length > spaceRemaining;
-        const newPinnedJobs = jobsToPin
-          .slice(0, spaceRemaining)
-          .reduce((acc, job) => ({ ...acc, [job.id]: job }), {});
-
-        if (!spaceRemaining || showError) {
-          notify(COUNT_ERROR, 'danger', { sticky: true });
+        if (newJobs.length === 0) {
           return;
         }
 
-        set({
-          pinnedJobs: { ...pinnedJobs, ...newPinnedJobs },
-          isPinBoardVisible: true,
-        });
+        const spaceRemaining = MAX_SIZE - Object.keys(pinnedJobs).length;
+        const overLimit = newJobs.length > spaceRemaining;
+        const jobsToAdd = newJobs.slice(0, spaceRemaining);
+
+        if (jobsToAdd.length > 0) {
+          const additions = jobsToAdd.reduce(
+            (acc, job) => ({ ...acc, [job.id]: job }),
+            {},
+          );
+          set({
+            pinnedJobs: { ...pinnedJobs, ...additions },
+            isPinBoardVisible: true,
+          });
+          pulsePinCount();
+        }
+
+        if (overLimit || spaceRemaining === 0) {
+          notify(COUNT_ERROR, 'danger', { sticky: true });
+        }
       },
 
       addBug: (bug, job = null) => {


### PR DESCRIPTION
This change fixes an issue where the pinboard counter could get out of sync when using the "Pin All" functionality. The `pinJobs` action now correctly filters out jobs that are already pinned before calculating the remaining space.

Key improvements:
- The store now allows partial filling of the pinboard up to the 500-job limit instead of failing the entire operation when a batch is too large.
- Improved the logic to ensure the `pulsePinCount` animation and max-size notifications trigger accurately based on newly added jobs.
- Added a new unit test suite in treeherder/tests/ui/job-view/stores/pinnedJobsStore_test.jsx to verify these synchronization edge cases.

Fixes [Bug-1125248](https://bugzilla.mozilla.org/show_bug.cgi?id=1125248)