### PR TITLE
Bug 1901066 - Make the graph tooltip job hyperlink show the job on treeherder filtered to just the single selected job

### DIFF
--- a/tests/ui/perfherder/graphs-view/graphs_view_test.jsx
+++ b/tests/ui/perfherder/graphs-view/graphs_view_test.jsx
@@ -34,6 +34,21 @@ import {
 
 fetchMock.mock(`begin:${getApiUrl(endpoints.changelog)}`, changelogData);
 
+// Mock the single-job endpoint so that request resolves in tests
+fetchMock.mock(/\/jobs\/\d+\/$/, {
+  id: 1,
+  job_type_name: 'test-linux64/opt-talos-tp5o',
+  job_type_symbol: 'tp5o',
+  job_group_name: 'Talos performance tests',
+  platform: 'linux64',
+  platform_option: 'opt',
+  result: 'success',
+  state: 'completed',
+  submit_timestamp: 0,
+  start_timestamp: 0,
+  end_timestamp: 0,
+});
+
 const graphData = createGraphData(
   testData,
   alertSummaries,
@@ -346,6 +361,20 @@ test('Using select query param displays tooltip for correct datapoint', async ()
   expect(revision).toBeInTheDocument();
   expect(repoName).toHaveTextContent(testData[0].repository_name);
   expect(platform).toHaveTextContent(testData[0].platform);
+});
+
+test('Job link includes searchStr query param to filter to the single job', async () => {
+  const { getByRole } = await graphsViewControls(graphData, false);
+
+  const jobLink = await waitFor(() => getByRole('link', { name: 'job' }));
+
+  // The tokens come from the mocked job's searchStr, so the Job View filters
+  // down to this job instead of showing every job on the push.
+  await waitFor(() =>
+    expect(decodeURIComponent(jobLink.search)).toContain(
+      'searchStr=Linux,opt,Talos,performance,tests,test-linux64/opt-talos-tp5o,tp5o',
+    ),
+  );
 });
 
 test("Alert's ID can be copied to clipboard from tooltip", async () => {

--- a/ui/perfherder/graphs/GraphTooltip.jsx
+++ b/ui/perfherder/graphs/GraphTooltip.jsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import countBy from 'lodash/countBy';
 import { Button } from 'react-bootstrap';
@@ -115,11 +115,37 @@ const GraphTooltip = ({
     });
   }
 
+  // Only a clicked graph point displays the tooltip jobs hyperlink
+  const [fetchedJob, setFetchedJob] = useState(null);
+  const jobSearchStr =
+    fetchedJob?.jobId === dataPointDetails.jobId ? fetchedJob.searchStr : '';
+
+  useEffect(() => {
+    if (!lockTooltip || !dataPointDetails.jobId) return;
+
+    const controller = new AbortController();
+    JobModel.get(
+      testDetails.repository_name,
+      dataPointDetails.jobId,
+      controller.signal,
+    )
+      .then((job) =>
+        setFetchedJob({
+          jobId: dataPointDetails.jobId,
+          searchStr: job.searchStr || '',
+        }),
+      )
+      .catch(() => {});
+
+    return () => controller.abort();
+  }, [lockTooltip, dataPointDetails.jobId, testDetails.repository_name]);
+
   const jobsUrl = getJobsUrl({
     repo: testDetails.repository_name,
     revision: dataPointDetails.revision,
     selectedJob: dataPointDetails.jobId,
     group_state: 'expanded',
+    ...(jobSearchStr ? { searchStr: jobSearchStr.split(' ') } : {}),
   });
 
   const createAlert = async () => {


### PR DESCRIPTION
Clicking a job from perfherder graphs view takes you to the treeherder job view, where the task is selected, but not filtered out. 

Over many times this result overwhelms and tires out the sheriffs with a lot of redundant visual clutter presented to them.

This change makes it so when you click the jobs link you just see the job from the graphs view

