### PR TITLE
Speed up CI test runs (parallelism + caching)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,44 @@ orbs:
 
 # Reusable commands for Docker jobs
 commands:
+  setup-pnpm:
+    description: "Install pnpm and project dependencies with store caching"
+    steps:
+      - run:
+          name: Install pnpm
+          command: sudo corepack enable && corepack prepare pnpm@10.30.3 --activate
+      - run:
+          name: Configure pnpm store dir
+          command: pnpm config set store-dir ~/.pnpm-store
+      - restore_cache:
+          keys:
+            - pnpm-store-v1-{{ checksum "pnpm-lock.yaml" }}
+            - pnpm-store-v1-
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile
+      - save_cache:
+          key: pnpm-store-v1-{{ checksum "pnpm-lock.yaml" }}
+          paths:
+            - ~/.pnpm-store
+
+  install-tox:
+    description: "Install tox with pip download caching"
+    steps:
+      - restore_cache:
+          keys:
+            - pip-tox-v1-{{ checksum "tox.ini" }}
+            - pip-tox-v1-
+      - run:
+          name: Install tox
+          command: |
+            pip install --upgrade pip
+            pip install tox
+      - save_cache:
+          key: pip-tox-v1-{{ checksum "tox.ini" }}
+          paths:
+            - ~/.cache/pip
+
   create-version-json:
     description: "Create version.json for Dockerflow"
     steps:
@@ -102,24 +140,32 @@ jobs:
       # The Node version here should be compatible with `package.json` engines.
       # Note: cimg/node requires at least a minor version (e.g., '22.0'), not just major version
       tag: '22.0'
+    # Run on a 4-vCPU box and let Jest's worker pool balance the test files
+    # dynamically (`--maxWorkers=4`). A single container means install is paid
+    # once and there is no static shard imbalance — faster end-to-end than
+    # container sharding at this suite size (tests ~= install time).
+    resource_class: large
     steps:
       - checkout
+      - setup-pnpm
       - run:
-          name: Install pnpm
-          command: sudo corepack enable && corepack prepare pnpm@10.30.3 --activate
-      - run:
-          name: Install dependencies
-          command: pnpm install --frozen-lockfile
+          command: pnpm test:ci
+          name: Run Jest tests
+      - codecov/upload
+
+  javascript-lint:
+    executor:
+      name: node/default
+      tag: '22.0'
+    steps:
+      - checkout
+      - setup-pnpm
       - run:
           command: pnpm lint
           name: Run linting
       - run:
           command: pnpm markdownlint
           name: Check markdown linting
-      - run:
-          command: pnpm test:ci
-          name: Run Jest tests
-      - codecov/upload
 
   builds:
     docker:
@@ -139,12 +185,10 @@ jobs:
       image: default
     steps:
       - checkout
+      - install-tox
       - run:
           name: Run tests and coverage within Docker container
-          command: |
-            pip install --upgrade pip
-            pip install tox
-            tox -e docker-general
+          command: tox -e docker-general
       - codecov/upload
 
   python-tests-perf:
@@ -152,12 +196,10 @@ jobs:
       image: default
     steps:
       - checkout
+      - install-tox
       - run:
           name: Run tests and coverage within Docker container
-          command: |
-            pip install --upgrade pip
-            pip install tox
-            tox -e docker-perf
+          command: tox -e docker-perf
       - codecov/upload
 
   python-tests-frontend:
@@ -165,12 +207,10 @@ jobs:
       image: default
     steps:
       - checkout
+      - install-tox
       - run:
           name: Run tests and coverage within Docker container
-          command: |
-            pip install --upgrade pip
-            pip install tox
-            tox -e docker-frontend
+          command: tox -e docker-frontend
       - codecov/upload
 
   python-tests-telemetry:
@@ -178,12 +218,10 @@ jobs:
       image: default
     steps:
       - checkout
+      - install-tox
       - run:
           name: Run tests and coverage within Docker container
-          command: |
-            pip install --upgrade pip
-            pip install tox
-            tox -e docker-telemetry
+          command: tox -e docker-telemetry
       - codecov/upload
 
   test-docker-build:
@@ -214,6 +252,7 @@ workflows:
   run-tests:
     jobs:
       - javascript-tests
+      - javascript-lint
       - builds
       - python-tests-frontend
       - python-tests-general

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,8 @@ jobs:
   python-tests-general:
     machine:
       image: default
+    # 4 vCPU so `pytest -n auto` gets more workers (default machine class is 2 vCPU).
+    resource_class: large
     steps:
       - checkout
       - install-tox
@@ -194,6 +196,7 @@ jobs:
   python-tests-perf:
     machine:
       image: default
+    resource_class: large
     steps:
       - checkout
       - install-tox
@@ -205,6 +208,7 @@ jobs:
   python-tests-frontend:
     machine:
       image: default
+    resource_class: large
     steps:
       - checkout
       - install-tox
@@ -216,6 +220,7 @@ jobs:
   python-tests-telemetry:
     machine:
       image: default
+    resource_class: large
     steps:
       - checkout
       - install-tox

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "start:local": "BACKEND=http://localhost:8000 rspack serve --mode development",
     "test": "jest --maxWorkers=50%",
     "test:coverage": "jest --maxWorkers=50% --coverage",
-    "test:ci": "jest --maxWorkers=2 --coverage",
+    "test:ci": "jest --maxWorkers=4 --coverage",
     "test:integration": "jest --config jest.integration.config.js",
     "test:watch": "jest --watch --maxWorkers=25%"
   },

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -13,6 +13,9 @@ pre-commit==4.5.1
 pytest-testmon==2.2.0
 pytest-watch==4.2.0
 
+# for parallel test execution (pytest -n)
+pytest-xdist==3.8.0
+
 # Required by django-extension's runserver_plus command.
 pytest-django==4.11.1
 pytest==8.4.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -267,6 +267,10 @@ django-extensions==4.1 \
 docopt==0.6.2 \
     --hash=sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491
     # via pytest-watch
+execnet==2.1.2 \
+    --hash=sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd \
+    --hash=sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec
+    # via pytest-xdist
 filelock==3.17.0 \
     --hash=sha256:533dc2f7ba78dc2f0f531fc6c4940addf7b70a481e269a5a3b93be94ffbe8338 \
     --hash=sha256:ee4e77401ef576ebb38cd7f13b9b28893194acc20a8e68e18730ba9c0e54660e
@@ -371,6 +375,7 @@ pytest==8.4.2 \
     #   pytest-freezer
     #   pytest-testmon
     #   pytest-watch
+    #   pytest-xdist
 pytest-asyncio==1.3.0 \
     --hash=sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5 \
     --hash=sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5
@@ -393,6 +398,10 @@ pytest-testmon==2.2.0 \
     # via -r requirements/dev.in
 pytest-watch==4.2.0 \
     --hash=sha256:06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9
+    # via -r requirements/dev.in
+pytest-xdist==3.8.0 \
+    --hash=sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88 \
+    --hash=sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1
     # via -r requirements/dev.in
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \

--- a/tox.ini
+++ b/tox.ini
@@ -51,28 +51,28 @@ commands_pre =
 allowlist_externals=
     docker
 commands =
-    docker compose run -e TREEHERDER_DEBUG=False backend bash -c "pytest --cov --cov-report=xml -m 'not (perf or frontend)' --runslow -p no:unraisableexception"
+    docker compose run -e TREEHERDER_DEBUG=False backend bash -c "pytest --cov --cov-report=xml -m 'not (perf or frontend)' --runslow -p no:unraisableexception -n auto --dist load"
 
 [testenv:docker-perf]
 commands_pre =
 allowlist_externals=
     docker
 commands =
-    docker compose run -e TREEHERDER_DEBUG=False backend bash -c "pytest --cov --cov-report=xml -m 'perf and not telemetry_alerting' --runslow -p no:unraisableexception"
+    docker compose run -e TREEHERDER_DEBUG=False backend bash -c "pytest --cov --cov-report=xml -m 'perf and not telemetry_alerting' --runslow -p no:unraisableexception -n auto --dist load"
 
 [testenv:docker-telemetry]
 commands_pre =
 allowlist_externals=
     docker
 commands =
-    docker compose run -e TREEHERDER_DEBUG=False backend bash -c "pytest --cov --cov-report=xml -m telemetry_alerting --runslow -p no:unraisableexception"
+    docker compose run -e TREEHERDER_DEBUG=False backend bash -c "pytest --cov --cov-report=xml -m telemetry_alerting --runslow -p no:unraisableexception -n auto --dist load"
 
 [testenv:docker-frontend]
 commands_pre =
 allowlist_externals=
     docker
 commands =
-    docker compose run -e TREEHERDER_DEBUG=False backend bash -c "pytest --cov --cov-report=xml -m frontend --runslow -p no:unraisableexception"
+    docker compose run -e TREEHERDER_DEBUG=False backend bash -c "pytest --cov --cov-report=xml -m frontend --runslow -p no:unraisableexception -n auto --dist load"
 
 [flake8]
 per-file-ignores = treeherder/model/models.py:E402


### PR DESCRIPTION
## Summary

Reduce wall-clock time of the CI unit-test jobs by parallelizing execution, giving the heavy jobs more cores, and trimming repeated setup cost. **No test files are modified** — changes are limited to CI config and test-runner settings.

## Measured results

Overall CI wall-clock is gated by the slowest parallel job (`python-tests-general`): **925s → 416s, −55%, ~8.5 min saved per run.** All jobs pass. Master numbers are medians over recent runs (low variance).

| Job | Master (2 vCPU, serial) | + xdist (2 vCPU) | + 4 vCPU (this PR) | vs master |
|---|--:|--:|--:|--:|
| python-tests-general | 925s | 661s | **416s** | **−55%** |
| python-tests-perf | 598s | 488s | **349s** | **−42%** |
| python-tests-frontend | 495s | 391s | **294s** | **−41%** |
| python-tests-telemetry | 317s | 279s | **237s** | **−25%** |
| javascript-tests | 64s* | — | **40s** | **−37%** |
| javascript-lint | (bundled above) | — | **18s** (parallel) | new |

\* the old JS job bundled lint + markdownlint + tests serially.

Cost note: a `large` machine bills ~2× credits/minute, but each job now runs in roughly half the wall-clock — so vs today's master the 4-vCPU jobs are both faster **and** slightly cheaper in total credits.

## Changes

**JavaScript (`javascript-tests`)**
- Run on a 4-vCPU box (`resource_class: large`) and let Jest's worker pool balance files dynamically (`--maxWorkers=4`). Container sharding was measured and rejected: it partitions files statically by path (18.5s vs 5.1s imbalance when the two heavy perfherder files collided on one shard) and re-pays the ~40s `pnpm install` per container, for a suite whose tests total ~41s. One bigger box wins on both wall-clock and cost, and Jest's in-process pool already balances dynamically.
- Split linting into its own `javascript-lint` job so test results are no longer gated behind `pnpm lint` + `markdownlint`; the two now run concurrently.

**Python (`python-tests-*`)**
- Add `pytest-xdist` and run each of the four marker jobs with `-n auto --dist load` (multi-process instead of serial, no extra Docker-stack startups).
- Bump the four jobs to `resource_class: large` (4 vCPU) so `-n auto` gets more workers — the default machine class is 2 vCPU.
- `--dist load` (not `loadscope`): profiling the two biggest general-marker files showed `loadscope` pinned the 52s `test_perf_data_adapters.py` to one worker (53.7s on `-n 4`), while `load` spread its 32 independent parametrized tests across workers for ~2× (26.3s), identical pass counts. An audit confirmed every module/session-scoped fixture in `tests/` is read-only setup, so per-worker re-creation under `load` is safe.
- DB isolation is automatic: `pytest-django` creates a separate test database per worker (`test_treeherder_gw0`, …), so fixtures that assume specific row IDs remain valid.

**Caching**
- Reusable `setup-pnpm` command caches the pnpm store (keyed on `pnpm-lock.yaml`).
- Reusable `install-tox` command caches the `pip`/`tox` install across the four Python jobs.

## Verification

- All 8 CircleCI checks pass on this PR; durations above are from the actual PR runs vs master medians.
- Locally: Jest on 4 workers green with coverage; `pytest -n auto --dist load` pass counts match the serial run with per-worker databases created as expected.