### PR TITLE
Bug 2007005 - Mirror bug status with unlinked bug status

### DIFF
--- a/tests/perf/auto_perf_sheriffing/performance_alerting/test_alert_modifier.py
+++ b/tests/perf/auto_perf_sheriffing/performance_alerting/test_alert_modifier.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 import pytest
@@ -206,3 +206,110 @@ class TestResolutionModifier:
         assert summaries == {}
         assert "Failed to get bugs for alert resolution updates" in caplog.text
         assert "API Error" in caplog.text
+
+
+class TestNullBugStatusModifier:
+    @pytest.fixture
+    def null_bug_status_modifier_class(self):
+        for updater in PerformanceAlertSummaryModifier.get_updaters():
+            if updater.__name__ == "NullBugStatusModifier":
+                return updater
+        pytest.fail("NullBugStatusModifier not found in updaters list")
+
+    @pytest.fixture
+    def summary_with_bug_number(self, test_perf_alert_summary_for_modifier):
+        s = test_perf_alert_summary_for_modifier
+        s.bug_number = 12345
+        s.save()
+        return s
+
+    @pytest.mark.django_db
+    @patch("treeherder.perf.auto_perf_sheriffing.performance_alerting.alert_modifier.BugSearcher")
+    def test_no_matching_summaries_returns_empty(
+        self, mock_bug_searcher_class, null_bug_status_modifier_class
+    ):
+        mock_searcher = Mock()
+        mock_searcher.get_today_date.return_value = datetime.now().date()
+        mock_bug_searcher_class.return_value = mock_searcher
+
+        updates, summaries = null_bug_status_modifier_class.update_alerts()
+
+        assert updates == {}
+        assert summaries == {}
+        mock_searcher.get_bugs.assert_not_called()
+
+    @patch(
+        "treeherder.perf.auto_perf_sheriffing.performance_alerting.alert_modifier.PerformanceAlertSummary"
+    )
+    @patch("treeherder.perf.auto_perf_sheriffing.performance_alerting.alert_modifier.BugSearcher")
+    def test_large_result_set_is_chunked(
+        self, mock_bug_searcher_class, mock_pas_class, null_bug_status_modifier_class
+    ):
+        mock_pas_class.objects.filter.return_value = [Mock(bug_number=i) for i in range(51)]
+        mock_pas_class.BUG_STATUSES = PerformanceAlertSummary.BUG_STATUSES
+
+        mock_searcher = Mock()
+        mock_searcher.get_today_date.return_value = datetime.now().date()
+        mock_searcher.get_bugs.return_value = {"bugs": []}
+        mock_bug_searcher_class.return_value = mock_searcher
+
+        null_bug_status_modifier_class.update_alerts()
+
+        assert mock_searcher.get_bugs.call_count == 2
+
+    @patch("treeherder.perf.auto_perf_sheriffing.performance_alerting.alert_modifier.BugSearcher")
+    def test_update_bug_status(
+        self,
+        mock_bug_searcher_class,
+        null_bug_status_modifier_class,
+        test_perf_alert_summary_for_modifier,
+        create_perf_alert_summary,
+    ):
+        mock_searcher = Mock()
+        mock_searcher.get_today_date.return_value = datetime.now().date()
+        mock_searcher.get_bugs.return_value = {
+            "bugs": [
+                {"id": 12345, "resolution": "FIXED", "status": "RESOLVED"},
+                {"id": 67890, "resolution": "", "status": "NEW"},
+            ]
+        }
+        mock_bug_searcher_class.return_value = mock_searcher
+
+        summary1 = test_perf_alert_summary_for_modifier
+        summary1.bug_number = 12345
+        summary1.save()
+
+        summary2 = create_perf_alert_summary()
+        summary2.bug_number = 67890
+        summary2.save()
+
+        updates, summaries = null_bug_status_modifier_class.update_alerts()
+
+        assert updates[str(summary1.id)]["bug_status"] == PerformanceAlertSummary.BUG_FIXED
+        assert updates[str(summary2.id)]["bug_status"] == PerformanceAlertSummary.BUG_NEW
+        assert str(summary1.id) in summaries
+        assert str(summary2.id) in summaries
+
+    @patch("treeherder.perf.auto_perf_sheriffing.performance_alerting.alert_modifier.BugSearcher")
+    def test_summary_outside_lookback_window_is_excluded(
+        self,
+        mock_bug_searcher_class,
+        null_bug_status_modifier_class,
+        test_perf_alert_summary_for_modifier,
+    ):
+        mock_searcher = Mock()
+        mock_searcher.get_today_date.return_value = datetime.now().date()
+        mock_bug_searcher_class.return_value = mock_searcher
+
+        s = test_perf_alert_summary_for_modifier
+        s.bug_number = 12345
+        s.save()
+        PerformanceAlertSummary.objects.filter(id=s.id).update(
+            bug_updated=datetime.now() - timedelta(days=91)
+        )
+
+        updates, summaries = null_bug_status_modifier_class.update_alerts()
+
+        assert updates == {}
+        assert summaries == {}
+        mock_searcher.get_bugs.assert_not_called()

--- a/treeherder/perf/auto_perf_sheriffing/performance_alerting/alert_modifier.py
+++ b/treeherder/perf/auto_perf_sheriffing/performance_alerting/alert_modifier.py
@@ -78,3 +78,51 @@ class ResolutionModifier:
             summaries_to_update[str(summary.id)] = summary
 
         return updates, summaries_to_update
+
+
+@PerformanceAlertSummaryModifier.add
+class NullBugStatusModifier:
+    @staticmethod
+    def update_alerts(**kwargs):
+        chunk_size = 50
+        start_date = BugSearcher().get_today_date() - timedelta(days=90)
+        alert_summaries = list(
+            PerformanceAlertSummary.objects.filter(
+                bug_number__isnull=False,
+                bug_status__isnull=True,
+                bug_updated__gte=start_date,
+            )
+        )
+        if not alert_summaries:
+            return {}, {}
+
+        bug_searcher = BugSearcher()
+        bug_searcher.set_include_fields(["id", "resolution", "status"])
+        bug_numbers = [s.bug_number for s in alert_summaries]
+        all_bugs = {}
+        for i in range(0, len(bug_numbers), chunk_size):
+            chunk = bug_numbers[i : i + chunk_size]
+            bug_searcher.set_query({"id": ",".join(str(n) for n in chunk)})
+            try:
+                result = bug_searcher.get_bugs()
+            except Exception as e:
+                logger.warning(f"Failed to get bugs for null bug_status updates: {str(e)}")
+                continue
+            all_bugs.update({bug["id"]: bug for bug in result["bugs"]})
+
+        bug_status_map = {label: value for value, label in PerformanceAlertSummary.BUG_STATUSES}
+        updates = {}
+        summaries_to_update = {}
+        for summary in alert_summaries:
+            bug = all_bugs.get(summary.bug_number)
+            if not bug:
+                continue
+            new_bug_status = bug_status_map.get(bug["resolution"])
+            if new_bug_status is None and bug["resolution"] == "":
+                new_bug_status = PerformanceAlertSummary.BUG_NEW
+            if new_bug_status is None:
+                continue
+            updates[str(summary.id)] = {"bug_status": new_bug_status}
+            summaries_to_update[str(summary.id)] = summary
+
+        return updates, summaries_to_update


### PR DESCRIPTION
Before this PR, the bug status was only mirrored when the `RESOLUTION` field in Bugzilla was changed. This meant that alert summaries linked to a bug would keep no bug_status value until the bug's resolution was updated.
This PR updates bug status for alert summaries that have a linked bug but no bug_status value, within the last 90 days.
I've decided on 90 days as the standard. This period seems neither too long nor too short. 
While querying all data would work, some bugs can't be accessed due to insufficient permissions. Since those would keep getting queried every time, I added a date condition to limit the range.
If you have any suggestions or opinions, please let me know.