### PR TITLE
Bug 2012482 - When opening the graphs view link, highlight the datapoint of the alert I’ve clicked on

### DIFF
--- a/tests/ui/perfherder/alerts-view/alerts_table_row_test.jsx
+++ b/tests/ui/perfherder/alerts-view/alerts_table_row_test.jsx
@@ -1,4 +1,3 @@
-
 import { render, cleanup, waitFor, fireEvent } from '@testing-library/react';
 
 import AlertTableRow from '../../../../ui/perfherder/alerts/AlertTableRow';
@@ -381,7 +380,7 @@ test('Chart icon opens the graph link for an alert in a new tab', async () => {
   expect(graphLink).toBeInTheDocument();
   expect(graphLink).toHaveAttribute(
     'href',
-    '/perfherder/graphs?timerange=31536000&series=autoland,1944439,1,1',
+    '/perfherder/graphs?timerange=31536000&series=autoland,1944439,1,1&highlightedToRevision=930f0f51b681aea2a5e915a2770f80a9914ed3df',
   );
   expect(graphLink).toHaveAttribute('target', '_blank');
 });

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -365,7 +365,7 @@ export default class AlertTableRow extends React.Component {
   render() {
     const { user = null, alert, alertSummary } = this.props;
     const { starred, checkboxSelected, icons } = this.state;
-    const { repository, framework } = alertSummary;
+    const { repository, framework, revision } = alertSummary;
 
     const { tags, extra_options: options } = alert.series_signature;
 
@@ -465,7 +465,13 @@ export default class AlertTableRow extends React.Component {
               />
             </Button>
             <a
-              href={getGraphsURL(alert, timeRange, repository, framework)}
+              href={getGraphsURL(
+                alert,
+                timeRange,
+                repository,
+                framework,
+                revision,
+              )}
               target="_blank"
               rel="noopener noreferrer"
               className="text-dark button btn border p-0 border-0 bg-transparent"

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -397,6 +397,7 @@ class GraphsContainer extends React.Component {
       showTable,
       zoom = {},
       highlightedRevisions = ['', ''],
+      highlightedToRevision = '',
       highlightChangelogData,
       highlightCommonAlerts,
       highlightInitialDataPoints,
@@ -530,7 +531,11 @@ class GraphsContainer extends React.Component {
                       <VictoryLine
                         key={item}
                         style={{
-                          data: { stroke: 'gray', strokeWidth: 1 },
+                          data: {
+                            stroke: 'gray',
+                            strokeWidth:
+                              item.revision === highlightedToRevision ? 2 : 1,
+                          },
                         }}
                         x={() => item.x}
                       />
@@ -562,10 +567,7 @@ class GraphsContainer extends React.Component {
                       }))}
                       labels={({ datum }) => datum.label}
                       labelComponent={
-                        <VictoryTooltip
-                          renderInPortal
-                          pointerLength={6}
-                        />
+                        <VictoryTooltip renderInPortal pointerLength={6} />
                       }
                       style={{
                         data: { fill: this.infraChangeColor, width: 1 },
@@ -627,7 +629,7 @@ class GraphsContainer extends React.Component {
                       style={{
                         data: {
                           fill: 'transparent',
-                          stroke:({ datum }) => datum.z,
+                          stroke: ({ datum }) => datum.z,
                           strokeWidth: 2,
                         },
                       }}

--- a/ui/perfherder/graphs/GraphsView.jsx
+++ b/ui/perfherder/graphs/GraphsView.jsx
@@ -45,6 +45,11 @@ function GraphsView({ projects, frameworks, user }) {
       : phDefaultTimeRangeValue;
     return phTimeRanges.find((time) => time.value === defaultValue);
   };
+  const getHighlightedToRevision = () => {
+    const { highlightedToRevision } = parseQueryParams(location.search);
+
+    return highlightedToRevision;
+  };
 
   const [timeRange, setTimeRange] = useState(getDefaultTimeRange);
   const [zoom, setZoom] = useState({});
@@ -55,6 +60,9 @@ function GraphsView({ projects, frameworks, user }) {
   const [highlightInitialDataPoints, setHighlightInitialDataPoints] =
     useState(false);
   const [highlightedRevisions, setHighlightedRevisions] = useState(['', '']);
+  const [highlightedToRevision, setHighlightedToRevision] = useState(
+    getHighlightedToRevision(),
+  );
   const [testData, setTestData] = useState([]);
   const [errorMessages, setErrorMessages] = useState([]);
   const [options, setOptions] = useState({});
@@ -114,30 +122,27 @@ function GraphsView({ projects, frameworks, user }) {
     };
   }, []);
 
-  const getAlertSummaries = useCallback(
-    async (signatureId, repository) => {
-      const data = await getData(
-        createApiUrl(endpoints.alertSummary, {
-          alerts__series_signature: signatureId,
-          repository,
-          limit: alertSummaryLimit,
-          timerange: timeRangeRef.current.value,
-        }),
-      );
-      const response = processResponse(
-        data,
-        'alertSummaries',
-        errorMessagesRef.current,
-      );
+  const getAlertSummaries = useCallback(async (signatureId, repository) => {
+    const data = await getData(
+      createApiUrl(endpoints.alertSummary, {
+        alerts__series_signature: signatureId,
+        repository,
+        limit: alertSummaryLimit,
+        timerange: timeRangeRef.current.value,
+      }),
+    );
+    const response = processResponse(
+      data,
+      'alertSummaries',
+      errorMessagesRef.current,
+    );
 
-      if (response.alertSummaries) {
-        return response.alertSummaries.results;
-      }
-      setErrorMessages(response.errorMessages);
-      return [];
-    },
-    [],
-  );
+    if (response.alertSummaries) {
+      return response.alertSummaries.results;
+    }
+    setErrorMessages(response.errorMessages);
+    return [];
+  }, []);
 
   const getCommonAlerts = useCallback(async (frameworkId, timeRangeValue) => {
     const params = {
@@ -162,9 +167,13 @@ function GraphsView({ projects, frameworks, user }) {
       const uniqueFrameworkIds = [
         ...new Set(seriesData.map((series) => series.framework_id)),
       ];
-      const commonAlertsFlat = (await Promise.all(
-        uniqueFrameworkIds.map(id => getCommonAlerts(id, timeRangeRef.current.value))
-      )).flat();
+      const commonAlertsFlat = (
+        await Promise.all(
+          uniqueFrameworkIds.map((id) =>
+            getCommonAlerts(id, timeRangeRef.current.value),
+          ),
+        )
+      ).flat();
       const commonAlerts = [commonAlertsFlat];
       const newColors = [...colorsRef.current];
       const newSymbols = [...symbolsRef.current];
@@ -226,6 +235,10 @@ function GraphsView({ projects, frameworks, user }) {
       params.selected = [signatureId, dataPointId].join(',');
     }
 
+    if (highlightedToRevision) {
+      params.highlightedToRevision = highlightedToRevision;
+    }
+
     if (Object.keys(zoom).length === 0) {
       delete params.zoom;
     } else {
@@ -239,6 +252,7 @@ function GraphsView({ projects, frameworks, user }) {
     highlightChangelogData,
     highlightInitialDataPoints,
     highlightedRevisions,
+    highlightedToRevision,
     selectedDataPoint,
     zoom,
     updateUrlParams,
@@ -317,45 +331,50 @@ function GraphsView({ projects, frameworks, user }) {
     [getAlertSummaries],
   );
 
-  const updateStateParams = useCallback((state) => {
-    const replicatesChanged =
-      state.replicates !== undefined &&
-      state.replicates !== replicatesRef.current;
+  const updateStateParams = useCallback(
+    (state) => {
+      const replicatesChanged =
+        state.replicates !== undefined &&
+        state.replicates !== replicatesRef.current;
 
-    if (state.testData !== undefined) setTestData(state.testData);
-    if (state.selectedDataPoint !== undefined)
-      setSelectedDataPoint(state.selectedDataPoint);
-    if (state.zoom !== undefined) setZoom(state.zoom);
-    if (state.highlightAlerts !== undefined)
-      setHighlightAlerts(state.highlightAlerts);
-    if (state.highlightCommonAlerts !== undefined)
-      setHighlightCommonAlerts(state.highlightCommonAlerts);
-    if (state.highlightChangelogData !== undefined)
-      setHighlightChangelogData(state.highlightChangelogData);
-    if (state.highlightInitialDataPoints !== undefined)
-      setHighlightInitialDataPoints(state.highlightInitialDataPoints);
-    if (state.highlightedRevisions !== undefined)
-      setHighlightedRevisions(state.highlightedRevisions);
-    if (state.visibilityChanged !== undefined)
-      setVisibilityChanged(state.visibilityChanged);
-    if (state.colors !== undefined) setColors(state.colors);
-    if (state.symbols !== undefined) setSymbols(state.symbols);
+      if (state.testData !== undefined) setTestData(state.testData);
+      if (state.selectedDataPoint !== undefined)
+        setSelectedDataPoint(state.selectedDataPoint);
+      if (state.zoom !== undefined) setZoom(state.zoom);
+      if (state.highlightAlerts !== undefined)
+        setHighlightAlerts(state.highlightAlerts);
+      if (state.highlightCommonAlerts !== undefined)
+        setHighlightCommonAlerts(state.highlightCommonAlerts);
+      if (state.highlightChangelogData !== undefined)
+        setHighlightChangelogData(state.highlightChangelogData);
+      if (state.highlightInitialDataPoints !== undefined)
+        setHighlightInitialDataPoints(state.highlightInitialDataPoints);
+      if (state.highlightedRevisions !== undefined)
+        setHighlightedRevisions(state.highlightedRevisions);
+      if (state.highlightedToRevision !== undefined)
+        setHighlightedToRevision(state.highlightedToRevision);
+      if (state.visibilityChanged !== undefined)
+        setVisibilityChanged(state.visibilityChanged);
+      if (state.colors !== undefined) setColors(state.colors);
+      if (state.symbols !== undefined) setSymbols(state.symbols);
 
-    if (state.replicates !== undefined) {
-      setReplicates(state.replicates);
-      replicatesRef.current = state.replicates;
-    }
+      if (state.replicates !== undefined) {
+        setReplicates(state.replicates);
+        replicatesRef.current = state.replicates;
+      }
 
-    if (replicatesChanged) {
-      setZoom({});
-      setSelectedDataPoint(null);
-      setColors([...graphColors]);
-      setSymbols([...graphSymbols]);
-      getTestData();
-    } else {
-      pendingChangeParams.current = true;
-    }
-  }, [getTestData]);
+      if (replicatesChanged) {
+        setZoom({});
+        setSelectedDataPoint(null);
+        setColors([...graphColors]);
+        setSymbols([...graphSymbols]);
+        getTestData();
+      } else {
+        pendingChangeParams.current = true;
+      }
+    },
+    [getTestData],
+  );
 
   // componentDidMount - check query params
   useEffect(() => {
@@ -368,6 +387,7 @@ function GraphsView({ projects, frameworks, user }) {
       highlightChangelogData: hlChangelogData,
       highlightInitialDataPoints: hlInitialDataPoints,
       highlightedRevisions: hlRevisions,
+      highlightedToRevision: hlToRevision,
       replicates: replicatesParam,
     } = queryString.parse(location.search);
 
@@ -377,7 +397,7 @@ function GraphsView({ projects, frameworks, user }) {
       updates.replicates = Boolean(parseInt(replicatesParam, 10));
       replicatesRef.current = updates.replicates;
     }
-    
+
     if (series) {
       const _series = typeof series === 'string' ? [series] : series;
       const seriesParams = parseSeriesParam(
@@ -405,6 +425,9 @@ function GraphsView({ projects, frameworks, user }) {
       updates.highlightedRevisions =
         typeof hlRevisions === 'string' ? [hlRevisions] : hlRevisions;
     }
+    if (hlToRevision) {
+      updates.highlightedToRevision = hlToRevision;
+    }
     if (zoomParam) {
       const zoomArray = zoomParam.replace(/[[{}\]"]+/g, '').split(',');
       updates.zoom = {
@@ -428,6 +451,8 @@ function GraphsView({ projects, frameworks, user }) {
     if (updates.replicates !== undefined) setReplicates(updates.replicates);
     if (updates.highlightedRevisions !== undefined)
       setHighlightedRevisions(updates.highlightedRevisions);
+    if (updates.highlightedToRevision !== undefined)
+      setHighlightedToRevision(updates.highlightedToRevision);
     if (updates.zoom !== undefined) setZoom(updates.zoom);
     if (updates.selectedDataPoint !== undefined)
       setSelectedDataPoint(updates.selectedDataPoint);
@@ -493,9 +518,7 @@ function GraphsView({ projects, frameworks, user }) {
 
         <Row className="justify-content-center">
           {!showTable && (
-            <Col
-              className={`${testData.length ? 'graph-chooser' : 'col-12'}`}
-            >
+            <Col className={`${testData.length ? 'graph-chooser' : 'col-12'}`}>
               <Button
                 className="sr-only"
                 onClick={() => setShowTable(!showTable)}
@@ -567,6 +590,7 @@ function GraphsView({ projects, frameworks, user }) {
               highlightChangelogData={highlightChangelogData}
               highlightInitialDataPoints={highlightInitialDataPoints}
               highlightedRevisions={highlightedRevisions}
+              highlightedToRevision={highlightedToRevision}
               highlightCommonAlerts={highlightCommonAlerts}
               zoom={zoom}
               selectedDataPoint={selectedDataPoint}

--- a/ui/perfherder/perf-helpers/helpers.js
+++ b/ui/perfherder/perf-helpers/helpers.js
@@ -433,6 +433,7 @@ export const getGraphsURL = (
   timeRange,
   alertRepository,
   performanceFrameworkId,
+  highlightedToRevision,
 ) => {
   let url = `/perfherder/graphs?timerange=${timeRange}&series=${alertRepository},${alert.series_signature.id},1,${alert.series_signature.framework_id}`;
 
@@ -448,6 +449,7 @@ export const getGraphsURL = (
       )
       .join('');
   }
+  url = url.concat(`&highlightedToRevision=${highlightedToRevision}`);
 
   return url;
 };
@@ -523,26 +525,23 @@ export const getFilledBugSummary = (alertSummary) => {
   }
 
   // Find the max and min magnitude alerts
-  const {
-    maxMagnitudeAlert,
-    maxMagnitude,
-    minMagnitude,
-  } = filteredAlerts.reduce(
-    (acc, alert) => {
-      const val = alert.amount_pct;
-      return {
-        maxMagnitudeAlert:
-          val > acc.maxMagnitude ? alert : acc.maxMagnitudeAlert,
-        maxMagnitude: Math.max(acc.maxMagnitude, val),
-        minMagnitude: Math.min(acc.minMagnitude, val),
-      };
-    },
-    {
-      maxMagnitudeAlert: filteredAlerts[0],
-      maxMagnitude: filteredAlerts[0].amount_pct,
-      minMagnitude: filteredAlerts[0].amount_pct,
-    },
-  );
+  const { maxMagnitudeAlert, maxMagnitude, minMagnitude } =
+    filteredAlerts.reduce(
+      (acc, alert) => {
+        const val = alert.amount_pct;
+        return {
+          maxMagnitudeAlert:
+            val > acc.maxMagnitude ? alert : acc.maxMagnitudeAlert,
+          maxMagnitude: Math.max(acc.maxMagnitude, val),
+          minMagnitude: Math.min(acc.minMagnitude, val),
+        };
+      },
+      {
+        maxMagnitudeAlert: filteredAlerts[0],
+        maxMagnitude: filteredAlerts[0].amount_pct,
+        minMagnitude: filteredAlerts[0].amount_pct,
+      },
+    );
 
   // Build string components
   const magnitudeStr =


### PR DESCRIPTION
[Bugzilla ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=2012482)

The alert datapoint is highlighted with a wider vertical line.

[localhost alert to test on](http://localhost:5000/perfherder/alerts?id=50766&hideDwnToInv=0)

Before
<img width="1353" height="410" alt="Screenshot 2026-06-16 at 10 49 55" src="https://github.com/user-attachments/assets/25977eb2-69d0-4a65-9e6d-bc69fafaa5bb" />


After
<img width="1364" height="417" alt="Screenshot 2026-06-16 at 10 49 47" src="https://github.com/user-attachments/assets/136832f5-3ac4-4a72-aa2e-1597317f79e4" />
