### PR TITLE
Bug 1985314 - Show side-by-side link only when the comparison exists.

### DIFF
--- a/tests/ui/mock/alert_summaries.json
+++ b/tests/ui/mock/alert_summaries.json
@@ -249,6 +249,7 @@
       {
         "id": 177726,
         "status": 0,
+        "side_by_side_available": true,
         "series_signature": {
           "id": 3777239,
           "framework_id": 13,

--- a/tests/ui/perfherder/alerts-view/alerts_test.jsx
+++ b/tests/ui/perfherder/alerts-view/alerts_test.jsx
@@ -928,26 +928,16 @@ test('Sherlock status 0 in tooltip on alerts', async () => {
   });
 });
 
-test(`Side-by-side icon is not displayed in Debug Tools column when Sherlock status is 0 (Not backfilled) in tooltip alerts`, async () => {
+test(`Side-by-side icon is displayed in Debug Tools column when a side-by-side comparison is available for the alert`, async () => {
   const alert = testAlertSummaries[2].alerts[0];
-  alert.backfill_record.status = alertBackfillResultStatusMap.preliminary;
+  alert.side_by_side_available = true;
   expect(alert.id).toBe(177726);
 
-  const { getByTestId, getByText, queryByTestId } = alertsViewControls();
-  // hovering over the Sherlock icon should display the tooltip
-  const sherlockIcon = await waitFor(() =>
-    getByTestId(`alert ${alert.id.toString()} sherlock icon`),
+  const { getByTestId } = alertsViewControls();
+  const sxsIcon = await waitFor(() =>
+    getByTestId(`alert ${alert.id.toString()} side-by-side icon`),
   );
-  fireEvent.mouseOver(sherlockIcon);
-  await waitFor(() => {
-    const tooltipText = getByText(
-      alertBackfillResultVisual.preliminary.message,
-    );
-    expect(tooltipText).toBeInTheDocument();
-    expect(
-      queryByTestId(`alert ${alert.id.toString()} side-by-side icon`),
-    ).not.toBeInTheDocument();
-  });
+  expect(sxsIcon).toBeInTheDocument();
 });
 
 test('Sherlock status 1 in tooltip on alerts', async () => {
@@ -970,27 +960,20 @@ test('Sherlock status 1 in tooltip on alerts', async () => {
   });
 });
 
-test(`Side-by-side icon is not displayed in Debug Tools column when Sherlock status is 1 (Soon to be backfilled) in tooltip on alerts`, async () => {
+test(`Side-by-side icon is not displayed in Debug Tools column when no side-by-side comparison is available for the alert`, async () => {
   const alert = testAlertSummaries[2].alerts[0];
-  alert.backfill_record.status =
-    alertBackfillResultStatusMap.readyForProcessing;
+  alert.side_by_side_available = false;
   expect(alert.id).toBe(177726);
 
-  const { getByTestId, getByText, queryByTestId } = alertsViewControls();
-  // hovering over the Sherlock icon should display the tooltip
-  const sherlockIcon = await waitFor(() =>
-    getByTestId(`alert ${alert.id.toString()} sherlock icon`),
-  );
-  fireEvent.mouseOver(sherlockIcon);
-  await waitFor(() => {
-    const tooltipText = getByText(
-      alertBackfillResultVisual.readyForProcessing.message,
-    );
-    expect(tooltipText).toBeInTheDocument();
-    expect(
-      queryByTestId(`alert ${alert.id.toString()} side-by-side icon`),
-    ).not.toBeInTheDocument();
-  });
+  const { getByTestId, queryByTestId } = alertsViewControls();
+  // the Sherlock icon still renders; the side-by-side icon must not
+  await waitFor(() => getByTestId(`alert ${alert.id.toString()} sherlock icon`));
+  expect(
+    queryByTestId(`alert ${alert.id.toString()} side-by-side icon`),
+  ).not.toBeInTheDocument();
+
+  // restore for other tests sharing this mock alert
+  alert.side_by_side_available = true;
 });
 
 test('Sherlock status 2 in tooltip on alerts', async () => {
@@ -1010,24 +993,6 @@ test('Sherlock status 2 in tooltip on alerts', async () => {
   });
 });
 
-test(`Side-by-side icon is not displayed in Debug Tools column when Sherlock status is 2 (Backfilling in progress) in tooltip on alerts`, async () => {
-  const alert = testAlertSummaries[2].alerts[0];
-  alert.backfill_record.status = alertBackfillResultStatusMap.backfilled;
-  expect(alert.id).toBe(177726);
-
-  const { getByTestId, getByText } = alertsViewControls();
-  // hovering over the Sherlock icon should display the tooltip
-  const sherlockIcon = await waitFor(() =>
-    getByTestId(`alert ${alert.id.toString()} sherlock icon`),
-  );
-  fireEvent.mouseOver(sherlockIcon);
-  await waitFor(() => getByText(alertBackfillResultVisual.backfilled.message));
-  const sxsIcon = await waitFor(() =>
-    getByTestId(`alert ${alert.id.toString()} side-by-side icon`),
-  );
-  expect(sxsIcon).toBeInTheDocument();
-});
-
 test('Sherlock status 3 in tooltip on alerts', async () => {
   const alert = testAlertSummaries[0].alerts[3];
   alert.backfill_record.status = alertBackfillResultStatusMap.successful;
@@ -1045,24 +1010,6 @@ test('Sherlock status 3 in tooltip on alerts', async () => {
   });
 });
 
-test(`Side-by-side icon is displayed in Debug Tools column when Sherlock status is 3 (Backfilled successfully some jobs) in tooltip on alerts`, async () => {
-  const alert = testAlertSummaries[2].alerts[0];
-  alert.backfill_record.status = alertBackfillResultStatusMap.successful;
-  expect(alert.id).toBe(177726);
-
-  const { getByTestId, getByText } = alertsViewControls();
-  // hovering over the Sherlock icon should display the tooltip
-  const sherlockIcon = await waitFor(() =>
-    getByTestId(`alert ${alert.id.toString()} sherlock icon`),
-  );
-  fireEvent.mouseOver(sherlockIcon);
-  await waitFor(() => getByText(alertBackfillResultVisual.successful.message));
-  const sxsIcon = await waitFor(() =>
-    getByTestId(`alert ${alert.id.toString()} side-by-side icon`),
-  );
-  expect(sxsIcon).toBeInTheDocument();
-});
-
 test('Sherlock status 4 in tooltip on alerts', async () => {
   const alert = testAlertSummaries[0].alerts[3];
   alert.backfill_record.status = alertBackfillResultStatusMap.failed;
@@ -1078,24 +1025,6 @@ test('Sherlock status 4 in tooltip on alerts', async () => {
     const tooltipText = getByText(alertBackfillResultVisual.failed.message);
     expect(tooltipText).toBeInTheDocument();
   });
-});
-
-test(`Side-by-side icon is displayed in Debug Tools column when Sherlock status is 4 (Backfilling failed for some jobs) in tooltip on alerts`, async () => {
-  const alert = testAlertSummaries[2].alerts[0];
-  alert.backfill_record.status = alertBackfillResultStatusMap.failed;
-  expect(alert.id).toBe(177726);
-
-  const { getByTestId, getByText } = alertsViewControls();
-  // hovering over the Sherlock icon should display the tooltip
-  const sherlockIcon = await waitFor(() =>
-    getByTestId(`alert ${alert.id.toString()} sherlock icon`),
-  );
-  fireEvent.mouseOver(sherlockIcon);
-  await waitFor(() => getByText(alertBackfillResultVisual.failed.message));
-  const sxsIcon = await waitFor(() =>
-    getByTestId(`alert ${alert.id.toString()} side-by-side icon`),
-  );
-  expect(sxsIcon).toBeInTheDocument();
 });
 
 test("Alert's ID can be copied to clipboard", async () => {

--- a/tests/webapp/api/test_performance_alerts_api.py
+++ b/tests/webapp/api/test_performance_alerts_api.py
@@ -49,6 +49,7 @@ def test_alerts_get(
         "classifier",
         "classifier_email",
         "backfill_record",
+        "side_by_side_available",
         "noise_profile",
     }
     assert resp.json()["results"][0]["related_summary_id"] is None

--- a/tests/webapp/api/test_performance_alertsummary_api.py
+++ b/tests/webapp/api/test_performance_alertsummary_api.py
@@ -5,7 +5,7 @@ import pytest
 from django.urls import reverse
 
 from tests.conftest import create_perf_alert
-from treeherder.model.models import Push
+from treeherder.model.models import Job, JobType, Push
 from treeherder.perf.models import (
     PerformanceAlert,
     PerformanceAlertSummary,
@@ -124,6 +124,7 @@ def test_alert_summaries_get(
         "classifier",
         "classifier_email",
         "backfill_record",
+        "side_by_side_available",
         "noise_profile",
     }
     assert resp.json()["results"][0]["related_alerts"] == []
@@ -156,6 +157,105 @@ def test_alert_summaries_get_multiple_alerts(
 
     # make sure the 2 alert summaries are unique
     assert len(set([result["id"] for result in data["results"]])) == 2
+
+
+def _create_side_by_side_job(
+    repository,
+    push_id,
+    refdata,
+    platform,
+    suite,
+    result="success",
+):
+    # side-by-side jobs are identified by their job type symbol ("side-by-side-*");
+    # the compared platform and suite are encoded in the job type name, which is how
+    # a job is matched to a specific alert.
+    job_type = JobType.objects.create(
+        symbol=f"side-by-side-{suite}",
+        name=f"test-{platform} browsertime-tp6-firefox-{suite} aaaaaaaaaaaa bbbbbbbbbbbb",
+    )
+    now = datetime.now()
+    return Job.objects.create(
+        guid=str(uuid.uuid4()),
+        repository=repository,
+        push_id=push_id,
+        signature=refdata.signature,
+        build_platform=refdata.build_platform,
+        machine_platform=refdata.machine_platform,
+        machine=refdata.machine,
+        option_collection_hash=refdata.option_collection_hash,
+        job_type=job_type,
+        job_group=refdata.job_group,
+        product=refdata.product,
+        failure_classification_id=1,
+        who="test@example.com",
+        reason="scheduled",
+        result=result,
+        state="completed",
+        submit_time=now,
+        start_time=now,
+        end_time=now,
+        tier=1,
+    )
+
+
+def _alert_sbs(resp, alert_id):
+    alerts = resp.json()["results"][0]["alerts"]
+    return next(a["side_by_side_available"] for a in alerts if a["id"] == alert_id)
+
+
+def test_side_by_side_available_when_matching_job_on_push(
+    client, test_repository, test_perf_alert, generic_reference_data, failure_classifications
+):
+    # test_perf_alert: platform "win7", suite "mysuite", on the summary's push
+    _create_side_by_side_job(
+        test_repository, test_perf_alert.summary.push_id, generic_reference_data, "win7", "mysuite"
+    )
+
+    resp = client.get(reverse("performance-alert-summaries-list"))
+    assert resp.status_code == 200
+    assert _alert_sbs(resp, test_perf_alert.id) is True
+
+
+def test_side_by_side_not_available_without_job(client, test_perf_alert):
+    resp = client.get(reverse("performance-alert-summaries-list"))
+    assert resp.status_code == 200
+    assert _alert_sbs(resp, test_perf_alert.id) is False
+
+
+def test_side_by_side_not_available_when_platform_differs(
+    client, test_repository, test_perf_alert, generic_reference_data, failure_classifications
+):
+    # a side-by-side job exists for the same suite but a different platform
+    _create_side_by_side_job(
+        test_repository,
+        test_perf_alert.summary.push_id,
+        generic_reference_data,
+        "linux64",
+        "mysuite",
+    )
+
+    resp = client.get(reverse("performance-alert-summaries-list"))
+    assert resp.status_code == 200
+    assert _alert_sbs(resp, test_perf_alert.id) is False
+
+
+def test_side_by_side_not_available_when_job_unsuccessful(
+    client, test_repository, test_perf_alert, generic_reference_data, failure_classifications
+):
+    # a side-by-side job that ran but did not succeed must not count
+    _create_side_by_side_job(
+        test_repository,
+        test_perf_alert.summary.push_id,
+        generic_reference_data,
+        "win7",
+        "mysuite",
+        result="testfailed",
+    )
+
+    resp = client.get(reverse("performance-alert-summaries-list"))
+    assert resp.status_code == 200
+    assert _alert_sbs(resp, test_perf_alert.id) is False
 
 
 def test_alert_summaries_sheriffed_frameworks(
@@ -255,6 +355,7 @@ def test_alert_summaries_get_onhold(
         "classifier",
         "classifier_email",
         "backfill_record",
+        "side_by_side_available",
         "noise_profile",
     }
     assert resp.json()["results"][0]["related_alerts"] == []

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -638,10 +638,54 @@ class PerformanceAlertSummaryViewSet(viewsets.ModelViewSet):
                 result[key] = {"task_id": task_id, "retry_id": retry_id}
         return result
 
+    def _build_sxs_availability_map(self, page):
+        """
+        Returns a dict mapping alert_id -> bool, indicating whether a successful
+        side-by-side job for that alert's platform + suite exists on its summary's
+        culprit (regression) push. side-by-side jobs are identified by their job
+        type symbol ("side-by-side-*"); the compared platform and suite are encoded
+        in the job type name, which is how a job is matched to a specific alert.
+        Batched per page so the serializer doesn't query per alert.
+        """
+        # (alert, its own summary) pairs, covering both alerts and related_alerts
+        alert_summary_pairs = []
+        for summary in page:
+            for alert in summary.alerts.all():
+                alert_summary_pairs.append((alert, summary))
+            for alert in summary.related_alerts.all():
+                alert_summary_pairs.append((alert, alert.summary))
+
+        push_keys = {(sm.repository_id, sm.push_id) for _, sm in alert_summary_pairs}
+        if not push_keys:
+            return {}
+        sxs_jobs = [
+            (repo_id, push_id, name.lower())
+            for repo_id, push_id, name in models.Job.objects.filter(
+                repository_id__in={repo_id for repo_id, _ in push_keys},
+                push_id__in={push_id for _, push_id in push_keys},
+                job_type__symbol__icontains="side-by-side",
+                result="success",
+            ).values_list("repository_id", "push_id", "job_type__name")
+        ]
+
+        result = {}
+        for alert, sm in alert_summary_pairs:
+            platform = alert.series_signature.platform.platform.lower()
+            suite = alert.series_signature.suite.lower()
+            result[alert.id] = any(
+                repo_id == sm.repository_id
+                and push_id == sm.push_id
+                and platform in name
+                and suite in name
+                for repo_id, push_id, name in sxs_jobs
+            )
+        return result
+
     def get_serializer_context(self):
         ctx = super().get_serializer_context()
         ctx["duplicated_summaries_map"] = None
         ctx["tc_metadata_map"] = None
+        ctx["sxs_availability_map"] = None
         return ctx
 
     @staticmethod
@@ -665,6 +709,7 @@ class PerformanceAlertSummaryViewSet(viewsets.ModelViewSet):
             context = self.get_serializer_context()
             context["duplicated_summaries_map"] = self._build_duplicated_summaries_map(page)
             context["tc_metadata_map"] = self._build_tc_metadata_map(page)
+            context["sxs_availability_map"] = self._build_sxs_availability_map(page)
             serializer = self.get_serializer(page, many=True, context=context)
             if pk:
                 for summary in serializer.data:

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from rest_framework import exceptions, serializers
 
-from treeherder.model.models import Repository, TaskclusterMetadata
+from treeherder.model.models import Job, Repository, TaskclusterMetadata
 from treeherder.perf.models import (
     BackfillRecord,
     IssueTracker,
@@ -160,6 +160,7 @@ class PerformanceAlertSerializer(serializers.ModelSerializer):
     )
     classifier_email = serializers.SerializerMethodField()
     backfill_record = BackfillRecordSerializer(read_only=True, allow_null=True)
+    side_by_side_available = serializers.SerializerMethodField()
 
     # Force `is_regression` to be an optional field, even when using PUT, since in
     # Django 2.1 BooleanField no longer has an implicit `blank=True` on the model.
@@ -242,6 +243,26 @@ class PerformanceAlertSerializer(serializers.ModelSerializer):
     def get_classifier_email(self, performance_alert):
         return getattr(performance_alert.classifier, "email", None)
 
+    def get_side_by_side_available(self, alert):
+        # Whether a successful side-by-side job for this alert's platform + suite
+        # exists on its summary's culprit (regression) push. side-by-side jobs are
+        # identified by their job type symbol ("side-by-side-*"), and their job
+        # type name encodes the compared platform and suite, which is how we match
+        # a job to a specific alert. The frontend uses this to show the link.
+        sxs_map = self.context.get("sxs_availability_map")
+        if sxs_map is not None:
+            return sxs_map.get(alert.id, False)
+        summary = alert.summary
+        platform = alert.series_signature.platform.platform.lower()
+        suite = alert.series_signature.suite.lower()
+        names = Job.objects.filter(
+            repository_id=summary.repository_id,
+            push_id=summary.push_id,
+            job_type__symbol__icontains="side-by-side",
+            result="success",
+        ).values_list("job_type__name", flat=True)
+        return any(platform in name.lower() and suite in name.lower() for name in names)
+
     class Meta:
         model = PerformanceAlert
         fields = [
@@ -265,6 +286,7 @@ class PerformanceAlertSerializer(serializers.ModelSerializer):
             "starred",
             "classifier_email",
             "backfill_record",
+            "side_by_side_available",
             "noise_profile",
         ]
 

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -287,7 +287,6 @@ export default class AlertTableRow extends React.Component {
     }
     const jobUrl = getSideBySideLink(
       alertSummary.repository,
-      alertSummary.prev_push_revision,
       alertSummary.revision,
       platform,
       testName,
@@ -389,21 +388,13 @@ export default class AlertTableRow extends React.Component {
     const noiseProfileTooltip = alert.noise_profile
       ? noiseProfiles[alert.noise_profile.replace('/', '')]
       : noiseProfiles.NA;
-    // TODO: make a side-by-side status of its own. We know that side-by-side was triggered
-    //  if only backfill bot has one of the three statuses below
-    const backfillResultStatuses = [
-      alertBackfillResultStatusMap.backfilled,
-      alertBackfillResultStatusMap.successful,
-      alertBackfillResultStatusMap.failed,
-    ];
-    const sxsTriggered =
-      alert.backfill_record &&
-      backfillResultStatuses.includes(alert.backfill_record.status);
+    // side_by_side_available is computed per-alert on the backend: it's true only
+    // when a successful side-by-side job for this alert's platform + suite exists.
     const showSideBySideLink =
       alert.series_signature.framework_id === browsertimeId &&
       !alert.series_signature.tags.includes('interactive') &&
       !browsertimeBenchmarksTests.includes(alert.series_signature.suite) &&
-      sxsTriggered;
+      alert.side_by_side_available;
 
     const backfillStatusInfo = this.getBackfillStatusInfo(alert);
     let sherlockTooltip = backfillStatusInfo?.message;

--- a/ui/perfherder/perf-helpers/helpers.js
+++ b/ui/perfherder/perf-helpers/helpers.js
@@ -381,20 +381,11 @@ export const createGraphsLinks = (
   return links;
 };
 
-export const getSideBySideLink = (
-  repository,
-  baseRevision,
-  newRevision,
-  platform,
-  testName,
-) => {
-  const revisions = `${baseRevision.slice(0, 12)} ${newRevision.slice(0, 12)}`;
-
+export const getSideBySideLink = (repository, revision, platform, testName) => {
   const jobUrl = getJobsUrl({
     repo: repository,
-    tochange: newRevision,
-    fromchange: baseRevision,
-    searchStr: `${platform} ${testName} ${revisions} ${sxsTaskName}`,
+    revision,
+    searchStr: `${platform} ${testName} ${sxsTaskName}`,
     group_state: 'expanded',
   });
 


### PR DESCRIPTION
Verify per-alert that a successful side-by-side job matching the alert's platform and suite exists on the culprit push, instead of inferring it from the backfill status. Also fix the job-view link to filter by push only.