### PR TITLE
Cap Django session lifetime so revoked SSO access ends the session promptly

### DIFF
--- a/tests/webapp/api/test_auth.py
+++ b/tests/webapp/api/test_auth.py
@@ -1,6 +1,7 @@
 import time
 
 import pytest
+from django.conf import settings
 from django.contrib.auth import SESSION_KEY
 from django.urls import reverse
 from rest_framework import status
@@ -10,6 +11,8 @@ from rest_framework.test import APIRequestFactory
 
 from treeherder.auth.backends import AuthBackend
 from treeherder.model.models import User
+
+GROUPS_CLAIM = "https://sso.mozilla.com/claim/groups"
 
 one_hour_in_seconds = 60 * 60
 one_day_in_seconds = 24 * one_hour_in_seconds
@@ -94,7 +97,9 @@ def test_login_logout_relogin(client, monkeypatch, id_token_sub, id_token_email,
     }
     assert SESSION_KEY in client.session
     # Uses a tolerance of up to 5 seconds to account for rounding/the time the test takes to run.
-    assert client.session.get_expiry_age() == pytest.approx(one_hour_in_seconds, abs=5)
+    assert client.session.get_expiry_age() == pytest.approx(
+        min(one_hour_in_seconds, settings.AUTH_MAX_SESSION_AGE_SECONDS), abs=5
+    )
 
     assert User.objects.count() == 1
     session_user_id = int(client.session[SESSION_KEY])
@@ -119,7 +124,9 @@ def test_login_logout_relogin(client, monkeypatch, id_token_sub, id_token_email,
     assert resp.status_code == 200
     assert resp.json()["username"] == expected_username
     assert SESSION_KEY in client.session
-    assert client.session.get_expiry_age() == pytest.approx(one_hour_in_seconds, abs=5)
+    assert client.session.get_expiry_age() == pytest.approx(
+        min(one_hour_in_seconds, settings.AUTH_MAX_SESSION_AGE_SECONDS), abs=5
+    )
     assert User.objects.count() == 1
 
 
@@ -388,4 +395,155 @@ def test_login_id_token_expires_before_access_token(test_ldap_user, client, monk
         HTTP_ACCESS_TOKEN_EXPIRES_AT=str(access_token_expiration_timestamp),
     )
     assert resp.status_code == 200
-    assert client.session.get_expiry_age() == pytest.approx(one_hour_in_seconds, abs=5)
+    assert client.session.get_expiry_age() == pytest.approx(
+        min(one_hour_in_seconds, settings.AUTH_MAX_SESSION_AGE_SECONDS), abs=5
+    )
+
+
+# Session expiry cap tests
+#
+# The Django session cookie is what authorizes every mutating API call, so its
+# lifetime bounds how long a user whose SSO access was revoked can keep acting.
+# The session is capped at AUTH_MAX_SESSION_AGE_SECONDS so that when the
+# frontend's silent renewals stop (e.g. a terminated employee) the session
+# lapses within that window rather than coasting on the token's full lifetime.
+
+
+def test_login_session_capped_when_tokens_outlive_cap(test_ldap_user, client, monkeypatch):
+    """When both tokens outlive the cap, the session is capped, not left at ~24h."""
+    now_in_seconds = int(time.time())
+    long_lived_timestamp = now_in_seconds + one_day_in_seconds
+
+    def userinfo_mock(*args, **kwargs):
+        return {"sub": "email", "email": test_ldap_user.email, "exp": long_lived_timestamp}
+
+    monkeypatch.setattr(AuthBackend, "_get_user_info", userinfo_mock)
+
+    resp = client.get(
+        reverse("auth-login"),
+        HTTP_AUTHORIZATION="Bearer meh",
+        HTTP_ID_TOKEN="meh",
+        HTTP_ACCESS_TOKEN_EXPIRES_AT=str(long_lived_timestamp),
+    )
+    assert resp.status_code == 200
+    assert client.session.get_expiry_age() == pytest.approx(
+        settings.AUTH_MAX_SESSION_AGE_SECONDS, abs=5
+    )
+
+
+def test_login_session_uses_token_expiry_when_shorter_than_cap(test_ldap_user, client, monkeypatch):
+    """A token expiring sooner than the cap still wins (the cap only shortens)."""
+    now_in_seconds = int(time.time())
+    ten_minutes = 10 * 60
+    id_token_expiration_timestamp = now_in_seconds + one_day_in_seconds
+    access_token_expiration_timestamp = now_in_seconds + ten_minutes
+
+    def userinfo_mock(*args, **kwargs):
+        return {
+            "sub": "email",
+            "email": test_ldap_user.email,
+            "exp": id_token_expiration_timestamp,
+        }
+
+    monkeypatch.setattr(AuthBackend, "_get_user_info", userinfo_mock)
+
+    resp = client.get(
+        reverse("auth-login"),
+        HTTP_AUTHORIZATION="Bearer meh",
+        HTTP_ID_TOKEN="meh",
+        HTTP_ACCESS_TOKEN_EXPIRES_AT=str(access_token_expiration_timestamp),
+    )
+    assert resp.status_code == 200
+    assert client.session.get_expiry_age() == pytest.approx(ten_minutes, abs=5)
+
+
+# is_staff / sheriff group claim tests
+#
+# The backend derives is_staff from the SSO groups claim on every /auth/login/,
+# including silent token renewals. Silent-renewal tokens frequently omit the
+# (large) groups claim entirely, so an absent claim must NOT demote the user --
+# otherwise renewals would strip a sheriff's permissions. A claim that IS present
+# is authoritative, so it both promotes and demotes.
+
+
+def _login_with_groups(client, user, groups, monkeypatch):
+    """Log `user` in via /auth/login/, injecting `groups` into the id token.
+
+    Pass `groups=None` to omit the groups claim entirely (the silent-renewal
+    case). Returns the /auth/login/ response.
+    """
+    now_in_seconds = int(time.time())
+    userinfo = {
+        "sub": "Mozilla-LDAP",
+        "email": user.email,
+        "exp": now_in_seconds + one_day_in_seconds,
+    }
+    if groups is not None:
+        userinfo[GROUPS_CLAIM] = groups
+
+    monkeypatch.setattr(AuthBackend, "_get_user_info", lambda *a, **k: userinfo)
+
+    return client.get(
+        reverse("auth-login"),
+        HTTP_AUTHORIZATION="Bearer meh",
+        HTTP_ID_TOKEN="meh",
+        HTTP_ACCESS_TOKEN_EXPIRES_AT=str(now_in_seconds + one_hour_in_seconds),
+    )
+
+
+def test_login_absent_groups_claim_preserves_staff(test_ldap_user, client, monkeypatch):
+    """Absent groups claim (e.g. silent renewal) must not demote an existing staff user."""
+    test_ldap_user.is_staff = True
+    test_ldap_user.save()
+
+    resp = _login_with_groups(client, test_ldap_user, None, monkeypatch)
+
+    assert resp.status_code == 200
+    assert resp.json()["is_staff"] is True
+    test_ldap_user.refresh_from_db()
+    assert test_ldap_user.is_staff is True
+
+
+def test_login_groups_claim_without_sheriff_demotes(test_ldap_user, client, monkeypatch):
+    """A present groups claim lacking a sheriff group is authoritative: demote."""
+    test_ldap_user.is_staff = True
+    test_ldap_user.save()
+
+    resp = _login_with_groups(
+        client, test_ldap_user, ["all_scm_level_1", "all_scm_level_2"], monkeypatch
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["is_staff"] is False
+    test_ldap_user.refresh_from_db()
+    assert test_ldap_user.is_staff is False
+
+
+def test_login_empty_groups_claim_demotes(test_ldap_user, client, monkeypatch):
+    """A present-but-empty groups claim is treated as authoritative: demote."""
+    test_ldap_user.is_staff = True
+    test_ldap_user.save()
+
+    resp = _login_with_groups(client, test_ldap_user, [], monkeypatch)
+
+    assert resp.status_code == 200
+    assert resp.json()["is_staff"] is False
+    test_ldap_user.refresh_from_db()
+    assert test_ldap_user.is_staff is False
+
+
+@pytest.mark.parametrize("sheriff_group", ["sheriff", "perf_sheriff"])
+def test_login_groups_claim_with_sheriff_promotes(
+    test_ldap_user, client, monkeypatch, sheriff_group
+):
+    """A present groups claim containing a sheriff group promotes a non-staff user."""
+    assert test_ldap_user.is_staff is False
+
+    resp = _login_with_groups(
+        client, test_ldap_user, ["all_scm_level_1", sheriff_group], monkeypatch
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["is_staff"] is True
+    test_ldap_user.refresh_from_db()
+    assert test_ldap_user.is_staff is True

--- a/treeherder/auth/backends.py
+++ b/treeherder/auth/backends.py
@@ -2,12 +2,15 @@ import json
 import logging
 import time
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from jose import jwt
 from rest_framework.exceptions import AuthenticationFailed
 
 from treeherder.config.settings import AUTH0_CLIENTID, AUTH0_DOMAIN
+
+GROUPS_CLAIM = "https://sso.mozilla.com/claim/groups"
 
 logger = logging.getLogger(__name__)
 
@@ -72,11 +75,7 @@ class AuthBackend:
         Set users in sheriffing group in jwt response as is_staff
         """
 
-        groups = (
-            user_info["https://sso.mozilla.com/claim/groups"]
-            if "https://sso.mozilla.com/claim/groups" in user_info
-            else []
-        )
+        groups = user_info.get(GROUPS_CLAIM, [])
 
         return 1 if ("sheriff" in groups or "perf_sheriff" in groups) else 0
 
@@ -205,7 +204,13 @@ class AuthBackend:
             )
             raise AuthError("Session expiry time has already passed!")
 
-        return seconds_until_expiry
+        # Cap the session so it can't outlive the frontend's renewal heartbeat.
+        # The renewal re-extends the session every RENEW_INTERVAL, so this never
+        # shortens an actively-renewing user's session; it only ensures that once
+        # renewals stop (e.g. SSO access revoked) the session lapses promptly
+        # instead of coasting on the token's much longer lifetime.
+        # See AUTH_MAX_SESSION_AGE_SECONDS in settings.py.
+        return min(seconds_until_expiry, settings.AUTH_MAX_SESSION_AGE_SECONDS)
 
     def authenticate(self, request):
         logger.debug("Authentication attempt started")
@@ -217,7 +222,7 @@ class AuthBackend:
             user_info = self._get_user_info(access_token, id_token)
             username = self._get_username_from_userinfo(user_info)
             is_sheriff = self._get_is_sheriff_from_userinfo(user_info)
-            groups_claim_present = "https://sso.mozilla.com/claim/groups" in user_info
+            groups_claim_present = GROUPS_CLAIM in user_info
             logger.debug("User info retrieved for: %s", username)
 
             seconds_until_expiry = self._calculate_session_expiry(request, user_info)
@@ -237,10 +242,33 @@ class AuthBackend:
             try:
                 user = User.objects.get(username=username)
                 logger.debug("Existing user authenticated: %s", username)
-                if groups_claim_present and user.is_staff != is_sheriff:
-                    user.is_staff = is_sheriff
-                    user.save()
-                    logger.debug("Updated staff status for user %s to %s", username, is_sheriff)
+                if groups_claim_present:
+                    # An empty groups claim demotes just like a claim that lacks
+                    # the sheriff groups. This is expected on a genuine login by a
+                    # user who has lost their groups, but if it shows up on silent
+                    # renewals it would mean the "absent claim" assumption below is
+                    # wrong -- log it so that case is visible.
+                    if not user_info.get(GROUPS_CLAIM) and user.is_staff:
+                        logger.warning(
+                            "Groups claim present but empty for %s; demoting is_staff. "
+                            "If this recurs on token renewals, the absent-claim "
+                            "assumption in this backend needs revisiting.",
+                            username,
+                        )
+                    if user.is_staff != is_sheriff:
+                        user.is_staff = is_sheriff
+                        user.save()
+                        logger.debug("Updated staff status for user %s to %s", username, is_sheriff)
+                elif user.is_staff:
+                    # No groups claim on this token. This is typical of a silent
+                    # token renewal, where Auth0 omits the large custom claim.
+                    # Preserve the user's existing is_staff rather than demoting
+                    # them; logged at info so we can confirm how often it fires.
+                    logger.info(
+                        "Preserving is_staff=True for %s: groups claim absent from token "
+                        "(expected on silent renewals)",
+                        username,
+                    )
                 return user
             except ObjectDoesNotExist:
                 # The user doesn't already exist, so create it since we allow

--- a/treeherder/config/settings.py
+++ b/treeherder/config/settings.py
@@ -200,6 +200,23 @@ AUTHENTICATION_BACKENDS = [
 # Use the cache-based backend rather than the default of database.
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 
+# Cap on the Django session lifetime, in seconds.
+#
+# The frontend silently renews the SSO session every RENEW_INTERVAL (15 minutes,
+# see ui/helpers/auth.js), and each renewal re-extends this session by calling
+# /auth/login/ again. So while the user's SSO access is valid, the renewal
+# heartbeat keeps them logged in indefinitely regardless of this cap.
+#
+# Without a cap the session inherits the identity token's much longer lifetime,
+# which means a user whose SSO access has been revoked (e.g. a terminated
+# employee) could keep acting through their existing session -- authorized by the
+# Django session cookie, not the now-unrenewable token -- until that long-lived
+# token finally expired. Capping the session to a small multiple of the renewal
+# interval means that once renewals start failing, the session lapses within this
+# window instead. The default (45 min = 3x the renewal interval) tolerates one
+# missed renewal without logging out an active user.
+AUTH_MAX_SESSION_AGE_SECONDS = env.int("AUTH_MAX_SESSION_AGE_SECONDS", default=45 * 60)
+
 # Path to redirect to on successful login.
 LOGIN_REDIRECT_URL = "/"
 


### PR DESCRIPTION
## Problem

The Django session cookie authorizes every mutating API call (DRF uses `SessionAuthentication`), and its expiry was set to the identity token's lifetime and re-extended on each silent renewal. A user whose SSO access has been revoked (e.g. a terminated employee) could therefore keep acting through their existing session — authorized by the session cookie, not the now-unrenewable token — until that long-lived token finally expired.

## Fix

Cap the Django session at `AUTH_MAX_SESSION_AGE_SECONDS` (default 45 min, ~3× the frontend's 15-minute renewal interval, env-tunable):

```python
return min(seconds_until_expiry, settings.AUTH_MAX_SESSION_AGE_SECONDS)
```

The frontend silently renews every 15 min and each renewal re-extends the session via `/auth/login/`, so an actively-renewing user is unaffected. Once renewals start failing (SSO access revoked), the session is no longer re-extended and lapses within the cap instead of coasting on the token's much longer lifetime.

The 45-min default tolerates one missed renewal (worst-case gap between successful renewals is ~40 min: a failed attempt plus its retry, including jitter) without prematurely logging out active users. It is configurable via `AUTH_MAX_SESSION_AGE_SECONDS`.

## Also included

- **Tests** for the groups-claim → `is_staff` contract the renewal fix relies on: absent claim preserves, present claim promotes/demotes, empty claim demotes — plus session-cap coverage.
- **Logging**: an info log when `is_staff` is preserved due to an absent claim (expected on silent renewals), and a warning when it is demoted due to a present-but-empty claim, so the assumption is observable in production.

## Testing

`tests/webapp/api/test_auth.py` — 30 passing, including the new cases.