### PR TITLE
Bug 2006399 - Add validation to ensure distinct from and to hashes on editing summary revisions

### DIFF
--- a/tests/webapp/api/test_performance_alertsummary_api.py
+++ b/tests/webapp/api/test_performance_alertsummary_api.py
@@ -430,6 +430,19 @@ def test_performance_alert_summary_change_from_revision(
     assert PerformanceAlertSummary.objects.get(id=1).prev_push.revision == original_revision
 
 
+def test_performance_alert_summary_same_from_to_revision(
+    client, test_perf_alert_summary, test_sheriff, test_push
+):
+    client.force_authenticate(user=test_sheriff)
+
+    # verify we cannot set the same revision for both from and to revision
+    resp = client.put(
+        reverse("performance-alert-summaries-list") + "1/",
+        {"revision": test_push.revision, "prev_push_revision": test_push.revision},
+    )
+    assert resp.status_code == 400
+
+
 def test_performance_alert_summary_change_revision(
     client, test_perf_alert_summary, test_sheriff, test_push
 ):

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -348,6 +348,13 @@ class PerformanceAlertSummarySerializer(serializers.ModelSerializer):
     bug_due_date = serializers.ReadOnlyField()
     monitored_alerts = serializers.BooleanField(required=False)
 
+    def validate(self, data):
+        push = data.get("push", getattr(self.instance, "push", None))
+        prev_push = data.get("prev_push", getattr(self.instance, "prev_push", None))
+        if push and prev_push and push.revision == prev_push.revision:
+            raise serializers.ValidationError("From and To revisions should be distinct.")
+        return data
+
     def update(self, instance, validated_data):
         instance.timestamp_first_triage()
         return super().update(instance, validated_data)


### PR DESCRIPTION
This Perfherder patch adds backend serializer validation to prevent performance sheriffs from setting the same hash for both the from and to revisions.
If there is a match between from and to revisions, a validation message is displayed with the following text: "From and To revisions should be distinct" (check attached image).

<img width="1872" height="878" alt="image" src="https://github.com/user-attachments/assets/b9738bee-826e-4f04-8c09-c25233ea1879" />
