### PR TITLE
Bug 2044976 - Fix react suspense lazy load on deploy

### DIFF
--- a/tests/ui/helpers/chunkError.test.js
+++ b/tests/ui/helpers/chunkError.test.js
@@ -48,6 +48,11 @@ describe('chunkError helper', () => {
       expect(isChunkLoadError(error)).toBe(true);
     });
 
+    it('returns true for Safari\'s "Importing a module script failed" message', () => {
+      const error = chunkError('Importing a module script failed.', 'TypeError');
+      expect(isChunkLoadError(error)).toBe(true);
+    });
+
     it('returns false for an ordinary application error', () => {
       expect(isChunkLoadError(new Error('Cannot read properties of undefined'))).toBe(
         false,

--- a/tests/ui/helpers/chunkError.test.js
+++ b/tests/ui/helpers/chunkError.test.js
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for the chunkError helper module.
+ *
+ * These helpers back the ChunkErrorBoundary, which recovers from failures to
+ * load a lazily-imported route bundle. After a deploy, old content-hashed
+ * chunks are deleted, so a tab still running the pre-deploy runtime gets a
+ * ChunkLoadError when it navigates to a not-yet-loaded route. This module
+ * decides whether such an error should trigger a one-time reload (to pick up
+ * the current assets) without getting stuck in a reload loop.
+ *
+ * This suite covers:
+ * - isChunkLoadError: classifying chunk-load failures vs. ordinary errors
+ * - reloadOnChunkError: the reload-with-cooldown decision logic
+ */
+
+import {
+  isChunkLoadError,
+  reloadOnChunkError,
+} from '../../../ui/helpers/chunkError';
+
+const chunkError = (message, name = 'ChunkLoadError') => {
+  const error = new Error(message);
+  error.name = name;
+  return error;
+};
+
+describe('chunkError helper', () => {
+  describe('isChunkLoadError', () => {
+    it('returns true for an error named ChunkLoadError', () => {
+      expect(isChunkLoadError(chunkError('boom'))).toBe(true);
+    });
+
+    it('returns true for a webpack/rspack "Loading chunk N failed" message', () => {
+      const error = chunkError('Loading chunk 437 failed.', 'Error');
+      expect(isChunkLoadError(error)).toBe(true);
+    });
+
+    it('returns true for a "Loading CSS chunk" failure message', () => {
+      const error = chunkError('Loading CSS chunk 12 failed.', 'Error');
+      expect(isChunkLoadError(error)).toBe(true);
+    });
+
+    it('returns true for a dynamically-imported-module fetch failure', () => {
+      const error = chunkError(
+        'Failed to fetch dynamically imported module: https://th/assets/logviewer.abcd1234.js',
+        'TypeError',
+      );
+      expect(isChunkLoadError(error)).toBe(true);
+    });
+
+    it('returns false for an ordinary application error', () => {
+      expect(isChunkLoadError(new Error('Cannot read properties of undefined'))).toBe(
+        false,
+      );
+    });
+
+    it('returns false for null/undefined', () => {
+      expect(isChunkLoadError(null)).toBe(false);
+      expect(isChunkLoadError(undefined)).toBe(false);
+    });
+  });
+
+  describe('reloadOnChunkError', () => {
+    let storage;
+    let location;
+
+    beforeEach(() => {
+      const store = {};
+      storage = {
+        getItem: (key) => (key in store ? store[key] : null),
+        setItem: (key, value) => {
+          store[key] = String(value);
+        },
+        removeItem: (key) => {
+          delete store[key];
+        },
+      };
+      location = { reload: jest.fn() };
+    });
+
+    it('reloads once when a chunk error is seen for the first time', () => {
+      const reloaded = reloadOnChunkError(chunkError('Loading chunk 1 failed.'), {
+        storage,
+        location,
+        now: 1000,
+      });
+
+      expect(reloaded).toBe(true);
+      expect(location.reload).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reload again for a repeat chunk error within the cooldown window', () => {
+      // First failure triggers a reload and records the timestamp.
+      reloadOnChunkError(chunkError('Loading chunk 1 failed.'), {
+        storage,
+        location,
+        now: 1000,
+      });
+      location.reload.mockClear();
+
+      // The reloaded page immediately fails again (e.g. a corrupt immutable
+      // cache entry that a normal reload cannot bust). We must NOT loop.
+      const reloaded = reloadOnChunkError(chunkError('Loading chunk 1 failed.'), {
+        storage,
+        location,
+        now: 3000,
+      });
+
+      expect(reloaded).toBe(false);
+      expect(location.reload).not.toHaveBeenCalled();
+    });
+
+    it('reloads again once the cooldown has elapsed (e.g. a later deploy)', () => {
+      reloadOnChunkError(chunkError('Loading chunk 1 failed.'), {
+        storage,
+        location,
+        now: 1000,
+      });
+      location.reload.mockClear();
+
+      const reloaded = reloadOnChunkError(chunkError('Loading chunk 9 failed.'), {
+        storage,
+        location,
+        now: 1000 + 60 * 1000,
+      });
+
+      expect(reloaded).toBe(true);
+      expect(location.reload).toHaveBeenCalledTimes(1);
+    });
+
+    it('never reloads for a non-chunk error', () => {
+      const reloaded = reloadOnChunkError(new Error('regular bug'), {
+        storage,
+        location,
+        now: 1000,
+      });
+
+      expect(reloaded).toBe(false);
+      expect(location.reload).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/ui/shared/ChunkErrorBoundary.test.jsx
+++ b/tests/ui/shared/ChunkErrorBoundary.test.jsx
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for the ChunkErrorBoundary component.
+ *
+ * The boundary wraps the lazily-loaded routes in ui/App.jsx. When loading a
+ * route bundle fails (a stale/removed chunk after a deploy, or a corrupt
+ * cached asset), it should attempt a one-time recovery reload instead of
+ * leaving the user on an infinite Suspense spinner, and fall back to a
+ * readable message when a reload cannot fix it.
+ *
+ * This suite covers:
+ * - Rendering children when there is no error
+ * - Triggering a recovery reload on a chunk-load error
+ * - Showing a recoverable message when the reload is suppressed (cooldown)
+ * - Showing a generic fallback for ordinary (non-chunk) errors
+ */
+
+import { render, screen } from '@testing-library/react';
+
+import ChunkErrorBoundary from '../../../ui/shared/ChunkErrorBoundary';
+import { reloadOnChunkError } from '../../../ui/helpers/chunkError';
+
+jest.mock('../../../ui/helpers/chunkError', () => {
+  const actual = jest.requireActual('../../../ui/helpers/chunkError');
+  return {
+    __esModule: true,
+    ...actual,
+    reloadOnChunkError: jest.fn(),
+  };
+});
+
+const chunkLoadError = () => {
+  const error = new Error('Loading chunk 437 failed.');
+  error.name = 'ChunkLoadError';
+  return error;
+};
+
+const Bomb = ({ error }) => {
+  throw error;
+};
+
+describe('ChunkErrorBoundary', () => {
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    reloadOnChunkError.mockReset();
+    // React logs caught render errors to console.error; keep test output clean.
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renders its children when nothing throws', () => {
+    render(
+      <ChunkErrorBoundary>
+        <div>healthy content</div>
+      </ChunkErrorBoundary>,
+    );
+
+    expect(screen.getByText('healthy content')).toBeInTheDocument();
+    expect(reloadOnChunkError).not.toHaveBeenCalled();
+  });
+
+  it('attempts a recovery reload when a chunk fails to load', () => {
+    reloadOnChunkError.mockReturnValue(true);
+    const error = chunkLoadError();
+
+    render(
+      <ChunkErrorBoundary>
+        <Bomb error={error} />
+      </ChunkErrorBoundary>,
+    );
+
+    expect(reloadOnChunkError).toHaveBeenCalledWith(error);
+    expect(screen.getByText(/reloading/i)).toBeInTheDocument();
+  });
+
+  it('shows a recoverable message when a reload cannot fix the chunk error', () => {
+    reloadOnChunkError.mockReturnValue(false);
+
+    render(
+      <ChunkErrorBoundary>
+        <Bomb error={chunkLoadError()} />
+      </ChunkErrorBoundary>,
+    );
+
+    expect(reloadOnChunkError).toHaveBeenCalled();
+    expect(screen.getByText(/refresh/i)).toBeInTheDocument();
+  });
+
+  it('shows a generic fallback for an ordinary error without reloading', () => {
+    reloadOnChunkError.mockReturnValue(false);
+
+    render(
+      <ChunkErrorBoundary>
+        <Bomb error={new Error('something unrelated broke')} />
+      </ChunkErrorBoundary>,
+    );
+
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.queryByText(/reloading/i)).not.toBeInTheDocument();
+  });
+});

--- a/ui/App.jsx
+++ b/ui/App.jsx
@@ -9,6 +9,7 @@ import {
 } from 'react-router';
 import { permaLinkPrefix } from './perfherder/perf-helpers/constants';
 import LoadingSpinner from './shared/LoadingSpinner';
+import ChunkErrorBoundary from './shared/ChunkErrorBoundary';
 import LoginCallback from './login-callback/LoginCallback';
 import TaskclusterCallback from './taskcluster-auth-callback/TaskclusterCallback';
 import UserGuideApp from './userguide/App';
@@ -125,8 +126,9 @@ const UrlUpdater = ({ children }) => {
 const AppRoutes = () => {
   return (
     <UrlUpdater>
-      <Suspense fallback={<LoadingSpinner />}>
-        <Routes>
+      <ChunkErrorBoundary>
+        <Suspense fallback={<LoadingSpinner />}>
+          <Routes>
           <Route path="/login" element={<LoginCallback />} />
           <Route path="/taskcluster-auth" element={<TaskclusterCallback />} />
           <Route
@@ -171,8 +173,9 @@ const AppRoutes = () => {
           />
           <Route path="/docs/*" element={<RedocApp />} />
           <Route path="*" element={<Navigate to="/jobs" replace />} />
-        </Routes>
-      </Suspense>
+          </Routes>
+        </Suspense>
+      </ChunkErrorBoundary>
     </UrlUpdater>
   );
 };

--- a/ui/App.jsx
+++ b/ui/App.jsx
@@ -129,50 +129,50 @@ const AppRoutes = () => {
       <ChunkErrorBoundary>
         <Suspense fallback={<LoadingSpinner />}>
           <Routes>
-          <Route path="/login" element={<LoginCallback />} />
-          <Route path="/taskcluster-auth" element={<TaskclusterCallback />} />
-          <Route
-            path="/jobs/*"
-            element={
-              <WithFavicon route="/jobs">
-                <JobsViewApp />
-              </WithFavicon>
-            }
-          />
-          <Route
-            path="/logviewer/*"
-            element={
-              <WithFavicon route="/logviewer">
-                <LogviewerApp />
-              </WithFavicon>
-            }
-          />
-          <Route
-            path="/userguide/*"
-            element={
-              <WithFavicon route="/userguide">
-                <UserGuideApp />
-              </WithFavicon>
-            }
-          />
-          <Route
-            path="/intermittent-failures/*"
-            element={
-              <WithFavicon route="/intermittent-failures">
-                <IntermittentFailuresApp />
-              </WithFavicon>
-            }
-          />
-          <Route
-            path="/perfherder/*"
-            element={
-              <WithFavicon route="/perfherder">
-                <PerfherderApp />
-              </WithFavicon>
-            }
-          />
-          <Route path="/docs/*" element={<RedocApp />} />
-          <Route path="*" element={<Navigate to="/jobs" replace />} />
+            <Route path="/login" element={<LoginCallback />} />
+            <Route path="/taskcluster-auth" element={<TaskclusterCallback />} />
+            <Route
+              path="/jobs/*"
+              element={
+                <WithFavicon route="/jobs">
+                  <JobsViewApp />
+                </WithFavicon>
+              }
+            />
+            <Route
+              path="/logviewer/*"
+              element={
+                <WithFavicon route="/logviewer">
+                  <LogviewerApp />
+                </WithFavicon>
+              }
+            />
+            <Route
+              path="/userguide/*"
+              element={
+                <WithFavicon route="/userguide">
+                  <UserGuideApp />
+                </WithFavicon>
+              }
+            />
+            <Route
+              path="/intermittent-failures/*"
+              element={
+                <WithFavicon route="/intermittent-failures">
+                  <IntermittentFailuresApp />
+                </WithFavicon>
+              }
+            />
+            <Route
+              path="/perfherder/*"
+              element={
+                <WithFavicon route="/perfherder">
+                  <PerfherderApp />
+                </WithFavicon>
+              }
+            />
+            <Route path="/docs/*" element={<RedocApp />} />
+            <Route path="*" element={<Navigate to="/jobs" replace />} />
           </Routes>
         </Suspense>
       </ChunkErrorBoundary>

--- a/ui/helpers/chunkError.js
+++ b/ui/helpers/chunkError.js
@@ -22,7 +22,12 @@ export const isChunkLoadError = function isChunkLoadError(error) {
   return (
     name === 'ChunkLoadError' ||
     /Loading (CSS )?chunk [\d]+ failed/i.test(message) ||
-    /(failed to fetch|error loading) dynamically imported module/i.test(message)
+    // Chrome/Firefox native-ESM import failures, plus Safari's variant
+    // ("Importing a module script failed.").
+    /(failed to fetch|error loading) dynamically imported module/i.test(
+      message,
+    ) ||
+    /importing a module script failed/i.test(message)
   );
 };
 

--- a/ui/helpers/chunkError.js
+++ b/ui/helpers/chunkError.js
@@ -1,0 +1,63 @@
+// Helpers for recovering from failures to load a lazily-imported route bundle.
+//
+// The UI code-splits each route (see `lazy(() => import(...))` in ui/App.jsx).
+// Bundles are content-hashed and old ones are removed on every deploy, so a
+// long-lived tab running a pre-deploy runtime can request a chunk URL that no
+// longer exists and fail with a ChunkLoadError. Reloading fetches the current
+// (always no-store) HTML shell and the matching assets. We reload at most once
+// per cooldown window so a failure that a reload cannot fix (e.g. a corrupt
+// immutable cache entry) surfaces an error instead of looping forever.
+
+const RELOAD_TIMESTAMP_KEY = 'thChunkReloadAt';
+const RELOAD_COOLDOWN_MS = 10 * 1000;
+
+export const isChunkLoadError = function isChunkLoadError(error) {
+  if (!error) {
+    return false;
+  }
+
+  const name = error.name || '';
+  const message = error.message || '';
+
+  return (
+    name === 'ChunkLoadError' ||
+    /Loading (CSS )?chunk [\d]+ failed/i.test(message) ||
+    /(failed to fetch|error loading) dynamically imported module/i.test(message)
+  );
+};
+
+export const reloadOnChunkError = function reloadOnChunkError(
+  error,
+  {
+    storage = window.sessionStorage,
+    location = window.location,
+    now = Date.now(),
+  } = {},
+) {
+  if (!isChunkLoadError(error)) {
+    return false;
+  }
+
+  let lastReloadAt = null;
+  try {
+    const stored = parseInt(storage.getItem(RELOAD_TIMESTAMP_KEY), 10);
+    lastReloadAt = Number.isNaN(stored) ? null : stored;
+  } catch (_storageError) {
+    lastReloadAt = null;
+  }
+
+  // A failure within the cooldown means the reload we already triggered did not
+  // fix it; don't loop. A missing timestamp means we have not reloaded yet.
+  if (lastReloadAt !== null && now - lastReloadAt < RELOAD_COOLDOWN_MS) {
+    return false;
+  }
+
+  try {
+    storage.setItem(RELOAD_TIMESTAMP_KEY, String(now));
+  } catch (_storageError) {
+    // sessionStorage can be unavailable (private mode quotas); reload anyway.
+  }
+
+  location.reload();
+  return true;
+};

--- a/ui/shared/ChunkErrorBoundary.jsx
+++ b/ui/shared/ChunkErrorBoundary.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { isChunkLoadError, reloadOnChunkError } from '../helpers/chunkError';
+
+import LoadingSpinner from './LoadingSpinner';
+
+/**
+ * Error boundary for the lazily-loaded routes in App.jsx.
+ *
+ * `<Suspense>` only handles the pending state of a dynamic import; it does not
+ * catch a rejected import. Without this boundary a failure to load a route
+ * bundle (a stale chunk removed by a deploy, or a corrupt cached asset) leaves
+ * the user stuck on the loading spinner. Here we attempt a one-time recovery
+ * reload to pick up the current assets, and otherwise show a readable message
+ * instead of spinning forever.
+ */
+export default class ChunkErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, isChunkError: false, reloadTriggered: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, isChunkError: isChunkLoadError(error) };
+  }
+
+  componentDidCatch(error) {
+    // For a chunk-load failure, try to reload onto the current assets. The
+    // helper reloads at most once per cooldown so it can't loop on a failure a
+    // reload won't fix.
+    const reloadTriggered = reloadOnChunkError(error);
+    if (reloadTriggered) {
+      this.setState({ reloadTriggered: true });
+    }
+  }
+
+  render() {
+    const { children = null } = this.props;
+    const { hasError, isChunkError, reloadTriggered } = this.state;
+
+    if (!hasError) {
+      return children;
+    }
+
+    if (isChunkError && reloadTriggered) {
+      // A reload is in flight; show the spinner until the page navigates away.
+      return (
+        <div className="text-center mt-5">
+          <LoadingSpinner />
+          <p>Reloading to load the latest version…</p>
+        </div>
+      );
+    }
+
+    if (isChunkError) {
+      return (
+        <div className="text-center mt-5" role="alert">
+          <p>Part of the app failed to load.</p>
+          <p>
+            Please refresh the page. If the problem persists, do a hard refresh
+            (Cmd/Ctrl+Shift+R) to clear cached files.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="text-center mt-5" role="alert">
+        <p>Something went wrong.</p>
+        <p>Please refresh the page to try again.</p>
+      </div>
+    );
+  }
+}
+
+ChunkErrorBoundary.propTypes = {
+  children: PropTypes.node,
+};


### PR DESCRIPTION
## Bug 2044976 - Recover from stale lazy-loaded chunks instead of spinning forever

The log viewer (and occasionally other views) would sometimes never load for a user — an infinite loading spinner — until they cleared their cache or did a hard refresh. A normal reload did not fix it.

### Root cause

Each top-level app is code-split via `lazy(() => import(...))` in `ui/App.jsx`, wrapped only in `<Suspense>`.  This helps with load times immensely when someone loads `/jobs` they don't pay the import price for perfherder, and vise-versa.

> [!NOTE]
> `Chunks` here are chunks of **Treeherder** deployed code, not test-chunking of jobs/tasks.

`<Suspense>` handles the *pending* state of a dynamic import, but it does **not** catch a *rejected* one. With no error boundary above it, a chunk that fails to load left React with nothing to catch — and the user stuck on the spinner.

A chunk load fails in two ways that both match the report:

1. **Deploy removes the chunk.** Bundles are content-hashed and old ones are deleted on each deploy (`clean: true`). Treeherder is an SPA people keep open for hours, so a tab still running the pre-deploy runtime requests an old chunk URL that no longer exists → `ChunkLoadError`. The app shell HTML is `no-store` (verified in prod), so a reload always pulls current assets — but nothing was triggering that reload.
2. **Corrupt/stale `immutable` cached asset.** Hashed assets are served `Cache-Control: …immutable`, so the browser never revalidates them on a normal reload — it keeps serving a bad cached copy. Only a cache-bypassing load replaces it. This matches Henrik's and Julian's description: reload doesn't help, "Disable Cache" fixes it permanently, intermittent, single-profile only.

> [!NOTE]
>Right now I believe that "always Wd3" is incidental: that log content renders through the `/logviewer` lazy route, so that's the chunk he kept hitting.  My suspicion was that it was one or more tabs that hadn't yet been reloaded after a deploy.  After this fix is deployed, we can reassess if there is another issue.

### Fix

Add a `ChunkErrorBoundary` around the lazy routes:

- On a chunk-load failure it triggers a **one-time reload** to fetch the current assets, recovering silently in the common (post-deploy) case.
- A 10-second cooldown prevents a reload loop when a reload can't fix it (the corrupt-`immutable`-cache case); instead it shows a readable message prompting a hard refresh.
- Ordinary (non-chunk) render errors get a generic fallback instead of an unhandled crash.

Caching behavior is intentionally unchanged — `immutable` hashing is correct and stays. This change only ensures a failed chunk load becomes recoverable rather than a permanent stuck spinner.

### Notes / possible follow-ups

This is a *reactive* fix (recovers after a failure). A *proactive* "a new version is available — reload" banner (poll a version hash, offer a manual reload) could further reduce occurrences; intentionally left out of scope here.  But we may keep that as a future option.