### PR TITLE
Narrow the time range used to re-check performance changes in Sherlock

### DIFF
--- a/treeherder/perf/auto_perf_sheriffing/secretary.py
+++ b/treeherder/perf/auto_perf_sheriffing/secretary.py
@@ -390,7 +390,7 @@ class Secretary:
             logger.warning(f"Record {record.alert.id}: Could not find last detected push: {ex}")
             return None, None, []
 
-        start_time = last_detected_push.time - django_settings.PERFHERDER_ALERTS_MAX_AGE
+        start_time = last_detected_push.time - timedelta(days=6)
         prev_alert = (
             PerformanceAlert.objects.filter(
                 series_signature=signature,
@@ -412,7 +412,7 @@ class Secretary:
         if fore_pushes:
             end_time = fore_pushes[-1].push_timestamp
         else:
-            end_time = last_detected_push.time + timedelta(days=7)
+            end_time = last_detected_push.time + timedelta(days=6)
         series = (
             PerformanceDatum.objects.filter(
                 signature=signature,


### PR DESCRIPTION
This PR narrows the time range used when re-checking performance changes in Sherlock.
Previously, the re-check used `django_settings.PERFHERDER_ALERTS_MAX_AGE`, which is set to 14 days. This setting is intended for the initial alert generation and is broader than necessary for re-checking.
Using such a wide time range can sometimes cause an unrelated push to be identified as the culprit. This PR introduces a narrower time range for re-checks to reduce that possibility.
Please let me know if you have any suggestions or questions.