### PR TITLE
Resolve job reference data from cache in jobs list queries

### DIFF
--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -5,7 +5,8 @@ from dateutil import parser
 from django.urls import reverse
 from rest_framework.status import HTTP_400_BAD_REQUEST
 
-from treeherder.model.models import Job, TextLogError
+from treeherder.model.models import Job, JobType, LazyRefreshMap, TextLogError
+from treeherder.webapp.api.jobs import JobsViewSet
 
 
 @pytest.mark.parametrize(
@@ -301,3 +302,52 @@ def test_last_modified(
     assert resp.status_code == exp_status
     if exp_status == 200:
         assert len(resp.json()["results"]) == exp_job_count
+
+
+def test_global_job_list_reference_data(client, eleven_jobs_stored):
+    """
+    The global /api/jobs/ endpoint (the one the job-view polls) resolves
+    job_type, job_group and machine_platform from cached id->value maps rather
+    than SQL joins. Verify the serialized values still match the job records.
+    """
+    resp = client.get(reverse("jobs-list"))
+    assert resp.status_code == 200
+
+    data = resp.json()
+    property_names = data["job_property_names"]
+    assert property_names == JobsViewSet._output_field_names
+
+    results_by_id = {
+        row[property_names.index("id")]: dict(zip(property_names, row)) for row in data["results"]
+    }
+    jobs = Job.objects.select_related("job_type", "job_group", "machine_platform", "signature")
+    assert results_by_id  # sanity: we got jobs back
+    for job in jobs:
+        row = results_by_id[job.id]
+        assert row["job_type_name"] == job.job_type.name
+        assert row["job_type_symbol"] == job.job_type.symbol
+        assert row["job_group_name"] == job.job_group.name
+        assert row["job_group_symbol"] == job.job_group.symbol
+        assert row["platform"] == job.machine_platform.platform
+        assert row["signature"] == job.signature.signature
+
+
+def test_lazy_refresh_map_refreshes_on_miss(transactional_db):
+    """
+    LazyRefreshMap serves lookups from the cached reference map and, on the
+    first miss (e.g. a reference row ingested after the map was cached), rebuilds
+    the map once from the database so newly added ids still resolve.
+    """
+    existing = JobType.objects.create(name="test-type-existing", symbol="e")
+    # Prime the cache so the map is built without the row we add next.
+    JobType.objects.get_id_map()
+    added = JobType.objects.create(name="test-type-added", symbol="a")
+
+    lazy = LazyRefreshMap(JobType.objects)
+
+    # The cached map predates `added`; the miss should trigger a single rebuild.
+    assert lazy.get(added.id) == {"name": "test-type-added", "symbol": "a"}
+    # Entries present in the original cached map still resolve.
+    assert lazy.get(existing.id) == {"name": "test-type-existing", "symbol": "e"}
+    # A genuinely unknown id falls back to the provided default.
+    assert lazy.get(-1, "missing") == "missing"

--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -332,6 +332,33 @@ def test_global_job_list_reference_data(client, eleven_jobs_stored):
         assert row["signature"] == job.signature.signature
 
 
+def test_project_job_list_reference_data(client, eleven_jobs_stored, test_repository):
+    """
+    The project-bound jobs list resolves job_type, job_group and
+    machine_platform (including their description/os/architecture fields) from
+    cached id->value maps rather than SQL joins. Verify the serialized values
+    still match the job records.
+    """
+    url = reverse("jobs-list", kwargs={"project": test_repository.name})
+    resp = client.get(f"{url}?count=2000")
+    assert resp.status_code == 200
+
+    results_by_id = {row["id"]: row for row in resp.json()["results"]}
+    jobs = Job.objects.select_related("job_type", "job_group", "machine_platform")
+    assert results_by_id  # sanity: we got jobs back
+    for job in jobs:
+        row = results_by_id[job.id]
+        assert row["job_type_name"] == job.job_type.name
+        assert row["job_type_symbol"] == job.job_type.symbol
+        assert row["job_type_description"] == job.job_type.description
+        assert row["job_group_name"] == job.job_group.name
+        assert row["job_group_symbol"] == job.job_group.symbol
+        assert row["job_group_description"] == job.job_group.description
+        assert row["platform"] == job.machine_platform.platform
+        assert row["machine_platform_os"] == job.machine_platform.os_name
+        assert row["machine_platform_architecture"] == job.machine_platform.architecture
+
+
 def test_lazy_refresh_map_refreshes_on_miss(transactional_db):
     """
     LazyRefreshMap serves lookups from the cached reference map and, on the
@@ -346,8 +373,12 @@ def test_lazy_refresh_map_refreshes_on_miss(transactional_db):
     lazy = LazyRefreshMap(JobType.objects)
 
     # The cached map predates `added`; the miss should trigger a single rebuild.
-    assert lazy.get(added.id) == {"name": "test-type-added", "symbol": "a"}
+    assert lazy.get(added.id) == {"name": "test-type-added", "symbol": "a", "description": ""}
     # Entries present in the original cached map still resolve.
-    assert lazy.get(existing.id) == {"name": "test-type-existing", "symbol": "e"}
+    assert lazy.get(existing.id) == {
+        "name": "test-type-existing",
+        "symbol": "e",
+        "description": "",
+    }
     # A genuinely unknown id falls back to the provided default.
     assert lazy.get(-1, "missing") == "missing"

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -313,7 +313,12 @@ class MachinePlatformManager(CachedIdMapManager):
     cache_key = "machine_platform_id_map"
 
     def _build_map(self):
-        return {id: platform for id, platform in self.get_queryset().values_list("id", "platform")}
+        return {
+            id: {"platform": platform, "os_name": os_name, "architecture": architecture}
+            for id, platform, os_name, architecture in self.get_queryset().values_list(
+                "id", "platform", "os_name", "architecture"
+            )
+        }
 
 
 class MachinePlatform(models.Model):
@@ -483,8 +488,10 @@ class JobGroupManager(CachedIdMapManager):
 
     def _build_map(self):
         return {
-            id: {"name": name, "symbol": symbol}
-            for id, name, symbol in self.get_queryset().values_list("id", "name", "symbol")
+            id: {"name": name, "symbol": symbol, "description": description}
+            for id, name, symbol, description in self.get_queryset().values_list(
+                "id", "name", "symbol", "description"
+            )
         }
 
 
@@ -559,8 +566,10 @@ class JobTypeManager(CachedIdMapManager):
 
     def _build_map(self):
         return {
-            id: {"name": name, "symbol": symbol}
-            for id, name, symbol in self.get_queryset().values_list("id", "name", "symbol")
+            id: {"name": name, "symbol": symbol, "description": description}
+            for id, name, symbol, description in self.get_queryset().values_list(
+                "id", "name", "symbol", "description"
+            )
         }
 
 

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -256,11 +256,73 @@ class Commit(models.Model):
         return f"{self.push.repository.name} {self.revision}"
 
 
+class CachedIdMapManager(models.Manager):
+    """
+    Base manager that caches a ``{id: value}`` map for a small, append-mostly
+    reference table. This lets hot queries (e.g. the jobs list) drop the join to
+    the table and resolve the referenced values from cache instead.
+
+    On a cache miss for an id (a row added since the map was last cached) the
+    map is rebuilt once via :meth:`refresh_id_map`, so callers never get stale
+    "missing" values for newly ingested reference data.
+    """
+
+    cache_key = None  # subclasses must set this
+
+    def _build_map(self):
+        raise NotImplementedError
+
+    def get_id_map(self):
+        id_map = cache.get(self.cache_key)
+        if id_map is None:
+            id_map = self._build_map()
+            # Caches for the default of 5 minutes.
+            cache.set(self.cache_key, id_map)
+        return id_map
+
+    def refresh_id_map(self):
+        id_map = self._build_map()
+        cache.set(self.cache_key, id_map)
+        return id_map
+
+
+class LazyRefreshMap:
+    """
+    Dict-like wrapper around a :class:`CachedIdMapManager` for use within a
+    single request (e.g. as serializer context). It serves lookups from the
+    cached map and, the first time an id is missing, rebuilds the map once from
+    the database before giving up. This keeps the common path query-free while
+    guaranteeing freshly ingested reference data still resolves correctly.
+    """
+
+    def __init__(self, manager):
+        self._manager = manager
+        self._map = manager.get_id_map()
+        self._refreshed = False
+
+    def get(self, key, default=None):
+        if key in self._map:
+            return self._map[key]
+        if not self._refreshed:
+            self._map = self._manager.refresh_id_map()
+            self._refreshed = True
+        return self._map.get(key, default)
+
+
+class MachinePlatformManager(CachedIdMapManager):
+    cache_key = "machine_platform_id_map"
+
+    def _build_map(self):
+        return {id: platform for id, platform in self.get_queryset().values_list("id", "platform")}
+
+
 class MachinePlatform(models.Model):
     id = models.AutoField(primary_key=True)
     os_name = models.CharField(max_length=25)
     platform = models.CharField(max_length=100, db_index=True)
     architecture = models.CharField(max_length=25, blank=True, db_index=True)
+
+    objects = MachinePlatformManager()
 
     class Meta:
         db_table = "machine_platform"
@@ -416,11 +478,23 @@ class Machine(NamedModel):
         db_table = "machine"
 
 
+class JobGroupManager(CachedIdMapManager):
+    cache_key = "job_group_id_map"
+
+    def _build_map(self):
+        return {
+            id: {"name": name, "symbol": symbol}
+            for id, name, symbol in self.get_queryset().values_list("id", "name", "symbol")
+        }
+
+
 class JobGroup(models.Model):
     id = models.AutoField(primary_key=True)
     symbol = models.CharField(max_length=25, default="?", db_index=True)
     name = models.CharField(max_length=255)
     description = models.TextField(blank=True)
+
+    objects = JobGroupManager()
 
     class Meta:
         db_table = "job_group"
@@ -480,11 +554,23 @@ class OptionCollection(models.Model):
         return f"{self.option}"
 
 
+class JobTypeManager(CachedIdMapManager):
+    cache_key = "job_type_id_map"
+
+    def _build_map(self):
+        return {
+            id: {"name": name, "symbol": symbol}
+            for id, name, symbol in self.get_queryset().values_list("id", "name", "symbol")
+        }
+
+
 class JobType(models.Model):
     id = models.AutoField(primary_key=True)
     symbol = models.CharField(max_length=25, default="?", db_index=True)
     name = models.CharField(max_length=140)
     description = models.TextField(blank=True)
+
+    objects = JobTypeManager()
 
     class Meta:
         db_table = "job_type"

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -221,9 +221,39 @@ class JobsProjectViewSet(viewsets.ViewSet):
         ("retry_id", "taskcluster_metadata__retry_id", None),
     ]
 
-    _option_collection_hash_idx = [pq[0] for pq in _property_query_mapping].index(
-        "option_collection_hash"
+    # Output properties resolved from cached reference-data maps (keyed by the
+    # job's FK id) instead of joining the reference table. Maps output property
+    # name -> the key within the cached reference dict. See JobsViewSet for the
+    # same approach on the global jobs endpoint.
+    _job_group_props = {
+        "job_group_description": "description",
+        "job_group_name": "name",
+        "job_group_symbol": "symbol",
+    }
+    _job_type_props = {
+        "job_type_description": "description",
+        "job_type_name": "name",
+        "job_type_symbol": "symbol",
+    }
+    _machine_platform_props = {
+        "machine_platform_architecture": "architecture",
+        "machine_platform_os": "os_name",
+        "platform": "platform",
+    }
+    _cached_property_names = (
+        _job_group_props.keys() | _job_type_props.keys() | _machine_platform_props.keys()
     )
+    # Columns fetched directly from the job row. The reference props above are
+    # resolved from cache, so we only need each FK id (job_group_id/job_type_id
+    # are already output props; machine_platform_id is added explicitly).
+    # Built with a loop rather than a comprehension so it can reference the
+    # sibling class attributes above (class-body comprehensions get their own
+    # scope and cannot see them).
+    _direct_query_fields = {"machine_platform_id"}
+    for _pq in _property_query_mapping:
+        if _pq[0] not in _cached_property_names:
+            _direct_query_fields.add(_pq[1])
+    del _pq
 
     def _get_job_list_response(self, job_qs, offset, count, return_type):
         """
@@ -234,41 +264,44 @@ class JobsProjectViewSet(viewsets.ViewSet):
         this function is often in the critical path
         """
         option_collection_map = OptionCollection.objects.get_option_collection_map()
+        job_type_map = LazyRefreshMap(JobType.objects)
+        job_group_map = LazyRefreshMap(JobGroup.objects)
+        machine_platform_map = LazyRefreshMap(MachinePlatform.objects)
+
+        property_names = [pq[0] for pq in self._property_query_mapping]
         results = []
-        for values in job_qs[offset : (offset + count)].values_list(
-            *[pq[1] for pq in self._property_query_mapping]
-        ):
-            platform_option = option_collection_map.get(
-                values[self._option_collection_hash_idx], ""
-            )
-            # some values need to be transformed
-            values = list(values)
-            for i, _ in enumerate(values):
-                func = self._property_query_mapping[i][2]
-                if func:
-                    values[i] = func(values[i])
+        for row in job_qs[offset : (offset + count)].values(*self._direct_query_fields):
+            platform_option = option_collection_map.get(row["option_collection_hash"], "")
+            job_group = job_group_map.get(row["job_group_id"]) or {}
+            job_type = job_type_map.get(row["job_type_id"]) or {}
+            machine_platform = machine_platform_map.get(row["machine_platform_id"]) or {}
+
+            values = []
+            for name, query_field, func in self._property_query_mapping:
+                if name in self._job_group_props:
+                    value = job_group.get(self._job_group_props[name], "")
+                elif name in self._job_type_props:
+                    value = job_type.get(self._job_type_props[name], "")
+                elif name in self._machine_platform_props:
+                    value = machine_platform.get(self._machine_platform_props[name], "")
+                else:
+                    value = row[query_field]
+                    if func:
+                        value = func(value)
+                values.append(value)
+
             # append results differently depending on if we are returning
             # a dictionary or a list
             if return_type == "dict":
                 results.append(
-                    dict(
-                        zip(
-                            [pq[0] for pq in self._property_query_mapping] + ["platform_option"],
-                            values + [platform_option],
-                        )
-                    )
+                    dict(zip(property_names + ["platform_option"], values + [platform_option]))
                 )
             else:
                 results.append(values + [platform_option])
 
         response_dict = {"results": results}
         if return_type == "list":
-            response_dict.update(
-                {
-                    "job_property_names": [pq[0] for pq in self._property_query_mapping]
-                    + ["platform_option"]
-                }
-            )
+            response_dict.update({"job_property_names": property_names + ["platform_option"]})
 
         return response_dict
 

--- a/treeherder/webapp/api/jobs.py
+++ b/treeherder/webapp/api/jobs.py
@@ -14,7 +14,11 @@ from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 from treeherder.model.error_summary import get_error_summary
 from treeherder.model.models import (
     Job,
+    JobGroup,
     JobLog,
+    JobType,
+    LazyRefreshMap,
+    MachinePlatform,
     OptionCollection,
     Repository,
     TextLogError,
@@ -87,10 +91,11 @@ class JobsViewSet(viewsets.ReadOnlyModelViewSet):
     This viewset is the jobs endpoint.
     """
 
+    # job_type, job_group and machine_platform are intentionally NOT joined here:
+    # they are small, append-mostly reference tables that we resolve from a
+    # cached id->value map in the serializer instead (see get_serializer_context).
+    # Dropping those joins keeps this hot, frequently polled query lean.
     _default_select_related = [
-        "job_type",
-        "job_group",
-        "machine_platform",
         "signature",
         "taskcluster_metadata",
         "push",
@@ -101,14 +106,11 @@ class JobsViewSet(viewsets.ReadOnlyModelViewSet):
         "end_time",
         "failure_classification_id",
         "id",
-        "job_group__name",
-        "job_group__symbol",
-        "job_type__name",
-        "job_type__symbol",
+        "job_group_id",
+        "job_type_id",
         "last_modified",
         "option_collection_hash",
-        "machine_platform__platform",
-        "option_collection_hash",
+        "machine_platform_id",
         "push_id",
         "push__revision",
         "result",
@@ -149,8 +151,12 @@ class JobsViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = pagination.JobPagination
 
     def get_serializer_context(self):
-        option_collection_map = OptionCollection.objects.get_option_collection_map()
-        return {"option_collection_map": option_collection_map}
+        return {
+            "option_collection_map": OptionCollection.objects.get_option_collection_map(),
+            "job_type_map": LazyRefreshMap(JobType.objects),
+            "job_group_map": LazyRefreshMap(JobGroup.objects),
+            "machine_platform_map": LazyRefreshMap(MachinePlatform.objects),
+        }
 
     def list(self, request, *args, **kwargs):
         resp = super().list(request, *args, **kwargs)

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -104,7 +104,7 @@ class JobSerializer(serializers.ModelSerializer):
         option_collection_map = context["option_collection_map"]
         job_type = context["job_type_map"].get(job["job_type_id"]) or {}
         job_group = context["job_group_map"].get(job["job_group_id"]) or {}
-        platform = context["machine_platform_map"].get(job["machine_platform_id"], "")
+        machine_platform = context["machine_platform_map"].get(job["machine_platform_id"]) or {}
 
         return [
             job["failure_classification_id"],
@@ -114,7 +114,7 @@ class JobSerializer(serializers.ModelSerializer):
             job_type.get("name", ""),
             job_type.get("symbol", ""),
             job["last_modified"],
-            platform,
+            machine_platform.get("platform", ""),
             job["push_id"],
             job["push__revision"],
             job["result"],

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -96,20 +96,38 @@ class JobProjectSerializer(serializers.ModelSerializer):
 
 class JobSerializer(serializers.ModelSerializer):
     def to_representation(self, job):
-        option_collection_map = self.context["option_collection_map"]
-        submit = job.pop("submit_time")
-        start = job.pop("start_time")
-        end = job.pop("end_time")
-        option_collection_hash = job.pop("option_collection_hash")
+        # job is a dict from JobsViewSet's .values(*_query_field_names) query.
+        # job_type, job_group and machine_platform are resolved from cached
+        # id->value maps rather than SQL joins (see JobsViewSet). The returned
+        # list MUST stay in the same order as JobsViewSet._output_field_names.
+        context = self.context
+        option_collection_map = context["option_collection_map"]
+        job_type = context["job_type_map"].get(job["job_type_id"]) or {}
+        job_group = context["job_group_map"].get(job["job_group_id"]) or {}
+        platform = context["machine_platform_map"].get(job["machine_platform_id"], "")
 
-        ret_val = list(job.values())
-        ret_val.extend(
-            [
-                models.Job.get_duration(submit, start, end),  # duration
-                option_collection_map.get(option_collection_hash, ""),  # platform option
-            ]
-        )
-        return ret_val
+        return [
+            job["failure_classification_id"],
+            job["id"],
+            job_group.get("name", ""),
+            job_group.get("symbol", ""),
+            job_type.get("name", ""),
+            job_type.get("symbol", ""),
+            job["last_modified"],
+            platform,
+            job["push_id"],
+            job["push__revision"],
+            job["result"],
+            job["signature__signature"],
+            job["state"],
+            job["tier"],
+            job["taskcluster_metadata__task_id"],
+            job["taskcluster_metadata__retry_id"],
+            models.Job.get_duration(
+                job["submit_time"], job["start_time"], job["end_time"]
+            ),  # duration
+            option_collection_map.get(job["option_collection_hash"], ""),  # platform option
+        ]
 
     class Meta:
         model = models.Job


### PR DESCRIPTION
## Problem

The jobs list queries are among the top read-write DB CPU consumers, and after the recent intermittent-classification fix (#9553) the `/jobs` query is now the **#1** consumer on the prod RW instance. Every row joined `job_type`, `job_group` and `machine_platform` purely to fetch a name / symbol / description / platform string.

These three are small, append-mostly reference tables — ideal cache candidates, and exactly the pattern `OptionCollection` already uses.

## Change

Cache an `id -> value` map for `JobType`, `JobGroup` and `MachinePlatform` (5-minute TTL, mirroring `OptionCollection.get_option_collection_map`) and resolve those values in the serializer instead of joining.

Applied to both jobs list endpoints:

- **`JobsViewSet`** (global `/api/jobs/`, the 60s polling endpoint) — selects the FK ids and resolves names/symbols/platform from cache in `JobSerializer`.
- **`JobsProjectViewSet`** (`/api/project/<repo>/jobs/`, initial push loads + similar-jobs) — `_get_job_list_response` now fetches only the FK ids and resolves the reference fields (including `description`, `os_name`, `architecture`) from the same cached maps.

The single-job `retrieve()` path is left on the ORM (one row, negligible join cost).

### Cache freshness

A `LazyRefreshMap` wrapper serves lookups from the cached map and, on the first miss within a request (e.g. a reference row ingested since the map was cached), rebuilds the map once from the DB before falling back to a default. This keeps the common path query-free while guaranteeing newly-ingested reference data still resolves correctly — strictly safer than a plain TTL cache.

## Verification

- Generated SQL confirmed: both list queries no longer join `job_type`, `job_group` or `machine_platform`.
- `tests/webapp/api/test_jobs_api.py` — 50 passed (incl. new tests asserting the global and project list outputs still match the underlying job records, and that `LazyRefreshMap` rebuilds once on a miss).
- `tests/model` — 211 passed.
- No migration required (manager additions don't change schema); lint + format clean.
