### PR TITLE
Fix "ingest push" for GitHub repos by reading the compare API as a dict

### DIFF
--- a/tests/etl/test_ingest_command.py
+++ b/tests/etl/test_ingest_command.py
@@ -1,0 +1,73 @@
+from treeherder.etl.management.commands import ingest
+
+REPO_META = {
+    "owner": "o",
+    "repo": "r",
+    "branch": "main",
+    "url": "https://github.com/o/r",
+    "tc_root_url": "https://tc.example.com",
+}
+
+
+def test_query_data_consumes_compare_dict(monkeypatch):
+    """query_data must read the GitHub compare REST response as a dict.
+
+    Regression guard for Bug 2009865, which switched ``compare_shas`` to return
+    a list of PyGithub commit objects (for the Pulse push loader) but left
+    query_data doing dict access (``.get("merge_base_commit")`` / ``["commits"]``),
+    breaking the ``ingest push`` command for GitHub repos.
+    """
+    compare_by_range = {
+        # base branch vs head: the head isn't on the base branch, so the API
+        # reports a merge base whose parent is the real fork point.
+        "main...HEAD": {
+            "merge_base_commit": {
+                "sha": "BASE",
+                "commit": {"committer": {"date": "2026-01-01T00:00:00Z"}},
+                "parents": [
+                    {
+                        "sha": "PARENT",
+                        "url": "https://api.github.com/repos/o/r/commits/PARENT",
+                    }
+                ],
+            },
+            "commits": [],
+        },
+        # re-compare with the corrected base yields the push's commits
+        "PARENT...HEAD": {
+            "merge_base_commit": {"sha": "PARENT", "parents": []},
+            "commits": [
+                {
+                    "sha": "C1",
+                    "commit": {
+                        "message": "Fix the thing",
+                        "author": {"name": "Dev", "email": "dev@example.com"},
+                        "committer": {"date": "2026-02-02T00:00:00Z"},
+                    },
+                }
+            ],
+        },
+    }
+
+    def fake_fetch_api(path, params=None):
+        return compare_by_range[path.split("/compare/")[1]]
+
+    def fake_fetch_api_full_url(url, params=None):
+        # The merge-base parent, with a committer date different from the merge
+        # base so query_data takes the simple (non-recursive) branch.
+        return {"sha": "PARENT", "commit": {"committer": {"date": "2026-02-02T00:00:00Z"}}}
+
+    monkeypatch.setattr(ingest, "fetch_api", fake_fetch_api)
+    monkeypatch.setattr(ingest, "fetch_api_full_url", fake_fetch_api_full_url)
+
+    event_base_sha, commits = ingest.query_data(REPO_META, "HEAD")
+
+    assert event_base_sha == "PARENT"
+    assert commits == [
+        {
+            "message": "Fix the thing",
+            "author": {"name": "Dev", "email": "dev@example.com"},
+            "committer": {"date": "2026-02-02T00:00:00Z"},
+            "id": "C1",
+        }
+    ]

--- a/treeherder/etl/management/commands/ingest.py
+++ b/treeherder/etl/management/commands/ingest.py
@@ -22,7 +22,7 @@ from treeherder.etl.pushlog import HgPushlogProcess, last_push_id_from_server
 from treeherder.etl.taskcluster_pulse.handler import EXCHANGE_EVENT_MAP, handle_message
 from treeherder.model.models import Repository
 from treeherder.utils import github
-from treeherder.utils.github import fetch_api_full_url
+from treeherder.utils.github import fetch_api, fetch_api_full_url
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -276,8 +276,8 @@ def query_data(repo_meta, commit):
     event_base_sha = repo_meta["branch"]
     # First we try with `master` being the base sha
     # e.g. https://api.github.com/repos/servo/servo/compare/master...1418c0555ff77e5a3d6cf0c6020ba92ece36be2e
-    compare_response = github.compare_shas(
-        repo_meta["owner"], repo_meta["repo"], repo_meta["branch"], commit
+    compare_response = fetch_api(
+        f"repos/{repo_meta['owner']}/{repo_meta['repo']}/compare/{event_base_sha}...{commit}"
     )
     merge_base_commit = compare_response.get("merge_base_commit")
     if merge_base_commit:
@@ -307,8 +307,8 @@ def query_data(repo_meta, commit):
         assert event_base_sha != repo_meta["branch"]
         logger.info("We have a new base: %s", event_base_sha)
         # When using the correct event_base_sha the "commits" field will be correct
-        compare_response = github.compare_shas(
-            repo_meta["owner"], repo_meta["repo"], event_base_sha, commit
+        compare_response = fetch_api(
+            f"repos/{repo_meta['owner']}/{repo_meta['repo']}/compare/{event_base_sha}...{commit}"
         )
 
     commits = []


### PR DESCRIPTION
Bug 2009865 switched github.compare_shas() from the compare REST endpoint (which returns a dict) to PyGithub (a list of commit objects) and updated the Pulse push loader to match — but left the `ingest` management command's query_data() doing dict access on the result:

    compare_response.get("merge_base_commit")
    compare_response["commits"]

The GitHub compare API always returns a merge_base_commit, so query_data hit `.get()` on a list and raised AttributeError immediately — meaning `./manage.py ingest push <github-repo>` has been broken since that change.

Call the compare REST endpoint directly via fetch_api() for both compare requests in query_data, restoring the dict shape it expects. The Pulse push loader is unaffected and keeps using compare_shas().

Add a regression test for query_data's dict handling; this code path had no test coverage, which is how the regression went unnoticed.