### PR TITLE
feat: added SummaryTab using summary.jsonl artifact

### DIFF
--- a/tests/perf/auto_perf_sheriffing/test_backfill_reports/conftest.py
+++ b/tests/perf/auto_perf_sheriffing/test_backfill_reports/conftest.py
@@ -208,8 +208,14 @@ ONE_DAY_INTERVAL = datetime.timedelta(days=1)
 
 def prepare_graph_data_scenario(push_ids_to_keep, highlighted_push_id, perf_alert, perf_signature):
     original_job_count = Job.objects.count()
-    selectable_jobs = Job.objects.filter(push_id__in=push_ids_to_keep).order_by("push_id", "id")
-    Job.objects.exclude(push_id__in=push_ids_to_keep).delete()
+    # sample data stores several jobs per push; keep a single one per push, so the
+    # scenarios match the graphs documented below (job.id == job.push.id)
+    selectable_job_ids = [
+        Job.objects.filter(push_id=push_id).order_by("id").values_list("id", flat=True).first()
+        for push_id in push_ids_to_keep
+    ]
+    Job.objects.exclude(id__in=selectable_job_ids).delete()
+    selectable_jobs = Job.objects.filter(id__in=selectable_job_ids).order_by("push_id", "id")
 
     assert Job.objects.count() < original_job_count
 

--- a/tests/perf/auto_perf_sheriffing/test_backfill_reports/test_identify_retriggerables.py
+++ b/tests/perf/auto_perf_sheriffing/test_backfill_reports/test_identify_retriggerables.py
@@ -59,8 +59,7 @@ def test_identify_retriggerables_selects_all_data_points(gapped_performance_data
     data_points_to_retrigger = identify_retriggerables(test_perf_alert)
 
     assert len(data_points_to_retrigger) == 1
-    # NOTE: this is so intermittent it fails at least 30% of the time
-    # assert {4} == set(map(get_key("job_id"), data_points_to_retrigger))
+    assert {4} == set(map(get_key("job_id"), data_points_to_retrigger))
 
     # timestamps are around November 13, 2019
     push_timestamps = list(map(get_key("push_timestamp"), data_points_to_retrigger))

--- a/tests/ui/helpers/testSummary.test.js
+++ b/tests/ui/helpers/testSummary.test.js
@@ -173,6 +173,75 @@ describe('buildTestSummary', () => {
   });
 });
 
+describe('buildFailureSuggestions', () => {
+  test('emits one failure line per unexpected subtest message', () => {
+    const summary = buildTestSummary([
+      { action: 'test_start', time: 0, group: 'g', test: 'browser_all.js' },
+      {
+        action: 'test_status',
+        time: 3,
+        group: 'g',
+        test: 'browser_all.js',
+        subtest: null,
+        status: 'FAIL',
+        expected: 'PASS',
+        message: 'there should be no unreferenced files - Got 1, expected +0',
+      },
+      {
+        action: 'test_status',
+        time: 4,
+        group: 'g',
+        test: 'browser_all.js',
+        subtest: null,
+        status: 'FAIL',
+        expected: 'PASS',
+        message: 'file only referenced from unreferenced files',
+      },
+      {
+        action: 'test_end',
+        time: 10,
+        group: 'g',
+        test: 'browser_all.js',
+        status: 'FAIL',
+        expected: 'PASS',
+        message: 'finished',
+      },
+    ]);
+
+    const suggestions = buildFailureSuggestions(summary);
+    expect(suggestions).toHaveLength(2);
+    expect(suggestions[0].search).toBe(
+      'TEST-UNEXPECTED-FAIL | browser_all.js | there should be no unreferenced files - Got 1, expected +0',
+    );
+    expect(suggestions[1].search).toBe(
+      'TEST-UNEXPECTED-FAIL | browser_all.js | file only referenced from unreferenced files',
+    );
+    // Both lines point at the same test path for bug matching / path filtering.
+    expect(suggestions.every((s) => s.path_end === 'browser_all.js')).toBe(true);
+  });
+
+  test('emits a single line for a failure with one message', () => {
+    const summary = buildTestSummary([
+      { action: 'test_start', time: 0, group: 'g', test: 'browser_one.js' },
+      {
+        action: 'test_end',
+        time: 10,
+        group: 'g',
+        test: 'browser_one.js',
+        status: 'FAIL',
+        expected: 'PASS',
+        message: 'boom',
+      },
+    ]);
+
+    const suggestions = buildFailureSuggestions(summary);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].search).toBe(
+      'TEST-UNEXPECTED-FAIL | browser_one.js | boom',
+    );
+  });
+});
+
 describe('matchBugSuggestions', () => {
   const buildFailures = () =>
     buildFailureSuggestions(buildTestSummary(lines));
@@ -251,5 +320,56 @@ describe('matchBugSuggestions', () => {
       expect(s.showBugSuggestions).toBe(false);
       expect(s.valid_open_recent).toBe(false);
     });
+  });
+
+  test('attaches bugs only to the first line of a multi-message test', () => {
+    const summary = buildTestSummary([
+      { action: 'test_start', time: 0, group: 'g', test: 'browser_all.js' },
+      {
+        action: 'test_status',
+        time: 3,
+        group: 'g',
+        test: 'browser_all.js',
+        subtest: null,
+        status: 'FAIL',
+        expected: 'PASS',
+        message: 'first failure',
+      },
+      {
+        action: 'test_status',
+        time: 4,
+        group: 'g',
+        test: 'browser_all.js',
+        subtest: null,
+        status: 'FAIL',
+        expected: 'PASS',
+        message: 'second failure',
+      },
+      {
+        action: 'test_end',
+        time: 10,
+        group: 'g',
+        test: 'browser_all.js',
+        status: 'FAIL',
+        expected: 'PASS',
+        message: 'finished',
+      },
+    ]);
+    const bugSuggestions = [
+      {
+        path_end: 'browser_all.js',
+        bugs: { open_recent: [{ id: 7, internal_id: 7 }], all_others: [] },
+      },
+    ];
+
+    const failures = matchBugSuggestions(
+      buildFailureSuggestions(summary),
+      bugSuggestions,
+    );
+    expect(failures).toHaveLength(2);
+    expect(failures[0].bugs.open_recent).toHaveLength(1);
+    expect(failures[0].showBugSuggestions).toBe(true);
+    expect(failures[1].bugs.open_recent).toHaveLength(0);
+    expect(failures[1].showBugSuggestions).toBe(false);
   });
 });

--- a/tests/ui/helpers/testSummary.test.js
+++ b/tests/ui/helpers/testSummary.test.js
@@ -2,17 +2,33 @@ import {
   buildTestSummary,
   buildFailureSuggestions,
   matchBugSuggestions,
+  NO_GROUP,
+  INCOMPLETE_STATUS,
 } from '../../../ui/helpers/testSummary';
 
 const lines = [
   {
-    action: 'test_result',
+    action: 'test_start',
+    time: 100,
+    group: 'dom/manifest.ini',
+    test: 'dom/tests/test_pass.html',
+  },
+  {
+    action: 'test_end',
+    time: 150,
     group: 'dom/manifest.ini',
     test: 'dom/tests/test_pass.html',
     status: 'PASS',
   },
   {
-    action: 'test_result',
+    action: 'test_start',
+    time: 200,
+    group: 'dom/manifest.ini',
+    test: 'dom/tests/test_fail.html',
+  },
+  {
+    action: 'test_end',
+    time: 260,
     group: 'dom/manifest.ini',
     test: 'dom/tests/test_fail.html',
     status: 'FAIL',
@@ -20,13 +36,142 @@ const lines = [
     message: 'assertion failed',
   },
   {
-    action: 'test_result',
+    action: 'test_start',
+    time: 300,
+    group: 'layout/manifest.ini',
+    test: 'layout/tests/test_other.html',
+  },
+  {
+    action: 'test_end',
+    time: 400,
     group: 'layout/manifest.ini',
     test: 'layout/tests/test_other.html',
     status: 'TIMEOUT',
     expected: 'PASS',
   },
 ];
+
+describe('buildTestSummary', () => {
+  const findTest = (summary, groupName, testName) =>
+    summary.groups
+      .find((g) => g.name === groupName)
+      .tests.find((t) => t.name === testName);
+
+  test('pairs test_start/test_end into a single run with a duration', () => {
+    const summary = buildTestSummary(lines);
+    const pass = findTest(summary, 'dom/manifest.ini', 'dom/tests/test_pass.html');
+
+    expect(pass.status).toBe('PASS');
+    expect(pass.success).toBe(true);
+    expect(pass.retried).toBe(false);
+    expect(pass.results).toHaveLength(1);
+    expect(pass.results[0].duration).toBe(50);
+  });
+
+  test('marks a test_end without `expected` as a success', () => {
+    const summary = buildTestSummary(lines);
+    const fail = findTest(summary, 'dom/manifest.ini', 'dom/tests/test_fail.html');
+    expect(fail.success).toBe(false);
+    expect(fail.status).toBe('FAIL');
+  });
+
+  test('collapses repeated start/end pairs of one test into a retried entry', () => {
+    const retried = buildTestSummary([
+      { action: 'test_start', time: 0, group: 'g', test: 't' },
+      { action: 'test_end', time: 10, group: 'g', test: 't', status: 'FAIL', expected: 'PASS' },
+      { action: 'test_start', time: 20, group: 'g', test: 't' },
+      { action: 'test_end', time: 25, group: 'g', test: 't', status: 'PASS' },
+    ]);
+    const test = findTest(retried, 'g', 't');
+    expect(test.results).toHaveLength(2);
+    expect(test.retried).toBe(true);
+    // Final status comes from the last run.
+    expect(test.status).toBe('PASS');
+    expect(test.success).toBe(true);
+  });
+
+  test('treats a test_start with no test_end as an unfinished (crashed) run', () => {
+    const summary = buildTestSummary([
+      { action: 'test_start', time: 0, group: 'g', test: 'never_ends' },
+    ]);
+    const test = findTest(summary, 'g', 'never_ends');
+    expect(test.status).toBe(INCOMPLETE_STATUS);
+    expect(test.success).toBe(false);
+    expect(test.results[0].duration).toBe(null);
+  });
+
+  test('falls back to the group_start group when a test event omits `group`', () => {
+    const summary = buildTestSummary([
+      { action: 'group_start', time: 0, name: 'manifest.toml' },
+      { action: 'test_start', time: 1, test: 'orphan' },
+      { action: 'test_end', time: 2, test: 'orphan', status: 'PASS' },
+    ]);
+    expect(findTest(summary, 'manifest.toml', 'orphan')).toBeTruthy();
+  });
+
+  test('enriches a failing test_end message with unexpected subtest messages', () => {
+    const summary = buildTestSummary([
+      { action: 'test_start', time: 0, group: 'g', test: 'browser_x.js' },
+      {
+        action: 'test_status',
+        time: 5,
+        group: 'g',
+        test: 'browser_x.js',
+        subtest: null,
+        status: 'FAIL',
+        expected: 'PASS',
+        message: 'This test exceeded the timeout threshold.',
+      },
+      {
+        action: 'test_end',
+        time: 10,
+        group: 'g',
+        test: 'browser_x.js',
+        status: 'FAIL',
+        expected: 'PASS',
+        message: 'finished in 452487ms',
+      },
+    ]);
+    const test = findTest(summary, 'g', 'browser_x.js');
+    expect(test.success).toBe(false);
+    expect(test.results[0].message).toBe(
+      'This test exceeded the timeout threshold.',
+    );
+  });
+
+  test('ignores passing (expected) subtest statuses', () => {
+    const summary = buildTestSummary([
+      { action: 'test_start', time: 0, group: 'g', test: 'browser_y.js' },
+      {
+        action: 'test_status',
+        time: 5,
+        group: 'g',
+        test: 'browser_y.js',
+        subtest: 'checks a thing',
+        status: 'PASS',
+      },
+      {
+        action: 'test_end',
+        time: 10,
+        group: 'g',
+        test: 'browser_y.js',
+        status: 'OK',
+        message: 'done',
+      },
+    ]);
+    const test = findTest(summary, 'g', 'browser_y.js');
+    expect(test.success).toBe(true);
+    expect(test.results[0].message).toBe('done');
+  });
+
+  test('files a result with no resolvable group under NO_GROUP', () => {
+    const summary = buildTestSummary([
+      { action: 'test_start', time: 1, test: 'lonely' },
+      { action: 'test_end', time: 2, test: 'lonely', status: 'PASS' },
+    ]);
+    expect(findTest(summary, NO_GROUP, 'lonely')).toBeTruthy();
+  });
+});
 
 describe('matchBugSuggestions', () => {
   const buildFailures = () =>

--- a/tests/ui/helpers/testSummary.test.js
+++ b/tests/ui/helpers/testSummary.test.js
@@ -1,0 +1,110 @@
+import {
+  buildTestSummary,
+  buildFailureSuggestions,
+  matchBugSuggestions,
+} from '../../../ui/helpers/testSummary';
+
+const lines = [
+  {
+    action: 'test_result',
+    group: 'dom/manifest.ini',
+    test: 'dom/tests/test_pass.html',
+    status: 'PASS',
+  },
+  {
+    action: 'test_result',
+    group: 'dom/manifest.ini',
+    test: 'dom/tests/test_fail.html',
+    status: 'FAIL',
+    expected: 'PASS',
+    message: 'assertion failed',
+  },
+  {
+    action: 'test_result',
+    group: 'layout/manifest.ini',
+    test: 'layout/tests/test_other.html',
+    status: 'TIMEOUT',
+    expected: 'PASS',
+  },
+];
+
+describe('matchBugSuggestions', () => {
+  const buildFailures = () =>
+    buildFailureSuggestions(buildTestSummary(lines));
+
+  test('attaches bugs whose path_end matches a failing test', () => {
+    const bugSuggestions = [
+      {
+        path_end: 'dom/tests/test_fail.html',
+        bugs: {
+          open_recent: [{ id: 123, internal_id: 1, summary: 'bug A' }],
+          all_others: [],
+        },
+      },
+    ];
+
+    const failures = matchBugSuggestions(buildFailures(), bugSuggestions);
+    const failed = failures.find(
+      (s) => s.path_end === 'dom/tests/test_fail.html',
+    );
+
+    expect(failed.bugs.open_recent).toHaveLength(1);
+    expect(failed.valid_open_recent).toBe(true);
+    expect(failed.showBugSuggestions).toBe(true);
+
+    const unmatched = failures.find(
+      (s) => s.path_end === 'layout/tests/test_other.html',
+    );
+    expect(unmatched.bugs.open_recent).toHaveLength(0);
+    expect(unmatched.showBugSuggestions).toBe(false);
+  });
+
+  test('matches when the API only stores the path tail', () => {
+    const bugSuggestions = [
+      {
+        path_end: 'test_fail.html',
+        bugs: { open_recent: [{ id: 9, internal_id: 9 }], all_others: [] },
+      },
+    ];
+
+    const failures = matchBugSuggestions(buildFailures(), bugSuggestions);
+    const failed = failures.find(
+      (s) => s.path_end === 'dom/tests/test_fail.html',
+    );
+    expect(failed.bugs.open_recent).toHaveLength(1);
+  });
+
+  test('merges and de-dupes bugs from multiple error lines of one test', () => {
+    const bugSuggestions = [
+      {
+        path_end: 'dom/tests/test_fail.html',
+        bugs: { open_recent: [{ id: 1, internal_id: 1 }], all_others: [] },
+      },
+      {
+        path_end: 'dom/tests/test_fail.html',
+        bugs: {
+          open_recent: [
+            { id: 1, internal_id: 1 },
+            { id: 2, internal_id: 2 },
+          ],
+          all_others: [],
+        },
+      },
+    ];
+
+    const failures = matchBugSuggestions(buildFailures(), bugSuggestions);
+    const failed = failures.find(
+      (s) => s.path_end === 'dom/tests/test_fail.html',
+    );
+    expect(failed.bugs.open_recent.map((b) => b.id)).toEqual([1, 2]);
+  });
+
+  test('returns decorated suggestions even with no bug suggestions', () => {
+    const failures = matchBugSuggestions(buildFailures(), []);
+    expect(failures).toHaveLength(2);
+    failures.forEach((s) => {
+      expect(s.showBugSuggestions).toBe(false);
+      expect(s.valid_open_recent).toBe(false);
+    });
+  });
+});

--- a/tests/ui/job-view/App_test.jsx
+++ b/tests/ui/job-view/App_test.jsx
@@ -44,6 +44,12 @@ describe('App', () => {
       },
     );
 
+    // Summary tab probes for a summary.jsonl artifact with a HEAD request.
+    fetchMock.head(
+      'begin:https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/',
+      404,
+    );
+
     fetchMock.get(getApiUrl('/repository/'), reposFixture);
     fetchMock.get(getApiUrl('/performance/framework/'), {});
     fetchMock.get(getApiUrl('/user/'), []);

--- a/tests/ui/job-view/Filtering_test.jsx
+++ b/tests/ui/job-view/Filtering_test.jsx
@@ -78,6 +78,11 @@ describe('Filtering', () => {
       'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/JFVlnwufR7G9tZu_pKM0dQ',
       taskDefinition,
     );
+    // Summary tab probes for a summary.jsonl artifact with a HEAD request.
+    fetchMock.head(
+      'begin:https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/',
+      404,
+    );
   });
   beforeEach(() => {
     locationTracker = null;

--- a/ui/helpers/testSummary.js
+++ b/ui/helpers/testSummary.js
@@ -1,0 +1,221 @@
+import { getSearchWords } from './display';
+
+// Parses the contents of a `*_testsummary.jsonl` artifact into a structured
+// object for the job-view Summary tab.
+//
+// Each line of the artifact is a JSON object describing an event. The events we
+// care about are:
+//
+//   {"action": "test_result", "group": "<manifest>", "test": "<path>",
+//    "status": "PASS", "start": <ms>, "end": <ms>, "message": "..."}
+//
+//   {"action": "crash", "group": "<manifest>", "test": "<path>",
+//    "signature": "<crash signature>", ...}
+//
+// A single test can appear more than once (e.g. when it is retried), and a few
+// results carry no `group`. We regroup the lines first by test (collapsing the
+// repeated runs of the same test into one entry), then by group.
+
+export const NO_GROUP = '(no group)';
+
+// Status buckets we report counts for. Anything unexpected falls back to its
+// raw status string so nothing is silently dropped.
+export const TEST_STATUSES = [
+  'PASS',
+  'FAIL',
+  'SKIP',
+  'TIMEOUT',
+  'ERROR',
+  'CRASH',
+];
+
+const safeParse = (line) => {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return null;
+  }
+};
+
+const parseLines = (content) => {
+  if (Array.isArray(content)) {
+    // Already an array of parsed objects or raw line strings.
+    return content
+      .map((line) => (typeof line === 'string' ? safeParse(line) : line))
+      .filter(Boolean);
+  }
+
+  if (typeof content !== 'string') {
+    return [];
+  }
+
+  return content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map(safeParse)
+    .filter(Boolean);
+};
+
+const emptyCounts = () => {
+  const counts = { total: 0 };
+  TEST_STATUSES.forEach((status) => {
+    counts[status] = 0;
+  });
+  return counts;
+};
+
+const tallyStatus = (counts, status) => {
+  counts.total += 1;
+  if (status in counts) {
+    counts[status] += 1;
+  } else {
+    counts[status] = (counts[status] || 0) + 1;
+  }
+};
+
+const durationOf = ({ start, end }) =>
+  Number.isFinite(start) && Number.isFinite(end) ? end - start : null;
+
+/**
+ * Build the Summary tab data from a `*_testsummary.jsonl` artifact.
+ *
+ * @param {string|Array} content Raw artifact text, or an array of raw lines /
+ *   already-parsed event objects.
+ * @returns {{
+ *   groups: Array<{
+ *     name: string,
+ *     counts: Object,
+ *     tests: Array<{
+ *       name: string,
+ *       status: string,
+ *       success: boolean,
+ *       retried: boolean,
+ *       results: Array<{ status: string, success: boolean, message: ?string, start: ?number, end: ?number, duration: ?number }>,
+ *     }>,
+ *   }>,
+ *   counts: Object,
+ * }}
+ */
+export const buildTestSummary = (content) => {
+  const lines = parseLines(content);
+
+  // group name -> Map(test name -> { name, results })
+  const groups = new Map();
+
+  lines.forEach((line) => {
+    if (!line) return;
+
+    let entry;
+    if (line.action === 'test_result' && line.test) {
+      entry = {
+        test: line.test,
+        group: line.group,
+        status: line.status,
+        success: !('expected' in line),
+        message: line.message || null,
+        start: Number.isFinite(line.start) ? line.start : null,
+        end: Number.isFinite(line.end) ? line.end : null,
+        duration: durationOf(line),
+      };
+    } else if (line.action === 'crash') {
+      const testName = line.test || line.signature || '(unknown test)';
+      entry = {
+        test: testName,
+        group: line.group,
+        status: 'CRASH',
+        success: false,
+        message: line.signature || null,
+        start: null,
+        end: null,
+        duration: null,
+      };
+    } else {
+      return;
+    }
+
+    const groupName = entry.group || NO_GROUP;
+    if (!groups.has(groupName)) {
+      groups.set(groupName, new Map());
+    }
+    const tests = groups.get(groupName);
+
+    if (!tests.has(entry.test)) {
+      tests.set(entry.test, { name: entry.test, results: [] });
+    }
+    tests.get(entry.test).results.push({
+      status: entry.status,
+      success: entry.success,
+      message: entry.message,
+      start: entry.start,
+      end: entry.end,
+      duration: entry.duration,
+    });
+  });
+
+  const overallCounts = emptyCounts();
+  // Per-status counts for tests where success=false (unexpected outcomes).
+  const overallRealFailCounts = {};
+
+  const groupList = Array.from(groups.entries()).map(([name, tests]) => {
+    const groupCounts = emptyCounts();
+
+    const testList = Array.from(tests.values()).map((test) => {
+      // The "final" status/success is the last run of the test (handles retries).
+      const lastResult = test.results[test.results.length - 1];
+      const { status, success } = lastResult;
+      tallyStatus(groupCounts, status);
+      tallyStatus(overallCounts, status);
+      if (!success) {
+        overallRealFailCounts[status] =
+          (overallRealFailCounts[status] || 0) + 1;
+      }
+      return {
+        ...test,
+        status,
+        success,
+        retried: test.results.length > 1,
+      };
+    });
+
+    return { name, counts: groupCounts, tests: testList };
+  });
+
+  return {
+    groups: groupList,
+    counts: overallCounts,
+    realFailCounts: overallRealFailCounts,
+  };
+};
+
+/**
+ * Build a flat, `bug_suggestions`-API-shaped list of the failing tests in a
+ * `buildTestSummary()` result, for use by the Summary tab (which
+ * reuses BugFiler/InternalIssueFiler but has no Bugzilla suggestion data).
+ *
+ * @param {ReturnType<typeof buildTestSummary>|null} summary
+ * @returns {Array<{ search: string, path_end: string, search_terms: string[], bugs: { open_recent: [], all_others: [] } }>}
+ */
+export const buildFailureSuggestions = (summary) => {
+  if (!summary) return [];
+
+  const suggestions = [];
+  summary.groups.forEach((group) => {
+    group.tests.forEach((test) => {
+      if (test.success) return;
+      const lastResult = test.results[test.results.length - 1];
+      const search = `TEST-UNEXPECTED-${test.status} | ${test.name}${
+        lastResult.message ? ` | ${lastResult.message}` : ''
+      }`;
+      suggestions.push({
+        search,
+        path_end: test.name,
+        search_terms: getSearchWords(search),
+        bugs: { open_recent: [], all_others: [] },
+      });
+    });
+  });
+  return suggestions;
+};
+
+export default buildTestSummary;

--- a/ui/helpers/testSummary.js
+++ b/ui/helpers/testSummary.js
@@ -1,4 +1,5 @@
 import { getSearchWords } from './display';
+import { thBugSuggestionLimit } from './constants';
 
 // Parses the contents of a `*_testsummary.jsonl` artifact into a structured
 // object for the job-view Summary tab.
@@ -216,6 +217,86 @@ export const buildFailureSuggestions = (summary) => {
     });
   });
   return suggestions;
+};
+
+// Normalize a test path so the testsummary test name and the bug_suggestions
+// `path_end` (which the backend trims/cleans) can be compared. We keep only the
+// trailing slash-free form so a full manifest path matches its `path_end`.
+const normalizePath = (path) =>
+  (path || '').replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+
+// True when a bug_suggestion's path matches a failing test's path. The backend
+// may store either the full path or only its tail in `path_end`, so we accept
+// an exact match or one being the suffix of the other.
+const pathsMatch = (testPath, bugPath) => {
+  if (!testPath || !bugPath) return false;
+  const a = normalizePath(testPath);
+  const b = normalizePath(bugPath);
+  if (!a || !b) return false;
+  return a === b || a.endsWith(`/${b}`) || b.endsWith(`/${a}`);
+};
+
+const bugKey = (bug) => bug.id ?? bug.internal_id;
+
+const mergeBugs = (target, incoming) => {
+  const seen = new Set(target.map(bugKey));
+  incoming.forEach((bug) => {
+    const key = bugKey(bug);
+    if (!seen.has(key)) {
+      seen.add(key);
+      target.push(bug);
+    }
+  });
+};
+
+// Mirror the validity flags FailureSummaryTab derives from the bug_suggestions
+// API, so SummaryItem can reuse the same display logic.
+const decorateBugs = (suggestion) => {
+  const { bugs } = suggestion;
+  bugs.too_many_open_recent = bugs.open_recent.length > thBugSuggestionLimit;
+  bugs.too_many_all_others = bugs.all_others.length > thBugSuggestionLimit;
+  suggestion.valid_open_recent =
+    bugs.open_recent.length > 0 && !bugs.too_many_open_recent;
+  suggestion.valid_all_others =
+    bugs.all_others.length > 0 &&
+    !bugs.too_many_all_others &&
+    !bugs.too_many_open_recent;
+  suggestion.showBugSuggestions =
+    suggestion.valid_open_recent || suggestion.valid_all_others;
+};
+
+/**
+ * Enrich the testsummary-derived failure suggestions with the Bugzilla bug
+ * suggestions returned by the `/bug_suggestions/` API, matching on test path.
+ *
+ * The testsummary artifact gives us the canonical list of failing tests, but
+ * carries no Bugzilla data; the API gives us bugs keyed by log error line. We
+ * match the two by test path (`path_end`) and attach every matching bug to the
+ * corresponding failing test, merging when several error lines map to one test.
+ *
+ * @param {ReturnType<typeof buildFailureSuggestions>} failureSuggestions
+ * @param {Array<{ path_end: ?string, bugs: { open_recent: [], all_others: [] } }>} bugSuggestions
+ * @returns {typeof failureSuggestions} the same suggestions, bugs attached.
+ */
+export const matchBugSuggestions = (failureSuggestions, bugSuggestions) => {
+  if (!failureSuggestions || !failureSuggestions.length) return failureSuggestions;
+  if (!bugSuggestions || !bugSuggestions.length) {
+    failureSuggestions.forEach(decorateBugs);
+    return failureSuggestions;
+  }
+
+  failureSuggestions.forEach((suggestion) => {
+    const matches = bugSuggestions.filter((bugSuggestion) =>
+      pathsMatch(suggestion.path_end, bugSuggestion.path_end),
+    );
+    matches.forEach((match) => {
+      mergeBugs(suggestion.bugs.open_recent, match.bugs?.open_recent || []);
+      mergeBugs(suggestion.bugs.all_others, match.bugs?.all_others || []);
+    });
+    decorateBugs(suggestion);
+  });
+
+  return failureSuggestions;
 };
 
 export default buildTestSummary;

--- a/ui/helpers/testSummary.js
+++ b/ui/helpers/testSummary.js
@@ -134,6 +134,7 @@ export const buildTestSummary = (content) => {
       status: entry.status,
       success: entry.success,
       message: entry.message,
+      messages: entry.messages || (entry.message ? [entry.message] : []),
       start: entry.start,
       end: entry.end,
       duration: entry.duration,
@@ -183,7 +184,7 @@ export const buildTestSummary = (content) => {
         const queue = pending.get(line.test);
         const run = queue && queue.length ? queue[0] : null;
         if (run && line.message) {
-          const label = line.subtest ? `${line.subtest}: ` : '';
+          const label = line.subtest ? `${line.subtest} - ` : '';
           run.subtestFailures.push(`${label}${line.message}`);
         }
         return;
@@ -195,18 +196,23 @@ export const buildTestSummary = (content) => {
         const end = finiteOrNull(line.time);
         const success = !('expected' in line);
         const subtestFailures = run?.subtestFailures || [];
-        // For a failing test prefer the (more informative) subtest messages;
-        // otherwise fall back to the test_end message.
-        const message =
-          (!success && subtestFailures.length
-            ? subtestFailures.join(' | ')
-            : line.message) || null;
+        // For a failing test prefer the (more informative) subtest messages,
+        // keeping each one separate so the Summary tab can render one failure
+        // line per message; otherwise fall back to the test_end message.
+        const messages =
+          !success && subtestFailures.length
+            ? subtestFailures
+            : line.message
+              ? [line.message]
+              : [];
+        const message = messages.length ? messages.join(' | ') : null;
         recordEntry({
           test: line.test,
           group: line.group || run?.group || currentGroup,
           status: line.status,
           success,
           message,
+          messages,
           start,
           end,
           duration: durationOf(start, end),
@@ -299,14 +305,26 @@ export const buildFailureSuggestions = (summary) => {
     group.tests.forEach((test) => {
       if (test.success) return;
       const lastResult = test.results[test.results.length - 1];
-      const search = `TEST-UNEXPECTED-${test.status} | ${test.name}${
-        lastResult.message ? ` | ${lastResult.message}` : ''
-      }`;
-      suggestions.push({
-        search,
-        path_end: test.name,
-        search_terms: getSearchWords(search),
-        bugs: { open_recent: [], all_others: [] },
+      // A single failing test can emit several unexpected messages (e.g. one
+      // subtest failure per line). Render each as its own failure line, mirroring
+      // FailureSummaryTab, instead of collapsing them into one joined line.
+      const messages = lastResult.messages?.length
+        ? lastResult.messages
+        : [lastResult.message].filter(Boolean);
+      if (!messages.length) messages.push(null);
+      messages.forEach((message, index) => {
+        const search = `TEST-UNEXPECTED-${test.status} | ${test.name}${
+          message ? ` | ${message}` : ''
+        }`;
+        suggestions.push({
+          search,
+          path_end: test.name,
+          search_terms: getSearchWords(search),
+          // Bug suggestions match on test path, so every line of a test would
+          // otherwise get the same bugs. Only the first line carries them.
+          primary: index === 0,
+          bugs: { open_recent: [], all_others: [] },
+        });
       });
     });
   });
@@ -380,6 +398,12 @@ export const matchBugSuggestions = (failureSuggestions, bugSuggestions) => {
   }
 
   failureSuggestions.forEach((suggestion) => {
+    // Non-primary lines share a test path with the primary one; attaching bugs
+    // to them too would duplicate the suggestions under every message line.
+    if (suggestion.primary === false) {
+      decorateBugs(suggestion);
+      return;
+    }
     const matches = bugSuggestions.filter((bugSuggestion) =>
       pathsMatch(suggestion.path_end, bugSuggestion.path_end),
     );

--- a/ui/helpers/testSummary.js
+++ b/ui/helpers/testSummary.js
@@ -4,20 +4,34 @@ import { thBugSuggestionLimit } from './constants';
 // Parses the contents of a `*_testsummary.jsonl` artifact into a structured
 // object for the job-view Summary tab.
 //
-// Each line of the artifact is a JSON object describing an event. The events we
-// care about are:
+// Each line of the artifact is a JSON object describing a mozlog structured-log
+// event. A test run is no longer a single `test_result` line — it is a
+// `test_start` / `test_end` pair:
 //
-//   {"action": "test_result", "group": "<manifest>", "test": "<path>",
-//    "status": "PASS", "start": <ms>, "end": <ms>, "message": "..."}
+//   {"action": "test_start", "time": <ms>, "group": "<manifest>",
+//    "test": "<path>"}
+//
+//   {"action": "test_end", "time": <ms>, "group": "<manifest>",
+//    "test": "<path>", "status": "PASS", "message": "...",
+//    "expected": "<status>"}   // `expected` present only when unexpected
 //
 //   {"action": "crash", "group": "<manifest>", "test": "<path>",
 //    "signature": "<crash signature>", ...}
+//
+// The `end` event is not guaranteed: a test that crashes or hangs gets a
+// `test_start` with no matching `test_end`. We pair the two events to recover
+// each run's duration, and treat an unpaired `test_start` as a run that never
+// finished (status CRASH).
 //
 // A single test can appear more than once (e.g. when it is retried), and a few
 // results carry no `group`. We regroup the lines first by test (collapsing the
 // repeated runs of the same test into one entry), then by group.
 
 export const NO_GROUP = '(no group)';
+
+// Status given to a test that emitted a `test_start` but never a matching
+// `test_end` — the harness died mid-run, which almost always means a crash.
+export const INCOMPLETE_STATUS = 'CRASH';
 
 // Status buckets we report counts for. Anything unexpected falls back to its
 // raw status string so nothing is silently dropped.
@@ -75,8 +89,10 @@ const tallyStatus = (counts, status) => {
   }
 };
 
-const durationOf = ({ start, end }) =>
+const durationOf = (start, end) =>
   Number.isFinite(start) && Number.isFinite(end) ? end - start : null;
+
+const finiteOrNull = (value) => (Number.isFinite(value) ? value : null);
 
 /**
  * Build the Summary tab data from a `*_testsummary.jsonl` artifact.
@@ -104,37 +120,7 @@ export const buildTestSummary = (content) => {
   // group name -> Map(test name -> { name, results })
   const groups = new Map();
 
-  lines.forEach((line) => {
-    if (!line) return;
-
-    let entry;
-    if (line.action === 'test_result' && line.test) {
-      entry = {
-        test: line.test,
-        group: line.group,
-        status: line.status,
-        success: !('expected' in line),
-        message: line.message || null,
-        start: Number.isFinite(line.start) ? line.start : null,
-        end: Number.isFinite(line.end) ? line.end : null,
-        duration: durationOf(line),
-      };
-    } else if (line.action === 'crash') {
-      const testName = line.test || line.signature || '(unknown test)';
-      entry = {
-        test: testName,
-        group: line.group,
-        status: 'CRASH',
-        success: false,
-        message: line.signature || null,
-        start: null,
-        end: null,
-        duration: null,
-      };
-    } else {
-      return;
-    }
-
+  const recordEntry = (entry) => {
     const groupName = entry.group || NO_GROUP;
     if (!groups.has(groupName)) {
       groups.set(groupName, new Map());
@@ -151,6 +137,114 @@ export const buildTestSummary = (content) => {
       start: entry.start,
       end: entry.end,
       duration: entry.duration,
+    });
+  };
+
+  // Open `test_start` events awaiting their `test_end`, queued per test name so
+  // retries of the same test pair up in order (FIFO).
+  const pending = new Map();
+  // The group most recently opened by `group_start`, used as a fallback when a
+  // test event carries no `group` of its own.
+  let currentGroup = null;
+
+  const takePending = (testName) => {
+    const queue = pending.get(testName);
+    return queue && queue.length ? queue.shift() : null;
+  };
+
+  lines.forEach((line) => {
+    if (!line) return;
+
+    switch (line.action) {
+      case 'group_start':
+        currentGroup = line.name || currentGroup;
+        return;
+      case 'group_end':
+        currentGroup = null;
+        return;
+      case 'test_start': {
+        if (!line.test) return;
+        const run = {
+          group: line.group || currentGroup,
+          start: finiteOrNull(line.time),
+          // Messages from unexpected `test_status` (subtest) events, which are
+          // usually more descriptive than the parent `test_end` message.
+          subtestFailures: [],
+        };
+        if (!pending.has(line.test)) pending.set(line.test, []);
+        pending.get(line.test).push(run);
+        return;
+      }
+      case 'test_status': {
+        // A subtest result. We only keep the unexpected ones (those carrying an
+        // `expected` field) to enrich the parent test's failure message. The
+        // pending run's *first* queued start owns the in-progress subtests.
+        if (!line.test || !('expected' in line)) return;
+        const queue = pending.get(line.test);
+        const run = queue && queue.length ? queue[0] : null;
+        if (run && line.message) {
+          const label = line.subtest ? `${line.subtest}: ` : '';
+          run.subtestFailures.push(`${label}${line.message}`);
+        }
+        return;
+      }
+      case 'test_end': {
+        if (!line.test) return;
+        const run = takePending(line.test);
+        const start = run ? run.start : null;
+        const end = finiteOrNull(line.time);
+        const success = !('expected' in line);
+        const subtestFailures = run?.subtestFailures || [];
+        // For a failing test prefer the (more informative) subtest messages;
+        // otherwise fall back to the test_end message.
+        const message =
+          (!success && subtestFailures.length
+            ? subtestFailures.join(' | ')
+            : line.message) || null;
+        recordEntry({
+          test: line.test,
+          group: line.group || run?.group || currentGroup,
+          status: line.status,
+          success,
+          message,
+          start,
+          end,
+          duration: durationOf(start, end),
+        });
+        return;
+      }
+      case 'crash': {
+        const testName = line.test || line.signature || '(unknown test)';
+        recordEntry({
+          test: testName,
+          group: line.group || currentGroup,
+          status: 'CRASH',
+          success: false,
+          message: line.signature || null,
+          start: null,
+          end: null,
+          duration: null,
+        });
+        return;
+      }
+      default:
+    }
+  });
+
+  // Any `test_start` left unpaired never produced a `test_end`: the run did not
+  // finish, which we surface as a crash so it is not silently dropped.
+  pending.forEach((queue, testName) => {
+    queue.forEach((run) => {
+      recordEntry({
+        test: testName,
+        group: run.group,
+        status: INCOMPLETE_STATUS,
+        success: false,
+        message: 'Test started but never finished',
+        start: run.start,
+        end: null,
+        duration: null,
+      });
     });
   });
 

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -67,13 +67,9 @@ const getDefaultTabIndex = (status, props) => {
     {},
   );
 
-  let tabIndex = showSummary
-    ? tabIndexes.summary
-    : showPerf
-      ? tabIndexes.perf
-      : tabIndexes.artifacts;
+  let tabIndex = showPerf ? tabIndexes.perf : tabIndexes.artifacts;
   if (['busted', 'testfailed', 'exception'].includes(status)) {
-    tabIndex = showSummary ? tabIndexes.summary : tabIndexes.failure;
+    tabIndex = tabIndexes.failure;
   }
   return tabIndex;
 };

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -26,22 +26,6 @@ import AnnotationsTab from './AnnotationsTab';
 import SimilarJobsTab from './SimilarJobsTab';
 import SummaryTab from './summaryTab/SummaryTab';
 
-const SUMMARY_ARTIFACT_SUFFIX = '_testsummary.jsonl';
-
-const getSummaryArtifact = (jobDetails = []) =>
-  jobDetails.find((detail) => detail.value?.endsWith(SUMMARY_ARTIFACT_SUFFIX));
-
-const hasSummaryArtifact = (jobDetails = []) =>
-  !!getSummaryArtifact(jobDetails);
-
-const showTabsFromProps = (props) => {
-  const { perfJobDetail, jobDetails } = props;
-  return {
-    showPerf: !!perfJobDetail.length,
-    showSummary: hasSummaryArtifact(jobDetails),
-  };
-};
-
 const getTabNames = ({ showPerf, showSummary }) => {
   // The order in here has to match the order within the render method
   return [
@@ -58,8 +42,7 @@ const getTabNames = ({ showPerf, showSummary }) => {
   );
 };
 
-const getDefaultTabIndex = (status, props) => {
-  const { showPerf, showSummary } = showTabsFromProps(props);
+const getDefaultTabIndex = (status, { showPerf, showSummary }) => {
   let idx = 0;
   const tabNames = getTabNames({ showPerf, showSummary });
   const tabIndexes = tabNames.reduce(
@@ -111,14 +94,14 @@ const TabsPanel = ({
   }, []);
 
   const [tabIndex, setTabIndex] = useState(0);
+  const [summaryUrl, setSummaryUrl] = useState(null);
   const [overflowTabs, setOverflowTabs] = useState([]);
   const [showOverflowDropdown, setShowOverflowDropdown] = useState(false);
-  const [jobId, setJobId] = useState(null);
-  const [perfJobDetailSize, setPerfJobDetailSize] = useState(0);
   const [dropdownShow, setDropdownShow] = useState(false);
 
   const tabListRef = useRef(null);
   const resizeObserverRef = useRef(null);
+  const defaultTabKeyRef = useRef(null);
 
   const checkTabOverflow = useCallback(() => {
     if (!tabListRef.current) return;
@@ -144,10 +127,8 @@ const TabsPanel = ({
       }
     });
 
-    const { showPerf, showSummary } = showTabsFromProps({
-      perfJobDetail,
-      jobDetails,
-    });
+    const showPerf = !!perfJobDetail.length;
+    const showSummary = !!summaryUrl;
     const enableTestGroupsTab = testGroups && testGroups.length > 0;
 
     // Create tab data array (order must match the render method)
@@ -215,7 +196,7 @@ const TabsPanel = ({
       setOverflowTabs([]);
       setShowOverflowDropdown(false);
     }
-  }, [perfJobDetail, testGroups, jobDetails]);
+  }, [perfJobDetail, testGroups, summaryUrl]);
 
   const setupResizeObserver = useCallback(() => {
     if (tabListRef.current && window.ResizeObserver) {
@@ -234,31 +215,58 @@ const TabsPanel = ({
 
   const onSelectNextTab = useCallback(() => {
     const nextIndex = tabIndex + 1;
-    const tabCount = getTabNames(
-      showTabsFromProps({ perfJobDetail, jobDetails }),
-    ).length;
+    const tabCount = getTabNames({
+      showPerf: !!perfJobDetail.length,
+      showSummary: !!summaryUrl,
+    }).length;
     setTabIndex(nextIndex < tabCount ? nextIndex : 0);
-  }, [tabIndex, perfJobDetail, jobDetails]);
+  }, [tabIndex, perfJobDetail, summaryUrl]);
 
   const handleOverflowTabClick = useCallback((newTabIndex) => {
     setTabIndex(newTabIndex);
   }, []);
 
-  // Effect for handling job changes and setting default tab index
+  // Probe for the summary.jsonl artifact; only show the Summary tab when it exists
   useEffect(() => {
-    if (
-      selectedJob &&
-      (jobId !== selectedJob.id || perfJobDetailSize !== perfJobDetail.length)
-    ) {
-      const newTabIndex = getDefaultTabIndex(selectedJob.resultStatus, {
-        perfJobDetail,
-        jobDetails,
+    const url =
+      jobDetails?.find((detail) => detail.value === 'summary.jsonl')?.url ||
+      jobDetails?.find((detail) => detail.value?.endsWith('_testsummary.jsonl'))
+        ?.url;
+
+    console.log('Probing for summary artifact at URL:', url);
+    setSummaryUrl(null);
+    if (!url) return undefined;
+
+    let cancelled = false;
+    fetch(url, { method: 'HEAD' })
+      .then((resp) => {
+        if (!cancelled && resp.ok) {
+          setSummaryUrl(url);
+        }
+      })
+      .catch(() => {
+        // No summary artifact for this task; leave the Summary tab hidden.
       });
-      setTabIndex(newTabIndex);
-      setJobId(selectedJob.id);
-      setPerfJobDetailSize(perfJobDetail.length);
-    }
-  }, [selectedJob, perfJobDetail, jobId, perfJobDetailSize, jobDetails]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedJob?.task_id, selectedJob?.retry_id, jobDetails]);
+
+  // Effect for handling job changes and setting default tab index.
+  // Re-runs when the summary probe resolves so tab indexes stay in sync.
+  useEffect(() => {
+    if (!selectedJob) return;
+    const key = `${selectedJob.id}-${perfJobDetail.length}-${!!summaryUrl}`;
+    if (defaultTabKeyRef.current === key) return;
+    defaultTabKeyRef.current = key;
+    setTabIndex(
+      getDefaultTabIndex(selectedJob.resultStatus, {
+        showPerf: !!perfJobDetail.length,
+        showSummary: !!summaryUrl,
+      }),
+    );
+  }, [selectedJob, perfJobDetail, summaryUrl]);
 
   // Effect for setting up event listeners and resize observer
   useEffect(() => {
@@ -283,10 +291,8 @@ const TabsPanel = ({
   }, [checkTabOverflow]);
 
   const countPinnedJobs = Object.keys(pinnedJobs).length;
-  const { showPerf, showSummary } = showTabsFromProps({
-    perfJobDetail,
-    jobDetails,
-  });
+  const showPerf = !!perfJobDetail.length;
+  const showSummary = !!summaryUrl;
   const enableTestGroupsTab = testGroups && testGroups.length > 0;
 
   return (
@@ -429,8 +435,8 @@ const TabsPanel = ({
           {showSummary && (
             <TabPanel>
               <SummaryTab
-                key={getSummaryArtifact(jobDetails)?.url}
-                artifactUrl={getSummaryArtifact(jobDetails)?.url}
+                key={summaryUrl}
+                artifactUrl={summaryUrl}
                 selectedJob={selectedJobFull}
                 jobLogUrls={jobLogUrls}
                 jobDetails={jobDetails}

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -24,38 +24,56 @@ import FailureSummaryTab from '../../../shared/tabs/failureSummary/FailureSummar
 import PerformanceTab from './PerformanceTab';
 import AnnotationsTab from './AnnotationsTab';
 import SimilarJobsTab from './SimilarJobsTab';
+import SummaryTab from './summaryTab/SummaryTab';
+
+const SUMMARY_ARTIFACT_SUFFIX = '_testsummary.jsonl';
+
+const getSummaryArtifact = (jobDetails = []) =>
+  jobDetails.find((detail) => detail.value?.endsWith(SUMMARY_ARTIFACT_SUFFIX));
+
+const hasSummaryArtifact = (jobDetails = []) =>
+  !!getSummaryArtifact(jobDetails);
 
 const showTabsFromProps = (props) => {
-  const { perfJobDetail } = props;
+  const { perfJobDetail, jobDetails } = props;
   return {
     showPerf: !!perfJobDetail.length,
+    showSummary: hasSummaryArtifact(jobDetails),
   };
 };
 
-const getTabNames = ({ showPerf }) => {
+const getTabNames = ({ showPerf, showSummary }) => {
   // The order in here has to match the order within the render method
   return [
+    'summary',
     'artifacts',
     'failure',
     'annotations',
     'similar',
     'perf',
     'test-groups',
-  ].filter((name) => !(name === 'perf' && !showPerf));
+  ].filter(
+    (name) =>
+      !(name === 'perf' && !showPerf) && !(name === 'summary' && !showSummary),
+  );
 };
 
 const getDefaultTabIndex = (status, props) => {
-  const { showPerf } = showTabsFromProps(props);
+  const { showPerf, showSummary } = showTabsFromProps(props);
   let idx = 0;
-  const tabNames = getTabNames({ showPerf });
+  const tabNames = getTabNames({ showPerf, showSummary });
   const tabIndexes = tabNames.reduce(
     (acc, name) => ({ ...acc, [name]: idx++ }),
     {},
   );
 
-  let tabIndex = showPerf ? tabIndexes.perf : tabIndexes.artifacts;
+  let tabIndex = showSummary
+    ? tabIndexes.summary
+    : showPerf
+      ? tabIndexes.perf
+      : tabIndexes.artifacts;
   if (['busted', 'testfailed', 'exception'].includes(status)) {
-    tabIndex = tabIndexes.failure;
+    tabIndex = showSummary ? tabIndexes.summary : tabIndexes.failure;
   }
   return tabIndex;
 };
@@ -130,16 +148,41 @@ const TabsPanel = ({
       }
     });
 
-    const { showPerf } = showTabsFromProps({ perfJobDetail });
+    const { showPerf, showSummary } = showTabsFromProps({
+      perfJobDetail,
+      jobDetails,
+    });
     const enableTestGroupsTab = testGroups && testGroups.length > 0;
 
-    // Create tab data array
-    const allTabs = [
-      { key: 'artifacts', label: 'Artifacts and Debugging Tools', index: 0 },
-      { key: 'failure', label: 'Failure Summary', index: 1 },
-      { key: 'annotations', label: 'Annotations', index: 2 },
-      { key: 'similar', label: 'Similar Jobs', index: 3 },
-    ];
+    // Create tab data array (order must match the render method)
+    const allTabs = [];
+    if (showSummary) {
+      allTabs.push({
+        key: 'summary',
+        label: 'Summary',
+        index: allTabs.length,
+      });
+    }
+    allTabs.push({
+      key: 'artifacts',
+      label: 'Artifacts and Debugging Tools',
+      index: allTabs.length,
+    });
+    allTabs.push({
+      key: 'failure',
+      label: 'Failure Summary',
+      index: allTabs.length,
+    });
+    allTabs.push({
+      key: 'annotations',
+      label: 'Annotations',
+      index: allTabs.length,
+    });
+    allTabs.push({
+      key: 'similar',
+      label: 'Similar Jobs',
+      index: allTabs.length,
+    });
 
     if (showPerf) {
       allTabs.push({
@@ -176,7 +219,7 @@ const TabsPanel = ({
       setOverflowTabs([]);
       setShowOverflowDropdown(false);
     }
-  }, [perfJobDetail, testGroups]);
+  }, [perfJobDetail, testGroups, jobDetails]);
 
   const setupResizeObserver = useCallback(() => {
     if (tabListRef.current && window.ResizeObserver) {
@@ -195,9 +238,11 @@ const TabsPanel = ({
 
   const onSelectNextTab = useCallback(() => {
     const nextIndex = tabIndex + 1;
-    const tabCount = getTabNames(showTabsFromProps({ perfJobDetail })).length;
+    const tabCount = getTabNames(
+      showTabsFromProps({ perfJobDetail, jobDetails }),
+    ).length;
     setTabIndex(nextIndex < tabCount ? nextIndex : 0);
-  }, [tabIndex, perfJobDetail]);
+  }, [tabIndex, perfJobDetail, jobDetails]);
 
   const handleOverflowTabClick = useCallback((newTabIndex) => {
     setTabIndex(newTabIndex);
@@ -211,12 +256,13 @@ const TabsPanel = ({
     ) {
       const newTabIndex = getDefaultTabIndex(selectedJob.resultStatus, {
         perfJobDetail,
+        jobDetails,
       });
       setTabIndex(newTabIndex);
       setJobId(selectedJob.id);
       setPerfJobDetailSize(perfJobDetail.length);
     }
-  }, [selectedJob, perfJobDetail, jobId, perfJobDetailSize]);
+  }, [selectedJob, perfJobDetail, jobId, perfJobDetailSize, jobDetails]);
 
   // Effect for setting up event listeners and resize observer
   useEffect(() => {
@@ -241,7 +287,10 @@ const TabsPanel = ({
   }, [checkTabOverflow]);
 
   const countPinnedJobs = Object.keys(pinnedJobs).length;
-  const { showPerf } = showTabsFromProps({ perfJobDetail });
+  const { showPerf, showSummary } = showTabsFromProps({
+    perfJobDetail,
+    jobDetails,
+  });
   const enableTestGroupsTab = testGroups && testGroups.length > 0;
 
   return (
@@ -255,6 +304,7 @@ const TabsPanel = ({
           <div className="tab-headers-wrapper" ref={tabListRef}>
             <TabList className="tab-headers">
               <span className="tab-header-tabs">
+                {showSummary && <Tab>Summary</Tab>}
                 <Tab>Artifacts and Debugging Tools</Tab>
                 <Tab>Failure Summary</Tab>
                 <Tab>Annotations</Tab>
@@ -380,6 +430,21 @@ const TabsPanel = ({
               </span>
             </TabList>
           </div>
+          {showSummary && (
+            <TabPanel>
+              <SummaryTab
+                key={getSummaryArtifact(jobDetails)?.url}
+                artifactUrl={getSummaryArtifact(jobDetails)?.url}
+                selectedJob={selectedJobFull}
+                jobLogUrls={jobLogUrls}
+                jobDetails={jobDetails}
+                logViewerFullUrl={logViewerFullUrl}
+                addBug={addBugAction}
+                pinJob={pinJobAction}
+                currentRepo={currentRepo}
+              />
+            </TabPanel>
+          )}
           <TabPanel>
             <JobArtifacts
               jobDetails={jobDetails}

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -233,7 +233,6 @@ const TabsPanel = ({
       jobDetails?.find((detail) => detail.value?.endsWith('_testsummary.jsonl'))
         ?.url;
 
-    console.log('Probing for summary artifact at URL:', url);
     setSummaryUrl(null);
     if (!url) return undefined;
 

--- a/ui/job-view/details/tabs/summaryTab/SummaryItem.jsx
+++ b/ui/job-view/details/tabs/summaryTab/SummaryItem.jsx
@@ -1,0 +1,94 @@
+import PropTypes from 'prop-types';
+import { Button } from 'react-bootstrap';
+import { Link } from 'react-router';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faBug,
+  faCircleExclamation,
+  faFilter,
+} from '@fortawesome/free-solid-svg-icons';
+
+import Clipboard from '../../../../shared/Clipboard';
+import { isReftest } from '../../../../helpers/job';
+import {
+  createQueryParams,
+  parseQueryParams,
+} from '../../../../helpers/url';
+import formatLogLineWithLinks from '../../../../helpers/logFormatting';
+
+const getPathFilter = (filterTestPath) => {
+  const path = filterTestPath[0].replace(/\/$/, '');
+  const filterParams = {
+    ...parseQueryParams(window.location.search),
+    test_paths: path,
+  };
+
+  return `${window.location.pathname}${createQueryParams(filterParams)}`;
+};
+
+const SummaryItem = ({
+  suggestion,
+  toggleBugFiler,
+  toggleInternalIssueFiler,
+  selectedJob,
+  jobDetails,
+}) => {
+  const filterTestPath = suggestion.search.match(/([a-z_\-0-9]+[/])+/gi);
+  const line = formatLogLineWithLinks(
+    suggestion.search,
+    jobDetails,
+    selectedJob,
+  );
+
+  return (
+    <li>
+      <div>
+        <span>
+          <Button
+            className="bg-light py-2 px-2 me-2 failure-action-btn"
+            variant="outline-secondary"
+            onClick={() => toggleInternalIssueFiler(suggestion)}
+            title="File an internal issue for this failure"
+          >
+            <FontAwesomeIcon icon={faCircleExclamation} />
+          </Button>
+          <span className="align-middle">{line} </span>
+          <Clipboard description=" text of error line" text={suggestion.search} />
+          {filterTestPath && !isReftest(selectedJob) && (
+            <Link
+              to={getPathFilter(filterTestPath)}
+              className="px-1 text-darker-secondary"
+              title={`Filter by test path: ${filterTestPath[0]}`}
+            >
+              <FontAwesomeIcon icon={faFilter} />
+            </Link>
+          )}
+          <Button
+            className="bg-light py-2 px-2 ms-2 failure-action-btn"
+            variant="outline-secondary"
+            onClick={() => toggleBugFiler(suggestion)}
+            title="File a bug for this failure"
+          >
+            <FontAwesomeIcon icon={faBug} />
+          </Button>
+        </span>
+      </div>
+    </li>
+  );
+};
+
+SummaryItem.propTypes = {
+  selectedJob: PropTypes.shape({}).isRequired,
+  suggestion: PropTypes.shape({}).isRequired,
+  jobDetails: PropTypes.arrayOf(
+    PropTypes.shape({
+      url: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  toggleBugFiler: PropTypes.func.isRequired,
+  toggleInternalIssueFiler: PropTypes.func.isRequired,
+};
+
+export default SummaryItem;

--- a/ui/job-view/details/tabs/summaryTab/SummaryItem.jsx
+++ b/ui/job-view/details/tabs/summaryTab/SummaryItem.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
 import { Link } from 'react-router';
@@ -9,7 +10,9 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 import Clipboard from '../../../../shared/Clipboard';
+import BugListItem from '../../../../shared/tabs/failureSummary/BugListItem';
 import { isReftest } from '../../../../helpers/job';
+import { thBugSuggestionLimit } from '../../../../helpers/constants';
 import {
   createQueryParams,
   parseQueryParams,
@@ -32,13 +35,23 @@ const SummaryItem = ({
   toggleInternalIssueFiler,
   selectedJob,
   jobDetails,
+  addBug = null,
 }) => {
+  const [showMore, setShowMore] = useState(false);
   const filterTestPath = suggestion.search.match(/([a-z_\-0-9]+[/])+/gi);
   const line = formatLogLineWithLinks(
     suggestion.search,
     jobDetails,
     selectedJob,
   );
+
+  const { bugs } = suggestion;
+  const showOpenRecent = suggestion.valid_open_recent;
+  const showAllOthers =
+    suggestion.valid_all_others && (showMore || !showOpenRecent);
+  const tooMany =
+    bugs?.too_many_open_recent ||
+    (bugs?.too_many_all_others && !suggestion.valid_open_recent);
 
   return (
     <li>
@@ -73,6 +86,57 @@ const SummaryItem = ({
           </Button>
         </span>
       </div>
+      {suggestion.showBugSuggestions && (
+        <div className="failure-summary-bugs-container">
+          {showOpenRecent && (
+            <ul className="list-unstyled failure-summary-bugs">
+              {bugs.open_recent.map((bug) => (
+                <BugListItem
+                  key={bug.internal_id ?? bug.id}
+                  bug={bug}
+                  suggestion={suggestion}
+                  selectedJob={selectedJob}
+                  addBug={addBug}
+                  toggleBugFiler={toggleBugFiler}
+                  title={bug.resolution !== '' ? bug.resolution : ''}
+                />
+              ))}
+            </ul>
+          )}
+          {showOpenRecent && suggestion.valid_all_others && (
+            <Button
+              size="sm"
+              variant="outline-dark"
+              rel="noopener"
+              onClick={() => setShowMore((prev) => !prev)}
+              className="show-more-suggestions my-2"
+            >
+              {showMore ? 'Hide bug suggestions' : 'Show more bug suggestions'}
+            </Button>
+          )}
+          {showAllOthers && (
+            <ul className="list-unstyled failure-summary-bugs">
+              {bugs.all_others.map((bug) => (
+                <BugListItem
+                  key={bug.id ?? bug.internal_id}
+                  bug={bug}
+                  suggestion={suggestion}
+                  selectedJob={selectedJob}
+                  addBug={addBug}
+                  toggleBugFiler={toggleBugFiler}
+                  title={bug.resolution !== '' ? bug.resolution : ''}
+                />
+              ))}
+            </ul>
+          )}
+          {tooMany && (
+            <mark>
+              Exceeded max {thBugSuggestionLimit} bug suggestions, most of which
+              are likely false positives.
+            </mark>
+          )}
+        </div>
+      )}
     </li>
   );
 };
@@ -89,6 +153,7 @@ SummaryItem.propTypes = {
   ).isRequired,
   toggleBugFiler: PropTypes.func.isRequired,
   toggleInternalIssueFiler: PropTypes.func.isRequired,
+  addBug: PropTypes.func,
 };
 
 export default SummaryItem;

--- a/ui/job-view/details/tabs/summaryTab/SummaryTab.jsx
+++ b/ui/job-view/details/tabs/summaryTab/SummaryTab.jsx
@@ -1,0 +1,210 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+
+import {
+  buildTestSummary,
+  buildFailureSuggestions,
+} from '../../../../helpers/testSummary';
+import { thEvents } from '../../../../helpers/constants';
+import { isReftest } from '../../../../helpers/job';
+import { getReftestUrl } from '../../../../helpers/url';
+import BugFiler from '../../../../shared/BugFiler';
+import InternalIssueFiler from '../../../../shared/InternalIssueFiler';
+
+import SummaryItem from './SummaryItem';
+
+const SummaryTab = ({
+  artifactUrl = null,
+  selectedJob,
+  jobLogUrls = [],
+  jobDetails = [],
+  logViewerFullUrl = null,
+  addBug = null,
+  pinJob,
+  currentRepo,
+}) => {
+  const [summary, setSummary] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [isBugFilerOpen, setIsBugFilerOpen] = useState(false);
+  const [isInternalIssueFilerOpen, setIsInternalIssueFilerOpen] =
+    useState(false);
+  const [activeSuggestion, setActiveSuggestion] = useState(null);
+
+  useEffect(() => {
+    if (!artifactUrl) {
+      setSummary(null);
+      return undefined;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    fetch(artifactUrl)
+      .then((resp) => {
+        if (!resp.ok) {
+          throw new Error(`Failed to load summary (${resp.status})`);
+        }
+        return resp.text();
+      })
+      .then((text) => {
+        if (!cancelled) {
+          setSummary(buildTestSummary(text));
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err.message);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [artifactUrl]);
+
+  const suggestions = useMemo(
+    () => buildFailureSuggestions(summary),
+    [summary],
+  );
+
+  const fileBug = useCallback(
+    (suggestion) => {
+      pinJob(selectedJob);
+      setActiveSuggestion(suggestion);
+      setIsBugFilerOpen(true);
+    },
+    [pinJob, selectedJob],
+  );
+
+  const fileInternalIssue = useCallback(
+    (suggestion) => {
+      pinJob(selectedJob);
+      setActiveSuggestion(suggestion);
+      setIsInternalIssueFilerOpen(true);
+    },
+    [pinJob, selectedJob],
+  );
+
+  const bugFilerCallback = async (data) => {
+    await addBug({ id: data.id, newBug: data.id });
+    window.dispatchEvent(new CustomEvent(thEvents.saveClassification));
+    window.open(data.url);
+  };
+
+  const internalIssueFilerCallback = async (data) => {
+    await addBug({ ...data, newBug: `i${data.internal_id}` });
+    window.dispatchEvent(new CustomEvent(thEvents.saveClassification));
+  };
+
+  if (isLoading) {
+    return (
+      <div id="summary-tab" role="region" aria-label="Summary">
+        <p className="failure-summary-line-empty mb-0">
+          <FontAwesomeIcon icon={faSpinner} pulse className="me-2" />
+          Loading summary…
+        </p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div id="summary-tab" role="region" aria-label="Summary">
+        <p className="failure-summary-line-empty text-danger mb-0">{error}</p>
+      </div>
+    );
+  }
+
+  const logs = jobLogUrls.filter(
+    (jlu) => !jlu.name.includes('perfherder-data'),
+  );
+
+  return (
+    <div id="summary-tab" role="region" aria-label="Summary">
+      {!!summary && (
+        <p className="failure-summary-line-empty mb-0">
+          <strong>{summary.counts.total}</strong> tests:{' '}
+          <span className="text-success">
+            {summary.counts.PASS || 0} passed
+          </span>
+          {', '}
+          <span className="text-danger">{suggestions.length} failed</span>
+          {summary.counts.SKIP > 0 && (
+            <>
+              {', '}
+              <span className="text-muted">{summary.counts.SKIP} skipped</span>
+            </>
+          )}
+        </p>
+      )}
+      <ul className="list-unstyled w-100 h-100 mb-0 overflow-auto text-small font-size-11">
+        {suggestions.length === 0 && (
+          <li>
+            <p className="failure-summary-line-empty mb-0">
+              No failures found in the summary.
+            </p>
+          </li>
+        )}
+        {suggestions.map((suggestion, index) => (
+          <SummaryItem
+            key={`${selectedJob.id}-${index}`} // eslint-disable-line react/no-array-index-key
+            suggestion={suggestion}
+            toggleBugFiler={fileBug}
+            toggleInternalIssueFiler={fileInternalIssue}
+            selectedJob={selectedJob}
+            jobDetails={jobDetails}
+          />
+        ))}
+      </ul>
+      {isBugFilerOpen && (
+        <BugFiler
+          isOpen={isBugFilerOpen}
+          toggle={() => setIsBugFilerOpen(false)}
+          suggestion={activeSuggestion}
+          suggestions={suggestions}
+          fullLog={logs[0]?.url}
+          parsedLog={logViewerFullUrl}
+          reftestUrl={
+            isReftest(selectedJob) && logs[0] ? getReftestUrl(logs[0].url) : ''
+          }
+          successCallback={bugFilerCallback}
+          selectedJob={selectedJob}
+          currentRepo={currentRepo}
+          platform={selectedJob.platform}
+        />
+      )}
+      {isInternalIssueFilerOpen && (
+        <InternalIssueFiler
+          isOpen={isInternalIssueFilerOpen}
+          suggestion={activeSuggestion}
+          toggle={() => setIsInternalIssueFilerOpen(false)}
+          jobGroupName={selectedJob.job_group_name}
+          jobTypeName={selectedJob.job_type_name}
+          successCallback={internalIssueFilerCallback}
+        />
+      )}
+    </div>
+  );
+};
+
+SummaryTab.propTypes = {
+  artifactUrl: PropTypes.string,
+  selectedJob: PropTypes.shape({}).isRequired,
+  jobLogUrls: PropTypes.arrayOf(PropTypes.shape({})),
+  jobDetails: PropTypes.arrayOf(PropTypes.shape({})),
+  logViewerFullUrl: PropTypes.string,
+  addBug: PropTypes.func,
+  pinJob: PropTypes.func.isRequired,
+  currentRepo: PropTypes.shape({}).isRequired,
+};
+
+export default SummaryTab;

--- a/ui/job-view/details/tabs/summaryTab/SummaryTab.jsx
+++ b/ui/job-view/details/tabs/summaryTab/SummaryTab.jsx
@@ -166,7 +166,9 @@ const SummaryTab = ({
             {summary.counts.PASS || 0} passed
           </span>
           {', '}
-          <span className="text-danger">{suggestions.length} failed</span>
+          <span className={suggestions.length && 'text-danger'}>
+            {suggestions.length} failed
+          </span>
           {summary.counts.SKIP > 0 && (
             <>
               {', '}

--- a/ui/job-view/details/tabs/summaryTab/SummaryTab.jsx
+++ b/ui/job-view/details/tabs/summaryTab/SummaryTab.jsx
@@ -105,6 +105,11 @@ const SummaryTab = ({
     [summary, bugSuggestions],
   );
 
+  // Number of failing tests (not error lines — a test can emit several).
+  const failedCount = summary
+    ? Object.values(summary.realFailCounts || {}).reduce((a, b) => a + b, 0)
+    : 0;
+
   const fileBug = useCallback(
     (suggestion) => {
       pinJob(selectedJob);
@@ -166,8 +171,8 @@ const SummaryTab = ({
             {summary.counts.PASS || 0} passed
           </span>
           {', '}
-          <span className={suggestions.length && 'text-danger'}>
-            {suggestions.length} failed
+          <span className={failedCount && 'text-danger'}>
+            {failedCount} failed
           </span>
           {summary.counts.SKIP > 0 && (
             <>

--- a/ui/job-view/details/tabs/summaryTab/SummaryTab.jsx
+++ b/ui/job-view/details/tabs/summaryTab/SummaryTab.jsx
@@ -6,12 +6,14 @@ import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 import {
   buildTestSummary,
   buildFailureSuggestions,
+  matchBugSuggestions,
 } from '../../../../helpers/testSummary';
 import { thEvents } from '../../../../helpers/constants';
 import { isReftest } from '../../../../helpers/job';
 import { getReftestUrl } from '../../../../helpers/url';
 import BugFiler from '../../../../shared/BugFiler';
 import InternalIssueFiler from '../../../../shared/InternalIssueFiler';
+import BugSuggestionsModel from '../../../../models/bugSuggestions';
 
 import SummaryItem from './SummaryItem';
 
@@ -26,6 +28,7 @@ const SummaryTab = ({
   currentRepo,
 }) => {
   const [summary, setSummary] = useState(null);
+  const [bugSuggestions, setBugSuggestions] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [isBugFilerOpen, setIsBugFilerOpen] = useState(false);
@@ -71,9 +74,35 @@ const SummaryTab = ({
     };
   }, [artifactUrl]);
 
+  const jobId = selectedJob?.id;
+
+  useEffect(() => {
+    if (!jobId) {
+      setBugSuggestions([]);
+      return undefined;
+    }
+
+    let cancelled = false;
+    BugSuggestionsModel.get(jobId)
+      .then((data) => {
+        if (!cancelled) {
+          setBugSuggestions(Array.isArray(data) ? data : []);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setBugSuggestions([]);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [jobId]);
+
   const suggestions = useMemo(
-    () => buildFailureSuggestions(summary),
-    [summary],
+    () => matchBugSuggestions(buildFailureSuggestions(summary), bugSuggestions),
+    [summary, bugSuggestions],
   );
 
   const fileBug = useCallback(
@@ -162,6 +191,7 @@ const SummaryTab = ({
             toggleInternalIssueFiler={fileInternalIssue}
             selectedJob={selectedJob}
             jobDetails={jobDetails}
+            addBug={addBug}
           />
         ))}
       </ul>

--- a/ui/job-view/details/tabs/summaryTab/SummaryTab.jsx
+++ b/ui/job-view/details/tabs/summaryTab/SummaryTab.jsx
@@ -171,7 +171,7 @@ const SummaryTab = ({
             {summary.counts.PASS || 0} passed
           </span>
           {', '}
-          <span className={failedCount && 'text-danger'}>
+          <span className={failedCount ? 'text-danger' : ''}>
             {failedCount} failed
           </span>
           {summary.counts.SKIP > 0 && (


### PR DESCRIPTION
Following https://bugzilla.mozilla.org/show_bug.cgi?id=2047559 and https://bugzilla.mozilla.org/show_bug.cgi?id=2051646
Update tabs to show a new "Summary" tab to use this new artifact.
We will build on that tab to add features. By default this new tab appears first in the list but not selected.

Features already available:
- List failures
- Copy failure log
- Filter by test path
- File a bug for that failure button
- Bug suggestion listed

Not yet covered:
- Access to the line in logviewer

<img width="1186" height="299" alt="Screenshot 2026-06-26 at 15 31 18" src="https://github.com/user-attachments/assets/7949b5d3-f9e6-4784-9328-1cd447c77b3b" />
<img width="1012" height="262" alt="Screenshot 2026-06-29 at 16 00 05" src="https://github.com/user-attachments/assets/0c05f0d5-c249-4e83-ad6d-38fc0dfa4ecf" />

