### PR TITLE
Bug 2048375 - Skip re-triggering backfill when gap size is already 0

### DIFF
--- a/tests/perf/auto_perf_sheriffing/test_secretary.py
+++ b/tests/perf/auto_perf_sheriffing/test_secretary.py
@@ -386,8 +386,13 @@ class TestVerifyAndIterate:
             time=anchor_push.time - timedelta(days=5),
         )
 
-        with patch.object(
-            secretary, "re_run_detect_changes", return_value=(earlier_push.id, 3.0, [])
+        with (
+            patch.object(
+                secretary, "re_run_detect_changes", return_value=(earlier_push.id, 3.0, [])
+            ),
+            patch(
+                "treeherder.perf.auto_perf_sheriffing.secretary.calculate_gap_size", return_value=2
+            ),
         ):
             secretary.verify_and_iterate(record_successful)
 
@@ -405,8 +410,11 @@ class TestVerifyAndIterate:
             time=anchor_push.time + timedelta(days=1),
         )
 
-        with patch.object(
-            secretary, "re_run_detect_changes", return_value=(later_push.id, 3.0, [])
+        with (
+            patch.object(secretary, "re_run_detect_changes", return_value=(later_push.id, 3.0, [])),
+            patch(
+                "treeherder.perf.auto_perf_sheriffing.secretary.calculate_gap_size", return_value=2
+            ),
         ):
             secretary.verify_and_iterate(record_successful)
 
@@ -416,6 +424,32 @@ class TestVerifyAndIterate:
         logs = record_successful.get_backfill_logs()
         assert len(logs) == 1
         assert logs[0]["status"] == "right"
+
+    def test_stops_when_culprit_moves_left_with_zero_gap(
+        self, secretary, record_successful, create_push, test_repository, anchor_push
+    ):
+        earlier_push = create_push(
+            test_repository,
+            revision=uuid.uuid4(),
+            time=anchor_push.time - timedelta(days=5),
+        )
+
+        with (
+            patch.object(
+                secretary, "re_run_detect_changes", return_value=(earlier_push.id, 3.0, [])
+            ),
+            patch(
+                "treeherder.perf.auto_perf_sheriffing.secretary.calculate_gap_size", return_value=0
+            ),
+        ):
+            secretary.verify_and_iterate(record_successful)
+
+        record_successful.refresh_from_db()
+        assert record_successful.status == BackfillRecord.SUCCESSFUL
+        assert record_successful.last_detected_push_id == earlier_push.id
+        logs = record_successful.get_backfill_logs()
+        assert len(logs) == 1
+        assert logs[0]["status"] == "stabilized"
 
     def test_stops_when_gap_not_shrinking(self, secretary, record_successful):
         """If gap_size doesn't decrease between iterations, pushes lack the target job — stop."""

--- a/treeherder/perf/auto_perf_sheriffing/secretary.py
+++ b/treeherder/perf/auto_perf_sheriffing/secretary.py
@@ -229,6 +229,7 @@ class Secretary:
                 record.save()
                 return
 
+            detected_push_gap_size = calculate_gap_size(record, detected_push)
             log_entry = {
                 "iteration": record.iteration_count,
                 "detected_push_id": detected_push_id,
@@ -238,7 +239,7 @@ class Secretary:
                 "timestamp": datetime.now(UTC).isoformat(),
                 "previous_push_id": record.last_detected_push_id,
                 "previous_push_revision": previous_push.revision,
-                "detected_push_gap_size": calculate_gap_size(record, detected_push),
+                "detected_push_gap_size": detected_push_gap_size,
             }
 
             if detected_push_id == record.last_detected_push_id:
@@ -298,17 +299,29 @@ class Secretary:
             else:
                 direction = "right"
 
+            record.last_detected_push_id = detected_push_id
+            move_note = f"Detected push moved {direction} (from {previous_push.revision[:7]} to {detected_push.revision[:7]})"
+
+            if detected_push_gap_size == 0:
+                log_entry["status"] = "stabilized"
+                log_entry["notes"] = f"{move_note}; gap size is already 0, marking as stabilized."
+                record.update_backfill_log(record.iteration_count, log_entry)
+                record.save()
+                logger.info(
+                    f"Backfill Record [alert_id={record.alert.id}]: Detected push moved {direction} "
+                    f"from {log_entry['previous_push_id']} to {detected_push_id} with gap size 0, "
+                    f"stabilized without re-triggering backfill."
+                )
+                return
+
             log_entry["status"] = direction
-            log_entry["notes"] = (
-                f"Detected push moved {direction} (from {previous_push.revision[:7]} to {detected_push.revision[:7]})"
-            )
+            log_entry["notes"] = move_note
             logger.info(
                 f"Backfill Record [alert_id={record.alert.id}]: Detected push moved {direction} "
-                f"from {record.last_detected_push_id} to {detected_push_id}, "
+                f"from {log_entry['previous_push_id']} to {detected_push_id}, "
                 f"iteration {record.iteration_count}/{max_iterations}, triggering next backfill."
             )
 
-            record.last_detected_push_id = detected_push_id
             record.update_backfill_log(record.iteration_count, log_entry)
             record.status = BackfillRecord.READY_FOR_PROCESSING
             record.save()


### PR DESCRIPTION
When Sherlock moves the detected push (left or right) and the resulting gap size is 0, skip the next backfill trigger and mark the record as `stabilized` immediately.
If Iteration 2 moves LEFT and the gap becomes 0, Iteration 3 does not need to be triggered, since there are no missing pushes left to backfill.

Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2048375

```
Before:
{
"iteration": 2, 
"status": "left", 
"detected_push_gap_size": 0, 
"notes": "Detected push moved left (from 0d9ff7a to ca7cf4c)"
}, {
"iteration": 3, 
"status": "stabilized", 
"detected_push_gap_size": 0, 
"notes": "Detected push same as previous, culprit stabilized"
}

Now:
{
"iteration": 2,
"status": "stabilized",
"detected_push_gap_size": 0, 
"notes": "Detected push moved left (from 0d9ff7a to ca7cf4c); gap size is already 0, marking as stabilized."
}
```