### PR TITLE
Improvements to ingest.py command

### DIFF
--- a/treeherder/etl/management/commands/ingest.py
+++ b/treeherder/etl/management/commands/ingest.py
@@ -420,7 +420,9 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "ingestion_type", nargs=1, help="Type of ingestion to do: [task|hg-push|git-commit|pr]"
+            "ingestion_type",
+            nargs=1,
+            help="Type of ingestion to do: [task|push|git-push|git-pushes|pr]",
         )
         parser.add_argument("-p", "--project", help="Hg repository to query (e.g. autoland)")
         parser.add_argument("-c", "--commit", "-r", "--revision", help="Commit/revision to import")

--- a/treeherder/etl/management/commands/ingest.py
+++ b/treeherder/etl/management/commands/ingest.py
@@ -464,6 +464,12 @@ class Command(BaseCommand):
         type_of_ingestion = options["ingestion_type"][0]
         root_url = options["root_url"]
 
+        # Use the verbosity option provided by Django to set log level
+        verbosity = options.get("verbosity", 2)  # Set default to INFO
+        levels = {0: logging.ERROR, 1: logging.WARNING, 2: logging.INFO, 3: logging.DEBUG}
+        log_level = levels.get(verbosity, logging.INFO)
+        logger.setLevel(level=log_level)
+
         if not options["enable_eager_celery"]:
             logger.info("If you want all logs to be parsed use --enable-eager-celery")
         else:


### PR DESCRIPTION
### Changes Introduced
- Mapped the verbosity levels to the logging levels
- Updated the list of ingestion types in the `--help`

Output
```
usage: manage.py ingest [-h] [-p PROJECT] [-c COMMIT] [--enable-eager-celery] [-a] [--root-url ROOT_URL]
                        [--task-id [TASKID]] [--pr-url PRURL] [--dry-run] [--last-n-pushes LAST_N_PUSHES] [--version]
                        [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color]
                        [--force-color] [--skip-checks]
                        ingestion_type

Ingests a single push and tasks into Treeherder

positional arguments:
  ingestion_type        Type of ingestion to do: [task|push|git-push|git-pushes|pr]
...
```

### Testing
- Test manually and checked that no errors are seen when running the command


Fixes [Bug-2053986](https://bugzilla.mozilla.org/show_bug.cgi?id=2053986) [Bug-2053978](https://bugzilla.mozilla.org/show_bug.cgi?id=2053978)

@Archaeopteryx @gmierz 