### PR TITLE
Fix pushesStore import path in summary panel tests

### DIFF
--- a/tests/ui/job-view/details/summary/ActionBar_test.jsx
+++ b/tests/ui/job-view/details/summary/ActionBar_test.jsx
@@ -4,7 +4,7 @@ import ActionBar from '../../../../../ui/job-view/details/summary/ActionBar';
 import {
   usePushesStore,
   initialState as pushesInitialState,
-} from '../../../../../ui/job-view/stores/pushesStore';
+} from '../../../../../ui/shared/stores/pushesStore';
 import { thEvents } from '../../../../../ui/helpers/constants';
 import JobModel from '../../../../../ui/models/job';
 

--- a/tests/ui/job-view/details/summary/SummaryPanel_test.jsx
+++ b/tests/ui/job-view/details/summary/SummaryPanel_test.jsx
@@ -5,7 +5,7 @@ import SummaryPanel from '../../../../../ui/job-view/details/summary/SummaryPane
 import {
   usePushesStore,
   initialState as pushesInitialState,
-} from '../../../../../ui/job-view/stores/pushesStore';
+} from '../../../../../ui/shared/stores/pushesStore';
 
 const selectedJobFull = {
   id: 1,


### PR DESCRIPTION
## Summary

`ActionBar_test.jsx` and `SummaryPanel_test.jsx` import the pushes store from `ui/job-view/stores/pushesStore`, which does not exist. The store actually lives at `ui/shared/stores/pushesStore` (where every other consumer imports it from).

This broke both test suites in CI:

```
Cannot find module '../../../../../ui/job-view/stores/pushesStore'
```

This appears to have been merged to master and is currently red in CI.

## Fix

Point both test imports at the correct path, `ui/shared/stores/pushesStore`.

## Testing

```
pnpm test -- tests/ui/job-view/details/summary/ActionBar_test.jsx tests/ui/job-view/details/summary/SummaryPanel_test.jsx --no-coverage
```

Both suites pass (6 tests).