### PR TITLE
Bug 2053387 - Hide the “create alert” Graphs View tooltip button when an alert already exists

### DIFF
--- a/ui/perfherder/graphs/GraphTooltip.jsx
+++ b/ui/perfherder/graphs/GraphTooltip.jsx
@@ -392,7 +392,7 @@ const GraphTooltip = ({
                 <p className="small text-danger">Common alert</p>
               </p>
             )}
-            {!dataPointDetails.alertSummary && prevPushId && (
+            {!dataPointDetails.alertSummary && !dataPointDetails.commonAlert && prevPushId && (
               <p className="pt-2">
                 {user.isStaff ? (
                   <Button


### PR DESCRIPTION
[Bug 2053387 - Hide the “create alert” Graphs View tooltip button when an alert already exists](https://bugzilla.mozilla.org/show_bug.cgi?id=2053387)

Before: 
<img width="276" height="305" alt="Screenshot 2026-07-08 at 14 31 03" src="https://github.com/user-attachments/assets/89ec9928-52ed-43b0-af83-6573bbbdb799" />

After: 
<img width="276" height="267" alt="Screenshot 2026-07-08 at 14 30 43" src="https://github.com/user-attachments/assets/2fc730f4-4f13-4f32-bdce-138a7aaf41f1" />
