### PR TITLE
Bug 2007009 - Change the bot used for bug filling to a PerfSheriff Bot

### DIFF
--- a/tests/webapp/api/test_bugzilla.py
+++ b/tests/webapp/api/test_bugzilla.py
@@ -1,10 +1,44 @@
 import json
 
 import responses
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
 from treeherder.model.models import Bugscache
+
+PERF_BUG_PAYLOAD = {
+    "type": "defect",
+    "product": "Firefox",
+    "component": "General",
+    "summary": "Perf regression",
+    "version": "unspecified",
+    "description": "Perf description",
+    "needinfo_from": "dev@example.com",
+    "cc": [],
+}
+
+
+@responses.activate
+@override_settings(PERF_SHERIFF_API_KEY="perf-key", BUGFILER_API_KEY="bug-key")
+def test_create_perf_bug_uses_perf_sheriff_api_key(client, test_user):
+    responses.add(responses.POST, "https://thisisnotbugzilla.org/rest/bug", json={"id": 1})
+    client.force_authenticate(user=test_user)
+
+    resp = client.post(reverse("bugzilla-create-bug"), PERF_BUG_PAYLOAD)
+
+    assert resp.status_code == 200
+    assert responses.calls[0].request.headers["x-bugzilla-api-key"] == "perf-key"
+
+
+@override_settings(PERF_SHERIFF_API_KEY=None)
+def test_create_perf_bug_without_api_key_returns_400(client, test_user):
+    client.force_authenticate(user=test_user)
+
+    resp = client.post(reverse("bugzilla-create-bug"), PERF_BUG_PAYLOAD)
+
+    assert resp.status_code == 400
+    assert resp.json()["failure"] == "Performance sheriff bot API key not set!"
 
 
 def test_create_bug(client, eleven_jobs_stored, activate_responses, test_user):

--- a/treeherder/webapp/api/bugzilla.py
+++ b/treeherder/webapp/api/bugzilla.py
@@ -17,10 +17,22 @@ class BugzillaViewSet(viewsets.ViewSet):
         """
         Create a bugzilla bug with passed params
         """
-        if settings.BUGFILER_API_KEY is None:
-            return Response({"failure": "Bugzilla API key not set!"}, status=HTTP_400_BAD_REQUEST)
-
         params = request.data
+        # Only Perfherder is setting the param needinfo_from when filing a regression bug
+        is_perf_bug = bool(params.get("needinfo_from"))
+        if is_perf_bug:
+            if settings.PERF_SHERIFF_API_KEY is None:
+                return Response(
+                    {"failure": "Performance sheriff bot API key not set!"},
+                    status=HTTP_400_BAD_REQUEST,
+                )
+            api_key = settings.PERF_SHERIFF_API_KEY
+        else:
+            if settings.BUGFILER_API_KEY is None:
+                return Response(
+                    {"failure": "Bugzilla API key not set!"}, status=HTTP_400_BAD_REQUEST
+                )
+            api_key = settings.BUGFILER_API_KEY
 
         # Arbitrarily cap crash signatures at 2048 characters to prevent perf issues on bmo
         crash_signature = params.get("crash_signature")
@@ -36,7 +48,7 @@ class BugzillaViewSet(viewsets.ViewSet):
         summary = params.get("summary").encode("utf-8").strip()
         url = settings.BUGFILER_API_URL + "/rest/bug"
         headers = {
-            "x-bugzilla-api-key": settings.BUGFILER_API_KEY,
+            "x-bugzilla-api-key": api_key,
             "Accept": "application/json",
         }
         data = {
@@ -56,8 +68,7 @@ class BugzillaViewSet(viewsets.ViewSet):
             "comment_tags": "treeherder",
         }
 
-        # Only Perfherder is setting the param needinfo_from when filing a regression bug
-        if params.get("needinfo_from"):
+        if is_perf_bug:
             data["type"] = params.get("type")
             data["description"] = params.get("description").encode("utf-8")
             data["cc"] = params.get("cc")


### PR DESCRIPTION
This PR replaces the API key used to file performance bugs from the intermittent bot key to the `Performance Sheriff Bot` key.

Note:
If `needinfo_from` is not set (e.g. when no triage owner is available [0]), the intermittent bot key will still be used as a fallback. This case hasn't been observed yet, but if it occurs, the `StatusDropdown` component will need to be updated.

Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2007009
[0] https://github.com/mozilla/treeherder/blob/2e8e5f7f41b4ca85dd33c46aab260d51c56529a6/ui/perfherder/alerts/StatusDropdown.jsx#L63-L71