### PR TITLE
Revert "Bump pytest-cov from 7.0.0 to 7.1.0" because it breaks dependency installations: backports-asyncio-runner==1.2.0 requires Python <3.12

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,5 @@
 # Dependencies needed only for development/testing.
-pytest-cov==7.1.0
+pytest-cov==7.0.0
 django-debug-toolbar==6.2.0
 mock==5.2.0
 responses==0.25.8

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,10 +14,6 @@ attrs==23.2.0 \
     # via
     #   outcome
     #   trio
-backports-asyncio-runner==1.2.0 \
-    --hash=sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5 \
-    --hash=sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162
-    # via pytest-asyncio
 black==25.9.0 \
     --hash=sha256:0172a012f725b792c358d57fe7b6b6e8e67375dd157f64fa7a3097b3ed3e2175 \
     --hash=sha256:0474bca9a0dd1b51791fcc507a4e02078a1c63f6d4e4ae5544b9848c7adfb619 \
@@ -384,9 +380,9 @@ pytest-asyncio==1.3.0 \
     --hash=sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5 \
     --hash=sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5
     # via -r requirements/dev.in
-pytest-cov==7.1.0 \
-    --hash=sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2 \
-    --hash=sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678
+pytest-cov==7.0.0 \
+    --hash=sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1 \
+    --hash=sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861
     # via -r requirements/dev.in
 pytest-django==4.12.0 \
     --hash=sha256:3ff300c49f8350ba2953b90297d23bf5f589db69545f56f1ec5f8cff5da83e85 \
@@ -541,16 +537,6 @@ sqlparse==0.5.0 \
     # via
     #   django
     #   django-debug-toolbar
-tomli==2.2.1 \
-    --hash=sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc \
-    --hash=sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff
-    # via
-    #   black
-    #   build
-    #   coverage
-    #   pip-tools
-    #   pyproject-hooks
-    #   pytest
 trio==0.24.0 \
     --hash=sha256:c3bd3a4e3e3025cd9a2241eae75637c43fe0b9e88b4c97b9161a55b9e54cd72c \
     --hash=sha256:ffa09a74a6bf81b84f8613909fb0beaee84757450183a7a2e0b47b455c0cac5d
@@ -564,12 +550,7 @@ trio-websocket==0.11.1 \
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
-    # via
-    #   asgiref
-    #   black
-    #   exceptiongroup
-    #   pytest-asyncio
-    #   selenium
+    # via selenium
 urllib3[socks]==2.0.3 \
     --hash=sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1 \
     --hash=sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825


### PR DESCRIPTION
Reverts mozilla/treeherder#9327