### PR TITLE
Bug 2052225 - Fix - Edit Revisions Internal Server Error

### DIFF
--- a/tests/webapp/api/test_performance_alertsummary_api.py
+++ b/tests/webapp/api/test_performance_alertsummary_api.py
@@ -484,11 +484,6 @@ def test_performance_alert_summary_change_revision_duplicated_across_repositorie
 ):
     client.force_authenticate(user=test_sheriff)
 
-    from treeherder.webapp.api.performance_serializers import (
-        PerformanceAlertSummarySerializer,
-    )
-
-    print(PerformanceAlertSummarySerializer().fields["revision"].__class__)
     assert Push.objects.filter(revision=test_push.revision).count() == 2
 
     resp = client.put(

--- a/tests/webapp/api/test_performance_alertsummary_api.py
+++ b/tests/webapp/api/test_performance_alertsummary_api.py
@@ -474,6 +474,63 @@ def test_performance_alert_summary_change_revision(
     assert PerformanceAlertSummary.objects.get(id=1).push.revision == original_revision
 
 
+@pytest.fixture
+def duplicated_push(create_push, test_push, test_repository_2):
+    return create_push(test_repository_2, revision=test_push.revision)
+
+
+def test_performance_alert_summary_change_revision_duplicated_across_repositories(
+    client, test_perf_alert_summary, test_sheriff, test_push, duplicated_push
+):
+    client.force_authenticate(user=test_sheriff)
+
+    from treeherder.webapp.api.performance_serializers import (
+        PerformanceAlertSummarySerializer,
+    )
+
+    print(PerformanceAlertSummarySerializer().fields["revision"].__class__)
+    assert Push.objects.filter(revision=test_push.revision).count() == 2
+
+    resp = client.put(
+        reverse("performance-alert-summaries-list") + "1/", {"revision": test_push.revision}
+    )
+
+    assert resp.status_code == 200
+    summary = PerformanceAlertSummary.objects.get(id=1)
+    assert summary.push == test_push
+    assert summary.push.repository == test_perf_alert_summary.repository
+
+
+def test_performance_alert_summary_change_from_revision_duplicated_across_repositories(
+    client, test_perf_alert_summary, test_sheriff, test_push, duplicated_push
+):
+    client.force_authenticate(user=test_sheriff)
+
+    resp = client.put(
+        reverse("performance-alert-summaries-list") + "1/",
+        {"prev_push_revision": test_push.revision},
+    )
+
+    assert resp.status_code == 200
+    summary = PerformanceAlertSummary.objects.get(id=1)
+    assert summary.prev_push == test_push
+    assert summary.prev_push.repository == test_perf_alert_summary.repository
+
+
+def test_performance_alert_summary_revision_from_other_repository_rejected(
+    client, test_perf_alert_summary, test_sheriff, test_repository_2, create_push
+):
+    client.force_authenticate(user=test_sheriff)
+    foreign_push = create_push(test_repository_2, revision="abcdef1234567890abcd")
+
+    resp = client.put(
+        reverse("performance-alert-summaries-list") + "1/", {"revision": foreign_push.revision}
+    )
+
+    assert resp.status_code == 400
+    assert PerformanceAlertSummary.objects.get(id=1).push_id != foreign_push.id
+
+
 def test_auth_for_alert_summary_post(
     client,
     test_repository,

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -74,6 +74,15 @@ class WordsField(serializers.CharField):
         return []
 
 
+class RepositoryScopedRevisionField(serializers.SlugRelatedField):
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        repository_id = getattr(self.root.instance, "repository_id", None)
+        if repository_id is not None:
+            queryset = queryset.filter(repository_id=repository_id)
+        return queryset
+
+
 class BackfillRecordSerializer(serializers.Serializer):
     context = serializers.JSONField()
     status = serializers.IntegerField()
@@ -307,7 +316,7 @@ class PerformanceAlertSummarySerializer(serializers.ModelSerializer):
     )
     repository = serializers.SlugRelatedField(read_only=True, slug_field="name")
     framework = serializers.SlugRelatedField(read_only=True, slug_field="id")
-    revision = serializers.SlugRelatedField(
+    revision = RepositoryScopedRevisionField(
         read_only=False,
         slug_field="revision",
         source="push",
@@ -318,7 +327,7 @@ class PerformanceAlertSummarySerializer(serializers.ModelSerializer):
         read_only=True, slug_field="revision", source="original_push"
     )
     push_timestamp = TimestampField(source="push", read_only=True)
-    prev_push_revision = serializers.SlugRelatedField(
+    prev_push_revision = RepositoryScopedRevisionField(
         read_only=False,
         slug_field="revision",
         source="prev_push",


### PR DESCRIPTION
[Bug 2052225 - Fix - Edit Revisions Internal Server Error](https://bugzilla.mozilla.org/show_bug.cgi?id=2052225)

The unscoped SlugRelatedField doesn't catch MultipleObjectsReturned when editing revisions with a push that exists in multiple repositories, which then returns the 500 Internal Server Error.

The fix should impact PUT/PATCH requests where `self.root.instance` references the `PerformanceAlertSummary` being modified, while GET/POST requests should default to `None`