### PR TITLE
Bug 2051952 - Isolate each xdist worker's Redis cache to fix flaky auth session tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import platform
 import time
 from os.path import dirname, join
 from unittest.mock import MagicMock
+from urllib.parse import urlparse, urlunparse
 
 import kombu
 import moz_measure_noise
@@ -15,6 +16,10 @@ import yaml
 from _pytest.monkeypatch import MonkeyPatch
 from django.conf import settings
 from django.core.management import call_command
+
+# Importing this module registers the ``setting_changed`` receiver that resets
+# Django's cache handler when ``settings.CACHES`` changes (see pytest_configure).
+from django.test.signals import setting_changed
 from rest_framework.test import APIClient
 
 import treeherder.etl.bugzilla
@@ -41,6 +46,53 @@ def pytest_addoption(parser):
         action="store_true",
         help="run slow tests",
     )
+
+
+# Redis exposes 16 logical databases (0-15) by default.
+REDIS_DB_COUNT = 16
+
+
+def redis_url_for_worker(base_url, worker_id):
+    """
+    Return ``base_url`` pointing at a per-xdist-worker Redis logical database.
+
+    Sessions and other cached data live in a single shared Redis instance, and
+    ``pytest_runtest_setup`` clears the cache (a Redis ``FLUSHDB``) before every
+    test. Under ``-n auto`` that means one worker's flush wipes another worker's
+    in-flight session, which intermittently breaks the auth session tests (see
+    Bug 2051952). Giving each worker its own database keeps a ``FLUSHDB`` local
+    to the worker that issued it.
+
+    Non-Redis locations (and an empty ``worker_id``) are returned unchanged.
+    """
+    if not worker_id or not isinstance(base_url, str):
+        return base_url
+    if not base_url.startswith(("redis://", "rediss://")):
+        return base_url
+
+    # xdist worker ids look like "gw0", "gw1", ...
+    db_index = int(worker_id.removeprefix("gw")) % REDIS_DB_COUNT
+    return urlunparse(urlparse(base_url)._replace(path=f"/{db_index}"))
+
+
+def pytest_configure(config):
+    """
+    Isolate each xdist worker's Redis cache into its own logical database so the
+    per-test ``cache.clear()`` cannot wipe another worker's session mid-request.
+    """
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if not worker_id:
+        return
+
+    caches = copy.deepcopy(settings.CACHES)
+    for cache_config in caches.values():
+        cache_config["LOCATION"] = redis_url_for_worker(cache_config.get("LOCATION"), worker_id)
+
+    settings.CACHES = caches
+    # Force Django's cache handler to drop its cached settings/connections so the
+    # rewritten LOCATION takes effect. This is the same reset Django performs for
+    # ``override_settings(CACHES=...)``.
+    setting_changed.send(sender=None, setting="CACHES", value=caches, enter=True)
 
 
 def pytest_runtest_setup(item):

--- a/tests/test_redis_worker_isolation.py
+++ b/tests/test_redis_worker_isolation.py
@@ -1,0 +1,36 @@
+import pytest
+
+from tests.conftest import REDIS_DB_COUNT, redis_url_for_worker
+
+
+@pytest.mark.parametrize(
+    ("base_url", "worker_id", "expected"),
+    [
+        # Each worker maps to its own Redis logical database.
+        ("redis://redis:6379", "gw0", "redis://redis:6379/0"),
+        ("redis://redis:6379", "gw3", "redis://redis:6379/3"),
+        # Worker indexes above the number of Redis DBs wrap around.
+        ("redis://redis:6379", "gw17", f"redis://redis:6379/{17 % REDIS_DB_COUNT}"),
+        # An existing database path is replaced rather than appended.
+        ("redis://redis:6379/0", "gw2", "redis://redis:6379/2"),
+        # The TLS scheme is preserved.
+        ("rediss://redis:6379", "gw1", "rediss://redis:6379/1"),
+    ],
+)
+def test_redis_url_for_worker_assigns_per_worker_db(base_url, worker_id, expected):
+    assert redis_url_for_worker(base_url, worker_id) == expected
+
+
+@pytest.mark.parametrize(
+    ("base_url", "worker_id"),
+    [
+        # No xdist worker (running with -n0) leaves the URL untouched.
+        ("redis://redis:6379", ""),
+        ("redis://redis:6379", None),
+        # Non-Redis cache locations (e.g. the database cache) are left alone.
+        ("new_failure_cache", "gw0"),
+        (None, "gw0"),
+    ],
+)
+def test_redis_url_for_worker_leaves_non_redis_unchanged(base_url, worker_id):
+    assert redis_url_for_worker(base_url, worker_id) == base_url


### PR DESCRIPTION
## Problem

`test_login_logout_relogin` in `tests/webapp/api/test_auth.py` fails intermittently in CI (Bug 2051952), with either a `400` response ("The request's session was deleted before the request completed") or a `KeyError: '_auth_user_id'` when re-reading the session.

## Root cause

- Sessions use the cache-based session backend (`SESSION_ENGINE = "django.contrib.sessions.backends.cache"`).
- The `default` cache is a single **shared** Redis instance (`docker-compose.yml` → `redis://redis:6379`), with no per-worker isolation.
- `tests/conftest.py` clears the cache (a Redis `FLUSHDB`) before **every** test.
- CI runs `pytest -n auto --dist load`, so multiple worker processes share that one Redis database.

The result is a race: one worker writes a session during login, another worker's `cache.clear()` issues a `FLUSHDB` that wipes it, and the first worker then fails to read `_auth_user_id`. Raising the CI worker count made this more frequent, exactly as suspected in the bug report.

## Fix

Point each xdist worker at its own Redis logical database in `pytest_configure`, so a `FLUSHDB` stays local to the worker that issued it. This is test-infra only — no product code changes.

- `redis_url_for_worker()` rewrites a Redis `LOCATION` to target a per-worker DB (`gw0` → DB 0, `gw1` → DB 1, …), wrapping with `% 16` since Redis exposes 16 logical DBs by default. Non-Redis locations and non-xdist runs are left unchanged.
- `pytest_configure` applies this to every entry in `settings.CACHES` and fires Django's `setting_changed` signal so the cache handler rebuilds against the new DB.

## Testing

- Added `tests/test_redis_worker_isolation.py` unit tests for the URL helper.
- Verified at runtime under `-n 3` that each worker's live cache connection resolves to its own Redis DB.
- `test_auth.py` runs green across repeated `-n auto` runs.