### PR TITLE
Fix comm-central error-line cache selection in get_error_summary

### DIFF
--- a/tests/model/test_error_summary.py
+++ b/tests/model/test_error_summary.py
@@ -1,3 +1,6 @@
+import datetime
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from treeherder.model.error_summary import (
@@ -5,6 +8,7 @@ from treeherder.model.error_summary import (
     get_cleaned_line,
     get_crash_signature,
     get_error_search_term_and_path,
+    get_error_summary,
 )
 
 LINE_CLEANING_TEST_CASES = (
@@ -376,3 +380,39 @@ LINES_TO_CACHE_TEST_CASES = (
 def test_cache_error_line_cleaning(line, exp_cache_line_cleaned):
     actual_cache_line_cleaned = cache_clean_error_line(line)
     assert actual_cache_line_cleaned == exp_cache_line_cleaned
+
+
+def _fake_job(repository_name):
+    """A minimal stand-in for a Job with just what get_error_summary reads
+    before it returns early on an empty queryset."""
+    job = MagicMock()
+    job.id = 1
+    job.repository.name = repository_name
+    job.submit_time = datetime.datetime(2024, 1, 15, 12, 0, 0)
+    return job
+
+
+ERROR_LINE_CACHE_KEYROOT_CASES = (
+    ("comm-central", "cc_error_lines"),
+    ("autoland", "mc_error_lines"),
+    ("mozilla-central", "mc_error_lines"),
+    ("try", "mc_error_lines"),
+)
+
+
+@pytest.mark.parametrize(("repository_name", "expected_keyroot"), ERROR_LINE_CACHE_KEYROOT_CASES)
+@patch("treeherder.model.error_summary.MemDBCache")
+@patch("treeherder.model.error_summary.cache")
+def test_error_line_cache_selected_by_repository_name(
+    mock_cache, mock_memdbcache, repository_name, expected_keyroot
+):
+    """Only comm-central uses the cc_error_lines cache; everything else uses
+    mc_error_lines. The keyroot is chosen from the repository *name*, so a
+    comm-central job must not fall through to the mozilla-central namespace."""
+    # No cached error summary, so we proceed to the error-line cache selection.
+    mock_cache.get.return_value = None
+    # Empty queryset makes get_error_summary return early right after it picks
+    # the error-line cache, so no DB/log processing is needed.
+    get_error_summary(_fake_job(repository_name), queryset=[])
+
+    mock_memdbcache.assert_called_once_with(expected_keyroot)

--- a/treeherder/model/error_summary.py
+++ b/treeherder/model/error_summary.py
@@ -128,7 +128,11 @@ def get_error_summary(job, queryset=None):
         return cached_error_summary
 
     # add support for error line caching
-    if job.repository == "comm-central":
+    # job.repository is a Repository instance, so compare its name rather than
+    # the instance itself (which is never equal to a string). Without .name,
+    # comm-central jobs fell through to the "mc_error_lines" cache and shared a
+    # namespace with mozilla-central/autoland error-line counts.
+    if job.repository.name == "comm-central":
         lcache = MemDBCache("cc_error_lines")
     else:
         lcache = MemDBCache("mc_error_lines")


### PR DESCRIPTION
## Summary

`get_error_summary()` selects a per-tree error-line cache with:

```python
if job.repository == "comm-central":
    lcache = MemDBCache("cc_error_lines")
else:
    lcache = MemDBCache("mc_error_lines")
```

But `job.repository` is a `Repository` model instance, not a string, so `job.repository == "comm-central"` is **always False**. As a result comm-central jobs never used the `cc_error_lines` cache — they fell through to `mc_error_lines` and shared a namespace with mozilla-central/autoland error-line counts.

Those counts feed the recent-failure counter and the "new in revision" detection in `bug_suggestions_line` (which correctly uses `str(project.name)`), so cross-contaminating the namespaces skews which failure lines get flagged as new for comm-central.

The fix compares `job.repository.name`, consistent with how `bug_suggestions_line` already inspects the repository name.

## Testing

- Added parametrized unit tests asserting the error-line cache keyroot is chosen from the repository name (`comm-central` → `cc_error_lines`; `autoland`/`mozilla-central`/`try` → `mc_error_lines`). Verified the comm-central case fails against the pre-fix code and passes after.
- `tests/model/test_error_summary.py` passes (29 tests).

## Note

There is a second, currently **commented-out** occurrence of the same pattern in `treeherder/webapp/api/note.py` (disabled under Bug 2026428 for performance). It is left untouched here since it is inactive, but would need the same `.name` fix if ever re-enabled.