### PR TITLE
Optional: Skip blocking on Codecov CLI integrity check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,11 @@ jobs:
       - run:
           command: pnpm test:ci
           name: Run Jest tests
-      - codecov/upload
+      - codecov/upload:
+          # Skip the CLI GPG/integrity check: the keyserver step is flaky and
+          # was hard-failing jobs (exit 2, "no valid OpenPGP data"). fail_on_error
+          # defaults to false, so a failed upload itself never blocks CI either.
+          skip_validation: true
 
   javascript-lint:
     executor:
@@ -191,7 +195,11 @@ jobs:
       - run:
           name: Run tests and coverage within Docker container
           command: tox -e docker-general
-      - codecov/upload
+      - codecov/upload:
+          # Skip the CLI GPG/integrity check: the keyserver step is flaky and
+          # was hard-failing jobs (exit 2, "no valid OpenPGP data"). fail_on_error
+          # defaults to false, so a failed upload itself never blocks CI either.
+          skip_validation: true
 
   python-tests-perf:
     machine:
@@ -203,7 +211,11 @@ jobs:
       - run:
           name: Run tests and coverage within Docker container
           command: tox -e docker-perf
-      - codecov/upload
+      - codecov/upload:
+          # Skip the CLI GPG/integrity check: the keyserver step is flaky and
+          # was hard-failing jobs (exit 2, "no valid OpenPGP data"). fail_on_error
+          # defaults to false, so a failed upload itself never blocks CI either.
+          skip_validation: true
 
   python-tests-frontend:
     machine:
@@ -215,7 +227,11 @@ jobs:
       - run:
           name: Run tests and coverage within Docker container
           command: tox -e docker-frontend
-      - codecov/upload
+      - codecov/upload:
+          # Skip the CLI GPG/integrity check: the keyserver step is flaky and
+          # was hard-failing jobs (exit 2, "no valid OpenPGP data"). fail_on_error
+          # defaults to false, so a failed upload itself never blocks CI either.
+          skip_validation: true
 
   python-tests-telemetry:
     machine:
@@ -227,7 +243,11 @@ jobs:
       - run:
           name: Run tests and coverage within Docker container
           command: tox -e docker-telemetry
-      - codecov/upload
+      - codecov/upload:
+          # Skip the CLI GPG/integrity check: the keyserver step is flaky and
+          # was hard-failing jobs (exit 2, "no valid OpenPGP data"). fail_on_error
+          # defaults to false, so a failed upload itself never blocks CI either.
+          skip_validation: true
 
   test-docker-build:
     docker:


### PR DESCRIPTION
[!NOTE]
Optional - we can close this if you'd rather keep codecov blocking.

## Problem

If `codecov/upload` step fails to load, it prevents the rest of the CI from passing, when codecov is not the primary need of those jobs.

This happens while the Codecov orb downloads its CLI binary and GPG-verifies it — a flaky keyserver/CDN step, not anything to do with the tests (which run in the prior step). When it fails, the whole job goes red even though the tests passed.

## Fix

Pass `skip_validation: true` to all five `codecov/upload` invocations, which bypasses the CLI integrity/GPG check that's failing. The `fail_on_error` parameter already defaults to `false`, so a failed coverage upload never blocks CI either way.