### PR TITLE
Guard against native datetime comparison in Sherlock check outcome

### DIFF
--- a/treeherder/perf/auto_perf_sheriffing/secretary.py
+++ b/treeherder/perf/auto_perf_sheriffing/secretary.py
@@ -169,6 +169,8 @@ class Secretary:
             last_log = logs[-1] if logs else None
             if last_log:
                 log_timestamp = datetime.fromisoformat(last_log["timestamp"])
+                if log_timestamp.tzinfo is None:
+                    log_timestamp = log_timestamp.replace(tzinfo=UTC)
                 if log_timestamp < datetime.now(UTC) - timedelta(hours=72):
                     record.status = BackfillRecord.FAILED
                     new_note = "Backfill exceeded 72-hour limit, marking as FAILED."


### PR DESCRIPTION
Sherlock saves timestamps in the backfill_logs field. The way these timestamps were saved changed: old code saved them without timezone info, new code saves them with UTC.
Because the old and new timestamp formats don't match, comparing them causes an error.
Old records saved in the old format are still in the database. When Sherlock checks whether 72 hours have passed, it compares "now" (which has timezone info) with the saved timestamp. If that saved timestamp is one of the old ones (no timezone info), Python can't compare them and throws an error:
```
TypeError: can't compare offset-naive and offset-aware datetimes
```
So I added a guard to also handle the old format properly before comparing.