### PR TITLE
Bug 2044773 - Add command to run test locally in comment0. r?#perftest

### DIFF
--- a/treeherder/perf/fixtures/performance_bug_templates.yaml
+++ b/treeherder/perf/fixtures/performance_bug_templates.yaml
@@ -21,6 +21,7 @@
       - Review the [alert summary]({{ alertHref }}) for affected tests, graphs, and comparisons.
       - Check the [PerfCompare results]({{ perfCompareURL }}).
       - Tests on Try: Run all tests using `./mach try perf --alert {{ alertSummaryId }}` (See [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) for details).
+      - Test locally: To run the tests locally use `./mach perftest {{ alertSummaryId }}` 
       - Profiling jobs: [Trigger jobs from Treeherder job view](https://firefox-source-docs.mozilla.org/testing/perfdocs/perftest-in-a-nutshell.html#using-the-firefox-profiler) or request them from {{ user }}.
     critical_text: |
       Perfherder has detected a {{ framework }} performance regression from push [{{ revision }}]({{ revisionHref }}). We would like to inform you that we are requesting an immediate back out from sheriffs@mozilla.bugs of the current patch due to performance regressions on the following critical test(s):  {{ criticalTests }}.
@@ -38,6 +39,7 @@
       - Review the [alert summary]({{ alertHref }}) for affected tests, graphs, and comparisons.
       - Check the [PerfCompare results]({{ perfCompareURL }}).
       - Tests on Try: Run all tests using `./mach try perf --alert {{ alertSummaryId }}` (See [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) for details).
+      - Test locally: To run the tests locally use `./mach perftest {{ alertSummaryId }}` 
       - Profiling jobs: [Trigger jobs from Treeherder job view](https://firefox-source-docs.mozilla.org/testing/perfdocs/perftest-in-a-nutshell.html#using-the-firefox-profiler) or request them from {{ user }}.
     no_action_required_text: |
       Perfherder has detected a {{ framework }} performance change from push [{{ revision }}]({{ revisionHref }}). 
@@ -127,6 +129,7 @@
       - Review the [alert summary]({{ alertHref }}) for affected tests, graphs, and comparisons.
       - Check the [PerfCompare results]({{ perfCompareURL }}).
       - Tests on Try: Run all tests using `./mach try perf --alert {{ alertSummaryId }}` (See [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) for details).
+      - Test locally: To run the tests locally use `./mach perftest {{ alertSummaryId }}` 
       - Profiling jobs: [Trigger jobs from Treeherder job view](https://firefox-source-docs.mozilla.org/testing/perfdocs/perftest-in-a-nutshell.html#using-the-firefox-profiler) or request them from {{ user }}.
     critical_text: |
       Perfherder has detected a {{ framework }} performance regression from push [{{ revision }}]({{ revisionHref }}). We would like to inform you that we are requesting an immediate back out from sheriffs@mozilla.bugs of the current patch due to performance regressions on the following critical test(s):  {{ criticalTests }}.
@@ -144,6 +147,7 @@
       - Review the [alert summary]({{ alertHref }}) for affected tests, graphs, and comparisons.
       - Check the [PerfCompare results]({{ perfCompareURL }}).
       - Tests on Try: Run all tests using `./mach try perf --alert {{ alertSummaryId }}` (See [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) for details).
+      - Test locally: To run the tests locally use `./mach perftest {{ alertSummaryId }}` 
       - Profiling jobs: [Trigger jobs from Treeherder job view](https://firefox-source-docs.mozilla.org/testing/perfdocs/perftest-in-a-nutshell.html#using-the-firefox-profiler) or request them from {{ user }}.
     no_action_required_text: |
       Perfherder has detected a {{ framework }} performance change from push [{{ revision }}]({{ revisionHref }}). 
@@ -286,6 +290,7 @@
       - Review the [alert summary]({{ alertHref }}) for affected tests, graphs, and comparisons.
       - Check the [PerfCompare results]({{ perfCompareURL }}).
       - Tests on Try: Run all tests using `./mach try perf --alert {{ alertSummaryId }}` (See [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) for details).
+      - Test locally: To run the tests locally use `./mach perftest {{ alertSummaryId }}` 
       - Profiling jobs: [Trigger jobs from Treeherder job view](https://firefox-source-docs.mozilla.org/testing/perfdocs/perftest-in-a-nutshell.html#using-the-firefox-profiler) or request them from {{ user }}.
     critical_text: |
       Perfherder has detected a {{ framework }} performance regression from push [{{ revision }}]({{ revisionHref }}). We would like to inform you that we are requesting an immediate back out from sheriffs@mozilla.bugs of the current patch due to performance regressions on the following critical test(s):  {{ criticalTests }}.
@@ -303,6 +308,7 @@
       - Review the [alert summary]({{ alertHref }}) for affected tests, graphs, and comparisons.
       - Check the [PerfCompare results]({{ perfCompareURL }}).
       - Tests on Try: Run all tests using `./mach try perf --alert {{ alertSummaryId }}` (See [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) for details).
+      - Test locally: To run the tests locally use `./mach perftest {{ alertSummaryId }}` 
       - Profiling jobs: [Trigger jobs from Treeherder job view](https://firefox-source-docs.mozilla.org/testing/perfdocs/perftest-in-a-nutshell.html#using-the-firefox-profiler) or request them from {{ user }}.
     no_action_required_text: |
       Perfherder has detected a {{ framework }} performance change from push [{{ revision }}]({{ revisionHref }}). 
@@ -392,6 +398,7 @@
       - Review the [alert summary]({{ alertHref }}) for affected tests, graphs, and comparisons.
       - Check the [PerfCompare results]({{ perfCompareURL }}).
       - Tests on Try: Run all tests using `./mach try perf --alert {{ alertSummaryId }}` (See [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) for details).
+      - Test locally: To run the tests locally use `./mach perftest {{ alertSummaryId }}` 
       - Profiling jobs: [Trigger jobs from Treeherder job view](https://firefox-source-docs.mozilla.org/testing/perfdocs/perftest-in-a-nutshell.html#using-the-firefox-profiler) or request them from {{ user }}.
     critical_text: |
       Perfherder has detected a {{ framework }} performance regression from push [{{ revision }}]({{ revisionHref }}). We would like to inform you that we are requesting an immediate back out from sheriffs@mozilla.bugs of the current patch due to performance regressions on the following critical test(s):  {{ criticalTests }}.
@@ -409,6 +416,7 @@
       - Review the [alert summary]({{ alertHref }}) for affected tests, graphs, and comparisons.
       - Check the [PerfCompare results]({{ perfCompareURL }}).
       - Tests on Try: Run all tests using `./mach try perf --alert {{ alertSummaryId }}` (See [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) for details).
+      - Test locally: To run the tests locally use `./mach perftest {{ alertSummaryId }}` 
       - Profiling jobs: [Trigger jobs from Treeherder job view](https://firefox-source-docs.mozilla.org/testing/perfdocs/perftest-in-a-nutshell.html#using-the-firefox-profiler) or request them from {{ user }}.
     no_action_required_text: |
       Perfherder has detected a {{ framework }} performance change from push [{{ revision }}]({{ revisionHref }}). 
@@ -445,6 +453,7 @@
       - Review the [alert summary]({{ alertHref }}) for affected tests, graphs, and comparisons.
       - Check the [PerfCompare results]({{ perfCompareURL }}).
       - Tests on Try: Run all tests using `./mach try perf --alert {{ alertSummaryId }}` (See [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) for details).
+      - Test locally: To run the tests locally use `./mach perftest {{ alertSummaryId }}` 
       - Profiling jobs: [Trigger jobs from Treeherder job view](https://firefox-source-docs.mozilla.org/testing/perfdocs/perftest-in-a-nutshell.html#using-the-firefox-profiler) or request them from {{ user }}.
     critical_text: |
       Perfherder has detected a {{ framework }} performance regression from push [{{ revision }}]({{ revisionHref }}). We would like to inform you that we are requesting an immediate back out from sheriffs@mozilla.bugs of the current patch due to performance regressions on the following critical test(s):  {{ criticalTests }}.
@@ -462,6 +471,7 @@
       - Review the [alert summary]({{ alertHref }}) for affected tests, graphs, and comparisons.
       - Check the [PerfCompare results]({{ perfCompareURL }}).
       - Tests on Try: Run all tests using `./mach try perf --alert {{ alertSummaryId }}` (See [documentation link](https://firefox-source-docs.mozilla.org/testing/perfdocs/mach-try-perf.html#running-alert-tests) for details).
+      - Test locally: To run the tests locally use `./mach perftest {{ alertSummaryId }}` 
       - Profiling jobs: [Trigger jobs from Treeherder job view](https://firefox-source-docs.mozilla.org/testing/perfdocs/perftest-in-a-nutshell.html#using-the-firefox-profiler) or request them from {{ user }}.
     no_action_required_text: |
       Perfherder has detected a {{ framework }} performance change from push [{{ revision }}]({{ revisionHref }}). 


### PR DESCRIPTION
[From our interviews on how to improve comment 0](https://bugzilla.mozilla.org/show_bug.cgi?id=2044755)

We noticed that all candidates were able to figure out how to run a try job.
They were able to by looking within comment 0 and copying the command from [comment0](https://bugzilla.mozilla.org/show_bug.cgi?id=2044773#c0).

No candidate knew how to run locally however.
While not a definitive solution having a section in [comment0](https://bugzilla.mozilla.org/show_bug.cgi?id=2044773#c0) for running locally we would be able to help many people out with running tests locally.