### PR TITLE
Bug 2048055 - Mark BACKFILLED records as FAILED after 72 hours

### DIFF
--- a/tests/perf/auto_perf_sheriffing/test_secretary.py
+++ b/tests/perf/auto_perf_sheriffing/test_secretary.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import pytest
@@ -242,6 +242,27 @@ def test_no_action_when_in_progress(get_outcome_checker_mock, record_backfilled)
     assert BackfillRecord.objects.filter(status=BackfillRecord.BACKFILLED).count() == 1
     secretary.check_outcome()
     assert BackfillRecord.objects.filter(status=BackfillRecord.BACKFILLED).count() == 1
+
+
+def test_check_outcome_marks_failed_after_72h(get_outcome_checker_mock, record_backfilled):
+    outcome_checker_mock = get_outcome_checker_mock(OutcomeStatus.IN_PROGRESS)
+    secretary = Secretary(outcome_checker_mock)
+
+    stale_timestamp = (datetime.now(UTC) - timedelta(hours=73)).isoformat()
+    record_backfilled.append_to_backfill_logs(
+        {"iteration": 0, "timestamp": stale_timestamp, "notes": "some notes."}
+    )
+    record_backfilled.save()
+
+    assert BackfillRecord.objects.filter(status=BackfillRecord.BACKFILLED).count() == 1
+    assert BackfillRecord.objects.filter(status=BackfillRecord.FAILED).count() == 0
+    secretary.check_outcome()
+    assert BackfillRecord.objects.filter(status=BackfillRecord.BACKFILLED).count() == 0
+    assert BackfillRecord.objects.filter(status=BackfillRecord.FAILED).count() == 1
+
+    record_backfilled.refresh_from_db()
+    last_log = record_backfilled.get_backfill_logs()[-1]
+    assert last_log["notes"] == "some notes. Backfill exceeded 72-hour limit, marking as FAILED."
 
 
 class TestOutcomeChecker:

--- a/treeherder/perf/auto_perf_sheriffing/secretary.py
+++ b/treeherder/perf/auto_perf_sheriffing/secretary.py
@@ -165,6 +165,20 @@ class Secretary:
         backfilled_records = BackfillRecord.objects.filter(status=BackfillRecord.BACKFILLED)
 
         for record in backfilled_records:
+            logs = record.get_backfill_logs()
+            last_log = logs[-1] if logs else None
+            if last_log:
+                log_timestamp = datetime.fromisoformat(last_log["timestamp"])
+                if log_timestamp < datetime.now(UTC) - timedelta(hours=72):
+                    record.status = BackfillRecord.FAILED
+                    new_note = "Backfill exceeded 72-hour limit, marking as FAILED."
+                    log_entry = {
+                        "notes": f"{last_log.get('notes', '')} {new_note}".strip(),
+                    }
+                    record.update_backfill_log(last_log["iteration"], log_entry)
+                    record.save()
+                    continue
+
             # ensure each push in push range has at least one job of job type
             try:
                 outcome = self.outcome_checker.check(record)
@@ -243,13 +257,7 @@ class Secretary:
 
             if detected_push_id == record.last_detected_push_id:
                 if log_entry["detected_push_gap_size"] > 0:
-                    previous_logs = record.get_backfill_logs()
-                    previous_iteration = record.iteration_count - 1
-                    previous_log = None
-                    for log in previous_logs:
-                        if log.get("iteration") == previous_iteration:
-                            previous_log = log
-                            break
+                    previous_log = record.get_backfill_log(record.iteration_count - 1)
                     previous_gap_size = (
                         previous_log.get("detected_push_gap_size") if previous_log else None
                     )

--- a/treeherder/perf/models.py
+++ b/treeherder/perf/models.py
@@ -1188,6 +1188,13 @@ class BackfillRecord(models.Model):
             log.append(updates)
         self.backfill_logs = json.dumps(log, default=str)
 
+    def get_backfill_log(self, iteration: int) -> dict:
+        log = self.get_backfill_logs()
+        for entry in log:
+            if entry.get("iteration") == iteration:
+                return entry
+        return None
+
     def save(self, *args, **kwargs):
         # refresh parent's latest update time
         super().save(*args, **kwargs)


### PR DESCRIPTION
If a BackfillRecord remains in BACKFILLED status for more than 72 hours, it should be automatically transitioned to FAILED. This acts as a safety guard to prevent OutcomeChecker from being indefinitely blocked by long-running or stale jobs.

Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2048055