### PR TITLE
Don't file perfherder bugs in `Web Compatibility :: Site Reports`

### DIFF
--- a/ui/perfherder/alerts/StatusDropdown.jsx
+++ b/ui/perfherder/alerts/StatusDropdown.jsx
@@ -154,13 +154,14 @@ export default class StatusDropdown extends React.Component {
 
     if (!culpritDetails.failureStatus) {
       let cc = culpritDetails.ccList.add(result.cc_list);
+      const [product, component] = this.getBugComponent(culpritDetails);
       cc = Array.from(cc);
       defaultParams = {
         ...defaultParams,
         cc,
         needinfo_from: culpritDetails.needinfoFrom,
-        component: culpritDetails.component,
-        product: culpritDetails.product,
+        component: component,
+        product: product,
         regressed_by: culpritId,
       };
     }
@@ -187,6 +188,13 @@ export default class StatusDropdown extends React.Component {
       failureStatus: null,
     };
   };
+
+  getBugComponent= (culpritDetails) => {
+      const overrides = new Map();
+      overrides.set(["Web Compatbility", "Site Reports"], ["Web Compatbility", "Interventions"]);
+      const inputs = [culpritDetails.product, culpritDetails.component];
+      return overrides.get(inputs) ?? inputs;
+  }
 
   getTemplateArgs(
     frameworks,


### PR DESCRIPTION
This component is only for site reports, any perf regression must have come from an intervention, so put the bugs in the right component for interventions.

This adds a generic mechanism for overridding the product/component of bugs, in case this same use case comes up in another context.