### PR TITLE
Cache bug suggestions client-side to avoid redundant refetches

### DIFF
--- a/tests/ui/models/bugSuggestions_test.js
+++ b/tests/ui/models/bugSuggestions_test.js
@@ -1,0 +1,74 @@
+import fetchMock from 'fetch-mock';
+
+import BugSuggestionsModel, {
+  bugSuggestionsCache,
+  BUG_SUGGESTIONS_CACHE_LIMIT,
+  BUG_SUGGESTIONS_CACHE_TTL_MS,
+} from '../../../ui/models/bugSuggestions';
+import { getProjectJobUrl } from '../../../ui/helpers/location';
+
+describe('BugSuggestionsModel', () => {
+  const jobUrl = (jobId) => getProjectJobUrl('/bug_suggestions/', jobId);
+  const sampleSuggestions = [{ search: 'a failure', bugs: { open_recent: [] } }];
+
+  afterEach(() => {
+    fetchMock.reset();
+    bugSuggestionsCache.clear();
+  });
+
+  test('caches non-empty results so a repeat get does not refetch', async () => {
+    fetchMock.get(jobUrl(1), sampleSuggestions);
+
+    const first = await BugSuggestionsModel.get(1);
+    expect(first).toEqual(sampleSuggestions);
+    expect(fetchMock.calls(jobUrl(1))).toHaveLength(1);
+
+    const second = await BugSuggestionsModel.get(1);
+    expect(second).toEqual(sampleSuggestions);
+    // Served from cache; still only the one network call.
+    expect(fetchMock.calls(jobUrl(1))).toHaveLength(1);
+  });
+
+  test('does not cache empty results, so a still-parsing job refetches', async () => {
+    fetchMock.get(jobUrl(2), []);
+
+    await BugSuggestionsModel.get(2);
+    await BugSuggestionsModel.get(2);
+
+    // Empty results are never cached, so both calls hit the network.
+    expect(fetchMock.calls(jobUrl(2))).toHaveLength(2);
+  });
+
+  test('refetches once a cached entry is older than the TTL', async () => {
+    fetchMock.get(jobUrl(3), sampleSuggestions);
+
+    await BugSuggestionsModel.get(3);
+    expect(fetchMock.calls(jobUrl(3))).toHaveLength(1);
+
+    // Age the cached entry past its TTL.
+    bugSuggestionsCache.get(3).timestamp -= BUG_SUGGESTIONS_CACHE_TTL_MS + 1;
+
+    await BugSuggestionsModel.get(3);
+    // Expired -> refetched.
+    expect(fetchMock.calls(jobUrl(3))).toHaveLength(2);
+  });
+
+  test('evicts the oldest entry once the cache limit is exceeded', async () => {
+    // Fill the cache to its limit with distinct jobIds.
+    for (let jobId = 1; jobId <= BUG_SUGGESTIONS_CACHE_LIMIT; jobId++) {
+      fetchMock.get(jobUrl(jobId), sampleSuggestions);
+      await BugSuggestionsModel.get(jobId);
+    }
+    expect(bugSuggestionsCache.size).toBe(BUG_SUGGESTIONS_CACHE_LIMIT);
+    expect(bugSuggestionsCache.has(1)).toBe(true);
+
+    // One more job evicts the oldest (jobId 1).
+    const overflowId = BUG_SUGGESTIONS_CACHE_LIMIT + 1;
+    fetchMock.get(jobUrl(overflowId), sampleSuggestions);
+    await BugSuggestionsModel.get(overflowId);
+
+    expect(bugSuggestionsCache.size).toBe(BUG_SUGGESTIONS_CACHE_LIMIT);
+    expect(bugSuggestionsCache.has(1)).toBe(false);
+    expect(bugSuggestionsCache.has(overflowId)).toBe(true);
+  });
+});

--- a/tests/ui/shared/FailureSummaryTab_test.jsx
+++ b/tests/ui/shared/FailureSummaryTab_test.jsx
@@ -16,6 +16,7 @@ import {
   usePinnedJobsStore,
 } from '../../../ui/shared/stores/pinnedJobsStore';
 import FailureSummaryTab from '../../../ui/shared/tabs/failureSummary/FailureSummaryTab';
+import { bugSuggestionsCache } from '../../../ui/models/bugSuggestions';
 import jobMap from '../mock/job_map';
 import bugSuggestions from '../mock/bug_suggestions.json';
 import jobLogUrls from '../mock/job_log_urls.json';
@@ -39,6 +40,9 @@ describe('FailureSummaryTab', () => {
   afterEach(() => {
     cleanup();
     fetchMock.reset();
+    // Bug suggestions are cached per jobId at module level; clear between
+    // tests so each test's fetch mock is actually exercised.
+    bugSuggestionsCache.clear();
     // Reset Zustand pinned jobs store
     usePinnedJobsStore.setState({
       pinnedJobs: {},

--- a/ui/models/bugSuggestions.js
+++ b/ui/models/bugSuggestions.js
@@ -1,9 +1,45 @@
 import { getProjectJobUrl } from '../helpers/location';
 
+// Per-session, bounded cache of bug-suggestion responses keyed by jobId. The
+// Failure Summary tab unmounts/remounts every time the user switches tabs (or
+// re-selects a job), which would otherwise refetch and re-process the same
+// suggestions on every remount. See ui/models/push.js `decisionTaskIdCache`
+// for the same pattern.
+//
+// Entries carry a timestamp and expire after BUG_SUGGESTIONS_CACHE_TTL_MS so a
+// long-lived session (e.g. a dashboard left open for days) eventually picks up
+// a newly-filed bug once the backend's own cache has refreshed. The backend
+// caches error summaries for 24h, so a shorter TTL here mostly bounds the
+// worst case rather than surfacing new bugs faster.
+export const bugSuggestionsCache = new Map();
+export const BUG_SUGGESTIONS_CACHE_LIMIT = 50;
+export const BUG_SUGGESTIONS_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
 export default class BugSuggestionsModel {
-  static get(jobId) {
-    return fetch(getProjectJobUrl('/bug_suggestions/', jobId)).then((resp) =>
-      resp.json(),
-    );
+  static async get(jobId) {
+    const cached = bugSuggestionsCache.get(jobId);
+    if (cached && Date.now() - cached.timestamp < BUG_SUGGESTIONS_CACHE_TTL_MS) {
+      return cached.data;
+    }
+
+    const resp = await fetch(getProjectJobUrl('/bug_suggestions/', jobId));
+    const suggestions = await resp.json();
+
+    // Only cache meaningful results. An empty array means "no failures yet" or
+    // "log parsing still in progress"; leaving those uncached lets a later
+    // revisit pick up suggestions once the log finishes parsing.
+    if (Array.isArray(suggestions) && suggestions.length > 0) {
+      // A stale entry past its TTL is being replaced; drop it first so the
+      // refreshed entry counts as the newest for eviction ordering.
+      bugSuggestionsCache.delete(jobId);
+      // Evict the oldest entry once we exceed the limit (Map preserves
+      // insertion order).
+      if (bugSuggestionsCache.size >= BUG_SUGGESTIONS_CACHE_LIMIT) {
+        bugSuggestionsCache.delete(bugSuggestionsCache.keys().next().value);
+      }
+      bugSuggestionsCache.set(jobId, { data: suggestions, timestamp: Date.now() });
+    }
+
+    return suggestions;
   }
 }


### PR DESCRIPTION
## Problem

The `/jobs` details panel Failure Summary tab felt slow. `BugSuggestionsModel.get()` was a bare `fetch` with no client-side caching. Because react-tabs unmounts inactive `TabPanel`s (no `forceRenderTabPanel`), switching away from and back to the Failure Summary tab — or re-selecting a previously viewed job — remounted `FailureSummaryTab`, which refetched `/bug_suggestions/` and re-ran `filterGenericFailures` on identical data every time. The backend already caches the error summary per job for 24h, so this was pure redundant work on a warm backend.

`forceRenderTabPanel` was considered and rejected: it eagerly mounts all sibling tabs for every selected job, and `SimilarJobsTab` fetches on mount, so it would add network load nobody asked for.

## Change

Add a bounded, per-session cache in `BugSuggestionsModel` keyed by `jobId`, mirroring the existing `decisionTaskIdCache` pattern in `models/push.js`:

- Serve cache hits without a network round trip.
- **Only cache non-empty results** — an empty response means "no failures yet" or "log parsing still in progress", so leaving those uncached lets a later revisit pick up suggestions once the log finishes parsing.
- Cap the cache at 50 entries, evicting the oldest.
- Expire entries after a **1h TTL** so a long-lived session eventually picks up a newly-filed bug once the backend's own 24h cache has refreshed.

`FailureSummaryTab` is untouched — it just benefits from the now cache-aware model.

## Why 1h TTL is enough

Measured against the prod replica (30d, 57,486 classifications): **96.5%** of classifications reference a bug that was already in use before the job even finished (a lower bound), and of the ≤3.5% "new bug" cases, 97% are filed within 24h of the job during active triage — where the backend's 24h cache is the binding constraint, not the frontend. So staleness from a genuinely new bug is rare, and the 1h TTL comfortably covers it.

## Tests

New unit tests in `tests/ui/models/bugSuggestions_test.js` cover cache hits, the empty-result bypass, TTL expiry, and size-limit eviction.