### PR TITLE
Fix bug Bug 2012482 - When opening the graphs view link, highlight the datapoint of the alert I’ve clicked on

### DIFF
--- a/ui/perfherder/perf-helpers/helpers.js
+++ b/ui/perfherder/perf-helpers/helpers.js
@@ -449,7 +449,10 @@ export const getGraphsURL = (
       )
       .join('');
   }
-  url = url.concat(`&highlightedToRevision=${highlightedToRevision}`);
+
+  if (highlightedToRevision) {
+    url = url.concat(`&highlightedToRevision=${highlightedToRevision}`);
+  }
 
   return url;
 };


### PR DESCRIPTION
Fixed bug from #9608