### PR TITLE
Use the bugscache trigram index in search and cut N+1 queries in the job details panel

### DIFF
--- a/tests/model/test_bugscache.py
+++ b/tests/model/test_bugscache.py
@@ -3,8 +3,9 @@ import os
 from datetime import datetime, timedelta
 
 import pytest
+from django.utils import timezone
 
-from treeherder.model.models import Bugscache
+from treeherder.model.models import BugJobMap, Bugscache, Job
 
 fifty_days_ago = datetime.now() - timedelta(days=50)
 
@@ -160,6 +161,50 @@ def test_search_uses_trigram_ilike_not_upper(transactional_db):
     assert "UPPER(" not in sql.upper()
     # \ % _ escaped, then wrapped as a "contains" pattern, matching __icontains.
     assert params[-1] == r"%Some\_Term\%%"
+
+
+def _internal_bug(summary):
+    return Bugscache.objects.create(
+        bugzilla_id=None,
+        status="",
+        resolution="",
+        summary=summary,
+        dupe_of=None,
+        crash_signature="",
+        keywords="",
+        modified=datetime.now(),
+        whiteboard="",
+    )
+
+
+def test_internal_occurrences_batches_counts(
+    transactional_db, eleven_jobs_stored, test_user, django_assert_num_queries
+):
+    """internal_occurrences returns per-bug counts within the window, in one query.
+
+    This replaces the per-row jobmap.count() that serialize() used to run for
+    every internal issue in a search result.
+    """
+    jobs = list(Job.objects.all()[:3])
+    bug_a = _internal_bug("internal issue a")
+    bug_b = _internal_bug("internal issue b")
+
+    # bug_a: two recent maps -> 2; bug_b: one recent map -> 1
+    BugJobMap.objects.create(job=jobs[0], bug=bug_a, user=test_user)
+    BugJobMap.objects.create(job=jobs[1], bug=bug_a, user=test_user)
+    BugJobMap.objects.create(job=jobs[0], bug=bug_b, user=test_user)
+
+    # An old map for bug_a, outside the 7-day window, must be excluded.
+    old = BugJobMap.objects.create(job=jobs[2], bug=bug_a, user=test_user)
+    BugJobMap.objects.filter(pk=old.pk).update(created=timezone.now() - timedelta(days=30))
+
+    with django_assert_num_queries(1):
+        counts = Bugscache.internal_occurrences([bug_a.id, bug_b.id])
+
+    assert counts == {bug_a.id: 2, bug_b.id: 1}
+    # No ids -> no query, empty result.
+    with django_assert_num_queries(0):
+        assert Bugscache.internal_occurrences([]) == {}
 
 
 @pytest.mark.django_db(transaction=True)

--- a/tests/model/test_bugscache.py
+++ b/tests/model/test_bugscache.py
@@ -144,6 +144,24 @@ def test_bug_properties(transactional_db, sample_bugs):
     assert set(suggestions["open_recent"][0].keys()) == expected_keys
 
 
+def test_search_uses_trigram_ilike_not_upper(transactional_db):
+    """The bug search must apply ILIKE directly to the summary column.
+
+    Django's __icontains compiles to UPPER(summary) LIKE UPPER(%s), which the
+    planner cannot serve with the gin_trgm_ops index on the plain summary
+    column (it falls back to a full sequential scan). This guards against a
+    regression back to __icontains by asserting the compiled SQL uses ILIKE on
+    the bare column, with the same wildcard-escaping semantics as __icontains.
+    """
+    qs = Bugscache.objects.filter(summary__trigram_ilike="Some_Term%")
+    sql, params = qs.query.sql_with_params()
+
+    assert "ILIKE" in sql.upper()
+    assert "UPPER(" not in sql.upper()
+    # \ % _ escaped, then wrapped as a "contains" pattern, matching __icontains.
+    assert params[-1] == r"%Some\_Term\%%"
+
+
 @pytest.mark.django_db(transaction=True)
 def test_import(mock_bugscache_bugzilla_request):
     """

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -339,7 +339,7 @@ class Bugscache(models.Model):
     def __str__(self):
         return f"{self.id}"
 
-    def serialize(self):
+    def serialize(self, occurrences=None):
         exclude_fields = ["modified", "processed_update"]
 
         attrs = model_to_dict(self, exclude=exclude_fields)
@@ -347,14 +347,31 @@ class Bugscache(models.Model):
         attrs["internal_id"] = attrs["id"]
         attrs["id"] = attrs.pop("bugzilla_id")
 
-        attrs["occurrences"] = None
-        if attrs["id"] is None:
-            # Only fetch occurrences for internal issues. It causes one extra query
-            attrs["occurrences"] = self.jobmap.filter(
-                created__gte=timezone.now()
-                - datetime.timedelta(days=settings.INTERNAL_OCCURRENCES_DAYS_WINDOW)
-            ).count()
+        # occurrences is only meaningful for internal issues (no bugzilla id).
+        # The count is passed in (see internal_occurrences) so serializing a
+        # list of bugs doesn't fire one query per row.
+        attrs["occurrences"] = occurrences if attrs["id"] is None else None
         return attrs
+
+    @staticmethod
+    def internal_occurrences(bug_ids):
+        """Count recent job maps per internal-issue bug in a single query.
+
+        Returns {bugscache_id: count} for the given ids, so callers can serialize
+        a batch of bugs without the per-row jobmap.count() that serialize() would
+        otherwise do for each internal issue.
+        """
+        if not bug_ids:
+            return {}
+        window_start = timezone.now() - datetime.timedelta(
+            days=settings.INTERNAL_OCCURRENCES_DAYS_WINDOW
+        )
+        rows = (
+            BugJobMap.objects.filter(bug_id__in=bug_ids, created__gte=window_start)
+            .values("bug_id")
+            .annotate(occurrences=Count("id"))
+        )
+        return {row["bug_id"]: row["occurrences"] for row in rows}
 
     @classmethod
     def search(cls, search_term):
@@ -389,7 +406,15 @@ class Bugscache(models.Model):
         )
 
         try:
-            open_recent_match_string = [item.serialize() for item in recent_qs]
+            recent = list(recent_qs)
+            # One grouped query for all internal issues in the result set,
+            # instead of a per-row count inside serialize().
+            occurrences_by_id = Bugscache.internal_occurrences(
+                [bug.id for bug in recent if bug.bugzilla_id is None]
+            )
+            open_recent_match_string = [
+                item.serialize(occurrences=occurrences_by_id.get(item.id)) for item in recent
+            ]
             all_data = [
                 match
                 for match in open_recent_match_string

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -18,7 +18,7 @@ from django.core.exceptions import (
 )
 from django.core.validators import MinLengthValidator
 from django.db import models, transaction
-from django.db.models import Count, Max, Min, Q, Subquery
+from django.db.models import Count, Lookup, Max, Min, Q, Subquery
 from django.db.utils import ProgrammingError
 from django.forms import model_to_dict
 from django.utils import timezone
@@ -274,6 +274,35 @@ class MachinePlatform(models.Model):
         return f"{self.os_name} {self.platform} {self.architecture}"
 
 
+@models.CharField.register_lookup
+class TrigramILike(Lookup):
+    """Case-insensitive substring match that compiles to ``col ILIKE %s``.
+
+    Django's built-in ``__icontains`` compiles to ``UPPER(col) LIKE UPPER(%s)``
+    on PostgreSQL. Because the predicate is on ``UPPER(col)`` rather than the
+    bare column, the planner cannot use a ``gin_trgm_ops`` index defined on the
+    plain column (e.g. bugscache_summary_gin_trgm_idx) and falls back to a full
+    sequential scan. Applying ILIKE (``~~*``) directly to the column lets that
+    trigram GIN index serve the search.
+
+    LIKE wildcards are escaped so matching is literal, identical to the
+    semantics of ``__icontains``.
+    """
+
+    lookup_name = "trigram_ilike"
+
+    def get_prep_lookup(self):
+        # Mirror Django's prep_for_like_query escaping, then wrap as a
+        # "contains" pattern (%term%), so behaviour matches __icontains.
+        escaped = str(self.rhs).replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+        return f"%{escaped}%"
+
+    def as_sql(self, compiler, connection):
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+        return f"{lhs} ILIKE {rhs}", lhs_params + rhs_params
+
+
 class Bugscache(models.Model):
     id = models.BigAutoField(primary_key=True)
 
@@ -336,9 +365,12 @@ class Bugscache(models.Model):
         # as the ranking algorithm expects english words, not paths
         # So we use standard pattern matching AND trigram similarity to compare suite of characters
         # instead of words
-        # Django already escapes special characters, so we do not need to handle that here
+        # LIKE wildcards in the term are escaped by the trigram_ilike lookup below.
         recent_qs = (
-            Bugscache.objects.filter(summary__icontains=search_term)
+            # Use ILIKE directly on the column (not UPPER(...) LIKE UPPER(...),
+            # which is what __icontains compiles to) so the trigram GIN index
+            # on summary is used instead of a full sequential scan.
+            Bugscache.objects.filter(summary__trigram_ilike=search_term)
             # Only fetch the fields that serialize() returns; modified and
             # processed_update are excluded there, so there's no need to load them.
             .only(

--- a/treeherder/webapp/api/note.py
+++ b/treeherder/webapp/api/note.py
@@ -62,7 +62,13 @@ class NoteViewSet(viewsets.ViewSet):
 
         push = Push.objects.get(repository__name=project, revision=revision)
         notes = JobNote.objects.filter(job__push=push).select_related(
-            "job", "job__push", "job__job_type", "job__taskcluster_metadata"
+            "job",
+            "job__push",
+            "job__job_type",
+            "job__taskcluster_metadata",
+            # JobNoteDetailSerializer reads failure_classification.name; join it
+            # so the name isn't fetched with a separate query per note.
+            "failure_classification",
         )
         serializer = JobNoteDetailSerializer(notes, many=True)
         return Response(serializer.data)

--- a/treeherder/webapp/api/serializers.py
+++ b/treeherder/webapp/api/serializers.py
@@ -204,8 +204,11 @@ class JobNoteSerializer(serializers.ModelSerializer):
     job_id = serializers.PrimaryKeyRelatedField(source="job", read_only=True)
 
     # these custom fields are for backwards compatibility
-    failure_classification_id = serializers.SlugRelatedField(
-        slug_field="id", source="failure_classification", read_only=True
+    # PrimaryKeyRelatedField reads the FK id already on the row (pk-only
+    # optimization), avoiding a per-note query to load the related
+    # FailureClassification just to read its id (which SlugRelatedField would do).
+    failure_classification_id = serializers.PrimaryKeyRelatedField(
+        source="failure_classification", read_only=True
     )
 
     class Meta:


### PR DESCRIPTION
## Summary

Optimizes the database queries behind the job details / failure summary panel, where the `bug_suggestions` endpoint has been reported as slow. The main fix makes an already-shipped index actually get used; two smaller commits remove N+1 queries on the same path.

## 1. `Bugscache.search()` never used the trigram index (main fix)

`search()` filtered with `summary__icontains`, which Django compiles to `UPPER(summary) LIKE UPPER(%s)` on PostgreSQL. Because the predicate is on `UPPER(summary)` rather than the bare column, the planner **cannot** use the `gin_trgm_ops` index on `bugscache.summary` (added in #9555) and runs a **full sequential scan on every call** — and `search()` runs once per distinct error term in the bug suggestions panel.

A small `TrigramILike` lookup applies `ILIKE` directly to the column (same wildcard-escaping as `__icontains`), so the existing trigram GIN index serves the query. No migration required.

### Measured on the prod replica (`bugscache` ≈ 52,800 rows / 106 MB)

`EXPLAIN (ANALYZE, BUFFERS)` for three representative terms:

| Term | Before | After |
|---|---|---|
| `test-verify` (generic) | Seq Scan, 52,806 rows removed, **128 ms** | Bitmap Index Scan, **5.8 ms** |
| `shutdownleaks` (leak) | Seq Scan, 52,793 rows removed, **131 ms** | Bitmap Index Scan, **5.3 ms** |
| long test-path string | Seq Scan, whole table, **123 ms** | Bitmap Index Scan, **64 ms** |

Shared buffers per call drop from ~5,724 to 76–702. The cost goes from O(table size) — which grows unbounded as bugs accumulate — to O(matches).

## 2. Batch the per-row occurrences count

`Bugscache.serialize()` ran `jobmap.count()` for every internal-issue row, i.e. one query per internal issue in a search result. Added `internal_occurrences()` to compute all counts in a single grouped query and pass them into `serialize()`.

## 3. Remove N+1 in job note serialization

- `JobNoteSerializer.failure_classification_id` used `SlugRelatedField(slug_field="id")`, loading the whole related `FailureClassification` per note just to read its id (already present as the FK column). Switched to `PrimaryKeyRelatedField` (pk-only, no query).
- `push_notes` reads `failure_classification.name`, so its queryset now `select_related`s the classification instead of fetching it per note.

## Testing

- All existing `Bugscache.search()` parametrized tests pass, confirming behaviour parity (literal `_`/`%` handling and case-insensitivity are unchanged).
- Added a test asserting the compiled search SQL uses `ILIKE` on the bare column (no `UPPER(...)` wrapping) and escapes wildcards.
- Added a test for `internal_occurrences` verifying per-bug counts, window exclusion, and that it runs in a single query.
- `error_summary`, note, and job-note suites pass. `ruff` clean.
